### PR TITLE
cmake.py: include transitive run deps in CMAKE_PREFIX_PATH

### DIFF
--- a/repos/spack_repo/builtin/build_systems/cmake.py
+++ b/repos/spack_repo/builtin/build_systems/cmake.py
@@ -175,7 +175,7 @@ def get_cmake_prefix_path(pkg: PackageBase) -> List[str]:
     edges = traverse.traverse_topo_edges_generator(
         traverse.with_artificial_edges([pkg.spec]),
         visitor=traverse.MixedDepthVisitor(
-            direct=dt.BUILD | dt.TEST, transitive=dt.LINK, key=traverse.by_dag_hash
+            direct=dt.BUILD | dt.TEST, transitive=dt.LINK | dt.RUN, key=traverse.by_dag_hash
         ),
         key=traverse.by_dag_hash,
         root=False,


### PR DESCRIPTION
> [!NOTE]
> This PR was migrated from **https://github.com/spack/spack/pull/47840**.

- Run deps often need to be located during the build
- In cases like python-venv and python, where there's a direct build dep
  on both, but python-venv has a run dep on python, meaning we'd rather
  see python-venv in path before python topologically. When including
  only link edges, the python - python-venv order is also allowed as there
  is no link edge between those.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->