### PR TITLE
intel-oneapi-mkl: Make `threads!=none` work after compilers-as-nodes

### DIFF
--- a/repos/spack_repo/builtin/build_systems/oneapi.py
+++ b/repos/spack_repo/builtin/build_systems/oneapi.py
@@ -11,6 +11,7 @@ from llnl.util.link_tree import LinkTree
 
 import spack.util.path
 from spack.build_environment import dso_suffix
+from spack.compilers.libraries import CompilerPropertyDetector
 from spack.package import (
     EnvironmentModifications,
     Executable,
@@ -219,8 +220,8 @@ class IntelOneApiLibraryPackage(IntelOneApiPackage):
             )
 
         # query the compiler for the library path
-        with self.compiler.compiler_environment():
-            omp_lib_path = Executable(self.compiler.cc)(
+        with CompilerPropertyDetector(self["c"].spec).compiler_environment():
+            omp_lib_path = Executable(self["c"].cc)(
                 "--print-file-name", f"{libname}.{dso_suffix}", output=str
             ).strip()
 

--- a/repos/spack_repo/builtin/packages/intel_oneapi_mkl/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_mkl/package.py
@@ -191,7 +191,10 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         msg="MKL with OpenMP threading requires GCC, clang, or Intel compilers",
     )
 
-    depends_on("tbb")
+    # Nothing is compiled, but openmp_libs in the oneapi build system queries
+    # the compiler for openmp library paths.
+    depends_on("c", when="threads=openmp")
+    depends_on("tbb", when="threads=tbb")
     # cluster libraries need mpi
     depends_on("mpi", when="+cluster")
 


### PR DESCRIPTION
> [!NOTE]
> This PR was migrated from **https://github.com/spack/spack/pull/50233**.

Previously the `intel-oneapi-mkl` package (or the `oneapi` build system) had an implicit dependency on a compiler, from which openmp library paths were extracted. After compilers-as-nodes, `intel-oneapi-mkl` no longer has an implicit compiler, so this detection broke.

This PR adds an explicit `depends_on("c")` to the `intel-oneapi-mkl` package (could be `cxx` as well, but I figured `c` is the most basic compiler from which the openmp paths can be extracted). This means that the `oneapi` build system can query the `"c"` package for compiler paths and call the compiler. I also had to change the way the compiler is used in `oneapi.py` (@alalazo, does that look sane to you?).

A bit of an unrelated change, but this also changes the `tbb` dependency to be optional.

As before, using `intel-oneapi-mkl` remains broken as an external when `threads!=none`, since externals don't have dependencies (this was also implicit before compilers-as-nodes), and I'm not attempting to fix that here.