### PR TITLE
remove repos/README.md

### DIFF
--- a/repos/README.md
+++ b/repos/README.md
@@ -1,5 +1,0 @@
-# `builtin` Spack Package Repository
-
-This is the default Spack package repository, which contains the set of packages maintained by
-the Spack community. In Spack v1.0, this repository is automatically added to the Spack
-configuration.


### PR DESCRIPTION
So that it's one click to `repos/spack_repo/builtin` from the github interface.