### PR TITLE
py-tensorflow: add v2.19, v2.20

### DIFF
--- a/repos/spack_repo/builtin/packages/py_tensorboard/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorboard/package.py
@@ -21,6 +21,7 @@ class PyTensorboard(PythonPackage):
     license("Apache-2.0")
     maintainers("aweits")
 
+    version("2.20.0", sha256="9dc9f978cb84c0723acf9a345d96c184f0293d18f166bb8d59ee098e6cfaaba6")
     version("2.19.0", sha256="5e71b98663a641a7ce8a6e70b0be8e1a4c0c45d48760b076383ac4755c35b9a0")
     version("2.18.0", sha256="107ca4821745f73e2aefa02c50ff70a9b694f39f790b11e6f682f7d326745eab")
     version("2.17.1", sha256="253701a224000eeca01eee6f7e978aea7b408f60b91eb0babdb04e78947b773e")
@@ -68,6 +69,7 @@ class PyTensorboard(PythonPackage):
         # https://github.com/tensorflow/tensorboard/pull/5138
         depends_on("py-numpy@:1.23", when="@:2.5")
         depends_on("py-packaging", when="@2.18:")
+        depends_on("pil", when="@2.20:")
         depends_on("py-protobuf@3.19.6:", when="@2.15.2:2.16,2.18:")
         depends_on("py-protobuf@3.19.6:4", when="@2.17")
         depends_on("py-protobuf@3.19.6:4.23", when="@2.12:2.15.1")
@@ -75,7 +77,6 @@ class PyTensorboard(PythonPackage):
         depends_on("py-protobuf@3.9.2:3.19", when="@2.9:2.10")
         depends_on("py-protobuf@3.6.0:3.19", when="@:2.8")
         depends_on("py-setuptools@41:")
-        depends_on("py-six@1.10:", when="@:2.4,2.14:")
         depends_on("py-tensorboard-data-server@0.7", when="@2.12:")
         depends_on("py-tensorboard-data-server@0.6", when="@2.5:2.11")
         depends_on("py-werkzeug@1.0.1:", when="@2.9:")
@@ -88,6 +89,7 @@ class PyTensorboard(PythonPackage):
         depends_on("py-google-auth-oauthlib@0.5:1.0", when="@2.12.1:2.14")
         depends_on("py-google-auth-oauthlib@0.4.1:0.4", when="@:2.12.0")
         depends_on("py-requests@2.21.0:2", when="@:2.15")
+        depends_on("py-six@1.9.1:", when="@:2.4,2.14:2.19")
         depends_on("py-tensorboard-plugin-wit@1.6.0:", when="@:2.13")
 
     conflicts("^py-protobuf@4.24.0")

--- a/repos/spack_repo/builtin/packages/py_tensorboard/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorboard/package.py
@@ -21,6 +21,7 @@ class PyTensorboard(PythonPackage):
     license("Apache-2.0")
     maintainers("aweits")
 
+    version("2.19.0", sha256="5e71b98663a641a7ce8a6e70b0be8e1a4c0c45d48760b076383ac4755c35b9a0")
     version("2.18.0", sha256="107ca4821745f73e2aefa02c50ff70a9b694f39f790b11e6f682f7d326745eab")
     version("2.17.1", sha256="253701a224000eeca01eee6f7e978aea7b408f60b91eb0babdb04e78947b773e")
     version("2.17.0", sha256="859a499a9b1fb68a058858964486627100b71fcb21646861c61d31846a6478fb")

--- a/repos/spack_repo/builtin/packages/py_tensorflow/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow/package.py
@@ -513,7 +513,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
 
         # Please input the desired Python library path to use
         env.set("PYTHON_LIB_PATH", python_platlib)
-        env.set("TF_PYTHON_VERSION", spec["python"].version.up_to(2))
+        env.set("TF_PYTHON_VERSION", str(spec["python"].version.up_to(2)))
 
         # Ensure swig is in PATH or set SWIG_PATH
         env.set("SWIG_PATH", spec["swig"].prefix.bin.swig)

--- a/repos/spack_repo/builtin/packages/py_tensorflow/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow/package.py
@@ -49,6 +49,8 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     maintainers("adamjstewart", "aweits")
     tags = ["e4s"]
 
+    version("2.20.0", sha256="a640d1f97be316a09301dfc9347e3d929ad4d9a2336e3ca23c32c93b0ff7e5d0")
+    version("2.19.1", sha256="fcfb3e88ab3eebdbab98a03c869a4d2616d52ea166c8d8021de1ef921b47be8d")
     version("2.19.0", sha256="4691b18e8c914cdf6759b80f1b3b7f3e17be41099607ed0143134f38836d058e")
     version("2.18.1", sha256="467c512b631e72ad5c9d5c16b23669bcf89675de630cfbb58f9dde746d34afa8")
     version(
@@ -158,7 +160,8 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
 
     with default_args(type="build"):
         # See .bazelversion
-        depends_on("bazel@6.5.0", when="@2.16:")
+        depends_on("bazel@7.4.1", when="@2.20:")
+        depends_on("bazel@6.5.0", when="@2.16:2.19")
         depends_on("bazel@6.1.0", when="@2.14:2.15")
         depends_on("bazel@5.3.0", when="@2.11:2.13")
         depends_on("bazel@5.1.1", when="@2.10")
@@ -179,13 +182,14 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
 
     with default_args(type=("build", "run")):
         # Python support based on wheel availability
-        depends_on("python@3.9:3.12", when="@2.16:")
+        depends_on("python@3.9:3.13", when="@2.20:")
+        depends_on("python@3.9:3.12", when="@2.16:2.19")
         depends_on("python@3.9:3.11", when="@2.14:2.15")
         depends_on("python@3.8:3.11", when="@2.12:2.13")
         depends_on("python@:3.10", when="@2.8:2.11")
         depends_on("python@:3.9", when="@:2.7")
 
-        # Listed under REQUIRED_PACKAGES in tensorflow/tools/pip_package/setup.py
+        # Listed under REQUIRED_PACKAGES in tensorflow/tools/pip_package/setup.py.tpl
         depends_on("py-absl-py@1:", when="@2.9:")
         depends_on("py-absl-py@0.4:", when="@2.7:2.8")
         depends_on("py-absl-py@0.10:0", when="@2.4:2.6")
@@ -211,7 +215,8 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         depends_on("py-opt-einsum@2.3.2:", when="@2.7:")
         depends_on("py-opt-einsum@3.3", when="@2.4:2.6")
         depends_on("py-packaging", when="@2.9:")
-        depends_on("py-protobuf@3.20.3:4.20,4.21.6:5", when="@2.18:")
+        depends_on("py-protobuf@5.28:", when="@2.20:")
+        depends_on("py-protobuf@3.20.3:4.20,4.21.6:5", when="@2.18:2.19")
         depends_on("py-protobuf@3.20.3:4.20,4.21.6:4", when="@2.12:2.17")
         depends_on("py-protobuf@3.9.2:", when="@2.3:2.11")
         # https://github.com/protocolbuffers/protobuf/issues/10051
@@ -231,23 +236,20 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         depends_on("py-wrapt@1.11:1.14", when="@2.12,2.14:2.15")
         depends_on("py-wrapt@1.12.1:1.12", when="@2.4:2.6")
 
-        # TODO: add packages for these dependencies
-        # depends_on('py-tensorflow-io-gcs-filesystem@0.23.1:', when='@2.8:')
-        # depends_on('py-tensorflow-io-gcs-filesystem@0.21:', when='@2.7')
-
         if sys.byteorder == "little":
             # Only builds correctly on little-endian machines
             depends_on("py-grpcio@1.24.3:1", when="@2.7:")
             depends_on("py-grpcio@1.37.0:1", when="@2.6")
             depends_on("py-grpcio@1.34", when="@2.5")
 
-        for minor_ver in range(5, 20):
+        for minor_ver in range(5, 21):
             depends_on("py-tensorboard@2.{}".format(minor_ver), when="@2.{}".format(minor_ver))
 
         # TODO: support circular run-time dependencies
         # depends_on('py-keras')
 
-        depends_on("py-numpy@1.26:2.1", when="@2.19:")
+        depends_on("py-numpy@1.26:", when="@2.20:")
+        depends_on("py-numpy@1.26:2.1", when="@2.19")
         depends_on("py-numpy@1.26:2.0", when="@2.18")
         depends_on("py-numpy@1.23.5:", when="@2.14:2.17")
         depends_on("py-numpy@1.22:1.24.3", when="@2.13")
@@ -281,6 +283,10 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         depends_on("py-wheel@0.32:0", when="@2.7")
         depends_on("py-wheel@0.35:0", when="@2.4:2.6")
 
+        # TODO: add packages for these dependencies
+        # depends_on("py-tensorflow-io-gcs-filesystem@0.23.1:", when="@2.8:2.19")
+        # depends_on("py-tensorflow-io-gcs-filesystem@0.21:", when="@2.7")
+
     # TODO: add packages for some of these dependencies
     depends_on("mkl", when="+mkl")
     depends_on("curl", when="+gcp")
@@ -288,6 +294,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     # depends_on('trisycl',    when='+opencl~computepp')
     with when("+cuda"):
         # https://www.tensorflow.org/install/source#gpu
+        depends_on("cuda@12.5:", when="@2.18:")
         depends_on("cuda@12.3:", when="@2.16:")
         depends_on("cuda@12.2:", when="@2.15:")
         depends_on("cuda@11.8:", when="@2.12:")
@@ -296,6 +303,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         depends_on("cuda@:11.7.0", when="@:2.9")
         depends_on("cuda@:11.4", when="@2.4:2.7")
 
+        depends_on("cudnn@9.3:", when="@2.18:")
         depends_on("cudnn@8.9:8", when="@2.15:")
         depends_on("cudnn@8.7:8", when="@2.14:")
         depends_on("cudnn@8.6:8", when="@2.12:")

--- a/repos/spack_repo/builtin/packages/py_tensorflow/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow/package.py
@@ -798,7 +798,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
                 ".tf_configure.bazelrc",
             )
 
-        if spec.satisfies("@:1~opencl"):
+        if spec.satisfies("@:1.19~opencl"):
             # 1.8.0 and 1.9.0 aborts with numpy import error during python_api
             # generation somehow the wrong PYTHONPATH is used...
             # set --distinct_host_configuration=false as a workaround

--- a/repos/spack_repo/builtin/packages/py_tensorflow/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow/package.py
@@ -394,7 +394,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     patch(
         "https://github.com/tensorflow/tensorflow/pull/90563.patch?full_index=1",
         sha256="78b858380521f4624fd95bfa32fd038cdd8168b783c2a13502c4169431517618",
-        when="@2.19:",
+        when="@2.19",
     )
 
     # Fix build error with GCC 13
@@ -402,7 +402,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     patch(
         "https://github.com/tensorflow/tensorflow/pull/90558.patch?full_index=1",
         sha256="3c93c6226bbde3a4c2aedbac42bc136eacf8da65f5623f7effad437ebf2ba4aa",
-        when="@2.19:",
+        when="@2.19",
     )
 
     # https://github.com/tensorflow/tensorflow/issues/94277

--- a/repos/spack_repo/builtin/packages/py_tensorflow/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow/package.py
@@ -49,6 +49,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     maintainers("adamjstewart", "aweits")
     tags = ["e4s"]
 
+    version("2.19.0", sha256="4691b18e8c914cdf6759b80f1b3b7f3e17be41099607ed0143134f38836d058e")
     version("2.18.1", sha256="467c512b631e72ad5c9d5c16b23669bcf89675de630cfbb58f9dde746d34afa8")
     version(
         "2.18.0-rocm-enhanced",
@@ -240,13 +241,14 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
             depends_on("py-grpcio@1.37.0:1", when="@2.6")
             depends_on("py-grpcio@1.34", when="@2.5")
 
-        for minor_ver in range(5, 19):
+        for minor_ver in range(5, 20):
             depends_on("py-tensorboard@2.{}".format(minor_ver), when="@2.{}".format(minor_ver))
 
         # TODO: support circular run-time dependencies
         # depends_on('py-keras')
 
-        depends_on("py-numpy@1.26:2.0", when="@2.18:")
+        depends_on("py-numpy@1.26:2.1", when="@2.19:")
+        depends_on("py-numpy@1.26:2.0", when="@2.18")
         depends_on("py-numpy@1.23.5:", when="@2.14:2.17")
         depends_on("py-numpy@1.22:1.24.3", when="@2.13")
         depends_on("py-numpy@1.22:1.23", when="@2.12")
@@ -264,6 +266,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         depends_on("py-h5py~mpi", when="~mpi")
         depends_on("hdf5+mpi", when="+mpi")
         depends_on("hdf5~mpi", when="~mpi")
+        depends_on("py-ml-dtypes@0.5.1:0", when="@2.19:")
         depends_on("py-ml-dtypes@0.4:0", when="@2.18.1")
         depends_on("py-ml-dtypes@0.4", when="@2.18.0")
         depends_on("py-ml-dtypes@0.3.1:0.4", when="@2.17")
@@ -378,6 +381,21 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     conflicts("%clang@:15", when="@2.18:")
     # https://github.com/tensorflow/tensorflow/issues/62416
     conflicts("%clang@17:", when="@:2.14")
+
+    # https://github.com/spack/spack/issues/49958
+    patch(
+        "https://github.com/tensorflow/tensorflow/pull/90563.patch?full_index=1",
+        sha256="78b858380521f4624fd95bfa32fd038cdd8168b783c2a13502c4169431517618",
+        when="@2.19:",
+    )
+
+    # Fix build error with GCC 13
+    # https://github.com/tensorflow/tensorflow/issues/84977
+    patch(
+        "https://github.com/tensorflow/tensorflow/pull/90558.patch?full_index=1",
+        sha256="3c93c6226bbde3a4c2aedbac42bc136eacf8da65f5623f7effad437ebf2ba4aa",
+        when="@2.19:",
+    )
 
     # https://github.com/tensorflow/tensorflow/issues/94277
     # https://github.com/tensorflow/tensorflow/pull/94289

--- a/repos/spack_repo/builtin/packages/py_tensorflow/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow/package.py
@@ -442,7 +442,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
 
     # allow linker to be found in PATH
     # https://github.com/tensorflow/tensorflow/issues/39263
-    patch("null_linker_bin_path.patch", when="@2.5:")
+    patch("null_linker_bin_path.patch", when="@2.5:2.19")
 
     # Reset import order to that of 2.4. Part of
     # https://bugs.gentoo.org/800824#c3 From the patch:

--- a/repos/spack_repo/builtin/packages/py_tensorflow/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow/package.py
@@ -418,12 +418,11 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         when="@2.9:2.10.0",
     )
 
-    # can set an upper bound if/when
-    # https://github.com/tensorflow/tensorflow/pull/89032 is merged
+    # https://github.com/tensorflow/tensorflow/pull/89032
     patch(
         "allow-empty-config-environment-variables.patch",
         sha256="e061875c2ca9c157a7837d02afdd25205817def3460745523d5089bbeaa77d29",
-        when="@1.4.0:",
+        when="@1.4.0:2.19",
     )
 
     # Version 2.10 produces an error related to cuBLAS:

--- a/repos/spack_repo/builtin/packages/py_tensorflow/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow/package.py
@@ -798,7 +798,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
                 ".tf_configure.bazelrc",
             )
 
-        if spec.satisfies("~opencl"):
+        if spec.satisfies("@:1~opencl"):
             # 1.8.0 and 1.9.0 aborts with numpy import error during python_api
             # generation somehow the wrong PYTHONPATH is used...
             # set --distinct_host_configuration=false as a workaround

--- a/stacks/ml-linux-aarch64-cpu/spack.yaml
+++ b/stacks/ml-linux-aarch64-cpu/spack.yaml
@@ -16,7 +16,8 @@ spack:
     py-jaxlib:
       require: "%c,cxx=clang"
     py-tensorflow:
-      require: "%c,cxx=clang"
+      require:
+        - any_of: ["@:2.18 %c,cxx=gcc", "@2.19: %c,cxx=clang"]
     py-torch:
       require: "%c,cxx=gcc"
 

--- a/stacks/ml-linux-aarch64-cpu/spack.yaml
+++ b/stacks/ml-linux-aarch64-cpu/spack.yaml
@@ -16,7 +16,7 @@ spack:
     py-jaxlib:
       require: "%c,cxx=clang"
     py-tensorflow:
-      require: "%c,cxx=gcc"
+      require: "%c,cxx=clang"
     py-torch:
       require: "%c,cxx=gcc"
 

--- a/stacks/ml-linux-aarch64-cuda/spack.yaml
+++ b/stacks/ml-linux-aarch64-cuda/spack.yaml
@@ -21,7 +21,7 @@ spack:
     py-jaxlib:
       require: "%c,cxx=clang"
     py-tensorflow:
-      require: "%c,cxx=gcc"
+      require: "%c,cxx=clang"
     py-torch:
       require:
       - target=aarch64

--- a/stacks/ml-linux-aarch64-cuda/spack.yaml
+++ b/stacks/ml-linux-aarch64-cuda/spack.yaml
@@ -21,7 +21,8 @@ spack:
     py-jaxlib:
       require: "%c,cxx=clang"
     py-tensorflow:
-      require: "%c,cxx=clang"
+      require:
+        - any_of: ["@:2.18 %c,cxx=gcc", "@2.19: %c,cxx=clang"]
     py-torch:
       require:
       - target=aarch64


### PR DESCRIPTION
Ported from https://github.com/spack/spack/pull/49440

Probably still waiting on Clang to be added to the CI images.