### PR TITLE
README.md: document repository structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,34 @@ This is the default [Spack](https://github.com/spack/spack) packages repository,
 contains the set of packages maintained by the Spack community. In Spack v1.0 and later,
 the repository here is automatically added to the Spack configuration.
 
+## Structure of this repo
+
+This repository does not look like the original Spack package repositories. Its structure
+has been renovated a bit to make it work better with modern python tooling. The repo
+looks like this:
+
+```
+spack-packages/
+    repos/                          # add this to PYTHONPATH for your editor
+        spack_repo/                 # dedicated python package for spack repositories
+            builtin/                # namespace of this package repository
+                build_systems/      # build_systems: common base classes used by many packages
+                packages/           # This is where all the package.py files go
+                    <PKG_NAME>/     # e.g., hdf5, zlib, mfem
+                        package.py  # actual package recipes
+```
+
+The new repository structure is designed around several goals:
+
+1. Make it easy to add the repository to `PYTHONPATH`;
+2. Allow common python code like `build_systems` to live in the package repo, not core
+   Spack; and
+3. Allow multiple reositories (e.g. something in addition to `builtin` to live in the
+   same git repository.
+
+If you use an editor like vscode, you should be able to point it directly to the `repos/`
+directory and have the editor understand the package code.
+
 ## Contributing
 
 To contribute, simply make a pull request to this repository with your package changes.


### PR DESCRIPTION
So that I can point to this when people ask why the repository is structured this way.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
