### PR TITLE
Bazel: add compiler deps, Apple Clang patches

### DIFF
--- a/repos/spack_repo/builtin/packages/bazel/01_remove_werror_7.patch
+++ b/repos/spack_repo/builtin/packages/bazel/01_remove_werror_7.patch
@@ -1,0 +1,66 @@
+diff --color=auto --color=never -Naur a/MODULE.bazel b/MODULE.bazel
+--- a/MODULE.bazel	1980-01-01 00:00:00
++++ b/MODULE.bazel	2025-05-27 10:49:45
+@@ -57,6 +57,13 @@
+ bazel_dep(name = "c-ares", version = "1.15.0")
+ bazel_dep(name = "rules_go", version = "0.39.1")
+ bazel_dep(name = "upb", version = "0.0.0-20220923-a547704")
++single_version_override(
++    module_name = "upb",
++    patch_strip = 1,
++    patches = [
++        "//third_party/upb:01_remove_werror.patch",
++    ],
++)
+ 
+ # =========================================
+ # Java dependencies
+diff --color=auto --color=never -Naur a/third_party/BUILD b/third_party/BUILD
+--- a/third_party/BUILD	1980-01-01 00:00:00
++++ b/third_party/BUILD	2025-05-27 10:50:18
+@@ -33,6 +33,7 @@
+         "//third_party/py/frozendict:srcs",
+         "//third_party/py/mock:srcs",
+         "//third_party/py/six:srcs",
++        "//third_party/upb:srcs",
+         "//third_party/zlib:srcs",
+         "@googleapis//:srcs",
+         "@remoteapis//:srcs",
+diff --color=auto --color=never -Naur a/third_party/upb/01_remove_werror.patch b/third_party/upb/01_remove_werror.patch
+--- a/third_party/upb/01_remove_werror.patch	1970-01-01 01:00:00
++++ b/third_party/upb/01_remove_werror.patch	2025-05-27 10:50:45
+@@ -0,0 +1,19 @@
++diff --git a/bazel/upb_proto_library.bzl b/bazel/upb_proto_library.bzl
++--- a/bazel/build_defs.bzl
+++++ b/bazel/build_defs.bzl
++@@ -34,13 +34,13 @@
++ _DEFAULT_CPPOPTS.extend([
++     "-Wextra",
++     # "-Wshorten-64-to-32",  # not in GCC (and my Kokoro images doesn't have Clang)
++-    "-Werror",
+++    # "-Werror",
++     "-Wno-long-long",
++ ])
++ _DEFAULT_COPTS.extend([
++     "-std=c99",
++     "-pedantic",
++-    "-Werror=pedantic",
+++    # "-Werror=pedantic",
++     "-Wall",
++     "-Wstrict-prototypes",
++     # GCC (at least) emits spurious warnings for this that cannot be fixed
+diff --color=auto --color=never -Naur a/third_party/upb/BUILD b/third_party/upb/BUILD
+--- a/third_party/upb/BUILD	1970-01-01 01:00:00
++++ b/third_party/upb/BUILD	2025-05-27 10:51:08
+@@ -0,0 +1,11 @@
++licenses(["notice"])
++
++filegroup(
++    name = "srcs",
++    srcs = glob(["**"]),  # glob everything to satisfy the compile.sh srcs test
++    visibility = ["//third_party:__pkg__"],
++)
++
++exports_files([
++    "01_remove_werror.patch",
++])

--- a/repos/spack_repo/builtin/packages/bazel/package.py
+++ b/repos/spack_repo/builtin/packages/bazel/package.py
@@ -150,12 +150,21 @@ class Bazel(Package):
     )
 
     # https://bazel.build/install/compile-source#bootstrap-unix-prereq
+    depends_on("bash", type="build")
+    depends_on("zip", when="platform=linux", type=("build", "run"))
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
     depends_on("java@21", when="@7.2:", type=("build", "run"))
     depends_on("java@11", when="@5.3:7.1", type=("build", "run"))
     depends_on("java@8,11", when="@3.3:5.2", type=("build", "run"))
     depends_on("java@8", when="@0.6:3.2", type=("build", "run"))
     depends_on("python+pythoncmd", type=("build", "run"))
-    depends_on("zip", when="platform=linux", type=("build", "run"))
+
+    patch(
+        "https://github.com/bazelbuild/bazel/commit/05b1f061c9256ec0eb6fb71716ed93feb0c31b59.patch?full_index=1",
+        sha256="e695708d20fbb84d94e1d2a896330de6222f9f20bb34ef65cdfe634d3454f06c",
+        when="@7.0",
+    )
 
     # Pass Spack environment variables to the build
     patch("bazelruleclassprovider-0.25.patch")
@@ -213,7 +222,13 @@ class Bazel(Package):
     conflicts("@4.0.0", when="%gcc@11:")
 
     # https://github.com/bazelbuild/bazel/pull/23667
-    conflicts("%apple-clang@16:", when="@:7.3")
+    patch(
+        "https://github.com/bazelbuild/bazel/commit/4a32d7b98423682be9c47f571afbfbb587605895.patch?full_index=1",
+        sha256="18152e63b1d07aca11c126656175ceab92d4937bade13477f93322efdaf0fca1",
+        when="@7.1:7.3",
+    )
+    patch("01_remove_werror_7.patch", when="@7.0")
+    conflicts("%apple-clang@16:", when="@:6")
 
     executables = ["^bazel$"]
 


### PR DESCRIPTION
Tried backporting the Apple Clang patches even earlier but haven't yet succeeded yet.

Ported from https://github.com/spack/spack/pull/50623