### PR TITLE
vecgeom: new versions 2.0.0-rc.4, 1.2.11

### DIFF
--- a/repos/spack_repo/builtin/packages/vecgeom/package.py
+++ b/repos/spack_repo/builtin/packages/vecgeom/package.py
@@ -38,10 +38,15 @@ class Vecgeom(CMakePackage, CudaPackage):
         deprecated=True,
     )
     version(
+        "1.2.11",
+        url="https://gitlab.cern.ch/-/project/981/uploads/f2a483a4a073fac560714280e0e223ec/VecGeom-v1.2.11.tar.gz",
+        sha256="0e251b0c6d79401e49cd2137a32b499ce3857045683d1fc8b6cd3b527247a3ef",
+        preferred=True,
+    )
+    version(
         "1.2.10",
         url="https://gitlab.cern.ch/-/project/981/uploads/8e0a94013efdd1b2d4f44c3fbb10bcdf/VecGeom-v1.2.10.tar.gz",
         sha256="3e0934842694452e4cb4a265428cb99af1ecc45f0e2d28a32dfeaa0634c21e2a",
-        preferred=True,
     )
     version(
         "1.2.9",

--- a/repos/spack_repo/builtin/packages/vecgeom/package.py
+++ b/repos/spack_repo/builtin/packages/vecgeom/package.py
@@ -31,19 +31,10 @@ class Vecgeom(CMakePackage, CudaPackage):
     maintainers("drbenmorgan", "sethrj")
 
     version("master", branch="master", get_full_repo=True)
-    # NOTE: the surfacedev branches are not stable or official and will be
-    # deleted when the next 2.0 RC comes out
     version(
-        "2.0.0-surfacedev.2",
-        tag="v2.0.0-surfacedev.2",
-        commit="91f5ee554e012ffa3baecd2b30e6f5e6905e5ffb",
-        deprecated=True,
-    )
-    version(
-        "2.0.0-surfacedev.1",
-        tag="v2.0.0-surfacedev.1",
-        commit="1d9797ea47e3b35ab0114e72ce5925ecbd59cbf4",
-        deprecated=True,
+        "2.0.0-rc.4",
+        url="https://gitlab.cern.ch/-/project/981/uploads/0bad6dbe49bb754f96db48dc048d8bb8/VecGeom-v2.0.0-rc.4.tar.gz",
+        sha256="fb6bae9269187c1a55509583636827b1ec232bfb3e1d78d6514a4e777477ee33",
     )
     version(
         "1.2.10",

--- a/repos/spack_repo/builtin/packages/vecgeom/package.py
+++ b/repos/spack_repo/builtin/packages/vecgeom/package.py
@@ -35,6 +35,7 @@ class Vecgeom(CMakePackage, CudaPackage):
         "2.0.0-rc.4",
         url="https://gitlab.cern.ch/-/project/981/uploads/0bad6dbe49bb754f96db48dc048d8bb8/VecGeom-v2.0.0-rc.4.tar.gz",
         sha256="fb6bae9269187c1a55509583636827b1ec232bfb3e1d78d6514a4e777477ee33",
+        deprecated=True,
     )
     version(
         "1.2.10",


### PR DESCRIPTION
Moved from https://github.com/spack/spack/pull/50813 .