### PR TITLE
mgard: Add configuration for compiling mgard with hip

### DIFF
--- a/repos/spack_repo/builtin/packages/mgard/hip-abs-reduce-type.patch
+++ b/repos/spack_repo/builtin/packages/mgard/hip-abs-reduce-type.patch
@@ -1,0 +1,32 @@
+From 61fcf45bc9a8324ae00a8ab21d5c65529d04eb9c Mon Sep 17 00:00:00 2001
+From: Kenneth Moreland <morelandkd@ornl.gov>
+Date: Tue, 18 Mar 2025 10:38:15 -0400
+Subject: [PATCH] Correct type for AbsMax reduction in HIP
+
+The hip device collective for AbsMax does a reduction operation.
+The initial value was set to a literal int 0, which is wrong for
+floating types of arrays. This could cause wrong results or compile
+errors.
+
+Fixes #241
+---
+ include/mgard-x/RuntimeX/DeviceAdapters/DeviceAdapterHip.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/include/mgard-x/RuntimeX/DeviceAdapters/DeviceAdapterHip.h b/include/mgard-x/RuntimeX/DeviceAdapters/DeviceAdapterHip.h
+index 5689be9f..77e40b04 100644
+--- a/include/mgard-x/RuntimeX/DeviceAdapters/DeviceAdapterHip.h
++++ b/include/mgard-x/RuntimeX/DeviceAdapters/DeviceAdapterHip.h
+@@ -2341,7 +2341,8 @@ public:
+     AbsMaxOp absMaxOp;
+     hipStream_t stream = DeviceRuntime<HIP>::GetQueue(queue_idx);
+     hipcub::DeviceReduce::Reduce(d_temp_storage, temp_storage_bytes, v.data(),
+-                                 result.data(), n, absMaxOp, 0, stream);
++                                 result.data(), n, absMaxOp, static_cast<T>(0),
++                                 stream);
+     ErrorAsyncCheck(hipGetLastError(), "DeviceCollective<HIP>::AbsMax");
+     if (DeviceRuntime<HIP>::SyncAllKernelsAndCheckErrors) {
+       ErrorSyncCheck(hipDeviceSynchronize(), "DeviceCollective<HIP>::AbsMax");
+-- 
+2.39.5 (Apple Git-154)
+

--- a/repos/spack_repo/builtin/packages/mgard/hip-cub-configure.patch
+++ b/repos/spack_repo/builtin/packages/mgard/hip-cub-configure.patch
@@ -1,0 +1,42 @@
+From 18a2fdb77d5b936ecd22a65443bd6e7b2934b1c6 Mon Sep 17 00:00:00 2001
+From: Kenneth Moreland <morelandkd@ornl.gov>
+Date: Tue, 4 Feb 2025 09:39:34 -0500
+Subject: [PATCH] Properly configure hipCUB dependency
+
+The HIP backend of MGARDX required the use of hipCUB. This is often
+installed with hip and will just be available, but it is not always.
+In the case where it is installed separately, make sure it is
+configured.
+---
+ CMakeLists.txt | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a41973e5..5652501c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -207,6 +207,21 @@ if (MGARD_ENABLE_HIP)
+   target_compile_definitions(mgard-library PUBLIC MGARD_ENABLE_HIP)
+   set (CMAKE_HIP_FLAGS  "${CMAKE_HIP_FLAGS} -w")
+   set_source_files_properties(${MGARD_X_HIP_SRC} PROPERTIES LANGUAGE HIP)
++
++  # Find the required hipCUB packages, which is usually, but not always,
++  # installed with hip.
++  find_package(rocprim REQUIRED CONFIG)
++  find_package(hipcub REQUIRED CONFIG)
++  # Normally, we would use target_link_libraries to include the hip::hipcub
++  # include directories and other parameters. However, for some reason this
++  # library has been changing the compiler and causing errors. Perhaps this
++  # is because different sources require different compilers. So, instead just
++  # grab the include directories.
++  target_include_directories(mgard-library
++    PRIVATE $<TARGET_PROPERTY:hip::hipcub,INTERFACE_INCLUDE_DIRECTORIES>
++    PRIVATE $<TARGET_PROPERTY:roc::rocprim_hip,INTERFACE_INCLUDE_DIRECTORIES>
++    PRIVATE $<TARGET_PROPERTY:roc::rocprim,INTERFACE_INCLUDE_DIRECTORIES>
++    )
+ endif()
+ 
+ if (MGARD_ENABLE_SYCL)
+-- 
+2.39.5 (Apple Git-154)
+

--- a/repos/spack_repo/builtin/packages/mgard/hip-pointer-attribute-struct-fix.patch
+++ b/repos/spack_repo/builtin/packages/mgard/hip-pointer-attribute-struct-fix.patch
@@ -1,0 +1,29 @@
+From 343ce23b3ef9cbe49df22befedd0fda06215349a Mon Sep 17 00:00:00 2001
+From: Kenneth Moreland <morelandkd@ornl.gov>
+Date: Mon, 16 Dec 2024 16:33:32 -0500
+Subject: [PATCH] Fix reference to HIP point attribute structure
+
+When checking whether a pointer is on a HIP device, the previous code
+had an incorrect name for the member of the `hipPointerAttribute_t`
+structure. The code is changed to use the correct identifier for
+this member.
+---
+ include/mgard-x/RuntimeX/DeviceAdapters/DeviceAdapterHip.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/mgard-x/RuntimeX/DeviceAdapters/DeviceAdapterHip.h b/include/mgard-x/RuntimeX/DeviceAdapters/DeviceAdapterHip.h
+index cb6feeaa..5689be9f 100644
+--- a/include/mgard-x/RuntimeX/DeviceAdapters/DeviceAdapterHip.h
++++ b/include/mgard-x/RuntimeX/DeviceAdapters/DeviceAdapterHip.h
+@@ -928,7 +928,7 @@ public:
+     log::dbg("Calling MemoryManager<HIP>::IsDevicePointer");
+     hipPointerAttribute_t attr;
+     hipPointerGetAttributes(&attr, ptr);
+-    return attr.memoryType == hipMemoryTypeDevice;
++    return attr.type == hipMemoryTypeDevice;
+   }
+ 
+   template <typename T> MGARDX_CONT static int GetPointerDevice(T *ptr) {
+-- 
+2.47.1
+

--- a/repos/spack_repo/builtin/packages/mgard/package.py
+++ b/repos/spack_repo/builtin/packages/mgard/package.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems.cmake import CMakeBuilder, CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
+from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
 from spack.package import *
 
 
-class Mgard(CMakePackage, CudaPackage):
+class Mgard(CMakePackage, CudaPackage, ROCmPackage):
     """MGARD error bounded lossy compressor
 
     For versions up to 2023-12-09, uses a fork from https://github.com/robertu94/MGARD
@@ -101,6 +102,7 @@ class Mgard(CMakePackage, CudaPackage):
     depends_on("cmake@3.19:", type="build")
     depends_on("nvcomp@2.2.0:", when="@compat-2022-11-18:+cuda")
     depends_on("nvcomp@2.0.2", when="@:compat-2021-11-12+cuda")
+    depends_on("hipcub", when="+rocm")
     with when("+openmp"):
         depends_on("llvm-openmp", when="%apple-clang")
 
@@ -110,6 +112,7 @@ class Mgard(CMakePackage, CudaPackage):
         when="@compat-2021-11-12",
         msg="without cuda MGARD@compat-2021-11-12 has undefined symbols",
     )
+    conflicts("+openmp", when="+rocm", msg="compiling with both rocm and openmp not supported")
     conflicts(
         "%gcc@:7", when="@compat-2022-11-18:", msg="requires std::optional and other c++17 things"
     )
@@ -117,6 +120,10 @@ class Mgard(CMakePackage, CudaPackage):
     conflicts("protobuf@3.22:", when="+cuda target=aarch64:", msg="nvcc fails on ARM SIMD headers")
     # https://github.com/abseil/abseil-cpp/issues/1629
     conflicts("abseil-cpp@20240116.1", when="+cuda", msg="triggers nvcc parser bug")
+
+    patch("hip-pointer-attribute-struct-fix.patch", when="@:2023-12-09")
+    patch("hip-cub-configure.patch", when="@:2023-12-09")
+    patch("hip-abs-reduce-type.patch", when="@:2023-12-09")
 
     def flag_handler(self, name, flags):
         if name == "cxxflags":
@@ -135,11 +142,14 @@ class Mgard(CMakePackage, CudaPackage):
         spec = self.spec
         args = ["-DBUILD_TESTING=OFF"]
         args.append(self.define_from_variant("MGARD_ENABLE_CUDA", "cuda"))
+        args.append(self.define_from_variant("MGARD_ENABLE_HIP", "rocm"))
         if "+cuda" in spec:
             cuda_arch_list = spec.variants["cuda_arch"].value
             arch_str = ";".join(cuda_arch_list)
             if cuda_arch_list[0] != "none":
                 args.append(self.define("CMAKE_CUDA_ARCHITECTURES", arch_str))
+        if "+rocm" in spec:
+            args.append(CMakeBuilder.define_hip_architectures(self))
         if self.spec.satisfies("@:compat-2021-11-12"):
             if "+cuda" in self.spec:
                 if "75" in cuda_arch:


### PR DESCRIPTION
This also provides patches for properly compiling MGARD with hip. These include fixing compile errors for a bad types in templates that was not caught by compilers that do not check non-instantiated templates. It also has a patch to properly configure the hipcub library. These patches will be part of MGARD after version 1.5.

This is a transfer of https://github.com/spack/spack/pull/48148 to the new, separate spack packages repo.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
