### PR TITLE
aocc: help flang find gcc

### DIFF
--- a/repos/spack_repo/builtin/packages/aocc/package.py
+++ b/repos/spack_repo/builtin/packages/aocc/package.py
@@ -1,7 +1,8 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os.path
+import glob
+import os
 
 from spack_repo.builtin.build_systems.compiler import CompilerPackage
 from spack_repo.builtin.build_systems.generic import Package
@@ -69,6 +70,8 @@ class Aocc(Package, LlvmDetection, CompilerPackage):
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
+    depends_on("patchelf@:0.17", when="@:5 %gcc", type="build")
 
     depends_on("libxml2")
     depends_on("zlib-api")
@@ -118,6 +121,33 @@ class Aocc(Package, LlvmDetection, CompilerPackage):
             for compiler in ["clang", "clang++"]:
                 with open(join_path(self.prefix.bin, "{}.cfg".format(compiler)), "w") as f:
                     f.write(compiler_options)
+
+        # help flang find gcc
+        if self.spec.satisfies("@:5 %gcc") and self.compiler.prefix != "/usr":
+            # help flang{1,2} find libquadmath
+            libdir = self._libquadmath_dir()
+            patchelf = which("patchelf")
+            patchelf.add_default_arg("--set-rpath", libdir)
+            patchelf(join_path(self.prefix.bin, "flang1"))
+            patchelf(join_path(self.prefix.bin, "flang2"))
+
+            # pass --gcc-toolchain & -Wl,-rpath to flang
+            # flang.cfg is ignored, so replace the flang symlink with a wrapper script
+            compiler_options += ' -Wno-unused-command-line-argument "-Wl,-rpath,{libdir}"'
+            clang = join_path(self.prefix.bin, "clang")
+            flang = join_path(self.prefix.bin, "flang")
+            assert os.path.islink(flang)
+            os.unlink(flang)
+            with open(flang, "x") as f:
+                f.write(f'#!/bin/sh\nexec -a "$0" "{clang}" {compiler_options} "$@"\n')
+            set_executable(flang)
+
+    def _libquadmath_dir(self):
+        for lib in ["lib64", "lib"]:
+            libdir = join_path(self.compiler.prefix, lib)
+            if glob.glob(join_path(libdir, "libquadmath.*")):
+                return libdir
+        return None
 
     def _cc_path(self):
         return os.path.join(self.spec.prefix.bin, "clang")


### PR DESCRIPTION
> [!NOTE]
> This PR was migrated from **https://github.com/spack/spack/pull/50227**.

AOCC `flang` can't find `gcc` if `gcc` is installed in a non-standard location.

This commit:

- Patches `flang1` & `flang2` with the rpath for libquadmath.
- Creates a wrapper script to pass options to `flang`, since `flang.cfg` is currently ignored.
- Passes `--gcc-toolchain`.
- Passes `-Wl,-rpath` so executables can find libquadmath.
- Passes `-Wno-unused-command-line-argument` to silence warnings generated by `-Wl,-rpath`, since they can cause problems.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->