### PR TITLE
LLVM 20 depends on Python 3.8

### DIFF
--- a/repos/spack_repo/builtin/packages/llvm/package.py
+++ b/repos/spack_repo/builtin/packages/llvm/package.py
@@ -417,10 +417,12 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
         for runtime in ["libunwind", "libcxx", "compiler-rt"]:
             depends_on("cmake@:3.16", type="build", when="{0}=runtime".format(runtime))
         del runtime
+    depends_on("python@3.8:", when="@20: ~python", type="build")
     depends_on("python", when="~python", type="build")
     depends_on("pkgconfig", type="build")
 
     # Universal dependency
+    depends_on("python@3.8:", when="@20: +python")
     depends_on("python", when="+python")
 
     # clang and clang-tools dependencies


### PR DESCRIPTION
Closes https://github.com/spack/spack/issues/50453 by requiring Python 3.8+ when building LLVM 20+.

Replaces https://github.com/spack/spack/pull/50454.