### PR TITLE
Kokkos: add conflict between shared and cuda_relocatable_device_code

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -382,6 +382,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     )
 
     variant("shared", default=True, description="Build shared libraries")
+    conflicts("+shared", when="+cuda_relocatable_device_code")
 
     # Filter spack-generated files that may include links to the
     # spack compiler wrappers


### PR DESCRIPTION
The PR adds a conflict between `+shared` and `+cuda_relocatable_device_code`. It follows the behavior found in cmake
https://github.com/kokkos/kokkos/blob/64edd7263e2d8ece5cdf140e674761dc29f7ad5a/cmake/kokkos_enable_options.cmake#L251-L253