### PR TITLE
gitlab: config:shared_linking:missing_library_policy:error (don't merge)

### DIFF
--- a/.ci/gitlab/configs/config.yaml
+++ b/.ci/gitlab/configs/config.yaml
@@ -1,7 +1,7 @@
 config:
   db_lock_timeout: 120
   shared_linking:
-    missing_library_policy: warn
+    missing_library_policy: error
   install_tree:
     root: /home/software/spack
     padded_length: 256

--- a/repos/spack_repo/builtin/packages/hpcviewer/package.py
+++ b/repos/spack_repo/builtin/packages/hpcviewer/package.py
@@ -207,6 +207,9 @@ class Hpcviewer(Package):
     # Eclipse requires a newer glibc on powerpc, but not x86.
     depends_on("glibc@2.34:", when="@2025.3: target=ppc64le:")
 
+    # contains precompiled binaries without rpaths
+    unresolved_libraries = ["*"]
+
     # Install for MacOSX / Darwin
     @when("platform=darwin @:2025.2")
     def install(self, spec, prefix):

--- a/repos/spack_repo/builtin/packages/ruby/package.py
+++ b/repos/spack_repo/builtin/packages/ruby/package.py
@@ -56,6 +56,7 @@ class Ruby(AutotoolsPackage, NMakePackage):
             depends_on("tk", when="@:2.3")
             depends_on("readline", when="+readline")
             depends_on("zlib-api")
+            depends_on("openssl")
             depends_on("libyaml", when="@3:")
             with when("+yjit"):
                 depends_on("rust@1.58:")


### PR DESCRIPTION
> [!NOTE]
> This PR was migrated from **https://github.com/spack/spack/pull/50048**.

This PR is intended to surface the remaining missing library errors in a rebuild-all, and then as new packages are added (https://github.com/spack/spack/pull/48646#pullrequestreview-2562241346).