### PR TITLE
turnserver: add v4.6.2 (fix CVEs)

### DIFF
--- a/repos/spack_repo/builtin/packages/turnserver/package.py
+++ b/repos/spack_repo/builtin/packages/turnserver/package.py
@@ -10,13 +10,18 @@ from spack.package import *
 class Turnserver(AutotoolsPackage):
     """coturn TURN server project."""
 
-    homepage = "https://coturn.net/turnserver"
-    url = "https://coturn.net/turnserver/v4.5.1.3/turnserver-4.5.1.3.tar.gz"
+    homepage = "https://github.com/coturn/coturn"
+    url = "https://github.com/coturn/coturn/archive/4.6.2.tar.gz"
 
-    license("OpenSSL")
+    license("BSD-3-Clause", checked_by="wdconinc")
 
-    version("4.5.1.3", sha256="408bf7fde455d641bb2a23ba2df992ea0ae87b328de74e66e167ef58d8e9713a")
+    version("4.6.2", sha256="408bf7fde455d641bb2a23ba2df992ea0ae87b328de74e66e167ef58d8e9713a")
+    version(
+        "4.5.1.3",
+        sha256="408bf7fde455d641bb2a23ba2df992ea0ae87b328de74e66e167ef58d8e9713a",
+        url="https://coturn.net/turnserver/v4.5.1.3/turnserver-4.5.1.3.tar.gz",
+    )
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     depends_on("libevent")

--- a/repos/spack_repo/builtin/packages/turnserver/package.py
+++ b/repos/spack_repo/builtin/packages/turnserver/package.py
@@ -15,7 +15,7 @@ class Turnserver(AutotoolsPackage):
 
     license("BSD-3-Clause", checked_by="wdconinc")
 
-    version("4.6.2", sha256="408bf7fde455d641bb2a23ba2df992ea0ae87b328de74e66e167ef58d8e9713a")
+    version("4.6.2", sha256="13f2a38b66cffb73d86b5ed24acba4e1371d738d758a6039e3a18f0c84c176ad")
     version(
         "4.5.1.3",
         sha256="408bf7fde455d641bb2a23ba2df992ea0ae87b328de74e66e167ef58d8e9713a",


### PR DESCRIPTION
> [!NOTE]
> This PR was migrated from **https://github.com/spack/spack/pull/46626**.

This PR adds `turnserver`, v4.6.2, which fixes CVE-2020-4067, CVE-2020-6061, CVE-2020-6062, CVE-2020-26262. I checked the license and it's actually BSD-3-Clause, see https://github.com/coturn/coturn/blob/master/LICENSE.

Currently fails to build with:
```
     174     1441 | int stun_attr_add_str(uint8_t* buf, size_t *len, uint16_t attr, const uint8_t* avalue, int alen) {
     175          |     ^~~~~~~~~~~~~~~~~
     176    src/client/ns_turn_msg.c:1831:17: note: 'hmac' declared here
     177     1831 |         uint8_t hmac[MAXSHASIZE];
     178          |                 ^~~~
     179    /usr/bin/ld: /tmp/ccBBZG3e.o: in function `stun_produce_integrity_key_str':
  >> 180    /opt/spack/stage/wdconinc/spack-stage-turnserver-4.6.2-yetatxrkje7nigf3zw63ewxx2r4dwdlm/spack-src/src/client/ns_turn_m
            sg.c:260:(.text+0x672): undefined reference to `FIPS_mode'
  >> 181    collect2: error: ld returned 1 exit status
  >> 182    make: *** [Makefile:136: bin/turnserver] Error 1
```