### PR TITLE
meson: define and define_from_variant

### DIFF
--- a/repos/spack_repo/builtin/build_systems/meson.py
+++ b/repos/spack_repo/builtin/build_systems/meson.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import collections.abc
-import inspect
 import os
 from typing import List
 

--- a/repos/spack_repo/builtin/build_systems/meson.py
+++ b/repos/spack_repo/builtin/build_systems/meson.py
@@ -1,6 +1,8 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import collections.abc
+import inspect
 import os
 from typing import List
 

--- a/repos/spack_repo/builtin/build_systems/meson.py
+++ b/repos/spack_repo/builtin/build_systems/meson.py
@@ -1,6 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import collections.abc
 import os
 from typing import Any, List, Optional
 

--- a/repos/spack_repo/builtin/build_systems/meson.py
+++ b/repos/spack_repo/builtin/build_systems/meson.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
-from typing import List
+from typing import Any, List, Optional
 
 from spack.package import (
     PackageBase,

--- a/repos/spack_repo/builtin/build_systems/meson.py
+++ b/repos/spack_repo/builtin/build_systems/meson.py
@@ -199,7 +199,7 @@ class MesonBuilder(BuilderWithDefaults):
         # Create a list of pairs. Each pair includes a configuration
         # option and whether or not that option is activated
         if isinstance(value, bool):
-            value = "ON" if value else "OFF"
+            value = "true" if value else "false"
         else:
             if isinstance(value, collections.abc.Sequence) and not isinstance(value, str):
                 value = ",".join(str(v) for v in value)

--- a/repos/spack_repo/builtin/build_systems/meson.py
+++ b/repos/spack_repo/builtin/build_systems/meson.py
@@ -287,7 +287,7 @@ def define_from_variant(pkg: PackageBase, meson_var: str, variant: Optional[str]
     of ``meson_var``.
 
     This utility function is similar to
-    :meth:`~spack.build_systems.autotools.AutotoolsBuilder.with_or_without`.
+    :meth:`~spack_repo.builtin.build_systems.cmake.define_from_variant`.
 
     Examples:
 

--- a/repos/spack_repo/builtin/build_systems/meson.py
+++ b/repos/spack_repo/builtin/build_systems/meson.py
@@ -171,6 +171,103 @@ class MesonBuilder(BuilderWithDefaults):
             "-Dwrap_mode=nodownload",
         ]
 
+    @staticmethod
+    def define(meson_var, value):
+        """Return a meson command line argument that defines a variable.
+
+        The resulting argument will convert boolean values to false/true
+        and lists/tuples to meson colon-separated string lists. All other
+        values will be interpreted as strings.
+
+        Examples:
+
+            .. code-block:: python
+
+                [define('prefer_static', True),
+                 define('cpp_std', 14),
+                 define('swr', ['avx', 'avx2'])]
+
+            will generate the following configuration options:
+
+            .. code-block:: console
+
+                ["-Dprefer_static=true",
+                 "-Dcpp_std=14",
+                 "-Dswr=avx,avx2]
+
+        """
+        # Create a list of pairs. Each pair includes a configuration
+        # option and whether or not that option is activated
+        if isinstance(value, bool):
+            value = "ON" if value else "OFF"
+        else:
+            if isinstance(value, collections.abc.Sequence) and not isinstance(value, str):
+                value = ",".join(str(v) for v in value)
+            else:
+                value = str(value)
+
+        return "".join(["-D", meson_var, "=", value])
+
+    def define_from_variant(self, meson_var, variant=None):
+        """Return a meson command line argument from the given variant's value.
+
+        The optional ``variant`` argument defaults to the lower-case transform
+        of ``meson_var``.
+
+        This utility function is similar to
+        :meth:`~spack.build_systems.autotools.AutotoolsBuilder.with_or_without`.
+
+        Examples:
+
+            Given a package with:
+
+            .. code-block:: python
+
+                variant('cxxstd', default='11', values=('11', '14'),
+                        multi=False, description='')
+                variant('static', default=True, description='')
+                variant('swr', values=any_combination_of('avx', 'avx2'),
+                        description='')
+
+            calling this function like:
+
+            .. code-block:: python
+
+                [self.define_from_variant('prefer_static', 'static'),
+                 self.define_from_variant('cpp_std', 'cxxstd'),
+                 self.define_from_variant('swr')]
+
+            will generate the following configuration options:
+
+            .. code-block:: console
+
+                ["-Dprefer_static=true",
+                 "-Dcpp_std=14",
+                 "-Dswr=avx,avx2]
+
+            for ``<spec-name> cxxstd=14 +shared swr=avx,avx2``
+
+        Note: if the provided variant is conditional, and the condition is not met,
+                this function returns an empty string. Meson does NOT discard empty
+                strings provided on the command line.
+        """
+
+        if variant is None:
+            variant = meson_var.lower()
+
+        if variant not in self.pkg.variants:
+            raise KeyError('"{0}" is not a variant of "{1}"'.format(variant, self.pkg.name))
+
+        if variant not in self.pkg.spec.variants:
+            return ""
+
+        value = self.pkg.spec.variants[variant].value
+        if isinstance(value, (tuple, list)):
+            # Sort multi-valued variants for reproducibility
+            value = sorted(value)
+
+        return self.define(meson_var, value)
+
     @property
     def build_dirname(self):
         """Returns the directory name to use when building the package."""

--- a/repos/spack_repo/builtin/build_systems/meson.py
+++ b/repos/spack_repo/builtin/build_systems/meson.py
@@ -1,7 +1,6 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import collections.abc
 import os
 from typing import List
 
@@ -69,6 +68,13 @@ class MesonPackage(PackageBase):
         compiler flags to meson."""
         # Has to be dynamic attribute due to caching
         setattr(self, "meson_flag_args", [])
+
+    # Convenience methods
+    def define(self, meson_var: str, value: Any) -> str:
+        return define(meson_var, value)
+
+    def define_from_variant(self, meson_var: str, variant: Optional[str] = None) -> str:
+        return define_from_variant(self, meson_var, variant)
 
 
 @register_builder("meson")
@@ -173,101 +179,11 @@ class MesonBuilder(BuilderWithDefaults):
         ]
 
     @staticmethod
-    def define(meson_var, value):
-        """Return a meson command line argument that defines a variable.
+    def define(meson_var: str, value: Any) -> str:
+        return define(meson_var, value)
 
-        The resulting argument will convert boolean values to false/true
-        and lists/tuples to meson colon-separated string lists. All other
-        values will be interpreted as strings.
-
-        Examples:
-
-            .. code-block:: python
-
-                [define('prefer_static', True),
-                 define('cpp_std', 14),
-                 define('swr', ['avx', 'avx2'])]
-
-            will generate the following configuration options:
-
-            .. code-block:: console
-
-                ["-Dprefer_static=true",
-                 "-Dcpp_std=14",
-                 "-Dswr=avx,avx2]
-
-        """
-        # Create a list of pairs. Each pair includes a configuration
-        # option and whether or not that option is activated
-        if isinstance(value, bool):
-            value = "true" if value else "false"
-        else:
-            if isinstance(value, collections.abc.Sequence) and not isinstance(value, str):
-                value = ",".join(str(v) for v in value)
-            else:
-                value = str(value)
-
-        return "".join(["-D", meson_var, "=", value])
-
-    def define_from_variant(self, meson_var, variant=None):
-        """Return a meson command line argument from the given variant's value.
-
-        The optional ``variant`` argument defaults to the lower-case transform
-        of ``meson_var``.
-
-        This utility function is similar to
-        :meth:`~spack.build_systems.autotools.AutotoolsBuilder.with_or_without`.
-
-        Examples:
-
-            Given a package with:
-
-            .. code-block:: python
-
-                variant('cxxstd', default='11', values=('11', '14'),
-                        multi=False, description='')
-                variant('static', default=True, description='')
-                variant('swr', values=any_combination_of('avx', 'avx2'),
-                        description='')
-
-            calling this function like:
-
-            .. code-block:: python
-
-                [self.define_from_variant('prefer_static', 'static'),
-                 self.define_from_variant('cpp_std', 'cxxstd'),
-                 self.define_from_variant('swr')]
-
-            will generate the following configuration options:
-
-            .. code-block:: console
-
-                ["-Dprefer_static=true",
-                 "-Dcpp_std=14",
-                 "-Dswr=avx,avx2]
-
-            for ``<spec-name> cxxstd=14 +shared swr=avx,avx2``
-
-        Note: if the provided variant is conditional, and the condition is not met,
-                this function returns an empty string. Meson does NOT discard empty
-                strings provided on the command line.
-        """
-
-        if variant is None:
-            variant = meson_var.lower()
-
-        if variant not in self.pkg.variants:
-            raise KeyError('"{0}" is not a variant of "{1}"'.format(variant, self.pkg.name))
-
-        if variant not in self.pkg.spec.variants:
-            return ""
-
-        value = self.pkg.spec.variants[variant].value
-        if isinstance(value, (tuple, list)):
-            # Sort multi-valued variants for reproducibility
-            value = sorted(value)
-
-        return self.define(meson_var, value)
+    def define_from_variant(self, meson_var: str, variant: Optional[str] = None) -> str:
+        return define_from_variant(self.pkg, meson_var, variant)
 
     @property
     def build_dirname(self):
@@ -300,6 +216,8 @@ class MesonBuilder(BuilderWithDefaults):
         options.append(os.path.abspath(self.root_mesonlists_dir))
         options += self.std_meson_args
         options += self.meson_args()
+        # # remove empty option strings from the list
+        options[:] = [arg for arg in options if arg]
         with working_dir(self.build_directory, create=True):
             pkg.module.meson(*options)
 
@@ -322,3 +240,101 @@ class MesonBuilder(BuilderWithDefaults):
         with working_dir(self.build_directory):
             self.pkg._if_ninja_target_execute("test")
             self.pkg._if_ninja_target_execute("check")
+
+
+def define(meson_var: str, value: Any) -> str:
+    """Return a meson command line argument that defines a variable.
+
+    The resulting argument will convert boolean values to false/true
+    and lists/tuples to meson colon-separated string lists. All other
+    values will be interpreted as strings.
+
+    Examples:
+
+        .. code-block:: python
+
+            [define('prefer_static', True),
+             define('cpp_std', 14),
+             define('swr', ['avx', 'avx2'])]
+
+        will generate the following configuration options:
+
+        .. code-block:: console
+
+            ["-Dprefer_static=true",
+             "-Dcpp_std=14",
+             "-Dswr=avx,avx2]
+
+    """
+    # Create a list of pairs. Each pair includes a configuration
+    # option and whether or not that option is activated
+    if isinstance(value, bool):
+        value = "true" if value else "false"
+    else:
+        if isinstance(value, collections.abc.Sequence) and not isinstance(value, str):
+            value = ",".join(str(v) for v in value)
+        else:
+            value = str(value)
+
+    return "".join(["-D", meson_var, "=", value])
+
+
+def define_from_variant(pkg: PackageBase, meson_var: str, variant: Optional[str] = None) -> str:
+    """Return a meson command line argument from the given variant's value.
+
+    The optional ``variant`` argument defaults to the lower-case transform
+    of ``meson_var``.
+
+    This utility function is similar to
+    :meth:`~spack.build_systems.autotools.AutotoolsBuilder.with_or_without`.
+
+    Examples:
+
+        Given a package with:
+
+        .. code-block:: python
+
+            variant('cxxstd', default='11', values=('11', '14'),
+                    multi=False, description='')
+            variant('static', default=True, description='')
+            variant('swr', values=any_combination_of('avx', 'avx2'),
+                    description='')
+
+        calling this function like:
+
+        .. code-block:: python
+
+            [self.define_from_variant('prefer_static', 'static'),
+             self.define_from_variant('cpp_std', 'cxxstd'),
+             self.define_from_variant('swr')]
+
+        will generate the following configuration options:
+
+        .. code-block:: console
+
+            ["-Dprefer_static=true",
+             "-Dcpp_std=14",
+             "-Dswr=avx,avx2]
+
+        for ``<spec-name> cxxstd=14 +shared swr=avx,avx2``
+
+    Note: if the provided variant is conditional, and the condition is not met,
+            this function returns an empty string. Meson does NOT discard empty
+            strings provided on the command line.
+    """
+
+    if variant is None:
+        variant = meson_var.lower()
+
+    if not pkg.has_variant(variant):
+        raise KeyError('"{0}" is not a variant of "{1}"'.format(variant, pkg.name))
+
+    if variant not in pkg.spec.variants:
+        return ""
+
+    value = pkg.spec.variants[variant].value
+    if isinstance(value, (tuple, list)):
+        # Sort multi-valued variants for reproducibility
+        value = sorted(value)
+
+    return define(meson_var, value)

--- a/tests/build_systems.py
+++ b/tests/build_systems.py
@@ -324,6 +324,40 @@ class TestCMakePackage:
 
 
 @pytest.mark.usefixtures("config", "mock_packages")
+class TestMesonPackage:
+
+    def test_define(self, default_mock_concretization):
+        s = default_mock_concretization("meson-client")
+
+        define = s.package.define
+        for cls in (list, tuple):
+            assert define("multi", cls(["right", "up"])) == "-Dmulti=right,up"
+
+        file_list = fs.FileList(["/foo", "/bar"])
+        assert define("multi", file_list) == "-Dmulti=/foo,/bar"
+
+        assert define("enable_truth", False) == "-Denable_truth=false"
+        assert define("enable_truth", True) == "-Denable_truth=true"
+
+        assert define("single", "red") == "-Dsingle=red"
+
+    def test_define_from_variant(self):
+        s = Spec("meson-client multi=up,right ~truthy single=red").concretized()
+
+        arg = s.package.define_from_variant("multi")
+        assert arg == "-Dmulti=right,up"
+
+        arg = s.package.define_from_variant("enable_truth", "truthy")
+        assert arg == "-Denable_truth=false"
+
+        arg = s.package.define_from_variant("single")
+        assert arg == "-Dsingle=red"
+
+        with pytest.raises(KeyError, match="not a variant"):
+            s.package.define_from_variant("nonexistent")
+
+
+@pytest.mark.usefixtures("config", "mock_packages")
 class TestDownloadMixins:
     """Test GnuMirrorPackage, SourceforgePackage, SourcewarePackage and XorgPackage."""
 

--- a/tests/build_systems.py
+++ b/tests/build_systems.py
@@ -325,7 +325,6 @@ class TestCMakePackage:
 
 @pytest.mark.usefixtures("config", "mock_packages")
 class TestMesonPackage:
-
     def test_define(self, default_mock_concretization):
         s = default_mock_concretization("meson-client")
 

--- a/var/spack/repos/builtin.mock/packages/meson-client/package.py
+++ b/var/spack/repos/builtin.mock/packages/meson-client/package.py
@@ -1,5 +1,4 @@
-# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
-# Spack Project Developers. See the top-level COPYRIGHT file for details.
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 

--- a/var/spack/repos/builtin.mock/packages/meson-client/package.py
+++ b/var/spack/repos/builtin.mock/packages/meson-client/package.py
@@ -1,0 +1,124 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack.package import *
+
+
+def check(condition, msg):
+    """Raise an install error if condition is False."""
+    if not condition:
+        raise InstallError(msg)
+
+
+class MesonClient(MesonPackage):
+    """A dummy package that uses meson."""
+
+    homepage = "https://www.example.com"
+    url = "https://www.example.com/meson-client-1.0.tar.gz"
+
+    version("1.0", md5="4cb3ff35b2472aae70f542116d616e63")
+
+    variant(
+        "multi",
+        description="",
+        values=any_combination_of("up", "right", "back").with_default("up"),
+    )
+    variant("single", description="", default="blue", values=("blue", "red", "green"), multi=False)
+    variant("truthy", description="", default=True)
+
+    callback_counter = 0
+
+    flipped = False
+    run_this = True
+    check_this_is_none = None
+    did_something = False
+
+    @run_after("meson")
+    @run_before("meson")
+    @run_before("build")
+    @run_before("install")
+    def increment(self):
+        MesonClient.callback_counter += 1
+
+    @run_after("meson")
+    @on_package_attributes(run_this=True, check_this_is_none=None)
+    def flip(self):
+        MesonClient.flipped = True
+
+    @run_after("meson")
+    @on_package_attributes(does_not_exist=None)
+    def do_not_execute(self):
+        self.did_something = True
+
+    def setup_build_environment(self, spack_env):
+        spack_cc  # Ensure spack module-scope variable is available
+        check(
+            from_meson == "from_meson",
+            "setup_build_environment couldn't read global set by meson.",
+        )
+
+        check(
+            self.spec["meson"].link_arg == "test link arg",
+            "link arg on dependency spec not readable from " "setup_build_environment.",
+        )
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        spack_cc  # Ensure spack module-scope variable is available
+        check(
+            from_meson == "from_meson",
+            "setup_dependent_build_environment couldn't read global set by meson.",
+        )
+
+        check(
+            self.spec["meson"].link_arg == "test link arg",
+            "link arg on dependency spec not readable from " "setup_dependent_build_environment.",
+        )
+
+    def setup_dependent_package(self, module, dspec):
+        spack_cc  # Ensure spack module-scope variable is available
+        check(
+            from_meson == "from_meson",
+            "setup_dependent_package couldn't read global set by meson.",
+        )
+
+        check(
+            self.spec["meson"].link_arg == "test link arg",
+            "link arg on dependency spec not readable from " "setup_dependent_package.",
+        )
+
+    def meson(self, spec, prefix):
+        assert self.callback_counter == 1
+
+    def build(self, spec, prefix):
+        assert self.did_something is False
+        assert self.flipped is True
+        assert self.callback_counter == 3
+
+    def install(self, spec, prefix):
+        assert self.callback_counter == 4
+        # check that meson is in the global scope.
+        global meson
+        check(meson is not None, "No meson was in environment!")
+
+        # check that which('meson') returns the right one.
+        meson = which("meson")
+        print(meson)
+        print(meson.exe)
+        check(
+            meson.path.startswith(spec["meson"].prefix.bin),
+            "Wrong meson was in environment: %s" % meson,
+        )
+
+        check(from_meson == "from_meson", "Couldn't read global set by meson.")
+
+        check(
+            os.environ["from_meson"] == "from_meson",
+            "Couldn't read env var set in envieonmnt by dependency",
+        )
+
+        mkdirp(prefix.bin)
+        touch(join_path(prefix.bin, "dummy"))

--- a/var/spack/repos/builtin.mock/packages/meson/package.py
+++ b/var/spack/repos/builtin.mock/packages/meson/package.py
@@ -1,5 +1,4 @@
-# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
-# Spack Project Developers. See the top-level COPYRIGHT file for details.
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 

--- a/var/spack/repos/builtin.mock/packages/meson/package.py
+++ b/var/spack/repos/builtin.mock/packages/meson/package.py
@@ -1,0 +1,46 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class Meson(Package):
+    """A dummy package for the meson build system."""
+
+    homepage = "https://mesonbuild.com/"
+    url = "https://github.com/mesonbuild/meson/archive/0.49.0.tar.gz"
+
+    version("0.49.0", sha256="11bc959e7173e714e4a4e85dd2bd9d0149b0a51c8ba82d5f44cc63735f603c74")
+
+    def setup_build_environment(self, env):
+        spack_cc  # Ensure spack module-scope variable is avaiable
+        env.set("for_install", "for_install")
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        spack_cc  # Ensure spack module-scope variable is avaiable
+        env.set("from_meson", "from_meson")
+
+    def setup_dependent_package(self, module, dspec):
+        spack_cc  # Ensure spack module-scope variable is avaiable
+
+        module.meson = Executable(self.spec.prefix.bin.meson)
+        module.ctest = Executable(self.spec.prefix.bin.ctest)
+        self.spec.from_meson = "from_meson"
+        module.from_meson = "from_meson"
+
+        self.spec.link_arg = "test link arg"
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+
+        check(
+            os.environ["for_install"] == "for_install",
+            "Couldn't read env var set in compile envieonmnt",
+        )
+        meson_exe_ext = ".exe" if sys.platform == "win32" else ""
+        meson_exe = join_path(prefix.bin, "meson{}".format(meson_exe_ext))
+        touch(meson_exe)
+        set_executable(meson_exe)


### PR DESCRIPTION
> [!NOTE]
> This PR was migrated from **https://github.com/spack/spack/pull/40269**.

Based on user code in https://github.com/spack/spack/pull/39854/files#diff-5376f65afcea4f0f272594553d063ebb89de44fd25747f6931bef681ae755edfR69-R74 it seems we may benefit from an approach to defining build options in Meson packages that is similar to what is already in common use for Autotools and CMake packages. There are currently 23 MesonPackage packages that implement `meson_args` and may benefit from this.

Based on CMakeBuilder, this introduces:
- `MesonBuilder.define(meson_var, value)`
- `MesonBuilder.define_from_variant(self, meson_var, variant=None)`

There are the following differences:
- Meson developers don't have caps lock on, so examples use lowercase,
- Meson does not ignore options with empty values, so for conditional variant values this needs caution.

Out of scope: actually changing the packages to use this.