### PR TITLE
Add kokkos-fft

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos_fft/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_fft/package.py
@@ -25,7 +25,9 @@ class KokkosFft(CMakePackage):
     variant("tests", default=False, description="Enable tests")
 
     depends_on("kokkos@4.4:4 +complex_align") # not supported in Spack 0.23.1
-    requires("^kokkos +wrapper", when="^kokkos +cuda")
+    requires("^kokkos +cuda +wrapper", when="+cufft")
+    requires("^kokkos +rocm", when="+hipfft")
+    requires("^kokkos +sycl", when="+onemkl")
     depends_on("googletest@1.15:1", when="+tests")
 
     depends_on("fftw@3.3:3 ~mpi precision=float,double", when="+fftw")
@@ -34,10 +36,6 @@ class KokkosFft(CMakePackage):
     depends_on("cuda@11:12", when="+cufft")
     depends_on("hipfft@5.3:6", when="+hipfft")
     depends_on("intel-oneapi-mkl@2023:2025", when="+onemkl")
-
-    requires("^kokkos +cuda", when="+cufft")
-    requires("^kokkos +rocm", when="+hipfft")
-    requires("^kokkos +sycl", when="+onemkl")
 
     def cmake_args(self):
         args = [

--- a/repos/spack_repo/builtin/packages/kokkos_fft/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_fft/package.py
@@ -64,8 +64,8 @@ class KokkosFft(CMakePackage):
             args.append(self.define("KokkosFFT_ENABLE_ONEMKL", "ON"))
 
         if self.spec.satisfies("^kokkos+rocm"):
-            args.append(self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc))
+            args.append(self.define("CMAKE_CXX_COMPILER", self["hip"].hipcc))
         else:
-            args.append(self.define("CMAKE_CXX_COMPILER", self.spec["kokkos"].kokkos_cxx))
+            args.append(self.define("CMAKE_CXX_COMPILER", self["kokkos"].kokkos_cxx))
 
         return args

--- a/repos/spack_repo/builtin/packages/kokkos_fft/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_fft/package.py
@@ -29,6 +29,7 @@ class KokkosFft(CMakePackage):
     variant("tests", default=False, description="Enable tests")
 
     depends_on("kokkos@4.4:4 +complex_align") # not supported in Spack 0.23.1
+    # kokkos-fft currently only supports compilation with the Kokkos nvcc wrapper
     requires("^kokkos +cuda +wrapper", when="device_backend=cufft")
     requires("^kokkos +rocm", when="device_backend=hipfft")
     requires("^kokkos +sycl", when="device_backend=onemkl")

--- a/repos/spack_repo/builtin/packages/kokkos_fft/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_fft/package.py
@@ -28,6 +28,8 @@ class KokkosFft(CMakePackage):
             description="Enable device backend")
     variant("tests", default=False, description="Enable tests")
 
+    depends_on("cxx", type="build")
+
     depends_on("kokkos@4.4:4 +complex_align")
     # kokkos-fft currently only supports compilation with the Kokkos nvcc wrapper
     requires("^kokkos +cuda +wrapper", when="device_backend=cufft")

--- a/repos/spack_repo/builtin/packages/kokkos_fft/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_fft/package.py
@@ -38,7 +38,9 @@ class KokkosFft(CMakePackage):
     depends_on("googletest@1.15:1", when="+tests")
 
     depends_on("fftw@3.3:3 ~mpi ~openmp precision=float,double", when="host_backend=fftw-serial")
+    requires("^kokkos +serial", when="host_backend=fftw-serial")
     depends_on("fftw@3.3:3 ~mpi +openmp precision=float,double", when="host_backend=fftw-openmp")
+    requires("^kokkos +openmp", when="host_backend=fftw-openmp")
     depends_on("cuda@11:12", when="device_backend=cufft")
     depends_on("hipfft@5.3:6", when="device_backend=hipfft")
     depends_on("intel-oneapi-mkl@2023:2025", when="device_backend=onemkl")

--- a/repos/spack_repo/builtin/packages/kokkos_fft/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_fft/package.py
@@ -32,15 +32,15 @@ class KokkosFft(CMakePackage):
 
     depends_on("kokkos@4.4:4 +complex_align")
     # kokkos-fft currently only supports compilation with the Kokkos nvcc wrapper
+    requires("^kokkos +serial", when="host_backend=fftw-serial")
+    requires("^kokkos +openmp", when="host_backend=fftw-openmp")
     requires("^kokkos +cuda +wrapper", when="device_backend=cufft")
     requires("^kokkos +rocm", when="device_backend=hipfft")
     requires("^kokkos +sycl", when="device_backend=onemkl")
     depends_on("googletest@1.15:1", when="+tests")
 
     depends_on("fftw@3.3:3 ~mpi ~openmp precision=float,double", when="host_backend=fftw-serial")
-    requires("^kokkos +serial", when="host_backend=fftw-serial")
     depends_on("fftw@3.3:3 ~mpi +openmp precision=float,double", when="host_backend=fftw-openmp")
-    requires("^kokkos +openmp", when="host_backend=fftw-openmp")
     depends_on("cuda@11:12", when="device_backend=cufft")
     depends_on("hipfft@5.3:6", when="device_backend=hipfft")
     depends_on("intel-oneapi-mkl@2023:2025", when="device_backend=onemkl")

--- a/repos/spack_repo/builtin/packages/kokkos_fft/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_fft/package.py
@@ -39,8 +39,8 @@ class KokkosFft(CMakePackage):
     requires("^kokkos +sycl", when="device_backend=onemkl")
     depends_on("googletest@1.15:1", when="+tests")
 
-    depends_on("fftw@3.3:3 ~mpi ~openmp precision=float,double", when="host_backend==fftw-serial")
-    depends_on("fftw@3.3:3 ~mpi +openmp precision=float,double", when="host_backend=fftw-openmp")
+    depends_on("fftw@3.3:3 ~mpi precision=float,double")
+    requires("^fftw +openmp", when="host_backend=fftw-openmp")
     depends_on("cuda@11:12", when="device_backend=cufft")
     depends_on("hipfft@5.3:6", when="device_backend=hipfft")
     depends_on("intel-oneapi-mkl@2023:2025", when="device_backend=onemkl")

--- a/repos/spack_repo/builtin/packages/kokkos_fft/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_fft/package.py
@@ -37,9 +37,8 @@ class KokkosFft(CMakePackage):
     requires("^kokkos +sycl", when="device_backend=onemkl")
     depends_on("googletest@1.15:1", when="+tests")
 
-    depends_on("fftw@3.3:3 ~mpi precision=float,double", when="host_backend=fftw-serial")
-    depends_on("fftw@3.3:3 ~mpi precision=float,double", when="host_backend=fftw-openmp")
-    requires("^fftw +openmp", when="host_backend=fftw-openmp")
+    depends_on("fftw@3.3:3 ~mpi ~openmp precision=float,double", when="host_backend=fftw-serial")
+    depends_on("fftw@3.3:3 ~mpi +openmp precision=float,double", when="host_backend=fftw-openmp")
     depends_on("cuda@11:12", when="device_backend=cufft")
     depends_on("hipfft@5.3:6", when="device_backend=hipfft")
     depends_on("intel-oneapi-mkl@2023:2025", when="device_backend=onemkl")

--- a/repos/spack_repo/builtin/packages/kokkos_fft/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_fft/package.py
@@ -39,7 +39,7 @@ class KokkosFft(CMakePackage):
     requires("^kokkos +sycl", when="device_backend=onemkl")
     depends_on("googletest@1.15:1", when="+tests")
 
-    depends_on("fftw@3.3:3 ~mpi ~openmp precision=float,double", when="host_backend=fftw-serial")
+    depends_on("fftw@3.3:3 ~mpi ~openmp precision=float,double", when="host_backend==fftw-serial")
     depends_on("fftw@3.3:3 ~mpi +openmp precision=float,double", when="host_backend=fftw-openmp")
     depends_on("cuda@11:12", when="device_backend=cufft")
     depends_on("hipfft@5.3:6", when="device_backend=hipfft")

--- a/repos/spack_repo/builtin/packages/kokkos_fft/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_fft/package.py
@@ -55,13 +55,23 @@ class KokkosFft(CMakePackage):
 
         if self.spec.satisfies("host_backend=fftw-serial") or self.spec.satisfies("host_backend=fftw-openmp"):
             args.append(self.define("KokkosFFT_ENABLE_FFTW", "ON"))
+        else:
+            args.append(self.define("KokkosFFT_ENABLE_FFTW", "OFF"))
 
         if self.spec.satisfies("device_backend=cufft"):
             args.append(self.define("KokkosFFT_ENABLE_CUFFT", "ON"))
+        else:
+            args.append(self.define("KokkosFFT_ENABLE_CUFFT", "OFF"))
+
         if self.spec.satisfies("device_backend=hipfft"):
             args.append(self.define("KokkosFFT_ENABLE_HIPFFT", "ON"))
+        else:
+            args.append(self.define("KokkosFFT_ENABLE_HIPFFT", "OFF"))
+
         if self.spec.satisfies("device_backend=onemkl"):
             args.append(self.define("KokkosFFT_ENABLE_ONEMKL", "ON"))
+        else:
+            args.append(self.define("KokkosFFT_ENABLE_ONEMKL", "OFF"))
 
         if self.spec.satisfies("^kokkos+rocm"):
             args.append(self.define("CMAKE_CXX_COMPILER", self["hip"].hipcc))

--- a/repos/spack_repo/builtin/packages/kokkos_fft/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_fft/package.py
@@ -18,37 +18,47 @@ class KokkosFft(CMakePackage):
 
     version("0.3.0", sha256="a13c423775afec5f9f79fa9a23dd6001d3d63bae9f4786b1e0cd3ed65b3993a3")
 
-    variant("fftw", default=True, description="Enable FFTW")
-    variant("cufft", default=False, description="Enable cufft")
-    variant("hipfft", default=False, description="Enable hipfft")
-    variant("onemkl", default=False, description="Enable oneMKL fft")
+    variant("host_backend", default="fftw-serial",
+            values=("fftw-serial", "fftw-openmp"),
+            multi=True,
+            description="Enable host backend")
+    variant("device_backend", default="none",
+            values=("none", "cufft", "hipfft", "onemkl"),
+            multi=False,
+            description="Enable device backend")
     variant("tests", default=False, description="Enable tests")
 
     depends_on("kokkos@4.4:4 +complex_align") # not supported in Spack 0.23.1
-    requires("^kokkos +cuda +wrapper", when="+cufft")
-    requires("^kokkos +rocm", when="+hipfft")
-    requires("^kokkos +sycl", when="+onemkl")
+    requires("^kokkos +cuda +wrapper", when="device_backend=cufft")
+    requires("^kokkos +rocm", when="device_backend=hipfft")
+    requires("^kokkos +sycl", when="device_backend=onemkl")
     depends_on("googletest@1.15:1", when="+tests")
 
-    depends_on("fftw@3.3:3 ~mpi precision=float,double", when="+fftw")
-    requires("^fftw +openmp", when="^kokkos +openmp")
-    # requires("^fftw +threads", when="^kokkos +threads") # the option +threads does not exist
-    depends_on("cuda@11:12", when="+cufft")
-    depends_on("hipfft@5.3:6", when="+hipfft")
-    depends_on("intel-oneapi-mkl@2023:2025", when="+onemkl")
+    depends_on("fftw@3.3:3 ~mpi precision=float,double", when="host_backend=fftw-serial")
+    depends_on("fftw@3.3:3 ~mpi precision=float,double", when="host_backend=fftw-openmp")
+    requires("^fftw +openmp", when="host_backend=fftw-openmp")
+    depends_on("cuda@11:12", when="device_backend=cufft")
+    depends_on("hipfft@5.3:6", when="device_backend=hipfft")
+    depends_on("intel-oneapi-mkl@2023:2025", when="device_backend=onemkl")
 
     def cmake_args(self):
         args = [
             self.define("KokkosFFT_ENABLE_INTERNAL_KOKKOS", False),
             self.define_from_variant("KokkosFFT_ENABLE_TESTS", "tests"),
-            self.define_from_variant("KokkosFFT_ENABLE_FFTW", "fftw"),
-            self.define_from_variant("KokkosFFT_ENABLE_CUFFT", "cufft"),
-            self.define_from_variant("KokkosFFT_ENABLE_HIPFFT", "hipfft"),
-            self.define_from_variant("KokkosFFT_ENABLE_ONEMKL", "onemkl"),
             self.define("KokkosFFT_ENABLE_DOCS", False),
             self.define("KokkosFFT_ENABLE_BENCHMARK", False),
             self.define("KokkosFFT_ENABLE_EXAMPLES", False),
         ]
+
+        if self.spec.satisfies("host_backend=fftw-serial") or self.spec.satisfies("host_backend=fftw-openmp"):
+            args.append(self.define("KokkosFFT_ENABLE_FFTW", "ON"))
+
+        if self.spec.satisfies("device_backend=cufft"):
+            args.append(self.define("KokkosFFT_ENABLE_CUFFT", "ON"))
+        if self.spec.satisfies("device_backend=hipfft"):
+            args.append(self.define("KokkosFFT_ENABLE_HIPFFT", "ON"))
+        if self.spec.satisfies("device_backend=onemkl"):
+            args.append(self.define("KokkosFFT_ENABLE_ONEMKL", "ON"))
 
         if self.spec.satisfies("^kokkos+rocm"):
             args.append(self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc))

--- a/repos/spack_repo/builtin/packages/kokkos_fft/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_fft/package.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+
 from spack.package import *
 
 
@@ -18,14 +19,20 @@ class KokkosFft(CMakePackage):
 
     version("0.3.0", sha256="a13c423775afec5f9f79fa9a23dd6001d3d63bae9f4786b1e0cd3ed65b3993a3")
 
-    variant("host_backend", default="fftw-serial",
-            values=("fftw-serial", "fftw-openmp"),
-            multi=True,
-            description="Enable host backend")
-    variant("device_backend", default="none",
-            values=("none", "cufft", "hipfft", "onemkl"),
-            multi=False,
-            description="Enable device backend")
+    variant(
+        "host_backend",
+        default="fftw-serial",
+        values=("fftw-serial", "fftw-openmp"),
+        multi=True,
+        description="Enable host backend",
+    )
+    variant(
+        "device_backend",
+        default="none",
+        values=("none", "cufft", "hipfft", "onemkl"),
+        multi=False,
+        description="Enable device backend",
+    )
     variant("tests", default=False, description="Enable tests")
 
     depends_on("cxx", type="build")

--- a/repos/spack_repo/builtin/packages/kokkos_fft/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_fft/package.py
@@ -1,0 +1,60 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack.package import *
+
+
+class KokkosFft(CMakePackage):
+    """FFT interfaces for Kokkos C++ Performance Portability Programming EcoSystem"""
+
+    homepage = "https://github.com/kokkos/kokkos-fft"
+    url = "https://github.com/kokkos/kokkos-fft/archive/refs/tags/v0.3.0.tar.gz"
+
+    maintainers("cedricchevalier19", "tpadioleau", "yasahi-hpc")
+
+    license("Apache-2.0 WITH LLVM-exception OR MIT", checked_by="cedricchevalier19")
+
+    version("0.3.0", sha256="a13c423775afec5f9f79fa9a23dd6001d3d63bae9f4786b1e0cd3ed65b3993a3")
+
+    variant("fftw", default=True, description="Enable FFTW")
+    variant("cufft", default=False, description="Enable cufft")
+    variant("hipfft", default=False, description="Enable hipfft")
+    variant("onemkl", default=False, description="Enable oneMKL fft")
+    variant("tests", default=False, description="Enable tests")
+
+    depends_on("kokkos@4.4:4 +complex_align") # not supported in Spack 0.23.1
+    requires("^kokkos +wrapper", when="^kokkos +cuda")
+    depends_on("googletest", when="+tests")
+
+    depends_on("fftw ~mpi precision=float,double", when="+fftw")
+    requires("^fftw +openmp", when="^kokkos +openmp")
+    # requires("^fftw +threads", when="^kokkos +threads") # the option +threads does not exist
+    depends_on("cuda", when="+cufft")
+    depends_on("hipfft", when="+hipfft")
+    depends_on("intel-oneapi-mkl", when="+onemkl")
+
+    requires("^kokkos +cuda", when="+cufft")
+    requires("^kokkos +rocm", when="+hipfft")
+    requires("^kokkos +sycl", when="+onemkl")
+
+    def cmake_args(self):
+        args = [
+            self.define("KokkosFFT_ENABLE_INTERNAL_KOKKOS", False),
+            self.define_from_variant("KokkosFFT_ENABLE_TESTS", "tests"),
+            self.define_from_variant("KokkosFFT_ENABLE_FFTW", "fftw"),
+            self.define_from_variant("KokkosFFT_ENABLE_CUFFT", "cufft"),
+            self.define_from_variant("KokkosFFT_ENABLE_HIPFFT", "hipfft"),
+            self.define_from_variant("KokkosFFT_ENABLE_ONEMKL", "onemkl"),
+            self.define("KokkosFFT_ENABLE_DOCS", False),
+            self.define("KokkosFFT_ENABLE_BENCHMARK", False),
+            self.define("KokkosFFT_ENABLE_EXAMPLES", False),
+        ]
+
+        if self.spec.satisfies("^kokkos+rocm"):
+            args.append(self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc))
+        else:
+            args.append(self.define("CMAKE_CXX_COMPILER", self.spec["kokkos"].kokkos_cxx))
+
+        return args

--- a/repos/spack_repo/builtin/packages/kokkos_fft/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_fft/package.py
@@ -28,7 +28,7 @@ class KokkosFft(CMakePackage):
             description="Enable device backend")
     variant("tests", default=False, description="Enable tests")
 
-    depends_on("kokkos@4.4:4 +complex_align") # not supported in Spack 0.23.1
+    depends_on("kokkos@4.4:4 +complex_align")
     # kokkos-fft currently only supports compilation with the Kokkos nvcc wrapper
     requires("^kokkos +cuda +wrapper", when="device_backend=cufft")
     requires("^kokkos +rocm", when="device_backend=hipfft")

--- a/repos/spack_repo/builtin/packages/kokkos_fft/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_fft/package.py
@@ -26,14 +26,14 @@ class KokkosFft(CMakePackage):
 
     depends_on("kokkos@4.4:4 +complex_align") # not supported in Spack 0.23.1
     requires("^kokkos +wrapper", when="^kokkos +cuda")
-    depends_on("googletest", when="+tests")
+    depends_on("googletest@1.15:1", when="+tests")
 
-    depends_on("fftw ~mpi precision=float,double", when="+fftw")
+    depends_on("fftw@3.3:3 ~mpi precision=float,double", when="+fftw")
     requires("^fftw +openmp", when="^kokkos +openmp")
     # requires("^fftw +threads", when="^kokkos +threads") # the option +threads does not exist
-    depends_on("cuda", when="+cufft")
-    depends_on("hipfft", when="+hipfft")
-    depends_on("intel-oneapi-mkl", when="+onemkl")
+    depends_on("cuda@11:12", when="+cufft")
+    depends_on("hipfft@5.3:6", when="+hipfft")
+    depends_on("intel-oneapi-mkl@2023:2025", when="+onemkl")
 
     requires("^kokkos +cuda", when="+cufft")
     requires("^kokkos +rocm", when="+hipfft")

--- a/repos/spack_repo/builtin/packages/kokkos_fft/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_fft/package.py
@@ -52,27 +52,15 @@ class KokkosFft(CMakePackage):
             self.define("KokkosFFT_ENABLE_DOCS", False),
             self.define("KokkosFFT_ENABLE_BENCHMARK", False),
             self.define("KokkosFFT_ENABLE_EXAMPLES", False),
+            self.define(
+                "KokkosFFT_ENABLE_FFTW",
+                self.spec.satisfies("host_backend=fftw-serial")
+                or self.spec.satisfies("host_backend=fftw-openmp"),
+            ),
+            self.define("KokkosFFT_ENABLE_CUFFT", self.spec.satisfies("device_backend=cufft")),
+            self.define("KokkosFFT_ENABLE_HIPFFT", self.spec.satisfies("device_backend=hipfft")),
+            self.define("KokkosFFT_ENABLE_ONEMKL", self.spec.satisfies("device_backend=onemkl")),
         ]
-
-        if self.spec.satisfies("host_backend=fftw-serial") or self.spec.satisfies("host_backend=fftw-openmp"):
-            args.append(self.define("KokkosFFT_ENABLE_FFTW", "ON"))
-        else:
-            args.append(self.define("KokkosFFT_ENABLE_FFTW", "OFF"))
-
-        if self.spec.satisfies("device_backend=cufft"):
-            args.append(self.define("KokkosFFT_ENABLE_CUFFT", "ON"))
-        else:
-            args.append(self.define("KokkosFFT_ENABLE_CUFFT", "OFF"))
-
-        if self.spec.satisfies("device_backend=hipfft"):
-            args.append(self.define("KokkosFFT_ENABLE_HIPFFT", "ON"))
-        else:
-            args.append(self.define("KokkosFFT_ENABLE_HIPFFT", "OFF"))
-
-        if self.spec.satisfies("device_backend=onemkl"):
-            args.append(self.define("KokkosFFT_ENABLE_ONEMKL", "ON"))
-        else:
-            args.append(self.define("KokkosFFT_ENABLE_ONEMKL", "OFF"))
 
         if self.spec.satisfies("^kokkos+rocm"):
             args.append(self.define("CMAKE_CXX_COMPILER", self["hip"].hipcc))


### PR DESCRIPTION
The PR introduces kokkos-fft.

I can see three ways to implement the recipe, for example with the `cufft` backend:

1. It is a boolean option, default is off, the `cufft` backend is enabled by explicitly requesting `kokkos-fft +cufft` (`+cufft` requires `kokkos +cuda`).
2. It is a boolean option, default is on, the `cufft` backend is enabled if we have `kokkos +cuda` (`+cufft` does not require `kokkos +cuda`)
3. Three values: auto, on, off:
   - "on"/"off" correspond to behavior 1.
   - "auto" is kind of behavior 2.

For now I have implemented the **behavior 1**.

Does it make sense ?

Note that the handling of FFTW is a bit different, we don't control whether we want the OpenMP or serial version. Should we fix this behavior ?