### PR TITLE
py-astropy: add v7.0.1 and dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/py_astropy/package.py
+++ b/repos/spack_repo/builtin/packages/py_astropy/package.py
@@ -18,8 +18,9 @@ class PyAstropy(PythonPackage):
     pypi = "astropy/astropy-4.0.1.post1.tar.gz"
     git = "https://github.com/astropy/astropy.git"
 
-    license("BSD-3-Clause")
+    license("BSD-3-Clause", checked_by="lgarrison")
 
+    version("7.0.1", sha256="392feeb443b2437cd4c2e0641a65e0f15ba791e148e9b1e5ed7de7dfcb38e460")
     version("6.1.0", sha256="6c3b915f10b1576190730ddce45f6245f9927dda3de6e3f692db45779708950f")
     version("5.1", sha256="1db1b2c7eddfc773ca66fa33bd07b25d5b9c3b5eee2b934e0ca277fa5b1b7b7e")
     version(
@@ -32,20 +33,29 @@ class PyAstropy(PythonPackage):
 
     variant("all", default=False, when="@3.2:", description="Enable all functionality")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     # Required dependencies
+    depends_on("python@3.11:", when="@7.0.1:", type=("build", "run"))
     depends_on("python@3.10:", when="@6.1.0:", type=("build", "run"))
     depends_on("python@3.8:", when="@5.1:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-cython@0.29.13:", type="build")
     depends_on("py-cython@0.29.30", when="@5.1:6.0", type="build")
-    depends_on("py-cython@3.0.0", when="@6.1.0:", type="build")
+    depends_on("py-cython@3.0", when="@6.1.0:6", type="build")
+    depends_on("py-cython@3", when="@7.0.1:", type="build")
+    depends_on("py-numpy@2", when="@7.0.1:", type="build")
+    depends_on("py-setuptools-scm@6.2:", when="@5.1:", type="build")
+    depends_on("py-extension-helpers", when="@5.1:", type="build")
+    depends_on("py-extension-helpers@1", when="@7.0.1:", type="build")
+    depends_on("pkgconfig", type="build")
 
     # in newer pip versions --install-option does not exist
-    depends_on("py-pip@:23.0", type="build")
+    depends_on("py-pip@:23.0", when="@:4.0", type="build")
 
+    depends_on("py-astropy-iers-data@0.2025.1.31.12.41.4:", when="@7.0.1:", type=("build", "run"))
     depends_on("py-astropy-iers-data", when="@6:", type=("build", "run"))
+    depends_on("py-numpy@1.23.2:", when="@7.0.1:", type="run")
     depends_on("py-numpy@1.23:", when="@6.1:", type=("build", "run"))
     depends_on("py-numpy@1.18:", when="@5.1:", type=("build", "run"))
     depends_on("py-numpy@1.16:", when="@4.0:", type=("build", "run"))
@@ -56,52 +66,74 @@ class PyAstropy(PythonPackage):
     depends_on("py-numpy", type=("build", "run"))
     # https://github.com/astropy/astropy/issues/16200
     depends_on("py-numpy@:1", when="@:6.0")
+    depends_on("py-packaging@22:", when="@7.0.1:", type=("build", "run"))
     depends_on("py-packaging@19.0:", when="@5.1:", type=("build", "run"))
+    depends_on("py-pyyaml@6:", when="@7.0.1:", type=("build", "run"))
     depends_on("py-pyyaml@3.13:", when="@5.1:", type=("build", "run"))
     depends_on("py-pyerfa@2.0:", when="@5.1:", type=("build", "run"))
     depends_on("py-pyerfa@2.0.1.1:", when="@6.1.0:", type=("build", "run"))
-    depends_on("py-setuptools-scm@6.2:", when="@5.1:", type="build")
-    depends_on("py-extension-helpers", when="@5.1:", type="build")
-    depends_on("pkgconfig", type="build")
 
+    depends_on("py-coverage@6.4.4:", when="@7.0.1:", type="test")
+    depends_on("py-pytest@7.3:", when="@7.0.1:", type="test")
     depends_on("py-pytest@7:", type="test")
     depends_on("py-pytest-doctestplus@0.12:", type="test")
     depends_on("py-pytest-astropy-header@0.2.1:", type="test")
     depends_on("py-pytest-astropy@0.10:", type="test")
+    depends_on("py-pytest-xdist@2.5.0:", when="@7.0.1:", type="test")
     depends_on("py-pytest-xdist", type="test")
+    depends_on("py-threadpoolctl@3:", when="@7.0.1:", type="test")
 
     # Optional dependencies
     with when("+all"):
+        depends_on("py-scipy@1.9.2:", when="@7.0.1:", type=("build", "run"))
         depends_on("py-scipy@1.8:", when="@6:", type=("build", "run"))
         depends_on("py-scipy@1.3:", when="@5:", type=("build", "run"))
         depends_on("py-scipy@0.18:", type=("build", "run"))
+        depends_on("py-matplotlib@3.6:", when="@7.0.1:", type=("build", "run"))
         depends_on("py-matplotlib@3.3:", when="@6:", type=("build", "run"))
         depends_on("py-matplotlib@3.1:", when="@5:", type=("build", "run"))
         depends_on("py-matplotlib@2.1:", when="@4:", type=("build", "run"))
         depends_on("py-matplotlib@2.0:", type=("build", "run"))
+        depends_on("py-certifi@2022.6.15.1:", when="@7.0.1:", type=("build", "run"))
         depends_on("py-certifi", when="@4.3:", type=("build", "run"))
+        depends_on("py-dask+array@2022.5.1:", when="@7.0.1:", type=("build", "run"))
         depends_on("py-dask+array", when="@4.1:", type=("build", "run"))
+        depends_on("py-h5py@3.8.0:", when="@7.0.1:", type=("build", "run"))
         depends_on("py-h5py", type=("build", "run"))
+        depends_on("py-pyarrow@10.0.1:", when="@7.0.1:", type=("build", "run"))
         depends_on("py-pyarrow@5:", when="@5:", type=("build", "run"))
+        depends_on("py-beautifulsoup4@4.9.3:", when="@7.0.1:", type=("build", "run"))
         depends_on("py-beautifulsoup4", type=("build", "run"))
+        depends_on("py-html5lib@1.1:", when="@7.0.1:", type=("build", "run"))
         depends_on("py-html5lib", type=("build", "run"))
+        depends_on("py-bleach@3.2.1:", when="@7.0.1:", type=("build", "run"))
         depends_on("py-bleach", type=("build", "run"))
+        depends_on("py-pandas-stubs@2.0:", when="@7.0.1:", type=("build", "run"))
+        depends_on("py-pandas@2:", when="@7.0.1:", type=("build", "run"))
         depends_on("py-pandas", type=("build", "run"))
         depends_on("py-sortedcontainers", type=("build", "run"))
         depends_on("py-pytz", type=("build", "run"))
         depends_on("py-jplephem", type=("build", "run"))
+        depends_on("py-mpmath@1.2.1:", when="@7.0.1:", type=("build", "run"))
         depends_on("py-mpmath", type=("build", "run"))
-        depends_on("py-asdf@2.10:", when="@5.1:", type=("build", "run"))
+        depends_on("py-asdf@2.8.3:", when="@7.0.1:", type=("build", "run"))
+        depends_on("py-asdf-astropy@0.3:", when="@7.0.1:", type=("build", "run"))
+        depends_on("py-asdf@2.10:", when="@5.1:6", type=("build", "run"))
         depends_on("py-asdf@2.5:", when="@4.0.1post1:", type=("build", "run"))
         depends_on("py-asdf@2.3:", type=("build", "run"))
+        depends_on("py-bottleneck@1.3.3:", when="@7.0.1:", type=("build", "run"))
         depends_on("py-bottleneck", type=("build", "run"))
+        depends_on("py-ipywidgets", when="@7.0.1:", type=("build", "run"))
+        depends_on("py-ipykernel", when="@7.0.1:", type=("build", "run"))
+        # depends_on("py-ipydatagrid", when="@7.0.1:", type=("build", "run"))
+        depends_on("py-ipython@8:", when="@7.0.1:", type=("build", "run"))
         depends_on("py-ipython@4.2:", when="@4.3:", type=("build", "run"))
         depends_on("py-ipython", type=("build", "run"))
-        depends_on("py-pytest@7:", when="@5.0.2:", type=("build", "run"))
-        depends_on("py-pytest", type=("build", "run"))
+        depends_on("py-pytest@7:", when="@5.0.2:6", type=("build", "run"))
+        depends_on("py-pytest", when="@:6", type=("build", "run"))
         depends_on("py-fsspec+http@2023.4:", when="@6.1:", type=("build", "run"))
         depends_on("py-s3fs@2023.4:", when="@6.1:", type=("build", "run"))
-        depends_on("py-typing-extensions@3.10.0.1:", when="@5.0.2:", type=("build", "run"))
+        depends_on("py-typing-extensions@3.10.0.1:", when="@5.0.2:6", type=("build", "run"))
 
         # Historical optional dependencies
         depends_on("py-pyyaml", when="@:5", type=("build", "run"))
@@ -111,9 +143,10 @@ class PyAstropy(PythonPackage):
         conflicts("^py-matplotlib@3.4.0,3.5.2")
 
     # System dependencies
-    depends_on("erfa")
+    depends_on("erfa", when="@:6")
     depends_on("wcslib")
-    depends_on("cfitsio@:3")
+    depends_on("wcslib@8:", when="@7.0.1:")
+    depends_on("cfitsio@:3", when="@:6")
     depends_on("expat")
 
     def patch(self):
@@ -124,6 +157,7 @@ class PyAstropy(PythonPackage):
         if os.path.exists("astropy/cython_version.py"):
             os.remove("astropy/cython_version.py")
 
+    @when("@:4.0")
     def install_options(self, spec, prefix):
         args = [
             "--use-system-libraries",
@@ -134,6 +168,10 @@ class PyAstropy(PythonPackage):
         ]
 
         return args
+
+    @when("@4.0:")
+    def setup_build_environment(self, env):
+        env.set("ASTROPY_USE_SYSTEM_ALL", "1")
 
     @run_after("install")
     @on_package_attributes(run_tests=True)

--- a/repos/spack_repo/builtin/packages/py_astropy_iers_data/package.py
+++ b/repos/spack_repo/builtin/packages/py_astropy_iers_data/package.py
@@ -17,6 +17,10 @@ class PyAstropyIersData(PythonPackage):
     pypi = "astropy-iers-data/astropy_iers_data-0.2024.4.29.0.28.48.tar.gz"
 
     version(
+        "0.2025.3.10.0.29.26",
+        sha256="dd4865861f00dec8a442ef8135f034675a7b05f17846562e2ea71678f5dbaa97",
+    )
+    version(
         "0.2024.5.20.0.29.40",
         sha256="7fff3d3404ae8560533ac0e685db7acc02c4d8984faa4ac3d607096879fba2d1",
     )

--- a/repos/spack_repo/builtin/packages/wcslib/package.py
+++ b/repos/spack_repo/builtin/packages/wcslib/package.py
@@ -14,8 +14,9 @@ class Wcslib(AutotoolsPackage):
     homepage = "https://www.atnf.csiro.au/people/mcalabre/WCS/wcslib/"
     url = "ftp://ftp.atnf.csiro.au/pub/software/wcslib/wcslib-7.3.tar.bz2"
 
-    license("LGPL-3.0-or-later")
+    license("LGPL-3.0-or-later", checked_by="lgarrison")
 
+    version("8.4", sha256="960b844426d14a8b53cdeed78258aa9288cded99a7732c0667c64fa6a50126dc")
     version("7.3", sha256="4b01cf425382a26ca4f955ed6841a5f50c55952a2994367f8e067e4183992961")
     version("6.4", sha256="13c11ff70a7725563ec5fa52707a9965fce186a1766db193d08c9766ea107000")
 


### PR DESCRIPTION
> [!NOTE]
> This PR was migrated from **https://github.com/spack/spack/pull/49594**.

https://github.com/astropy/astropy/releases/tag/v7.0.1
https://github.com/astropy/astropy-iers-data/releases/tag/v0.2025.3.10.0.29.26


In the `+all` extras, I couldn't get `py-ipydatagrid` to build, so I left that out. For a few astropy deps (like `sortedcontainers`), I took the "older versions may work" note in `pyproject.toml` at face value. There's also a pre-commit test dep that I think we don't need.

The `--use-system-libraries` `install_option` that forced `py-pip@:23` is replaced with `ASTROPY_USE_SYSTEM_ALL` since `py-astropy@4`. This lets us build with modern Python.