### PR TITLE
README: add instructions for linking spack to spack-packages clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ To contribute, simply make a pull request to this repository with your package c
 We run continuous integration on this repository to test builds of a large number of
 Spack packages.
 
+If you want to test your package changes locally before submitting a pull request,
+simply change Spack's default package repo from the default cache location to your
+local git clone:
+```
+spack repo set --destination /path/to/local/spack-packages builtin
+```
+
 If you are migrating your pull requests from
 [github.com/spack/spack](https://github.com/spack/spack), it is recommended to use the [the migration tool](https://github.com/spack/migrate-package-prs).
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ We run continuous integration on this repository to test builds of a large numbe
 Spack packages.
 
 If you want to test your package changes locally before submitting a pull request,
-simply change Spack's default package repo from the default cache location to your
-local git clone:
+simply change Spack's default package repo from the default cache location to the full
+path to your local git clone:
 ```
 spack repo set --destination /path/to/local/spack-packages builtin
 ```
+`$spack` can be used to form a relative path to your Spack root directory.
 
 If you are migrating your pull requests from
 [github.com/spack/spack](https://github.com/spack/spack), it is recommended to use the [the migration tool](https://github.com/spack/migrate-package-prs).


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Happy to hear wordsmithing or placement suggestions.