### PR TITLE
[Draft] deepmd: new package with deps

### DIFF
--- a/repos/spack_repo/builtin/packages/deepmd_lib/cmake-patch.diff
+++ b/repos/spack_repo/builtin/packages/deepmd_lib/cmake-patch.diff
@@ -1,0 +1,50 @@
+diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
+index 44868531..ad06422a 100644
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -15,9 +15,14 @@ set(DEEPMD_C_ROOT
+     ""
+     CACHE PATH "Path to imported DeePMD-kit C library")
+ 
+-if(NOT DEFINED CMAKE_CXX_STANDARD)
+-  set(CMAKE_CXX_STANDARD 11)
+-endif()
++#if(NOT DEFINED CMAKE_CXX_STANDARD)
++#  set(CMAKE_CXX_STANDARD 11)
++#endif()
++
++set(CMAKE_CUDA_STANDARD 14)
++set(CMAKE_HIP_STANDARD 14)
++set(CMAKE_CXX_STANDARD 17)
++
+ macro(set_if_higher VARIABLE VALUE)
+   # ${VARIABLE} is a variable name, not a string
+   if(${VARIABLE} LESS "${VALUE}")
+@@ -438,6 +443,7 @@ set(LOW_PREC_VARIANT "_low")
+ 
+ # find openmp
+ find_package(OpenMP)
++
+ if(OPENMP_FOUND)
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+@@ -504,6 +510,7 @@ if(DEEPMD_C_ROOT)
+     PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                IMPORTED_LOCATION "${deepmd_c}"
+                INTERFACE_INCLUDE_DIRECTORIES "${DEEPMD_INCLUDE_C_DIR}/deepmd")
++
+   # use variable for TF path to set deepmd_c path
+   set(TENSORFLOW_ROOT "${DEEPMD_C_ROOT}")
+   set(TensorFlow_LIBRARY_PATH "${DEEPMD_C_ROOT}/lib")
+diff --git a/source/lib/src/gpu/CMakeLists.txt b/source/lib/src/gpu/CMakeLists.txt
+index 0d176dc3..0281b8f1 100644
+--- a/source/lib/src/gpu/CMakeLists.txt
++++ b/source/lib/src/gpu/CMakeLists.txt
+@@ -9,7 +9,6 @@ if(USE_CUDA_TOOLKIT)
+     set(CMAKE_CUDA_ARCHITECTURES all)
+   endif()
+   enable_language(CUDA)
+-  set(CMAKE_CUDA_STANDARD 11)
+ 
+   find_package(CUDAToolkit REQUIRED)
+ 

--- a/repos/spack_repo/builtin/packages/deepmd_lib/package.py
+++ b/repos/spack_repo/builtin/packages/deepmd_lib/package.py
@@ -1,0 +1,146 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
+from spack_repo.builtin.build_systems.cuda import CudaPackage
+from spack_repo.builtin.build_systems.rocm import ROCmPackage
+from spack.package import *
+
+
+class DeepmdLib(CudaPackage, ROCmPackage, CMakePackage):
+    """DeePMD-kit is a package written in Python/C++, designed to minimize the effort
+    required to build deep learning-based models of interatomic potential energy
+    and force field and to perform molecular dynamics (MD)"""
+
+    homepage = "https://docs.deepmodeling.com/projects/deepmd/en/stable/index.html#"
+    git = "https://github.com/deepmodeling/deepmd-kit.git"
+    url = "https://github.com/deepmodeling/deepmd-kit/archive/refs/tags/v2.2.11.tar.gz"
+
+    license("LGPL-3.0-only")
+
+    maintainers("mtaillefumier")
+    version("3.1.0", sha256="45f13df9ed011438d139a7f61416b8d7940f63c47fcde53180bfccd60c9d22ee")
+    version("3.0.3", sha256="f562ee5c07e77274425cf6d19e28ffcb07017a6f07c56fe82b5c9974dd0fb3b6")
+    version("3.0.2", sha256="b828d3a44730ea852505abbdb24ea5b556f2bf8b16de5a9c76018ed1ced7121b")
+    version("3.0.1", sha256="e842edbc2714bc948ce708c411e5fed751e67c88d5c493c2978f11c849027dca")
+    version("3.0.0", sha256="4df1091ce90dbea87734a20c6d826b8cbe80ac44646cb592c2e8586be319023c")
+    version("2.2.11", sha256="d22893a08c2556c5cb29682378105849cf672545c91ee52b10a97da6e9075ac3")
+
+    variant(
+        "tensorflow", default=True, description="Enable tensorflow support (original ML backend)"
+    )
+    variant(
+        "pytorch",
+        default=False,
+        description="Enable pytorch support (starting v3.0.0)",
+        when="@3.0:",
+    )
+    variant("cuda", default=False, description="Enable cuda support")
+    variant("rocm", default=False, description="Enable rocm support")
+    variant("gromacs", default=False, description="Enable gromacs plugins")
+    variant("horovod", default=True, description="Enable horovod support")
+    variant("jax", default=False, description="Enable JaX support", when="@3.0:")
+    variant("fp64", default=True, description="Enable double precision ops", when="+tensorflow")
+    variant("fp64", default=False, description="Enable double precision ops", when="+pytorch")
+    # deepmd library uses cmake as a build system but deepmd itself uses pip.
+
+    depends_on("c")
+    depends_on("cxx")
+
+    # Historical dependencies
+    depends_on("py-setuptools", type="build")
+    depends_on("py-tensorflow@2.16:", when="+tensorflow")
+    depends_on("py-tensorflow+mpi", when="+tensorflow")
+    depends_on("py-torch", when="+pytorch")
+    # depends_on("py-ase")
+    # depends_on("py-scipy")
+    # depends_on("py-numpy")
+    # depends_on("py-pyyaml")
+    # depends_on("py-args")
+    # depends_on("py-pyproject-metadata")
+    # depends_on("py-python-hostlist@1.21:")
+    # depends_on("py-typing-extensions", when="^python@:3.8")
+    # depends_on("py-importlib-metadata", when="^python@:3.8")
+    # depends_on("py-sphinx-argparse")
+    # depends_on("py-pygments")
+    # depends_on("py-sphinxcontrib-bibtex")
+    # depends_on("py-scikit-build-core")
+    # depends_on("py-setuptools-scm")
+    # depends_on("py-scikit-build")
+    # depends_on("py-hatch-fancy-pypi-readme")
+    # depends_on("py-pip", type="build")
+    # depends_on("python@3.10:")
+    # depends_on("py-h5py")
+    depends_on("py-jax", when="+jax")
+
+    # horovod needs some special settings
+    # depends_on("py-horovod controllers=mpi", when="+horovod")
+    # depends_on("py-horovod frameworks=tensorflow", when="+tensorflow+horovod")
+    # depends_on("py-horovod frameworks=pytorch", when="+pytorch+horovod")
+
+    # we can install deepmd with tensorflow, py-torch and jax
+
+    with when("+cuda"):
+        depends_on("nccl")
+        #   depends_on("py-horovod+cuda tensor_ops=nccl", when="+horovod")
+        for target in CudaPackage.cuda_arch_values:
+            depends_on(f"nccl cuda_arch={target}", when=f"cuda_arch={target}")
+            #      depends_on(
+            #          f"py-horovod+cuda tensor_ops=nccl cuda_arch={target}",
+            #          when=f"+horovod cuda_arch={target}",
+            #      )
+            depends_on(
+                f"py-tensorflow+cuda+nccl+mpi cuda_arch={target}",
+                when=f"+tensorflow cuda_arch={target}",
+            )
+            depends_on(f"py-torch+cuda cuda_arch={target}", when=f"+pytorch cuda_arch={target}")
+
+    with when("+rocm"):
+        depends_on("rccl")
+        # depends_on("py-horovod+rocm", when="+horovod")
+        depends_on("hipcub+rocm")
+        depends_on("hip+rocm")
+
+        for target in ROCmPackage.amdgpu_targets:
+            depends_on(
+                f"py-tensorflow@2.16:+rocm+mpi amdgpu_target={target}",
+                when=f"+tensorflow amdgpu_target={target}",
+            )
+            depends_on(
+                f"py-torch+rocm amdgpu_target={target}", when=f"+pytorch amdgpu_target={target}"
+            )
+
+    root_cmakelists_dir = "source"
+
+    patch("cmake-patch.diff", when="%gcc@14")
+
+    def setup_build_environment(self, env):
+        if "+cuda" in self.spec:
+            env.set("DP_VARIANT", "cuda")
+        if "+rocm" in self.spec:
+            env.set("DP_VARIANT", "rocm")
+        if "+tensorflow" in self.spec:
+            # turn on double presicion suppport
+            env.set("DP_ENABLE_TENSORFLOW", "1")
+            # turn off all tensorflow errors, warnings and info messages
+            env.set("TF_CPP_MIN_LOG_LEVEL", "3")
+            env.set("TENSORFLOW_ROOT", self.spec["py-tensorflow"].prefix)
+        if "+pytorch" in self.spec:
+            env.set("DP_ENABLE_PYTORCH", "1")
+
+    def cmake_args(self):
+        spec = self.spec
+        args = [
+            self.define_from_variant("USE_CUDA_TOOLKIT", "cuda"),
+            self.define_from_variant("USE_ROCM_TOOLKIT", "rocm"),
+            self.define_from_variant("ENABLE_TENSORFLOW", "tensorflow"),
+            self.define_from_variant("ENABLE_PYTORCH", "pytorch"),
+            self.define_from_variant("USE_TF_PYTHON_LIBS", "tensorflow"),
+            self.define_from_variant("ENABLE_JAX", "jax"),
+        ]
+
+        if "+rocm" in spec:
+            args += [self.define_from_variant("TENSORFLOW_USE_ROCM", "tensorflow")]
+        return args

--- a/repos/spack_repo/builtin/packages/deepmd_lib/package.py
+++ b/repos/spack_repo/builtin/packages/deepmd_lib/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
+from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 

--- a/repos/spack_repo/builtin/packages/deepmd_lib/package.py
+++ b/repos/spack_repo/builtin/packages/deepmd_lib/package.py
@@ -41,10 +41,10 @@ class DeepmdLib(CudaPackage, ROCmPackage, CMakePackage):
     variant("cuda", default=False, description="Enable cuda support")
     variant("rocm", default=False, description="Enable rocm support")
     variant("gromacs", default=False, description="Enable gromacs plugins")
-    variant("horovod", default=True, description="Enable horovod support")
     variant("jax", default=False, description="Enable JaX support", when="@3.0:")
     variant("fp64", default=True, description="Enable double precision ops", when="+tensorflow")
     variant("fp64", default=False, description="Enable double precision ops", when="+pytorch")
+
     # deepmd library uses cmake as a build system but deepmd itself uses pip.
 
     depends_on("c")
@@ -55,43 +55,18 @@ class DeepmdLib(CudaPackage, ROCmPackage, CMakePackage):
     depends_on("py-tensorflow@2.16:", when="+tensorflow")
     depends_on("py-tensorflow+mpi", when="+tensorflow")
     depends_on("py-torch", when="+pytorch")
-    # depends_on("py-ase")
-    # depends_on("py-scipy")
-    # depends_on("py-numpy")
-    # depends_on("py-pyyaml")
-    # depends_on("py-args")
-    # depends_on("py-pyproject-metadata")
-    # depends_on("py-python-hostlist@1.21:")
-    # depends_on("py-typing-extensions", when="^python@:3.8")
-    # depends_on("py-importlib-metadata", when="^python@:3.8")
-    # depends_on("py-sphinx-argparse")
-    # depends_on("py-pygments")
-    # depends_on("py-sphinxcontrib-bibtex")
-    # depends_on("py-scikit-build-core")
-    # depends_on("py-setuptools-scm")
-    # depends_on("py-scikit-build")
-    # depends_on("py-hatch-fancy-pypi-readme")
-    # depends_on("py-pip", type="build")
-    # depends_on("python@3.10:")
-    # depends_on("py-h5py")
-    depends_on("py-jax", when="+jax")
 
-    # horovod needs some special settings
-    # depends_on("py-horovod controllers=mpi", when="+horovod")
-    # depends_on("py-horovod frameworks=tensorflow", when="+tensorflow+horovod")
-    # depends_on("py-horovod frameworks=pytorch", when="+pytorch+horovod")
+    with when("+jax"):
+        depends_on("py-jax@0.4.33:")
+        depends_on("py-flax@0.10.0:")
+        depends_on("py-orbax_checkpoint")
+        depends_on("jax-ai-stack")
 
     # we can install deepmd with tensorflow, py-torch and jax
-
     with when("+cuda"):
         depends_on("nccl")
-        #   depends_on("py-horovod+cuda tensor_ops=nccl", when="+horovod")
         for target in CudaPackage.cuda_arch_values:
             depends_on(f"nccl cuda_arch={target}", when=f"cuda_arch={target}")
-            #      depends_on(
-            #          f"py-horovod+cuda tensor_ops=nccl cuda_arch={target}",
-            #          when=f"+horovod cuda_arch={target}",
-            #      )
             depends_on(
                 f"py-tensorflow+cuda+nccl+mpi cuda_arch={target}",
                 when=f"+tensorflow cuda_arch={target}",
@@ -100,7 +75,6 @@ class DeepmdLib(CudaPackage, ROCmPackage, CMakePackage):
 
     with when("+rocm"):
         depends_on("rccl")
-        # depends_on("py-horovod+rocm", when="+horovod")
         depends_on("hipcub+rocm")
         depends_on("hip+rocm")
 

--- a/repos/spack_repo/builtin/packages/deepmd_lib/package.py
+++ b/repos/spack_repo/builtin/packages/deepmd_lib/package.py
@@ -6,6 +6,7 @@
 from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
+
 from spack.package import *
 
 

--- a/repos/spack_repo/builtin/packages/py_dargs/package.py
+++ b/repos/spack_repo/builtin/packages/py_dargs/package.py
@@ -30,7 +30,5 @@ class PyDargs(PythonPackage):
     version("0.4.2", sha256="285684743feec7d28cad31a090949c97a549fa94c9eea1c1d65fd8138f2458df")
     version("0.4.1", sha256="6f04fa6a67b2a7dcb27b36896cd8062ee19f95cc74ab3ca2a08c3985da68a495")
 
-
     depends_on("py-typeguard", type="build")
     depends_on("py-typing-extensions", when="^python@:3.8")
-

--- a/repos/spack_repo/builtin/packages/py_dargs/package.py
+++ b/repos/spack_repo/builtin/packages/py_dargs/package.py
@@ -1,0 +1,36 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyDargs(PythonPackage):
+    """Argument checking for python programs"""
+
+    homepage = "https://github.com/deepmodeling/dargs"
+    url = "https://github.com/deepmodeling/dargs/archive/refs/tags/v0.4.10.tar.gz"
+    git = "https://github.com/deepmodeling/dargs.git"
+    pypi = "dargs/dargs-0.4.10.tar.gz"
+
+    license("LGPL-3.0-or-later")
+    maintainers("mtaillefumier")
+
+    version("master", branch="master")
+    version("0.4.10", sha256="7dc9a0b213bed71a281997dbf2be6612e988caadc566b4aec1bf253243a22ea0")
+    version("0.4.9", sha256="cbd68ed97fd49ba7b5701ea980ad495c64e41db2785357f2666490531995c407")
+    version("0.4.8", sha256="95f3085dc912af4bcefbd38ced60717f023b7b59ff9ce6aadabfaceca2f11243")
+    version("0.4.7", sha256="3132ea3f39dc1aaa342b3f045d262ed81c1d52fa2e817bae60839cf67c0d152b")
+    version("0.4.6", sha256="864dfa7a61f483d9a025f1f843afd6e9eefe728fdc9a06f991bcef92f0018bed")
+    version("0.4.5", sha256="46ddd9aba01be1c185b693cabee481c8a3d95b2d5f2a4f31d190f12c95fa23f3")
+    version("0.4.4", sha256="9cc8e9e36bfb401de19ca6e0de5cc5ab76871dacb9071c3f6ff078ca9aec38c0")
+    version("0.4.3", sha256="2c0b2f7ea2eef932f2a4d0a3a5801f00854bf2b2b69cb3c415ace0bd224afd7f")
+    version("0.4.2", sha256="285684743feec7d28cad31a090949c97a549fa94c9eea1c1d65fd8138f2458df")
+    version("0.4.1", sha256="6f04fa6a67b2a7dcb27b36896cd8062ee19f95cc74ab3ca2a08c3985da68a495")
+
+
+    depends_on("py-typeguard", type="build")
+    depends_on("py-typing-extensions", when="^python@:3.8")
+

--- a/repos/spack_repo/builtin/packages/py_deepmd/cmake-patch.diff
+++ b/repos/spack_repo/builtin/packages/py_deepmd/cmake-patch.diff
@@ -1,0 +1,50 @@
+diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
+index 44868531..ad06422a 100644
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -15,9 +15,14 @@ set(DEEPMD_C_ROOT
+     ""
+     CACHE PATH "Path to imported DeePMD-kit C library")
+ 
+-if(NOT DEFINED CMAKE_CXX_STANDARD)
+-  set(CMAKE_CXX_STANDARD 11)
+-endif()
++#if(NOT DEFINED CMAKE_CXX_STANDARD)
++#  set(CMAKE_CXX_STANDARD 11)
++#endif()
++
++set(CMAKE_CUDA_STANDARD 14)
++set(CMAKE_HIP_STANDARD 14)
++set(CMAKE_CXX_STANDARD 17)
++
+ macro(set_if_higher VARIABLE VALUE)
+   # ${VARIABLE} is a variable name, not a string
+   if(${VARIABLE} LESS "${VALUE}")
+@@ -438,6 +443,7 @@ set(LOW_PREC_VARIANT "_low")
+ 
+ # find openmp
+ find_package(OpenMP)
++
+ if(OPENMP_FOUND)
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+@@ -504,6 +510,7 @@ if(DEEPMD_C_ROOT)
+     PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                IMPORTED_LOCATION "${deepmd_c}"
+                INTERFACE_INCLUDE_DIRECTORIES "${DEEPMD_INCLUDE_C_DIR}/deepmd")
++
+   # use variable for TF path to set deepmd_c path
+   set(TENSORFLOW_ROOT "${DEEPMD_C_ROOT}")
+   set(TensorFlow_LIBRARY_PATH "${DEEPMD_C_ROOT}/lib")
+diff --git a/source/lib/src/gpu/CMakeLists.txt b/source/lib/src/gpu/CMakeLists.txt
+index 0d176dc3..0281b8f1 100644
+--- a/source/lib/src/gpu/CMakeLists.txt
++++ b/source/lib/src/gpu/CMakeLists.txt
+@@ -9,7 +9,6 @@ if(USE_CUDA_TOOLKIT)
+     set(CMAKE_CUDA_ARCHITECTURES all)
+   endif()
+   enable_language(CUDA)
+-  set(CMAKE_CUDA_STANDARD 11)
+ 
+   find_package(CUDAToolkit REQUIRED)
+ 

--- a/repos/spack_repo/builtin/packages/py_deepmd/package.py
+++ b/repos/spack_repo/builtin/packages/py_deepmd/package.py
@@ -1,0 +1,136 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+#from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
+from spack_repo.builtin.build_systems.cuda import CudaPackage
+from spack_repo.builtin.build_systems.python import PythonPackage
+from spack_repo.builtin.build_systems.rocm import ROCmPackage
+from spack.package import *
+
+
+class PyDeepmd(PythonPackage, CudaPackage, ROCmPackage):
+    """DeePMD-kit is a package written in Python/C++, designed to minimize the effort required
+    to build deep learning-based models of interatomic potential energy and force field and
+    to perform molecular dynamics (MD)"""
+
+    homepage = "https://docs.deepmodeling.com/projects/deepmd/en/stable/index.html#"
+    git = "https://github.com/deepmodeling/deepmd-kit.git"
+    url = "https://github.com/deepmodeling/deepmd-kit/archive/refs/tags/v2.2.11.tar.gz"
+
+    license("LGPL-3.0-only")
+    maintainers("mtaillefumier")
+
+    version("3.1.0", sha256="45f13df9ed011438d139a7f61416b8d7940f63c47fcde53180bfccd60c9d22ee")
+    version("3.0.3", sha256="f562ee5c07e77274425cf6d19e28ffcb07017a6f07c56fe82b5c9974dd0fb3b6")
+    version("3.0.2", sha256="b828d3a44730ea852505abbdb24ea5b556f2bf8b16de5a9c76018ed1ced7121b")
+    version("3.0.1", sha256="e842edbc2714bc948ce708c411e5fed751e67c88d5c493c2978f11c849027dca")
+    version("3.0.0", sha256="4df1091ce90dbea87734a20c6d826b8cbe80ac44646cb592c2e8586be319023c")
+    version("2.2.11", sha256="d22893a08c2556c5cb29682378105849cf672545c91ee52b10a97da6e9075ac3")
+    variant(
+        "tensorflow", default=True, description="Enable tensorflow support (original ML backend)"
+    )
+    variant(
+        "pytorch",
+        default=False,
+        description="Enable pytorch support (starting v3.0.0)",
+        when="@3.0:",
+    )
+    variant("cuda", default=False, description="Enable cuda support")
+    variant("rocm", default=False, description="Enable rocm support")
+    variant("gromacs", default=False, description="Enable gromacs plugins")
+    variant("horovod", default=True, description="Enable horovod support")
+    variant("jax", default=False, description="Enable JaX support", when="@3.0:")
+    variant("fp64", default=True, description="Enable double precision ops", when="+tensorflow")
+    variant("fp64", default=False, description="Enable double precision ops", when="+pytorch")
+    # deepmd library uses cmake as a build system but deepmd itself uses pip.
+
+    depends_on("c")
+    depends_on("cxx")
+    # Historical dependencies
+    depends_on("py-setuptools", type="build")
+    depends_on("py-tensorflow@2.16:", when="+tensorflow")
+    depends_on("py-tensorflow+mpi", when="+tensorflow")
+    depends_on("py-torch", when="+pytorch")
+    depends_on("py-mpi4py", when="+horovod")
+    depends_on("py-ase")
+    depends_on("py-scipy")
+    depends_on("py-numpy")
+    depends_on("py-pyyaml")
+    depends_on("py-args")
+    depends_on("py-pyproject-metadata")
+    depends_on("py-python-hostlist@1.21:")
+    depends_on("py-typing-extensions", when="^python@:3.8")
+    depends_on("py-importlib-metadata", when="^python@:3.8")
+    depends_on("py-sphinx-argparse")
+    depends_on("py-pygments")
+    depends_on("py-sphinxcontrib-bibtex")
+    depends_on("py-scikit-build-core")
+    depends_on("py-setuptools-scm")
+    depends_on("py-scikit-build")
+    depends_on("py-hatch-fancy-pypi-readme")
+    depends_on("py-pip", type="build")
+    depends_on("python@3.10:")
+    depends_on("py-h5py")
+    depends_on("py-jax", when="+jax")
+
+    # pip requires cmake to build the library
+    depends_on("cmake")
+
+    # horovod needs some special settings
+    depends_on("py-horovod controllers=mpi", when="+horovod")
+    depends_on("py-horovod frameworks=tensorflow", when="+tensorflow+horovod")
+    depends_on("py-horovod frameworks=pytorch", when="+pytorch+horovod")
+
+    # we can install deepmd with tensorflow, py-torch and jax
+
+    with when("+cuda"):
+        depends_on("nccl")
+        depends_on("py-horovod+cuda tensor_ops=nccl", when="+horovod")
+        for target in CudaPackage.cuda_arch_values:
+            depends_on(f"nccl cuda_arch={target}", when=f"cuda_arch={target}")
+            depends_on(
+                f"py-horovod+cuda tensor_ops=nccl cuda_arch={target}",
+                when=f"+horovod cuda_arch={target}",
+            )
+            depends_on(
+                f"py-tensorflow+cuda+nccl+mpi cuda_arch={target}",
+                when=f"+tensorflow cuda_arch={target}",
+            )
+            depends_on(f"py-torch+cuda cuda_arch={target}", when=f"+pytorch cuda_arch={target}")
+
+    with when("+rocm"):
+        depends_on("rccl")
+        depends_on("py-horovod+rocm", when="+horovod")
+        depends_on("hipcub+rocm")
+        depends_on("hip+rocm")
+
+        for target in ROCmPackage.amdgpu_targets:
+            depends_on(
+                f"py-tensorflow@2.16:+rocm+mpi amdgpu_target={target}",
+                when=f"+tensorflow amdgpu_target={target}",
+            )
+            depends_on(
+                f"py-torch+rocm amdgpu_target={target}", when=f"+pytorch amdgpu_target={target}"
+            )
+
+    root_cmakelists_dir = "source"
+
+    patch("cmake-patch.diff", when="%gcc@14")
+
+    def setup_build_environment(self, env):
+        if "+cuda" in self.spec:
+            env.set("DP_VARIANT", "cuda")
+        if "+rocm" in self.spec:
+            env.set("DP_VARIANT", "rocm")
+        if "+tensorflow" in self.spec:
+            # turn on double precision suppport
+            env.set("DP_ENABLE_TENSORFLOW", "1")
+            # turn off all tensorflow errors, warnings and info messages
+            env.set("TF_CPP_MIN_LOG_LEVEL", "3")
+            env.set("TENSORFLOW_ROOT", self.spec["py-tensorflow"].prefix)
+        else:
+            env.set("DP_ENABLE_TENSORFLOW", "0")
+        if "+pytorch" in self.spec:
+            env.set("DP_ENABLE_PYTORCH", "1")

--- a/repos/spack_repo/builtin/packages/py_deepmd/package.py
+++ b/repos/spack_repo/builtin/packages/py_deepmd/package.py
@@ -48,40 +48,60 @@ class PyDeepmd(PythonPackage, CudaPackage, ROCmPackage):
 
     depends_on("c")
     depends_on("cxx")
+    depends_on("mpi")
+
     # Historical dependencies
     depends_on("py-setuptools", type="build")
-    depends_on("py-tensorflow@2.16:", when="+tensorflow")
-    depends_on("py-tensorflow+mpi", when="+tensorflow")
-    depends_on("py-torch", when="+pytorch")
-    depends_on("py-mpi4py", when="+horovod")
+
+    depends_on("py-tensorflow@2.16:+mpi", when="+tensorflow")
+
     depends_on("py-ase")
     depends_on("py-scipy")
-    depends_on("py-numpy")
+    depends_on("py-numpy@1.21:")
     depends_on("py-pyyaml")
     depends_on("py-args")
     depends_on("py-pyproject-metadata")
     depends_on("py-python-hostlist@1.21:")
-    depends_on("py-typing-extensions", when="^python@:3.8")
-    depends_on("py-importlib-metadata", when="^python@:3.8")
+
+    depends_on("py-dargs@0.4.1:")
+
+
+    with when("^python@:3.8"):
+        depends_on("py-typing-extensions")
+        depends_on("py-importlib-metadata@1.4")
+
     depends_on("py-sphinx-argparse")
     depends_on("py-pygments")
     depends_on("py-sphinxcontrib-bibtex")
-    depends_on("py-scikit-build-core")
+    depends_on("py-scikit-build-core@0.5:0.11")
     depends_on("py-setuptools-scm")
     depends_on("py-scikit-build")
     depends_on("py-hatch-fancy-pypi-readme")
     depends_on("py-pip", type="build")
     depends_on("python@3.10:")
     depends_on("py-h5py")
-    depends_on("py-jax", when="+jax")
+    depends_on("py-dargs@0.4.1:")
+
+    with when("@3:"):
+        depends_on("py-h5py@3.6:")
+        depends_on("py-dargs@0.4.7:")
+        depends_on("py-torch", when="+pytorch")
+
+    with when("+jax"):
+        depends_on("py-jax@0.4.33:")
+        depends_on("py-flax@0.10.0:")
+        depends_on("py-orbax_checkpoint")
+        depends_on("jax-ai-stack")
 
     # pip requires cmake to build the library
     depends_on("cmake")
 
     # horovod needs some special settings
-    depends_on("py-horovod controllers=mpi", when="+horovod")
-    depends_on("py-horovod frameworks=tensorflow", when="+tensorflow+horovod")
-    depends_on("py-horovod frameworks=pytorch", when="+pytorch+horovod")
+    with when("+horovod"):
+        depends_on("py-mpi4py")
+        depends_on("py-horovod controllers=mpi")
+        depends_on("py-horovod frameworks=tensorflow", when="+tensorflow")
+        depends_on("py-horovod frameworks=pytorch", when="+pytorch")
 
     # we can install deepmd with tensorflow, py-torch and jax
 

--- a/repos/spack_repo/builtin/packages/py_deepmd/package.py
+++ b/repos/spack_repo/builtin/packages/py_deepmd/package.py
@@ -40,7 +40,6 @@ class PyDeepmd(PythonPackage, CudaPackage, ROCmPackage):
     variant("cuda", default=False, description="Enable cuda support")
     variant("rocm", default=False, description="Enable rocm support")
     variant("gromacs", default=False, description="Enable gromacs plugins")
-    variant("horovod", default=True, description="Enable horovod support")
     variant("jax", default=False, description="Enable JaX support", when="@3.0:")
     variant("fp64", default=True, description="Enable double precision ops", when="+tensorflow")
     variant("fp64", default=False, description="Enable double precision ops", when="+pytorch")
@@ -64,7 +63,6 @@ class PyDeepmd(PythonPackage, CudaPackage, ROCmPackage):
     depends_on("py-python-hostlist@1.21:")
 
     depends_on("py-dargs@0.4.1:")
-
 
     with when("^python@:3.8"):
         depends_on("py-typing-extensions")
@@ -96,24 +94,12 @@ class PyDeepmd(PythonPackage, CudaPackage, ROCmPackage):
     # pip requires cmake to build the library
     depends_on("cmake")
 
-    # horovod needs some special settings
-    with when("+horovod"):
-        depends_on("py-mpi4py")
-        depends_on("py-horovod controllers=mpi")
-        depends_on("py-horovod frameworks=tensorflow", when="+tensorflow")
-        depends_on("py-horovod frameworks=pytorch", when="+pytorch")
-
     # we can install deepmd with tensorflow, py-torch and jax
 
     with when("+cuda"):
         depends_on("nccl")
-        depends_on("py-horovod+cuda tensor_ops=nccl", when="+horovod")
         for target in CudaPackage.cuda_arch_values:
             depends_on(f"nccl cuda_arch={target}", when=f"cuda_arch={target}")
-            depends_on(
-                f"py-horovod+cuda tensor_ops=nccl cuda_arch={target}",
-                when=f"+horovod cuda_arch={target}",
-            )
             depends_on(
                 f"py-tensorflow+cuda+nccl+mpi cuda_arch={target}",
                 when=f"+tensorflow cuda_arch={target}",
@@ -122,7 +108,6 @@ class PyDeepmd(PythonPackage, CudaPackage, ROCmPackage):
 
     with when("+rocm"):
         depends_on("rccl")
-        depends_on("py-horovod+rocm", when="+horovod")
         depends_on("hipcub+rocm")
         depends_on("hip+rocm")
 

--- a/repos/spack_repo/builtin/packages/py_deepmd/package.py
+++ b/repos/spack_repo/builtin/packages/py_deepmd/package.py
@@ -3,10 +3,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-#from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.python import PythonPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
+
 from spack.package import *
 
 


### PR DESCRIPTION
> [!NOTE]
> This PR was migrated from **https://github.com/spack/spack/pull/49366**.

- This PR adds the package file to build the python package deepmd and the deepmd library. It does not support building the modules needed for gromacs and lammps yet. 
- cuda@12.8 and gcc@14 generate a lot of failure unless the C++ standard is set to c++14. Many packages still do not use the `CMAKE_CXX_STANDARD ` syntax which makes these changes tedious. 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->