### PR TITLE
mgard: allow newer versions to follow upstream

### DIFF
--- a/.ci/gitlab/stacks/e4s-cray-rhel/spack.yaml
+++ b/.ci/gitlab/stacks/e4s-cray-rhel/spack.yaml
@@ -69,7 +69,7 @@ spack:
     mgard:
       require:
         - target=x86_64_v3
-        - "@2023-01-10:"
+        - "@compat-2023-01-10:"
     mpich:
       variants: ~wrapperrpath
     paraview:

--- a/repos/spack_repo/builtin/packages/adios2/package.py
+++ b/repos/spack_repo/builtin/packages/adios2/package.py
@@ -192,8 +192,8 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("libpng@1.6:", when="+png")
     depends_on("zfp@0.5.1:0.5", when="+zfp")
     depends_on("sz@2.0.2.0:", when="+sz")
-    depends_on("mgard@2022-11-18:", when="+mgard")
-    depends_on("mgard@2023-01-10:", when="@2.9: +mgard")
+    depends_on("mgard@compat-2022-11-18:", when="+mgard")
+    depends_on("mgard@compat-2023-01-10:", when="@2.9: +mgard")
 
     extends("python", when="+python")
     depends_on("python", when="+python", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/libpressio/package.py
+++ b/repos/spack_repo/builtin/packages/libpressio/package.py
@@ -291,9 +291,9 @@ class Libpressio(CMakePackage, CudaPackage):
     depends_on("matio+shared@1.5.17:", when="+matio")
     depends_on("llvm@17: +clang", when="+clang")
     conflicts(
-        "^ mgard@2022-11-18",
+        "^ mgard@compat-2022-11-18",
         when="@:0.88.3+mgard",
-        msg="mgard@2022-11-18 is not supported before 0.89.0",
+        msg="mgard@compat-2022-11-18 is not supported before 0.89.0",
     )
     conflicts(
         "+mgardx", when="+szauto", msg="SZ auto and MGARDx cause symbol conflicts with each other"

--- a/repos/spack_repo/builtin/packages/mgard/package.py
+++ b/repos/spack_repo/builtin/packages/mgard/package.py
@@ -10,13 +10,25 @@ from spack.package import *
 
 class Mgard(CMakePackage, CudaPackage):
     """MGARD error bounded lossy compressor
-    forked from https://github.com/CODARcode/MGARD with patches to support Spack"""
 
-    # This is a research compressor with a fast evolving API.  The fork is updated
-    # when releases are made with minimal changes to support spack
+    For versions up to 2023-12-09, uses a fork from https://github.com/robertu94/MGARD
+    with patches to support Spack. For versions after 2023-12-09, uses the upstream
+    repository at https://github.com/CODARcode/MGARD directly from the master branch.
+    """
+
+    # This is a research compressor with a fast evolving API. Historical versions
+    # use a fork with minimal changes to support spack, while new versions use upstream master.
 
     homepage = "https://github.com/CODARcode/MGARD"
-    git = "https://github.com/robertu94/MGARD"
+    git = "https://github.com/robertu94/MGARD"  # Fork for existing date- versions
+
+    def url_for_version(self, version):
+        """For newer versions, use upstream MGARD repository"""
+        version_str = str(version)
+        if not version_str.startswith("date-"):
+            return "https://github.com/CODARcode/MGARD"
+        else:
+            return "https://github.com/robertu94/MGARD"
 
     maintainers("robertu94")
     maintainers("vicentebolea")
@@ -26,24 +38,32 @@ class Mgard(CMakePackage, CudaPackage):
 
     license("Apache-2.0")
 
-    version("2023-12-09", commit="d61d8c06c49a72b2e582cc02de88b7b27e1275d2", preferred=True)
-    version("2023-03-31", commit="a8a04a86ff30f91d0b430a7c52960a12fa119589")
-    version("2023-01-10", commit="3808bd8889a0f8e6647fc0251a3189bc4dfc920f")
-    version("2022-11-18", commit="72dd230ed1af88f62ed3c0f662e2387a6e587748")
-    version("2021-11-12", commit="3c05c80a45a51bb6cc5fb5fffe7b1b16787d3366")
-    version("2020-10-01", commit="b67a0ac963587f190e106cc3c0b30773a9455f7a")
+    # In spack numbers take precedence over alphabetic chars when sorting versions.
+    version("1.5.2", commit="208b0c42af6ba552387aec321664d5cbb757b2e2")  # upstream v1.5.2
+
+    # Historical versions using fork (with patches for Spack compatibility)
+    version("compat-2023-12-09", commit="d61d8c06c49a72b2e582cc02de88b7b27e1275d2", preferred=True)
+    version("compat-2023-03-31", commit="a8a04a86ff30f91d0b430a7c52960a12fa119589")
+    version("compat-2023-01-10", commit="3808bd8889a0f8e6647fc0251a3189bc4dfc920f")
+    version("compat-2022-11-18", commit="72dd230ed1af88f62ed3c0f662e2387a6e587748")
+    version("compat-2021-11-12", commit="3c05c80a45a51bb6cc5fb5fffe7b1b16787d3366")
+    version("compat-2020-10-01", commit="b67a0ac963587f190e106cc3c0b30773a9455f7a")
 
     variant(
         "serial",
-        when="@2022-11-18:",
+        when="@compat-2022-11-18:",
         default=True,
         description="Enable the classic non-parallel implmementation",
     )
-    variant("openmp", when="@2022-11-18:", default=True, description="Enable OpenMP support")
-    variant("timing", when="@2022-11-18:", default=False, description="Enable profile timings")
+    variant(
+        "openmp", when="@compat-2022-11-18:", default=True, description="Enable OpenMP support"
+    )
+    variant(
+        "timing", when="@compat-2022-11-18:", default=False, description="Enable profile timings"
+    )
     variant(
         "unstructured",
-        when="@2022-11-18:",
+        when="@compat-2022-11-18:",
         default=False,
         description="Enable experimental unstructured mesh support",
     )
@@ -51,29 +71,33 @@ class Mgard(CMakePackage, CudaPackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
-    depends_on("python", type=("build",), when="@2022-11-18:")
-    depends_on("sed", type=("build",), when="@2022-11-18:")
+    depends_on("python", type=("build",), when="@compat-2022-11-18:")
+    depends_on("sed", type=("build",), when="@compat-2022-11-18:")
     depends_on("zlib-api")
     depends_on("zlib@1.2.9:", when="^[virtuals=zlib-api] zlib")  # crc32_z
-    depends_on("pkgconfig", type=("build",), when="@2022-11-18:")
+    depends_on("pkgconfig", type=("build",), when="@compat-2022-11-18:")
     depends_on("zstd")
-    depends_on("protobuf@3.4:", when="@2022-11-18:")
+    depends_on("protobuf@3.4:", when="@compat-2022-11-18:")
     # See https://github.com/CODARcode/MGARD/issues/240
-    depends_on("protobuf@:3.28", when="@:2023-12-09")
-    depends_on("libarchive", when="@2021-11-12:")
-    depends_on("tclap", when="@2021-11-12")
-    depends_on("yaml-cpp", when="@2021-11-12:")
+    depends_on("protobuf@:3.28", when="@:compat-2023-12-09")
+    depends_on("libarchive", when="@compat-2021-11-12:")
+    depends_on("tclap", when="@compat-2021-11-12")
+    depends_on("yaml-cpp", when="@compat-2021-11-12:")
     depends_on("cmake@3.19:", type="build")
-    depends_on("nvcomp@2.2.0:", when="@2022-11-18:+cuda")
-    depends_on("nvcomp@2.0.2", when="@:2021-11-12+cuda")
+    depends_on("nvcomp@2.2.0:", when="@compat-2022-11-18:+cuda")
+    depends_on("nvcomp@2.0.2", when="@:compat-2021-11-12+cuda")
     with when("+openmp"):
         depends_on("llvm-openmp", when="%apple-clang")
 
     conflicts("cuda_arch=none", when="+cuda")
     conflicts(
-        "~cuda", when="@2021-11-12", msg="without cuda MGARD@2021-11-12 has undefined symbols"
+        "~cuda",
+        when="@compat-2021-11-12",
+        msg="without cuda MGARD@compat-2021-11-12 has undefined symbols",
     )
-    conflicts("%gcc@:7", when="@2022-11-18:", msg="requires std::optional and other c++17 things")
+    conflicts(
+        "%gcc@:7", when="@compat-2022-11-18:", msg="requires std::optional and other c++17 things"
+    )
     conflicts("protobuf@3.22:", when="target=ppc64le", msg="GCC 9.4 segfault in CI")
     conflicts("protobuf@3.22:", when="+cuda target=aarch64:", msg="nvcc fails on ARM SIMD headers")
     # https://github.com/abseil/abseil-cpp/issues/1629
@@ -82,11 +106,11 @@ class Mgard(CMakePackage, CudaPackage):
     def flag_handler(self, name, flags):
         if name == "cxxflags":
             for a_spec in [
-                "@2020-10-01 %oneapi@2023:",
-                "@2020-10-01 %apple-clang@15:",
-                "@2020-10-01 %aocc@3:",
-                "@2020-10-01 %cce@15:",
-                "@2020-10-01 %rocmcc@4:",
+                "@compat-2020-10-01 %oneapi@2023:",
+                "@compat-2020-10-01 %apple-clang@15:",
+                "@compat-2020-10-01 %aocc@3:",
+                "@compat-2020-10-01 %cce@15:",
+                "@compat-2020-10-01 %rocmcc@4:",
             ]:
                 if self.spec.satisfies(a_spec):
                     flags.append("-Wno-error=c++11-narrowing")
@@ -101,13 +125,13 @@ class Mgard(CMakePackage, CudaPackage):
             arch_str = ";".join(cuda_arch_list)
             if cuda_arch_list[0] != "none":
                 args.append(self.define("CMAKE_CUDA_ARCHITECTURES", arch_str))
-        if self.spec.satisfies("@:2021-11-12"):
+        if self.spec.satisfies("@:compat-2021-11-12"):
             if "+cuda" in self.spec:
                 if "75" in cuda_arch:
                     args.append("-DMGARD_ENABLE_CUDA_OPTIMIZE_TURING=ON")
                 if "70" in cuda_arch:
                     args.append("-DMGARD_ENABLE_CUDA_OPTIMIZE_VOLTA=ON")
-        elif self.spec.satisfies("@2022-11-18:"):
+        elif self.spec.satisfies("@compat-2022-11-18:"):
             args.append("-DMAXIMUM_DIMENSION=4")  # how do we do variants with arbitrary values
             args.append("-DMGARD_ENABLE_CLI=OFF")  # the CLI is busted
             args.append(self.define_from_variant("MGARD_ENABLE_OPENMP", "openmp"))

--- a/repos/spack_repo/builtin/packages/mgard/package.py
+++ b/repos/spack_repo/builtin/packages/mgard/package.py
@@ -94,7 +94,7 @@ class Mgard(CMakePackage, CudaPackage):
     depends_on("zstd")
     depends_on("protobuf@3.4:", when="@compat-2022-11-18:")
     # See https://github.com/CODARcode/MGARD/issues/240
-    depends_on("protobuf@:3.28", when="@:compat-2023-12-09")
+    depends_on("protobuf@:3.28", when="@:1.5.2")
     depends_on("libarchive", when="@compat-2021-11-12:")
     depends_on("tclap", when="@compat-2021-11-12")
     depends_on("yaml-cpp", when="@compat-2021-11-12:")

--- a/repos/spack_repo/builtin/packages/mgard/package.py
+++ b/repos/spack_repo/builtin/packages/mgard/package.py
@@ -16,19 +16,9 @@ class Mgard(CMakePackage, CudaPackage):
     repository at https://github.com/CODARcode/MGARD directly from the master branch.
     """
 
-    # This is a research compressor with a fast evolving API. Historical versions
-    # use a fork with minimal changes to support spack, while new versions use upstream master.
-
     homepage = "https://github.com/CODARcode/MGARD"
-    git = "https://github.com/robertu94/MGARD"  # Fork for existing date- versions
-
-    def url_for_version(self, version):
-        """For newer versions, use upstream MGARD repository"""
-        version_str = str(version)
-        if not version_str.startswith("date-"):
-            return "https://github.com/CODARcode/MGARD"
-        else:
-            return "https://github.com/robertu94/MGARD"
+    git = "https://github.com/CODARcode/MGARD.git"
+    url = "https://github.com/CODARcode/MGARD/archive/refs/tags/1.5.2.tar.gz"
 
     maintainers("robertu94")
     maintainers("vicentebolea")
@@ -39,15 +29,40 @@ class Mgard(CMakePackage, CudaPackage):
     license("Apache-2.0")
 
     # In spack numbers take precedence over alphabetic chars when sorting versions.
-    version("1.5.2", commit="208b0c42af6ba552387aec321664d5cbb757b2e2")  # upstream v1.5.2
+    version("1.5.2", sha256="d78ff8735e9fc6f86abc4830563799a3dd3c9abf33d13d82ed42dbc28d48685d")
 
     # Historical versions using fork (with patches for Spack compatibility)
-    version("compat-2023-12-09", commit="d61d8c06c49a72b2e582cc02de88b7b27e1275d2", preferred=True)
-    version("compat-2023-03-31", commit="a8a04a86ff30f91d0b430a7c52960a12fa119589")
-    version("compat-2023-01-10", commit="3808bd8889a0f8e6647fc0251a3189bc4dfc920f")
-    version("compat-2022-11-18", commit="72dd230ed1af88f62ed3c0f662e2387a6e587748")
-    version("compat-2021-11-12", commit="3c05c80a45a51bb6cc5fb5fffe7b1b16787d3366")
-    version("compat-2020-10-01", commit="b67a0ac963587f190e106cc3c0b30773a9455f7a")
+    version(
+        "compat-2023-12-09",
+        commit="d61d8c06c49a72b2e582cc02de88b7b27e1275d2",
+        git="https://github.com/robertu94/MGARD.git",
+        preferred=True,
+    )
+    version(
+        "compat-2023-03-31",
+        commit="a8a04a86ff30f91d0b430a7c52960a12fa119589",
+        git="https://github.com/robertu94/MGARD.git",
+    )
+    version(
+        "compat-2023-01-10",
+        commit="3808bd8889a0f8e6647fc0251a3189bc4dfc920f",
+        git="https://github.com/robertu94/MGARD.git",
+    )
+    version(
+        "compat-2022-11-18",
+        commit="72dd230ed1af88f62ed3c0f662e2387a6e587748",
+        git="https://github.com/robertu94/MGARD.git",
+    )
+    version(
+        "compat-2021-11-12",
+        commit="3c05c80a45a51bb6cc5fb5fffe7b1b16787d3366",
+        git="https://github.com/robertu94/MGARD.git",
+    )
+    version(
+        "compat-2020-10-01",
+        commit="b67a0ac963587f190e106cc3c0b30773a9455f7a",
+        git="https://github.com/robertu94/MGARD.git",
+    )
 
     variant(
         "serial",


### PR DESCRIPTION
> [!NOTE]
> This PR was migrated from **https://github.com/spack/spack/pull/50799**.

This commit allows mgard to use its upstream git repository for newer
versions. It does this while remaining the existing fork versions for
compatibilty reasons.

* Latest fork version remains the preferred one.
* Previous fork versions have been prefixes with date- with the idea
  that when spack is sorting versions upstream (X.Y.Z) comes first since
  numbers take precedence over alpha chars.
* Updated existing packages that use mgard with an expectic date version
  to use this date- prefix
