### PR TITLE
mepo: add v2.4.0

### DIFF
--- a/repos/spack_repo/builtin/packages/mepo/package.py
+++ b/repos/spack_repo/builtin/packages/mepo/package.py
@@ -18,6 +18,7 @@ class Mepo(PythonPackage):
 
     license("Apache-2.0", checked_by="mathomp4")
 
+    version("2.4.0", sha256="70088348f0671bd339b93dc22bbd0c8325387193a799218c794990987a848d1a")
     version("2.3.2", sha256="82affbf7e40856c6d8e8b3c4998ab4ea4d37c0baac73ddc1d698bce0d73a5082")
     version("2.3.1", sha256="76b7fe081de7b34e5680879352a070dd447e2b113f3e34e4ce20c02486c3c0d8")
     version("2.3.0", sha256="e80d7157553d33382ab0c399fcd5ec43ab5ff642504b07c8aef266165f9095d2")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR adds the new [mepo 2.4.0](https://github.com/GEOS-ESM/mepo/releases/tag/v2.4.0)