### PR TITLE
DarshanRuntime: Do not override `DARSHAN_LOG_DIR_PATH` if already set

### DIFF
--- a/repos/spack_repo/builtin/packages/darshan_runtime/package.py
+++ b/repos/spack_repo/builtin/packages/darshan_runtime/package.py
@@ -160,9 +160,10 @@ class DarshanRuntime(AutotoolsPackage):
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.variants["log_path"].value == "none":
-            # set a default path for log file that can be overrode by user
-            darshan_log_dir = os.environ["HOME"]
-            env.set("DARSHAN_LOG_DIR_PATH", darshan_log_dir)
+            if os.environ.get("DARSHAN_LOG_DIR_PATH") is None:
+                # set a default path for log file that can be overrode by user
+                darshan_log_dir = os.environ["HOME"]
+                env.set("DARSHAN_LOG_DIR_PATH", darshan_log_dir)
 
     @property
     def basepath(self):


### PR DESCRIPTION
> [!NOTE]
> This PR was migrated from **https://github.com/spack/spack/pull/50755**.

This is more just an annoyance as it doesn't allow for setting the env var prior to activating the spack environment.

Before the change:

```
$ export DARSHAN_LOG_DIR_PATH=~/darshan_logs
$ spack load darshan_runtime /tds
$ echo $DARSHAN_LOG_DIR_PATH
/home/linsword_google_com
```

With the change:

```
$ export DARSHAN_LOG_DIR_PATH=~/darshan_logs
$ spack load darshan-runtime /tds
$ echo $DARSHAN_LOG_DIR_PATH
/home/linsword_google_com/darshan_logs
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->