### PR TITLE
Python: pyconfig.h changed locations in 3.13 on Windows

### DIFF
--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -622,7 +622,10 @@ class Python(Package):
         copy_tree(tools_dir, prefix.Tools)
         lib_dir = os.path.join(proj_root, "Lib")
         copy_tree(lib_dir, prefix.Lib)
-        pyconfig = os.path.join(proj_root, "PC", "pyconfig.h")
+        if self.spec.satisfies("@3.13:"):
+            pyconfig = os.path.join(pcbuild_root, platform.machine().lower(), "pyconfig.h")
+        else:
+            pyconfig = os.path.join(proj_root, "PC", "pyconfig.h")
         copy(pyconfig, prefix.include)
         shared_libraries = []
         shared_libraries.extend(glob.glob("%s\\*.exe" % build_root))


### PR DESCRIPTION
> [!NOTE]
> This PR was migrated from **https://github.com/spack/spack/pull/48820**.

Title pretty much sums up the whole issue.
pyconfig.h moved from `<root>\PC\pyconfig.h` --> `<root>\PCBuild\<platform>\pyconfig.h` on WIndows 
This PR adds handling for that.

This will enable builds of Qt in CI without constraining the python version, last step before paraview+qt in gitlab