### PR TITLE
CMake: No ncurses variant on Windows

### DIFF
--- a/repos/spack_repo/builtin/packages/cmake/package.py
+++ b/repos/spack_repo/builtin/packages/cmake/package.py
@@ -103,12 +103,15 @@ class Cmake(Package):
         default=False,
         description="Enables the generation of html and man page documentation",
     )
-    variant(
-        "ncurses",
-        default=sys.platform != "win32",
-        description="Enables the build of the ncurses gui",
-    )
     variant("qtgui", default=False, description="Enables the build of the Qt GUI")
+
+    for spack_platform in ["freebsd", "linux", "darwin"]:
+        with when(f"platform={spack_platform}"):
+                variant(
+                    "ncurses",
+                    default=True,
+                    description="Enables the build of the ncurses gui",
+                )
 
     # Revert the change that introduced a regression when parsing mpi link
     # flags, see: https://gitlab.kitware.com/cmake/cmake/issues/19516

--- a/repos/spack_repo/builtin/packages/cmake/package.py
+++ b/repos/spack_repo/builtin/packages/cmake/package.py
@@ -107,11 +107,7 @@ class Cmake(Package):
 
     for spack_platform in ["freebsd", "linux", "darwin"]:
         with when(f"platform={spack_platform}"):
-                variant(
-                    "ncurses",
-                    default=True,
-                    description="Enables the build of the ncurses gui",
-                )
+            variant("ncurses", default=True, description="Enables the build of the ncurses gui")
 
     # Revert the change that introduced a regression when parsing mpi link
     # flags, see: https://gitlab.kitware.com/cmake/cmake/issues/19516


### PR DESCRIPTION
> [!NOTE]
> This PR was migrated from **https://github.com/spack/spack/pull/50817**.

See title

Editing description to see if this triggers sync script