### PR TITLE
root: Change the default value of the runtime_cxxmodules option

### DIFF
--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -656,7 +656,7 @@ class Root(CMakePackage):
             define("libcxx", False),
             define("roottest", False),
             define_from_variant("rpath"),
-            define("runtime_cxxmodules", False),
+            define("runtime_cxxmodules", False if self.spec.satisfies("@:6.18") else True),
             define("shared", True),
             define("soversion", True),
             define("testing", self.run_tests),

--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -658,7 +658,6 @@ class Root(CMakePackage):
             define("libcxx", False),
             define("roottest", False),
             define_from_variant("rpath"),
-            define("runtime_cxxmodules", False if self.spec.satisfies("@:6.18") else True),
             define("shared", True),
             define("soversion", True),
             define("testing", self.run_tests),
@@ -932,8 +931,8 @@ class Root(CMakePackage):
             env.prepend_path(self.root_library_path, self.prefix.lib.root)
 
         # https://github.com/root-project/root/issues/18949
-        if "+cxxmodules" in self.spec:
-            env.prepend_path("ROOT_INCLUDE_PATH", self.prefix.include)
+        if "+cxxmodules" in self.spec and "+vc" in self.spec:
+            env.prepend_path("ROOT_INCLUDE_PATH", self.spec["vc"].prefix.include)
 
     def setup_dependent_build_environment(self, env: EnvironmentModifications, dependent_spec):
         env.set("ROOTSYS", self.prefix)
@@ -948,6 +947,10 @@ class Root(CMakePackage):
         if "platform=darwin" in self.spec:
             # Newer deployment targets cause fatal errors in rootcling
             env.unset("MACOSX_DEPLOYMENT_TARGET")
+
+        # https://github.com/root-project/root/issues/18949
+        if "+cxxmodules" in self.spec and "+vc" in self.spec:
+            env.prepend_path("ROOT_INCLUDE_PATH", self.spec["vc"].prefix.include)
 
     def setup_dependent_run_environment(self, env: EnvironmentModifications, dependent_spec):
         env.prepend_path("ROOT_INCLUDE_PATH", dependent_spec.prefix.include)

--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -165,6 +165,7 @@ class Root(CMakePackage):
     variant("arrow", default=False, description="Enable Arrow interface")
     variant("cuda", when="@6.08.00:", default=False, description="Enable CUDA support")
     variant("cudnn", when="@6.20.02:", default=False, description="Enable cuDNN support")
+    variant("cxxmodules", when="@6.16:", default=True, description="Enable C++ modules")
     variant(
         "daos", default=False, description="Enable RNTuple support for DAOS storage", when="@6.26:"
     )
@@ -615,6 +616,7 @@ class Root(CMakePackage):
         else:
             _add_variant(v, f, ("root7", "webui"), "+webgui")
         _add_variant(v, f, "rpath", "+rpath")
+        _add_variant(v, f, "runtime_cxxmodules", "+cxxmodules")
         _add_variant(v, f, "shadowpw", "+shadow")
         _add_variant(v, f, "spectrum", "+spectrum")
         _add_variant(v, f, "sqlite", "+sqlite")
@@ -928,6 +930,10 @@ class Root(CMakePackage):
         env.set("CPPYY_BACKEND_LIBRARY", self.prefix.lib.root.libcppyy_backend)
         if "+rpath" not in self.spec:
             env.prepend_path(self.root_library_path, self.prefix.lib.root)
+
+        # https://github.com/root-project/root/issues/18949
+        if "+cxxmodules" in self.spec:
+            env.prepend_path("ROOT_INCLUDE_PATH", self.prefix.include)
 
     def setup_dependent_build_environment(self, env: EnvironmentModifications, dependent_spec):
         env.set("ROOTSYS", self.prefix)

--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -941,7 +941,6 @@ class Root(CMakePackage):
         env.prepend_path("PATH", self.prefix.bin)
         env.append_path("CMAKE_MODULE_PATH", self.prefix.cmake)
         env.prepend_path("ROOT_INCLUDE_PATH", dependent_spec.prefix.include)
-        env.prepend_path("ROOT_INCLUDE_PATH", self.prefix.include)
         if "+rpath" not in self.spec:
             env.prepend_path(self.root_library_path, self.prefix.lib.root)
         if "platform=darwin" in self.spec:

--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -942,6 +942,7 @@ class Root(CMakePackage):
         env.prepend_path("PATH", self.prefix.bin)
         env.append_path("CMAKE_MODULE_PATH", self.prefix.cmake)
         env.prepend_path("ROOT_INCLUDE_PATH", dependent_spec.prefix.include)
+        env.prepend_path("ROOT_INCLUDE_PATH", self.prefix.include)
         if "+rpath" not in self.spec:
             env.prepend_path(self.root_library_path, self.prefix.lib.root)
         if "platform=darwin" in self.spec:


### PR DESCRIPTION
> [!NOTE]
> This PR was migrated from **https://github.com/spack/spack/pull/50432**.

Since ROOT 6.20 the default (https://github.com/root-project/root/pull/4452) is to have `runtime_cxxmodules` ON and we have it OFF by default with no way of configuring it, so I propose to follow the default value and set it to ON. I have found that in our stack having this set to off causes some slow downs in some IO operations (https://github.com/key4hep/key4hep-spack/issues/743). The PCH option was removed in https://github.com/root-project/root/commit/898171f5a4619ac07245d70b7f8943da067516ba so I propose not to set it.