### PR TITLE
CMake 4.0 as default: package updates/fixes for CMake 4.0

### DIFF
--- a/repos/spack_repo/builtin/packages/callpath/package.py
+++ b/repos/spack_repo/builtin/packages/callpath/package.py
@@ -26,7 +26,7 @@ class Callpath(CMakePackage):
     depends_on("dyninst")
     depends_on("adept-utils")
     depends_on("mpi")
-    depends_on("cmake@2.8:", type="build")
+    depends_on("cmake@2.8:3", when="build_system=cmake", type="build")
 
     def cmake_args(self):
         # TODO: offer options for the walker used.

--- a/repos/spack_repo/builtin/packages/cmake/package.py
+++ b/repos/spack_repo/builtin/packages/cmake/package.py
@@ -34,11 +34,7 @@ class Cmake(Package):
     version("4.2.3", sha256="7efaccde8c5a6b2968bad6ce0fe60e19b6e10701a12fce948c2bf79bac8a11e9")
     version("4.1.5", sha256="50ce77215cf266630fa5de97c360f4c313bb79f94b35236b63c1216de3196356")
     version("4.0.6", sha256="9ebe11be8d304336d62a3e71ca36c18f0a4e40036b97c533d63cf730364b6528")
-    version(
-        "3.31.11",
-        sha256="c0a3b3f2912b2166f522d5010ffb6029d8454ee635f5ad7a3247e0be7f9a15c9",
-        preferred=True,
-    )
+    version("3.31.11", sha256="c0a3b3f2912b2166f522d5010ffb6029d8454ee635f5ad7a3247e0be7f9a15c9")
     version("3.30.9", sha256="65f765bb87c8019316cabe67cbe5e8f45ede334eeb5afd161ca6874d17994e0d")
     version("3.29.6", sha256="1391313003b83d48e2ab115a8b525a557f78d8c1544618b48d1d90184a10f0af")
     version("3.28.6", sha256="c39c733900affc4eb0e9688b4d1a45435a732105d9bf9cc1e75dd2b9b81a36bb")

--- a/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
+++ b/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
@@ -99,7 +99,7 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
-    depends_on("cmake@3.13.4:", type="build")
+    depends_on("cmake@3.13.4:3", when="build_system=cmake", type="build")
     depends_on("python", type="build")
     depends_on("z3", type="link")
     depends_on("zlib-api", type="link")

--- a/repos/spack_repo/builtin/packages/magma/package.py
+++ b/repos/spack_repo/builtin/packages/magma/package.py
@@ -58,6 +58,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("rocm-core", when="@2.8.0: +rocm")
     depends_on("python", when="@master", type="build")
 
+    depends_on("cmake@:3", when="build_system=cmake", type="build")
     conflicts("~cuda", when="~rocm", msg="magma: Either CUDA or HIP support must be enabled")
     conflicts("+rocm", when="+cuda", msg="magma: CUDA must be disabled to support HIP (ROCm)")
     conflicts("+rocm", when="@:2.5.4", msg="magma: HIP support starts in version 2.6.0")

--- a/repos/spack_repo/builtin/packages/opencl_clhpp/package.py
+++ b/repos/spack_repo/builtin/packages/opencl_clhpp/package.py
@@ -31,8 +31,6 @@ class OpenclClhpp(CMakePackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
-    root_cmakelists_dir = "include"
-
     @run_after("install")
     def post_install(self):
         if sys.platform == "darwin":

--- a/repos/spack_repo/builtin/packages/pandorasdk/package.py
+++ b/repos/spack_repo/builtin/packages/pandorasdk/package.py
@@ -37,6 +37,7 @@ class Pandorasdk(CMakePackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
+    depends_on("cmake@:3", when="build_system=cmake", type="build")
     depends_on("pandorapfa")
 
     def cmake_args(self):

--- a/repos/spack_repo/builtin/packages/plasma/package.py
+++ b/repos/spack_repo/builtin/packages/plasma/package.py
@@ -42,6 +42,7 @@ class Plasma(CMakePackage):
         "17.1",
         sha256="d4b89f7c3d240a69dfe986284a14471eec4830b9e352ae902ea8861f15573dee",
         url="https://github.com/icl-utk-edu/plasma/releases/download/17.01/plasma-17.01.tar.gz",
+        deprecated=True,
     )
 
     build_system(
@@ -49,6 +50,7 @@ class Plasma(CMakePackage):
         conditional("cmake", when="@18.9:"),
         default="cmake",
     )
+    depends_on("cmake@:3", when="build_system=cmake", type="build")
 
     variant("shared", default=True, description="Build shared library (disables static library)")
     variant("lua", default=False, description="Build Lua support for tuning tile sizes")

--- a/repos/spack_repo/builtin/packages/visit/package.py
+++ b/repos/spack_repo/builtin/packages/visit/package.py
@@ -126,8 +126,8 @@ class Visit(CMakePackage):
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
-    depends_on("cmake@3.14.7:", type="build")
     depends_on("cmake@3.24:", type="build", when="@3.4:")
+    depends_on("cmake@3.14.7:3", when="build_system=cmake", type="build")
     depends_on("mpi", when="+mpi")
     conflicts("mpi", when="~mpi")
 


### PR DESCRIPTION
> [!NOTE]  
> This PR is based on #49731 as as such the diff includes those changes for pipeline purposes, but those will be landing separately 

https://github.com/spack/spack/pull/49731 Adds initial CMake 4.0 support but does not actually prefer CMake 4.0.

This PR:

* Prefers 4.0
* Updates relevant packages to be compatible with the new CMake version (or update constraints as appropriate)
* Fixes generally broken packages