### PR TITLE
Python: Add Windows 'py' launcher to the PATH

### DIFF
--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -1271,10 +1271,10 @@ print(json.dumps(config))
         """Set PYTHONPATH to include the site-packages directory for the
         extension and any other python extensions it depends on.
         """
-        env.prepend_path("PATH", self.prefix)
         # The logic below is linux specific, and used to inject the compiler wrapper to
         # compile Python extensions. Thus, it is not needed on Windows.
         if sys.platform == "win32":
+            env.prepend_path("PATH", self.prefix)
             return
 
         # We need to make sure that the extensions are compiled and linked with
@@ -1345,7 +1345,8 @@ print(json.dumps(config))
         """Set PYTHONPATH to include the site-packages directory for the
         extension and any other python extensions it depends on.
         """
-        env.prepend_path("PATH", self.prefix)
+        if sys.platform == "win32":
+            env.prepend_path("PATH", self.prefix)
         if not dependent_spec.package.extends(self.spec) or dependent_spec.dependencies(
             "python-venv"
         ):

--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -1271,6 +1271,7 @@ print(json.dumps(config))
         """Set PYTHONPATH to include the site-packages directory for the
         extension and any other python extensions it depends on.
         """
+        env.prepend_path("PATH", self.prefix)
         # The logic below is linux specific, and used to inject the compiler wrapper to
         # compile Python extensions. Thus, it is not needed on Windows.
         if sys.platform == "win32":
@@ -1344,6 +1345,7 @@ print(json.dumps(config))
         """Set PYTHONPATH to include the site-packages directory for the
         extension and any other python extensions it depends on.
         """
+        env.prepend_path("PATH", self.prefix)
         if not dependent_spec.package.extends(self.spec) or dependent_spec.dependencies(
             "python-venv"
         ):


### PR DESCRIPTION
Python (on Windows) installs a dynamic python launcher into
the root of its install prefix
Some packages expect that launcher to be in the path as they
rely on that as a generic entrypoint to python.

This PR adds said launcher to the PATH for dependent
packages of Python