### PR TITLE
Meson: no pkg conf requirement on Windows

### DIFF
--- a/repos/spack_repo/builtin/build_systems/meson.py
+++ b/repos/spack_repo/builtin/build_systems/meson.py
@@ -54,7 +54,9 @@ class MesonPackage(PackageBase):
         depends_on("ninja", type="build")
         # Meson uses pkg-config for dependency detection, and this dependency is
         # often overlooked by packages that use meson as a build system.
-        depends_on("pkgconfig", type="build")
+        for plat in ["linux", "freebsd", "darwin"]:
+            with when(f"platform={plat}"):
+                depends_on("pkgconfig", type="build")
         # Python detection in meson requires distutils to be importable, but distutils no longer
         # exists in Python 3.12. In Spack, we can't use setuptools as distutils replacement,
         # because the distutils-precedence.pth startup file that setuptools ships with is not run


### PR DESCRIPTION
Windows does support meson, but does not support pkg-conf.\nRemove the requirement on the unsupported package