### PR TITLE
Qt: Conflict frameworks properly on non Mac

### DIFF
--- a/repos/spack_repo/builtin/build_systems/meson.py
+++ b/repos/spack_repo/builtin/build_systems/meson.py
@@ -54,7 +54,9 @@ class MesonPackage(PackageBase):
         depends_on("ninja", type="build")
         # Meson uses pkg-config for dependency detection, and this dependency is
         # often overlooked by packages that use meson as a build system.
-        depends_on("pkgconfig", type="build")
+        for plat in ["linux", "freebsd", "darwin"]:
+            with when(f"platform={plat}"):
+                depends_on("pkgconfig", type="build")
         # Python detection in meson requires distutils to be importable, but distutils no longer
         # exists in Python 3.12. In Spack, we can't use setuptools as distutils replacement,
         # because the distutils-precedence.pth startup file that setuptools ships with is not run

--- a/repos/spack_repo/builtin/packages/qt/package.py
+++ b/repos/spack_repo/builtin/packages/qt/package.py
@@ -224,7 +224,9 @@ class Qt(Package):
             depends_on("libxext")
             depends_on("libxrender")
 
-        conflicts("+framework", msg="QT cannot be built as a framework except on macOS.")
+    for plat in ["linux", "freebsd", "windows"]:
+        with when(f"platform={plat}"):
+            conflicts("+framework", msg="QT cannot be built as a framework except on macOS.")
 
     with when("platform=windows +sql"):
         # Windows sqlite has no column_metadata variant unlike all other platforms


### PR DESCRIPTION
Previous PR refactored this variant expression, but in doing placed this conflict\nat the wrong place in the loop.\nPlace the conflict under the when constraint