### PR TITLE
dd4hep: allow +utliityapps with root ~x ~opengl

### DIFF
--- a/repos/spack_repo/builtin/packages/dd4hep/package.py
+++ b/repos/spack_repo/builtin/packages/dd4hep/package.py
@@ -124,7 +124,9 @@ class Dd4hep(CMakePackage):
         conflicts("^root ~webgui", when="^root@6.28:")
         # For DD4hep >= 1.24, DDEve_Interface needs ROOT::ROOTGeomViewer only if ROOT >= 6.27
         requires("^root +root7 +webgui", when="@1.24: ^root @6.27:")
-    depends_on("root @6.08: +gdml +geom +math +python +x +opengl", when="+utilityapps")
+    # As of https://github.com/AIDASoft/DD4hep/pull/1426, ROOT::Eve is not required
+    depends_on("root @6.08: +gdml +geom +math +python", when="@1.32: +utilityapps")
+    depends_on("root @6.08: +gdml +geom +math +python +x +opengl", when="@:1.31 +utilityapps")
 
     with when("+ddg4"):
         depends_on("boost +iostreams")


### PR DESCRIPTION
This PR removes the requirement in `dd4hep` that `+utlityapps` means `^root +x +opengl`. That was removed in https://github.com/AIDASoft/DD4hep/pull/1426, where the utility apps that depend on ROOT::Gui and ROOT::Eve are now only built when that is available in ROOT (i.e. `+utlityapps` and `+ddeve` are composable).