### PR TITLE
ghostscript: add variant to make gtk+ optional.

### DIFF
--- a/repos/spack_repo/builtin/packages/ghostscript/package.py
+++ b/repos/spack_repo/builtin/packages/ghostscript/package.py
@@ -57,6 +57,7 @@ class Ghostscript(AutotoolsPackage):
 
     # https://www.ghostscript.com/ocr.html
     variant("tesseract", default=False, description="Use the Tesseract library for OCR")
+    variant("gtk", default=True, description="Enable gtk+ device for screen output")
 
     depends_on("c", type="build")
 
@@ -70,7 +71,9 @@ class Ghostscript(AutotoolsPackage):
     depends_on("libtiff")
     depends_on("zlib-api")
     depends_on("libxext")
-    depends_on("gtkplus")
+    depends_on("gtkplus", type="link", when="+gtk")
+    depends_on("dbus", type="link")
+    depends_on("libiconv", type="link")
 
     # https://www.ghostscript.com/doc/9.53.0/News.htm
     conflicts("+tesseract", when="@:9.52", msg="Tesseract OCR engine added in 9.53.0")
@@ -132,6 +135,9 @@ class Ghostscript(AutotoolsPackage):
                 args.append("--disable-hidden-visibility")
         else:
             args.append("--disable-dynamic")
+
+        args.extend(self.enable_or_disable("gtk"))
+        args.append("--with-libiconv=gnu")
 
         return args
 

--- a/repos/spack_repo/builtin/packages/gimp/package.py
+++ b/repos/spack_repo/builtin/packages/gimp/package.py
@@ -74,7 +74,7 @@ class Gimp(AutotoolsPackage):
     depends_on("fontconfig@2.12.4:")
     depends_on("gegl")
     depends_on("gexiv2")
-    depends_on("ghostscript", when="+ghostscript")
+    depends_on("ghostscript+gtk", when="+ghostscript")
     depends_on("glib")
     depends_on("glib-networking")
     depends_on("gtk-doc", when="+doc")

--- a/repos/spack_repo/builtin/packages/graphicsmagick/package.py
+++ b/repos/spack_repo/builtin/packages/graphicsmagick/package.py
@@ -33,7 +33,7 @@ class Graphicsmagick(AutotoolsPackage):
     depends_on("cxx", type="build")  # generated
 
     depends_on("bzip2")
-    depends_on("ghostscript")
+    depends_on("ghostscript+gtk")
     depends_on("ghostscript-fonts")
     depends_on("graphviz")
     depends_on("jasper")

--- a/repos/spack_repo/builtin/packages/graphviz/package.py
+++ b/repos/spack_repo/builtin/packages/graphviz/package.py
@@ -121,7 +121,7 @@ class Graphviz(AutotoolsPackage):
     depends_on("libgd", when="+libgd")
     depends_on("fontconfig", when="+libgd")
     depends_on("freetype", when="+libgd")
-    depends_on("ghostscript", when="+ghostscript")
+    depends_on("ghostscript+gtk", when="+ghostscript")
     depends_on("gtkplus", when="+gtkplus")
     depends_on("gts", when="+gts")
     depends_on("cairo+pdf+png", when="+pangocairo")


### PR DESCRIPTION
There are packages like texlive which only use ghostscript as a postscript2pdf converter, in which case gtk+ is not necessary.

This PR adds variant `gtk` to ghostscript, making gtkplus a optional dependency, to make packages like texlive could be installed without gtkplus. In order to maintain consistency with existing ghostscript install, the default value of `gtk` is set to be `True`.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
