### PR TITLE
Revert ".gitattributes: Checkout LF (mostly)"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,0 @@
-* text eol=lf
-*.bat text eol=crlf
-*.pwsh text eol=crlf
-*.ps1 text eol=crlf


### PR DESCRIPTION
Reverts spack/spack-packages#118

This is likely causing issues in both `spack/spack` and `spack-packages` Gitlab pipelines, due to patches that are now checksummed differently:
- https://gitlab.spack.io/spack/spack-packages/-/jobs/17001967
- https://github.com/spack/spack/actions/runs/15505359709/job/43659490389