### PR TITLE
Charmpp: fix spack test

### DIFF
--- a/repos/spack_repo/builtin/packages/charmpp/package.py
+++ b/repos/spack_repo/builtin/packages/charmpp/package.py
@@ -421,7 +421,7 @@ class Charmpp(Package):
             "-C",
             join_path(self.stage.source_path, "tests"),
             "test",
-            "TESTOPTS=++local",
+            "TESTOPTS=++local +setcpuaffinity",
             parallel=False,
         )
 


### PR DESCRIPTION
I help develop Charm++, and our spack test in Github Actions is failing due to an error caused by a missing argument in the tests command. This is intended to fix that so that we can merge our PRs.
