### PR TITLE
gaudi: should not depend on gdb

### DIFF
--- a/.ci/gitlab/stacks/hep/spack.yaml
+++ b/.ci/gitlab/stacks/hep/spack.yaml
@@ -82,7 +82,7 @@ spack:
   - feynhiggs
   - fjcontrib
   #- garfieldpp
-  - gaudi +aida +examples +heppdt +xercesc ^gdb +debuginfod +python
+  - gaudi +aida +examples +heppdt +xercesc
   - geant4 ~vtk ^[virtuals=qmake] qt
   - geant4 ~vtk ^[virtuals=qmake] qt-base
   #- genie +atmo

--- a/repos/spack_repo/builtin/packages/gaudi/package.py
+++ b/repos/spack_repo/builtin/packages/gaudi/package.py
@@ -147,8 +147,6 @@ class Gaudi(CMakePackage, CudaPackage):
     depends_on("cppunit", when="+cppunit")
     depends_on("doxygen +graphviz", when="+docs")
     depends_on("gperftools", when="+gperftools")
-    # gdb is optional, but useful to have as gaudi adds hooks for it if present during build
-    depends_on("gdb", when=sys.platform != "darwin")
     depends_on("heppdt", when="+heppdt")
     depends_on("jemalloc", when="+jemalloc")
     depends_on("libunwind", when="+unwind")


### PR DESCRIPTION
This PR removes the dependency of `gaudi` on `gdb`. The comment summarizes it well:
> gdb is optional, but useful to have as gaudi adds hooks for it if present during build

The extent of the 'dependency' is that `gaudirun.py` has a `--gdb` [argument](https://gitlab.cern.ch/gaudi/Gaudi/-/blob/master/Gaudi/scripts/gaudirun.py#L255), and that [hooks](https://gitlab.cern.ch/gaudi/Gaudi/-/blob/master/Gaudi/python/Gaudi/Main.py?ref_type=heads#L468) `gdb` to the run. This is indeed entirely optional.

Furthermore, comparing the sizes, `gdb` is more than 4 times larger than `gaudi` itself:
```
50M     gcc-12.2.0/gaudi-39.0-unpppbz2hkve724wo2kin7wwtowhvi3v
212M    gcc-12.2.0/gdb-15.2-l3vgam3vyj5fcmdx4ong24oufnteas3w
```