### PR TITLE
gha: set builtin path as part of checkout

### DIFF
--- a/.github/actions/checkout-spack/action.yml
+++ b/.github/actions/checkout-spack/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: Number of commits to fetch
     required: false
     default: '1'
+  builtin:
+    description: Path to local clone of the builtin repository
+    required: false
+    default: ${{ github.workspace }}
 runs:
   using: "composite"
   steps:
@@ -25,3 +29,9 @@ runs:
         ref: ${{ steps.spack-version.outputs.version }}
         path: ${{ inputs.path }}
         fetch-depth: ${{ inputs.fetch-depth }}
+    - name: Override builtin repository path
+      shell: bash
+      run: ${{ inputs.path }}/bin/spack repo set --destination "${{ inputs.builtin }}" --scope site builtin
+    - name: Spack package repositories
+      shell: bash
+      run: ${{ inputs.path }}/bin/spack config blame repos

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -41,7 +41,6 @@ jobs:
       if: ${{ runner.os != 'Windows' }}
       run: |
           . ./spack-core/share/spack/setup-env.sh
-          spack config add -f ./.ci/configs/repos.yaml
           spack -d audit packages
           spack -d audit configs
           spack -d audit externals
@@ -49,7 +48,6 @@ jobs:
       if: ${{ runner.os == 'Windows' }}
       run: |
           ./spack-core/share/spack/setup-env.ps1
-          spack config add -f ./.ci/configs/repos.yaml
           spack -d audit packages
           ./.ci/validate_last_exit.ps1
           spack -d audit configs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,11 +15,6 @@ concurrency:
   group: ci-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
   cancel-in-progress: true
 
-# Setup global configs to ensure spack points at this package repo
-env:
-  SPACK_USER_CONFIG_PATH: .ci/configs
-  SPACK_DISABLE_LOCAL_CONFIG: "true"
-
 jobs:
   # Check which files have been updated by the PR
   changes:

--- a/.github/workflows/prechecks.yml
+++ b/.github/workflows/prechecks.yml
@@ -73,7 +73,4 @@ jobs:
     - name: Verify Added Checksums
       run: |
         . spack-core/share/spack/setup-env.sh
-        spack repo set --destination $GITHUB_WORKSPACE builtin
-        spack config get repos
-        spack repo list
         spack ci verify-versions HEAD~1 HEAD

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -55,9 +55,6 @@ jobs:
     - name: Run unit tests (without coverage)
       run: |
         . ./spack-core/share/spack/setup-env.sh
-        spack repo set --destination $GITHUB_WORKSPACE builtin
-        spack config get repos
-        spack repo list
         PYTHONPATH=${SPACK_ROOT}/lib/spack:${SPACK_ROOT}/lib/spack/external:${PYTHONPATH} python3 -m pytest -v --exitfirst
 
   # Run unit tests on MacOS
@@ -83,9 +80,6 @@ jobs:
     - name: Run unit tests (without coverage)
       run: |
         . ./spack-core/share/spack/setup-env.sh
-        spack repo set --destination $GITHUB_WORKSPACE builtin
-        spack config get repos
-        spack repo list
         PYTHONPATH=${SPACK_ROOT}/lib/spack:${SPACK_ROOT}/lib/spack/external:${PYTHONPATH} python3 -m pytest -v --exitfirst
 
   # Run unit tests on Windows


### PR DESCRIPTION
* In GitHub actions, the variable `${CI_PROJECT_DIR}` is not set, and as a result considered a literal path component.
* Every action seems to reinvent the wheel

So, simplify by making the checkout action take care of updating the path of builtin.

On the Spack side we should probably restore hard errors when no package repository is available.