### PR TITLE
CP2K: apply patch to follow api change in sirius 7.7.0

### DIFF
--- a/repos/spack_repo/builtin/packages/cp2k/package.py
+++ b/repos/spack_repo/builtin/packages/cp2k/package.py
@@ -460,6 +460,14 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         when="@2024.2:2024.3",
     )
 
+    # Follow api change of sirius
+    # https://github.com/electronic-structure/SIRIUS/pull/1048
+    patch(
+        "https://github.com/cp2k/cp2k/commit/9ae0441d1aa760e247a8a389793207ec65a35775.patch?full_index=1",
+        sha256="81a4716dbda9121c8abfb46064994c332c0bb99af3a8b4556c481743b5398da4",
+        when="@2024.2:2025.1 ^sirius@7.7.0"
+            )
+
     def patch(self):
         # Patch for an undefined constant due to incompatible changes in ELPA
         if self.spec.satisfies("@9.1:2022.2 +elpa"):

--- a/repos/spack_repo/builtin/packages/cp2k/package.py
+++ b/repos/spack_repo/builtin/packages/cp2k/package.py
@@ -459,14 +459,10 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         sha256="37f4f1a76634ff4a5617fe0c670e6acfe2afa2b2cfc5b2875e438a54baa4525e",
         when="@2024.2:2024.3",
     )
-
-    # Follow api change of sirius
+    # Follow api change of sirius, deleted unrelated tools part.
+    # https://github.com/cp2k/cp2k/commit/9ae0441d1aa760e247a8a389793207ec65a35775
     # https://github.com/electronic-structure/SIRIUS/pull/1048
-    patch(
-        "https://github.com/cp2k/cp2k/commit/9ae0441d1aa760e247a8a389793207ec65a35775.patch?full_index=1",
-        sha256="81a4716dbda9121c8abfb46064994c332c0bb99af3a8b4556c481743b5398da4",
-        when="@2024.2:2025.1 ^sirius@7.7.0"
-            )
+    patch("sirius-api-7.7.0.patch", when="@2024.2:2025.1 ^sirius@7.7.0")
 
     def patch(self):
         # Patch for an undefined constant due to incompatible changes in ELPA

--- a/repos/spack_repo/builtin/packages/cp2k/sirius-api-7.7.0.patch
+++ b/repos/spack_repo/builtin/packages/cp2k/sirius-api-7.7.0.patch
@@ -1,0 +1,44 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b9e660fbfd2..06ccb802a9b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -692,7 +692,7 @@ endif()
+
+ # SIRIUS
+ if(CP2K_USE_SIRIUS)
+-  find_package(sirius REQUIRED)
++  find_package(sirius 7.7.0 REQUIRED)
+ endif()
+
+ if(CP2K_USE_PLUMED)
+diff --git a/src/sirius_interface.F b/src/sirius_interface.F
+index f6dc257c5d4..a84223d2433 100644
+--- a/src/sirius_interface.F
++++ b/src/sirius_interface.F
+@@ -145,7 +145,7 @@ SUBROUTINE cp_sirius_create_env(pwdft_env)
+                                                             magnetization, mass, pf, rl, zeff, alpha_u, beta_u, &
+                                                             J0_u, J_u, U_u, occ_u, u_minus_J
+       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: beta, corden, ef, fe, locpot, rc, rp
+-      REAL(KIND=dp), DIMENSION(3)                        :: vr, vs
++      REAL(KIND=dp), DIMENSION(3)                        :: vr, vs, j_t
+       REAL(KIND=dp), DIMENSION(:), POINTER               :: density
+       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: wavefunction, wfninfo
+       TYPE(atom_gthpot_type), POINTER                    :: gth_atompot
+@@ -464,12 +464,14 @@ SUBROUTINE cp_sirius_create_env(pwdft_env)
+                CPABORT("CP2K/SIRIUS (hubbard): the occupation number can not be negative.")
+             END IF
+
++            j_t(:) = 0.0
+             IF (ABS(u_minus_j) < 1e-8) THEN
++               j_t(1) = J_u
+                CALL sirius_set_atom_type_hubbard(sctx, label, lu, nu, &
+-                                                 occ_u, U_u, J_u, alpha_u, beta_u, J0_u)
++                                                 occ_u, U_u, j_t, alpha_u, beta_u, J0_u)
+             ELSE
+                CALL sirius_set_atom_type_hubbard(sctx, label, lu, nu, &
+-                                                 occ_u, u_minus_j, 0.0_dp, alpha_u, beta_u, J0_u)
++                                                 occ_u, u_minus_j, j_t, alpha_u, beta_u, J0_u)
+             END IF
+          END IF
+
+


### PR DESCRIPTION
In SIRIUS, type of J in sirius_set_atom_type_hubbard() had changed to array(3) by https://github.com/electronic-structure/SIRIUS/pull/1048. This PR applies patch trimmed from https://github.com/cp2k/cp2k/commit/9ae0441d1aa760e247a8a389793207ec65a35775 to catch up these api changes. 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
