### PR TITLE
Add missing language dependency for various packages

### DIFF
--- a/repos/spack_repo/builtin/packages/coordgen/package.py
+++ b/repos/spack_repo/builtin/packages/coordgen/package.py
@@ -23,6 +23,7 @@ class Coordgen(CMakePackage):
     variant("example", default=False, description="Build sample executable")
     variant("shared", default=True, description="Build as shared library")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     depends_on("maeparser", when="+maeparser")

--- a/repos/spack_repo/builtin/packages/maeparser/package.py
+++ b/repos/spack_repo/builtin/packages/maeparser/package.py
@@ -26,6 +26,7 @@ class Maeparser(CMakePackage):
         description="Build maeparser as a shared library (turn off for a static one)",
     )
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     depends_on("boost +iostreams +filesystem +test")

--- a/repos/spack_repo/builtin/packages/multicharge/package.py
+++ b/repos/spack_repo/builtin/packages/multicharge/package.py
@@ -28,6 +28,7 @@ class Multicharge(CMakePackage, MesonPackage):
 
     variant("openmp", default=True, description="Enable OpenMP support")
 
+    depends_on("fortran", type="build")
     depends_on("lapack")
     depends_on("mctc-lib build_system=cmake", when="build_system=cmake")
     depends_on("mctc-lib build_system=meson", when="build_system=meson")


### PR DESCRIPTION
Several packages, including coordgen, maeparser, and multicharge, lack some language virtual package dependency, making their build fail. 
This PR adds the virtual dependencies.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
