### PR TITLE
disable ncurses default deps

### DIFF
--- a/repos/spack_repo/builtin/packages/cmake/package.py
+++ b/repos/spack_repo/builtin/packages/cmake/package.py
@@ -140,7 +140,7 @@ class Cmake(Package):
         default=False,
         description="Enables the generation of html and man page documentation",
     )
-    variant("ncurses", default=True, description="Enables the build of the ncurses gui")
+    variant("ncurses", default=False, description="Enables the build of the ncurses gui")
     variant("qtgui", default=False, description="Enables the build of the Qt GUI")
 
     # Revert the change that introduced a regression when parsing mpi link
@@ -217,11 +217,9 @@ class Cmake(Package):
                 depends_on("rhash", when="@3.8.0:")
                 depends_on("jsoncpp build_system=meson", when="@3.2:")
 
-    conflicts(
-        "+ncurses platform=windows",
-        msg="ncurses GUI cannot be built on windows",
-    )
-    depends_on("ncurses", when="+ncurses")
+    with when("+ncurses"):
+        conflicts("platform=windows", msg="ncurses GUI cannot be built on windows")
+        depends_on("ncurses")
 
     with when("+doc"):
         depends_on("python@2.7.11:", type="build")

--- a/repos/spack_repo/builtin/packages/cmake/package.py
+++ b/repos/spack_repo/builtin/packages/cmake/package.py
@@ -140,11 +140,7 @@ class Cmake(Package):
         default=False,
         description="Enables the generation of html and man page documentation",
     )
-    variant(
-        "ncurses",
-        default=sys.platform != "win32",
-        description="Enables the build of the ncurses gui",
-    )
+    variant("ncurses", default=True, description="Enables the build of the ncurses gui")
     variant("qtgui", default=False, description="Enables the build of the Qt GUI")
 
     # Revert the change that introduced a regression when parsing mpi link
@@ -221,6 +217,10 @@ class Cmake(Package):
                 depends_on("rhash", when="@3.8.0:")
                 depends_on("jsoncpp build_system=meson", when="@3.2:")
 
+    conflicts(
+        "+ncurses platform=windows",
+        msg="ncurses GUI cannot be built on windows",
+    )
     depends_on("ncurses", when="+ncurses")
 
     with when("+doc"):

--- a/repos/spack_repo/builtin/packages/gdbm/package.py
+++ b/repos/spack_repo/builtin/packages/gdbm/package.py
@@ -39,12 +39,13 @@ class Gdbm(AutotoolsPackage, GNUMirrorPackage):
 
     depends_on("c", type="build")  # generated
 
-    variant("readline", default=True, description="Build with readline support.")
+    variant("readline", default=False, description="Build with readline support.")
     variant("nls", default=True, description="Build with message translation.")
 
     depends_on("readline", when="+readline")
     with when("+nls"):
         depends_on("gettext")
+        # The configure script specifically refers to libiconv. It may work with others?
         depends_on("libiconv")
 
     patch("macOS.patch", when="@1.21 platform=darwin")

--- a/repos/spack_repo/builtin/packages/gdbm/package.py
+++ b/repos/spack_repo/builtin/packages/gdbm/package.py
@@ -19,6 +19,8 @@ class Gdbm(AutotoolsPackage, GNUMirrorPackage):
 
     license("GPL-3.0-or-later")
 
+    maintainers("cosmicexplorer")
+
     version("1.25", sha256="d02db3c5926ed877f8817b81cd1f92f53ef74ca8c6db543fbba0271b34f393ec")
     version("1.24", sha256="695e9827fdf763513f133910bc7e6cfdb9187943a4fec943e57449723d2b8dbf")
     version("1.23", sha256="74b1081d21fff13ae4bd7c16e5d6e504a4c26f7cde1dca0d963a484174bbcacd")
@@ -37,20 +39,48 @@ class Gdbm(AutotoolsPackage, GNUMirrorPackage):
 
     depends_on("c", type="build")  # generated
 
-    depends_on("readline")
+    variant("readline", default=True, description="Build with readline support.")
+    variant("nls", default=True, description="Build with message translation.")
+
+    depends_on("readline", when="+readline")
+    with when("+nls"):
+        depends_on("gettext")
+        depends_on("libiconv")
 
     patch("macOS.patch", when="@1.21 platform=darwin")
-    patch("gdbm.patch", when="@:1.18 %gcc@10:")
-    patch("gdbm.patch", when="@:1.18 %clang@11:")
-    patch("gdbm.patch", when="@:1.18 %cce@11:")
-    patch("gdbm.patch", when="@:1.18 %aocc@2:")
-    patch("gdbm.patch", when="@:1.18 %oneapi")
-    patch("gdbm.patch", when="@:1.18 %arm@21:")
+
+    with when("@:1.18"):
+        patch("gdbm.patch", when="%gcc@10:")
+        patch("gdbm.patch", when="%clang@11:")
+        patch("gdbm.patch", when="%cce@11:")
+        patch("gdbm.patch", when="%aocc@2:")
+        patch("gdbm.patch", when="%oneapi")
+        patch("gdbm.patch", when="%arm@21:")
 
     def configure_args(self):
+        opts = []
+
         # GDBM uses some non-standard GNU extensions,
         # enabled with -D_GNU_SOURCE.  See:
         #   https://patchwork.ozlabs.org/patch/771300/
         #   https://stackoverflow.com/questions/5582211
         #   https://www.gnu.org/software/automake/manual/html_node/Flag-Variables-Ordering.html
-        return ["--enable-libgdbm-compat", "CPPFLAGS=-D_GNU_SOURCE"]
+        opts.extend(["--enable-libgdbm-compat", "CPPFLAGS=-D_GNU_SOURCE"])
+
+        if "~readline" in self.spec:
+            opts.append("--without-readline")
+
+        if "+nls" in self.spec:
+            libiconv_pfx = self.spec["libiconv"].prefix
+            libintl_pfx = self.spec["gettext"].prefix
+            opts.extend(
+                [f"--with-libiconv-prefix={libiconv_pfx}", f"--with-libintl-prefix={libintl_pfx}"]
+            )
+        else:
+            opts.append("--disable-nls")
+
+        # Up to 1.24, the new c23 keyword 'bool' was used in an invalid way for a keyword.
+        if self.spec.satisfies("@:1.24"):
+            opts.append("CFLAGS=-std=c18")
+
+        return opts

--- a/repos/spack_repo/builtin/packages/gettext/package.py
+++ b/repos/spack_repo/builtin/packages/gettext/package.py
@@ -43,12 +43,14 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
     variant("xz", default=True, description="Enable xz support")
     variant("shared", default=True, description="Build shared libraries")
     variant("pic", default=True, description="Enable position-independent code (PIC)")
+    variant("cxx", default=True, description="Build C++ sources.")
+    variant("year2038", default=True, description="Support timestamps after 2038.")
 
     # Optional variants
     variant("libunistring", default=False, description="Use libunistring")
 
     depends_on("c", type="build")
-    depends_on("cxx", type="build")
+    depends_on("cxx", when="+cxx", type="build")
 
     depends_on("iconv")
     # Recommended dependencies
@@ -60,6 +62,14 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
     # depends_on('gzip',     when='+gzip')
     depends_on("bzip2", when="+bzip2")
     depends_on("xz", when="+xz", type=("build", "link", "run"))
+
+    # These are invoked during the build process as well as by the autopoint script.
+    with default_args(type=("build", "run", "test")):
+        depends_on("diffutils")
+        depends_on("grep")
+        depends_on("awk")
+        depends_on("git", when="+git")
+        depends_on("gzip")
 
     # Optional dependencies
     # depends_on('glib')  # circular dependency?
@@ -143,6 +153,12 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
 
         if not spec.satisfies("+xz"):
             config_args.append("--without-xz")
+
+        if not spec.satisfies("+cxx"):
+            config_args.append("--disable-c++")
+
+        if spec.satisfies("+year2038"):
+            config_args.append("--enable-year2038")
 
         if spec.satisfies("+libunistring"):
             config_args.append(

--- a/repos/spack_repo/builtin/packages/gettext/package.py
+++ b/repos/spack_repo/builtin/packages/gettext/package.py
@@ -35,7 +35,6 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
     version("0.19.7", sha256="378fa86a091cec3acdece3c961bb8d8c0689906287809a8daa79dc0c6398d934")
 
     # Recommended variants
-    variant("curses", default=True, description="Use libncurses")
     variant("libxml2", default=True, description="Use libxml2")
     variant("git", default=True, description="Enable git support")
     variant("tar", default=True, description="Enable tar support")
@@ -47,6 +46,7 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
     variant("year2038", default=True, description="Support timestamps after 2038.")
 
     # Optional variants
+    variant("curses", default=False, description="Use libncurses")
     variant("libunistring", default=False, description="Use libunistring")
 
     depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/ncurses/package.py
+++ b/repos/spack_repo/builtin/packages/ncurses/package.py
@@ -26,6 +26,8 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
 
     license("X11")
 
+    maintainers("cosmicexplorer")
+
     version("6.5", sha256="136d91bc269a9a5785e5f9e980bc76ab57428f604ce3e5a5a90cebc767971cc6")
     version("6.4", sha256="6931283d9ac87c5073f30b6290c4c75f21632bb4fc3603ac8100812bed248159")
     version("6.3", sha256="97fc51ac2b085d4cde31ef4d2c3122c21abc217e9090a43a30fc5ec21684e059")
@@ -49,11 +51,13 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
         values=("none", "5", "6"),
         multi=False,
     )
+    variant("cxx", default=True, description="Build C++ bindings.")
+    variant("shared", default=True, description="Build shared libraries.")
 
     conflicts("abi=6", when="@:5.9", msg="6 is not compatible with this release")
 
     depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", when="+cxx", type="build")  # generated
 
     depends_on("pkgconfig", type="build")
 
@@ -111,7 +115,8 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
         if name == "cflags":
             flags.append(self["c"].pic_flag)
         elif name == "cxxflags":
-            flags.append(self["cxx"].pic_flag)
+            if "+cxx" in self.spec:
+                flags.append(self["cxx"].pic_flag)
 
         # ncurses@:6.0 fails in definition of macro 'mouse_trafo' without -P
         if self.spec.satisfies("@:6.0 %gcc@5.0:"):
@@ -121,20 +126,33 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
         # ncurses@:6.0 uses dynamic exception specifications not allowed in c++17
         if self.spec.satisfies("@:5"):
             if name == "cxxflags":
-                flags.append(self["cxx"].standard_flag(language="cxx", standard="14"))
+                if "+cxx" in self.spec:
+                    flags.append(self["cxx"].standard_flag(language="cxx", standard="14"))
 
         return (flags, None, None)
 
     def configure(self, spec, prefix):
         opts = [
             "--disable-stripping",
-            "--with-shared",
-            "--with-cxx-shared",
             "--enable-overwrite",
             "--without-ada",
             "--enable-pc-files",
             "--disable-overwrite",
         ]
+
+        if "+shared" in spec:
+            opts.append("--with-shared")
+            if "+cxx" in spec:
+                opts.append("--with-cxx-shared")
+
+        if "~cxx" in spec:
+            opts.extend(["--without-cxx", "--without-cxx-binding"])
+
+        # All versions of ncurses C++ currently fail to build against gcc 15. There is a fix
+        # upcoming apparently, but this works around it:
+        # https://gitlab.archlinux.org/archlinux/packaging/packages/ncurses/-/issues/3
+        if spec.satisfies("+cxx%gcc@15:"):
+            opts.append("CFLAGS=-std=gnu17")
 
         if spec.satisfies("@:6.2"):
             opts.append("--with-pkg-config-libdir={0}/pkgconfig".format(prefix.lib))


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

*This is on top of #91. See the `+7/-8` diff [here](https://github.com/cosmicexplorer/spack-packages/compare/spack-pr-50564...disable-ncurses-default-deps?expand=1).*

# Problem
See the issue fixed in #91. `ncurses` is being added as a default dependency in many places which are not necessarily used in the terminal. If this sort of breakage occurs again, it could break quite a few packages that shouldn't need to worry about ncurses being broken.

See discussion at https://github.com/spack/spack-packages/pull/91#discussion_r2132453038, continued from https://github.com/spack/spack/pull/50564#discussion_r2129100681.

# Solution
- Disable ncurses C++ builds by default.
- Remove ncurses as a default dependency from other places like gettext and cmake which are not necessarily going to be used in an interactive terminal.
- Disable `readline` dependency from `gdbm` by default.

# Result
If this sort of ncurses breakage occurs again, it should be less likely to propagate to packages that shouldn't be depending on it.