### PR TITLE
Add build dependency on fortran to address issue #43

### DIFF
--- a/repos/spack_repo/builtin/packages/ipopt/package.py
+++ b/repos/spack_repo/builtin/packages/ipopt/package.py
@@ -55,6 +55,7 @@ class Ipopt(AutotoolsPackage):
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
 
     depends_on("blas")
     depends_on("lapack")


### PR DESCRIPTION
package.py needs 
```python
      depends_on("fortran", type="build")  
```