### PR TITLE
qt: explicitly disable vulkan

### DIFF
--- a/repos/spack_repo/builtin/packages/qt/package.py
+++ b/repos/spack_repo/builtin/packages/qt/package.py
@@ -617,6 +617,8 @@ class Qt(Package):
             use_spack_dep("freetype")
             if spec.satisfies("platform=linux") or spec.satisfies("platform=freebsd"):
                 config_args.append("-fontconfig")
+            # Avoid sporadic vkconvenience bug by explicitly disabling vulkan
+            config_args.append("-no-vulkan")
         else:
             config_args.append("-no-freetype")
             config_args.append("-no-gui")


### PR DESCRIPTION
This PR explicitly disables vulkan in qt. In principle, this doesn't change anything, as no vulkan variant is defined, and it is (supposedly) off by default. I have however found that even for the same qt hash, the vulkan build option gets mysteriously enabled during some builds, and explicitly setting `-no-vulkan` resolves the issue (based on 10+ test rebuilds).