### PR TITLE
Melissa packages updates

### DIFF
--- a/repos/spack_repo/builtin/packages/melissa/package.py
+++ b/repos/spack_repo/builtin/packages/melissa/package.py
@@ -44,6 +44,21 @@ class Melissa(CMakePackage):
     depends_on("python@3.9:3.12", type=("build", "run"))
     depends_on("mpi", type=("build", "run"))
 
+    def cmake_args(self):
+        args = []
+
+        # embed runtime library search paths
+        rpaths = [
+            self.spec["libzmq"].prefix.lib,
+            self.spec["mpi"].prefix.lib,
+        ]
+        joined_rpaths = ";".join(rpaths)
+
+        args.append(f"-DCMAKE_INSTALL_RPATH={joined_rpaths}")
+        args.append("-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON")
+
+        return args
+
     def setup_run_environment(self, env):
         python = self.spec["python"]
         python_version = python.version.up_to(2)

--- a/repos/spack_repo/builtin/packages/melissa/package.py
+++ b/repos/spack_repo/builtin/packages/melissa/package.py
@@ -13,14 +13,15 @@ class Melissa(CMakePackage):
     """
 
     homepage = "https://gitlab.inria.fr/melissa/melissa"
-    url = "https://gitlab.inria.fr/melissa/melissa/-/archive/v1.0/melissa-v1.0.tar.bz2"
     git = "https://gitlab.inria.fr/melissa/melissa.git"
-
+    url = "https://gitlab.inria.fr/melissa/melissa/-/archive/v2.0.0/melissa-v2.0.0.tar.gz"
     # attention: Git**Hub**.com accounts
-    maintainers("christoph-conrads", "raffino")
+    maintainers("abhishek1297", "viperML", "raffino")
 
-    version("master", branch="master", deprecated=True)
-    version("develop", branch="develop", deprecated=True)
+    version("2.0.0", sha256="75957d1933cd9c228a6e8643bc855587162c31f3b0ca94c3f5e0e380d01775dd", preferred=True)
+    version("develop", branch="develop")
+
+    # ====================================DEPRECATED VERSIONS=========================================
     version(
         "0.7.1",
         sha256="c30584f15fecf6297712a88e4d28851bfd992f31209fd7bb8af2feebe73d539d",
@@ -31,24 +32,21 @@ class Melissa(CMakePackage):
         sha256="a801d0b512e31a0750f98cfca80f8338985e06abf9b26e96f7645a022864e41c",
         deprecated=True,
     )
-
-    variant("no_mpi_api", default=False, description="Enable the deprecated no-MPI API")
-    variant("shared", default=True, description="Build shared libraries")
+    # ================================================================================================
 
     depends_on("c", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
-    depends_on("cmake@3.7.2:", type="build")
-    depends_on("libzmq@4.1.5:")
-    depends_on("mpi")
+    depends_on("cmake@3.15:", type="build")
     depends_on("pkgconfig", type="build")
-    depends_on("python@3.5.3:", type=("build", "run"))
 
-    def cmake_args(self):
-        args = [
-            self.define("BUILD_TESTING", self.run_tests),
-            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
-            self.define_from_variant("MELISSA_ENABLE_NO_MPI_API", "no_mpi_api"),
-        ]
+    depends_on("libzmq@4.2:4", type=("build", "run"))
+    depends_on("python@3.9:3.12", type=("build", "run"))
+    depends_on("mpi", type=("build", "run"))
 
-        return args
+    def setup_run_environment(self, env):
+        python = self.spec["python"]
+        python_version = python.version.up_to(2)
+        # This path points to the python client API scripts installed in $CMAKE_INSTALL_PREFIX/lib
+        melissa_api_site_packages = f"{self.prefix.lib}/python{python_version}/site-packages"
+        env.prepend_path("PYTHONPATH", melissa_api_site_packages)

--- a/repos/spack_repo/builtin/packages/melissa_api/package.py
+++ b/repos/spack_repo/builtin/packages/melissa_api/package.py
@@ -20,7 +20,7 @@ class MelissaApi(CMakePackage):
 
     license("BSD-3-Clause")
 
-    version("develop", branch="develop")
+    version("develop", branch="develop", deprecated=True)
 
     depends_on("c", type="build")  # generated
     depends_on("fortran", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_melissa_core/package.py
+++ b/repos/spack_repo/builtin/packages/py_melissa_core/package.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.python import PythonPackage
 
 from spack.package import *
 
 
-class PyMelissaCore(PythonPackage):
+class PyMelissaCore(PythonPackage, CudaPackage):
     """Melissa is a file-avoiding, adaptive, fault-tolerant and elastic
     framework, to run large-scale sensitivity analysis or deep-surrogate
     training on supercomputers.
@@ -16,47 +17,92 @@ class PyMelissaCore(PythonPackage):
 
     homepage = "https://gitlab.inria.fr/melissa/melissa"
     git = "https://gitlab.inria.fr/melissa/melissa.git"
-    maintainers("robcaulk", "mschouler", "raffino")
+    url = "https://gitlab.inria.fr/melissa/melissa/-/archive/v2.0.0/melissa-v2.0.0.tar.gz"
+    maintainers("abhishek1297", "viperML", "raffino")
 
     license("BSD-3-Clause")
 
-    version("develop", branch="develop", preferred=True)
-    version("joss", tag="JOSS_v2", commit="20bbe68c1a7b73aa2ea3ad35681c332c7a5fc516")
-    version("sc23", tag="SC23", commit="8bb5b6817d4abe4eaa5893552d711150e53535f3")
+    version("2.0.0", sha256="75957d1933cd9c228a6e8643bc855587162c31f3b0ca94c3f5e0e380d01775dd", preferred=True)
+    version("develop", branch="develop")
+
+    # ====================================DEPRECATED VERSIONS=========================================
+    version(
+        "joss", tag="JOSS_v2", commit="20bbe68c1a7b73aa2ea3ad35681c332c7a5fc516", deprecated=True
+    )
+    version("sc23", tag="SC23", commit="8bb5b6817d4abe4eaa5893552d711150e53535f3", deprecated=True)
+    # ================================================================================================
 
     # define variants for the deep learning server (torch, tf)
     variant(
         "torch", default=False, description="Install Deep Learning requirements with Pytorch only"
     )
     variant(
-        "tf", default=False, description="Install Deep Learning requirements with TensorFlow only"
+        "tf",
+        default=True,
+        when="~torch",
+        description="Install Deep Learning requirements with TensorFlow only",
     )
-
+    # ==============================
+    #       Base dependencies
+    # ==============================
     depends_on("c", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
-    depends_on("python@3.8.0:", type=("build", "run"))
-    depends_on("py-setuptools@46.4:", type=("build"))
-    # requirements.txt (SA)
+    depends_on("python@3.9:3.12", type=("build", "run"))
+    depends_on("py-setuptools@46.4:", type="build")
     depends_on("py-pyzmq@22.3.0:", type="run")
-    depends_on("py-mpi4py@3.1.3:", when="@develop,joss", type="run")
-    depends_on("py-mpi4py@3.1.3", when="@sc23", type="run")
-    depends_on("py-numpy@1.21:", type="run")
+    depends_on("py-mpi4py@3.1.3:3", type="run")
+    depends_on("py-numpy@1.21:1", type="run")
     depends_on("py-jsonschema@4.5:", type="run")
-    depends_on("py-python-rapidjson@1.8:", when="@develop,joss", type="run")
-    depends_on("py-python-rapidjson@1.9:", when="@sc23", type="run")
-    depends_on("py-scipy@1.10.0:", type="run")
+    depends_on("py-python-rapidjson@1.8:", type="run")
+    depends_on("py-scipy@1.10.0:1", type="run")
     depends_on("py-plotext@5.2.8:", type="run")
-    depends_on("py-cloudpickle@2.2.0:", type="run", when="@develop,joss")
-    depends_on("py-iterative-stats@0.1.0", type="run", when="@develop")
-    depends_on("py-iterative-stats@0.0.4", type="run", when="@joss")
-    # requirements_deep_learning.txt (DL with torch)
-    depends_on("py-tensorboard@2.10.0:", type="run", when="+torch")
-    depends_on("py-matplotlib", type="run", when="+torch")
-    depends_on("py-torch@1.12.1:", type="run", when="+torch")
-    depends_on("py-python-hostlist", type="run", when="@sc23+torch")
-    # requirements_deep_learning.txt  (DL with tensorflow)
-    depends_on("py-tensorboard@2.10.0:", type="run", when="+tf")
-    depends_on("py-matplotlib", type="run", when="+tf")
-    depends_on("py-tensorflow@2.8.0:", type="run", when="+tf")
-    conflicts("@sc23", when="+tf", msg="tensorflow is only supported with newer versions")
+    depends_on("py-cloudpickle@2.2.0:", type="run")
+    depends_on("py-iterative-stats@0.1:", type="run")
+    depends_on("py-psutil@5:", type="run")
+    # ==============================
+    #       DL dependencies
+    # ==============================
+    for framework in ["+tf", "+torch"]:
+        conflicts(
+            "%gcc@:9",
+            when=framework,
+            msg=f"GCC must be greater than version 9 when using {framework}",
+        )
+        depends_on("py-tensorboard@2.10.0:2", type="run", when=framework)
+        depends_on("py-matplotlib", type="run", when=framework)
+        depends_on("py-pandas", type="run", when=framework)
+        # WARNING: If using a gcc compiler, then support with AVX512-VNNI is
+        # expected for bazel source builds.
+        # The instruction set comes with binutils. If you are installing a gcc
+        # through spack then do spack install `gcc+binutils`
+        depends_on("binutils@2.29:", type="build", when=f"{framework} %gcc")
+
+    # WARNING: do not change the upper limit for tensorflow beyond 2.17, which requires
+    # AVX-VNNI-INT8 support.
+    # Check cpu flags to ensure if avxvnniint8 is available on your machine,
+    # if you want to increase the upper limit.
+    depends_on("py-tensorflow@2.8.0:2.17 ~cuda", type="run", when="+tf ~cuda")
+    depends_on("py-torch@1.12.1:2.6 ~cuda", type="run", when="+torch ~cuda")
+
+    # ==============================
+    #       CUDA dependencies
+    # ==============================
+    for arch in CudaPackage.cuda_arch_values:
+        # Support beyond ampere (A100) GPUs hasn't been tested yet.
+        # FIXME: free to modify and test
+        if arch.isdigit() and 60 <= int(arch) <= 80:
+            cuda_specs = f"+cuda cuda_arch={arch}"
+            depends_on(f"nccl {cuda_specs}", when=cuda_specs)  # it is set by default
+            depends_on(
+                f"py-tensorflow@2.8.0:2.17 {cuda_specs}", type="run", when=f"+tf {cuda_specs}"
+            )
+            depends_on(
+                f"py-torch@1.12.1:2.6 {cuda_specs}", type="run", when=f"+torch {cuda_specs}"
+            )
+        else:
+            conflicts(
+                f"+cuda cuda_arch={arch}",
+                msg="Support beyond Ampere GPUs has not been tested yet. "
+                "Accepted values are between 60 and 80 inclusive.",
+            )


### PR DESCRIPTION
> [!NOTE]
> This PR was migrated from **https://github.com/spack/spack/pull/49258**.

### Updates
- Updated maintainers
- Deprecated all versions `melissa-api` package. This is no longer needed.
- Updated dependencies and versions (new v2.0.0)
- Support for cuda with `torch` and `tensorflow`
- Only keeping the `develop` version

Now, Melissa altogether requires only `melissa` and `py-melissa-core` packages to work.