### PR TITLE
exawind: changes to packages for new timestep dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/amr_wind/package.py
+++ b/repos/spack_repo/builtin/packages/amr_wind/package.py
@@ -25,6 +25,9 @@ class AmrWind(CMakePackage, CudaPackage, ROCmPackage):
 
     version("main", branch="main", submodules=True)
     version(
+        "3.5.0", tag="v3.5.0", commit="412f015f2496cb0c0c802240bb9c11848b408fa0", submodules=True
+    )
+    version(
         "3.4.2", tag="v3.4.2", commit="ed475a0533dfacf1fdff0b707518ccf99040d9f9", submodules=True
     )
     version(

--- a/repos/spack_repo/builtin/packages/exawind/package.py
+++ b/repos/spack_repo/builtin/packages/exawind/package.py
@@ -80,6 +80,8 @@ class Exawind(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("mpi")
     depends_on("nalu-wind+gpu-aware-mpi", when="+gpu-aware-mpi")
     depends_on("amr-wind+gpu-aware-mpi", when="+gpu-aware-mpi")
+    depends_on("nalu-wind@2.3:", when="@2:")
+    depends_on("amr-wind@3.5:", when="@2:")
     depends_on("nalu-wind@2.0.0:", when="@1.0.0:")
     depends_on("amr-wind@0.9.0:", when="@1.0.0:")
     depends_on("tioga@1.0.0:", when="@1.0.0:")

--- a/repos/spack_repo/builtin/packages/exawind/package.py
+++ b/repos/spack_repo/builtin/packages/exawind/package.py
@@ -23,6 +23,9 @@ class Exawind(CMakePackage, CudaPackage, ROCmPackage):
 
     version("master", branch="main", submodules=True)
     version(
+        "2.0.0", tag="v2.0.0", commit="d25aa549c7cbd9d6213541cd4b046bd9c0c54652", submodules=True
+    )
+    version(
         "1.2.0", tag="v1.2.0", commit="4c49c7775c580b6bd2556e6c00fd13c08737d5eb", submodules=True
     )
     version(

--- a/repos/spack_repo/builtin/packages/nalu_wind/package.py
+++ b/repos/spack_repo/builtin/packages/nalu_wind/package.py
@@ -29,6 +29,9 @@ class NaluWind(CMakePackage, CudaPackage, ROCmPackage):
 
     version("master", branch="master", submodules=True)
     version(
+        "2.3.0", tag="v2.3.0", commit="94cea346455f6841c8ce28d54c6d894bbf5e9a0a", submodules=True
+    )
+    version(
         "2.2.2", tag="v2.2.2", commit="6e98cb004e5cc2dcb60d09b155182a7095007c8e", submodules=True
     )
     version(


### PR DESCRIPTION
> [!NOTE]
> This PR was migrated from **https://github.com/spack/spack/pull/50723**.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Incorporating adaptive timestepping introduces new version dependencies within the exawind stack.