### PR TITLE
podman: add macOS support and v5

### DIFF
--- a/repos/spack_repo/builtin/packages/gvproxy/package.py
+++ b/repos/spack_repo/builtin/packages/gvproxy/package.py
@@ -1,0 +1,25 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
+
+from spack.package import *
+
+
+class Gvproxy(MakefilePackage):
+    """A new network stack based on gVisor."""
+
+    homepage = "https://github.com/containers/gvisor-tap-vsock"
+    url = "https://github.com/containers/gvisor-tap-vsock/archive/refs/tags/v0.8.6.tar.gz"
+
+    license("Apache-2.0", checked_by="cmelone")
+
+    version("0.8.6", sha256="eb08309d452823ca7e309da2f58c031bb42bb1b1f2f0bf09ca98b299e326b215")
+
+    depends_on("go@1.23.0:", type="build")
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        make("gvproxy")
+        install("bin/gvproxy", prefix.bin)

--- a/repos/spack_repo/builtin/packages/passt/package.py
+++ b/repos/spack_repo/builtin/packages/passt/package.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
 from spack.package import *
 
@@ -16,7 +15,11 @@ class Passt(MakefilePackage):
 
     license("GPL-2.0-or-later", checked_by="cmelone")
 
-    version("2025_01_21.4f2c8e7", sha256="c4e23a965db3a22776b89c8cef9a2cd66df04db5f1462f0f36ef499c70d2e607", url="https://passt.top/passt/snapshot/passt-2025_01_21.4f2c8e7.tar.gz")
+    version(
+        "2025_01_21.4f2c8e7",
+        sha256="1f3dc31502b4fa7c997c9f029e2472b7055bdee956f49551f4187fc75b7cbe13",
+        url="https://passt.top/passt/snapshot/passt-2025_01_21.4f2c8e7.tar.gz",
+    )
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/repos/spack_repo/builtin/packages/passt/package.py
+++ b/repos/spack_repo/builtin/packages/passt/package.py
@@ -13,11 +13,10 @@ class Passt(MakefilePackage):
     virtual machines in user-mode without requiring any capabilities or privileges."""
 
     homepage = "https://passt.top"
-    git = "https://passt.top/passt"
 
-    license("GPL-2.0-or-later AND BSD-3-Clause", checked_by="cmelone")
+    license("GPL-2.0-or-later", checked_by="cmelone")
 
-    version("2025_01_21.4f2c8e7", tag="2025_01_21.4f2c8e7")
+    version("2025_01_21.4f2c8e7", sha256="c4e23a965db3a22776b89c8cef9a2cd66df04db5f1462f0f36ef499c70d2e607", url="https://passt.top/passt/snapshot/passt-2025_01_21.4f2c8e7.tar.gz")
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/repos/spack_repo/builtin/packages/passt/package.py
+++ b/repos/spack_repo/builtin/packages/passt/package.py
@@ -4,6 +4,7 @@
 
 
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
+
 from spack.package import *
 
 

--- a/repos/spack_repo/builtin/packages/passt/package.py
+++ b/repos/spack_repo/builtin/packages/passt/package.py
@@ -1,0 +1,26 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
+from spack.package import *
+
+
+class Passt(MakefilePackage):
+    """Passt provides full, quasi-native network connectivity to
+    virtual machines in user-mode without requiring any capabilities or privileges."""
+
+    homepage = "https://passt.top"
+    git = "https://passt.top/passt"
+
+    license("GPL-2.0-or-later AND BSD-3-Clause", checked_by="cmelone")
+
+    version("2025_01_21.4f2c8e7", tag="2025_01_21.4f2c8e7")
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        make()
+        install("passt", prefix.bin)
+        install("pasta", prefix.bin)

--- a/repos/spack_repo/builtin/packages/podman/package.py
+++ b/repos/spack_repo/builtin/packages/podman/package.py
@@ -2,12 +2,12 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import sys
+
 from spack_repo.builtin.build_systems.generic import Package
 
-from spack.package import *
-
-import sys
 from spack.operating_systems.mac_os import macos_version
+from spack.package import *
 
 _is_macos = sys.platform == "darwin"
 

--- a/repos/spack_repo/builtin/packages/podman/package.py
+++ b/repos/spack_repo/builtin/packages/podman/package.py
@@ -6,6 +6,33 @@ from spack_repo.builtin.build_systems.generic import Package
 
 from spack.package import *
 
+import sys
+from spack.operating_systems.mac_os import macos_version
+
+_is_macos = sys.platform == "darwin"
+
+
+def write_containers_conf(pkg_obj, dep_names):
+    """
+    writes podman runtime dependency paths to containers.conf
+    args:
+        pkg_obj: the self object during the install() phase
+        dep_names (list): strings of the dependencies to add to the config
+    """
+
+    # podman requires its runtime deps to be in a configured directory
+    # https://github.com/containers/common/blob/main/docs/containers.conf.5.md
+    # we choose the user-friendly option of CONTAINERS_CONF_OVERRIDE, which respects
+    # existing configurations set by the user
+    helper_dirs = ", ".join(f'"{x}"' for x in [pkg_obj.spec[dep].prefix.bin for dep in dep_names])
+
+    config = f"""
+    [engine]
+    helper_binaries_dir=[{helper_dirs}]
+    """
+
+    with open(join_path(pkg_obj.prefix, "containers.conf"), "w") as f:
+        f.write(config)
 
 class Podman(Package):
     """An optionally rootless and daemonless container engine: alias docker=podman"""
@@ -16,6 +43,7 @@ class Podman(Package):
 
     license("Apache-2.0")
 
+    version("5.5.1", sha256="00d02f85ad27a46e77456fef1be81865a43147544ed2487e6c4c8decd0e3748f")
     version("4.9.3", sha256="37afc5bba2738c68dc24400893b99226c658cc9a2b22309f4d7abe7225d8c437")
     version("4.8.3", sha256="3a99b6c82644fa52929cf4143943c63d6784c84094892bc0e14197fa38a1c7fa")
     version("4.7.2", sha256="10346c5603546427bd809b4d855d1e39b660183232309128ad17a64969a0193d")
@@ -27,24 +55,66 @@ class Podman(Package):
 
     depends_on("c", type="build")  # generated
 
+    requires(
+        "@5.5.1:",
+        when="platform=darwin",
+        msg="podman for macOS is only supported on version 5.5.1 and above.",
+    )
+
+    # see https://github.com/containers/podman/issues/22121
+    if _is_macos and macos_version() < Version("13"):
+        raise InstallError("podman for macOS requires Ventura or later")
+
     # See <https://github.com/containers/podman/issues/16996> for the
     # respective issue and the suggested patch
     # issue was fixed as of 4.4.0
     patch("markdown-utf8.diff", when="@4:4.3.1")
 
+    depends_on("go@1.23.3:", type="build", when="@5.5.1:")
     depends_on("go", type="build")
     depends_on("go-md2man", type="build")
-    depends_on("pkgconfig", type="build")
-    depends_on("cni-plugins", type="run")
-    depends_on("conmon", type="run")
-    depends_on("runc", type="run")
-    depends_on("slirp4netns", type="run")
-    depends_on("gpgme")
-    depends_on("libassuan")
-    depends_on("libgpg-error")
-    depends_on("libseccomp")
     depends_on("gmake", type="build")
 
+    with when("platform=linux"):
+        depends_on("pkgconfig", type="build")
+        depends_on("cni-plugins", type="run")
+        depends_on("conmon", type="run")
+        depends_on("runc", type="run")
+        depends_on("slirp4netns", type="run")
+        depends_on("passt", type="run", when="@5.5.1:")
+        depends_on("gpgme")
+        depends_on("libassuan")
+        depends_on("libgpg-error")
+        depends_on("libseccomp")
+
+    with when("platform=darwin"):
+        # for context on the dependencies (strictness of version constraints), see
+        # https://github.com/containers/podman/blob/#{version}/contrib/pkginstaller/Makefile
+        # via https://github.com/Homebrew/homebrew-core/blob/master/Formula/p/podman.rb
+        # the gvproxy constraint is listed at podman/go.mod --> gvisor-tap-vsock
+        depends_on("gvproxy@0.8.6", type="run", when="@5.5.1")
+        depends_on("vfkit@0.6.1", type="run", when="@5.5.1")
+
+
+    @when("@5.5.1:")
+    def setup_run_environment(self, env):
+        # sets configuration for runtime dependencies
+        # needs to be set any time a user loads the package
+        env.set("CONTAINERS_CONF_OVERRIDE", join_path(self.prefix, "containers.conf"))
+
+    @when("platform=darwin")
+    def install(self, spec, prefix):
+        # macos-specific installation
+        # ported from the homebrew formula
+        mkdirp(prefix.bin)
+        make("podman-remote")
+        make("podman-mac-helper")
+        install("bin/darwin/podman", prefix.bin)
+        install("bin/darwin/podman-mac-helper", prefix.bin)
+
+        write_containers_conf(self, ["gvproxy", "vfkit"])
+
+    @when("platform=linux")
     def patch(self):
         defs = FileFilter("vendor/github.com/containers/common/pkg/config/default.go")
 
@@ -75,6 +145,7 @@ class Podman(Package):
             r"/usr", self.prefix, "vendor/github.com/containers/common/pkg/config/config.go"
         )
 
+    @when("platform=linux")
     def install(self, spec, prefix):
         # Set default policy.json to be located in the install prefix (documented)
         env["EXTRA_LDFLAGS"] = (
@@ -84,7 +155,7 @@ class Podman(Package):
         )
         # Build and installation needs to be in two separate make calls
         # The devicemapper and btrfs drivers are (so far) not enabled in this recipe
-        tags = "seccomp exclude_graphdriver_devicemapper exclude_graphdriver_btrfs"
+        tags = "seccomp exclude_graphdriver_devicemapper exclude_graphdriver_btrfs cni"
         make("-e", "BUILDTAGS=" + tags)
         make("install", "PREFIX=" + prefix)
         # Install an initial etc/containers/policy.json (configured in prefix above)
@@ -93,3 +164,7 @@ class Podman(Package):
         # Cleanup directory trees which are created as part of the go build process
         remove_linked_tree(prefix.src)
         remove_linked_tree(prefix.pkg)
+
+        # passt becomes a dep on newer versions of podman
+        if spec.satisfies("@5.5.1:"):
+            write_containers_conf(self, ["passt"])

--- a/repos/spack_repo/builtin/packages/podman/package.py
+++ b/repos/spack_repo/builtin/packages/podman/package.py
@@ -34,6 +34,7 @@ def write_containers_conf(pkg_obj, dep_names):
     with open(join_path(pkg_obj.prefix, "containers.conf"), "w") as f:
         f.write(config)
 
+
 class Podman(Package):
     """An optionally rootless and daemonless container engine: alias docker=podman"""
 
@@ -94,7 +95,6 @@ class Podman(Package):
         # the gvproxy constraint is listed at podman/go.mod --> gvisor-tap-vsock
         depends_on("gvproxy@0.8.6", type="run", when="@5.5.1")
         depends_on("vfkit@0.6.1", type="run", when="@5.5.1")
-
 
     @when("@5.5.1:")
     def setup_run_environment(self, env):

--- a/repos/spack_repo/builtin/packages/runc/package.py
+++ b/repos/spack_repo/builtin/packages/runc/package.py
@@ -16,6 +16,7 @@ class Runc(MakefilePackage):
 
     license("Apache-2.0")
 
+    version("1.3.0", sha256="f2f799a1000e16cc37776fae1745f2a302633fad94dd52de9bece83df8dc4b4e")
     version("1.1.13", sha256="d20e76688ce0681dc687369e18b47aeffcfdac5184c978befa7ce5da35e797fe")
     version("1.1.6", sha256="548506fc1de8f0a4790d8e937eeede17db4beb79c53d66acb4f7ec3edbc31668")
     version("1.1.4", sha256="9f5972715dffb0b2371e4d678c1206cc8c4ec5eb80f2d48755d150bac49be35b")
@@ -23,6 +24,7 @@ class Runc(MakefilePackage):
 
     depends_on("c", type="build")  # generated
 
+    depends_on("go@1.23.0:", type="build", when="@1.3.0:")
     depends_on("go", type="build")
     depends_on("go-md2man", type="build")
     depends_on("pkgconfig", type="build")

--- a/repos/spack_repo/builtin/packages/vfkit/package.py
+++ b/repos/spack_repo/builtin/packages/vfkit/package.py
@@ -4,7 +4,6 @@
 
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
 
-
 from spack.package import *
 
 

--- a/repos/spack_repo/builtin/packages/vfkit/package.py
+++ b/repos/spack_repo/builtin/packages/vfkit/package.py
@@ -1,0 +1,28 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
+
+
+from spack.package import *
+
+
+class Vfkit(MakefilePackage):
+    """Simple command line tool to start VMs through the macOS Virtualization framework."""
+
+    homepage = "https://github.com/crc-org/vfkit"
+    url = "https://github.com/crc-org/vfkit/archive/refs/tags/v0.6.1.tar.gz"
+
+    license("Apache-2.0", checked_by="cmelone")
+
+    version("0.6.1", sha256="e35b44338e43d465f76dddbd3def25cbb31e56d822db365df9a79b13fc22698c")
+
+    depends_on("go@1.23.0:", type="build")
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        env["CGO_ENABLED"] = "1"
+        env["CGO_CFLAGS"] = "-mmacosx-version-min=11.0"
+        make("out/vfkit")
+        install("out/vfkit", prefix.bin)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Adds macOS-specific logic for installing Podman. The [Homebrew formula](https://github.com/Homebrew/homebrew-core/blob/1e395560e93baa944df8099c9cbafd3642d487b7/Formula/p/podman.rb) was super helpful.

This PR also adds the following dependencies as packages:
- vfkit
- passt
- gvproxy

migrated from https://github.com/spack/spack/pull/50015

test on sequoia:
```
podman machine init
podman machine start
podman run -ti node:16-buster-slim
```

test on linux:
```
# tested with specs
spack install podman@5.5.1
spack install podman@4.9.3

# make sure you're running the container on tmpfs /non-NFS
podman run -ti node:16-buster-slim