### PR TITLE
spack blame: add equivalent ignore revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# .git-blame-ignore-revs
+# Formatted entire codebase with black 23
+45b292f8f26f2cf272065ff08587d5bdb39291f1
+# Formatted entire codebase with black 22
+b1457e0808d9f8da46a2f1ccc158c40d1ee1ae18


### PR DESCRIPTION
depends on https://github.com/spack/spack/pull/50877

This PR adds the equivalent commits to Spack's https://github.com/spack/spack/blob/develop/.git-blame-ignore-revs for `spack blame` to pick up in the package repository.

The differences in output with and without this file are shown in the above PR.