### PR TITLE
data-vis-sdk: modify pipeline to shorten concretization time

### DIFF
--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -488,6 +488,9 @@ radiuss-aws-aarch64-build:
 
 data-vis-sdk-generate:
   extends: [ ".data-vis-sdk", ".generate-x86_64"]
+  variables:
+    # Override concretization pool because of memory requests
+    SPACK_CONCRETIZE_JOBS: 2
   image: ghcr.io/spack/ubuntu20.04-runner-x86_64:2023-01-01
 
 data-vis-sdk-build:

--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -490,7 +490,7 @@ data-vis-sdk-generate:
   extends: [ ".data-vis-sdk", ".generate-x86_64"]
   variables:
     # Override concretization pool because of memory requests
-    SPACK_CONCRETIZE_JOBS: 2
+    SPACK_CONCRETIZE_JOBS: 3
   image: ghcr.io/spack/ubuntu20.04-runner-x86_64:2023-01-01
 
 data-vis-sdk-build:

--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -491,6 +491,7 @@ data-vis-sdk-generate:
   variables:
     # Override concretization pool because of memory requests
     SPACK_CONCRETIZE_JOBS: 2
+    KUBERNETES_MEMORY_REQUEST: 32G
   image: ghcr.io/spack/ubuntu20.04-runner-x86_64:2023-01-01
 
 data-vis-sdk-build:

--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -491,7 +491,6 @@ data-vis-sdk-generate:
   variables:
     # Override concretization pool because of memory requests
     SPACK_CONCRETIZE_JOBS: 2
-    KUBERNETES_MEMORY_REQUEST: 32G
   image: ghcr.io/spack/ubuntu20.04-runner-x86_64:2023-01-01
 
 data-vis-sdk-build:

--- a/.ci/gitlab/stacks/data-vis-sdk/spack.yaml
+++ b/.ci/gitlab/stacks/data-vis-sdk/spack.yaml
@@ -8,6 +8,16 @@ spack:
       target: ["x86_64_v3"]
       require:
       - target=x86_64_v3
+    c:
+      require:
+      - gcc@11
+    cxx:
+      require:
+      - gcc@11
+    fortran:
+      require:
+        - gcc@11
+
     cmake:
       variants: ~ownlibs
     ecp-data-vis-sdk:

--- a/.ci/gitlab/stacks/data-vis-sdk/spack.yaml
+++ b/.ci/gitlab/stacks/data-vis-sdk/spack.yaml
@@ -42,9 +42,8 @@ spack:
       - "@3.4.1"
       - target=x86_64_v3
 
-
   concretizer:
-    unify: when_possible
+    unify: false
 
   definitions:
   - paraview_specs:

--- a/repos/spack_repo/builtin/packages/ecp_data_vis_sdk/package.py
+++ b/repos/spack_repo/builtin/packages/ecp_data_vis_sdk/package.py
@@ -58,10 +58,6 @@ def dav_sdk_depends_on(spec, when=None, propagate=None):
             depends_on("{0} {1}".format(spec, v_then), when="{0} {1}".format(base_variant, v_when))
 
 
-def exclude_variants(variants, exclude):
-    return [variant for variant in variants if variant not in exclude]
-
-
 class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
     """ECP Data & Vis SDK"""
 


### PR DESCRIPTION
fixes https://github.com/spack/spack/issues/50891

Modifications:
- [x] Use `unify:false` for the pipeline. 
- [x] Force using just `gcc@11`
- [x] Clean some dead code from the `ecp-data-vis-sdk` recipe
- [x] Tweak parallelism due to memory requests of the `ecp-data-vis-sdk` package when concretizing


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
