### PR TITLE
kokkos-kernels: declare dependency on c/fortran when using tpl blas libraries

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
@@ -186,9 +186,9 @@ class KokkosKernels(CMakePackage, CudaPackage):
         description="Scalars",
     )
 
-    depends_on("c", type="build")
+    depends_on("cxx", type="build")
     for tpl in ("blas", "mkl"):
-        depends_on("cxx", type="build", when=f"+{tpl}")
+        depends_on("c", type="build", when=f"+{tpl}")
         depends_on("fortran", type="build", when=f"+{tpl}")
     depends_on("kokkos")
     depends_on("kokkos@master", when="@master")

--- a/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
@@ -186,7 +186,10 @@ class KokkosKernels(CMakePackage, CudaPackage):
         description="Scalars",
     )
 
-    depends_on("cxx", type="build")
+    depends_on("c", type="build")
+    for tpl in ("blas", "mkl"):
+        depends_on("cxx", type="build", when=f"+{tpl}")
+        depends_on("fortran", type="build", when=f"+{tpl}")
     depends_on("kokkos")
     depends_on("kokkos@master", when="@master")
     depends_on("kokkos@develop", when="@develop")


### PR DESCRIPTION
cf. https://github.com/kokkos/kokkos-kernels/blob/e94234855d50831e6ad4ed0d78777cc84ae3f3c8/cmake/kokkoskernels_tpls.cmake#L434-L436.

For some third-party libraries kokkos-kernels enables the CMake C and Fortran languages. kokkos-kernels currently fails to build with those libraries enabled.

In theory the dependencies should be added for magma and armpl as well, but those are not supported by the spack package yet, and I'm not planning to add support for those in this PR. Hence the dependencies are only added for `+blas` and `+mkl`.

CC @lucbv @srajama1 @brian-kelley 