### PR TITLE
Ipopt: fix spacing between mumps_flags when ^mumps~mpi

### DIFF
--- a/repos/spack_repo/builtin/packages/ipopt/package.py
+++ b/repos/spack_repo/builtin/packages/ipopt/package.py
@@ -103,7 +103,7 @@ class Ipopt(AutotoolsPackage):
             mumps_dir = spec["mumps"].prefix
             mumps_flags = "-ldmumps -lmumps_common -lpord"
             if "^mumps~mpi" in spec:
-                mumps_flags = mumps_flags + "-lmpiseq"
+                mumps_flags = mumps_flags + " -lmpiseq"
             mumps_libcmd = "-L%s " % mumps_dir.lib + mumps_flags
             if spec.satisfies("@:3.12.13"):
                 args.extend(


### PR DESCRIPTION
This fixes a bug encountered when trying to build Ipopt with ^mumps~mpi. The current version results in `-lpord-lmpiseq`, which is not found and should be `-lpord -lmpiseq`.
