### PR TITLE
cgns: patch for compiling with nvfortran

### DIFF
--- a/repos/spack_repo/builtin/packages/cgns/cgns-4.5-nvfortran.patch
+++ b/repos/spack_repo/builtin/packages/cgns/cgns-4.5-nvfortran.patch
@@ -1,0 +1,13 @@
+diff --git a/src/cgns_f.F90 b/src/cgns_f.F90
+index 25abe51..734c8bf 100644
+--- a/src/cgns_f.F90
++++ b/src/cgns_f.F90
+@@ -7753,7 +7753,7 @@ CONTAINS
+ 
+      INTERFACE
+          INTEGER(C_INT) FUNCTION  cg_particle_governing_write(ParticleEquationstype) &
+-               BIND(C, NAME=" cg_particle_governing_write")
++               BIND(C, NAME="cg_particle_governing_write")
+            IMPORT :: C_INT, CGENUM_T
+            IMPLICIT NONE
+            INTEGER(CGENUM_T), VALUE :: ParticleEquationstype

--- a/repos/spack_repo/builtin/packages/cgns/package.py
+++ b/repos/spack_repo/builtin/packages/cgns/package.py
@@ -85,6 +85,8 @@ class Cgns(CMakePackage):
     patch("gcc14.patch", when="@:4.4.0 %gcc@14:")
     # "wrong" include for spack (tk-private) from the patch above made it into the official version
     patch("cgns-4.5-tk-private.patch", when="@4.5.0")
+    # patch spurious space in function name (breaks nvfortran compilation)
+    patch("cgns-4.5-nvfortran.patch", when="@4.5.0 +fortran %nvhpc")
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
Fixes compiling with Fortran enabled and nvhpc (tested with nvhpc24.5)

There is a space in a `bind(C, name="...")` which shouldn't be there. Other Fortran compilers seem to be less critical about it.
(at least while compiling, I didn't check if they create a wrong function name that has a space in it!)