### PR TITLE
dla-future-fortran: add v0.5.0

### DIFF
--- a/repos/spack_repo/builtin/packages/dla_future_fortran/package.py
+++ b/repos/spack_repo/builtin/packages/dla_future_fortran/package.py
@@ -4,7 +4,6 @@
 
 # dlaf-no-license-check
 from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
-
 from spack.package import *
 
 
@@ -22,6 +21,7 @@ class DlaFutureFortran(CMakePackage):
     license("BSD-3-Clause")
 
     version("main", branch="main")
+    version("0.5.0", sha256="c62e37b785a86097a0e83e5373b78f59ea4f8d0b34592c9e743cab79c939eb42")
     version("0.4.0", sha256="1c42ed1a12b472ee02702c507a0a4fc94d2090701726ebc782b1b5e8278c8c5b")
     version("0.3.0", sha256="404ce0d2d3df9317764450158901fd6cb2198b37f5687e9616519100ad6e9ece")
     version("0.2.0", sha256="7fd3e1779c111b35f0d2701a024398b4f6e8dea4af523b6c8617d28c0b7ae61a")
@@ -42,6 +42,7 @@ class DlaFutureFortran(CMakePackage):
     depends_on("dla-future@0.6.0: +scalapack", when="@0.2.0:")
     depends_on("dla-future@0.7.3: +scalapack", when="@0.3:")
     depends_on("dla-future@0.9: +scalapack", when="@0.4:")
+    depends_on("dla-future@0.10: +scalapack", when="@0.5:")
     depends_on("dla-future +shared", when="+shared")
 
     depends_on("mpi", when="+test")


### PR DESCRIPTION
https://github.com/eth-cscs/DLA-Future-Fortran/releases/tag/v0.5.0