### PR TITLE
fmi4cpp: Adding missing C dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/fmi4cpp/package.py
+++ b/repos/spack_repo/builtin/packages/fmi4cpp/package.py
@@ -24,6 +24,7 @@ class Fmi4cpp(CMakePackage):
 
     variant("shared", default=True, description="Build shared library")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("libzip")
     depends_on("pugixml")


### PR DESCRIPTION
Build fails without the change:
```
spack/cc: line 401: SPACK_CC_LINKER_ARG: ERROR: LINKER ARG WAS NOT SET, MAYBE THE PACKAGE DOES NOT DEPEND ON CC?
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
