### PR TITLE
CI: Add TOOLS SDK

### DIFF
--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -505,6 +505,28 @@ data-vis-sdk-build:
       job: data-vis-sdk-generate
 
 ########################################
+# TOOLS SDK
+########################################
+.tools-sdk:
+  variables:
+    SPACK_CI_STACK_NAME: tools-sdk
+
+tools-sdk-generate:
+  extends: [ ".tools-sdk", ".generate-x86_64"]
+  image: ghcr.io/spack/ubuntu20.04-runner-x86_64:2023-01-01
+
+tools-sdk-build:
+  extends: [ ".tools-sdk", ".build" ]
+  trigger:
+    include:
+      - artifact: jobs_scratch_dir/tools-sdk/cloud-ci-pipeline.yml
+        job: tools-sdk-generate
+    strategy: depend
+  needs:
+    - artifacts: True
+      job: tools-sdk-generate
+
+########################################
 # Spack Tutorial
 ########################################
 .tutorial:

--- a/.ci/gitlab/stacks/tools-sdk/spack.yaml
+++ b/.ci/gitlab/stacks/tools-sdk/spack.yaml
@@ -1,0 +1,35 @@
+spack:
+  view: false
+
+  include:
+  # Include the SDK package configurations
+  # TODO: Tag this with a release
+  - path: https://raw.githubusercontent.com/tools-integration/tools-sdk/refs/heads/main/spack/configs/packages.yaml
+    sha256: 026634f98320690230b9160ac2af54d7fe9319a001e08736b7ea900834c4982d
+  - $CI_PROJECT_DIR/.ci/gitlab/
+
+  packages:
+    all:
+      require: target=x86_64_v3
+    cmake:
+      variants: ~ownlibs
+
+  concretizer:
+    unify: when_possible
+
+  specs:
+  - darshan-runtime
+  - darshan-util
+  - dyninst
+  - hpctoolkit
+  - papi
+  - tau
+
+  ci:
+    pipeline-gen:
+    - build-job:
+        image: ghcr.io/spack/ubuntu20.04-runner-x86_64:2023-01-01
+
+  cdash:
+    'build-group:': TOOLS SDK
+


### PR DESCRIPTION
This PR adds the Tools SDK stack to the Spack-packages CI. The Tools SDK is composed by the following packages:

  - darshan-runtime
  - darshan-util
  - dyninst
  - hpctoolkit
  - papi
  - tau
  