### PR TITLE
shadow: depends_on libxcrypt

### DIFF
--- a/repos/spack_repo/builtin/packages/shadow/package.py
+++ b/repos/spack_repo/builtin/packages/shadow/package.py
@@ -25,6 +25,7 @@ class Shadow(AutotoolsPackage):
     version("4.6", sha256="4668f99bd087399c4a586084dc3b046b75f560720d83e92fd23bf7a89dda4d31")
 
     depends_on("c", type="build")
+    depends_on("libxcrypt")
 
     def configure_args(self):
         # Fix build when libbsd is not installed on the host:


### PR DESCRIPTION
This PR adds to `shadow` the [dependency](https://github.com/shadow-maint/shadow/blob/master/configure.ac#L349) on `libxcrypt` to avoid
```
==> Warning: bin/chfn
        libcrypt.so.1 => not found
bin/chsh
        libcrypt.so.1 => not found
bin/gpasswd
        libcrypt.so.1 => not found
bin/login
        libcrypt.so.1 => not found
bin/newgrp
        libcrypt.so.1 => not found
bin/passwd
        libcrypt.so.1 => not found
bin/su
        libcrypt.so.1 => not found
lib/libsubid.so.5.0.0
        libcrypt.so.1 => not found
sbin/chgpasswd
        libcrypt.so.1 => not found
sbin/chpasswd
        libcrypt.so.1 => not found
sbin/newusers
        libcrypt.so.1 => not found
==> shadow: Successfully installed shadow-4.17.4-4452bs4tra5qapfwgraibhurcmd2vdox
```