### PR TITLE
zig: fix LLVM-19 dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/zig/package.py
+++ b/repos/spack_repo/builtin/packages/zig/package.py
@@ -39,6 +39,7 @@ class Zig(CMakePackage):
     depends_on("llvm@16", when="@0.11.0")
     depends_on("llvm@17", when="@0.12.0")
     depends_on("llvm@18", when="@0.13.0")
+    depends_on("llvm@19", when="@0.14.0")
 
     depends_on("git", type="build")
     depends_on("ccache")


### PR DESCRIPTION
The LLVM-19 dependency was missed in 912865a2ba1145c087c3d614fa11c535425e4ba8 .

According to the official Zig 0.14 docs, LLVM-19 is required. See https://github.com/ziglang/zig/blob/6d1f0eca773e688c802e441589495b7bde2f9e3f/README.md?plain=1#L50 .

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
