### PR TITLE
qt-*: add v6.9.1

### DIFF
--- a/repos/spack_repo/builtin/packages/qt_5compat/package.py
+++ b/repos/spack_repo/builtin/packages/qt_5compat/package.py
@@ -18,6 +18,7 @@ class Qt5compat(QtPackage):
 
     license("LicenseRef-Qt-Commercial OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only")
 
+    version("6.9.1", sha256="14a97fb93c342a6dcfff3bc827c7cdaff4dcb4853135aa7e391aa5df96fd7440")
     version("6.9.0", sha256="7c8fe0709d8efd758a788b1db47294ec1fb33387b11b4765e5ef98606aaa562c")
     version("6.8.3", sha256="67340c9c7a1d2007b593847363342c65570dc9e86edb6315226589dc4533e5ed")
     version("6.8.2", sha256="9b78a025f17d65eb826ee153f167546e6c12790235d75b7f4fcd03c166d9c689")

--- a/repos/spack_repo/builtin/packages/qt_base/package.py
+++ b/repos/spack_repo/builtin/packages/qt_base/package.py
@@ -149,6 +149,7 @@ class QtBase(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.9.1", sha256="487e49508b8b4bb74908882cde04d3473f2c783651c72c75ee4a2a4691788263")
     version("6.9.0", sha256="defc1b7e6a98f0093254126b1cd80681f1d2a170df127d60c6297358ced43090")
     version("6.8.3", sha256="cea5c8f2c20d9cbd684f8a402721e63b87a2886e906f6ec7e0f7e1ff69c83206")
     version("6.8.2", sha256="9dddbb2ea3c107e20a99b816c1c6ba1483915325918936dda2c762bd73836ad9")

--- a/repos/spack_repo/builtin/packages/qt_declarative/package.py
+++ b/repos/spack_repo/builtin/packages/qt_declarative/package.py
@@ -16,6 +16,7 @@ class QtDeclarative(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.9.1", sha256="00f09b210c7c4268646645baf39fa436563f1cfc232f12ce0b2d37f9bb83da94")
     version("6.9.0", sha256="b6ef116dba80badf1cf36efc111e164edc4dd7e47c568d5d35165c6e8bca2c5d")
     version("6.8.3", sha256="e5e0d67236bf0a436f0dda6363c7a31085c9a8147f92f817c3fa817186a5a151")
     version("6.8.2", sha256="1c29e98fac88f6d3b8a790248f4e6ad80439fe6e791116339d080e064ad8ae91")

--- a/repos/spack_repo/builtin/packages/qt_quick3d/package.py
+++ b/repos/spack_repo/builtin/packages/qt_quick3d/package.py
@@ -16,6 +16,7 @@ class QtQuick3d(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.9.1", sha256="127ea0306c5ca1a67d90b13c8d60a21b8e52ade007853bac7bcbf55af61ae0db")
     version("6.9.0", sha256="49c743ca41528787fb26057e603854c115a85efb3edb56977e49bf81ba3fada0")
     version("6.8.3", sha256="7a6d2087a5112b1d1bfe7455ae023418a2d5f6ef6d3d8de8ccdcef979a7cdd17")
     version("6.8.2", sha256="2901927d84fa3e55cd598575fa8a47dd97c770ed3c1893af9c9ee2aa167b7433")

--- a/repos/spack_repo/builtin/packages/qt_quicktimeline/package.py
+++ b/repos/spack_repo/builtin/packages/qt_quicktimeline/package.py
@@ -16,6 +16,7 @@ class QtQuicktimeline(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.9.1", sha256="b9e06d733003097fa72ec4987c44ef6967ff9e630770e8cb6763a65d20d97532")
     version("6.9.0", sha256="5945693d20ca9ab753ff2cb0324c2535b47db86072c6652b26d90f34f768c5e4")
     version("6.8.3", sha256="e2129c5a4301ba8c8805837f399178d24f9eeea1757fd14cb5053e6b8ea3f260")
     version("6.8.2", sha256="74050e1b87495a500b66d114ba2311e9d2feb5bdadb46979b6986aedf93cd97e")

--- a/repos/spack_repo/builtin/packages/qt_shadertools/package.py
+++ b/repos/spack_repo/builtin/packages/qt_shadertools/package.py
@@ -18,6 +18,7 @@ class QtShadertools(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.9.1", sha256="c2aafc1f28a59e69f19494211763948cc8f69f71d22fdbdbefd418e40c267b86")
     version("6.9.0", sha256="27bdda7abee92d6573e2b3ecc9113eb2f625a3ae952693d6cfc45c4062987ec9")
     version("6.8.3", sha256="b6c6cf0006476a219f8f3494ae0f356c8ca98cdd6be43dd9b105d7bea17d0ea0")
     version("6.8.2", sha256="13d62df354ca2ca034d8a28263ee67104a6d94f5671417152556eb5eb3d64839")

--- a/repos/spack_repo/builtin/packages/qt_svg/package.py
+++ b/repos/spack_repo/builtin/packages/qt_svg/package.py
@@ -18,6 +18,7 @@ class QtSvg(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.9.1", sha256="4b6b98dde835263a344c5bd696c3aae36f20239daaf42a3b38057dc85c739085")
     version("6.9.0", sha256="2f58d8c021b3d221204c1f623f84a6ba5f69d5fcdf9bd26b8c2da2934cf90444")
     version("6.8.3", sha256="fb53da582e98d23cbf6e8bedb71efb60720e61a982d31a741742c543e2f3838d")
     version("6.8.2", sha256="b2d1f8acc7471658c963cacf8dc99912fd20e7072b3bdf7a53ccf99ba41788e8")

--- a/repos/spack_repo/builtin/packages/qt_tools/package.py
+++ b/repos/spack_repo/builtin/packages/qt_tools/package.py
@@ -48,7 +48,6 @@ class QtTools(QtPackage):
     depends_on("qt-base +network")
     depends_on("qt-base +widgets", when="+designer")
 
-    depends_on("llvm +clang")
     depends_on("zstd@1.3:", when="+designer")
 
     for _v in QtBase.versions:
@@ -70,8 +69,9 @@ class QtTools(QtPackage):
 
         if spec.satisfies("+designer"):
             define("FEATURE_designer", True)
-            define("FEATURE_zstd", False)
+            define("FEATURE_zstd", True)
         else:
             define("FEATURE_designer", False)
+            define("FEATURE_zstd", False)
 
         return args

--- a/repos/spack_repo/builtin/packages/qt_tools/package.py
+++ b/repos/spack_repo/builtin/packages/qt_tools/package.py
@@ -20,6 +20,7 @@ class QtTools(QtPackage):
     license("BSD-3-Clause")
 
     # src/assistant/qlitehtml is a submodule that is not in the git archive
+    version("6.9.1", commit="9e8f157b49c78c05abf8fa87da21e04cdf09780c", submodules=True)
     version("6.9.0", commit="087e300bf286aaee92682d828ee0bd622e00d52a", submodules=True)
     version("6.8.3", commit="2649ea1aa5cc1c23bd920ae94dd50071315ea30f", submodules=True)
     version("6.8.2", commit="8aa2456d4461516f54c98916fcd699557afb41ad", submodules=True)
@@ -47,6 +48,9 @@ class QtTools(QtPackage):
     depends_on("qt-base +network")
     depends_on("qt-base +widgets", when="+designer")
 
+    depends_on("llvm +clang")
+    depends_on("zstd@1.3:", when="+designer")
+
     for _v in QtBase.versions:
         v = str(_v)
         depends_on("qt-base@" + v, when="@" + v)
@@ -61,8 +65,13 @@ class QtTools(QtPackage):
 
         if spec.satisfies("+assistant"):
             define("FEATURE_assistant", True)
+        else:
+            define("FEATURE_assistant", False)
 
         if spec.satisfies("+designer"):
             define("FEATURE_designer", True)
+            define("FEATURE_zstd", False)
+        else:
+            define("FEATURE_designer", False)
 
         return args


### PR DESCRIPTION
This PR adds the Qt6.9.1 release, https://www.qt.io/blog/qt-6.9.1-released. No changes to dependencies.

Diffs:
- https://github.com/qt/qt5compat/compare/v6.9.0...v6.9.1
- https://github.com/qt/qtbase/compare/v6.9.0...v6.9.1
- https://github.com/qt/qtdeclarative/compare/v6.9.0...v6.9.1
- https://github.com/qt/qtquick3d/compare/v6.9.0...v6.9.1
- https://github.com/qt/qtquicktimeline/compare/v6.9.0...v6.9.1
- https://github.com/qt/qtshadertools/compare/v6.9.0...v6.9.1
- https://github.com/qt/qtsvg/compare/v6.9.0...v6.9.1
- https://github.com/qt/qttools/compare/v6.9.0...v6.9.1