### PR TITLE
node-js: add v24.2.0

### DIFF
--- a/repos/spack_repo/builtin/packages/node_js/package.py
+++ b/repos/spack_repo/builtin/packages/node_js/package.py
@@ -24,6 +24,7 @@ class NodeJs(Package):
     license("Unicode-TOU")
 
     # Current (latest features) - odd major number
+    version("23.11.1", sha256="75509306732090bfa99b004d097909315f7789badb4a495e82b5f17b6329247a")
     version("21.7.3", sha256="ce1f61347671ef219d9c2925313d629d3fef98fc8d7f5ef38dd4656f7d0f58e7")
     version("19.2.0", sha256="aac9d1a366fb57d68f4639f9204d1de5d6387656959a97ed929a5ba9e62c033a")
     version("17.9.1", sha256="1102f5e0aafaab8014d19c6c57142caf2ba3ef69d88d7a7f0f82798051796027")
@@ -39,10 +40,11 @@ class NodeJs(Package):
 
     # LTS (recommended for most users) - even major number
     version(
-        "22.16.0",
-        sha256="108f250ff79cc103b464b3ef41fa60f4866e4e6c962117171adaac7325ebdab2",
+        "24.2.0",
+        sha256="da739aedc45729436587cda9f063b28c1d881a32ba149b0a2f4e8aff55a18929",
         preferred=True,
     )
+    version("22.16.0", sha256="108f250ff79cc103b464b3ef41fa60f4866e4e6c962117171adaac7325ebdab2")
     version("20.18.3", sha256="eba088fa562735140b283c7bb33f53e026ccd5febe68c52c5737ef6e577ec874")
     version("20.18.2", sha256="cf3ef49fafbfee3cdcd936a0d6031341b73bfa6b26a484ea0a4936c26d24b829")
     version("20.18.1", sha256="5bad8ced873eef3b32e7daee703156bce9224920ac6044f4232f5393df0628b8")
@@ -131,6 +133,8 @@ class NodeJs(Package):
     depends_on("python@:3.11", when="@21.0.0:21.1.0", type="build")
     depends_on("python@:3.12", when="@21.2.0:22.2.0", type="build")
     depends_on("python@:3.13", when="@22.3.0:22.16.0", type="build")
+    depends_on("python@3.8:3.13", when="@23.0.0:23", type="build")
+    depends_on("python@3.9:3.13", when="@24.3.0:24", type="build")
 
     depends_on("libtool", type="build", when=sys.platform != "darwin")
     depends_on("pkgconfig", type="build")


### PR DESCRIPTION
This PR adds `node-js`, v24.2.0, and makes it preferred.
