### PR TITLE
Add actions/stale to GitHub actions

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,40 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    # Run every day at 2:39 UTC
+    - cron: '39 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639
+        with:
+          # Issues configuration
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had 
+            recent activity in the last 6 months. It will be closed if no further activity occurs.
+            Thank you for your contributions.
+          close-issue-message: |
+            This issue was closed because it has been stalled for 30 days with no activity.
+          stale-issue-label: 'stale'
+          exempt-issue-labels: 'pinned,bug'
+
+          # Pull requests configuration
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had 
+            recent activity in the last 6 months. It will be closed if no further activity occurs.
+            Thank you for your contributions.
+          close-pr-message: |
+            This pull request was closed because it has been stalled for 30 days with no activity.
+          stale-pr-label: 'stale'
+          exempt-pr-labels: 'pinned'
+
+          # General configuration
+          ascending: true
+          operations-per-run: 30
+          remove-stale-when-updated: true
+          enable-statistics: true
+          days-before-stale: 180
+          days-before-close: 30


### PR DESCRIPTION
As voted in November 2024 by the steering committee, add actions/stale and:
- [x] Wait 6 months before marking an issue / PR as stale
- [x] Wait an additional month before closing it

Issues / PRs labeled as "pinned", or "bug", are exempted from stalebot checks.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
