### PR TITLE
geomodel: add v6.11.0 through v6.14.0

### DIFF
--- a/.ci/gitlab/stacks/hep/spack.yaml
+++ b/.ci/gitlab/stacks/hep/spack.yaml
@@ -89,7 +89,7 @@ spack:
   - geant4 ~vtk ^[virtuals=qmake] qt
   - geant4 ~vtk ^[virtuals=qmake] qt-base
   #- genie +atmo
-  - geomodel +examples +fullsimlight +geomodelg4 +hepmc3 +pythia +tools +visualization
+  - geomodel +examples +fullsimlight +geomodelg4 +hepmc3 +pythia +tools ~visualization
   - hepmc
   - hepmc3 +interfaces +protobuf +python +rootio
   #- herwig3 +njet +vbfnlo  # Note: herwig3 fails to find evtgen

--- a/repos/spack_repo/builtin/packages/geomodel/package.py
+++ b/repos/spack_repo/builtin/packages/geomodel/package.py
@@ -19,6 +19,11 @@ class Geomodel(CMakePackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    version("6.14.0", sha256="b294f624145f922efd1da4016b79e698cabb0034cc6791841648d7845fd9fb15")
+    version("6.13.0", sha256="8f1ebfe7fb502af078ed535410160becca2eb81286b94154b43c89873a3c45ad")
+    version("6.12.0", sha256="4fa32672c6cb3d9b89ddf5e9566d0c283e5769768db6236883d72fecdd6207cd")
+    version("6.11.1", sha256="f7b47ff4ed264e1bfb013e6cdb724e7532109f1d58ab5774656e6ff871afb362")
+    version("6.11.0", sha256="fc9fdd7d64b623586089949d9790182dcd93ebb35a05198c91eac8adbbbfd778")
     version("6.10.0", sha256="968a0f7c8108b14f22041ca0c6ae8a3293175131c6f61055527ecdefe8c7839a")
     version("6.9.0", sha256="ea34dad8a0cd392e06794b8a1b7407dd6ad617fefd19fb4cccdf36b154749793")
     version("6.8.0", sha256="4dfd5a932955ee2618a880bb210aed9ce7087cfadd31f23f92e5ff009c8384eb")
@@ -65,12 +70,16 @@ class Geomodel(CMakePackage):
         description="Use the specified C++ standard when building",
     )
 
+    # GeoModel 6.11 drops support for C++17.
+    conflicts("cxxstd=17", when="@6.11:")
+
     conflicts("+fullsimlight", when="+fsl", msg="FSL triggers the build of the FullSimLight")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
     depends_on("cmake@3.16:", type="build")
+    depends_on("cmake@:3", when="@:6.10", type="build")
 
     depends_on("eigen@3.2.9:")
     depends_on("nlohmann-json@3.6.1:")
@@ -93,6 +102,9 @@ class Geomodel(CMakePackage):
         depends_on("coin3d")
         depends_on("soqt")
         depends_on("gl")
+        depends_on("egl", when="@6.11:")
+
+    depends_on("googletest", when="@6.11:")
 
     def cmake_args(self):
         args = [
@@ -107,4 +119,8 @@ class Geomodel(CMakePackage):
                 "GEOMODEL_USE_QT6", self.spec.satisfies("+visualization ^[virtuals=qmake] qt-base")
             ),
         ]
+
+        if self.spec.satisfies("@6.12:"):
+            args.append(self.define("GEOMODEL_BUILD_TESTING", "OFF"))
+
         return args

--- a/repos/spack_repo/builtin/packages/geomodel/package.py
+++ b/repos/spack_repo/builtin/packages/geomodel/package.py
@@ -107,7 +107,8 @@ class Geomodel(CMakePackage):
         depends_on("gl")
         depends_on("egl", when="@6.11:")
 
-    depends_on("googletest", when="@6.11:")
+    depends_on("googletest", when="@6.11", type="build")
+    depends_on("googletest", when="@6.12:", type="test")
 
     def cmake_args(self):
         args = [

--- a/repos/spack_repo/builtin/packages/geomodel/package.py
+++ b/repos/spack_repo/builtin/packages/geomodel/package.py
@@ -125,6 +125,6 @@ class Geomodel(CMakePackage):
         ]
 
         if self.spec.satisfies("@6.12:"):
-            args.append(self.define("GEOMODEL_BUILD_TESTING", "OFF"))
+            args.append(self.define("GEOMODEL_BUILD_TESTING", self.run_tests))
 
         return args

--- a/repos/spack_repo/builtin/packages/geomodel/package.py
+++ b/repos/spack_repo/builtin/packages/geomodel/package.py
@@ -70,8 +70,11 @@ class Geomodel(CMakePackage):
         description="Use the specified C++ standard when building",
     )
 
-    # GeoModel 6.11 drops support for C++17.
-    conflicts("cxxstd=17", when="@6.11:")
+    # GeoModel 6.11 requires std::format and C++20
+    with when("@6.11:"):
+        conflicts("cxxstd=17")
+        conflicts("%gcc@:12")
+        conflicts("%clang@:16")
 
     conflicts("+fullsimlight", when="+fsl", msg="FSL triggers the build of the FullSimLight")
 


### PR DESCRIPTION
This commit adds v6.11.0, v6.11.1, v6.12.0, v6.13.0, and v6.14.0 of the geomodel package. The visualisation variant had to be disabled in the CI to handle the newly introduced EGL dependency.