### PR TITLE
gh: add v2.74.1

### DIFF
--- a/repos/spack_repo/builtin/packages/gh/package.py
+++ b/repos/spack_repo/builtin/packages/gh/package.py
@@ -17,6 +17,7 @@ class Gh(GoPackage):
 
     license("MIT")
 
+    version("2.74.1", sha256="ac894d0f16f78db34818c396aad542b1512a776b925a7639d5d5a30d205a103b")
     version("2.74.0", sha256="b13e60f114388cbc20ba410d57b43f262814dec7d3e37363accfd525c6885d3b")
     version("2.72.0", sha256="5a2cd4f2601d254d11a55dab463849ccccb5fa4bdcaa72b792ea9c3bf8c67d23")
     version("2.70.0", sha256="9e2247e5b31131fd4ac63916b9483a065fcfb861ebb93588cf2ff42952ae08c5")


### PR DESCRIPTION
Release notes: https://github.com/cli/cli/releases/tag/v2.74.1
Diff: https://github.com/cli/cli/compare/v2.74.0...v2.74.1