### PR TITLE
yarn: add v4.9.2

### DIFF
--- a/repos/spack_repo/builtin/packages/yarn/package.py
+++ b/repos/spack_repo/builtin/packages/yarn/package.py
@@ -21,6 +21,7 @@ class Yarn(Package):
 
     license("BSD-2-Clause")
 
+    version("4.9.2", sha256="cbcd6ab876407c0999eceb74bcdac29ae47a544339bc99b17fcbe67901ede9b3")
     version("4.9.1", sha256="58df07bd582586c57d250a28817a0016382458d981c8d15e292b72a0ecfcd7a7")
     version("4.9.0", sha256="933da2c124dd745404b996b3751481214e7cd34bd13978080111ded6ecdc5fb5")
     version("4.8.1", sha256="26eee1ff317c4a1ba40cb3c5a85bb3ca35b7feb23d4339509ce2b0fd112567e8")


### PR DESCRIPTION
Release notes: https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.9.2
Diff: https://github.com/yarnpkg/berry/compare/%40yarnpkg/cli/4.9.1...%40yarnpkg/cli/4.9.2