### PR TITLE
py-setuptools: add v80.9.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_setuptools/package.py
+++ b/repos/spack_repo/builtin/packages/py_setuptools/package.py
@@ -23,6 +23,7 @@ class PySetuptools(Package, PythonExtension):
     # Requires railroad
     skip_modules = ["setuptools._vendor", "pkg_resources._vendor"]
 
+    version("80.9.0", sha256="062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922")
     version("79.0.1", sha256="e147c0549f27767ba362f9da434eab9c5dc0045d5304feb602a0af001089fc51")
     version("78.1.1", sha256="c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561")
     version("78.1.0", sha256="3e386e96793c8702ae83d17b853fb93d3e09ef82ec62722e61da5cd22376dcd8")


### PR DESCRIPTION
Release notes: https://setuptools.pypa.io/en/latest/history.html#v80-9-0
Diff: https://github.com/pypa/setuptools/compare/v79.0.1...v80.9.0