### PR TITLE
repeatmodeler: patch perl shebangs

### DIFF
--- a/repos/spack_repo/builtin/packages/repeatmodeler/package.py
+++ b/repos/spack_repo/builtin/packages/repeatmodeler/package.py
@@ -85,7 +85,7 @@ class Repeatmodeler(Package):
             "util/visualizeAlignPNG.pl",
         ]
         for f in file_list:
-            filter_file("^#!/usr/bin/perl.*$", "#!/usr/bin/env perl", f)
+            filter_file("^#!/usr/bin/perl.*$", "#!/usr/bin/env perl", f, ignore_absent=True)
 
     def install(self, spec, prefix):
         # interactive configuration script

--- a/repos/spack_repo/builtin/packages/repeatmodeler/package.py
+++ b/repos/spack_repo/builtin/packages/repeatmodeler/package.py
@@ -83,9 +83,13 @@ class Repeatmodeler(Package):
             "util/TSD.pl",
             "util/viewMSA.pl",
             "util/visualizeAlignPNG.pl",
+            "configure",
         ]
         for f in file_list:
-            filter_file("^#!/usr/bin/perl.*$", "#!/usr/bin/env perl", f, ignore_absent=True)
+            filter_file(r"^#!.*perl( -w)?.*$", fr"#!{self.spec['perl'].prefix.bin.perl}\1", f, ignore_absent=True)
+        file_list = ["configure", "RepModelConfig.pm"]
+        for f in file_list:
+            filter_file(r'^.*system\( "clear" \).*$', "", f)
 
     def install(self, spec, prefix):
         # interactive configuration script

--- a/repos/spack_repo/builtin/packages/repeatmodeler/package.py
+++ b/repos/spack_repo/builtin/packages/repeatmodeler/package.py
@@ -47,6 +47,46 @@ class Repeatmodeler(Package):
     depends_on("blat", type="run", when="@2.0.4:")
     depends_on("ltr-retriever", type="run", when="@2.0.4:")
 
+    def patch(self):
+        file_list = [
+            "BuildDatabase",
+            "Job.pm",
+            "LTRPipeline",
+            "MultAln.pm",
+            "NeedlemanWunschGotohAlgorithm.pm",
+            "Refiner",
+            "RepeatClassifier",
+            "RepeatModeler",
+            "RepeatUtil.pm",
+            "RepModelConfig.pm",
+            "SeedAlignmentCollection.pm",
+            "SeedAlignment.pm",
+            "SequenceSimilarityMatrix.pm",
+            "Task.pm",
+            "ThreadedJob.pm",
+            "ThreadedTaskSimple.pm",
+            "TRFMask",
+            "util/alignAndCallConsensus.pl",
+            "util/align.pl",
+            "util/AutoRunBlocker.pl",
+            "util/bestwindow.pl",
+            "util/Blocker.pl",
+            "util/ClusterPartialMatchingSubs.pl",
+            "util/CntSubst",
+            "util/extendFlankingSeqs.pl",
+            "util/fasta-trf-filter.pl",
+            "util/generateSeedAlignments.pl",
+            "util/Linup",
+            "util/renameIds.pl",
+            "util/resolveIndels.pl",
+            "util/rmblast.pl",
+            "util/TSD.pl",
+            "util/viewMSA.pl",
+            "util/visualizeAlignPNG.pl",
+        ]
+        for f in file_list:
+            filter_file("^#!/usr/bin/perl.*$", "#!/usr/bin/env perl", f)
+
     def install(self, spec, prefix):
         # interactive configuration script
         if spec.satisfies("@1.0.11"):

--- a/repos/spack_repo/builtin/packages/repeatmodeler/package.py
+++ b/repos/spack_repo/builtin/packages/repeatmodeler/package.py
@@ -86,7 +86,12 @@ class Repeatmodeler(Package):
             "configure",
         ]
         for f in file_list:
-            filter_file(r"^#!.*perl( -w)?.*$", fr"#!{self.spec['perl'].prefix.bin.perl}\1", f, ignore_absent=True)
+            filter_file(
+                r"^#!.*perl( -w)?.*$",
+                rf"#!{self.spec['perl'].prefix.bin.perl}\1",
+                f,
+                ignore_absent=True,
+            )
         file_list = ["configure", "RepModelConfig.pm"]
         for f in file_list:
             filter_file(r'^.*system\( "clear" \).*$', "", f)


### PR DESCRIPTION
migrate from spack repo (https://github.com/spack/spack/pull/38420)

adds a list of files to patch (if present) to replace shebangs. There was some discussion in the original PR about reworking how this package worked but I do not believe a pr was ever submitted.