### PR TITLE
relion: add v5 runtime deps

### DIFF
--- a/repos/spack_repo/builtin/packages/ctffind/package.py
+++ b/repos/spack_repo/builtin/packages/ctffind/package.py
@@ -26,7 +26,8 @@ class Ctffind(AutotoolsPackage):
         extension="tar.gz",
     )
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     def url_for_version(self, version):
         url = "https://grigoriefflab.umassmed.edu/system/tdf?path=ctffind-{0}.tar.gz&file=1&type=node&id=26"

--- a/repos/spack_repo/builtin/packages/fltk/package.py
+++ b/repos/spack_repo/builtin/packages/fltk/package.py
@@ -29,12 +29,13 @@ class Fltk(Package):
     version("1.3.7", sha256="019f65810fb0ea5acac14c852193e8f374e822e6a3034a3c80ed8676f6f3a090")
     version("1.3.3", sha256="186bdc4234bea74bce4d47f186d41d35bdd47d48dbe5f829513a2183fbf8f3b2")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
     depends_on("gmake", type="build")
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
+    depends_on("pkgconfig", type="build", when="@1.3.7")
 
     depends_on("libx11")
     depends_on("freetype", when="@1.4.3:")

--- a/repos/spack_repo/builtin/packages/fltk/package.py
+++ b/repos/spack_repo/builtin/packages/fltk/package.py
@@ -25,6 +25,7 @@ class Fltk(Package):
     git = "https://github.com/fltk/fltk.git"
 
     version("master", branch="master")
+    version("1.4.4", sha256="cbf5f7846af596206e8e4489e14c9981f98d7b37168110a00dcd26d8d479a669")
     version("1.4.3", sha256="6a11c0bf91b7b193a87a1928c32a953f36d7dd4b65fef3e9d0c40a51882f97a6")
     version("1.3.7", sha256="019f65810fb0ea5acac14c852193e8f374e822e6a3034a3c80ed8676f6f3a090")
     version("1.3.3", sha256="186bdc4234bea74bce4d47f186d41d35bdd47d48dbe5f829513a2183fbf8f3b2")

--- a/repos/spack_repo/builtin/packages/model_angelo/package.py
+++ b/repos/spack_repo/builtin/packages/model_angelo/package.py
@@ -1,0 +1,34 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class ModelAngelo(PythonPackage):
+    """ModelAngelo is an automatic atomic model building program for cryo-EM maps."""
+
+    homepage = "https://github.com/3dem/model-angelo"
+
+    url = "https://github.com/3dem/model-angelo"
+    git = "https://github.com/3dem/model-angelo.git"
+
+    license("MIT", checked_by="snehring")
+
+    version("20250218", commit="ddd969038045c28c5f281353dd62e98afb57859c")
+
+    depends_on("py-setuptools@:58", type="build")
+
+    depends_on("py-tqdm", type=("build", "run"))
+    depends_on("py-scipy", type=("build", "run"))
+    depends_on("py-biopython@1.81:", type=("build", "run"))
+    depends_on("py-einops", type=("build", "run"))
+    depends_on("py-matplotlib", type=("build", "run"))
+    depends_on("py-mrcfile", type=("build", "run"))
+    depends_on("py-pandas", type=("build", "run"))
+    depends_on("py-fair-esm@1.0.3", type=("build", "run"))
+    depends_on("py-pyhmmer@0.7.1", type=("build", "run"))
+    depends_on("py-loguru", type=("build", "run"))
+    depends_on("py-numpy@1.24.4:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_deepspeed/package.py
+++ b/repos/spack_repo/builtin/packages/py_deepspeed/package.py
@@ -20,6 +20,10 @@ class PyDeepspeed(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.16.4", sha256="495febfb6dd20423f44b1c4a1bb6da2cadbcaf9b07962e17f87d52edfeec9bba")
+    version("0.15.4", sha256="60e7c044b7fc386cdad1206212d22b6963ea551f656ed51f7cb34b299459bf2c")
+    version("0.13.5", sha256="05404e083b5df36dcfe36884565dcb1d9fd1165e443a82c1c09370293943f6d1")
+    version("0.13.0", sha256="e890adca061af36c775b40252306191c3029f0b8bd33cceefa9fa7ecbf350a05")
     version("0.10.0", sha256="afb06a97fde2a33d0cbd60a8357a70087c037b9f647ca48377728330c35eff3e")
 
     depends_on("cxx", type="build")  # generated
@@ -31,7 +35,8 @@ class PyDeepspeed(PythonPackage):
     depends_on("py-packaging@20:", type=("build", "run"))
     depends_on("py-psutil", type=("build", "run"))
     depends_on("py-py-cpuinfo", type=("build", "run"))
-    depends_on("py-pydantic@:1", type=("build", "run"))
+    depends_on("py-pydantic@2:", type=("build", "run"), when="@0.15.4:")
+    depends_on("py-pydantic@:1", type=("build", "run"), when="@:0.13")
     # https://github.com/microsoft/DeepSpeed/issues/2830
     depends_on("py-torch+distributed", type=("build", "run"))
     depends_on("py-tqdm", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_fair_esm/package.py
+++ b/repos/spack_repo/builtin/packages/py_fair_esm/package.py
@@ -16,6 +16,7 @@ class PyFairEsm(PythonPackage):
     license("MIT")
 
     version("2.0.0", sha256="4ed34d4598ec75ed6550a4e581d023bf8d4a8375317ecba6269bb68135f80c85")
+    version("1.0.3", sha256="a37b5d86ffd5b0668ac594f2aa9665056fde782694eb1534d40f2b3e0b0d68a1")
 
     depends_on("py-setuptools@59.5.0:", type=("build"))
 

--- a/repos/spack_repo/builtin/packages/py_pyhmmer/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyhmmer/package.py
@@ -21,6 +21,7 @@ class PyPyhmmer(PythonPackage):
 
     version("0.10.15", sha256="bf8e97ce8da6fb5850298f3074640f3e998d5a655877f865c1592eb057dc7921")
     version("0.10.14", sha256="eb50bdfdf67a3b1fecfe877d7ca6d9bade9a9f3dea3ad60c959453bbb235573d")
+    version("0.7.1", sha256="e746cfc3b352656757286106fd210763f835ac20cf8466141bca5588567bcb5c")
 
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools@46.4:", type="build")

--- a/repos/spack_repo/builtin/packages/py_relion_blush/package.py
+++ b/repos/spack_repo/builtin/packages/py_relion_blush/package.py
@@ -1,0 +1,26 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyRelionBlush(PythonPackage):
+    """Blush Refinement for Relion."""
+
+    homepage = "https://github.com/3dem/relion-blush"
+
+    url = "https://github.com/3dem/relion-blush"
+    git = "https://github.com/3dem/relion-blush.git"
+
+    license("MIT", checked_by="github_user1")
+
+    version("20240529", commit="7889199242ab8227c628df72ea396826ed50185e")
+
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-torch@2.0.1:", type=("build", "run"))
+    depends_on("py-torchvision@0.15.2:", type=("build", "run"))
+    depends_on("py-numpy@1.24.4:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_relion_classranker/package.py
+++ b/repos/spack_repo/builtin/packages/py_relion_classranker/package.py
@@ -1,0 +1,29 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyRelionClassranker(PythonPackage):
+    """The class ranker is part of the cryogenic electron microscopy (cryo-EM)
+    dataset processing pipeline in RELION. It is used to automatically
+    select suitable particles (EM images) assigned to 2D class averages
+    for further downstream processing."""
+
+    homepage = "https://github.com/3dem/relion-classranker"
+
+    url = "https://github.com/3dem/relion-classranker"
+    git = "https://github.com/3dem/relion-classranker.git"
+
+    license("GPL-3.0-only", checked_by="snehring")
+
+    version("20250108", commit="8727e78cf00ffcbb0cb3dd5918db987a13cf4f3a")
+
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-torch@2.0.1:", type=("build", "run"))
+    depends_on("py-torchvision@0.15.2:", type=("build", "run"))
+    depends_on("py-numpy@1.24.4", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/relion/package.py
+++ b/repos/spack_repo/builtin/packages/relion/package.py
@@ -115,8 +115,6 @@ class Relion(CMakePackage, CudaPackage):
 
     def cmake_args(self):
         args = [
-            "-DCMAKE_C_FLAGS=-g",
-            "-DCMAKE_CXX_FLAGS=-g",
             "-DGUI=%s" % ("+gui" in self.spec),
             "-DDoublePrec_CPU=%s" % ("+double" in self.spec),
             "-DDoublePrec_GPU=%s" % ("+double-gpu" in self.spec),
@@ -124,6 +122,9 @@ class Relion(CMakePackage, CudaPackage):
             "-DMKLFFT=%s" % ("+mklfft" in self.spec),
             "-DALTCPU=%s" % ("+altcpu" in self.spec),
         ]
+        if spec.satisfies("+gui"):
+            incs = [f"-I{self.spec[lib].prefix.include}" for lib in ["libx11", "xproto"]]
+            args += ["-DCMAKE_CXX_FLAGS=" + " ".join(incs)]
 
         if "+cuda" in self.spec:
             carch = self.spec.variants["cuda_arch"].value[0]

--- a/repos/spack_repo/builtin/packages/relion/package.py
+++ b/repos/spack_repo/builtin/packages/relion/package.py
@@ -122,7 +122,7 @@ class Relion(CMakePackage, CudaPackage):
             "-DMKLFFT=%s" % ("+mklfft" in self.spec),
             "-DALTCPU=%s" % ("+altcpu" in self.spec),
         ]
-        if spec.satisfies("+gui"):
+        if self.spec.satisfies("+gui"):
             incs = [f"-I{self.spec[lib].prefix.include}" for lib in ["libx11", "xproto"]]
             args += ["-DCMAKE_CXX_FLAGS=" + " ".join(incs)]
 

--- a/repos/spack_repo/builtin/packages/relion/package.py
+++ b/repos/spack_repo/builtin/packages/relion/package.py
@@ -96,6 +96,11 @@ class Relion(CMakePackage, CudaPackage):
     depends_on("mkl", when="+mklfft")
     depends_on("ctffind", type="run")
     depends_on("motioncor2", type="run", when="+external_motioncor2")
+    # version 5 deps
+    depends_on("py-relion-blush", type="run", when="@5:")
+    depends_on("py-relion-classranker", type="run", when="@5:")
+    depends_on("topaz-3dem", type="run", when="@5:")
+    depends_on("model-angelo", type="run", when="@5:")
 
     # TODO: more externals to add
     # Spack packages needed

--- a/repos/spack_repo/builtin/packages/topaz_3dem/package.py
+++ b/repos/spack_repo/builtin/packages/topaz_3dem/package.py
@@ -1,0 +1,31 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class Topaz3dem(PythonPackage):
+    """topaz: Pipeline for particle picking in cryo-electron microscopy images using
+    convolutional neural networks trained from positive and unlabeled examples. Also
+    featuring micrograph and tomogram denoising with DNNs."""
+
+    homepage = "https://github.com/3dem/topaz"
+    git = "https://github.com/3dem/topaz.git"
+
+    license("GPL-3.0-or-later")
+
+    version("20220325", commit="14b2bc331768b67b3267397523de57c707fa1253")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-torch@1:2.3", type=("build", "run"))
+    depends_on("py-torchvision", type=("build", "run"))
+    depends_on("py-numpy@1.11:", type=("build", "run"))
+    depends_on("py-pandas", type=("build", "run"))
+    depends_on("py-scikit-learn@0.19.0:", type=("build", "run"))
+    depends_on("py-scipy@0.17.0:", type=("build", "run"))
+    depends_on("py-pillow@6.2.0:", type=("build", "run"))
+    depends_on("py-future", type=("build", "run"))
+    depends_on("py-scikit-image", type=("build", "run"))


### PR DESCRIPTION
model-angelo: add new package
py-fair-esm: add v1.0.3
py-pyhmmer: add v0.7.1
py-relion-blush: add new package
py-relion-classranker: add new package
topaz-3dem: add new package
py-deepspeed: add new versions
relion: adding whens to new deps, rework for repo changes

migrated from spack repo

