### PR TITLE
blast-plus: adding py-setuptools dep

### DIFF
--- a/repos/spack_repo/builtin/packages/blast_plus/package.py
+++ b/repos/spack_repo/builtin/packages/blast_plus/package.py
@@ -82,6 +82,7 @@ class BlastPlus(AutotoolsPackage):
     depends_on("pcre", when="+pcre")
 
     depends_on("python@:3.11", when="+python")
+    depends_on("py-setuptools@48:", when="+python ^python@3.12:", type="build")
     depends_on("perl", when="+perl")
 
     depends_on("lmdb", when="@2.7.1:")


### PR DESCRIPTION
migrated from spack repo (https://github.com/spack/spack/pull/47312)
