### PR TITLE
geopm: Add v3.2

### DIFF
--- a/repos/spack_repo/builtin/packages/geopm_runtime/package.py
+++ b/repos/spack_repo/builtin/packages/geopm_runtime/package.py
@@ -28,7 +28,7 @@ class GeopmRuntime(AutotoolsPackage):
     version(
         "3.0.1",
         sha256="32ba1948de58815ee055470dcdea64593d1113a6cad70ce00ab0286c127f8234",
-        deprecated=True
+        deprecated=True,
     )
 
     variant("debug", default=False, description="Enable debug")

--- a/repos/spack_repo/builtin/packages/geopm_runtime/package.py
+++ b/repos/spack_repo/builtin/packages/geopm_runtime/package.py
@@ -95,7 +95,7 @@ class GeopmRuntime(AutotoolsPackage):
     for ver in ["3.0.1", "3.1.0", "3.2.0", "develop"]:
         depends_on(f"geopm-service@{ver}", type=("build", "run"), when=f"@{ver}")
 
-    depends_on("py-setuptools-scm@7.0.3:", when="@3.1:", type="build")
+    depends_on("py-setuptools-scm@6.4.2:", when="@develop", type="build")  # Used in autogen.sh
     depends_on("bash-completion")
     depends_on("unzip")
     depends_on("mpi@2.2:", when="+mpi")

--- a/repos/spack_repo/builtin/packages/geopm_runtime/package.py
+++ b/repos/spack_repo/builtin/packages/geopm_runtime/package.py
@@ -16,15 +16,20 @@ class GeopmRuntime(AutotoolsPackage):
 
     homepage = "https://geopm.github.io"
     git = "https://github.com/geopm/geopm.git"
-    url = "https://github.com/geopm/geopm/tarball/v3.1.0"
+    url = "https://github.com/geopm/geopm/tarball/v3.2.0"
 
     maintainers("bgeltz", "cmcantalupo")
     license("BSD-3-Clause")
     tags = ["e4s"]
 
     version("develop", branch="dev", get_full_repo=True)
+    version("3.2.0", sha256="b708233e1bfda66408c500f2ac0cbaf042140870bffdced12dd7cabbd18e0025")
     version("3.1.0", sha256="2d890cad906fd2008dc57f4e06537695d4a027e1dc1ed92feed4d81bb1a1449e")
-    version("3.0.1", sha256="32ba1948de58815ee055470dcdea64593d1113a6cad70ce00ab0286c127f8234")
+    version(
+        "3.0.1",
+        sha256="32ba1948de58815ee055470dcdea64593d1113a6cad70ce00ab0286c127f8234",
+        deprecated=True
+    )
 
     variant("debug", default=False, description="Enable debug")
     variant("docs", default=False, when="@3.0.1", description="Create man pages with Sphinx")
@@ -87,23 +92,21 @@ class GeopmRuntime(AutotoolsPackage):
         depends_on("py-docutils@0.18:", type="run", when="+checkprogs")
 
     # Other dependencies
-    for ver in ["3.0.1", "3.1.0", "develop"]:
+    for ver in ["3.0.1", "3.1.0", "3.2.0", "develop"]:
         depends_on(f"geopm-service@{ver}", type=("build", "run"), when=f"@{ver}")
-        depends_on(f"py-geopmdpy@{ver}", type="run", when=f"@{ver}")
-        if ver != "3.0.1":  # geopmpy integrated into autotools build until 3.1
-            depends_on(f"py-geopmpy@{ver}", type="run", when=f"@{ver}")
+
     depends_on("py-setuptools-scm@7.0.3:", when="@3.1:", type="build")
     depends_on("bash-completion")
     depends_on("unzip")
     depends_on("mpi@2.2:", when="+mpi")
     depends_on("libelf")
-    depends_on("numactl", type="run", when="+checkprogs")
-    depends_on("stress-ng", type="run", when="+checkprogs")
+    depends_on("numactl", type="run", when="@3.0.1 +checkprogs")
+    depends_on("stress-ng", type="run", when="@3.0.1 +checkprogs")
 
     # Intel dependencies
     depends_on("intel-oneapi-mkl%oneapi", when="+intel-mkl")
 
-    extends("python")
+    extends("python", when="@3.0.1")
 
     @property
     def configure_directory(self):

--- a/repos/spack_repo/builtin/packages/geopm_service/libtool.patch
+++ b/repos/spack_repo/builtin/packages/geopm_service/libtool.patch
@@ -1,0 +1,23 @@
+From 63b206ad37da12871a49aa1391b8b9d657a1bd41 Mon Sep 17 00:00:00 2001
+From: Brad Geltz <brad.geltz@intel.com>
+Date: Thu, 17 Jul 2025 16:11:59 -0700
+Subject: [PATCH] Preserve ACLOCAL_PATH if it was already set
+
+Signed-off-by: Brad Geltz <brad.geltz@intel.com>
+---
+ libgeopmd/autogen.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libgeopmd/autogen.sh b/libgeopmd/autogen.sh
+index f56a3e730..a7df602bd 100755
+--- a/libgeopmd/autogen.sh
++++ b/libgeopmd/autogen.sh
+@@ -14,4 +14,4 @@ if [ ! -e VERSION ]; then
+ 	set -x
+     fi
+ fi
+-ACLOCAL_PATH=/usr/share/aclocal autoreconf -i -f
++ACLOCAL_PATH=${ACLOCAL_PATH:-/usr/share/aclocal} autoreconf -i -f
+-- 
+2.43.0
+

--- a/repos/spack_repo/builtin/packages/geopm_service/nvml-v3.0.1.patch
+++ b/repos/spack_repo/builtin/packages/geopm_service/nvml-v3.0.1.patch
@@ -1,0 +1,28 @@
+From cea9ceba3996e58af24c614c91a3d8721f0d8406 Mon Sep 17 00:00:00 2001
+From: Brad Geltz <brad.geltz@intel.com>
+Date: Thu, 14 Dec 2023 16:35:02 -0800
+Subject: [PATCH] Support NVML via CUDA installation
+
+Signed-off-by: Brad Geltz <brad.geltz@intel.com>
+---
+ configure.ac | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/service/configure.ac b/service/configure.ac
+index f9eb56d50..e8b523006 100644
+--- a/service/configure.ac
++++ b/service/configure.ac
+@@ -264,8 +264,8 @@ AC_ARG_WITH([nvml], [AS_HELP_STRING([--with-nvml=PATH],
+             [specify directory for installed nvml package.])])
+ if test "x$with_nvml" != x; then
+   AM_CPPFLAGS="$AM_CPPFLAGS -I$with_nvml/include"
+-  LD_LIBRARY_PATH="$with_nvml/lib64:$with_nvml/lib:$LD_LIBRARY_PATH"
+-  AM_LDFLAGS="$AM_LDFLAGS -L$with_nvml/lib -L$with_nvml/lib64"
++  LD_LIBRARY_PATH="$with_nvml/lib64:$with_nvml/lib:$with_nvml/lib/stubs:$LD_LIBRARY_PATH"
++  AM_LDFLAGS="$AM_LDFLAGS -L$with_nvml/lib -L$with_nvml/lib64 -L$with_nvml/lib/stubs"
+ fi
+
+ AC_ARG_WITH([dcgm], [AS_HELP_STRING([--with-dcgm=PATH],
+--
+2.26.2
+

--- a/repos/spack_repo/builtin/packages/geopm_service/nvml-v3.1+.patch
+++ b/repos/spack_repo/builtin/packages/geopm_service/nvml-v3.1+.patch
@@ -1,0 +1,28 @@
+From dd7aeed3a135610890626dc2c3d723406b264a04 Mon Sep 17 00:00:00 2001
+From: Brad Geltz <brad.geltz@intel.com>
+Date: Thu, 15 May 2025 16:46:00 -0700
+Subject: [PATCH] Support NVML via CUDA installation
+
+Signed-off-by: Brad Geltz <brad.geltz@intel.com>
+---
+ libgeopmd/configure.ac | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libgeopmd/configure.ac b/libgeopmd/configure.ac
+index 80e4d8abf..13cf54eef 100644
+--- a/libgeopmd/configure.ac
++++ b/libgeopmd/configure.ac
+@@ -272,8 +272,8 @@ AC_ARG_WITH([nvml], [AS_HELP_STRING([--with-nvml=PATH],
+             [specify directory for installed nvml package.])])
+ if test "x$with_nvml" != x; then
+   AM_CPPFLAGS="$AM_CPPFLAGS -I$with_nvml/include"
+-  LD_LIBRARY_PATH="$with_nvml/lib64:$with_nvml/lib:$LD_LIBRARY_PATH"
+-  AM_LDFLAGS="$AM_LDFLAGS -L$with_nvml/lib -L$with_nvml/lib64"
++  LD_LIBRARY_PATH="$with_nvml/lib64:$with_nvml/lib:$with_nvml/lib/stubs:$LD_LIBRARY_PATH"
++  AM_LDFLAGS="$AM_LDFLAGS -L$with_nvml/lib -L$with_nvml/lib64 -L$with_nvml/lib/stubs"
+ fi
+ 
+ AC_ARG_WITH([dcgm], [AS_HELP_STRING([--with-dcgm=PATH],
+-- 
+2.26.2
+

--- a/repos/spack_repo/builtin/packages/geopm_service/package.py
+++ b/repos/spack_repo/builtin/packages/geopm_service/package.py
@@ -69,6 +69,7 @@ class GeopmService(AutotoolsPackage):
 
     patch("nvml-v3.0.1.patch", when="@3.0.1 +nvml")
     patch("nvml-v3.1+.patch", when="@3.1: +nvml")
+    patch("libtool.patch", when="@3.2")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/geopm_service/package.py
+++ b/repos/spack_repo/builtin/packages/geopm_service/package.py
@@ -19,19 +19,25 @@ class GeopmService(AutotoolsPackage):
 
     homepage = "https://geopm.github.io"
     git = "https://github.com/geopm/geopm.git"
-    url = "https://github.com/geopm/geopm/tarball/v3.1.0"
+    url = "https://github.com/geopm/geopm/tarball/v3.2.0"
 
     maintainers("bgeltz", "cmcantalupo")
     license("BSD-3-Clause")
     tags = ["e4s"]
 
     version("develop", branch="dev", get_full_repo=True)
+    version("3.2.0", sha256="b708233e1bfda66408c500f2ac0cbaf042140870bffdced12dd7cabbd18e0025")
     version("3.1.0", sha256="2d890cad906fd2008dc57f4e06537695d4a027e1dc1ed92feed4d81bb1a1449e")
-    version("3.0.1", sha256="32ba1948de58815ee055470dcdea64593d1113a6cad70ce00ab0286c127f8234")
+    version(
+        "3.0.1",
+        sha256="32ba1948de58815ee055470dcdea64593d1113a6cad70ce00ab0286c127f8234",
+        deprecated=True
+    )
 
     variant("debug", default=False, description="Enable debug")
     variant("docs", default=True, when="@3.0.1", description="Create man pages with Sphinx")
     variant("systemd", default=True, description="Enable use of systemd/DBus")
+    variant("grpc", default=False, when="@3.2:", description="Enable gRPC support")
     variant("liburing", default=True, description="Enables the use of liburing for batch I/O")
     variant(
         "libcap", default=True, description="Enables the use of libcap to do capabilities checks"
@@ -45,10 +51,11 @@ class GeopmService(AutotoolsPackage):
         "rawmsr",
         default=True,
         description="Enable direct use of standard msr device driver",
-        when="@develop",
+        when="@3.2:",
     )
 
     conflicts("+nvml", when="+level_zero", msg="LevelZero and NVML support are mutually exclusive")
+    conflicts("+grpc", when="+systemd", msg="gRPC and systemd support are mutually exclusive")
 
     conflicts("%gcc@:7.2", msg="Requires C++17 support")
     conflicts("%clang@:4", msg="Requires C++17 support")
@@ -60,7 +67,8 @@ class GeopmService(AutotoolsPackage):
     conflicts("target=ppc64:", msg="Only available on x86_64", when="@3.0.1")
     conflicts("target=ppc64le:", msg="Only available on x86_64", when="@3.0.1")
 
-    patch("0001-Support-NVML-via-CUDA-installation.patch", when="+nvml")
+    patch("nvml-v3.0.1.patch", when="@3.0.1 +nvml")
+    patch("nvml-v3.1+.patch", when="@3.1: +nvml")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
@@ -93,9 +101,6 @@ class GeopmService(AutotoolsPackage):
         depends_on("py-cffi@1.14.5:", type="run")
 
     # Other dependencies
-    for ver in ["3.1.0", "develop"]:
-        depends_on(f"py-geopmdpy@{ver}", type="run", when=f"@{ver}")
-    depends_on("py-setuptools-scm@7.0.3:", when="@3.1:", type="build")
     depends_on("bash-completion")
     depends_on("unzip")
     depends_on("systemd", when="+systemd")
@@ -103,8 +108,11 @@ class GeopmService(AutotoolsPackage):
     depends_on("liburing", when="+liburing")
     depends_on("oneapi-level-zero", when="+level_zero")
     depends_on("cuda", when="+nvml")
+    depends_on("grpc+shared", when="+grpc")
+    depends_on("protobuf", when="+grpc")
+    depends_on("pkgconf", when="+grpc")
 
-    extends("python")
+    extends("python", when="@3.0.1")
 
     @property
     def configure_directory(self):
@@ -129,19 +137,23 @@ class GeopmService(AutotoolsPackage):
 
     def configure_args(self):
         args = [
-            "--with-bash-completion-dir="
-            + join_path(self.spec.prefix, "share", "bash-completion", "completions"),
             *self.enable_or_disable("debug"),
             *self.enable_or_disable("docs"),
             *self.enable_or_disable("systemd"),
-            *self.enable_or_disable("liburing"),
+            *self.enable_or_disable("io-uring", variant="liburing"),
             *self.with_or_without("liburing", activation_value="prefix"),
             *self.enable_or_disable("libcap"),
             *self.with_or_without("gnu-ld"),
             *self.enable_or_disable("levelzero", variant="level_zero"),
             *self.enable_or_disable("nvml"),
             *self.enable_or_disable("rawmsr"),
+            *self.enable_or_disable("grpc"),
         ]
+        if self.version == Version("3.0.1"):
+            args.append(
+                "--with-bash-completion-dir="
+                + join_path(self.spec.prefix, "share", "bash-completion", "completions")
+            )
 
         if self.spec.satisfies("+nvml"):
             args += [

--- a/repos/spack_repo/builtin/packages/geopm_service/package.py
+++ b/repos/spack_repo/builtin/packages/geopm_service/package.py
@@ -101,6 +101,7 @@ class GeopmService(AutotoolsPackage):
         depends_on("py-cffi@1.14.5:", type="run")
 
     # Other dependencies
+    depends_on("py-setuptools-scm@6.4.2:", when="@develop", type="build")  # Used in autogen.sh
     depends_on("bash-completion")
     depends_on("unzip")
     depends_on("systemd", when="+systemd")

--- a/repos/spack_repo/builtin/packages/geopm_service/package.py
+++ b/repos/spack_repo/builtin/packages/geopm_service/package.py
@@ -31,7 +31,7 @@ class GeopmService(AutotoolsPackage):
     version(
         "3.0.1",
         sha256="32ba1948de58815ee055470dcdea64593d1113a6cad70ce00ab0286c127f8234",
-        deprecated=True
+        deprecated=True,
     )
 
     variant("debug", default=False, description="Enable debug")

--- a/repos/spack_repo/builtin/packages/py_geopmdpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_geopmdpy/package.py
@@ -50,6 +50,7 @@ class PyGeopmdpy(PythonPackage):
     depends_on("py-build@0.9.0:", when="@3.1:", type="build")
     depends_on("py-defusedxml@0.7.1:", when="@3.2:", type="test")
     depends_on("py-grpcio", when="+grpc", type=("build", "run"))
+    depends_on("py-protobuf@3.12.4:", when="+grpc", type=("build", "run"))
 
     @property
     def build_directory(self):

--- a/repos/spack_repo/builtin/packages/py_geopmdpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_geopmdpy/package.py
@@ -46,7 +46,7 @@ class PyGeopmdpy(PythonPackage):
     depends_on("py-pyyaml@6.0:", type="run")
     depends_on("py-setuptools@53.0.0:", when="@3.0.1", type="build")
     depends_on("py-setuptools@59.6.0:", when="@3.2:", type="build")
-    depends_on("py-setuptools-scm@7.0.3:", when="@3.1:", type="build")
+    depends_on("py-setuptools-scm@6.4.2:", when="@3.1:", type="build")
     depends_on("py-build@0.9.0:", when="@3.1:", type="build")
     depends_on("py-defusedxml@0.7.1:", when="@3.2:", type="test")
     depends_on("py-grpcio", when="+grpc", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_geopmdpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_geopmdpy/package.py
@@ -20,6 +20,12 @@ class PyGeopmdpy(PythonPackage):
     tags = ["e4s"]
 
     variant("grpc", default=False, when="@3.2:", description="Enable gRPC support")
+    variant(
+        "stats",
+        default=False,
+        when="@3.2:",
+        description="Enable additional packages for data analysis and post-processing"
+    )
 
     version("develop", branch="dev", get_full_repo=True)
     version("3.2.0", sha256="b708233e1bfda66408c500f2ac0cbaf042140870bffdced12dd7cabbd18e0025")
@@ -43,7 +49,8 @@ class PyGeopmdpy(PythonPackage):
     depends_on("py-psutil@5.8.0:", when="@3.2:", type=("test", "run"))
     depends_on("py-jsonschema@3.2.0:", when="@3.0.1:3.1", type="run")
     depends_on("py-jsonschema@3.2.0:", when="@3.2:", type=("test", "run"))
-    depends_on("py-pyyaml@6.0:", type="run")
+    depends_on("py-pyyaml@6.0:", when="+stats", type="run")
+    depends_on("py-seaborn@0.11.2:", when="+stats", type="run")
     depends_on("py-setuptools@53.0.0:", when="@3.0.1", type="build")
     depends_on("py-setuptools@59.6.0:", when="@3.2:", type="build")
     depends_on("py-setuptools-scm@6.4.2:", when="@3.1:", type="build")

--- a/repos/spack_repo/builtin/packages/py_geopmdpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_geopmdpy/package.py
@@ -13,28 +13,43 @@ class PyGeopmdpy(PythonPackage):
 
     homepage = "https://geopm.github.io"
     git = "https://github.com/geopm/geopm.git"
-    url = "https://github.com/geopm/geopm/tarball/v3.1.0"
+    url = "https://github.com/geopm/geopm/tarball/v3.2.0"
 
     maintainers("bgeltz", "cmcantalupo")
     license("BSD-3-Clause")
     tags = ["e4s"]
 
+    variant("grpc", default=False, when="@3.2:", description="Enable gRPC support")
+
     version("develop", branch="dev", get_full_repo=True)
+    version("3.2.0", sha256="b708233e1bfda66408c500f2ac0cbaf042140870bffdced12dd7cabbd18e0025")
     version("3.1.0", sha256="2d890cad906fd2008dc57f4e06537695d4a027e1dc1ed92feed4d81bb1a1449e")
-    version("3.0.1", sha256="32ba1948de58815ee055470dcdea64593d1113a6cad70ce00ab0286c127f8234")
+    version(
+        "3.0.1",
+        sha256="32ba1948de58815ee055470dcdea64593d1113a6cad70ce00ab0286c127f8234",
+        deprecated=True
+    )
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
+    for ver in ["3.1.0", "3.2.0", "develop"]:
+        depends_on(f"geopm-service@{ver}", type=("build", "test", "run"), when=f"@{ver}")
     depends_on("py-dasbus@1.6.0:", type=("build", "run"))
-    depends_on("py-cffi@1.14.5:", type="run")
-    depends_on("py-psutil@5.8.0:", type="run")
-    depends_on("py-jsonschema@3.2.0:", type="run")
+    depends_on("py-cffi@1.14.5:", when="@3.0.1:3.1", type="run")
+    depends_on("py-cffi@1.14.5:", when="@3.2:", type=("build", "run"))
+    depends_on("py-psutil@5.8.0:", when="@3.0.1:3.1", type="run")
+    depends_on("py-psutil@5.8.0:", when="@3.2:", type=("test", "run"))
+    depends_on("py-jsonschema@3.2.0:", when="@3.0.1:3.1", type="run")
+    depends_on("py-jsonschema@3.2.0:", when="@3.2:", type=("test", "run"))
     depends_on("py-pyyaml@6.0:", type="run")
-    depends_on("py-setuptools@53.0.0:", type="build")
+    depends_on("py-setuptools@53.0.0:", when="@3.0.1", type="build")
+    depends_on("py-setuptools@59.6.0:", when="@3.2:", type="build")
     depends_on("py-setuptools-scm@7.0.3:", when="@3.1:", type="build")
     depends_on("py-build@0.9.0:", when="@3.1:", type="build")
+    depends_on("py-defusedxml@0.7.1:", when="@3.2:", type="test")
+    depends_on("py-grpcio", when="+grpc", type=("build", "run"))
 
     @property
     def build_directory(self):
@@ -46,6 +61,9 @@ class PyGeopmdpy(PythonPackage):
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if not self.spec.version.isdevelop():
             env.set("SETUPTOOLS_SCM_PRETEND_VERSION", self.version)
+        if self.version >= Version("3.2.0"):  # Required for CFFI API mode builds
+            env.append_path("C_INCLUDE_PATH", self.spec["geopm-service"].prefix.include)
+            env.append_path("LIBRARY_PATH", self.spec["geopm-service"].prefix.lib)
 
     @run_before("install")
     def populate_version(self):

--- a/repos/spack_repo/builtin/packages/py_geopmdpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_geopmdpy/package.py
@@ -24,7 +24,7 @@ class PyGeopmdpy(PythonPackage):
         "stats",
         default=False,
         when="@3.2:",
-        description="Enable additional packages for data analysis and post-processing"
+        description="Enable additional packages for data analysis and post-processing",
     )
 
     version("develop", branch="dev", get_full_repo=True)
@@ -33,7 +33,7 @@ class PyGeopmdpy(PythonPackage):
     version(
         "3.0.1",
         sha256="32ba1948de58815ee055470dcdea64593d1113a6cad70ce00ab0286c127f8234",
-        deprecated=True
+        deprecated=True,
     )
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_geopmdpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_geopmdpy/package.py
@@ -56,7 +56,7 @@ class PyGeopmdpy(PythonPackage):
     depends_on("py-setuptools-scm@6.4.2:", when="@3.1:", type="build")
     depends_on("py-build@0.9.0:", when="@3.1:", type="build")
     depends_on("py-defusedxml@0.7.1:", when="@3.2:", type="test")
-    depends_on("py-grpcio", when="+grpc", type=("build", "run"))
+    depends_on("py-grpcio@1.30.2:", when="+grpc", type=("build", "run"))
     depends_on("py-protobuf@3.12.4:", when="+grpc", type=("build", "run"))
 
     @property

--- a/repos/spack_repo/builtin/packages/py_geopmpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_geopmpy/package.py
@@ -30,7 +30,7 @@ class PyGeopmpy(PythonPackage):
     depends_on("python@3.6:3", type=("build", "run"))
     depends_on("py-setuptools@53.0.0:", when="@3.1", type="build")
     depends_on("py-setuptools@59.6.0:", when="@3.2:", type="build")
-    depends_on("py-setuptools-scm@7.0.3:", when="@3.1:", type="build")
+    depends_on("py-setuptools-scm@6.4.2:", when="@3.1:", type="build")
     depends_on("py-build@0.9.0:", when="@3.1:", type="build")
     depends_on("py-cffi@1.14.5:", when="@3.1.0", type="run")
     depends_on("py-cffi@1.14.5:", when="@3.2:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_geopmpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_geopmpy/package.py
@@ -13,30 +13,48 @@ class PyGeopmpy(PythonPackage):
 
     homepage = "https://geopm.github.io"
     git = "https://github.com/geopm/geopm.git"
-    url = "https://github.com/geopm/geopm/tarball/v3.1.0"
+    url = "https://github.com/geopm/geopm/tarball/v3.2.0"
 
     maintainers("bgeltz", "cmcantalupo")
     license("BSD-3-Clause")
     tags = ["e4s"]
 
     version("develop", branch="dev", get_full_repo=True)
+    version("3.2.0", sha256="b708233e1bfda66408c500f2ac0cbaf042140870bffdced12dd7cabbd18e0025")
     version("3.1.0", sha256="2d890cad906fd2008dc57f4e06537695d4a027e1dc1ed92feed4d81bb1a1449e")
 
+    for ver in ["3.1.0", "3.2.0", "develop"]:
+        depends_on(f"py-geopmdpy@{ver}", type="run", when=f"@{ver}")
+        depends_on(f"geopm-runtime@{ver}", type=("build", "run"), when=f"@{ver}")
+
     depends_on("python@3.6:3", type=("build", "run"))
-    depends_on("py-setuptools@53.0.0:", type="build")
+    depends_on("py-setuptools@53.0.0:", when="@3.1", type="build")
+    depends_on("py-setuptools@59.6.0:", when="@3.2:", type="build")
     depends_on("py-setuptools-scm@7.0.3:", when="@3.1:", type="build")
     depends_on("py-build@0.9.0:", when="@3.1:", type="build")
-    depends_on("py-cffi@1.14.5:", type="run")
+    depends_on("py-cffi@1.14.5:", when="@3.1.0", type="run")
+    depends_on("py-cffi@1.14.5:", when="@3.2:", type=("build", "run"))
     depends_on("py-natsort@8.2.0:", type="run")
     depends_on("py-numpy@1.19.5:", type="run")
     depends_on("py-pandas@1.1.5:", type="run")
     depends_on("py-tables@3.7.0:", type="run")
     depends_on("py-psutil@5.8.0:", type="run")
     depends_on("py-pyyaml@6.0:", type="run")
+
+    # Integration test dependencies
     depends_on("py-docutils@0.18:", type="run")
+    depends_on("py-dash@2.17.1:", type="run")
+    depends_on("py-matplotlib", type="run")
+    depends_on("py-plotly@5.18.0:", type="run")
+    depends_on("py-torch@1.10.2:", type="run")
+    depends_on("numactl", type="run")
+    depends_on("stress-ng", type="run")
 
     build_directory = "geopmpy"
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if not self.spec.version.isdevelop():
             env.set("SETUPTOOLS_SCM_PRETEND_VERSION", self.version)
+        if self.version >= Version("3.2.0"):  # Required for CFFI API mode builds
+            env.append_path("C_INCLUDE_PATH", self.spec["geopm-runtime"].prefix.include)
+            env.append_path("LIBRARY_PATH", self.spec["geopm-runtime"].prefix.lib)

--- a/repos/spack_repo/builtin/packages/py_geopmpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_geopmpy/package.py
@@ -36,6 +36,7 @@ class PyGeopmpy(PythonPackage):
     depends_on("py-cffi@1.14.5:", when="@3.2:", type=("build", "run"))
     depends_on("py-natsort@8.2.0:", type="run")
     depends_on("py-numpy@1.19.5:", type="run")
+    depends_on("py-numpy@1.19.5:1", when="@3.2", type="run")
     depends_on("py-pandas@1.1.5:", type="run")
     depends_on("py-tables@3.7.0:", type="run")
     depends_on("py-psutil@5.8.0:", type="run")

--- a/repos/spack_repo/builtin/packages/py_setuptools_scm/package.py
+++ b/repos/spack_repo/builtin/packages/py_setuptools_scm/package.py
@@ -23,6 +23,7 @@ class PySetuptoolsScm(PythonPackage):
     version("8.1.0", sha256="42dea1b65771cba93b7a515d65a65d8246e560768a66b9106a592c8e7f26c8a7")
     version("8.0.4", sha256="b5f43ff6800669595193fd09891564ee9d1d7dcb196cab4b2506d53a2e1c95c7")
     version("7.1.0", sha256="6c508345a771aad7d56ebff0e70628bf2b0ec7573762be9960214730de278f27")
+    version("6.4.2", sha256="6833ac65c6ed9711a4d5d2266f8024cfa07c533a0e55f4c12f6eff280a5a9e30")
     version("6.3.2", sha256="a49aa8081eeb3514eb9728fa5040f2eaa962d6c6f4ec9c32f6c1fba88f88a0f2")
     version("5.0.2", sha256="83a0cedd3449e3946307811a4c7b9d89c4b5fd464a2fb5eeccd0a5bb158ae5c8")
     version("4.1.2", sha256="a8994582e716ec690f33fec70cca0f85bd23ec974e3f783233e4879090a7faa8")

--- a/repos/spack_repo/builtin/packages/stress_ng/package.py
+++ b/repos/spack_repo/builtin/packages/stress_ng/package.py
@@ -15,11 +15,11 @@ class StressNg(MakefilePackage):
     kernel interfaces."""
 
     homepage = "https://github.com/ColinIanKing/stress-ng"
-    url = "https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V0.19.00.tar.gz"
+    url = "https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V0.12.06.tar.gz"
 
     license("GPL-2.0-or-later")
 
-    version("0.19.00", sha256="7d0be69dcdad655145026f499863de01d317e87ff87acd48c3343d451540d172")
+    version("0.12.06", sha256="ad15205e7e57cec0b00643a17329d74fe75055bb76267558830b32e31d0a584f")
 
     depends_on("libaio")
     depends_on("libbsd")

--- a/repos/spack_repo/builtin/packages/stress_ng/package.py
+++ b/repos/spack_repo/builtin/packages/stress_ng/package.py
@@ -14,12 +14,12 @@ class StressNg(MakefilePackage):
     subsystems of a computer as well as the various operating system
     kernel interfaces."""
 
-    homepage = "https://kernel.ubuntu.com/~cking/stress-ng/"
-    url = "https://kernel.ubuntu.com/~cking/tarballs/stress-ng/stress-ng-0.12.06.tar.xz"
+    homepage = "https://github.com/ColinIanKing/stress-ng"
+    url = "https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V0.19.00.tar.gz"
 
     license("GPL-2.0-or-later")
 
-    version("0.12.06", sha256="75eb340266b1bbae944d8f9281af978bd5bc2c8085df97a098d5500d6f177296")
+    version("0.19.00", sha256="7d0be69dcdad655145026f499863de01d317e87ff87acd48c3343d451540d172")
 
     depends_on("libaio")
     depends_on("libbsd")


### PR DESCRIPTION
- Add support for GEOPM v3.2 to all existing packages.
- Reworked package dependencies such that py-geopmdpy depends on geopm-service, and py-geopmpy depends on py-geopmdpy and geopm-runtime. This dependency direction was always the case, but it is now required for CFFI API mode builds in the Python modules.