### PR TITLE
cpmd: Fix configure.sh not executable, compatibility with newer compilers

### DIFF
--- a/repos/spack_repo/builtin/packages/cpmd/package.py
+++ b/repos/spack_repo/builtin/packages/cpmd/package.py
@@ -6,6 +6,7 @@ from spack_repo.builtin.build_systems.makefile import MakefilePackage
 
 from spack.package import *
 
+import os
 
 class Cpmd(MakefilePackage):
     """The CPMD code is a parallelized plane wave / pseudopotential
@@ -68,7 +69,14 @@ class Cpmd(MakefilePackage):
             cp.filter("-ffree-line-length-none", "")
             cp.filter("-falign-commons", "-Kalign_commons")
 
+        if spec.satisfies("%gcc@10:"):
+            cp.filter(r"FFLAGS='([^']*)'", "FFLAGS='\\1 -fallow-argument-mismatch'")
+
+        if spec.satisfies("%gcc@14:"):
+            cp.filter(r"CFLAGS='([^']*)'", "CFLAGS='\\1 -Wno-error=int-conversion'")
+
         # create Makefile
+        os.chmod("./scripts/configure.sh", 0o755)
         bash = which("bash")
         if spec.satisfies("+omp"):
             bash("./configure.sh", "-omp", cbase)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
