### PR TITLE
julia: test for compiler, not for dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/julia/package.py
+++ b/repos/spack_repo/builtin/packages/julia/package.py
@@ -446,8 +446,8 @@ class Julia(MakefilePackage):
             "USE_INTEL_JITEVENTS:=0",  # @1.9:
         ]
 
-        options.append("USEGCC:={}".format("1" if "%gcc" in spec else "0"))
-        options.append("USECLANG:={}".format("1" if "%clang" in spec else "0"))
+        options.append("USEGCC:={}".format("1" if "%c=gcc" in spec else "0"))
+        options.append("USECLANG:={}".format("1" if "%c=llvm" in spec else "0"))
 
         options.extend(
             [

--- a/repos/spack_repo/builtin/packages/open3d/package.py
+++ b/repos/spack_repo/builtin/packages/open3d/package.py
@@ -61,8 +61,8 @@ class Open3d(CMakePackage, CudaPackage):
     depends_on("cuda@10.1:", when="+cuda")
 
     # C++14 compiler required
-    conflicts("%gcc@:4")
-    conflicts("%clang@:6")
+    conflicts("%cxx=gcc@:4")
+    conflicts("%cxx=clang@:6")
 
     # LLVM must be built with the C++ library
     conflicts("^llvm libcxx=none")

--- a/repos/spack_repo/builtin/packages/py_jaxlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_jaxlib/package.py
@@ -240,7 +240,7 @@ class PyJaxlib(PythonPackage, CudaPackage, ROCmPackage):
                 args.append("--wheels=jaxlib")
 
         if spec.satisfies("@0.4.32:"):
-            if spec.satisfies("%clang"):
+            if spec.satisfies("%c,cxx=clang"):
                 args.append("--use_clang=true")
             else:
                 args.append("--use_clang=false")

--- a/repos/spack_repo/builtin/packages/qt/package.py
+++ b/repos/spack_repo/builtin/packages/qt/package.py
@@ -475,12 +475,12 @@ class Qt(Package):
             "qmake/qmake.pri",
             "src/tools/bootstrap/bootstrap.pro",
         ]
-        if "%clang" in self.spec or "%apple-clang" in self.spec:
+        if "%cxx=clang" in self.spec or "%cxx=apple-clang" in self.spec:
             files_to_filter += [
                 "mkspecs/unsupported/macx-clang-libc++/qmake.conf",
                 "mkspecs/common/clang.conf",
             ]
-        elif "%gcc" in self.spec:
+        elif "%cxx=gcc" in self.spec:
             files_to_filter += ["mkspecs/common/g++-macx.conf", "mkspecs/darwin-g++/qmake.conf"]
 
         # Filter inserted configure variables
@@ -543,7 +543,7 @@ class Qt(Package):
             with open(conf_file, "a") as f:
                 f.write("QMAKE_CXXFLAGS += -std=gnu++98\n")
 
-    @when("@4 %clang")
+    @when("@4 %cxx=clang")
     def patch(self):
         (mkspec_dir, platform) = self.get_mkspec()
         conf_file = os.path.join(mkspec_dir, platform, "qmake.conf")


### PR DESCRIPTION
Closes #255

`%clang` is an alias for `%llvm` which now means "direct dep on llvm".

That's always the case since julia depends on llvm.

What is meant to be tested is whether llvm is the provider for the C
compiler. (And maybe CXX?)