### PR TITLE
plink: add 1.9-beta7.7

### DIFF
--- a/repos/spack_repo/builtin/packages/plink/dynamic_zlib-1.3.patch
+++ b/repos/spack_repo/builtin/packages/plink/dynamic_zlib-1.3.patch
@@ -1,0 +1,70 @@
+diff -ur a/1.9/dose2plink.c b/1.9/dose2plink.c
+--- a/1.9/dose2plink.c	2022-12-19 11:00:05.000000000 -0600
++++ b/1.9/dose2plink.c	2022-12-19 13:08:50.022275377 -0600
+@@ -15,6 +15,8 @@
+ // You should have received a copy of the GNU General Public License
+ // along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
++#include "plink_common.h"
++
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+@@ -96,7 +98,11 @@
+   #endif
+ #endif
+ 
+-#include "../zlib-1.3/zlib.h"
++#ifdef DYNAMIC_ZLIB
++  #include <zlib.h>
++#else
++  #include "../zlib-1.3/zlib.h"
++#endif
+ 
+ #ifdef __APPLE__
+   #include <sys/sysctl.h>
+diff -ur a/1.9/pigz.c b/1.9/pigz.c
+--- a/1.9/pigz.c	2022-12-19 11:00:05.000000000 -0600
++++ b/1.9/pigz.c	2022-12-19 13:06:08.562023953 -0600
+@@ -485,6 +485,8 @@
+ }
+ #else
+ 
++#include "pigz.h"
++
+ #define VERSION "pigz 2.3\n"
+ 
+ /* use large file functions if available */
+@@ -543,8 +545,6 @@
+                            release(), peek_lock(), free_lock(), yarn_name */
+ #endif
+ 
+-#include "pigz.h"
+-
+ 
+ /* for local functions and globals */
+ #define local static
+diff -ur a/1.9/pigz.h b/1.9/pigz.h
+--- a/1.9/pigz.h	2022-12-19 11:00:05.000000000 -0600
++++ b/1.9/pigz.h	2022-12-19 12:58:40.385103423 -0600
+@@ -1,6 +1,8 @@
+ #ifndef __PIGZ_H__
+ #define __PIGZ_H__
+ 
++#include "plink_common.h"
++
+ #include <stdint.h>
+ #include <inttypes.h>
+ 
+diff -ur a/1.9/plink_common.h b/1.9/plink_common.h
+--- a/1.9/plink_common.h	2022-12-19 11:00:06.000000000 -0600
++++ b/1.9/plink_common.h	2022-12-19 12:58:06.819259147 -0600
+@@ -41,6 +41,8 @@
+ // Uncomment this to build this without CBLAS/CLAPACK.
+ // #define NOLAPACK
+ 
++#define DYNAMIC_ZLIB
++
+ // Uncomment this to prevent all unstable features from being accessible from
+ // the command line.
+ #define STABLE_BUILD

--- a/repos/spack_repo/builtin/packages/plink/package.py
+++ b/repos/spack_repo/builtin/packages/plink/package.py
@@ -15,6 +15,11 @@ class Plink(Package):
     homepage = "https://www.cog-genomics.org/plink/1.9/"
 
     version(
+        "1.9-beta7.7",
+        commit="8bf44299e6eed58f3ebd27f7e28cead11b814785",
+        git="https://github.com/chrchang/plink-ng.git",
+    )
+    version(
         "1.9-beta6.27",
         commit="a2ea957c893fbb0558358edef27f3ecbf3d360f8",
         git="https://github.com/chrchang/plink-ng.git",
@@ -45,7 +50,8 @@ class Plink(Package):
         depends_on("lapack", when="@1.9-beta6.27:")
     depends_on("gmake", type="build")
 
-    patch("dynamic_zlib.patch", when="@1.9-beta6.27:")
+    patch("dynamic_zlib.patch", when="@1.9-beta6.27:1.9-beta6.99")
+    patch("dynamic_zlib-1.3.patch", when="@1.9-beta7.7:")
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/repos/spack_repo/builtin/packages/plink/package.py
+++ b/repos/spack_repo/builtin/packages/plink/package.py
@@ -13,17 +13,10 @@ class Plink(Package):
     computationally efficient manner."""
 
     homepage = "https://www.cog-genomics.org/plink/1.9/"
+    git = "https://github.com/chrchang/plink-ng.git"
 
-    version(
-        "1.9-beta7.7",
-        commit="8bf44299e6eed58f3ebd27f7e28cead11b814785",
-        git="https://github.com/chrchang/plink-ng.git",
-    )
-    version(
-        "1.9-beta6.27",
-        commit="a2ea957c893fbb0558358edef27f3ecbf3d360f8",
-        git="https://github.com/chrchang/plink-ng.git",
-    )
+    version("1.9-beta7.7", commit="8bf44299e6eed58f3ebd27f7e28cead11b814785")
+    version("1.9-beta6.27", commit="a2ea957c893fbb0558358edef27f3ecbf3d360f8")
     version(
         "1.9-beta6.10",
         sha256="f8438656996c55a5edd95c223cce96277de6efaab1b9b1d457bfee0c272058d8",


### PR DESCRIPTION
The new plink version has a higher version of the bundled zlib library, so there is also a new version of the patch.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
