### PR TITLE
gaudi: remove nose dependency for v38r0

### DIFF
--- a/repos/spack_repo/builtin/packages/gaudi/package.py
+++ b/repos/spack_repo/builtin/packages/gaudi/package.py
@@ -139,7 +139,7 @@ class Gaudi(CMakePackage, CudaPackage):
 
     # Testing dependencies
     # Note: gaudi only builds examples when testing enabled
-    for pv in (["catch2", "@36.8:"], ["py-nose", "@35:"], ["py-pytest", "@36.2:"]):
+    for pv in (["catch2", "@36.8:"], ["py-nose", "@35:37"], ["py-pytest", "@36.2:"]):
         depends_on(pv[0], when=pv[1], type="test")
         depends_on(pv[0], when=pv[1] + " +examples")
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Remove the `py-nose` dependency starting from version 38. As per the release notes:

https://gitlab.cern.ch/gaudi/Gaudi/-/blob/master/CHANGELOG.md?ref_type=heads#v38r0---2024-01-25

specifically, this MR: https://gitlab.cern.ch/gaudi/Gaudi/-/merge_requests/1520