### PR TITLE
new packages: nmad, padicotm, pioman, puk, pukabi

### DIFF
--- a/repos/spack_repo/builtin/packages/nmad/package.py
+++ b/repos/spack_repo/builtin/packages/nmad/package.py
@@ -1,0 +1,154 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack.package import *
+from spack_repo.builtin.packages.puk.package import Puk
+
+
+class Nmad(AutotoolsPackage):
+    """NewMadeleine communication library.
+
+    NewMadeleine is a communication library for high-performance
+    networks, with its native interface as well as an MPI
+    interface. It comes with an optimizing scheduler that applies
+    optimization strategies on the flow of packets. It is fully
+    multi-threaded and very scalable. Its MPI implementation MadMPI
+    fully supports the MPI_THREAD_MULTIPLE multi-threading level.
+    """
+
+    homepage = "https://pm2.gitlabpages.inria.fr/newmadeleine/"
+    url = "https://pm2.gitlabpages.inria.fr/releases/pm2-2025-03-18.tar.gz"
+    list_url = "https://pm2.gitlabpages.inria.fr/releases/"
+    git = "git@gitlab.inria.fr:pm2/pm2.git"
+
+    maintainers("a-denis")
+    license("GPL-2.0-or-later", checked_by="a-denis")
+
+    def url_for_version(self, version):
+        url = "https://pm2.gitlabpages.inria.fr/releases/pm2-{0}.tar.gz"
+        return url.format(version)
+
+    version("master", branch="master")
+    version(
+        "2025-03-18", sha256="2d0208809dd17bac4fd7e7f97b22e2240b925d8828b9ab5dc5f435e58ff97010"
+    )
+    version(
+        "2024-11-21", sha256="76da169bbb9720a13be1f750480e1a7d6510830163878852876932639879d632"
+    )
+    version(
+        "2024-07-12", sha256="ea9bb91b213950a52eb99d787110905d45ed02954ea9133596d690db5be0c31b"
+    )
+    version(
+        "2022-05-31", sha256="afd19809a5a520a477ab596f951bbde3209868ab16febbc246592e8aed20c3ca"
+    )
+    version(
+        "2021-05-21", sha256="6a207b032e623b8be0196a42dcaf4311bfe45ede2e044bd47611b6610c04c61e"
+    )
+
+    variant("optimize", default=True, description="Build in optimized mode")
+    variant("debug", default=False, description="Build in debug mode")
+    variant("asan", default=False, description="Build with Address Sanitizer (ASAN)")
+    variant("mpi", default=True, description="Enable builtin MPI implementation MadMPI")
+    variant("pukabi", default=False, description="Build with PukABI")
+    variant("pioman", default=True, description="Build with pioman")
+    variant("fortran", default=True, description="Enable FORTRAN support in MadMPI")
+    variant("profile", default=False, description="Enable nmad stats & profiling")
+    variant("ibverbs", default=True, description="use InfiniBand ibverbs")
+    variant("psm", default=False, description="use Intel Performance Scaled Messaging (PSM)")
+    variant("psm2", default=False, description="use Intel Performance Scaled Messaging 2 (PSM2)")
+    variant("ofi", default=True, description="use OpenFabric Interface (libfabric)")
+    variant("ucx", default=True, description="use Unified Communication X Library (ucx)")
+    variant("craypmi", default=False, description="use Cray PMI support")
+    variant("pmix", default=True, description="use slurm PMIx support")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build", when="+fortran")
+    depends_on("pkgconfig", type="build")
+    depends_on("autoconf@2.69:", type="build")
+    depends_on("gmake", type="build")
+
+    depends_on("hwloc")
+    depends_on("psm", when="+psm")
+    depends_on("opa-psm2", when="+psm2")
+    depends_on("libfabric", when="+ofi")
+    depends_on("cray-pmi", when="+craypmi")
+    depends_on("pmix", when="+pmix")
+    depends_on("ucx", when="+ucx")
+    requires("+pukabi", when="+ibverbs", msg="ibverbs rcache requires pukabi")
+
+    for v in Puk.versions:
+        depends_on(f"puk@{v}", when=f"@{v}")
+        depends_on(f"pukabi@{v}", when=f"@{v} +pukabi")
+        depends_on(f"pioman@{v}", when=f"@{v} +pioman")
+        depends_on(f"padicotm@{v}", when=f"@{v}")
+
+    depends_on("puk")
+    depends_on("puk+asan", when="+asan")
+    depends_on("pukabi+mem", when="+pukabi")
+    depends_on("pioman", when="+pioman")
+    depends_on("padicotm~pioman", when="~pioman", type=("build", "link", "run"))
+    depends_on("padicotm+pioman", when="+pioman", type=("build", "link", "run"))
+    depends_on("padicotm+ibverbs", when="+ibverbs")
+    depends_on("padicotm+psm", when="+psm")
+    depends_on("padicotm+psm2", when="+psm2")
+    depends_on("padicotm+ofi", when="+ofi")
+    depends_on("padicotm+craypmi", when="+craypmi")
+    depends_on("padicotm+pmix", when="+pmix")
+    depends_on("padicotm+pukabi", when="+pukabi")
+    depends_on("padicotm~pukabi", when="~pukabi")
+
+    conflicts("platform=darwin", msg="Darwin is not supported.")
+    conflicts("platform=windows", msg="Windows is not supported.")
+    conflicts("%gcc@:5", msg="Requires at least gcc 6.")
+    conflicts("%gcc@14:", when="@:2024-07-12", msg="Older release do not support gcc >= 14")
+    conflicts("%clang", when="+fortran", msg="No FORTRAN support with clang.")
+
+    provides("mpi", when="+mpi")
+
+    configure_directory = "nmad"
+    build_directory = "build"
+
+    def autoreconf(self, spec, prefix):
+        with working_dir(self.configure_directory):
+            Executable("./autogen.sh")()
+
+    def configure_args(self):
+        config_args = [
+            "--without-pukabi",  # no pukabi for now in spack
+            "--disable-sampling",  # sampling currently broken; don"t attempt to use it
+            "--with-padicotm",  # always use PadicoTM
+        ]
+        config_args += self.enable_or_disable("optimize")
+        config_args += self.enable_or_disable("debug")
+        config_args += self.enable_or_disable("asan")
+        config_args += self.enable_or_disable("mpi")
+        config_args += self.enable_or_disable("fortran")
+        config_args += self.enable_or_disable("profile")
+        config_args += self.with_or_without("pukabi")
+        config_args += self.with_or_without("pioman")
+        config_args += self.with_or_without("ibverbs")
+        config_args += self.with_or_without("psm")
+        config_args += self.with_or_without("psm2")
+        config_args += self.with_or_without("ofi")
+        config_args += self.with_or_without("ucx")
+        config_args += self.with_or_without("ibverbs")
+        config_args += self.with_or_without("pmix")
+        config_args += self.with_or_without("pmi2", variant="craypmi")
+        return config_args
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        if "+mpi" in self.spec:
+            spack_env.set("MPICC", join_path(self.prefix.bin, "mpicc.madmpi"))
+            spack_env.set("MPICXX", join_path(self.prefix.bin, "mpicxx.madmpi"))
+            spack_env.set("MPIF77", join_path(self.prefix.bin, "mpif77.madmpi"))
+            spack_env.set("MPIF90", join_path(self.prefix.bin, "mpif90.madmpi"))
+
+    def setup_dependent_package(self, module, dependent_spec):
+        if "+mpi" in self.spec:
+            self.spec.mpicc = join_path(self.prefix.bin, "mpicc.madmpi")
+            self.spec.mpicxx = join_path(self.prefix.bin, "mpicxx.madmpi")
+            self.spec.mpifc = join_path(self.prefix.bin, "mpif90.madmpi")
+            self.spec.mpif77 = join_path(self.prefix.bin, "mpif77.madmpi")

--- a/repos/spack_repo/builtin/packages/padicotm/package.py
+++ b/repos/spack_repo/builtin/packages/padicotm/package.py
@@ -1,0 +1,116 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack.package import *
+from spack_repo.builtin.packages.puk.package import Puk
+
+
+class Padicotm(AutotoolsPackage):
+    """PadicoTM communication framework and launcher.
+
+    PadicoTM is the runtime infrastructure for the Padico software
+    environment for computational grids. It is composed of a core
+    which provides a high-performance framework for networking and
+    multi-threading, on top of which the abstraction layer is built
+    with freely and dynamically assembled components. Various
+    communications methods are embedded in components that the user
+    may assemble to get the needed communication stack.
+    """
+
+    homepage = "https://pm2.gitlabpages.inria.fr/PadicoTM/"
+    url = "https://pm2.gitlabpages.inria.fr/releases/"
+    list_url = "https://pm2.gitlabpages.inria.fr/releases/"
+    git = "https://gitlab.inria.fr/pm2/pm2.git"
+
+    maintainers("a-denis")
+    license("GPL-2.0-or-later", checked_by="a-denis")
+
+    def url_for_version(self, version):
+        url = "https://pm2.gitlabpages.inria.fr/releases/pm2-{0}.tar.gz"
+        return url.format(version)
+
+    version("master", branch="master")
+    version(
+        "2025-03-18", sha256="2d0208809dd17bac4fd7e7f97b22e2240b925d8828b9ab5dc5f435e58ff97010"
+    )
+    version(
+        "2024-11-21", sha256="76da169bbb9720a13be1f750480e1a7d6510830163878852876932639879d632"
+    )
+    version(
+        "2024-07-12", sha256="ea9bb91b213950a52eb99d787110905d45ed02954ea9133596d690db5be0c31b"
+    )
+    version(
+        "2022-05-31", sha256="afd19809a5a520a477ab596f951bbde3209868ab16febbc246592e8aed20c3ca"
+    )
+    version(
+        "2021-05-21", sha256="6a207b032e623b8be0196a42dcaf4311bfe45ede2e044bd47611b6610c04c61e"
+    )
+
+    variant("optimize", default=True, description="Build in optimized mode")
+    variant("debug", default=False, description="Build in debug mode")
+    variant("asan", default=False, description="Build with Address Sanitizer (ASAN)")
+    variant("pukabi", default=False, description="Build with PukABI")
+    variant("pioman", default=True, description="use pioman I/O manager")
+    variant("ibverbs", default=True, description="use InfiniBand ibverbs")
+    variant("psm", default=False, description="use Intel Performance Scaled Messaging (PSM)")
+    variant("psm2", default=False, description="use Intel Performance Scaled Messaging 2 (PSM2)")
+    variant("ofi", default=True, description="use OpenFabric Interface (libfabric)")
+    variant("craypmi", default=False, description="use Cray PMI support")
+    variant("pmix", default=True, description="use slurm PMIx support")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("pkgconfig", type="build")
+    depends_on("autoconf@2.69:", type="build")
+    depends_on("gmake", type="build")
+
+    depends_on("hwloc@2.0.0:", type=("build", "link", "run"))
+    depends_on("zlib")
+    depends_on("lz4")
+    depends_on("rdma-core", when="+ibverbs")
+    depends_on("psm", when="+psm")
+    depends_on("opa-psm2", when="+psm2")
+    depends_on("libfabric", when="+ofi")
+    depends_on("cray-pmi", when="+craypmi")
+    depends_on("pmix", when="+pmix")
+    requires("+pukabi", when="+ibverbs", msg="ibverbs rcache requires pukabi")
+
+    for v in Puk.versions:
+        depends_on(f"puk@{v}", when=f"@{v}")
+        depends_on(f"pukabi@{v}", when=f"@{v} +pukabi")
+        depends_on(f"pioman@{v}", when=f"@{v} +pioman")
+
+    depends_on("puk")
+    depends_on("pukabi", when="+pukabi")
+    depends_on("pioman", when="+pioman")
+    depends_on("puk+asan", when="+asan")
+
+    conflicts("+pukabi", when="+asan", msg="PukABI and ASAN conflicts for LD_PRELOAD")
+    conflicts("platform=darwin", msg="Darwin is not supported.")
+    conflicts("platform=windows", msg="Windows is not supported.")
+    conflicts("%gcc@:5", msg="Requires at least gcc 6.")
+    conflicts("%gcc@14:", when="@:2024-07-12", msg="Older release do not support gcc >= 14")
+
+    configure_directory = "PadicoTM"
+    build_directory = "build"
+
+    def autoreconf(self, spec, prefix):
+        with working_dir(self.configure_directory):
+            Executable("./autogen.sh")()
+
+    def configure_args(self):
+        config_args = ["--without-portals4"]  # portals4 not packaged in spack
+        config_args += self.enable_or_disable("optimize")
+        config_args += self.enable_or_disable("debug")
+        config_args += self.enable_or_disable("asan")
+        config_args += self.with_or_without("pukabi")
+        config_args += self.with_or_without("pioman")
+        config_args += self.with_or_without("psm")
+        config_args += self.with_or_without("psm2")
+        config_args += self.with_or_without("ofi")
+        config_args += self.with_or_without("ibverbs")
+        config_args += self.with_or_without("pmix")
+        config_args += self.with_or_without("pmi2", variant="craypmi")
+        return config_args

--- a/repos/spack_repo/builtin/packages/pioman/package.py
+++ b/repos/spack_repo/builtin/packages/pioman/package.py
@@ -1,0 +1,90 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack.package import *
+from spack_repo.builtin.packages.puk.package import Puk
+
+
+class Pioman(AutotoolsPackage):
+    """PIOMan I/O manager.
+
+    PIOMan is a generic I/O manager, designed to deal with
+    interactions between communication and multi-threading. It
+    guarantees a good level of reactivity, is able to automatically
+    choose between active polling and blocking calls depending on the
+    context, and may offload I/O requests to idle cores when availble
+    to handle multiple requests in parallel and overlap communication
+    and computation.
+    """
+
+    homepage = "https://pm2.gitlabpages.inria.fr/pioman/"
+    url = "https://pm2.gitlabpages.inria.fr/releases/pm2-2025-03-18.tar.gz"
+    list_url = "https://pm2.gitlabpages.inria.fr/releases/"
+    git = "https://gitlab.inria.fr/pm2/pm2.git"
+
+    maintainers("a-denis")
+    license("GPL-2.0-or-later", checked_by="a-denis")
+
+    def url_for_version(self, version):
+        url = "https://pm2.gitlabpages.inria.fr/releases/pm2-{0}.tar.gz"
+        return url.format(version)
+
+    version("master", branch="master")
+    version(
+        "2025-03-18", sha256="2d0208809dd17bac4fd7e7f97b22e2240b925d8828b9ab5dc5f435e58ff97010"
+    )
+    version(
+        "2024-11-21", sha256="76da169bbb9720a13be1f750480e1a7d6510830163878852876932639879d632"
+    )
+    version(
+        "2024-07-12", sha256="ea9bb91b213950a52eb99d787110905d45ed02954ea9133596d690db5be0c31b"
+    )
+    version(
+        "2022-05-31", sha256="afd19809a5a520a477ab596f951bbde3209868ab16febbc246592e8aed20c3ca"
+    )
+    version(
+        "2021-05-21", sha256="6a207b032e623b8be0196a42dcaf4311bfe45ede2e044bd47611b6610c04c61e"
+    )
+
+    variant("optimize", default=True, description="Build in optimized mode")
+    variant("debug", default=False, description="Build in debug mode")
+    variant("asan", default=False, description="Build with Address Sanitizer (ASAN)")
+    variant("pthread", default=True, description="use pthreads")
+
+    depends_on("c", type="build")
+    depends_on("pkgconfig", type="build")
+    depends_on("autoconf@2.69:", type="build")
+    depends_on("gmake", type="build")
+
+    depends_on("hwloc", type=("build", "link", "run"))
+
+    for v in Puk.versions:
+        depends_on(f"puk@{v}", when=f"@{v}")
+
+    depends_on("puk")
+    depends_on("puk+asan", when="+asan")
+
+    conflicts("platform=darwin", msg="Darwin is not supported.")
+    conflicts("platform=windows", msg="Windows is not supported.")
+    conflicts("%gcc@:5", msg="Requires at least gcc 6.")
+
+    configure_directory = "pioman"
+    build_directory = "build"
+
+    def autoreconf(self, spec, prefix):
+        with working_dir(self.configure_directory):
+            Executable("./autogen.sh")()
+
+    def configure_args(self):
+        config_args = [
+            "--with-hwloc",  # always use hwloc
+            "--without-gtg",  # no gtg package in spack
+            "--without-simgrid",  # no simgrid support in spack for now
+        ]
+        config_args += self.enable_or_disable("optimize")
+        config_args += self.enable_or_disable("debug")
+        config_args += self.enable_or_disable("asan")
+        config_args += self.with_or_without("pthread")
+        return config_args

--- a/repos/spack_repo/builtin/packages/puk/package.py
+++ b/repos/spack_repo/builtin/packages/puk/package.py
@@ -1,0 +1,87 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack.package import *
+
+
+class Puk(AutotoolsPackage):
+    """Puk: Padico micro-kernel.
+
+    Puk is the foundation module of PadicoTM. Its task is to manage
+    modules (loading, running and unloading). It comes with a powerful
+    component model used to assemble a communication stack.
+    """
+
+    homepage = "https://pm2.gitlabpages.inria.fr/"
+    url = "https://pm2.gitlabpages.inria.fr/releases/pm2-2025-03-18.tar.gz"
+    list_url = "https://pm2.gitlabpages.inria.fr/releases/"
+    git = "https://gitlab.inria.fr/pm2/pm2.git"
+
+    maintainers("a-denis")
+    license("GPL-2.0-or-later", checked_by="a-denis")
+
+    def url_for_version(self, version):
+        url = "https://pm2.gitlabpages.inria.fr/releases/pm2-{0}.tar.gz"
+        return url.format(version)
+
+    version("master", branch="master")
+    version(
+        "2025-03-18", sha256="2d0208809dd17bac4fd7e7f97b22e2240b925d8828b9ab5dc5f435e58ff97010"
+    )
+    version(
+        "2024-11-21", sha256="76da169bbb9720a13be1f750480e1a7d6510830163878852876932639879d632"
+    )
+    version(
+        "2024-07-12", sha256="ea9bb91b213950a52eb99d787110905d45ed02954ea9133596d690db5be0c31b"
+    )
+    version(
+        "2022-05-31", sha256="afd19809a5a520a477ab596f951bbde3209868ab16febbc246592e8aed20c3ca"
+    )
+    version(
+        "2021-05-21", sha256="6a207b032e623b8be0196a42dcaf4311bfe45ede2e044bd47611b6610c04c61e"
+    )
+
+    variant("optimize", default=True, description="Build in optimized mode")
+    variant("debug", default=False, description="Build in debug mode")
+    variant("trace", default=False, description="enable Puk traces")
+    variant("profile", default=False, description="enable Puk memory profiling")
+    variant("asan", default=False, description="Build with Address Sanitizer (ASAN)")
+    variant("builtin", default=False, description="Build all modules as builtin")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("autoconf@2.69:", type="build")
+    depends_on("pkgconfig", type="build")
+    depends_on("gmake", type="build")
+
+    depends_on("bash")
+    depends_on("expat@2.1.0:")
+    depends_on("gdb", when="+debug", type=("build", "run"))
+    depends_on("valgrind", when="+debug", type=("build", "run"))
+
+    conflicts("platform=darwin", msg="Darwin is not supported.")
+    conflicts("platform=windows", msg="Windows is not supported.")
+    conflicts("%gcc@:5", msg="Requires at least gcc 6.")
+    conflicts("%gcc@14:", when="@:2024-07-12", msg="Older release do not support gcc >= 14")
+
+    configure_directory = "Puk"
+    build_directory = "build"
+
+    def autoreconf(self, spec, prefix):
+        with working_dir(self.configure_directory):
+            Executable("./autogen.sh")()
+
+    def configure_args(self):
+        config_args = [
+            "--enable-lfqueue=nblfq",  # use nblfq by default for production
+            "--without-simgrid",  # no simgrid support with spack for now
+        ]
+        config_args += self.enable_or_disable("optimize")
+        config_args += self.enable_or_disable("debug")
+        config_args += self.enable_or_disable("asan")
+        config_args += self.enable_or_disable("trace")
+        config_args += self.enable_or_disable("profile")
+        config_args += self.enable_or_disable("builtin")
+        return config_args

--- a/repos/spack_repo/builtin/packages/pukabi/package.py
+++ b/repos/spack_repo/builtin/packages/pukabi/package.py
@@ -1,0 +1,89 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack.package import *
+from spack_repo.builtin.packages.puk.package import Puk
+
+
+class Pukabi(AutotoolsPackage):
+    """PukABI: ABI manager for PadicoTM.
+
+    PukABI is an ABI manager used by PadicoTM and NewMadeleine. It is
+    able to intercept symbols of the libc, so as to install a virtual
+    version or to add hooks.
+    """
+
+    homepage = "https://pm2.gitlabpages.inria.fr/"
+    url = "https://pm2.gitlabpages.inria.fr/releases/pm2-2025-03-18.tar.gz"
+    list_url = "https://pm2.gitlabpages.inria.fr/releases/"
+    git = "https://gitlab.inria.fr/pm2/pm2.git"
+
+    maintainers("a-denis")
+    license("GPL-2.0-or-later", checked_by="a-denis")
+
+    def url_for_version(self, version):
+        url = "https://pm2.gitlabpages.inria.fr/releases/pm2-{0}.tar.gz"
+        return url.format(version)
+
+    version("master", branch="master")
+    version(
+        "2025-03-18", sha256="2d0208809dd17bac4fd7e7f97b22e2240b925d8828b9ab5dc5f435e58ff97010"
+    )
+    version(
+        "2024-11-21", sha256="76da169bbb9720a13be1f750480e1a7d6510830163878852876932639879d632"
+    )
+    version(
+        "2024-07-12", sha256="ea9bb91b213950a52eb99d787110905d45ed02954ea9133596d690db5be0c31b"
+    )
+    version(
+        "2022-05-31", sha256="afd19809a5a520a477ab596f951bbde3209868ab16febbc246592e8aed20c3ca"
+    )
+    version(
+        "2021-05-21", sha256="6a207b032e623b8be0196a42dcaf4311bfe45ede2e044bd47611b6610c04c61e"
+    )
+
+    variant("optimize", default=True, description="Build in optimized mode")
+    variant("debug", default=False, description="Build in debug mode")
+    variant("mem", default=True, description="intercept memory-related symbols")
+    variant("fsys", default=False, description="intercept filesystem-related symbols")
+    variant("proc", default=False, description="intercept process-related symbols")
+    variant("errno", default=False, description="intercept errno symbols")
+    variant("sleep", default=False, description="intercept sleep symbols")
+    variant("file", default=False, description="intercept FILE*-related symbols")
+    variant("resolv", default=False, description="intercept DNS resolver-related symbols")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("autoconf@2.69:", type="build")
+    depends_on("pkgconfig", type="build")
+    depends_on("gmake", type="build")
+
+    for v in Puk.versions:
+        depends_on(f"puk@{v}", when=f"@{v}")
+
+    conflicts("platform=darwin", msg="Darwin is not supported.")
+    conflicts("platform=windows", msg="Windows is not supported.")
+    conflicts("%gcc@:5", msg="Requires at least gcc 6.")
+    conflicts("%gcc@14:", when="@:2024-07-12", msg="Older release do not support gcc >= 14")
+
+    configure_directory = "PukABI"
+    build_directory = "build"
+
+    def autoreconf(self, spec, prefix):
+        with working_dir(self.configure_directory):
+            Executable("./autogen.sh")()
+
+    def configure_args(self):
+        config_args = []
+        config_args += self.enable_or_disable("optimize")
+        config_args += self.enable_or_disable("debug")
+        config_args += self.enable_or_disable("fsys")
+        config_args += self.enable_or_disable("proc")
+        config_args += self.enable_or_disable("mem")
+        config_args += self.enable_or_disable("errno")
+        config_args += self.enable_or_disable("sleep")
+        config_args += self.enable_or_disable("file")
+        config_args += self.enable_or_disable("resolv")
+        return config_args


### PR DESCRIPTION
This PR adds package 'nmad' and its dependencies: padicotm, pioman, puk, and pukabi.

This PR was originally https://github.com/spack/spack/pull/49601 and was migrated manually to spack-packages.