### PR TITLE
[Conflicts] DNM: Update aws-pcluster-amazonlinux-2 stacks

### DIFF
--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -759,7 +759,7 @@ hep-build:
 ########################################
 
 .aws-pcluster-generate:
-  image: { "name": "ghcr.io/spack/pcluster-amazonlinux-2:v2024-10-07", "entrypoint": [""] }
+  image: { "name": "ghcr.io/spack/pcluster-amazonlinux-2:pr-66", "entrypoint": [""] }
 
 # X86_64_V4 (one pipeline per target)
 .aws-pcluster-x86_64_v4:

--- a/.ci/gitlab/stacks/aws-pcluster-neoverse_v1/spack.yaml
+++ b/.ci/gitlab/stacks/aws-pcluster-neoverse_v1/spack.yaml
@@ -17,7 +17,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: {name: ghcr.io/spack/pcluster-amazonlinux-2:v2024-10-07, entrypoint: ['']}
+        image: {name: ghcr.io/spack/pcluster-amazonlinux-2:pr-66, entrypoint: ['']}
         tags: [aarch64]
         before_script:
         - - mkdir spack
@@ -31,8 +31,10 @@ spack:
           - . /etc/profile.d/modules.sh
           - spack --version
           - spack arch
-          - export PATH=/home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/binutils-2.37-2yxz3xsjfmesxujxtlrgcctxlyilynmp/bin:$PATH
+          - spack mirror add --signed boot /bootstrap-gcc-cache/
+          - spack buildcache keys --install --trust --force
           - spack -c "config:install_tree:root:/home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh" reindex
+          - spack install --use-buildcache package:only gcc@12
     - signing-job:
         before_script:
             # Do not distribute Intel & ARM binaries
@@ -47,67 +49,59 @@ spack:
       missing_library_policy: ignore  # due to use of externals
 
   packages:
-    gcc:
-      externals:
-      - spec: gcc@=12.4.0
-        prefix: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b
-        extra_attributes:
-          compilers:
-            c: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/gcc
-            cxx: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/g++
-            fortran: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/gfortran
+    all:
+      permissions:
+        read: world
+        write: user
+      target: ["neoverse_v1"]
+      providers:
+        blas: [armpl-gcc, openblas]
+        fftw-api: [armpl-gcc, fftw]
+        mpi: [openmpi, mpich]
+        lapack: [armpl-gcc, openblas]
+        scalapack: [netlib-scalapack]
+        c: [gcc@12, acfl]
+        cxx: [gcc@12, acfl]
+        fortran: [gcc@12, acfl]
+    c:
+      require: gcc@12
     acfl:
       require:
-      - "%gcc"
       - "target=aarch64"
     gromacs:
-      require:
-      - gromacs@2024.3 ^armpl-gcc ^openmpi
-      - "%gcc"
-      - target=neoverse_v1
+      version: [2024.3]
     libfabric:
       buildable: true
       externals:
       - prefix: /opt/amazon/efa/
         spec: libfabric@1.17.0
-      require:
+      variants:
       - fabrics=shm,efa
-      - target=neoverse_v1
     llvm:
       variants: ~lldb
     mpas-model:
-      require:
-      - precision=single ^parallelio+pnetcdf
-      - "%gcc"
-      - target=neoverse_v1
+      variants:
+       - precision=single ^parallelio+pnetcdf
     mpich:
       require:
       - mpich pmi=pmi2 device=ch4 netmod=ofi +slurm
-      - target=neoverse_v1
     nvhpc:
       require:
       - "target=aarch64"
     openfoam:
       require:
       - openfoam ^scotch@6.0.9
-      - target=neoverse_v1
     openmpi:
       variants: ~atomics ~cuda ~cxx ~cxx_exceptions ~internal-hwloc ~java +legacylaunchers ~lustre ~memchecker +pmi +romio ~singularity +vt +wrapper-rpath fabrics=ofi schedulers=slurm
       require:
       - '@4:'
-      - target=neoverse_v1
     # Palace does not build correctly with armpl until https://github.com/awslabs/palace/pull/207 is merged into a version.
     # palace:
     #   require:
     #     - one_of: ["palace cxxflags=\"-include cstdint\" ^fmt@9.1.0"]
     pmix:
       require:
-      - "pmix@3:"
-      - target=neoverse_v1
-    quantum-espresso:
-      require:
-      - quantum-espresso@6.6 %gcc ^armpl-gcc
-      - target=neoverse_v1
+      - '@3:'
     slurm:
       buildable: false
       externals:
@@ -115,17 +109,3 @@ spack:
         spec: slurm@22.05.8 +pmix
       require:
       - "+pmix"
-    all:
-      target: ["neoverse_v1"]
-      require:
-      - "%gcc"
-      - "target=neoverse_v1"
-      providers:
-        blas: [armpl-gcc, openblas]
-        fftw-api: [armpl-gcc, fftw]
-        lapack: [armpl-gcc, openblas]
-        mpi: [openmpi, mpich]
-        scalapack: [netlib-scalapack]
-      permissions:
-        read: world
-        write: user

--- a/.ci/gitlab/stacks/aws-pcluster-x86_64_v4/spack.yaml
+++ b/.ci/gitlab/stacks/aws-pcluster-x86_64_v4/spack.yaml
@@ -22,7 +22,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: {name: ghcr.io/spack/pcluster-amazonlinux-2:v2024-10-07, entrypoint: ['']}
+        image: {name: ghcr.io/spack/pcluster-amazonlinux-2:pr-66, entrypoint: ['']}
         before_script:
         - - mkdir spack
           - cd spack
@@ -35,8 +35,11 @@ spack:
           - . /etc/profile.d/modules.sh
           - spack --version
           - spack arch
-          - export PATH=/home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/binutils-2.37-qvccg7zpskturysmr4bzbsfrx34kvazo/bin:$PATH
+          - spack mirror add --signed boot /bootstrap-gcc-cache/
+          - spack buildcache keys --install --trust --force
           - spack -c "config:install_tree:root:/home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh" reindex
+          - spack install --use-buildcache package:only gcc@12
+          - spack install --use-buildcache package:only intel-oneapi-compilers@2024.1.0 target=x86_64_v3
     - signing-job:
         before_script:
             # Do not distribute Intel & ARM binaries
@@ -51,29 +54,6 @@ spack:
       missing_library_policy: ignore  # due to use of externals
 
   packages:
-    gcc:
-      externals:
-        - spec: gcc@=12.4.0
-          prefix: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb
-          extra_attributes:
-            compilers:
-              c: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/bin/gcc
-              cxx: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/bin/g++
-              fortran: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/bin/gfortran
-    intel-oneapi-compilers:
-      externals:
-        - spec: intel-oneapi-compilers@=2024.1.0
-          prefix: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-12.4.0/intel-oneapi-compilers-2024.1.0-f5u3psfhbwscasajkn324igtupn3blop
-          extra_attributes:
-            compilers:
-              c: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-12.4.0/intel-oneapi-compilers-2024.1.0-f5u3psfhbwscasajkn324igtupn3blop/compiler/2024.1/bin/icx
-              cxx: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-12.4.0/intel-oneapi-compilers-2024.1.0-f5u3psfhbwscasajkn324igtupn3blop/compiler/2024.1/bin/icpx
-              fortran: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-12.4.0/intel-oneapi-compilers-2024.1.0-f5u3psfhbwscasajkn324igtupn3blop/compiler/2024.1/bin/ifx
-            extra_rpaths:
-              - /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/lib64
-    fortran:
-      require:
-      - "intel-oneapi-compilers"
     gettext:
       # Newer gettext cannot build with gcc@12 and old AL2 glibc headers
       # Older gettext versions do not build correctly with oneapi.
@@ -108,9 +88,6 @@ spack:
     mpich:
       require:
       - mpich pmi=pmi2 device=ch4 netmod=ofi +slurm
-    openfoam:
-      require:
-      - openfoam %gcc ^scotch@6.0.9
     openmpi:
       variants: ~atomics ~cuda ~cxx ~cxx_exceptions ~internal-hwloc ~java +legacylaunchers ~lustre ~memchecker +pmi +romio ~singularity +vt +wrapper-rpath fabrics=ofi schedulers=slurm
       require:
@@ -135,12 +112,13 @@ spack:
       require:
       - wrf@4 build_type=dm+sm
     all:
-      require:
-      - "%oneapi"
       permissions:
         read: world
         write: user
       providers:
+        c: [intel-oneapi-compilers, gcc]
+        cxx: [intel-oneapi-compilers, gcc]
+        fortran: [intel-oneapi-compilers, gcc]
         blas: [intel-oneapi-mkl]
         daal: [intel-oneapi-dal]
         fftw-api: [intel-oneapi-mkl]


### PR DESCRIPTION
Update the aws-pcluster-amazonlinux-2 stacks.  These stacks will now use an in-image build-cache for intel and gcc compilers.  I expect the gcc compiler to be pushed to the public build-cache where users can install directly without using our previous method of hosting a special buildcache on-the-side.

This change made possible by compilers-as-dependencies!

---
Replaces https://github.com/spack/spack-packages/pull/83, which wasn't re-building packages like I expected.  Fresh PR should help.