### PR TITLE
CI: Use set destination to override repo for gitlab CI

### DIFF
--- a/.ci/configs/repos.yaml
+++ b/.ci/configs/repos.yaml
@@ -1,2 +1,0 @@
-repos:
-  builtin:: ${CI_PROJECT_DIR}/repos/spack_repo/builtin

--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -21,7 +21,6 @@ default:
   - echo ${SPACK_CHECKOUT_VERSION}
   - git fetch --depth 1 origin ${SPACK_CHECKOUT_VERSION}
   - git checkout FETCH_HEAD
-  - spack repo set --destination "${CI_PROJECT_DIR}" --scope site builtin
   - cd ..
 
 ########################################
@@ -123,6 +122,7 @@ default:
     - cat /proc/meminfo | grep 'MemTotal\|MemFree' || true
     - *clone_spack
     - . "./spack/share/spack/setup-env.sh"
+    - spack repo set --destination "${CI_PROJECT_DIR}" --scope site builtin
   after_script:
     - cat /proc/loadavg || true
     - cat /proc/meminfo | grep 'MemTotal\|MemFree' || true
@@ -161,6 +161,7 @@ default:
     - $ErrorActionPreference=$ErrorActionOld
     - *clone_spack
     - . .\spack\share\spack\setup-env.ps1
+    - spack repo set --destination "${CI_PROJECT_DIR}" --scope site builtin
   after_script:
     - $ErrorActionOld=$ErrorActionPreference
     - $ErrorActionPreference="SilentlyContinue"
@@ -700,6 +701,7 @@ aws-pcluster-generate-x86_64_v4:
       - cat /proc/meminfo | grep 'MemTotal\|MemFree' || true
       - *clone_spack
       - . "./spack/share/spack/setup-env.sh"
+      - spack repo set --destination "${CI_PROJECT_DIR}" --scope site builtin
       - spack arch
     - - export PATH=/home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/binutils-2.37-qvccg7zpskturysmr4bzbsfrx34kvazo/bin:$PATH
       - spack -c "config:install_tree:root:/home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh" reindex
@@ -732,6 +734,7 @@ aws-pcluster-generate-neoverse_v1:
       - cat /proc/meminfo | grep 'MemTotal\|MemFree' || true
       - *clone_spack
       - . "./spack/share/spack/setup-env.sh"
+      - spack repo set --destination "${CI_PROJECT_DIR}" --scope site builtin
       - spack arch
     - - export PATH=/home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/binutils-2.37-2yxz3xsjfmesxujxtlrgcctxlyilynmp/bin:$PATH
       - spack -c "config:install_tree:root:/home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh" reindex
@@ -765,6 +768,7 @@ aws-pcluster-build-neoverse_v1:
     - cat /proc/meminfo | grep 'MemTotal\|MemFree' || true
     - *clone_spack
     - . "./spack/share/spack/setup-env.sh"
+    - spack repo set --destination "${CI_PROJECT_DIR}" --scope site builtin
   after_script:
     - cat /proc/loadavg || true
     - cat /proc/meminfo | grep 'MemTotal\|MemFree' || true

--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -21,7 +21,7 @@ default:
   - echo ${SPACK_CHECKOUT_VERSION}
   - git fetch --depth 1 origin ${SPACK_CHECKOUT_VERSION}
   - git checkout FETCH_HEAD
-  - ./bin/spack repo set --destination "${CI_PROJECT_DIR}" --scope site builtin
+  - spack repo set --destination "${CI_PROJECT_DIR}" --scope site builtin
   - cd ..
 
 ########################################
@@ -73,8 +73,10 @@ default:
   stage: generate
   script:
     - spack --version
-    - spack env activate --without-view ${CI_PROJECT_DIR}/.ci/gitlab/stacks/${SPACK_CI_STACK_NAME}
+    - spack repo set --destination "${CI_PROJECT_DIR}" --scope site builtin
     - spack repo list
+    - spack arch
+    - spack env activate --without-view ${CI_PROJECT_DIR}/.ci/gitlab/stacks/${SPACK_CI_STACK_NAME}
     - spack compiler find
     - spack audit configs
     - spack python ${SPACK_CI_SCRIPTS_ROOT}/common/expand_vars.py
@@ -121,7 +123,6 @@ default:
     - cat /proc/meminfo | grep 'MemTotal\|MemFree' || true
     - *clone_spack
     - . "./spack/share/spack/setup-env.sh"
-    - spack arch
   after_script:
     - cat /proc/loadavg || true
     - cat /proc/meminfo | grep 'MemTotal\|MemFree' || true
@@ -160,7 +161,6 @@ default:
     - $ErrorActionPreference=$ErrorActionOld
     - *clone_spack
     - . .\spack\share\spack\setup-env.ps1
-    - spack arch
   after_script:
     - $ErrorActionOld=$ErrorActionPreference
     - $ErrorActionPreference="SilentlyContinue"
@@ -765,7 +765,6 @@ aws-pcluster-build-neoverse_v1:
     - cat /proc/meminfo | grep 'MemTotal\|MemFree' || true
     - *clone_spack
     - . "./spack/share/spack/setup-env.sh"
-    - spack arch
   after_script:
     - cat /proc/loadavg || true
     - cat /proc/meminfo | grep 'MemTotal\|MemFree' || true

--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -21,6 +21,7 @@ default:
   - echo ${SPACK_CHECKOUT_VERSION}
   - git fetch --depth 1 origin ${SPACK_CHECKOUT_VERSION}
   - git checkout FETCH_HEAD
+  - ./bin/spack repo set --destination "${CI_PROJECT_DIR}" --scope site builtin
   - cd ..
 
 ########################################
@@ -73,7 +74,6 @@ default:
   script:
     - spack --version
     - spack env activate --without-view ${CI_PROJECT_DIR}/.ci/gitlab/stacks/${SPACK_CI_STACK_NAME}
-    - spack config add -f ./.ci/configs/repos.yaml
     - spack repo list
     - spack compiler find
     - spack audit configs

--- a/.ci/gitlab/configs/ci.yaml
+++ b/.ci/gitlab/configs/ci.yaml
@@ -136,6 +136,7 @@ ci:
         - git remote add origin https://github.com/spack/spack.git
         - git fetch --depth 1 origin ${SPACK_CHECKOUT_VERSION}
         - git checkout FETCH_HEAD
+        - ./bin/spack repo set --destination "${CI_PROJECT_DIR}" --scope site builtin
         - cd ..
       - - . "./spack/share/spack/setup-env.sh"
         - spack --version

--- a/.ci/gitlab/configs/win64/ci.yaml
+++ b/.ci/gitlab/configs/win64/ci.yaml
@@ -14,6 +14,7 @@ ci:
         - cd ..
       - fsutil 8dot3name set C:\ 0
       - . .\spack\share\spack\setup-env.ps1
+      - spack.ps1 repo set --destination "${CI_PROJECT_DIR}" --scope site builtin
       - If (Test-Path -path C:\\key\intermediate_ci_signing_key.gpg) { spack.ps1 gpg trust C:\\key\intermediate_ci_signing_key.gpg }
       - If (Test-Path -path C:\\key\spack_public_key.gpg) { spack.ps1 gpg trust C:\\key\spack_public_key.gpg }
 

--- a/.ci/gitlab/stacks/aws-pcluster-neoverse_v1/spack.yaml
+++ b/.ci/gitlab/stacks/aws-pcluster-neoverse_v1/spack.yaml
@@ -29,6 +29,7 @@ spack:
           - git remote add origin https://github.com/spack/spack.git
           - git fetch --depth 1 origin ${SPACK_CHECKOUT_VERSION}
           - git checkout FETCH_HEAD
+          - ./bin/spack repo set --destination "${CI_PROJECT_DIR}" --scope site builtin
           - cd ..
         - - . "./spack/share/spack/setup-env.sh"
           - . /etc/profile.d/modules.sh

--- a/.ci/gitlab/stacks/aws-pcluster-x86_64_v4/spack.yaml
+++ b/.ci/gitlab/stacks/aws-pcluster-x86_64_v4/spack.yaml
@@ -32,6 +32,7 @@ spack:
           - git init
           - git remote add origin https://github.com/spack/spack.git
           - git fetch --depth 1 origin ${SPACK_CHECKOUT_VERSION}
+          - ./bin/spack repo set --destination "${CI_PROJECT_DIR}" --scope site builtin
           - git checkout FETCH_HEAD
           - cd ..
         - - . "./spack/share/spack/setup-env.sh"


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Hopefully this fixes CI and actually test the repo. The override config was not being considered correctly and the head of develop was being cloned instead of using the spack-package PR.