### PR TITLE
README: Update Spack Package Repo Checkout Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ simply change Spack's default package repo from the default cache location to th
 spack repo set --scope user --destination /path/to/local/spack-packages builtin
 ```
 
-This updates `~/.spack/repos.yaml` to look like:
+This updates `~/.spack/repos.yaml` config to look like:
 
 ```yaml
 repos:

--- a/README.md
+++ b/README.md
@@ -14,16 +14,21 @@ If you want to test your package changes locally before submitting a pull reques
 simply change Spack's default package repo from the default cache location to the full path to your local git clone:
 
 ```shell
-spack repo set --destination /path/to/local/spack-packages builtin
+spack repo set --scope user --destination /path/to/local/spack-packages builtin
 ```
 
-Your Spack installation will be configured to pull from your local Spack
-packages checkout in perpetuity, meaning any updates/other management of the Spack
-packages repo will now be manual. To undo this, simply remove the local modification
-done to the repos configuration or run
+This updates `~/.spack/repos.yaml` to look like:
+
+```yaml
+repos:
+  builtin:
+    destination: /path/to/local/spack-packages
+```
+
+To undo this, you can run:
 
 ```shell
-spack config remove repos:builtin:destination
+spack config --scope user remove repos:builtin:destination
 ```
 
 `$spack` can be used to form a relative path to your Spack root directory.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We run continuous integration on this repository to test builds of a large numbe
 Spack packages.
 
 If you want to test your package changes locally before submitting a pull request,
-simply configure Spack's default package repo to the full path to your local git clone:
+simply configure Spack's default package repo to the full path of your local git clone:
 
 ```shell
 spack repo set --scope user --destination /path/to/local/spack-packages builtin

--- a/README.md
+++ b/README.md
@@ -11,11 +11,21 @@ We run continuous integration on this repository to test builds of a large numbe
 Spack packages.
 
 If you want to test your package changes locally before submitting a pull request,
-simply change Spack's default package repo from the default cache location to the full
-path to your local git clone:
-```
+simply change Spack's default package repo from the default cache location to the full path to your local git clone:
+
+```shell
 spack repo set --destination /path/to/local/spack-packages builtin
 ```
+
+Your Spack installation will be configured to pull from your local Spack
+packages checkout in perpetuity, meaning any updates/other management of the Spack
+packages repo will now be manual. To undo this, simply remove the local modification
+done to the repos configuration or run
+
+```shell
+spack config remove repos:builtin:destination
+```
+
 `$spack` can be used to form a relative path to your Spack root directory.
 
 If you are migrating your pull requests from

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We run continuous integration on this repository to test builds of a large numbe
 Spack packages.
 
 If you want to test your package changes locally before submitting a pull request,
-simply change Spack's default package repo from the default cache location to the full path to your local git clone:
+simply configure Spack's default package repo to the full path to your local git clone:
 
 ```shell
 spack repo set --scope user --destination /path/to/local/spack-packages builtin


### PR DESCRIPTION
Follow up to https://github.com/spack/spack-packages/pull/88

#88 is very helpful, however it does suggest the users make a change to their config that will persist after the one-off use case the operation is suggested to be used in the context of. 

This PR just adds instructions on how to undo the change.

Alternatively we could:

* Have the users add their local `spack-packages` checkout as another repo e.g. `test` (would that work? Can spack prefer repos?)
* Instead of refactoring the instructions, just rephase the use case to "If you want Spack to use your local spack-packages instead of its own checkout going forward..." rather than suggesting the behavior is one-off/temporary.

I think the un-do instruction is useful, but would probably be better lived in core spack's docs, so I don't really have a strong opinion which of these options we go with, just that we rephase this slightly.