### PR TITLE
gcc: add +amdgcn to enable omp offload to AMD GPUs; update +nvptx logic

### DIFF
--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -186,6 +186,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     )
     variant("strip", default=False, description="Strip executables to reduce installation size")
     variant("nvptx", default=False, description="Target nvptx offloading to NVIDIA GPUs")
+    variant("amdgcn", default=False, description="Target amdgcn offloading to AMD GPUs")
     variant("bootstrap", default=True, description="Enable 3-stage bootstrap")
     variant(
         "graphite", default=False, description="Enable Graphite loop optimizations (requires ISL)"
@@ -354,12 +355,35 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
                 msg="'gcc@12: languages=d' requires '%gcc@9:' with the D language support",
             )
 
+    # GPU offload backend supported by limited languages
+    with when("+nvptx") or when("+amdgcn"):
+        conflicts("languages=ada")
+        conflicts("languages=brig")
+        conflicts("languages=go")
+        conflicts("languages=java")
+        conflicts("languages=jit")
+        conflicts("languages=objc")
+        conflicts("languages=obj-c++")
+        conflicts("languages=d")
+
+    # Newlib version table
+    newlib_shasum = {
+        "3.0.0.20180831": "3ad3664f227357df15ff34e954bfd9f501009a647667cd307bf0658aefd6eb5b",
+        "3.3.0": "58dd9e3eaedf519360d92d84205c3deef0b3fc286685d1c562e245914ef72c66",
+        "4.1.0": "f296e372f51324224d387cc116dc37a6bd397198756746f93a2b02e9a5d40154",
+        "4.2.0.20211231": "c3a0e8b63bc3bef1aeee4ca3906b53b3b86c8d139867607369cb2915ffc54435",
+        "4.3.0.20230120": "83a62a99af59e38eb9b0c58ed092ee24d700fff43a22c03e433955113ef35150",
+        "4.4.0.20231231": "0c166a39e1bf0951dfafcd68949fe0e4b6d3658081d6282f39aeefc6310f2f13",
+        "4.5.0.20241231": "33f12605e0054965996c25c1382b3e463b0af91799001f5bb8c0630f2ec8c852",
+    }
+
     with when("+nvptx"):
         depends_on("cuda")
+        nvptx_newlib_ver = "4.5.0.20241231"
         resource(
             name="newlib",
-            url="ftp://sourceware.org/pub/newlib/newlib-3.0.0.20180831.tar.gz",
-            sha256="3ad3664f227357df15ff34e954bfd9f501009a647667cd307bf0658aefd6eb5b",
+            url="ftp://sourceware.org/pub/newlib/newlib-{0}.tar.gz".format(nvptx_newlib_ver),
+            sha256=newlib_shasum[nvptx_newlib_ver],
             destination="newlibsource",
             fetch_options=timeout,
         )
@@ -369,15 +393,57 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
 
         # NVPTX offloading supported in 7 and later by limited languages
         conflicts("@:6", msg="NVPTX only supported in gcc 7 and above")
-        conflicts("languages=ada")
-        conflicts("languages=brig")
-        conflicts("languages=go")
-        conflicts("languages=java")
-        conflicts("languages=jit")
-        conflicts("languages=objc")
-        conflicts("languages=obj-c++")
-        conflicts("languages=d")
+
         # NVPTX build disables bootstrap
+        conflicts("+bootstrap")
+
+    # AMDGCN build requires a Newlib version contemporaneous with GCC
+    # For GCC release dates, refer to https://gcc.gnu.org/index.html#news
+    # For Newlib versions, refer to https://sourceware.org/ftp/newlib/index.html
+    amdgcn_newlib_ver = {
+        "@master": "4.5.0.20241231",  # Newest version of Newlib
+        "@15.1.0": "4.5.0.20241231",
+        "@14.2.0": "4.4.0.20231231",  # GCC: 2024-08-01, Newlib: 2023-12-31
+        "@14.1.0": "4.4.0.20231231",  # GCC: 2024-05-07, Newlib: 2023-12-31
+        "@13.3.0": "4.4.0.20231231",  # GCC: 2024-05-21, Newlib: 2023-12-31
+        "@13.2.0": "4.3.0.20230120",  # GCC: 2023-07-27, Newlib: 2023-01-20
+        "@13.1.0": "4.3.0.20230120",  # GCC: 2023-04-26, Newlib: 2023-01-20
+        "@12.4.0": "4.4.0.20231231",  # GCC: 2024-06-20, Newlib: 2023-12-31
+        "@12.3.0": "4.3.0.20230120",  # GCC: 2023-05-08, Newlib: 2023-01-20
+        "@12.2.0": "4.2.0.20211231",  # GCC: 2022-08-19, Newlib: 2021-12-31
+        "@12.1.0": "4.2.0.20211231",  # GCC: 2022-05-06, Newlib: 2021-12-31
+        "@11.5.0": "4.4.0.20231231",  # GCC: 2024-07-19, Newlib: 2023-12-31
+        "@11.4.0": "4.3.0.20230120",  # GCC: 2023-05-29, Newlib: 2023-01-20
+        "@11.3.0": "4.2.0.20211231",  # GCC: 2022-04-21, Newlib: 2021-12-31
+        "@11.2.0": "4.1.0",  # GCC: 2021-07-28, Newlib: 2020-12-18
+        "@11.1.0": "4.1.0",  # GCC: 2021-04-27, Newlib: 2020-12-18
+        "@10.5.0": "4.3.0.20230120",  # GCC: 2023-07-07, Newlib: 2023-01-20
+        "@10.4.0": "4.2.0.20211231",  # GCC: 2022-06-28, Newlib: 2021-12-31
+        "@10.3.0": "4.1.0",  # GCC: 2021-04-08, Newlib: 2020-12-18
+        "@10.2.0": "3.3.0",  # GCC: 2020-07-23, Newlib: 2020-01-22
+        "@10.1.0": "3.3.0",  # GCC: 2020-05-07, Newlib: 2020-01-22
+    }
+
+    with when("+amdgcn"):
+        depends_on("hip")
+        # AMDGCN build requires LLVM utilities
+        llvm_variants = "+lld targets=amdgpu"
+        depends_on(f"llvm@9.0.1 {llvm_variants}", type=("build", "link"), when="@:11")
+        depends_on(f"llvm@13.0.1: {llvm_variants}", type=("build", "link"), when="@12:")
+
+        # Set up Newlib versions
+        for k, v in amdgcn_newlib_ver.items():
+            with when(k):
+                resource(
+                    name="newlib",
+                    url=f"ftp://sourceware.org/pub/newlib/newlib-{v}.tar.gz",
+                    sha256=newlib_shasum[v],
+                    destination="newlibsource",
+                    fetch_options=timeout,
+                )
+        # AMDGCN offloading supported in 10 and later
+        conflicts("@:9", msg="AMDGCN only supported in gcc 10 and above")
+        # AMDGCN build disables bootstrap
         conflicts("+bootstrap")
 
     # Binutils can't build ld on macOS
@@ -880,15 +946,27 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
                 ]
             )
 
-        # nvptx-none offloading for host compiler
+        # GPU offload targets
+        offload_targets = []
+        if spec.satisfies("+nvptx"):
+            offload_targets.append("nvptx-none")
+        if spec.satisfies("+amdgcn"):
+            offload_targets.append("amdgcn-amdhsa")
+        if offload_targets:
+            options.extend(
+                [
+                    "--enable-offload-targets={0}".format(",".join(offload_targets)),
+                    "--disable-bootstrap",
+                    "--disable-multilib",
+                ]
+            )
+
+        # arguments for nvptx-none offloading
         if spec.satisfies("+nvptx"):
             options.extend(
                 [
-                    "--enable-offload-targets=nvptx-none",
                     "--with-cuda-driver-include={0}".format(spec["cuda"].prefix.include),
                     "--with-cuda-driver-lib={0}".format(spec["cuda"].libs.directories[0]),
-                    "--disable-bootstrap",
-                    "--disable-multilib",
                 ]
             )
 
@@ -921,6 +999,15 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
                 options.append("GDC={0}".format(self.detect_gdc()))
 
         return options
+
+    # Common code for nvptx and amdgcn to link newlib source directory
+    newlib_linked = False
+    def link_newlib(self):
+        pattern = join_path(self.stage.source_path, "newlibsource", "*")
+        files = glob.glob(pattern)
+        if files and not self.newlib_linked:
+            symlink(join_path(files[0], "newlib"), "newlib")
+        self.newlib_linked = True
 
     # Copy nvptx-tools into the GCC install prefix
     def copy_nvptx_tools(self):
@@ -968,11 +1055,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
 
         self.copy_nvptx_tools()
 
-        pattern = join_path(self.stage.source_path, "newlibsource", "*")
-        files = glob.glob(pattern)
-
-        if files:
-            symlink(join_path(files[0], "newlib"), "newlib")
+        self.link_newlib()
 
         # self.build_directory = 'spack-build-nvptx'
         with working_dir("spack-build-nvptx", create=True):
@@ -992,6 +1075,86 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
             configure(*options)
             make()
             make("install")
+
+    # run configure/make/make(install) for the amdgcn-amdhsa target
+    # before running the host compiler phases
+    # See https://gcc.gnu.org/wiki/Offloading#For_AMD_GCN:
+    @run_before("configure")
+    def amdgcn_install(self):
+        spec = self.spec
+        prefix = self.prefix
+
+        if not spec.satisfies("+amdgcn"):
+            return
+
+        # config.guess returns the host triple, e.g. "x86_64-pc-linux-gnu"
+        guess = Executable("./config.guess")
+        targetguess = guess(output=str).rstrip("\n")
+
+        options = getattr(self, "configure_flag_args", [])
+        options += [f"--prefix={prefix}"]
+
+        # Copy LLVM utils
+        llvm_bin_path = join_path(spec["llvm"].prefix, "bin")
+        llvm_util_path = join_path(prefix, "amdgcn-amdhsa", "bin")
+        mkdirp(llvm_util_path)
+        copy(
+            "{0}".format(join_path(llvm_bin_path, "llvm-ar")),
+            "{0}".format(join_path(llvm_util_path, "ar")),
+        )
+        copy(
+            "{0}".format(join_path(llvm_bin_path, "llvm-ar")),
+            "{0}".format(join_path(llvm_util_path, "ranlib")),
+        )
+        copy(
+            "{0}".format(join_path(llvm_bin_path, "llvm-mc")),
+            "{0}".format(join_path(llvm_util_path, "as")),
+        )
+        copy(
+            "{0}".format(join_path(llvm_bin_path, "llvm-nm")),
+            "{0}".format(join_path(llvm_util_path, "nm")),
+        )
+        copy(
+            "{0}".format(join_path(llvm_bin_path, "lld")),
+            "{0}".format(join_path(llvm_util_path, "ld")),
+        )
+
+        self.link_newlib()
+
+        # self.build_directory = 'spack-build-amdgcn'
+        with working_dir("spack-build-amdgcn", create=True):
+            options = [
+                "--prefix={0}".format(prefix),
+                "--enable-languages={0}".format(",".join(spec.variants["languages"].value)),
+                "--with-mpfr={0}".format(spec["mpfr"].prefix),
+                "--with-gmp={0}".format(spec["gmp"].prefix),
+                "--target=amdgcn-amdhsa",
+                "--with-build-time-tools={0}".format(llvm_util_path),
+                "--enable-as-accelerator-for={0}".format(targetguess),
+                "--disable-sjlj-exceptions",
+                "--disable-libquadmath",
+            ]
+
+            configure = Executable("../configure")
+            configure(*options)
+            make()
+            make("install")
+
+    # Symlink amdgcn-amdhsa-ar and amdgcn-amdhsa-ranlibAdd commentMore actions
+    # See https://gcc.gnu.org/install/specific.html#amdgcn-x-amdhsa
+    @run_after("install")
+    def link_amdgcn(self):
+        spec = self.spec
+
+        if not spec.satisfies("+amdgcn"):
+            return
+
+        prefix = self.prefix
+        llvm_util_path = join_path(prefix, "amdgcn-amdhsa", "bin")
+        symlink(join_path(llvm_util_path, "ar"), join_path(prefix, "bin", "amdgcn-amdhsa-ar"))
+        symlink(
+            join_path(llvm_util_path, "ranlib"), join_path(prefix, "bin", "amdgcn-amdhsa-ranlib")
+        )
 
     @property
     def build_targets(self):
@@ -1053,6 +1216,32 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
 
         set_install_permissions(specs_file)
         tty.info(f"Wrote new spec file to {specs_file}")
+
+        # Do the same thing for libgomp on offload-enabled builds
+        if self.spec.satisfies("+nvptx") or self.spec.satisfies("+amdgcn"):
+            for dir in ["lib64", "lib"]:
+                libdir = join_path(self.prefix, dir)
+                if glob.glob(join_path(libdir, "libgomp.*")):
+                    libgomp_dir = libdir
+                    break
+            else:
+                tty.warn("libgomp dynamic library not found in lib/lib64")
+                libgomp_dir = None
+
+            if libgomp_dir:
+                libgomp_spec_file = join_path(libgomp_dir, "libgomp.spec")
+                copy(libgomp_spec_file, libgomp_spec_file + ".orig")
+                with open(libgomp_spec_file, "r+") as f:
+                    lines = f.readlines()
+                    f.seek(0)
+                    for line in lines:
+                        if line.startswith("*link_gomp:"):
+                            f.write("\n\n# Generated by Spack\n\n")
+                            f.write(line.strip("\n") + f" -rpath {libgomp_dir}\n\n")
+                        else:
+                            f.write(line)
+                set_install_permissions(libgomp_spec_file)
+                tty.info(f"Wrote new libgomp spec file to {libgomp_spec_file}")
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         if self.cc and self.spec.satisfies("languages=c"):


### PR DESCRIPTION
GCC: add `+amdgcn` variant to enable OpenMP offload to AMD GPUs.

Originally published to spack/spack by @wyphan 
* https://github.com/spack/spack/pull/35919

This is a work-in-progress. There are still some issues that need to be worked out, which will be documented in comments on this PR. Don't merge yet. 

CC @kweide