### PR TITLE
Windows: Initial attempt to stand up oneAPI

### DIFF
--- a/repos/spack_repo/builtin/build_systems/compiler.py
+++ b/repos/spack_repo/builtin/build_systems/compiler.py
@@ -219,7 +219,7 @@ class CompilerPackage(PackageBase):
 
 @memoized
 def _compiler_output(
-    compiler_path: Path, *, version_argument: str, ignore_errors: Tuple[int, ...] = ()
+    compiler_path: Path, *, version_argument: Optional[str], ignore_errors: Tuple[int, ...] = ()
 ) -> str:
     """Returns the output from the compiler invoked with the given version argument.
 
@@ -243,7 +243,7 @@ def _compiler_output(
 
 
 def compiler_output(
-    compiler_path: Path, *, version_argument: str, ignore_errors: Tuple[int, ...] = ()
+    compiler_path: Path, *, version_argument: Optional[str], ignore_errors: Tuple[int, ...] = ()
 ) -> str:
     """Wrapper for _get_compiler_version_output()."""
     # This ensures that we memoize compiler output by *absolute path*,

--- a/repos/spack_repo/builtin/build_systems/oneapi.py
+++ b/repos/spack_repo/builtin/build_systems/oneapi.py
@@ -48,6 +48,7 @@ class IntelOneApiPackage(Package):
         conflicts(c, msg="This package in only available for x86_64 and Linux/Windows")
 
     # env mods are mandatory on Windows, no variant option
+    # and oneAPI is currently unsupported on Darwin
     for plat in ["linux", "freebsd"]:
         # Add variant to toggle environment modifications from vars.sh
         variant(

--- a/repos/spack_repo/builtin/build_systems/oneapi.py
+++ b/repos/spack_repo/builtin/build_systems/oneapi.py
@@ -48,12 +48,13 @@ class IntelOneApiPackage(Package):
         "target=ppc64le:",
         "target=aarch64:",
         "platform=darwin",
-        "platform=windows",
     ]:
-        conflicts(c, msg="This package in only available for x86_64 and Linux")
+        conflicts(c, msg="This package in only available for x86_64 and Linux/Windows")
 
-    # Add variant to toggle environment modifications from vars.sh
-    variant("envmods", default=True, description="Toggles environment modifications")
+    # env mods are not an option on Windows AFAICT
+    for plat in ["linux", "freebsd"]:
+        # Add variant to toggle environment modifications from vars.sh
+        variant("envmods", default=True, description="Toggles environment modifications", when=f"platform={plat}")
 
     @staticmethod
     def update_description(cls):

--- a/repos/spack_repo/builtin/build_systems/oneapi.py
+++ b/repos/spack_repo/builtin/build_systems/oneapi.py
@@ -140,15 +140,16 @@ class IntelOneApiPackage(Package):
         elif sys.platform == "win32":
             # Installer can be executed directly
             # as it's a standalone executable
-            installer_extraction_path = os.path.join(self.stage.source_path, f"installer-{os.path.basename(self.component_dir)}"),
+            installer_extraction_path = os.path.join(self.stage.source_path, f"installer-{os.path.basename(self.component_dir)}")
             installer = Executable(installer_path)
             installer_args = [
-                "--extract-folder",
-                "--remove-extracted-files",
-                installer_extraction_path,
-                "yes",
-                "-a",
                 "-s",
+                "--extract-folder",
+                installer_extraction_path,
+                "--remove-extracted-files",
+                "yes",
+                "--a",
+                "--s",
                 "--eula",
                 "accept",
                 "--install-dir",

--- a/repos/spack_repo/builtin/build_systems/oneapi.py
+++ b/repos/spack_repo/builtin/build_systems/oneapi.py
@@ -5,8 +5,8 @@
 import os
 import platform
 import shutil
-from os.path import basename, isdir
 import sys
+from os.path import basename, isdir
 
 from llnl.util.link_tree import LinkTree
 
@@ -44,18 +44,18 @@ class IntelOneApiPackage(Package):
     # contains precompiled binaries without rpaths
     unresolved_libraries = ["*"]
 
-    for c in [
-        "target=ppc64:",
-        "target=ppc64le:",
-        "target=aarch64:",
-        "platform=darwin",
-    ]:
+    for c in ["target=ppc64:", "target=ppc64le:", "target=aarch64:", "platform=darwin"]:
         conflicts(c, msg="This package in only available for x86_64 and Linux/Windows")
 
     # env mods are mandatory on Windows, no variant option
     for plat in ["linux", "freebsd"]:
         # Add variant to toggle environment modifications from vars.sh
-        variant("envmods", default=True, description="Toggles environment modifications", when=f"platform={plat}")
+        variant(
+            "envmods",
+            default=True,
+            description="Toggles environment modifications",
+            when=f"platform={plat}",
+        )
 
     @staticmethod
     def update_description(cls):
@@ -140,7 +140,9 @@ class IntelOneApiPackage(Package):
         elif sys.platform == "win32":
             # Installer can be executed directly
             # as it's a standalone executable
-            installer_extraction_path = os.path.join(self.stage.source_path, f"installer-{os.path.basename(self.component_dir)}")
+            installer_extraction_path = os.path.join(
+                self.stage.source_path, f"installer-{os.path.basename(self.component_dir)}"
+            )
             installer = Executable(installer_path)
             installer_args = [
                 "-s",
@@ -153,10 +155,9 @@ class IntelOneApiPackage(Package):
                 "--eula",
                 "accept",
                 "--install-dir",
-                self.prefix
+                self.prefix,
             ]
             installer(*installer_args)
-            
 
         # Some installers have a bug and do not return an error code when failing
         install_dir = self.component_prefix

--- a/repos/spack_repo/builtin/build_systems/oneapi.py
+++ b/repos/spack_repo/builtin/build_systems/oneapi.py
@@ -140,11 +140,12 @@ class IntelOneApiPackage(Package):
         elif sys.platform == "win32":
             # Installer can be executed directly
             # as it's a standalone executable
+            installer_extraction_path = os.path.join(self.stage.source_path, f"installer-{os.path.basename(self.component_dir)}"),
             installer = Executable(installer_path)
             installer_args = [
                 "--extract-folder",
-                self.stage.source_path,
                 "--remove-extracted-files",
+                installer_extraction_path,
                 "yes",
                 "-a",
                 "-s",

--- a/repos/spack_repo/builtin/build_systems/oneapi.py
+++ b/repos/spack_repo/builtin/build_systems/oneapi.py
@@ -6,6 +6,7 @@ import os
 import platform
 import shutil
 from os.path import basename, isdir
+import sys
 
 from llnl.util.link_tree import LinkTree
 
@@ -51,7 +52,7 @@ class IntelOneApiPackage(Package):
     ]:
         conflicts(c, msg="This package in only available for x86_64 and Linux/Windows")
 
-    # env mods are not an option on Windows AFAICT
+    # env mods are mandatory on Windows, no variant option
     for plat in ["linux", "freebsd"]:
         # Add variant to toggle environment modifications from vars.sh
         variant("envmods", default=True, description="Toggles environment modifications", when=f"platform={plat}")
@@ -133,9 +134,27 @@ class IntelOneApiPackage(Package):
                 "--install-dir",
                 self.prefix,
             )
-
             if spack.util.path.get_user() == "root":
                 shutil.rmtree("/var/intel/installercache", ignore_errors=True)
+
+        elif sys.platform == "win32":
+            # Installer can be executed directly
+            # as it's a standalone executable
+            installer = Executable(installer_path)
+            installer_args = [
+                "--extract-folder",
+                self.stage.source_path,
+                "--remove-extracted-files",
+                "yes",
+                "-a",
+                "-s",
+                "--eula",
+                "accept",
+                "--install-dir",
+                self.prefix
+            ]
+            installer(*installer_args)
+            
 
         # Some installers have a bug and do not return an error code when failing
         install_dir = self.component_prefix
@@ -151,13 +170,17 @@ class IntelOneApiPackage(Package):
 
            $ source {prefix}/{component}/{version}/env/vars.sh
         """
-        # Only if environment modifications are desired (default is +envmods)
-        if "+envmods" in self.spec:
-            env.extend(
-                EnvironmentModifications.from_sourcing_file(
-                    self.component_prefix.env.join("vars.sh"), *self.env_script_args
+        if sys.platform == "win32":
+            # env mods can't be conditional on Windows
+            pass
+        else:
+            # Only if environment modifications are desired (default is +envmods)
+            if "+envmods" in self.spec:
+                env.extend(
+                    EnvironmentModifications.from_sourcing_file(
+                        self.component_prefix.env.join("vars.sh"), *self.env_script_args
+                    )
                 )
-            )
 
     def symlink_dir(self, src, dest):
         # Taken from: https://github.com/spack/spack/pull/31285/files

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers/oneapi_versions.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers/oneapi_versions.py
@@ -49,6 +49,8 @@ class oneAPIInstaller:
 
     @property
     def url(self):
+        if self._path.startswith("https"):
+            return self._path
         return self._url_base + self._path
 
 
@@ -69,6 +71,14 @@ class oneAPIVersion:
         self.amd = amd
         oneAPIVersions.versions.append(self)
         
+
+oneAPIVersion(version="2025.1.1",
+    platform="windows",
+    cxx=oneAPIInstaller(path="7f810440-2a66-4d34-b05f-8f4395667844/intel-dpcpp-cpp-compiler-2025.1.1.10_offline.exe",
+                        sha="7a8471a9e36e3595338427a91c426751cb4ca3a2cb49f8bb76e466df73534392"),
+    fortran=oneAPIInstaller(path="20fc9768-cb87-4aaa-adf8-6c83a5d8e8b4/intel-fortran-compiler-2025.1.1.11_offline.exe", 
+                            sha="5e3422654080b0ea799482c7baf08c75fd6a37b6246e972d41be72e6507986b9"),
+)
 
 oneAPIVersion(version="2025.1.1",
     platform="linux",
@@ -165,17 +175,17 @@ oneAPIVersion(version="2024.0.2",
 
 oneAPIVersion(version="2024.0.1",
               platform="linux",
-              cxx=oneAPIInstaller(path="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/c68c8f0a-47f5-4f26-8e8e-fa2627271279/l_dpcpp-cpp-compiler_p_2024.0.1.29_offline.sh", 
+              cxx=oneAPIInstaller(path="c68c8f0a-47f5-4f26-8e8e-fa2627271279/l_dpcpp-cpp-compiler_p_2024.0.1.29_offline.sh", 
                                  sha="22497c46bfb916c82677489775c113141510423799b7eca35f35dffeb2a14104"),
-              fortran=oneAPIInstaller(path="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/4eedf77e-e097-40de-b62d-5fb70efecb59/l_fortran-compiler_p_2024.0.1.31_offline.sh",
+              fortran=oneAPIInstaller(path="4eedf77e-e097-40de-b62d-5fb70efecb59/l_fortran-compiler_p_2024.0.1.31_offline.sh",
                                      sha="9d49ecc1862c60eb0627bfdd80d63a47118095af0ff5adeeda10ec36aaffc82c"),
                           )
 
 oneAPIVersion(version="2024.0.0",
               platform="linux",
-              cxx=oneAPIInstaller(path="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/5c8e686a-16a7-4866-b585-9cf09e97ef36/l_dpcpp-cpp-compiler_p_2024.0.0.49524_offline.sh", 
+              cxx=oneAPIInstaller(path="5c8e686a-16a7-4866-b585-9cf09e97ef36/l_dpcpp-cpp-compiler_p_2024.0.0.49524_offline.sh", 
                                  sha="d10bad2009c98c631fbb834aae62012548daeefc806265ea567316cd9180a684"),
-              fortran=oneAPIInstaller(path="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/89b0fcf9-5c00-448a-93a1-5ee4078e008e/l_fortran-compiler_p_2024.0.0.49493_offline.sh",
+              fortran=oneAPIInstaller(path="89b0fcf9-5c00-448a-93a1-5ee4078e008e/l_fortran-compiler_p_2024.0.0.49493_offline.sh",
                                      sha="57faf854b8388547ee4ef2db387a9f6f3b4d0cebd67b765cf5e844a0a970d1f9"),
                           )
 

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers/oneapi_versions.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers/oneapi_versions.py
@@ -1,0 +1,295 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import platform
+from spack.package import *
+
+class oneAPIVersions:
+    versions: List["oneAPIVersion"] = []
+
+    @staticmethod
+    def generate_versions():
+        for v in filter(lambda x: x.platform == platform.system().lower(), oneAPIVersions.versions):
+            version(v.version, expand=False, url=v.cxx.url, sha256=v.cxx.sha)
+            if v.fortran:
+                resource(
+                    name="fortran-installer",
+                    placement="fortran-installer",
+                    when=f"@{v.version}",
+                    expand=False,
+                    url=v.fortran.url,
+                    sha256=v.fortran.sha
+                )
+            if v.nvidia:
+                resource(
+                    name="nvidia-plugin-installer",
+                    placement="nvidia-plugin-installer",
+                    when=f"@{v.version}",
+                    expand=False,
+                    url=v.nvidia.url,
+                    sha256=v.nvidia.sha
+                )
+            if v.amd:
+                resource(
+                    name="amd-plugin-installer",
+                    placement="amd-plugin-installer",
+                    when=f"@{v.version}",
+                    expand=False,
+                    url=v.amd.url,
+                    sha256=v.amd.sha
+                )
+
+
+class oneAPIInstaller:
+    def __init__(self, *, url:str, sha:str):
+        self.url = url
+        self.sha = sha
+
+
+class oneAPIVersion:
+    def __init__(self, *, 
+                 version: str, 
+                 platform:str, 
+                 cxx:oneAPIInstaller, 
+                 fortran:Optional[oneAPIInstaller]=None, 
+                 nvidia:Optional[oneAPIInstaller]=None, 
+                 amd:Optional[oneAPIInstaller]=None):
+        self.version = version
+        assert platform.lower() in ("windows", "linux"), "OneAPI is only compatible with Windows or Linux"
+        self.platform = platform
+        self.cxx = cxx
+        self.fortran = fortran
+        self.nvidia = nvidia
+        self.amd = amd
+        oneAPIVersions.versions.append(self)
+        
+
+oneAPIVersion(version="2025.1.1",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/c4d2aef3-3123-475e-800c-7d66fd8da2a5/intel-dpcpp-cpp-compiler-2025.1.1.9_offline.sh",
+                                  sha="63ea61f54a5ea9d30059ea499697e04953915ef317c0e8fc457077b690c726df"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/0e4735b3-8721-422b-b204-00eefe413bfd/intel-fortran-compiler-2025.1.1.10_offline.sh",
+                                      sha="c59060a5b959fb0faeb1cde349689086da41d491adb41fd6c97177fcf59bf957")
+            )
+
+
+oneAPIVersion(version="2025.1.0",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/cd63be99-88b0-4981-bea1-2034fe17f5cf/intel-dpcpp-cpp-compiler-2025.1.0.573_offline.sh", 
+                                 sha="53489afcc9534e30ad807e94b158abfccf6a7eb3658f59655122d92fbad8fa72"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/577ebc28-d0f6-492b-9a43-b04354ce99da/intel-fortran-compiler-2025.1.0.601_offline.sh",
+                                     sha="27016329dede8369679f22b4e9f67936837ce7972a1ef4f5c76ee87d7c963c81")
+            )
+
+oneAPIVersion(version="2025.0.4",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/84c039b6-2b7d-4544-a745-3fcf8afd643f/intel-dpcpp-cpp-compiler-2025.0.4.20_offline.sh", 
+                                 sha="0537c6e462fe74063cb0b9209a0fd5c0ca3a29b4520d43d382ae27fb3f98b375"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ad42ee3b-7a2f-41cb-b902-689f651920da/intel-fortran-compiler-2025.0.4.21_offline.sh",
+                                     sha="ad453f1dd68111e7cf7053d6f86fa26d982bd9ab61982cbb6dbe5195fb6feedb"),
+            )
+
+oneAPIVersion(version="2025.0.3",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/1cac4f39-2032-4aa9-86d7-e4f3e40e4277/intel-dpcpp-cpp-compiler-2025.0.3.9_offline.sh", 
+                                 sha="0ca834002b9091dc9988da6798a2eb36ebc5933d8d523ed0fa78a55744c88823"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/fafa2df1-4bb1-43f7-87c6-3c82f1bdc712/intel-fortran-compiler-2025.0.3.9_offline.sh",
+                                     sha="1ad813cf6495ded730646d6c4fd065dcc840875fdea28fcc6bac2cafb8d22c8d"),
+            )
+
+oneAPIVersion(version="2025.0.1",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/4fd7c6b0-853f-458a-a8ec-421ab50a80a6/intel-dpcpp-cpp-compiler-2025.0.1.46_offline.sh", 
+                                 sha="1595397566b59a5c8f81e2c235b6bedd2405dc70309b5bf00ed75827d0f12449"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/7ba31291-8a27-426f-88d5-8c2d65316655/intel-fortran-compiler-2025.0.1.41_offline.sh",
+                                     sha="aa54f019ad8db79f716f880c72784dc117d64e525e4c3b62717bd9d18a6c9060"),
+                )
+
+oneAPIVersion(version="2025.0.0",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ac92f2bb-4818-4e53-a432-f8b34d502f23/intel-dpcpp-cpp-compiler-2025.0.0.740_offline.sh", 
+                                 sha="04fadf63789acee731895e631db63f65a98b8279db3d0f48bdf0d81e6103bdd8"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/69f79888-2d6c-4b20-999e-e99d72af68d4/intel-fortran-compiler-2025.0.0.723_offline.sh",
+                                     sha="2be6d607ce84f35921228595b118fbc516d28587cbc4e6dcf6b7219e5cd1a9a9"),
+              nvidia=oneAPIInstaller(url="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=2025.0.0&filters[]=12.0&filters[]=linux",
+                                     sha="264a43d2e07c08eb31d6483fb1c289a6b148709e48e9a250efc1b1e9a527feb6"),
+              amd=oneAPIInstaller(url="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=2025.0.0&filters[]=6.1.0&filters[]=linux",
+                                  sha="2c5a147e82f0e995b9c0457b53967cc066d5741d675cb64cb9eba8e3c791a064")
+            )
+
+oneAPIVersion(version="2024.2.1",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/74587994-3c83-48fd-b963-b707521a63f4/l_dpcpp-cpp-compiler_p_2024.2.1.79_offline.sh", 
+                                 sha="af0243f80640afa94c7f9c8151da91d7ab17f448f542fa76d785230dec712048"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/5e7b0f1c-6f25-4cc8-94d7-3a527e596739/l_fortran-compiler_p_2024.2.1.80_offline.sh",
+                                     sha="6f6dab82a88082a7a39f6feb699343c521f58c6481a1bb87edba7e2550995b6d"),
+              nvidia=oneAPIInstaller(url="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=2024.2.1&filters[]=12.0&filters[]=linux",
+                                     sha="2c377027c650291ccd8267cbf75bd3d00c7b11998cc59d5668a02a0cbc2c015f"),
+              amd=oneAPIInstaller(url="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=2024.2.1&filters[]=6.1.0&filters[]=linux",
+                                  sha="fbeb64f959f907cbf3469f4e154b2af6d8ff46fe4fc667c811e04f3872a13823")
+            )
+
+oneAPIVersion(version="2024.2.0",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/6780ac84-6256-4b59-a647-330eb65f32b6/l_dpcpp-cpp-compiler_p_2024.2.0.495_offline.sh", 
+                                 sha="9463aa979314d2acc51472d414ffcee032e9869ca85ac6ff4c71d39500e5173d"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/801143de-6c01-4181-9911-57e00fe40181/l_fortran-compiler_p_2024.2.0.426_offline.sh",
+                                     sha="fd19a302662b2f86f76fc115ef53a69f16488080278dba4c573cc705f3a52ffa"),
+              nvidia=oneAPIInstaller(url="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=2024.2.0&filters[]=12.0&filters[]=linux",
+                                     sha="0622df0054364b01e91e7ed72a33cb3281e281db5b0e86579f516b1cc5336b0f"),
+              amd=oneAPIInstaller(url="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=2024.2.0&filters[]=6.1.0&filters[]=linux",
+                                  sha="d1e9d30fa92f3ef606f054d8cbd7c338b3e46f6a9f8472736e29e8ccd9e50688")
+            )
+
+oneAPIVersion(version="2024.1.0",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2e562b6e-5d0f-4001-8121-350a828332fb/l_dpcpp-cpp-compiler_p_2024.1.0.468_offline.sh", 
+                                 sha="534ecc6e4b690c9011d7765cbe178f520aa8f49c0eb4ea80ea1415e48e5d7cf7"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/fd9342bd-7d50-442c-a3e4-f41974e14396/l_fortran-compiler_p_2024.1.0.465_offline.sh",
+                                     sha="30a02bad9a96a543c60f3bfa4238dfe07c2d26d76fc22ba9aa9b7c603e11f1b9"),
+                          )
+
+oneAPIVersion(version="2024.0.2",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/bb99984f-370f-413d-bbec-38928d2458f2/l_dpcpp-cpp-compiler_p_2024.0.2.29_offline.sh", 
+                                 sha="0ec22d69f4207fea4b7488d1c9e62adbc14fb6daa1574d6edcadc912da007b3c"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/41df6814-ec4b-4698-a14d-421ee2b02aa7/l_fortran-compiler_p_2024.0.2.28_offline.sh",
+                                     sha="396ac4fbcb3799d5c1a866a60cf81f85f7cab8c6f35289f61c5cda63c7101b5e"),
+                          )
+
+oneAPIVersion(version="2024.0.1",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/c68c8f0a-47f5-4f26-8e8e-fa2627271279/l_dpcpp-cpp-compiler_p_2024.0.1.29_offline.sh", 
+                                 sha="22497c46bfb916c82677489775c113141510423799b7eca35f35dffeb2a14104"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/4eedf77e-e097-40de-b62d-5fb70efecb59/l_fortran-compiler_p_2024.0.1.31_offline.sh",
+                                     sha="9d49ecc1862c60eb0627bfdd80d63a47118095af0ff5adeeda10ec36aaffc82c"),
+                          )
+
+oneAPIVersion(version="2024.0.0",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/5c8e686a-16a7-4866-b585-9cf09e97ef36/l_dpcpp-cpp-compiler_p_2024.0.0.49524_offline.sh", 
+                                 sha="d10bad2009c98c631fbb834aae62012548daeefc806265ea567316cd9180a684"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/89b0fcf9-5c00-448a-93a1-5ee4078e008e/l_fortran-compiler_p_2024.0.0.49493_offline.sh",
+                                     sha="57faf854b8388547ee4ef2db387a9f6f3b4d0cebd67b765cf5e844a0a970d1f9"),
+                          )
+
+oneAPIVersion(version="2023.2.4",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/b00a4b0e-bd21-41fa-ab34-19e8e2a77c5a/l_dpcpp-cpp-compiler_p_2023.2.4.24_offline.sh", 
+                                 sha="f143a764adba04a41e49ec405856ad781e5c3754812e90a7ffe06d08cd07f684"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/5bfaa204-689d-4bf1-9656-e37e35ea3fc2/l_fortran-compiler_p_2023.2.4.31_offline.sh",
+                                     sha="2f327d67cd207399b327df5b7c912baae800811d0180485ef5431f106686c94b"),
+                          )
+
+oneAPIVersion(version="2023.2.3",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/d85fbeee-44ec-480a-ba2f-13831bac75f7/l_dpcpp-cpp-compiler_p_2023.2.3.12_offline.sh", 
+                                 sha="b80119a3e54306b85198e907589b00b11c072f107ac39c1686a1996f76466b26"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/0ceccee5-353c-4fd2-a0cc-0aecb7492f87/l_fortran-compiler_p_2023.2.3.13_offline.sh",
+                                     sha="ef8d95b7165d42da8576bf89a100bd21be7253d0aec039ff76c9213fa2aa9c62"),
+                          )
+
+oneAPIVersion(version="2023.2.1",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/ebf5d9aa-17a7-46a4-b5df-ace004227c0e/l_dpcpp-cpp-compiler_p_2023.2.1.8_offline.sh", 
+                                 sha="f5656b2f5bb5d904639e6ef1f90a2d2e760d2906e82ebc0dd387709738ca714b"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/0d65c8d4-f245-4756-80c4-6712b43cf835/l_fortran-compiler_p_2023.2.1.8_offline.sh",
+                                     sha="d4e36abc014c184698fec318a127f15a696b5333b3b0282aba1968b351207185"),
+                          )
+
+oneAPIVersion(version="2023.2.0",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/748687b0-5a22-467c-86c6-c312fa0206b2/l_dpcpp-cpp-compiler_p_2023.2.0.49256_offline.sh", 
+                                 sha="21497b2dd2bc874794c2321561af313082725f61e3101e05a050f98b7351e08f"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/237236c4-434b-4576-96ac-020ceeb22619/l_fortran-compiler_p_2023.2.0.49254_offline.sh",
+                                     sha="37c0ad6f0013512d98e385f8708ca29b23c45fddc9ec76069f1d93663668d511"),
+                          )
+
+oneAPIVersion(version="2023.1.0",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/89283df8-c667-47b0-b7e1-c4573e37bd3e/l_dpcpp-cpp-compiler_p_2023.1.0.46347_offline.sh", 
+                                 sha="3ac1c1179501a2646cbb052b05426554194573b4f8e2344d7699eed03fbcfa1d"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/150e0430-63df-48a0-8469-ecebff0a1858/l_fortran-compiler_p_2023.1.0.46348_offline.sh",
+                                     sha="7639af4b6c928e9e3ba92297a054f78a55f4f4d0db9db0d144cc6653004e4f24"),
+            )
+
+oneAPIVersion(version="2023.0.0",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19123/l_dpcpp-cpp-compiler_p_2023.0.0.25393_offline.sh", 
+                                 sha="473eb019282c2735d65c6058f6890e60b79a5698ae18d2c1e4489fed8dd18a02"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19105/l_fortran-compiler_p_2023.0.0.25394_offline.sh",
+                                     sha="fd7525bf90646c8e43721e138f29c9c6f99e96dfe5648c13633f30ec64ac8b1b"),
+            )
+
+oneAPIVersion(version="2022.2.1",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19049/l_dpcpp-cpp-compiler_p_2022.2.1.16991_offline.sh", 
+                                 sha="3f0f02f9812a0cdf01922d2df9348910c6a4cb4f9dfe50fc7477a59bbb1f7173"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18998/l_fortran-compiler_p_2022.2.1.16992_offline.sh",
+                                     sha="64f1d1efbcdc3ac2182bec18313ca23f800d94f69758db83a1394490d9d4b042"),
+            )
+
+oneAPIVersion(version="2022.2.0",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18849/l_dpcpp-cpp-compiler_p_2022.2.0.8772_offline.sh", 
+                                 sha="8ca97f7ea8abf7876df6e10ce2789ea8cbc310c100ad7bf0b5ffccc4f3c7f2c9"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18909/l_fortran-compiler_p_2022.2.0.8773_offline.sh",
+                                     sha="4054e4bf5146d55638d21612396a19ea623d22cbb8ac63c0a7150773541e0311"),
+                          )
+
+oneAPIVersion(version="2022.1.0",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18717/l_dpcpp-cpp-compiler_p_2022.1.0.137_offline.sh", 
+                                 sha="1027819581ba820470f351abfc2b2658ff2684ed8da9ed0e722a45774a2541d6"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18703/l_fortran-compiler_p_2022.1.0.134_offline.sh",
+                                     sha="583082abe54a657eb933ea4ba3e988eef892985316be13f3e23e18a3c9515020"),
+                          )
+
+oneAPIVersion(version="2022.0.2",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18478/l_dpcpp-cpp-compiler_p_2022.0.2.84_offline.sh", 
+                                 sha="ade5bbd203e7226ca096d7bf758dce07857252ec54e83908cac3849e6897b8f3"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18481/l_fortran-compiler_p_2022.0.2.83_offline.sh",
+                                     sha="78532b4118fc3d7afd44e679fc8e7aed1e84efec0d892908d9368e0c7c6b190c"),
+                          )
+
+oneAPIVersion(version="2022.0.1",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18435/l_dpcpp-cpp-compiler_p_2022.0.1.71_offline.sh", 
+                                 sha="c7cddc64c3040eece2dcaf48926ba197bb27e5a46588b1d7b3beddcdc379926a"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18436/l_fortran-compiler_p_2022.0.1.70_offline.sh",
+                                     sha="2cb28a04f93554bfeffd6cad8bd0e7082735f33d73430655dea86df8933f50d1"),
+                          )
+
+oneAPIVersion(version="2021.4.0",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18209/l_dpcpp-cpp-compiler_p_2021.4.0.3201_offline.sh", 
+                                 sha="9206bff1c2fdeb1ca0d5f79def90dcf3e6c7d5711b9b5adecd96a2ba06503828"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18210/l_fortran-compiler_p_2021.4.0.3224_offline.sh",
+                                     sha="de2fcf40e296c2e882e1ddf2c45bb8d25aecfbeff2f75fcd7494068d621eb7e0"),
+                          )
+
+oneAPIVersion(version="2021.3.0",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17928/l_dpcpp-cpp-compiler_p_2021.3.0.3168_offline.sh", 
+                                 sha="f848d81b7cabc76c2841c9757abb2290921efd7b82491d830605f5785600e7a1"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17959/l_fortran-compiler_p_2021.3.0.3168_offline.sh",
+                                     sha="c4553f7e707be8e8e196f625e4e7fbc8eff5474f64ab85fc7146b5ed53ebc87c"),
+                          )
+
+oneAPIVersion(version="2021.2.0",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17749/l_dpcpp-cpp-compiler_p_2021.2.0.118_offline.sh", 
+                                 sha="5d01cbff1a574c3775510cd97ffddd27fdf56d06a6b0c89a826fb23da4336d59"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17756/l_fortran-compiler_p_2021.2.0.136_offline.sh",
+                                     sha="a62e04a80f6d2f05e67cd5acb03fa58857ee22c6bd581ec0651c0ccd5bdec5a1"),
+                          )
+
+oneAPIVersion(version="2021.1.2",
+              platform="linux",
+              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17513/l_dpcpp-cpp-compiler_p_2021.1.2.63_offline.sh", 
+                                 sha="68d6cb638091990e578e358131c859f3bbbbfbf975c581fd0b4b4d36476d6f0a"),
+              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17508/l_fortran-compiler_p_2021.1.2.62_offline.sh",
+                                     sha="29345145268d08a59fa7eb6e58c7522768466dd98f6d9754540d1a0803596829"),
+                          )

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers/oneapi_versions.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers/oneapi_versions.py
@@ -42,9 +42,14 @@ class oneAPIVersions:
 
 
 class oneAPIInstaller:
-    def __init__(self, *, url:str, sha:str):
-        self.url = url
+    def __init__(self, *, path:str, sha:str):
+        self._url_base = "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/"
+        self._path = path
         self.sha = sha
+
+    @property
+    def url(self):
+        return self._url_base + self._path
 
 
 class oneAPIVersion:
@@ -66,230 +71,230 @@ class oneAPIVersion:
         
 
 oneAPIVersion(version="2025.1.1",
-              platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/c4d2aef3-3123-475e-800c-7d66fd8da2a5/intel-dpcpp-cpp-compiler-2025.1.1.9_offline.sh",
-                                  sha="63ea61f54a5ea9d30059ea499697e04953915ef317c0e8fc457077b690c726df"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/0e4735b3-8721-422b-b204-00eefe413bfd/intel-fortran-compiler-2025.1.1.10_offline.sh",
-                                      sha="c59060a5b959fb0faeb1cde349689086da41d491adb41fd6c97177fcf59bf957")
-            )
+    platform="linux",
+    cxx=oneAPIInstaller(path="c4d2aef3-3123-475e-800c-7d66fd8da2a5/intel-dpcpp-cpp-compiler-2025.1.1.9_offline.sh",
+                        sha="63ea61f54a5ea9d30059ea499697e04953915ef317c0e8fc457077b690c726df"),
+    fortran=oneAPIInstaller(path="0e4735b3-8721-422b-b204-00eefe413bfd/intel-fortran-compiler-2025.1.1.10_offline.sh",
+                            sha="c59060a5b959fb0faeb1cde349689086da41d491adb41fd6c97177fcf59bf957")
+)
 
 
 oneAPIVersion(version="2025.1.0",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/cd63be99-88b0-4981-bea1-2034fe17f5cf/intel-dpcpp-cpp-compiler-2025.1.0.573_offline.sh", 
+              cxx=oneAPIInstaller(path="cd63be99-88b0-4981-bea1-2034fe17f5cf/intel-dpcpp-cpp-compiler-2025.1.0.573_offline.sh", 
                                  sha="53489afcc9534e30ad807e94b158abfccf6a7eb3658f59655122d92fbad8fa72"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/577ebc28-d0f6-492b-9a43-b04354ce99da/intel-fortran-compiler-2025.1.0.601_offline.sh",
+              fortran=oneAPIInstaller(path="577ebc28-d0f6-492b-9a43-b04354ce99da/intel-fortran-compiler-2025.1.0.601_offline.sh",
                                      sha="27016329dede8369679f22b4e9f67936837ce7972a1ef4f5c76ee87d7c963c81")
             )
 
 oneAPIVersion(version="2025.0.4",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/84c039b6-2b7d-4544-a745-3fcf8afd643f/intel-dpcpp-cpp-compiler-2025.0.4.20_offline.sh", 
+              cxx=oneAPIInstaller(path="84c039b6-2b7d-4544-a745-3fcf8afd643f/intel-dpcpp-cpp-compiler-2025.0.4.20_offline.sh", 
                                  sha="0537c6e462fe74063cb0b9209a0fd5c0ca3a29b4520d43d382ae27fb3f98b375"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ad42ee3b-7a2f-41cb-b902-689f651920da/intel-fortran-compiler-2025.0.4.21_offline.sh",
+              fortran=oneAPIInstaller(path="ad42ee3b-7a2f-41cb-b902-689f651920da/intel-fortran-compiler-2025.0.4.21_offline.sh",
                                      sha="ad453f1dd68111e7cf7053d6f86fa26d982bd9ab61982cbb6dbe5195fb6feedb"),
             )
 
 oneAPIVersion(version="2025.0.3",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/1cac4f39-2032-4aa9-86d7-e4f3e40e4277/intel-dpcpp-cpp-compiler-2025.0.3.9_offline.sh", 
+              cxx=oneAPIInstaller(path="1cac4f39-2032-4aa9-86d7-e4f3e40e4277/intel-dpcpp-cpp-compiler-2025.0.3.9_offline.sh", 
                                  sha="0ca834002b9091dc9988da6798a2eb36ebc5933d8d523ed0fa78a55744c88823"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/fafa2df1-4bb1-43f7-87c6-3c82f1bdc712/intel-fortran-compiler-2025.0.3.9_offline.sh",
+              fortran=oneAPIInstaller(path="fafa2df1-4bb1-43f7-87c6-3c82f1bdc712/intel-fortran-compiler-2025.0.3.9_offline.sh",
                                      sha="1ad813cf6495ded730646d6c4fd065dcc840875fdea28fcc6bac2cafb8d22c8d"),
             )
 
 oneAPIVersion(version="2025.0.1",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/4fd7c6b0-853f-458a-a8ec-421ab50a80a6/intel-dpcpp-cpp-compiler-2025.0.1.46_offline.sh", 
+              cxx=oneAPIInstaller(path="4fd7c6b0-853f-458a-a8ec-421ab50a80a6/intel-dpcpp-cpp-compiler-2025.0.1.46_offline.sh", 
                                  sha="1595397566b59a5c8f81e2c235b6bedd2405dc70309b5bf00ed75827d0f12449"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/7ba31291-8a27-426f-88d5-8c2d65316655/intel-fortran-compiler-2025.0.1.41_offline.sh",
+              fortran=oneAPIInstaller(path="7ba31291-8a27-426f-88d5-8c2d65316655/intel-fortran-compiler-2025.0.1.41_offline.sh",
                                      sha="aa54f019ad8db79f716f880c72784dc117d64e525e4c3b62717bd9d18a6c9060"),
                 )
 
 oneAPIVersion(version="2025.0.0",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ac92f2bb-4818-4e53-a432-f8b34d502f23/intel-dpcpp-cpp-compiler-2025.0.0.740_offline.sh", 
+              cxx=oneAPIInstaller(path="ac92f2bb-4818-4e53-a432-f8b34d502f23/intel-dpcpp-cpp-compiler-2025.0.0.740_offline.sh", 
                                  sha="04fadf63789acee731895e631db63f65a98b8279db3d0f48bdf0d81e6103bdd8"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/69f79888-2d6c-4b20-999e-e99d72af68d4/intel-fortran-compiler-2025.0.0.723_offline.sh",
+              fortran=oneAPIInstaller(path="69f79888-2d6c-4b20-999e-e99d72af68d4/intel-fortran-compiler-2025.0.0.723_offline.sh",
                                      sha="2be6d607ce84f35921228595b118fbc516d28587cbc4e6dcf6b7219e5cd1a9a9"),
-              nvidia=oneAPIInstaller(url="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=2025.0.0&filters[]=12.0&filters[]=linux",
+              nvidia=oneAPIInstaller(path="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=2025.0.0&filters[]=12.0&filters[]=linux",
                                      sha="264a43d2e07c08eb31d6483fb1c289a6b148709e48e9a250efc1b1e9a527feb6"),
-              amd=oneAPIInstaller(url="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=2025.0.0&filters[]=6.1.0&filters[]=linux",
+              amd=oneAPIInstaller(path="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=2025.0.0&filters[]=6.1.0&filters[]=linux",
                                   sha="2c5a147e82f0e995b9c0457b53967cc066d5741d675cb64cb9eba8e3c791a064")
             )
 
 oneAPIVersion(version="2024.2.1",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/74587994-3c83-48fd-b963-b707521a63f4/l_dpcpp-cpp-compiler_p_2024.2.1.79_offline.sh", 
+              cxx=oneAPIInstaller(path="74587994-3c83-48fd-b963-b707521a63f4/l_dpcpp-cpp-compiler_p_2024.2.1.79_offline.sh", 
                                  sha="af0243f80640afa94c7f9c8151da91d7ab17f448f542fa76d785230dec712048"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/5e7b0f1c-6f25-4cc8-94d7-3a527e596739/l_fortran-compiler_p_2024.2.1.80_offline.sh",
+              fortran=oneAPIInstaller(path="5e7b0f1c-6f25-4cc8-94d7-3a527e596739/l_fortran-compiler_p_2024.2.1.80_offline.sh",
                                      sha="6f6dab82a88082a7a39f6feb699343c521f58c6481a1bb87edba7e2550995b6d"),
-              nvidia=oneAPIInstaller(url="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=2024.2.1&filters[]=12.0&filters[]=linux",
+              nvidia=oneAPIInstaller(path="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=2024.2.1&filters[]=12.0&filters[]=linux",
                                      sha="2c377027c650291ccd8267cbf75bd3d00c7b11998cc59d5668a02a0cbc2c015f"),
-              amd=oneAPIInstaller(url="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=2024.2.1&filters[]=6.1.0&filters[]=linux",
+              amd=oneAPIInstaller(path="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=2024.2.1&filters[]=6.1.0&filters[]=linux",
                                   sha="fbeb64f959f907cbf3469f4e154b2af6d8ff46fe4fc667c811e04f3872a13823")
             )
 
 oneAPIVersion(version="2024.2.0",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/6780ac84-6256-4b59-a647-330eb65f32b6/l_dpcpp-cpp-compiler_p_2024.2.0.495_offline.sh", 
+              cxx=oneAPIInstaller(path="6780ac84-6256-4b59-a647-330eb65f32b6/l_dpcpp-cpp-compiler_p_2024.2.0.495_offline.sh", 
                                  sha="9463aa979314d2acc51472d414ffcee032e9869ca85ac6ff4c71d39500e5173d"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/801143de-6c01-4181-9911-57e00fe40181/l_fortran-compiler_p_2024.2.0.426_offline.sh",
+              fortran=oneAPIInstaller(path="801143de-6c01-4181-9911-57e00fe40181/l_fortran-compiler_p_2024.2.0.426_offline.sh",
                                      sha="fd19a302662b2f86f76fc115ef53a69f16488080278dba4c573cc705f3a52ffa"),
-              nvidia=oneAPIInstaller(url="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=2024.2.0&filters[]=12.0&filters[]=linux",
+              nvidia=oneAPIInstaller(path="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=2024.2.0&filters[]=12.0&filters[]=linux",
                                      sha="0622df0054364b01e91e7ed72a33cb3281e281db5b0e86579f516b1cc5336b0f"),
-              amd=oneAPIInstaller(url="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=2024.2.0&filters[]=6.1.0&filters[]=linux",
+              amd=oneAPIInstaller(path="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=2024.2.0&filters[]=6.1.0&filters[]=linux",
                                   sha="d1e9d30fa92f3ef606f054d8cbd7c338b3e46f6a9f8472736e29e8ccd9e50688")
             )
 
 oneAPIVersion(version="2024.1.0",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2e562b6e-5d0f-4001-8121-350a828332fb/l_dpcpp-cpp-compiler_p_2024.1.0.468_offline.sh", 
+              cxx=oneAPIInstaller(path="2e562b6e-5d0f-4001-8121-350a828332fb/l_dpcpp-cpp-compiler_p_2024.1.0.468_offline.sh", 
                                  sha="534ecc6e4b690c9011d7765cbe178f520aa8f49c0eb4ea80ea1415e48e5d7cf7"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/fd9342bd-7d50-442c-a3e4-f41974e14396/l_fortran-compiler_p_2024.1.0.465_offline.sh",
+              fortran=oneAPIInstaller(path="fd9342bd-7d50-442c-a3e4-f41974e14396/l_fortran-compiler_p_2024.1.0.465_offline.sh",
                                      sha="30a02bad9a96a543c60f3bfa4238dfe07c2d26d76fc22ba9aa9b7c603e11f1b9"),
                           )
 
 oneAPIVersion(version="2024.0.2",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/bb99984f-370f-413d-bbec-38928d2458f2/l_dpcpp-cpp-compiler_p_2024.0.2.29_offline.sh", 
+              cxx=oneAPIInstaller(path="bb99984f-370f-413d-bbec-38928d2458f2/l_dpcpp-cpp-compiler_p_2024.0.2.29_offline.sh", 
                                  sha="0ec22d69f4207fea4b7488d1c9e62adbc14fb6daa1574d6edcadc912da007b3c"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/41df6814-ec4b-4698-a14d-421ee2b02aa7/l_fortran-compiler_p_2024.0.2.28_offline.sh",
+              fortran=oneAPIInstaller(path="41df6814-ec4b-4698-a14d-421ee2b02aa7/l_fortran-compiler_p_2024.0.2.28_offline.sh",
                                      sha="396ac4fbcb3799d5c1a866a60cf81f85f7cab8c6f35289f61c5cda63c7101b5e"),
                           )
 
 oneAPIVersion(version="2024.0.1",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/c68c8f0a-47f5-4f26-8e8e-fa2627271279/l_dpcpp-cpp-compiler_p_2024.0.1.29_offline.sh", 
+              cxx=oneAPIInstaller(path="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/c68c8f0a-47f5-4f26-8e8e-fa2627271279/l_dpcpp-cpp-compiler_p_2024.0.1.29_offline.sh", 
                                  sha="22497c46bfb916c82677489775c113141510423799b7eca35f35dffeb2a14104"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/4eedf77e-e097-40de-b62d-5fb70efecb59/l_fortran-compiler_p_2024.0.1.31_offline.sh",
+              fortran=oneAPIInstaller(path="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/4eedf77e-e097-40de-b62d-5fb70efecb59/l_fortran-compiler_p_2024.0.1.31_offline.sh",
                                      sha="9d49ecc1862c60eb0627bfdd80d63a47118095af0ff5adeeda10ec36aaffc82c"),
                           )
 
 oneAPIVersion(version="2024.0.0",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/5c8e686a-16a7-4866-b585-9cf09e97ef36/l_dpcpp-cpp-compiler_p_2024.0.0.49524_offline.sh", 
+              cxx=oneAPIInstaller(path="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/5c8e686a-16a7-4866-b585-9cf09e97ef36/l_dpcpp-cpp-compiler_p_2024.0.0.49524_offline.sh", 
                                  sha="d10bad2009c98c631fbb834aae62012548daeefc806265ea567316cd9180a684"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/89b0fcf9-5c00-448a-93a1-5ee4078e008e/l_fortran-compiler_p_2024.0.0.49493_offline.sh",
+              fortran=oneAPIInstaller(path="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/89b0fcf9-5c00-448a-93a1-5ee4078e008e/l_fortran-compiler_p_2024.0.0.49493_offline.sh",
                                      sha="57faf854b8388547ee4ef2db387a9f6f3b4d0cebd67b765cf5e844a0a970d1f9"),
                           )
 
 oneAPIVersion(version="2023.2.4",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/b00a4b0e-bd21-41fa-ab34-19e8e2a77c5a/l_dpcpp-cpp-compiler_p_2023.2.4.24_offline.sh", 
+              cxx=oneAPIInstaller(path="b00a4b0e-bd21-41fa-ab34-19e8e2a77c5a/l_dpcpp-cpp-compiler_p_2023.2.4.24_offline.sh", 
                                  sha="f143a764adba04a41e49ec405856ad781e5c3754812e90a7ffe06d08cd07f684"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/5bfaa204-689d-4bf1-9656-e37e35ea3fc2/l_fortran-compiler_p_2023.2.4.31_offline.sh",
+              fortran=oneAPIInstaller(path="5bfaa204-689d-4bf1-9656-e37e35ea3fc2/l_fortran-compiler_p_2023.2.4.31_offline.sh",
                                      sha="2f327d67cd207399b327df5b7c912baae800811d0180485ef5431f106686c94b"),
                           )
 
 oneAPIVersion(version="2023.2.3",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/d85fbeee-44ec-480a-ba2f-13831bac75f7/l_dpcpp-cpp-compiler_p_2023.2.3.12_offline.sh", 
+              cxx=oneAPIInstaller(path="d85fbeee-44ec-480a-ba2f-13831bac75f7/l_dpcpp-cpp-compiler_p_2023.2.3.12_offline.sh", 
                                  sha="b80119a3e54306b85198e907589b00b11c072f107ac39c1686a1996f76466b26"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/0ceccee5-353c-4fd2-a0cc-0aecb7492f87/l_fortran-compiler_p_2023.2.3.13_offline.sh",
+              fortran=oneAPIInstaller(path="0ceccee5-353c-4fd2-a0cc-0aecb7492f87/l_fortran-compiler_p_2023.2.3.13_offline.sh",
                                      sha="ef8d95b7165d42da8576bf89a100bd21be7253d0aec039ff76c9213fa2aa9c62"),
                           )
 
 oneAPIVersion(version="2023.2.1",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/ebf5d9aa-17a7-46a4-b5df-ace004227c0e/l_dpcpp-cpp-compiler_p_2023.2.1.8_offline.sh", 
+              cxx=oneAPIInstaller(path="ebf5d9aa-17a7-46a4-b5df-ace004227c0e/l_dpcpp-cpp-compiler_p_2023.2.1.8_offline.sh", 
                                  sha="f5656b2f5bb5d904639e6ef1f90a2d2e760d2906e82ebc0dd387709738ca714b"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/0d65c8d4-f245-4756-80c4-6712b43cf835/l_fortran-compiler_p_2023.2.1.8_offline.sh",
+              fortran=oneAPIInstaller(path="0d65c8d4-f245-4756-80c4-6712b43cf835/l_fortran-compiler_p_2023.2.1.8_offline.sh",
                                      sha="d4e36abc014c184698fec318a127f15a696b5333b3b0282aba1968b351207185"),
                           )
 
 oneAPIVersion(version="2023.2.0",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/748687b0-5a22-467c-86c6-c312fa0206b2/l_dpcpp-cpp-compiler_p_2023.2.0.49256_offline.sh", 
+              cxx=oneAPIInstaller(path="748687b0-5a22-467c-86c6-c312fa0206b2/l_dpcpp-cpp-compiler_p_2023.2.0.49256_offline.sh", 
                                  sha="21497b2dd2bc874794c2321561af313082725f61e3101e05a050f98b7351e08f"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/237236c4-434b-4576-96ac-020ceeb22619/l_fortran-compiler_p_2023.2.0.49254_offline.sh",
+              fortran=oneAPIInstaller(path="237236c4-434b-4576-96ac-020ceeb22619/l_fortran-compiler_p_2023.2.0.49254_offline.sh",
                                      sha="37c0ad6f0013512d98e385f8708ca29b23c45fddc9ec76069f1d93663668d511"),
                           )
 
 oneAPIVersion(version="2023.1.0",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/89283df8-c667-47b0-b7e1-c4573e37bd3e/l_dpcpp-cpp-compiler_p_2023.1.0.46347_offline.sh", 
+              cxx=oneAPIInstaller(path="89283df8-c667-47b0-b7e1-c4573e37bd3e/l_dpcpp-cpp-compiler_p_2023.1.0.46347_offline.sh", 
                                  sha="3ac1c1179501a2646cbb052b05426554194573b4f8e2344d7699eed03fbcfa1d"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/150e0430-63df-48a0-8469-ecebff0a1858/l_fortran-compiler_p_2023.1.0.46348_offline.sh",
+              fortran=oneAPIInstaller(path="150e0430-63df-48a0-8469-ecebff0a1858/l_fortran-compiler_p_2023.1.0.46348_offline.sh",
                                      sha="7639af4b6c928e9e3ba92297a054f78a55f4f4d0db9db0d144cc6653004e4f24"),
             )
 
 oneAPIVersion(version="2023.0.0",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19123/l_dpcpp-cpp-compiler_p_2023.0.0.25393_offline.sh", 
+              cxx=oneAPIInstaller(path="19123/l_dpcpp-cpp-compiler_p_2023.0.0.25393_offline.sh", 
                                  sha="473eb019282c2735d65c6058f6890e60b79a5698ae18d2c1e4489fed8dd18a02"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19105/l_fortran-compiler_p_2023.0.0.25394_offline.sh",
+              fortran=oneAPIInstaller(path="19105/l_fortran-compiler_p_2023.0.0.25394_offline.sh",
                                      sha="fd7525bf90646c8e43721e138f29c9c6f99e96dfe5648c13633f30ec64ac8b1b"),
             )
 
 oneAPIVersion(version="2022.2.1",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19049/l_dpcpp-cpp-compiler_p_2022.2.1.16991_offline.sh", 
+              cxx=oneAPIInstaller(path="19049/l_dpcpp-cpp-compiler_p_2022.2.1.16991_offline.sh", 
                                  sha="3f0f02f9812a0cdf01922d2df9348910c6a4cb4f9dfe50fc7477a59bbb1f7173"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18998/l_fortran-compiler_p_2022.2.1.16992_offline.sh",
+              fortran=oneAPIInstaller(path="18998/l_fortran-compiler_p_2022.2.1.16992_offline.sh",
                                      sha="64f1d1efbcdc3ac2182bec18313ca23f800d94f69758db83a1394490d9d4b042"),
             )
 
 oneAPIVersion(version="2022.2.0",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18849/l_dpcpp-cpp-compiler_p_2022.2.0.8772_offline.sh", 
+              cxx=oneAPIInstaller(path="18849/l_dpcpp-cpp-compiler_p_2022.2.0.8772_offline.sh", 
                                  sha="8ca97f7ea8abf7876df6e10ce2789ea8cbc310c100ad7bf0b5ffccc4f3c7f2c9"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18909/l_fortran-compiler_p_2022.2.0.8773_offline.sh",
+              fortran=oneAPIInstaller(path="18909/l_fortran-compiler_p_2022.2.0.8773_offline.sh",
                                      sha="4054e4bf5146d55638d21612396a19ea623d22cbb8ac63c0a7150773541e0311"),
                           )
 
 oneAPIVersion(version="2022.1.0",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18717/l_dpcpp-cpp-compiler_p_2022.1.0.137_offline.sh", 
+              cxx=oneAPIInstaller(path="18717/l_dpcpp-cpp-compiler_p_2022.1.0.137_offline.sh", 
                                  sha="1027819581ba820470f351abfc2b2658ff2684ed8da9ed0e722a45774a2541d6"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18703/l_fortran-compiler_p_2022.1.0.134_offline.sh",
+              fortran=oneAPIInstaller(path="18703/l_fortran-compiler_p_2022.1.0.134_offline.sh",
                                      sha="583082abe54a657eb933ea4ba3e988eef892985316be13f3e23e18a3c9515020"),
                           )
 
 oneAPIVersion(version="2022.0.2",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18478/l_dpcpp-cpp-compiler_p_2022.0.2.84_offline.sh", 
+              cxx=oneAPIInstaller(path="18478/l_dpcpp-cpp-compiler_p_2022.0.2.84_offline.sh", 
                                  sha="ade5bbd203e7226ca096d7bf758dce07857252ec54e83908cac3849e6897b8f3"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18481/l_fortran-compiler_p_2022.0.2.83_offline.sh",
+              fortran=oneAPIInstaller(path="18481/l_fortran-compiler_p_2022.0.2.83_offline.sh",
                                      sha="78532b4118fc3d7afd44e679fc8e7aed1e84efec0d892908d9368e0c7c6b190c"),
                           )
 
 oneAPIVersion(version="2022.0.1",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18435/l_dpcpp-cpp-compiler_p_2022.0.1.71_offline.sh", 
+              cxx=oneAPIInstaller(path="18435/l_dpcpp-cpp-compiler_p_2022.0.1.71_offline.sh", 
                                  sha="c7cddc64c3040eece2dcaf48926ba197bb27e5a46588b1d7b3beddcdc379926a"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18436/l_fortran-compiler_p_2022.0.1.70_offline.sh",
+              fortran=oneAPIInstaller(path="18436/l_fortran-compiler_p_2022.0.1.70_offline.sh",
                                      sha="2cb28a04f93554bfeffd6cad8bd0e7082735f33d73430655dea86df8933f50d1"),
                           )
 
 oneAPIVersion(version="2021.4.0",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18209/l_dpcpp-cpp-compiler_p_2021.4.0.3201_offline.sh", 
+              cxx=oneAPIInstaller(path="18209/l_dpcpp-cpp-compiler_p_2021.4.0.3201_offline.sh", 
                                  sha="9206bff1c2fdeb1ca0d5f79def90dcf3e6c7d5711b9b5adecd96a2ba06503828"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18210/l_fortran-compiler_p_2021.4.0.3224_offline.sh",
+              fortran=oneAPIInstaller(path="18210/l_fortran-compiler_p_2021.4.0.3224_offline.sh",
                                      sha="de2fcf40e296c2e882e1ddf2c45bb8d25aecfbeff2f75fcd7494068d621eb7e0"),
                           )
 
 oneAPIVersion(version="2021.3.0",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17928/l_dpcpp-cpp-compiler_p_2021.3.0.3168_offline.sh", 
+              cxx=oneAPIInstaller(path="17928/l_dpcpp-cpp-compiler_p_2021.3.0.3168_offline.sh", 
                                  sha="f848d81b7cabc76c2841c9757abb2290921efd7b82491d830605f5785600e7a1"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17959/l_fortran-compiler_p_2021.3.0.3168_offline.sh",
+              fortran=oneAPIInstaller(path="17959/l_fortran-compiler_p_2021.3.0.3168_offline.sh",
                                      sha="c4553f7e707be8e8e196f625e4e7fbc8eff5474f64ab85fc7146b5ed53ebc87c"),
                           )
 
 oneAPIVersion(version="2021.2.0",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17749/l_dpcpp-cpp-compiler_p_2021.2.0.118_offline.sh", 
+              cxx=oneAPIInstaller(path="17749/l_dpcpp-cpp-compiler_p_2021.2.0.118_offline.sh", 
                                  sha="5d01cbff1a574c3775510cd97ffddd27fdf56d06a6b0c89a826fb23da4336d59"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17756/l_fortran-compiler_p_2021.2.0.136_offline.sh",
+              fortran=oneAPIInstaller(path="17756/l_fortran-compiler_p_2021.2.0.136_offline.sh",
                                      sha="a62e04a80f6d2f05e67cd5acb03fa58857ee22c6bd581ec0651c0ccd5bdec5a1"),
                           )
 
 oneAPIVersion(version="2021.1.2",
               platform="linux",
-              cxx=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17513/l_dpcpp-cpp-compiler_p_2021.1.2.63_offline.sh", 
+              cxx=oneAPIInstaller(path="17513/l_dpcpp-cpp-compiler_p_2021.1.2.63_offline.sh", 
                                  sha="68d6cb638091990e578e358131c859f3bbbbfbf975c581fd0b4b4d36476d6f0a"),
-              fortran=oneAPIInstaller(url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17508/l_fortran-compiler_p_2021.1.2.62_offline.sh",
+              fortran=oneAPIInstaller(path="17508/l_fortran-compiler_p_2021.1.2.62_offline.sh",
                                      sha="29345145268d08a59fa7eb6e58c7522768466dd98f6d9754540d1a0803596829"),
                           )

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers/oneapi_versions.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers/oneapi_versions.py
@@ -3,14 +3,19 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import platform
+from typing import List, Optional
+
 from spack.package import *
+
 
 class oneAPIVersions:
     versions: List["oneAPIVersion"] = []
 
     @staticmethod
     def generate_versions():
-        for v in filter(lambda x: x.platform == platform.system().lower(), oneAPIVersions.versions):
+        for v in filter(
+            lambda x: x.platform == platform.system().lower(), oneAPIVersions.versions
+        ):
             version(v.version, expand=False, url=v.cxx.url, sha256=v.cxx.sha)
             if v.fortran:
                 resource(
@@ -19,7 +24,7 @@ class oneAPIVersions:
                     when=f"@{v.version}",
                     expand=False,
                     url=v.fortran.url,
-                    sha256=v.fortran.sha
+                    sha256=v.fortran.sha,
                 )
             if v.nvidia:
                 resource(
@@ -28,7 +33,7 @@ class oneAPIVersions:
                     when=f"@{v.version}",
                     expand=False,
                     url=v.nvidia.url,
-                    sha256=v.nvidia.sha
+                    sha256=v.nvidia.sha,
                 )
             if v.amd:
                 resource(
@@ -37,12 +42,12 @@ class oneAPIVersions:
                     when=f"@{v.version}",
                     expand=False,
                     url=v.amd.url,
-                    sha256=v.amd.sha
+                    sha256=v.amd.sha,
                 )
 
 
 class oneAPIInstaller:
-    def __init__(self, *, path:str, sha:str):
+    def __init__(self, *, path: str, sha: str):
         self._url_base = "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/"
         self._path = path
         self.sha = sha
@@ -55,256 +60,414 @@ class oneAPIInstaller:
 
 
 class oneAPIVersion:
-    def __init__(self, *, 
-                 version: str, 
-                 platform:str, 
-                 cxx:oneAPIInstaller, 
-                 fortran:Optional[oneAPIInstaller]=None, 
-                 nvidia:Optional[oneAPIInstaller]=None, 
-                 amd:Optional[oneAPIInstaller]=None):
+    def __init__(
+        self,
+        *,
+        version: str,
+        platform: str,
+        cxx: oneAPIInstaller,
+        fortran: Optional[oneAPIInstaller] = None,
+        nvidia: Optional[oneAPIInstaller] = None,
+        amd: Optional[oneAPIInstaller] = None,
+    ):
         self.version = version
-        assert platform.lower() in ("windows", "linux"), "OneAPI is only compatible with Windows or Linux"
+        assert platform.lower() in (
+            "windows",
+            "linux",
+        ), "OneAPI is only compatible with Windows or Linux"
         self.platform = platform
         self.cxx = cxx
         self.fortran = fortran
         self.nvidia = nvidia
         self.amd = amd
         oneAPIVersions.versions.append(self)
-        
 
-oneAPIVersion(version="2025.1.1",
+
+oneAPIVersion(
+    version="2025.1.1",
     platform="windows",
-    cxx=oneAPIInstaller(path="7f810440-2a66-4d34-b05f-8f4395667844/intel-dpcpp-cpp-compiler-2025.1.1.10_offline.exe",
-                        sha="7a8471a9e36e3595338427a91c426751cb4ca3a2cb49f8bb76e466df73534392"),
-    fortran=oneAPIInstaller(path="20fc9768-cb87-4aaa-adf8-6c83a5d8e8b4/intel-fortran-compiler-2025.1.1.11_offline.exe", 
-                            sha="5e3422654080b0ea799482c7baf08c75fd6a37b6246e972d41be72e6507986b9"),
+    cxx=oneAPIInstaller(
+        path="7f810440-2a66-4d34-b05f-8f4395667844/intel-dpcpp-cpp-compiler-2025.1.1.10_offline.exe",
+        sha="7a8471a9e36e3595338427a91c426751cb4ca3a2cb49f8bb76e466df73534392",
+    ),
+    fortran=oneAPIInstaller(
+        path="20fc9768-cb87-4aaa-adf8-6c83a5d8e8b4/intel-fortran-compiler-2025.1.1.11_offline.exe",
+        sha="5e3422654080b0ea799482c7baf08c75fd6a37b6246e972d41be72e6507986b9",
+    ),
 )
 
-oneAPIVersion(version="2025.1.1",
+oneAPIVersion(
+    version="2025.1.1",
     platform="linux",
-    cxx=oneAPIInstaller(path="c4d2aef3-3123-475e-800c-7d66fd8da2a5/intel-dpcpp-cpp-compiler-2025.1.1.9_offline.sh",
-                        sha="63ea61f54a5ea9d30059ea499697e04953915ef317c0e8fc457077b690c726df"),
-    fortran=oneAPIInstaller(path="0e4735b3-8721-422b-b204-00eefe413bfd/intel-fortran-compiler-2025.1.1.10_offline.sh",
-                            sha="c59060a5b959fb0faeb1cde349689086da41d491adb41fd6c97177fcf59bf957")
+    cxx=oneAPIInstaller(
+        path="c4d2aef3-3123-475e-800c-7d66fd8da2a5/intel-dpcpp-cpp-compiler-2025.1.1.9_offline.sh",
+        sha="63ea61f54a5ea9d30059ea499697e04953915ef317c0e8fc457077b690c726df",
+    ),
+    fortran=oneAPIInstaller(
+        path="0e4735b3-8721-422b-b204-00eefe413bfd/intel-fortran-compiler-2025.1.1.10_offline.sh",
+        sha="c59060a5b959fb0faeb1cde349689086da41d491adb41fd6c97177fcf59bf957",
+    ),
 )
 
 
-oneAPIVersion(version="2025.1.0",
-              platform="linux",
-              cxx=oneAPIInstaller(path="cd63be99-88b0-4981-bea1-2034fe17f5cf/intel-dpcpp-cpp-compiler-2025.1.0.573_offline.sh", 
-                                 sha="53489afcc9534e30ad807e94b158abfccf6a7eb3658f59655122d92fbad8fa72"),
-              fortran=oneAPIInstaller(path="577ebc28-d0f6-492b-9a43-b04354ce99da/intel-fortran-compiler-2025.1.0.601_offline.sh",
-                                     sha="27016329dede8369679f22b4e9f67936837ce7972a1ef4f5c76ee87d7c963c81")
-            )
+oneAPIVersion(
+    version="2025.1.0",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="cd63be99-88b0-4981-bea1-2034fe17f5cf/intel-dpcpp-cpp-compiler-2025.1.0.573_offline.sh",
+        sha="53489afcc9534e30ad807e94b158abfccf6a7eb3658f59655122d92fbad8fa72",
+    ),
+    fortran=oneAPIInstaller(
+        path="577ebc28-d0f6-492b-9a43-b04354ce99da/intel-fortran-compiler-2025.1.0.601_offline.sh",
+        sha="27016329dede8369679f22b4e9f67936837ce7972a1ef4f5c76ee87d7c963c81",
+    ),
+)
 
-oneAPIVersion(version="2025.0.4",
-              platform="linux",
-              cxx=oneAPIInstaller(path="84c039b6-2b7d-4544-a745-3fcf8afd643f/intel-dpcpp-cpp-compiler-2025.0.4.20_offline.sh", 
-                                 sha="0537c6e462fe74063cb0b9209a0fd5c0ca3a29b4520d43d382ae27fb3f98b375"),
-              fortran=oneAPIInstaller(path="ad42ee3b-7a2f-41cb-b902-689f651920da/intel-fortran-compiler-2025.0.4.21_offline.sh",
-                                     sha="ad453f1dd68111e7cf7053d6f86fa26d982bd9ab61982cbb6dbe5195fb6feedb"),
-            )
+oneAPIVersion(
+    version="2025.0.4",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="84c039b6-2b7d-4544-a745-3fcf8afd643f/intel-dpcpp-cpp-compiler-2025.0.4.20_offline.sh",
+        sha="0537c6e462fe74063cb0b9209a0fd5c0ca3a29b4520d43d382ae27fb3f98b375",
+    ),
+    fortran=oneAPIInstaller(
+        path="ad42ee3b-7a2f-41cb-b902-689f651920da/intel-fortran-compiler-2025.0.4.21_offline.sh",
+        sha="ad453f1dd68111e7cf7053d6f86fa26d982bd9ab61982cbb6dbe5195fb6feedb",
+    ),
+)
 
-oneAPIVersion(version="2025.0.3",
-              platform="linux",
-              cxx=oneAPIInstaller(path="1cac4f39-2032-4aa9-86d7-e4f3e40e4277/intel-dpcpp-cpp-compiler-2025.0.3.9_offline.sh", 
-                                 sha="0ca834002b9091dc9988da6798a2eb36ebc5933d8d523ed0fa78a55744c88823"),
-              fortran=oneAPIInstaller(path="fafa2df1-4bb1-43f7-87c6-3c82f1bdc712/intel-fortran-compiler-2025.0.3.9_offline.sh",
-                                     sha="1ad813cf6495ded730646d6c4fd065dcc840875fdea28fcc6bac2cafb8d22c8d"),
-            )
+oneAPIVersion(
+    version="2025.0.3",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="1cac4f39-2032-4aa9-86d7-e4f3e40e4277/intel-dpcpp-cpp-compiler-2025.0.3.9_offline.sh",
+        sha="0ca834002b9091dc9988da6798a2eb36ebc5933d8d523ed0fa78a55744c88823",
+    ),
+    fortran=oneAPIInstaller(
+        path="fafa2df1-4bb1-43f7-87c6-3c82f1bdc712/intel-fortran-compiler-2025.0.3.9_offline.sh",
+        sha="1ad813cf6495ded730646d6c4fd065dcc840875fdea28fcc6bac2cafb8d22c8d",
+    ),
+)
 
-oneAPIVersion(version="2025.0.1",
-              platform="linux",
-              cxx=oneAPIInstaller(path="4fd7c6b0-853f-458a-a8ec-421ab50a80a6/intel-dpcpp-cpp-compiler-2025.0.1.46_offline.sh", 
-                                 sha="1595397566b59a5c8f81e2c235b6bedd2405dc70309b5bf00ed75827d0f12449"),
-              fortran=oneAPIInstaller(path="7ba31291-8a27-426f-88d5-8c2d65316655/intel-fortran-compiler-2025.0.1.41_offline.sh",
-                                     sha="aa54f019ad8db79f716f880c72784dc117d64e525e4c3b62717bd9d18a6c9060"),
-                )
+oneAPIVersion(
+    version="2025.0.1",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="4fd7c6b0-853f-458a-a8ec-421ab50a80a6/intel-dpcpp-cpp-compiler-2025.0.1.46_offline.sh",
+        sha="1595397566b59a5c8f81e2c235b6bedd2405dc70309b5bf00ed75827d0f12449",
+    ),
+    fortran=oneAPIInstaller(
+        path="7ba31291-8a27-426f-88d5-8c2d65316655/intel-fortran-compiler-2025.0.1.41_offline.sh",
+        sha="aa54f019ad8db79f716f880c72784dc117d64e525e4c3b62717bd9d18a6c9060",
+    ),
+)
 
-oneAPIVersion(version="2025.0.0",
-              platform="linux",
-              cxx=oneAPIInstaller(path="ac92f2bb-4818-4e53-a432-f8b34d502f23/intel-dpcpp-cpp-compiler-2025.0.0.740_offline.sh", 
-                                 sha="04fadf63789acee731895e631db63f65a98b8279db3d0f48bdf0d81e6103bdd8"),
-              fortran=oneAPIInstaller(path="69f79888-2d6c-4b20-999e-e99d72af68d4/intel-fortran-compiler-2025.0.0.723_offline.sh",
-                                     sha="2be6d607ce84f35921228595b118fbc516d28587cbc4e6dcf6b7219e5cd1a9a9"),
-              nvidia=oneAPIInstaller(path="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=2025.0.0&filters[]=12.0&filters[]=linux",
-                                     sha="264a43d2e07c08eb31d6483fb1c289a6b148709e48e9a250efc1b1e9a527feb6"),
-              amd=oneAPIInstaller(path="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=2025.0.0&filters[]=6.1.0&filters[]=linux",
-                                  sha="2c5a147e82f0e995b9c0457b53967cc066d5741d675cb64cb9eba8e3c791a064")
-            )
+oneAPIVersion(
+    version="2025.0.0",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="ac92f2bb-4818-4e53-a432-f8b34d502f23/intel-dpcpp-cpp-compiler-2025.0.0.740_offline.sh",
+        sha="04fadf63789acee731895e631db63f65a98b8279db3d0f48bdf0d81e6103bdd8",
+    ),
+    fortran=oneAPIInstaller(
+        path="69f79888-2d6c-4b20-999e-e99d72af68d4/intel-fortran-compiler-2025.0.0.723_offline.sh",
+        sha="2be6d607ce84f35921228595b118fbc516d28587cbc4e6dcf6b7219e5cd1a9a9",
+    ),
+    nvidia=oneAPIInstaller(
+        path="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=2025.0.0&filters[]=12.0&filters[]=linux",
+        sha="264a43d2e07c08eb31d6483fb1c289a6b148709e48e9a250efc1b1e9a527feb6",
+    ),
+    amd=oneAPIInstaller(
+        path="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=2025.0.0&filters[]=6.1.0&filters[]=linux",
+        sha="2c5a147e82f0e995b9c0457b53967cc066d5741d675cb64cb9eba8e3c791a064",
+    ),
+)
 
-oneAPIVersion(version="2024.2.1",
-              platform="linux",
-              cxx=oneAPIInstaller(path="74587994-3c83-48fd-b963-b707521a63f4/l_dpcpp-cpp-compiler_p_2024.2.1.79_offline.sh", 
-                                 sha="af0243f80640afa94c7f9c8151da91d7ab17f448f542fa76d785230dec712048"),
-              fortran=oneAPIInstaller(path="5e7b0f1c-6f25-4cc8-94d7-3a527e596739/l_fortran-compiler_p_2024.2.1.80_offline.sh",
-                                     sha="6f6dab82a88082a7a39f6feb699343c521f58c6481a1bb87edba7e2550995b6d"),
-              nvidia=oneAPIInstaller(path="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=2024.2.1&filters[]=12.0&filters[]=linux",
-                                     sha="2c377027c650291ccd8267cbf75bd3d00c7b11998cc59d5668a02a0cbc2c015f"),
-              amd=oneAPIInstaller(path="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=2024.2.1&filters[]=6.1.0&filters[]=linux",
-                                  sha="fbeb64f959f907cbf3469f4e154b2af6d8ff46fe4fc667c811e04f3872a13823")
-            )
+oneAPIVersion(
+    version="2024.2.1",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="74587994-3c83-48fd-b963-b707521a63f4/l_dpcpp-cpp-compiler_p_2024.2.1.79_offline.sh",
+        sha="af0243f80640afa94c7f9c8151da91d7ab17f448f542fa76d785230dec712048",
+    ),
+    fortran=oneAPIInstaller(
+        path="5e7b0f1c-6f25-4cc8-94d7-3a527e596739/l_fortran-compiler_p_2024.2.1.80_offline.sh",
+        sha="6f6dab82a88082a7a39f6feb699343c521f58c6481a1bb87edba7e2550995b6d",
+    ),
+    nvidia=oneAPIInstaller(
+        path="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=2024.2.1&filters[]=12.0&filters[]=linux",
+        sha="2c377027c650291ccd8267cbf75bd3d00c7b11998cc59d5668a02a0cbc2c015f",
+    ),
+    amd=oneAPIInstaller(
+        path="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=2024.2.1&filters[]=6.1.0&filters[]=linux",
+        sha="fbeb64f959f907cbf3469f4e154b2af6d8ff46fe4fc667c811e04f3872a13823",
+    ),
+)
 
-oneAPIVersion(version="2024.2.0",
-              platform="linux",
-              cxx=oneAPIInstaller(path="6780ac84-6256-4b59-a647-330eb65f32b6/l_dpcpp-cpp-compiler_p_2024.2.0.495_offline.sh", 
-                                 sha="9463aa979314d2acc51472d414ffcee032e9869ca85ac6ff4c71d39500e5173d"),
-              fortran=oneAPIInstaller(path="801143de-6c01-4181-9911-57e00fe40181/l_fortran-compiler_p_2024.2.0.426_offline.sh",
-                                     sha="fd19a302662b2f86f76fc115ef53a69f16488080278dba4c573cc705f3a52ffa"),
-              nvidia=oneAPIInstaller(path="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=2024.2.0&filters[]=12.0&filters[]=linux",
-                                     sha="0622df0054364b01e91e7ed72a33cb3281e281db5b0e86579f516b1cc5336b0f"),
-              amd=oneAPIInstaller(path="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=2024.2.0&filters[]=6.1.0&filters[]=linux",
-                                  sha="d1e9d30fa92f3ef606f054d8cbd7c338b3e46f6a9f8472736e29e8ccd9e50688")
-            )
+oneAPIVersion(
+    version="2024.2.0",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="6780ac84-6256-4b59-a647-330eb65f32b6/l_dpcpp-cpp-compiler_p_2024.2.0.495_offline.sh",
+        sha="9463aa979314d2acc51472d414ffcee032e9869ca85ac6ff4c71d39500e5173d",
+    ),
+    fortran=oneAPIInstaller(
+        path="801143de-6c01-4181-9911-57e00fe40181/l_fortran-compiler_p_2024.2.0.426_offline.sh",
+        sha="fd19a302662b2f86f76fc115ef53a69f16488080278dba4c573cc705f3a52ffa",
+    ),
+    nvidia=oneAPIInstaller(
+        path="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=2024.2.0&filters[]=12.0&filters[]=linux",
+        sha="0622df0054364b01e91e7ed72a33cb3281e281db5b0e86579f516b1cc5336b0f",
+    ),
+    amd=oneAPIInstaller(
+        path="https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=2024.2.0&filters[]=6.1.0&filters[]=linux",
+        sha="d1e9d30fa92f3ef606f054d8cbd7c338b3e46f6a9f8472736e29e8ccd9e50688",
+    ),
+)
 
-oneAPIVersion(version="2024.1.0",
-              platform="linux",
-              cxx=oneAPIInstaller(path="2e562b6e-5d0f-4001-8121-350a828332fb/l_dpcpp-cpp-compiler_p_2024.1.0.468_offline.sh", 
-                                 sha="534ecc6e4b690c9011d7765cbe178f520aa8f49c0eb4ea80ea1415e48e5d7cf7"),
-              fortran=oneAPIInstaller(path="fd9342bd-7d50-442c-a3e4-f41974e14396/l_fortran-compiler_p_2024.1.0.465_offline.sh",
-                                     sha="30a02bad9a96a543c60f3bfa4238dfe07c2d26d76fc22ba9aa9b7c603e11f1b9"),
-                          )
+oneAPIVersion(
+    version="2024.1.0",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="2e562b6e-5d0f-4001-8121-350a828332fb/l_dpcpp-cpp-compiler_p_2024.1.0.468_offline.sh",
+        sha="534ecc6e4b690c9011d7765cbe178f520aa8f49c0eb4ea80ea1415e48e5d7cf7",
+    ),
+    fortran=oneAPIInstaller(
+        path="fd9342bd-7d50-442c-a3e4-f41974e14396/l_fortran-compiler_p_2024.1.0.465_offline.sh",
+        sha="30a02bad9a96a543c60f3bfa4238dfe07c2d26d76fc22ba9aa9b7c603e11f1b9",
+    ),
+)
 
-oneAPIVersion(version="2024.0.2",
-              platform="linux",
-              cxx=oneAPIInstaller(path="bb99984f-370f-413d-bbec-38928d2458f2/l_dpcpp-cpp-compiler_p_2024.0.2.29_offline.sh", 
-                                 sha="0ec22d69f4207fea4b7488d1c9e62adbc14fb6daa1574d6edcadc912da007b3c"),
-              fortran=oneAPIInstaller(path="41df6814-ec4b-4698-a14d-421ee2b02aa7/l_fortran-compiler_p_2024.0.2.28_offline.sh",
-                                     sha="396ac4fbcb3799d5c1a866a60cf81f85f7cab8c6f35289f61c5cda63c7101b5e"),
-                          )
+oneAPIVersion(
+    version="2024.0.2",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="bb99984f-370f-413d-bbec-38928d2458f2/l_dpcpp-cpp-compiler_p_2024.0.2.29_offline.sh",
+        sha="0ec22d69f4207fea4b7488d1c9e62adbc14fb6daa1574d6edcadc912da007b3c",
+    ),
+    fortran=oneAPIInstaller(
+        path="41df6814-ec4b-4698-a14d-421ee2b02aa7/l_fortran-compiler_p_2024.0.2.28_offline.sh",
+        sha="396ac4fbcb3799d5c1a866a60cf81f85f7cab8c6f35289f61c5cda63c7101b5e",
+    ),
+)
 
-oneAPIVersion(version="2024.0.1",
-              platform="linux",
-              cxx=oneAPIInstaller(path="c68c8f0a-47f5-4f26-8e8e-fa2627271279/l_dpcpp-cpp-compiler_p_2024.0.1.29_offline.sh", 
-                                 sha="22497c46bfb916c82677489775c113141510423799b7eca35f35dffeb2a14104"),
-              fortran=oneAPIInstaller(path="4eedf77e-e097-40de-b62d-5fb70efecb59/l_fortran-compiler_p_2024.0.1.31_offline.sh",
-                                     sha="9d49ecc1862c60eb0627bfdd80d63a47118095af0ff5adeeda10ec36aaffc82c"),
-                          )
+oneAPIVersion(
+    version="2024.0.1",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="c68c8f0a-47f5-4f26-8e8e-fa2627271279/l_dpcpp-cpp-compiler_p_2024.0.1.29_offline.sh",
+        sha="22497c46bfb916c82677489775c113141510423799b7eca35f35dffeb2a14104",
+    ),
+    fortran=oneAPIInstaller(
+        path="4eedf77e-e097-40de-b62d-5fb70efecb59/l_fortran-compiler_p_2024.0.1.31_offline.sh",
+        sha="9d49ecc1862c60eb0627bfdd80d63a47118095af0ff5adeeda10ec36aaffc82c",
+    ),
+)
 
-oneAPIVersion(version="2024.0.0",
-              platform="linux",
-              cxx=oneAPIInstaller(path="5c8e686a-16a7-4866-b585-9cf09e97ef36/l_dpcpp-cpp-compiler_p_2024.0.0.49524_offline.sh", 
-                                 sha="d10bad2009c98c631fbb834aae62012548daeefc806265ea567316cd9180a684"),
-              fortran=oneAPIInstaller(path="89b0fcf9-5c00-448a-93a1-5ee4078e008e/l_fortran-compiler_p_2024.0.0.49493_offline.sh",
-                                     sha="57faf854b8388547ee4ef2db387a9f6f3b4d0cebd67b765cf5e844a0a970d1f9"),
-                          )
+oneAPIVersion(
+    version="2024.0.0",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="5c8e686a-16a7-4866-b585-9cf09e97ef36/l_dpcpp-cpp-compiler_p_2024.0.0.49524_offline.sh",
+        sha="d10bad2009c98c631fbb834aae62012548daeefc806265ea567316cd9180a684",
+    ),
+    fortran=oneAPIInstaller(
+        path="89b0fcf9-5c00-448a-93a1-5ee4078e008e/l_fortran-compiler_p_2024.0.0.49493_offline.sh",
+        sha="57faf854b8388547ee4ef2db387a9f6f3b4d0cebd67b765cf5e844a0a970d1f9",
+    ),
+)
 
-oneAPIVersion(version="2023.2.4",
-              platform="linux",
-              cxx=oneAPIInstaller(path="b00a4b0e-bd21-41fa-ab34-19e8e2a77c5a/l_dpcpp-cpp-compiler_p_2023.2.4.24_offline.sh", 
-                                 sha="f143a764adba04a41e49ec405856ad781e5c3754812e90a7ffe06d08cd07f684"),
-              fortran=oneAPIInstaller(path="5bfaa204-689d-4bf1-9656-e37e35ea3fc2/l_fortran-compiler_p_2023.2.4.31_offline.sh",
-                                     sha="2f327d67cd207399b327df5b7c912baae800811d0180485ef5431f106686c94b"),
-                          )
+oneAPIVersion(
+    version="2023.2.4",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="b00a4b0e-bd21-41fa-ab34-19e8e2a77c5a/l_dpcpp-cpp-compiler_p_2023.2.4.24_offline.sh",
+        sha="f143a764adba04a41e49ec405856ad781e5c3754812e90a7ffe06d08cd07f684",
+    ),
+    fortran=oneAPIInstaller(
+        path="5bfaa204-689d-4bf1-9656-e37e35ea3fc2/l_fortran-compiler_p_2023.2.4.31_offline.sh",
+        sha="2f327d67cd207399b327df5b7c912baae800811d0180485ef5431f106686c94b",
+    ),
+)
 
-oneAPIVersion(version="2023.2.3",
-              platform="linux",
-              cxx=oneAPIInstaller(path="d85fbeee-44ec-480a-ba2f-13831bac75f7/l_dpcpp-cpp-compiler_p_2023.2.3.12_offline.sh", 
-                                 sha="b80119a3e54306b85198e907589b00b11c072f107ac39c1686a1996f76466b26"),
-              fortran=oneAPIInstaller(path="0ceccee5-353c-4fd2-a0cc-0aecb7492f87/l_fortran-compiler_p_2023.2.3.13_offline.sh",
-                                     sha="ef8d95b7165d42da8576bf89a100bd21be7253d0aec039ff76c9213fa2aa9c62"),
-                          )
+oneAPIVersion(
+    version="2023.2.3",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="d85fbeee-44ec-480a-ba2f-13831bac75f7/l_dpcpp-cpp-compiler_p_2023.2.3.12_offline.sh",
+        sha="b80119a3e54306b85198e907589b00b11c072f107ac39c1686a1996f76466b26",
+    ),
+    fortran=oneAPIInstaller(
+        path="0ceccee5-353c-4fd2-a0cc-0aecb7492f87/l_fortran-compiler_p_2023.2.3.13_offline.sh",
+        sha="ef8d95b7165d42da8576bf89a100bd21be7253d0aec039ff76c9213fa2aa9c62",
+    ),
+)
 
-oneAPIVersion(version="2023.2.1",
-              platform="linux",
-              cxx=oneAPIInstaller(path="ebf5d9aa-17a7-46a4-b5df-ace004227c0e/l_dpcpp-cpp-compiler_p_2023.2.1.8_offline.sh", 
-                                 sha="f5656b2f5bb5d904639e6ef1f90a2d2e760d2906e82ebc0dd387709738ca714b"),
-              fortran=oneAPIInstaller(path="0d65c8d4-f245-4756-80c4-6712b43cf835/l_fortran-compiler_p_2023.2.1.8_offline.sh",
-                                     sha="d4e36abc014c184698fec318a127f15a696b5333b3b0282aba1968b351207185"),
-                          )
+oneAPIVersion(
+    version="2023.2.1",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="ebf5d9aa-17a7-46a4-b5df-ace004227c0e/l_dpcpp-cpp-compiler_p_2023.2.1.8_offline.sh",
+        sha="f5656b2f5bb5d904639e6ef1f90a2d2e760d2906e82ebc0dd387709738ca714b",
+    ),
+    fortran=oneAPIInstaller(
+        path="0d65c8d4-f245-4756-80c4-6712b43cf835/l_fortran-compiler_p_2023.2.1.8_offline.sh",
+        sha="d4e36abc014c184698fec318a127f15a696b5333b3b0282aba1968b351207185",
+    ),
+)
 
-oneAPIVersion(version="2023.2.0",
-              platform="linux",
-              cxx=oneAPIInstaller(path="748687b0-5a22-467c-86c6-c312fa0206b2/l_dpcpp-cpp-compiler_p_2023.2.0.49256_offline.sh", 
-                                 sha="21497b2dd2bc874794c2321561af313082725f61e3101e05a050f98b7351e08f"),
-              fortran=oneAPIInstaller(path="237236c4-434b-4576-96ac-020ceeb22619/l_fortran-compiler_p_2023.2.0.49254_offline.sh",
-                                     sha="37c0ad6f0013512d98e385f8708ca29b23c45fddc9ec76069f1d93663668d511"),
-                          )
+oneAPIVersion(
+    version="2023.2.0",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="748687b0-5a22-467c-86c6-c312fa0206b2/l_dpcpp-cpp-compiler_p_2023.2.0.49256_offline.sh",
+        sha="21497b2dd2bc874794c2321561af313082725f61e3101e05a050f98b7351e08f",
+    ),
+    fortran=oneAPIInstaller(
+        path="237236c4-434b-4576-96ac-020ceeb22619/l_fortran-compiler_p_2023.2.0.49254_offline.sh",
+        sha="37c0ad6f0013512d98e385f8708ca29b23c45fddc9ec76069f1d93663668d511",
+    ),
+)
 
-oneAPIVersion(version="2023.1.0",
-              platform="linux",
-              cxx=oneAPIInstaller(path="89283df8-c667-47b0-b7e1-c4573e37bd3e/l_dpcpp-cpp-compiler_p_2023.1.0.46347_offline.sh", 
-                                 sha="3ac1c1179501a2646cbb052b05426554194573b4f8e2344d7699eed03fbcfa1d"),
-              fortran=oneAPIInstaller(path="150e0430-63df-48a0-8469-ecebff0a1858/l_fortran-compiler_p_2023.1.0.46348_offline.sh",
-                                     sha="7639af4b6c928e9e3ba92297a054f78a55f4f4d0db9db0d144cc6653004e4f24"),
-            )
+oneAPIVersion(
+    version="2023.1.0",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="89283df8-c667-47b0-b7e1-c4573e37bd3e/l_dpcpp-cpp-compiler_p_2023.1.0.46347_offline.sh",
+        sha="3ac1c1179501a2646cbb052b05426554194573b4f8e2344d7699eed03fbcfa1d",
+    ),
+    fortran=oneAPIInstaller(
+        path="150e0430-63df-48a0-8469-ecebff0a1858/l_fortran-compiler_p_2023.1.0.46348_offline.sh",
+        sha="7639af4b6c928e9e3ba92297a054f78a55f4f4d0db9db0d144cc6653004e4f24",
+    ),
+)
 
-oneAPIVersion(version="2023.0.0",
-              platform="linux",
-              cxx=oneAPIInstaller(path="19123/l_dpcpp-cpp-compiler_p_2023.0.0.25393_offline.sh", 
-                                 sha="473eb019282c2735d65c6058f6890e60b79a5698ae18d2c1e4489fed8dd18a02"),
-              fortran=oneAPIInstaller(path="19105/l_fortran-compiler_p_2023.0.0.25394_offline.sh",
-                                     sha="fd7525bf90646c8e43721e138f29c9c6f99e96dfe5648c13633f30ec64ac8b1b"),
-            )
+oneAPIVersion(
+    version="2023.0.0",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="19123/l_dpcpp-cpp-compiler_p_2023.0.0.25393_offline.sh",
+        sha="473eb019282c2735d65c6058f6890e60b79a5698ae18d2c1e4489fed8dd18a02",
+    ),
+    fortran=oneAPIInstaller(
+        path="19105/l_fortran-compiler_p_2023.0.0.25394_offline.sh",
+        sha="fd7525bf90646c8e43721e138f29c9c6f99e96dfe5648c13633f30ec64ac8b1b",
+    ),
+)
 
-oneAPIVersion(version="2022.2.1",
-              platform="linux",
-              cxx=oneAPIInstaller(path="19049/l_dpcpp-cpp-compiler_p_2022.2.1.16991_offline.sh", 
-                                 sha="3f0f02f9812a0cdf01922d2df9348910c6a4cb4f9dfe50fc7477a59bbb1f7173"),
-              fortran=oneAPIInstaller(path="18998/l_fortran-compiler_p_2022.2.1.16992_offline.sh",
-                                     sha="64f1d1efbcdc3ac2182bec18313ca23f800d94f69758db83a1394490d9d4b042"),
-            )
+oneAPIVersion(
+    version="2022.2.1",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="19049/l_dpcpp-cpp-compiler_p_2022.2.1.16991_offline.sh",
+        sha="3f0f02f9812a0cdf01922d2df9348910c6a4cb4f9dfe50fc7477a59bbb1f7173",
+    ),
+    fortran=oneAPIInstaller(
+        path="18998/l_fortran-compiler_p_2022.2.1.16992_offline.sh",
+        sha="64f1d1efbcdc3ac2182bec18313ca23f800d94f69758db83a1394490d9d4b042",
+    ),
+)
 
-oneAPIVersion(version="2022.2.0",
-              platform="linux",
-              cxx=oneAPIInstaller(path="18849/l_dpcpp-cpp-compiler_p_2022.2.0.8772_offline.sh", 
-                                 sha="8ca97f7ea8abf7876df6e10ce2789ea8cbc310c100ad7bf0b5ffccc4f3c7f2c9"),
-              fortran=oneAPIInstaller(path="18909/l_fortran-compiler_p_2022.2.0.8773_offline.sh",
-                                     sha="4054e4bf5146d55638d21612396a19ea623d22cbb8ac63c0a7150773541e0311"),
-                          )
+oneAPIVersion(
+    version="2022.2.0",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="18849/l_dpcpp-cpp-compiler_p_2022.2.0.8772_offline.sh",
+        sha="8ca97f7ea8abf7876df6e10ce2789ea8cbc310c100ad7bf0b5ffccc4f3c7f2c9",
+    ),
+    fortran=oneAPIInstaller(
+        path="18909/l_fortran-compiler_p_2022.2.0.8773_offline.sh",
+        sha="4054e4bf5146d55638d21612396a19ea623d22cbb8ac63c0a7150773541e0311",
+    ),
+)
 
-oneAPIVersion(version="2022.1.0",
-              platform="linux",
-              cxx=oneAPIInstaller(path="18717/l_dpcpp-cpp-compiler_p_2022.1.0.137_offline.sh", 
-                                 sha="1027819581ba820470f351abfc2b2658ff2684ed8da9ed0e722a45774a2541d6"),
-              fortran=oneAPIInstaller(path="18703/l_fortran-compiler_p_2022.1.0.134_offline.sh",
-                                     sha="583082abe54a657eb933ea4ba3e988eef892985316be13f3e23e18a3c9515020"),
-                          )
+oneAPIVersion(
+    version="2022.1.0",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="18717/l_dpcpp-cpp-compiler_p_2022.1.0.137_offline.sh",
+        sha="1027819581ba820470f351abfc2b2658ff2684ed8da9ed0e722a45774a2541d6",
+    ),
+    fortran=oneAPIInstaller(
+        path="18703/l_fortran-compiler_p_2022.1.0.134_offline.sh",
+        sha="583082abe54a657eb933ea4ba3e988eef892985316be13f3e23e18a3c9515020",
+    ),
+)
 
-oneAPIVersion(version="2022.0.2",
-              platform="linux",
-              cxx=oneAPIInstaller(path="18478/l_dpcpp-cpp-compiler_p_2022.0.2.84_offline.sh", 
-                                 sha="ade5bbd203e7226ca096d7bf758dce07857252ec54e83908cac3849e6897b8f3"),
-              fortran=oneAPIInstaller(path="18481/l_fortran-compiler_p_2022.0.2.83_offline.sh",
-                                     sha="78532b4118fc3d7afd44e679fc8e7aed1e84efec0d892908d9368e0c7c6b190c"),
-                          )
+oneAPIVersion(
+    version="2022.0.2",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="18478/l_dpcpp-cpp-compiler_p_2022.0.2.84_offline.sh",
+        sha="ade5bbd203e7226ca096d7bf758dce07857252ec54e83908cac3849e6897b8f3",
+    ),
+    fortran=oneAPIInstaller(
+        path="18481/l_fortran-compiler_p_2022.0.2.83_offline.sh",
+        sha="78532b4118fc3d7afd44e679fc8e7aed1e84efec0d892908d9368e0c7c6b190c",
+    ),
+)
 
-oneAPIVersion(version="2022.0.1",
-              platform="linux",
-              cxx=oneAPIInstaller(path="18435/l_dpcpp-cpp-compiler_p_2022.0.1.71_offline.sh", 
-                                 sha="c7cddc64c3040eece2dcaf48926ba197bb27e5a46588b1d7b3beddcdc379926a"),
-              fortran=oneAPIInstaller(path="18436/l_fortran-compiler_p_2022.0.1.70_offline.sh",
-                                     sha="2cb28a04f93554bfeffd6cad8bd0e7082735f33d73430655dea86df8933f50d1"),
-                          )
+oneAPIVersion(
+    version="2022.0.1",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="18435/l_dpcpp-cpp-compiler_p_2022.0.1.71_offline.sh",
+        sha="c7cddc64c3040eece2dcaf48926ba197bb27e5a46588b1d7b3beddcdc379926a",
+    ),
+    fortran=oneAPIInstaller(
+        path="18436/l_fortran-compiler_p_2022.0.1.70_offline.sh",
+        sha="2cb28a04f93554bfeffd6cad8bd0e7082735f33d73430655dea86df8933f50d1",
+    ),
+)
 
-oneAPIVersion(version="2021.4.0",
-              platform="linux",
-              cxx=oneAPIInstaller(path="18209/l_dpcpp-cpp-compiler_p_2021.4.0.3201_offline.sh", 
-                                 sha="9206bff1c2fdeb1ca0d5f79def90dcf3e6c7d5711b9b5adecd96a2ba06503828"),
-              fortran=oneAPIInstaller(path="18210/l_fortran-compiler_p_2021.4.0.3224_offline.sh",
-                                     sha="de2fcf40e296c2e882e1ddf2c45bb8d25aecfbeff2f75fcd7494068d621eb7e0"),
-                          )
+oneAPIVersion(
+    version="2021.4.0",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="18209/l_dpcpp-cpp-compiler_p_2021.4.0.3201_offline.sh",
+        sha="9206bff1c2fdeb1ca0d5f79def90dcf3e6c7d5711b9b5adecd96a2ba06503828",
+    ),
+    fortran=oneAPIInstaller(
+        path="18210/l_fortran-compiler_p_2021.4.0.3224_offline.sh",
+        sha="de2fcf40e296c2e882e1ddf2c45bb8d25aecfbeff2f75fcd7494068d621eb7e0",
+    ),
+)
 
-oneAPIVersion(version="2021.3.0",
-              platform="linux",
-              cxx=oneAPIInstaller(path="17928/l_dpcpp-cpp-compiler_p_2021.3.0.3168_offline.sh", 
-                                 sha="f848d81b7cabc76c2841c9757abb2290921efd7b82491d830605f5785600e7a1"),
-              fortran=oneAPIInstaller(path="17959/l_fortran-compiler_p_2021.3.0.3168_offline.sh",
-                                     sha="c4553f7e707be8e8e196f625e4e7fbc8eff5474f64ab85fc7146b5ed53ebc87c"),
-                          )
+oneAPIVersion(
+    version="2021.3.0",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="17928/l_dpcpp-cpp-compiler_p_2021.3.0.3168_offline.sh",
+        sha="f848d81b7cabc76c2841c9757abb2290921efd7b82491d830605f5785600e7a1",
+    ),
+    fortran=oneAPIInstaller(
+        path="17959/l_fortran-compiler_p_2021.3.0.3168_offline.sh",
+        sha="c4553f7e707be8e8e196f625e4e7fbc8eff5474f64ab85fc7146b5ed53ebc87c",
+    ),
+)
 
-oneAPIVersion(version="2021.2.0",
-              platform="linux",
-              cxx=oneAPIInstaller(path="17749/l_dpcpp-cpp-compiler_p_2021.2.0.118_offline.sh", 
-                                 sha="5d01cbff1a574c3775510cd97ffddd27fdf56d06a6b0c89a826fb23da4336d59"),
-              fortran=oneAPIInstaller(path="17756/l_fortran-compiler_p_2021.2.0.136_offline.sh",
-                                     sha="a62e04a80f6d2f05e67cd5acb03fa58857ee22c6bd581ec0651c0ccd5bdec5a1"),
-                          )
+oneAPIVersion(
+    version="2021.2.0",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="17749/l_dpcpp-cpp-compiler_p_2021.2.0.118_offline.sh",
+        sha="5d01cbff1a574c3775510cd97ffddd27fdf56d06a6b0c89a826fb23da4336d59",
+    ),
+    fortran=oneAPIInstaller(
+        path="17756/l_fortran-compiler_p_2021.2.0.136_offline.sh",
+        sha="a62e04a80f6d2f05e67cd5acb03fa58857ee22c6bd581ec0651c0ccd5bdec5a1",
+    ),
+)
 
-oneAPIVersion(version="2021.1.2",
-              platform="linux",
-              cxx=oneAPIInstaller(path="17513/l_dpcpp-cpp-compiler_p_2021.1.2.63_offline.sh", 
-                                 sha="68d6cb638091990e578e358131c859f3bbbbfbf975c581fd0b4b4d36476d6f0a"),
-              fortran=oneAPIInstaller(path="17508/l_fortran-compiler_p_2021.1.2.62_offline.sh",
-                                     sha="29345145268d08a59fa7eb6e58c7522768466dd98f6d9754540d1a0803596829"),
-                          )
+oneAPIVersion(
+    version="2021.1.2",
+    platform="linux",
+    cxx=oneAPIInstaller(
+        path="17513/l_dpcpp-cpp-compiler_p_2021.1.2.63_offline.sh",
+        sha="68d6cb638091990e578e358131c859f3bbbbfbf975c581fd0b4b4d36476d6f0a",
+    ),
+    fortran=oneAPIInstaller(
+        path="17508/l_fortran-compiler_p_2021.1.2.62_offline.sh",
+        sha="29345145268d08a59fa7eb6e58c7522768466dd98f6d9754540d1a0803596829",
+    ),
+)

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers/oneapi_versions.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers/oneapi_versions.py
@@ -9,12 +9,15 @@ from spack.package import *
 
 
 class oneAPIVersions:
+    """Holds a list of defined oneAPI compiler versions
+    and provides an API to define the Spack directives required
+    to model them w/ their resources."""
     versions: List["oneAPIVersion"] = []
 
     @staticmethod
     def generate_versions():
         for v in filter(
-            lambda x: x.platform == platform.system().lower(), oneAPIVersions.versions
+            lambda x: platform.system().lower() in x.platform, oneAPIVersions.versions
         ):
             version(v.version, expand=False, url=v.cxx.url, sha256=v.cxx.sha)
             if v.fortran:
@@ -47,6 +50,13 @@ class oneAPIVersions:
 
 
 class oneAPIInstaller:
+    """Represents a specific oneAPI installer component
+    modeled by a path (typically a URL) and a checksum
+    to validate installer component download.
+    
+    Provides a default resource location for the installer components
+    if the installer does not define its own absolute location
+    """
     def __init__(self, *, path: str, sha: str):
         self._url_base = "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/"
         self._path = path
@@ -60,6 +70,15 @@ class oneAPIInstaller:
 
 
 class oneAPIVersion:
+    """Defines a oneAPI installer for a oneAPI version
+    including any language or component specific installers
+    compatible and associated with a given oneAPI version
+    
+    Takes
+        * Version
+        * Platform
+        * Compatible installer components
+    """
     def __init__(
         self,
         *,
@@ -71,10 +90,7 @@ class oneAPIVersion:
         amd: Optional[oneAPIInstaller] = None,
     ):
         self.version = version
-        assert platform.lower() in (
-            "windows",
-            "linux",
-        ), "OneAPI is only compatible with Windows or Linux"
+        assert platform != "darwin", "OneAPI unsupported on Darwin"
         self.platform = platform
         self.cxx = cxx
         self.fortran = fortran
@@ -98,7 +114,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2025.1.1",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="c4d2aef3-3123-475e-800c-7d66fd8da2a5/intel-dpcpp-cpp-compiler-2025.1.1.9_offline.sh",
         sha="63ea61f54a5ea9d30059ea499697e04953915ef317c0e8fc457077b690c726df",
@@ -112,7 +128,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2025.1.0",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="cd63be99-88b0-4981-bea1-2034fe17f5cf/intel-dpcpp-cpp-compiler-2025.1.0.573_offline.sh",
         sha="53489afcc9534e30ad807e94b158abfccf6a7eb3658f59655122d92fbad8fa72",
@@ -125,7 +141,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2025.0.4",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="84c039b6-2b7d-4544-a745-3fcf8afd643f/intel-dpcpp-cpp-compiler-2025.0.4.20_offline.sh",
         sha="0537c6e462fe74063cb0b9209a0fd5c0ca3a29b4520d43d382ae27fb3f98b375",
@@ -138,7 +154,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2025.0.3",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="1cac4f39-2032-4aa9-86d7-e4f3e40e4277/intel-dpcpp-cpp-compiler-2025.0.3.9_offline.sh",
         sha="0ca834002b9091dc9988da6798a2eb36ebc5933d8d523ed0fa78a55744c88823",
@@ -151,7 +167,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2025.0.1",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="4fd7c6b0-853f-458a-a8ec-421ab50a80a6/intel-dpcpp-cpp-compiler-2025.0.1.46_offline.sh",
         sha="1595397566b59a5c8f81e2c235b6bedd2405dc70309b5bf00ed75827d0f12449",
@@ -164,7 +180,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2025.0.0",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="ac92f2bb-4818-4e53-a432-f8b34d502f23/intel-dpcpp-cpp-compiler-2025.0.0.740_offline.sh",
         sha="04fadf63789acee731895e631db63f65a98b8279db3d0f48bdf0d81e6103bdd8",
@@ -185,7 +201,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2024.2.1",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="74587994-3c83-48fd-b963-b707521a63f4/l_dpcpp-cpp-compiler_p_2024.2.1.79_offline.sh",
         sha="af0243f80640afa94c7f9c8151da91d7ab17f448f542fa76d785230dec712048",
@@ -206,7 +222,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2024.2.0",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="6780ac84-6256-4b59-a647-330eb65f32b6/l_dpcpp-cpp-compiler_p_2024.2.0.495_offline.sh",
         sha="9463aa979314d2acc51472d414ffcee032e9869ca85ac6ff4c71d39500e5173d",
@@ -227,7 +243,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2024.1.0",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="2e562b6e-5d0f-4001-8121-350a828332fb/l_dpcpp-cpp-compiler_p_2024.1.0.468_offline.sh",
         sha="534ecc6e4b690c9011d7765cbe178f520aa8f49c0eb4ea80ea1415e48e5d7cf7",
@@ -240,7 +256,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2024.0.2",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="bb99984f-370f-413d-bbec-38928d2458f2/l_dpcpp-cpp-compiler_p_2024.0.2.29_offline.sh",
         sha="0ec22d69f4207fea4b7488d1c9e62adbc14fb6daa1574d6edcadc912da007b3c",
@@ -253,7 +269,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2024.0.1",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="c68c8f0a-47f5-4f26-8e8e-fa2627271279/l_dpcpp-cpp-compiler_p_2024.0.1.29_offline.sh",
         sha="22497c46bfb916c82677489775c113141510423799b7eca35f35dffeb2a14104",
@@ -266,7 +282,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2024.0.0",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="5c8e686a-16a7-4866-b585-9cf09e97ef36/l_dpcpp-cpp-compiler_p_2024.0.0.49524_offline.sh",
         sha="d10bad2009c98c631fbb834aae62012548daeefc806265ea567316cd9180a684",
@@ -279,7 +295,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2023.2.4",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="b00a4b0e-bd21-41fa-ab34-19e8e2a77c5a/l_dpcpp-cpp-compiler_p_2023.2.4.24_offline.sh",
         sha="f143a764adba04a41e49ec405856ad781e5c3754812e90a7ffe06d08cd07f684",
@@ -292,7 +308,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2023.2.3",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="d85fbeee-44ec-480a-ba2f-13831bac75f7/l_dpcpp-cpp-compiler_p_2023.2.3.12_offline.sh",
         sha="b80119a3e54306b85198e907589b00b11c072f107ac39c1686a1996f76466b26",
@@ -305,7 +321,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2023.2.1",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="ebf5d9aa-17a7-46a4-b5df-ace004227c0e/l_dpcpp-cpp-compiler_p_2023.2.1.8_offline.sh",
         sha="f5656b2f5bb5d904639e6ef1f90a2d2e760d2906e82ebc0dd387709738ca714b",
@@ -318,7 +334,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2023.2.0",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="748687b0-5a22-467c-86c6-c312fa0206b2/l_dpcpp-cpp-compiler_p_2023.2.0.49256_offline.sh",
         sha="21497b2dd2bc874794c2321561af313082725f61e3101e05a050f98b7351e08f",
@@ -331,7 +347,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2023.1.0",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="89283df8-c667-47b0-b7e1-c4573e37bd3e/l_dpcpp-cpp-compiler_p_2023.1.0.46347_offline.sh",
         sha="3ac1c1179501a2646cbb052b05426554194573b4f8e2344d7699eed03fbcfa1d",
@@ -344,7 +360,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2023.0.0",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="19123/l_dpcpp-cpp-compiler_p_2023.0.0.25393_offline.sh",
         sha="473eb019282c2735d65c6058f6890e60b79a5698ae18d2c1e4489fed8dd18a02",
@@ -357,7 +373,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2022.2.1",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="19049/l_dpcpp-cpp-compiler_p_2022.2.1.16991_offline.sh",
         sha="3f0f02f9812a0cdf01922d2df9348910c6a4cb4f9dfe50fc7477a59bbb1f7173",
@@ -370,7 +386,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2022.2.0",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="18849/l_dpcpp-cpp-compiler_p_2022.2.0.8772_offline.sh",
         sha="8ca97f7ea8abf7876df6e10ce2789ea8cbc310c100ad7bf0b5ffccc4f3c7f2c9",
@@ -383,7 +399,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2022.1.0",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="18717/l_dpcpp-cpp-compiler_p_2022.1.0.137_offline.sh",
         sha="1027819581ba820470f351abfc2b2658ff2684ed8da9ed0e722a45774a2541d6",
@@ -396,7 +412,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2022.0.2",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="18478/l_dpcpp-cpp-compiler_p_2022.0.2.84_offline.sh",
         sha="ade5bbd203e7226ca096d7bf758dce07857252ec54e83908cac3849e6897b8f3",
@@ -409,7 +425,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2022.0.1",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="18435/l_dpcpp-cpp-compiler_p_2022.0.1.71_offline.sh",
         sha="c7cddc64c3040eece2dcaf48926ba197bb27e5a46588b1d7b3beddcdc379926a",
@@ -422,7 +438,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2021.4.0",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="18209/l_dpcpp-cpp-compiler_p_2021.4.0.3201_offline.sh",
         sha="9206bff1c2fdeb1ca0d5f79def90dcf3e6c7d5711b9b5adecd96a2ba06503828",
@@ -435,7 +451,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2021.3.0",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="17928/l_dpcpp-cpp-compiler_p_2021.3.0.3168_offline.sh",
         sha="f848d81b7cabc76c2841c9757abb2290921efd7b82491d830605f5785600e7a1",
@@ -448,7 +464,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2021.2.0",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="17749/l_dpcpp-cpp-compiler_p_2021.2.0.118_offline.sh",
         sha="5d01cbff1a574c3775510cd97ffddd27fdf56d06a6b0c89a826fb23da4336d59",
@@ -461,7 +477,7 @@ oneAPIVersion(
 
 oneAPIVersion(
     version="2021.1.2",
-    platform="linux",
+    platform="linux,freebsd,darwin",
     cxx=oneAPIInstaller(
         path="17513/l_dpcpp-cpp-compiler_p_2021.1.2.63_offline.sh",
         sha="68d6cb638091990e578e358131c859f3bbbbfbf975c581fd0b4b4d36476d6f0a",

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
@@ -12,12 +12,22 @@ import warnings
 from spack_repo.builtin.build_systems.compiler import CompilerPackage
 from spack_repo.builtin.build_systems.oneapi import IntelOneApiPackage
 
-from .packages.intel_oneapi_compilers.oneapi_versions import oneAPIVersions
+from spack_repo.builtin.packages.intel_oneapi_compilers.oneapi_versions import oneAPIVersions
 
 from spack.build_environment import dso_suffix
 from spack.package import *
 
 IS_WINDOWS = sys.platform == "win32"
+
+
+class UnixDebugFlags:
+    DEBUG = "-debug"
+    G = "-g"
+    G0 = "-g0"
+    G1 = "-g1"
+    G2 = "-g2"
+    G3 = "-g3"
+
 
 class WindowsDebugFlags:
     DEBUG = "/debug"
@@ -55,6 +65,7 @@ class DebugFlagsMeta(type):
         else:
             getattr(UnixDebugFlags, attr.upper())
 
+
 class OptFlagsMeta(type):
     def __getattribute__(cls, attr):
         if IS_WINDOWS:
@@ -62,14 +73,31 @@ class OptFlagsMeta(type):
         else:
             getattr(UnixOptFlags, attr)
 
+
 class DebugFlags(metaclass=DebugFlagsMeta):
     """Class abstracting platform specific debug flags"""
+    DEBUG: str
+    G: str
+    G0: str
+    G1: str
+    G2: str
+    G3: str
+
 
 class OptFlags(metaclass=OptFlagsMeta):
     """Class abstracting platform specific optimization flags"""
+    O: str
+    O0: str
+    O1: str
+    O2: str
+    O3: str
+    OFast: str
+    OS: str
+
 
 class CompilerWrapperLinks:
     pass
+
 
 @IntelOneApiPackage.update_description
 class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
@@ -20,7 +20,17 @@ from spack.package import *
 IS_WINDOWS = sys.platform == "win32"
 
 
-class UnixDebugFlags:
+class Flags:
+    @classmethod
+    def flags(cls):
+        flags = []
+        for attr in cls.__dict__:
+            if not attr.startswith("__"):
+                flags.append(getattr(cls, attr))
+        return flags
+
+
+class UnixDebugFlags(Flags):
     DEBUG = "-debug"
     G = "-g"
     G0 = "-g0"
@@ -29,7 +39,7 @@ class UnixDebugFlags:
     G3 = "-g3"
 
 
-class WindowsDebugFlags:
+class WindowsDebugFlags(Flags):
     DEBUG = "/debug"
     G = "/g"
     G0 = "/g0"
@@ -38,7 +48,7 @@ class WindowsDebugFlags:
     G3 = "/g3"
 
 
-class UnixOptFlags:
+class UnixOptFlags(Flags):
     O = "-O"
     O0 = "-O0"
     O1 = "-O1"
@@ -48,7 +58,7 @@ class UnixOptFlags:
     OS = "-Os"
 
 
-class WindowsOptFlags:
+class WindowsOptFlags(Flags):
     O = "/O"
     O0 = "/O0"
     O1 = "/O1"
@@ -86,31 +96,24 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
         else (r"Intel\(R\) .* Version (\S+) Build (\S+)")
     )
 
-    debug_flags = [
-        DebugFlags.DEBUG,
-        DebugFlags.G,
-        DebugFlags.G0,
-        DebugFlags.G1,
-        DebugFlags.G2,
-        DebugFlags.G3,
-    ]
-    opt_flags = [
-        OptFlags.O,
-        OptFlags.O0,
-        OptFlags.O1,
-        OptFlags.O2,
-        OptFlags.O3,
-        OptFlags.OFAST,
-        OptFlags.OS,
-    ]
+    debug_flags = DebugFlags.flags()
+    opt_flags = OptFlags.flags()
 
     openmp_flag = "-fiopenmp"
 
-    compiler_wrapper_link_paths = {
+
+    unix_compiler_wrapper_link_paths = {
         "c": os.path.join("oneapi", "icx"),
         "cxx": os.path.join("oneapi", "icpx"),
         "fortran": os.path.join("oneapi", "ifx"),
     }
+    win_compiler_wrapper_link_paths = {
+        "c": "",
+        "cxx": "",
+        "fortran" : ""
+    }
+
+    compiler_wrapper_link_paths = unix_compiler_wrapper_link_paths if sys.platform != "win32" else win_compiler_wrapper_link_paths
 
     implicit_rpath_libs = [
         "libirc",

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
@@ -9,9 +9,9 @@ import re
 import sys
 import warnings
 
+import spack_repo.builtin.build_systems.compiler
 from spack_repo.builtin.build_systems.compiler import CompilerPackage
 from spack_repo.builtin.build_systems.oneapi import IntelOneApiPackage
-
 from spack_repo.builtin.packages.intel_oneapi_compilers.oneapi_versions import oneAPIVersions
 
 from spack.build_environment import dso_suffix
@@ -81,11 +81,28 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
     fortran_names = ["ifx"]
     compiler_version_argument = "--version" if not IS_WINDOWS else ""
     compiler_version_regex = (
-        r"(?:(?:oneAPI DPC\+\+(?:\/C\+\+)? Compiler)|(?:\(IFORT\))|(?:\(IFX\))) (\S+)"
+        (r"(?:(?:oneAPI DPC\+\+(?:\/C\+\+)? Compiler)|(?:\(IFORT\))|(?:\(IFX\))) (\S+)")
+        if not sys.platform == "win32"
+        else (r"Intel\(R\) .* Version (\S+) Build (\S+)")
     )
 
-    debug_flags = [DebugFlags.DEBUG, DebugFlags.G, DebugFlags.G0, DebugFlags.G1, DebugFlags.G2, DebugFlags.G3]
-    opt_flags = [OptFlags.O, OptFlags.O0, OptFlags.O1, OptFlags.O2, OptFlags.O3, OptFlags.OFAST, OptFlags.OS]
+    debug_flags = [
+        DebugFlags.DEBUG,
+        DebugFlags.G,
+        DebugFlags.G0,
+        DebugFlags.G1,
+        DebugFlags.G2,
+        DebugFlags.G3,
+    ]
+    opt_flags = [
+        OptFlags.O,
+        OptFlags.O0,
+        OptFlags.O1,
+        OptFlags.O2,
+        OptFlags.O3,
+        OptFlags.OFAST,
+        OptFlags.OS,
+    ]
 
     openmp_flag = "-fiopenmp"
 
@@ -126,16 +143,18 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
         }
         return flags[language][standard]
 
-    with when(f"platform=linux"):
+    with when("platform=linux"):
         # See https://github.com/spack/spack/issues/39252
         depends_on("patchelf@:0.17", type="build", when="@:2024.1")
 
         # Disable the variant below for now on Windows for simplicitys sake
-        # enable once basic oneAPI functionality is stable 
+        # enable once basic oneAPI functionality is stable
 
         # Add the nvidia variant
         variant("nvidia", default=False, description="Install NVIDIA plugin for OneAPI")
-        conflicts("@:2022.2.1", when="+nvidia", msg="Codeplay NVIDIA plugin requires newer release")
+        conflicts(
+            "@:2022.2.1", when="+nvidia", msg="Codeplay NVIDIA plugin requires newer release"
+        )
         # Add the amd variant
         variant("amd", default=False, description="Install AMD plugin for OneAPI")
         conflicts("@:2022.2.1", when="+amd", msg="Codeplay AMD plugin requires newer release")
@@ -226,7 +245,11 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
         # Copy instead of install to speed up debugging
         # install_tree("/opt/intel/oneapi/compiler", self.prefix)
         # return
-
+        if IS_WINDOWS:
+            raise RuntimeError(
+                "Intel oneAPI cannot currently be installed on Windows.\n"
+                "Please install independently and `spack external find` to use."
+            )
         # install cpp
         super().install(spec, prefix)
 
@@ -259,6 +282,8 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
                     Executable(amd_script[0])("-a", "-y", "--install-dir", self.prefix)
 
     @run_after("install", when="platform=linux")
+    @run_after("install", when="platform=darwin")
+    @run_after("install", when="platform=freebsd")
     def inject_rpaths(self):
         # The oneapi compilers cannot find their own internal shared
         # libraries. If you are using an externally installed oneapi,
@@ -302,6 +327,8 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
                 set_install_permissions(p)
 
     @run_after("install", when="platform=linux")
+    @run_after("install", when="platform=darwin")
+    @run_after("install", when="platform=freebsd")
     def extend_config_flags(self):
         # Extends compiler config files to inject additional compiler flags.
 
@@ -370,7 +397,7 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
             # Errors out and prints version info with no args
             match = re.search(
                 cls.compiler_version_regex,
-                spack.build_systems.compiler.compiler_output(
+                spack_repo.builtin.build_systems.compiler.compiler_output(
                     exe, version_argument=None, ignore_errors=(1,)
                 ),
             )
@@ -402,28 +429,30 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
 
     @classmethod
     def runtime_constraints(cls, *, spec, pkg):
-        for language in ("c", "cxx", "fortran"):
-            pkg("*").depends_on(
-                f"intel-oneapi-runtime@{spec.version}:",
-                when=f"%[deptypes=build virtuals={language}] {spec.name}@{spec.versions}",
-                type="link",
-                description="Inject intel-oneapi-runtime when oneapi is used as "
-                f"a {language} compiler",
-            )
+        if not IS_WINDOWS:
+            for language in ("c", "cxx", "fortran"):
+                pkg("*").depends_on(
+                    f"intel-oneapi-runtime@{spec.version}:",
+                    when=f"%[deptypes=build virtuals={language}] {spec.name}@{spec.versions}",
+                    type="link",
+                    description="Inject intel-oneapi-runtime when oneapi is used as "
+                    f"a {language} compiler",
+                )
 
-        for fortran_virtual in ("fortran-rt", "libifcore@5"):
-            pkg("*").depends_on(
-                fortran_virtual,
-                when=f"%[deptypes=build virtuals=fortran] {spec.name}@{spec.versions}",
-                type="link",
-                description="Add a dependency on 'libifcore' for nodes compiled with "
-                f"{spec.name}@{spec.versions} and using the 'fortran' language",
+            for fortran_virtual in ("fortran-rt", "libifcore@5"):
+                pkg("*").depends_on(
+                    fortran_virtual,
+                    when=f"%[deptypes=build virtuals=fortran] {spec.name}@{spec.versions}",
+                    type="link",
+                    description="Add a dependency on 'libifcore' for nodes compiled with "
+                    f"{spec.name}@{spec.versions} and using the 'fortran' language",
+                )
+            # The version of intel-oneapi-runtime is the same as the %oneapi used to "compile" it
+            pkg("intel-oneapi-runtime").requires(
+                f"@{spec.versions}", when=f"%[deptypes=build] {spec.name}@{spec.versions}"
             )
-        # The version of intel-oneapi-runtime is the same as the %oneapi used to "compile" it
-        pkg("intel-oneapi-runtime").requires(
-            f"@{spec.versions}", when=f"%[deptypes=build] {spec.name}@{spec.versions}"
-        )
-
+        else:
+            pkg("intel-oneapi-compiler").depends_on(f"msvc", when=f"%{spec.name}@{spec.versions}", type="build,link")
         # If a node used %intel-oneapi-runtime@X.Y its dependencies must use @:X.Y
         # (technically @:X is broader than ... <= @=X but this should work in practice)
         pkg("*").propagate(

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
@@ -5,6 +5,7 @@ import os
 import os.path
 import pathlib
 import platform
+import re
 import sys
 import warnings
 
@@ -13,6 +14,8 @@ from spack_repo.builtin.build_systems.oneapi import IntelOneApiPackage
 
 from spack.build_environment import dso_suffix
 from spack.package import *
+
+windows = sys.platform == "win32"
 
 versions = [
     {
@@ -338,6 +341,42 @@ versions = [
     },
 ]
 
+class UnixDebugFlags:
+    DEBUG = "-debug"
+    G = "-g"
+    G0 = "-g0"
+    G1 = "-g1"
+    G2 = "-g2"
+    G3 = "-g3"
+class WindowsDebugFlags:
+    DEBUG = "/debug"
+    G = "/g"
+    G0 = "/g0"
+    G1 = "/g1"
+    G2 = "/g2"
+    G3 = "/g3"
+
+class DebugFlagsMeta(type):
+    def __getattr__(cls, attr):
+        if windows:
+            getattr(WindowsDebugFlags, attr)
+        else:
+            getattr(UnixDebugFlags, attr)
+
+class OptFlagsMeta(type):
+    def __getattr__(cls, attr):
+        if windows:
+            getattr(WindowsDebugFlags, attr)
+        else:
+            getattr(UnixDebugFlags, attr)
+
+class DebugFlags(metaclass=DebugFlagsMeta):
+    """Class abstracting platform specific debug flags"""
+
+class OptFlags(metaclass=OptFlagsMeta):
+    """Class abstracting platform specific optimization flags"""
+
+
 
 @IntelOneApiPackage.update_description
 class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
@@ -352,7 +391,7 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
     c_names = ["icx"]
     cxx_names = ["icpx"]
     fortran_names = ["ifx"]
-    compiler_version_argument = "--version"
+    compiler_version_argument = "--version" if not windows else ""
     compiler_version_regex = (
         r"(?:(?:oneAPI DPC\+\+(?:\/C\+\+)? Compiler)|(?:\(IFORT\))|(?:\(IFX\))) (\S+)"
     )
@@ -397,16 +436,25 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
         }
         return flags[language][standard]
 
-    # See https://github.com/spack/spack/issues/39252
-    depends_on("patchelf@:0.17", type="build", when="@:2024.1")
-    # Add the nvidia variant
-    variant("nvidia", default=False, description="Install NVIDIA plugin for OneAPI")
-    conflicts("@:2022.2.1", when="+nvidia", msg="Codeplay NVIDIA plugin requires newer release")
-    # Add the amd variant
-    variant("amd", default=False, description="Install AMD plugin for OneAPI")
-    conflicts("@:2022.2.1", when="+amd", msg="Codeplay AMD plugin requires newer release")
+    for plat in ["linux", "darwin", "freebsd"]:
+        with when(f"platform={plat}"):
+            # See https://github.com/spack/spack/issues/39252
+            depends_on("patchelf@:0.17", type="build", when="@:2024.1")
 
-    depends_on("gcc languages=c,c++", type="run")
+            # Disable the variant below for now on Windows for simplicitys sake
+            # enable once basic oneAPI functionality is stable 
+
+            # Add the nvidia variant
+            variant("nvidia", default=False, description="Install NVIDIA plugin for OneAPI")
+            conflicts("@:2022.2.1", when="+nvidia", msg="Codeplay NVIDIA plugin requires newer release")
+            # Add the amd variant
+            variant("amd", default=False, description="Install AMD plugin for OneAPI")
+            conflicts("@:2022.2.1", when="+amd", msg="Codeplay AMD plugin requires newer release")
+
+            depends_on("gcc languages=c,c++", type="run")
+
+    with when("platform=windows"):
+        depends_on("msvc languages=c,c++", type="run")
 
     for v in versions:
         version(v["version"], expand=False, **v["cpp"])
@@ -646,6 +694,19 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
 
     def archspec_name(self):
         return "oneapi"
+
+    @classmethod
+    def determine_version(cls, exe):
+        # Intel compilers on Windows do not have a proper version argument
+        # Errors out and prints version info with no args
+        match = re.search(
+            cls.compiler_version_regex,
+            spack.build_systems.compiler.compiler_output(
+                exe, version_argument=None, ignore_errors=1
+            ),
+        )
+        if match:
+            return match.group(1)
 
     @classmethod
     def determine_variants(cls, exes, version_str):

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
@@ -12,342 +12,13 @@ import warnings
 from spack_repo.builtin.build_systems.compiler import CompilerPackage
 from spack_repo.builtin.build_systems.oneapi import IntelOneApiPackage
 
+from .packages.intel_oneapi_compilers.oneapi_versions import oneAPIVersions
+
 from spack.build_environment import dso_suffix
 from spack.package import *
 
-windows = sys.platform == "win32"
+IS_WINDOWS = sys.platform == "win32"
 
-versions = [
-    {
-        "version": "2025.1.1",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/c4d2aef3-3123-475e-800c-7d66fd8da2a5/intel-dpcpp-cpp-compiler-2025.1.1.9_offline.sh",
-            "sha256": "63ea61f54a5ea9d30059ea499697e04953915ef317c0e8fc457077b690c726df",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/0e4735b3-8721-422b-b204-00eefe413bfd/intel-fortran-compiler-2025.1.1.10_offline.sh",
-            "sha256": "c59060a5b959fb0faeb1cde349689086da41d491adb41fd6c97177fcf59bf957",
-        },
-    },
-    {
-        "version": "2025.1.0",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/cd63be99-88b0-4981-bea1-2034fe17f5cf/intel-dpcpp-cpp-compiler-2025.1.0.573_offline.sh",
-            "sha256": "53489afcc9534e30ad807e94b158abfccf6a7eb3658f59655122d92fbad8fa72",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/577ebc28-d0f6-492b-9a43-b04354ce99da/intel-fortran-compiler-2025.1.0.601_offline.sh",
-            "sha256": "27016329dede8369679f22b4e9f67936837ce7972a1ef4f5c76ee87d7c963c81",
-        },
-    },
-    {
-        "version": "2025.0.4",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/84c039b6-2b7d-4544-a745-3fcf8afd643f/intel-dpcpp-cpp-compiler-2025.0.4.20_offline.sh",
-            "sha256": "0537c6e462fe74063cb0b9209a0fd5c0ca3a29b4520d43d382ae27fb3f98b375",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ad42ee3b-7a2f-41cb-b902-689f651920da/intel-fortran-compiler-2025.0.4.21_offline.sh",
-            "sha256": "ad453f1dd68111e7cf7053d6f86fa26d982bd9ab61982cbb6dbe5195fb6feedb",
-        },
-    },
-    {
-        "version": "2025.0.3",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/1cac4f39-2032-4aa9-86d7-e4f3e40e4277/intel-dpcpp-cpp-compiler-2025.0.3.9_offline.sh",
-            "sha256": "0ca834002b9091dc9988da6798a2eb36ebc5933d8d523ed0fa78a55744c88823",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/fafa2df1-4bb1-43f7-87c6-3c82f1bdc712/intel-fortran-compiler-2025.0.3.9_offline.sh",
-            "sha256": "1ad813cf6495ded730646d6c4fd065dcc840875fdea28fcc6bac2cafb8d22c8d",
-        },
-    },
-    {
-        "version": "2025.0.1",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/4fd7c6b0-853f-458a-a8ec-421ab50a80a6/intel-dpcpp-cpp-compiler-2025.0.1.46_offline.sh",
-            "sha256": "1595397566b59a5c8f81e2c235b6bedd2405dc70309b5bf00ed75827d0f12449",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/7ba31291-8a27-426f-88d5-8c2d65316655/intel-fortran-compiler-2025.0.1.41_offline.sh",
-            "sha256": "aa54f019ad8db79f716f880c72784dc117d64e525e4c3b62717bd9d18a6c9060",
-        },
-    },
-    {
-        "version": "2025.0.0",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ac92f2bb-4818-4e53-a432-f8b34d502f23/intel-dpcpp-cpp-compiler-2025.0.0.740_offline.sh",
-            "sha256": "04fadf63789acee731895e631db63f65a98b8279db3d0f48bdf0d81e6103bdd8",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/69f79888-2d6c-4b20-999e-e99d72af68d4/intel-fortran-compiler-2025.0.0.723_offline.sh",
-            "sha256": "2be6d607ce84f35921228595b118fbc516d28587cbc4e6dcf6b7219e5cd1a9a9",
-        },
-        "nvidia-plugin": {
-            "url": "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=2025.0.0&filters[]=12.0&filters[]=linux",
-            "sha256": "264a43d2e07c08eb31d6483fb1c289a6b148709e48e9a250efc1b1e9a527feb6",
-        },
-        "amd-plugin": {
-            "url": "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=2025.0.0&filters[]=6.1.0&filters[]=linux",
-            "sha256": "2c5a147e82f0e995b9c0457b53967cc066d5741d675cb64cb9eba8e3c791a064",
-        },
-    },
-    {
-        "version": "2024.2.1",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/74587994-3c83-48fd-b963-b707521a63f4/l_dpcpp-cpp-compiler_p_2024.2.1.79_offline.sh",
-            "sha256": "af0243f80640afa94c7f9c8151da91d7ab17f448f542fa76d785230dec712048",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/5e7b0f1c-6f25-4cc8-94d7-3a527e596739/l_fortran-compiler_p_2024.2.1.80_offline.sh",
-            "sha256": "6f6dab82a88082a7a39f6feb699343c521f58c6481a1bb87edba7e2550995b6d",
-        },
-        "nvidia-plugin": {
-            "url": "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=2024.2.1&filters[]=12.0&filters[]=linux",
-            "sha256": "2c377027c650291ccd8267cbf75bd3d00c7b11998cc59d5668a02a0cbc2c015f",
-        },
-        "amd-plugin": {
-            "url": "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=2024.2.1&filters[]=6.1.0&filters[]=linux",
-            "sha256": "fbeb64f959f907cbf3469f4e154b2af6d8ff46fe4fc667c811e04f3872a13823",
-        },
-    },
-    {
-        "version": "2024.2.0",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/6780ac84-6256-4b59-a647-330eb65f32b6/l_dpcpp-cpp-compiler_p_2024.2.0.495_offline.sh",
-            "sha256": "9463aa979314d2acc51472d414ffcee032e9869ca85ac6ff4c71d39500e5173d",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/801143de-6c01-4181-9911-57e00fe40181/l_fortran-compiler_p_2024.2.0.426_offline.sh",
-            "sha256": "fd19a302662b2f86f76fc115ef53a69f16488080278dba4c573cc705f3a52ffa",
-        },
-        "nvidia-plugin": {
-            "url": "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=2024.2.0&filters[]=12.0&filters[]=linux",
-            "sha256": "0622df0054364b01e91e7ed72a33cb3281e281db5b0e86579f516b1cc5336b0f",
-        },
-        "amd-plugin": {
-            "url": "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=2024.2.0&filters[]=6.1.0&filters[]=linux",
-            "sha256": "d1e9d30fa92f3ef606f054d8cbd7c338b3e46f6a9f8472736e29e8ccd9e50688",
-        },
-    },
-    {
-        "version": "2024.1.0",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2e562b6e-5d0f-4001-8121-350a828332fb/l_dpcpp-cpp-compiler_p_2024.1.0.468_offline.sh",
-            "sha256": "534ecc6e4b690c9011d7765cbe178f520aa8f49c0eb4ea80ea1415e48e5d7cf7",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/fd9342bd-7d50-442c-a3e4-f41974e14396/l_fortran-compiler_p_2024.1.0.465_offline.sh",
-            "sha256": "30a02bad9a96a543c60f3bfa4238dfe07c2d26d76fc22ba9aa9b7c603e11f1b9",
-        },
-    },
-    {
-        "version": "2024.0.2",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/bb99984f-370f-413d-bbec-38928d2458f2/l_dpcpp-cpp-compiler_p_2024.0.2.29_offline.sh",
-            "sha256": "0ec22d69f4207fea4b7488d1c9e62adbc14fb6daa1574d6edcadc912da007b3c",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/41df6814-ec4b-4698-a14d-421ee2b02aa7/l_fortran-compiler_p_2024.0.2.28_offline.sh",
-            "sha256": "396ac4fbcb3799d5c1a866a60cf81f85f7cab8c6f35289f61c5cda63c7101b5e",
-        },
-    },
-    {
-        "version": "2024.0.1",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm//IRC_NAS/c68c8f0a-47f5-4f26-8e8e-fa2627271279/l_dpcpp-cpp-compiler_p_2024.0.1.29_offline.sh",
-            "sha256": "22497c46bfb916c82677489775c113141510423799b7eca35f35dffeb2a14104",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm//IRC_NAS/4eedf77e-e097-40de-b62d-5fb70efecb59/l_fortran-compiler_p_2024.0.1.31_offline.sh",
-            "sha256": "9d49ecc1862c60eb0627bfdd80d63a47118095af0ff5adeeda10ec36aaffc82c",
-        },
-    },
-    {
-        "version": "2024.0.0",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm//IRC_NAS/5c8e686a-16a7-4866-b585-9cf09e97ef36/l_dpcpp-cpp-compiler_p_2024.0.0.49524_offline.sh",
-            "sha256": "d10bad2009c98c631fbb834aae62012548daeefc806265ea567316cd9180a684",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm//IRC_NAS/89b0fcf9-5c00-448a-93a1-5ee4078e008e/l_fortran-compiler_p_2024.0.0.49493_offline.sh",
-            "sha256": "57faf854b8388547ee4ef2db387a9f6f3b4d0cebd67b765cf5e844a0a970d1f9",
-        },
-    },
-    {
-        "version": "2023.2.4",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/b00a4b0e-bd21-41fa-ab34-19e8e2a77c5a/l_dpcpp-cpp-compiler_p_2023.2.4.24_offline.sh",
-            "sha256": "f143a764adba04a41e49ec405856ad781e5c3754812e90a7ffe06d08cd07f684",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/5bfaa204-689d-4bf1-9656-e37e35ea3fc2/l_fortran-compiler_p_2023.2.4.31_offline.sh",
-            "sha256": "2f327d67cd207399b327df5b7c912baae800811d0180485ef5431f106686c94b",
-        },
-    },
-    {
-        "version": "2023.2.3",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/d85fbeee-44ec-480a-ba2f-13831bac75f7/l_dpcpp-cpp-compiler_p_2023.2.3.12_offline.sh",
-            "sha256": "b80119a3e54306b85198e907589b00b11c072f107ac39c1686a1996f76466b26",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/0ceccee5-353c-4fd2-a0cc-0aecb7492f87/l_fortran-compiler_p_2023.2.3.13_offline.sh",
-            "sha256": "ef8d95b7165d42da8576bf89a100bd21be7253d0aec039ff76c9213fa2aa9c62",
-        },
-    },
-    {
-        "version": "2023.2.1",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm//IRC_NAS/ebf5d9aa-17a7-46a4-b5df-ace004227c0e/l_dpcpp-cpp-compiler_p_2023.2.1.8_offline.sh",
-            "sha256": "f5656b2f5bb5d904639e6ef1f90a2d2e760d2906e82ebc0dd387709738ca714b",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm//IRC_NAS/0d65c8d4-f245-4756-80c4-6712b43cf835/l_fortran-compiler_p_2023.2.1.8_offline.sh",
-            "sha256": "d4e36abc014c184698fec318a127f15a696b5333b3b0282aba1968b351207185",
-        },
-    },
-    {
-        "version": "2023.2.0",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/748687b0-5a22-467c-86c6-c312fa0206b2/l_dpcpp-cpp-compiler_p_2023.2.0.49256_offline.sh",
-            "sha256": "21497b2dd2bc874794c2321561af313082725f61e3101e05a050f98b7351e08f",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/237236c4-434b-4576-96ac-020ceeb22619/l_fortran-compiler_p_2023.2.0.49254_offline.sh",
-            "sha256": "37c0ad6f0013512d98e385f8708ca29b23c45fddc9ec76069f1d93663668d511",
-        },
-    },
-    {
-        "version": "2023.1.0",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/89283df8-c667-47b0-b7e1-c4573e37bd3e/l_dpcpp-cpp-compiler_p_2023.1.0.46347_offline.sh",
-            "sha256": "3ac1c1179501a2646cbb052b05426554194573b4f8e2344d7699eed03fbcfa1d",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/150e0430-63df-48a0-8469-ecebff0a1858/l_fortran-compiler_p_2023.1.0.46348_offline.sh",
-            "sha256": "7639af4b6c928e9e3ba92297a054f78a55f4f4d0db9db0d144cc6653004e4f24",
-        },
-    },
-    {
-        "version": "2023.0.0",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19123/l_dpcpp-cpp-compiler_p_2023.0.0.25393_offline.sh",
-            "sha256": "473eb019282c2735d65c6058f6890e60b79a5698ae18d2c1e4489fed8dd18a02",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19105/l_fortran-compiler_p_2023.0.0.25394_offline.sh",
-            "sha256": "fd7525bf90646c8e43721e138f29c9c6f99e96dfe5648c13633f30ec64ac8b1b",
-        },
-    },
-    {
-        "version": "2022.2.1",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19049/l_dpcpp-cpp-compiler_p_2022.2.1.16991_offline.sh",
-            "sha256": "3f0f02f9812a0cdf01922d2df9348910c6a4cb4f9dfe50fc7477a59bbb1f7173",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18998/l_fortran-compiler_p_2022.2.1.16992_offline.sh",
-            "sha256": "64f1d1efbcdc3ac2182bec18313ca23f800d94f69758db83a1394490d9d4b042",
-        },
-    },
-    {
-        "version": "2022.2.0",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18849/l_dpcpp-cpp-compiler_p_2022.2.0.8772_offline.sh",
-            "sha256": "8ca97f7ea8abf7876df6e10ce2789ea8cbc310c100ad7bf0b5ffccc4f3c7f2c9",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18909/l_fortran-compiler_p_2022.2.0.8773_offline.sh",
-            "sha256": "4054e4bf5146d55638d21612396a19ea623d22cbb8ac63c0a7150773541e0311",
-        },
-    },
-    {
-        "version": "2022.1.0",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18717/l_dpcpp-cpp-compiler_p_2022.1.0.137_offline.sh",
-            "sha256": "1027819581ba820470f351abfc2b2658ff2684ed8da9ed0e722a45774a2541d6",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18703/l_fortran-compiler_p_2022.1.0.134_offline.sh",
-            "sha256": "583082abe54a657eb933ea4ba3e988eef892985316be13f3e23e18a3c9515020",
-        },
-    },
-    {
-        "version": "2022.0.2",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18478/l_dpcpp-cpp-compiler_p_2022.0.2.84_offline.sh",
-            "sha256": "ade5bbd203e7226ca096d7bf758dce07857252ec54e83908cac3849e6897b8f3",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18481/l_fortran-compiler_p_2022.0.2.83_offline.sh",
-            "sha256": "78532b4118fc3d7afd44e679fc8e7aed1e84efec0d892908d9368e0c7c6b190c",
-        },
-    },
-    {
-        "version": "2022.0.1",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18435/l_dpcpp-cpp-compiler_p_2022.0.1.71_offline.sh",
-            "sha256": "c7cddc64c3040eece2dcaf48926ba197bb27e5a46588b1d7b3beddcdc379926a",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18436/l_fortran-compiler_p_2022.0.1.70_offline.sh",
-            "sha256": "2cb28a04f93554bfeffd6cad8bd0e7082735f33d73430655dea86df8933f50d1",
-        },
-    },
-    {
-        "version": "2021.4.0",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18209/l_dpcpp-cpp-compiler_p_2021.4.0.3201_offline.sh",
-            "sha256": "9206bff1c2fdeb1ca0d5f79def90dcf3e6c7d5711b9b5adecd96a2ba06503828",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18210/l_fortran-compiler_p_2021.4.0.3224_offline.sh",
-            "sha256": "de2fcf40e296c2e882e1ddf2c45bb8d25aecfbeff2f75fcd7494068d621eb7e0",
-        },
-    },
-    {
-        "version": "2021.3.0",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17928/l_dpcpp-cpp-compiler_p_2021.3.0.3168_offline.sh",
-            "sha256": "f848d81b7cabc76c2841c9757abb2290921efd7b82491d830605f5785600e7a1",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17959/l_fortran-compiler_p_2021.3.0.3168_offline.sh",
-            "sha256": "c4553f7e707be8e8e196f625e4e7fbc8eff5474f64ab85fc7146b5ed53ebc87c",
-        },
-    },
-    {
-        "version": "2021.2.0",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17749/l_dpcpp-cpp-compiler_p_2021.2.0.118_offline.sh",
-            "sha256": "5d01cbff1a574c3775510cd97ffddd27fdf56d06a6b0c89a826fb23da4336d59",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17756/l_fortran-compiler_p_2021.2.0.136_offline.sh",
-            "sha256": "a62e04a80f6d2f05e67cd5acb03fa58857ee22c6bd581ec0651c0ccd5bdec5a1",
-        },
-    },
-    {
-        "version": "2021.1.2",
-        "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17513/l_dpcpp-cpp-compiler_p_2021.1.2.63_offline.sh",
-            "sha256": "68d6cb638091990e578e358131c859f3bbbbfbf975c581fd0b4b4d36476d6f0a",
-        },
-        "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17508/l_fortran-compiler_p_2021.1.2.62_offline.sh",
-            "sha256": "29345145268d08a59fa7eb6e58c7522768466dd98f6d9754540d1a0803596829",
-        },
-    },
-]
-
-class UnixDebugFlags:
-    DEBUG = "-debug"
-    G = "-g"
-    G0 = "-g0"
-    G1 = "-g1"
-    G2 = "-g2"
-    G3 = "-g3"
 class WindowsDebugFlags:
     DEBUG = "/debug"
     G = "/g"
@@ -356,19 +27,40 @@ class WindowsDebugFlags:
     G2 = "/g2"
     G3 = "/g3"
 
+
+class UnixOptFlags:
+    O = "-O"
+    O0 = "-O0"
+    O1 = "-O1"
+    O2 = "-O2"
+    O3 = "-O3"
+    OFAST = "-Ofast"
+    OS = "-Os"
+
+
+class WindowsOptFlags:
+    O = "/O"
+    O0 = "/O0"
+    O1 = "/O1"
+    O2 = "/O2"
+    O3 = "/O3"
+    OFAST = "/Ofast"
+    OS = "/Os"
+
+
 class DebugFlagsMeta(type):
-    def __getattr__(cls, attr):
-        if windows:
-            getattr(WindowsDebugFlags, attr)
+    def __getattribute__(cls, attr):
+        if IS_WINDOWS:
+            getattr(WindowsDebugFlags, attr.upper())
         else:
-            getattr(UnixDebugFlags, attr)
+            getattr(UnixDebugFlags, attr.upper())
 
 class OptFlagsMeta(type):
-    def __getattr__(cls, attr):
-        if windows:
-            getattr(WindowsDebugFlags, attr)
+    def __getattribute__(cls, attr):
+        if IS_WINDOWS:
+            getattr(WindowsOptFlags, attr)
         else:
-            getattr(UnixDebugFlags, attr)
+            getattr(UnixOptFlags, attr)
 
 class DebugFlags(metaclass=DebugFlagsMeta):
     """Class abstracting platform specific debug flags"""
@@ -376,7 +68,8 @@ class DebugFlags(metaclass=DebugFlagsMeta):
 class OptFlags(metaclass=OptFlagsMeta):
     """Class abstracting platform specific optimization flags"""
 
-
+class CompilerWrapperLinks:
+    pass
 
 @IntelOneApiPackage.update_description
 class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
@@ -391,13 +84,13 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
     c_names = ["icx"]
     cxx_names = ["icpx"]
     fortran_names = ["ifx"]
-    compiler_version_argument = "--version" if not windows else ""
+    compiler_version_argument = "--version" if not IS_WINDOWS else ""
     compiler_version_regex = (
         r"(?:(?:oneAPI DPC\+\+(?:\/C\+\+)? Compiler)|(?:\(IFORT\))|(?:\(IFX\))) (\S+)"
     )
 
-    debug_flags = ["-debug", "-g", "-g0", "-g1", "-g2", "-g3"]
-    opt_flags = ["-O", "-O0", "-O1", "-O2", "-O3", "-Ofast", "-Os"]
+    debug_flags = [DebugFlags.DEBUG, DebugFlags.G, DebugFlags.G0, DebugFlags.G1, DebugFlags.G2, DebugFlags.G3]
+    opt_flags = [OptFlags.O, OptFlags.O0, OptFlags.O1, OptFlags.O2, OptFlags.O3, OptFlags.OFast, OptFlags.OS]
 
     openmp_flag = "-fiopenmp"
 
@@ -421,6 +114,8 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
 
     stdcxx_libs = ("-cxxlib",)
 
+    oneAPIVersions.generate_versions()
+
     provides("c", "cxx")
     provides("fortran")
 
@@ -436,52 +131,24 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
         }
         return flags[language][standard]
 
-    for plat in ["linux", "darwin", "freebsd"]:
-        with when(f"platform={plat}"):
-            # See https://github.com/spack/spack/issues/39252
-            depends_on("patchelf@:0.17", type="build", when="@:2024.1")
+    with when(f"platform=linux"):
+        # See https://github.com/spack/spack/issues/39252
+        depends_on("patchelf@:0.17", type="build", when="@:2024.1")
 
-            # Disable the variant below for now on Windows for simplicitys sake
-            # enable once basic oneAPI functionality is stable 
+        # Disable the variant below for now on Windows for simplicitys sake
+        # enable once basic oneAPI functionality is stable 
 
-            # Add the nvidia variant
-            variant("nvidia", default=False, description="Install NVIDIA plugin for OneAPI")
-            conflicts("@:2022.2.1", when="+nvidia", msg="Codeplay NVIDIA plugin requires newer release")
-            # Add the amd variant
-            variant("amd", default=False, description="Install AMD plugin for OneAPI")
-            conflicts("@:2022.2.1", when="+amd", msg="Codeplay AMD plugin requires newer release")
+        # Add the nvidia variant
+        variant("nvidia", default=False, description="Install NVIDIA plugin for OneAPI")
+        conflicts("@:2022.2.1", when="+nvidia", msg="Codeplay NVIDIA plugin requires newer release")
+        # Add the amd variant
+        variant("amd", default=False, description="Install AMD plugin for OneAPI")
+        conflicts("@:2022.2.1", when="+amd", msg="Codeplay AMD plugin requires newer release")
 
-            depends_on("gcc languages=c,c++", type="run")
+        depends_on("gcc languages=c,c++", type="run")
 
     with when("platform=windows"):
         depends_on("msvc languages=c,c++", type="run")
-
-    for v in versions:
-        version(v["version"], expand=False, **v["cpp"])
-        if "ftn" in v:
-            resource(
-                name="fortran-installer",
-                placement="fortran-installer",
-                when="@{0}".format(v["version"]),
-                expand=False,
-                **v["ftn"],
-            )
-        if "nvidia-plugin" in v:
-            resource(
-                name="nvidia-plugin-installer",
-                placement="nvidia-plugin-installer",
-                when="@{0}".format(v["version"]),
-                expand=False,
-                **v["nvidia-plugin"],
-            )
-        if "amd-plugin" in v:
-            resource(
-                name="amd-plugin-installer",
-                placement="amd-plugin-installer",
-                when="@{0}".format(v["version"]),
-                expand=False,
-                **v["amd-plugin"],
-            )
 
     @property
     def v2_layout_versions(self):
@@ -521,7 +188,7 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
         super().setup_run_environment(env)
 
         # umf is packaged with compiler and not available as a standalone
-        if "~envmods" not in self.spec and self.spec.satisfies("@2025:"):
+        if "~envmods" not in self.spec and self.spec.satisfies("@2025:") and not IS_WINDOWS:
             env.extend(
                 EnvironmentModifications.from_sourcing_file(
                     self.prefix.umf.latest.env.join("vars.sh"), *self.env_script_args
@@ -584,6 +251,8 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
                     bash = Executable("bash")
                     # For NVIDIA plugin installer
                     bash(nvidia_script[0], "-y", "--install-dir", self.prefix)
+                elif IS_WINDOWS:
+                    Executable(nvidia_script[0])("-a", "-y", "--install-dir", self.prefix)
         if self.spec.satisfies("+amd"):
             amd_script = find("amd-plugin-installer", "*")
             if amd_script:
@@ -591,6 +260,8 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
                     bash = Executable("bash")
                     # For AMD plugin installer
                     bash(amd_script[0], "-y", "--install-dir", self.prefix)
+                elif IS_WINDOWS:
+                    Executable(amd_script[0])("-a", "-y", "--install-dir", self.prefix)
 
     @run_after("install", when="platform=linux")
     def inject_rpaths(self):
@@ -770,18 +441,3 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
 
     def _fortran_path(self):
         return str(self._llvm_bin.ifx)
-
-
-class WindowsGenericBuilder(spack.build_systems.generic.GenericBuilder):
-    pass
-
-class LinuxGenericBuilder(spack.build_systems.generic.GenericBuilder):
-    pass
-
-# Implement genric builders, one for Windows, one for Linux
-# I guess we could hide them behind actual if statements??
-
-class GenericBuilder(WindowsGenericBuilder, LinuxGenericBuilder):
-    def __init__(self, *args, **kwargs):
-        if sys.platform == "win32":
-            super()

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
@@ -5,6 +5,7 @@ import os
 import os.path
 import pathlib
 import platform
+import sys
 import warnings
 
 from spack_repo.builtin.build_systems.compiler import CompilerPackage
@@ -543,7 +544,7 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
                     # For AMD plugin installer
                     bash(amd_script[0], "-y", "--install-dir", self.prefix)
 
-    @run_after("install")
+    @run_after("install", when="platform=linux")
     def inject_rpaths(self):
         # The oneapi compilers cannot find their own internal shared
         # libraries. If you are using an externally installed oneapi,
@@ -586,7 +587,7 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
                     f.write(" ".join(flags))
                 set_install_permissions(p)
 
-    @run_after("install")
+    @run_after("install", when="platform=linux")
     def extend_config_flags(self):
         # Extends compiler config files to inject additional compiler flags.
 
@@ -708,3 +709,18 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
 
     def _fortran_path(self):
         return str(self._llvm_bin.ifx)
+
+
+class WindowsGenericBuilder(spack.build_systems.generic.GenericBuilder):
+    pass
+
+class LinuxGenericBuilder(spack.build_systems.generic.GenericBuilder):
+    pass
+
+# Implement genric builders, one for Windows, one for Linux
+# I guess we could hide them behind actual if statements??
+
+class GenericBuilder(WindowsGenericBuilder, LinuxGenericBuilder):
+    def __init__(self, *args, **kwargs):
+        if sys.platform == "win32":
+            super()

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
@@ -58,45 +58,12 @@ class WindowsOptFlags:
     OS = "/Os"
 
 
-class DebugFlagsMeta(type):
-    def __getattribute__(cls, attr):
-        if IS_WINDOWS:
-            getattr(WindowsDebugFlags, attr.upper())
-        else:
-            getattr(UnixDebugFlags, attr.upper())
-
-
-class OptFlagsMeta(type):
-    def __getattribute__(cls, attr):
-        if IS_WINDOWS:
-            getattr(WindowsOptFlags, attr)
-        else:
-            getattr(UnixOptFlags, attr)
-
-
-class DebugFlags(metaclass=DebugFlagsMeta):
-    """Class abstracting platform specific debug flags"""
-    DEBUG: str
-    G: str
-    G0: str
-    G1: str
-    G2: str
-    G3: str
-
-
-class OptFlags(metaclass=OptFlagsMeta):
-    """Class abstracting platform specific optimization flags"""
-    O: str
-    O0: str
-    O1: str
-    O2: str
-    O3: str
-    OFast: str
-    OS: str
-
-
-class CompilerWrapperLinks:
-    pass
+if IS_WINDOWS:
+    DebugFlags = WindowsDebugFlags
+    OptFlags = WindowsOptFlags
+else:
+    DebugFlags = UnixDebugFlags
+    OptFlags = UnixOptFlags
 
 
 @IntelOneApiPackage.update_description
@@ -118,7 +85,7 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
     )
 
     debug_flags = [DebugFlags.DEBUG, DebugFlags.G, DebugFlags.G0, DebugFlags.G1, DebugFlags.G2, DebugFlags.G3]
-    opt_flags = [OptFlags.O, OptFlags.O0, OptFlags.O1, OptFlags.O2, OptFlags.O3, OptFlags.OFast, OptFlags.OS]
+    opt_flags = [OptFlags.O, OptFlags.O0, OptFlags.O1, OptFlags.O2, OptFlags.O3, OptFlags.OFAST, OptFlags.OS]
 
     openmp_flag = "-fiopenmp"
 
@@ -176,7 +143,7 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
         depends_on("gcc languages=c,c++", type="run")
 
     with when("platform=windows"):
-        depends_on("msvc languages=c,c++", type="run")
+        depends_on("msvc", type="run")
 
     @property
     def v2_layout_versions(self):

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
@@ -368,16 +368,19 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
 
     @classmethod
     def determine_version(cls, exe):
-        # Intel compilers on Windows do not have a proper version argument
-        # Errors out and prints version info with no args
-        match = re.search(
-            cls.compiler_version_regex,
-            spack.build_systems.compiler.compiler_output(
-                exe, version_argument=None, ignore_errors=1
-            ),
-        )
-        if match:
-            return match.group(1)
+        if not IS_WINDOWS:
+            return super().determine_version(exe)
+        else:
+            # Intel compilers on Windows do not have a proper version argument
+            # Errors out and prints version info with no args
+            match = re.search(
+                cls.compiler_version_regex,
+                spack.build_systems.compiler.compiler_output(
+                    exe, version_argument=None, ignore_errors=(1,)
+                ),
+            )
+            if match:
+                return match.group(1)
 
     @classmethod
     def determine_variants(cls, exes, version_str):

--- a/repos/spack_repo/builtin/packages/msvc/package.py
+++ b/repos/spack_repo/builtin/packages/msvc/package.py
@@ -52,7 +52,7 @@ class Msvc(Package, CompilerPackage):
     # based on proper versions of MSVC from there
     # pending acceptance of #28117 for full support using
     # compiler wrappers
-    compiler_wrapper_link_paths = {"c": "", "cxx": "", "fortran": ""}
+    compiler_wrapper_link_paths = {"c": "", "cxx": ""}
 
     provides("c", "cxx")
     requires("platform=windows", msg="MSVC is only supported on Windows")

--- a/repos/spack_repo/builtin/packages/msvc/package.py
+++ b/repos/spack_repo/builtin/packages/msvc/package.py
@@ -40,10 +40,9 @@ class Msvc(Package, CompilerPackage):
             "detected on a system where they are externally installed"
         )
 
-    compiler_languages = ["c", "cxx", "fortran"]
+    compiler_languages = ["c", "cxx"]
     c_names = ["cl"]
     cxx_names = ["cl"]
-    fortran_names = ["ifx", "ifort"]
 
     compiler_version_argument = ""
     compiler_version_regex = r"([1-9][0-9]*\.[0-9]*\.[0-9]*)"
@@ -55,7 +54,7 @@ class Msvc(Package, CompilerPackage):
     # compiler wrappers
     compiler_wrapper_link_paths = {"c": "", "cxx": "", "fortran": ""}
 
-    provides("c", "cxx", "fortran")
+    provides("c", "cxx")
     requires("platform=windows", msg="MSVC is only supported on Windows")
 
     @classmethod


### PR DESCRIPTION
Spun from https://github.com/spack/spack/pull/50264

 * adds installation support on Windows (only viable if you're an administrator at the moment)
 * allows oneapi compilers to be externally detected on Windows
 * allows oneapi compilers to be used with MSVC compilers on Windows
 * Ensures proper ordering of oneAPI and msvc environment setup by injecting MSVC as a oneapi dependency. *

* This isn't actually true from a strict sense, but if MSVC is going to be used in the same environment as MSVC, MSVC's setup environment methods _need_ to be run first. Any suggestions for improvement there are more than welcome.