### PR TITLE
petsc, py-petsc4py: add v3.23.3

### DIFF
--- a/repos/spack_repo/builtin/packages/petsc/package.py
+++ b/repos/spack_repo/builtin/packages/petsc/package.py
@@ -24,6 +24,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     tags = ["e4s"]
 
     version("main", branch="main")
+    version("3.23.3", sha256="bb51e8cbaa3782afce38c6f0bdd64d20ed090695992b7d49817518aa7e909139")
     version("3.23.2", sha256="030ec6c4e9ed885457a6155f20b6f914593a1cd960b28706521a19a9cdadd5e2")
     version("3.23.1", sha256="f729885710c3b42b818fdb525cbd7e1b8c95c1cc25139a44968aa0e7f9e75418")
     version("3.23.0", sha256="aeebd7094f4d583fd04700e73779caa7d9a3d54742e95eff2c3dd87768a79063")
@@ -858,7 +859,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                 "+hypre": ["-pc_type", "hypre", "-pc_hypre_type", "boomeramg"],
                 "+mkl-pardiso": ["-pc_type", "lu", "-pc_factor_mat_solver_type", "mkl_pardiso"],
             }
-            make("ex50", parallel=False)
+            make("ex50")
             for feature, featureopts in testdict.items():
                 if not feature or feature in self.spec:
                     name = f"_{feature[1:]}" if feature else ""
@@ -876,7 +877,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
 
         w_dir = self.test_suite.current_test_cache_dir.src.ksp.ksp.tutorials
         with working_dir(w_dir):
-            make("ex7", parallel=False)
+            make("ex7")
             exeopts = [
                 "ex7",
                 "-mat_type",
@@ -903,7 +904,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
 
         w_dir = self.test_suite.current_test_cache_dir.src.snes.tutorials
         with working_dir(w_dir):
-            make("ex3k", parallel=False)
+            make("ex3k")
             exeopts = [
                 "ex3k",
                 "-view_initial",

--- a/repos/spack_repo/builtin/packages/py_petsc4py/package.py
+++ b/repos/spack_repo/builtin/packages/py_petsc4py/package.py
@@ -21,6 +21,7 @@ class PyPetsc4py(PythonPackage):
     license("BSD-2-Clause")
 
     version("main", branch="main")
+    version("3.23.3", sha256="e46914d30e55a91cd0100f7fb0bc99423e733e1a5c082cd69c6fb8f1b1a5b970")
     version("3.23.2", sha256="6e9220af93a9ee96ad90a47d1513cd5d86bfca02b3a9a902507146311cf4d059")
     version("3.23.1", sha256="7b98c5d21700d9a196302f176d52884b44009610e12627ca7d25da1d895855ce")
     version("3.23.0", sha256="3be542580763419750cdc67dc6515bae338320dbb53403f0af7ab5c8a948bf4e")
@@ -106,6 +107,7 @@ class PyPetsc4py(PythonPackage):
     depends_on("c", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
+    conflicts("py-cython@3.1:", when="@:3.23.1")
     depends_on("py-cython@3:", when="@3.20:", type="build")
     depends_on("py-cython@0.29.32:", when="^python@3.11:", type="build")
     depends_on("py-cython@0.24:", type="build")


### PR DESCRIPTION
```
petsc: fix: spack test run petsc
      >> 6    FAILED: Petsc::test_ex50: Executable.__call__() got an unexpected keyword argument 'parallel'

py-petsc4py: add in conflicts wrt cython@3.1 changes
```
Ref: https://github.com/spack/spack/pull/50753

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
