### PR TITLE
Kokkos: conflict between shared and any relocatable device code

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -383,7 +383,8 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     )
 
     variant("shared", default=True, description="Build shared libraries")
-    conflicts("+shared", when="+cuda_relocatable_device_code")
+    for backend_name in ("cuda", "hip", "sycl"):
+        conflicts("+shared", when=f"+{backend_name}_relocatable_device_code")
 
     # Filter spack-generated files that may include links to the
     # spack compiler wrappers


### PR DESCRIPTION
Update according to cmake change https://github.com/kokkos/kokkos/pull/8196

This gives for example:
```
spack spec -I kokkos@4.5 +sycl +sycl_relocatable_device_code
 -   kokkos@4.5.01~aggressive_vectorization~cmake_lang~compiler_warnings+complex_align~cuda~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~hip_relocatable_device_code~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl~openmp~openmptarget~pic~rocm+serial~shared+sycl+sycl_relocatable_device_code~tests~threads~tuning~wrapper build_system=cmake build_type=Release cxxstd=17 generator=make intel_gpu_arch=none arch=linux-ubuntu20.04-icelake %c,cxx=gcc@10.5.0
```