### PR TITLE
Kokkos: deprecate versions older than 3.7.2

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -82,71 +82,85 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         "3.7.01",
         sha256="0481b24893d1bcc808ec68af1d56ef09b82a1138a1226d6be27c3b3c3da65ceb",
         url="https://github.com/kokkos/kokkos/archive/3.7.01.tar.gz",
+        deprecated=True,
     )
     version(
         "3.7.00",
         sha256="62e3f9f51c798998f6493ed36463f66e49723966286ef70a9dcba329b8443040",
         url="https://github.com/kokkos/kokkos/archive/3.7.00.tar.gz",
+        deprecated=True,
     )
     version(
         "3.6.01",
         sha256="1b80a70c5d641da9fefbbb652e857d7c7a76a0ebad1f477c253853e209deb8db",
         url="https://github.com/kokkos/kokkos/archive/3.6.01.tar.gz",
+        deprecated=True,
     )
     version(
         "3.6.00",
         sha256="53b11fffb53c5d48da5418893ac7bc814ca2fde9c86074bdfeaa967598c918f4",
         url="https://github.com/kokkos/kokkos/archive/3.6.00.tar.gz",
+        deprecated=True,
     )
     version(
         "3.5.00",
         sha256="748f06aed63b1e77e3653cd2f896ef0d2c64cb2e2d896d9e5a57fec3ff0244ff",
         url="https://github.com/kokkos/kokkos/archive/3.5.00.tar.gz",
+        deprecated=True,
     )
     version(
         "3.4.01",
         sha256="146d5e233228e75ef59ca497e8f5872d9b272cb93e8e9cdfe05ad34a23f483d1",
         url="https://github.com/kokkos/kokkos/archive/3.4.01.tar.gz",
+        deprecated=True,
     )
     version(
         "3.4.00",
         sha256="2e4438f9e4767442d8a55e65d000cc9cde92277d415ab4913a96cd3ad901d317",
         url="https://github.com/kokkos/kokkos/archive/3.4.00.tar.gz",
+        deprecated=True,
     )
     version(
         "3.3.01",
         sha256="4919b00bb7b6eb80f6c335a32f98ebe262229d82e72d3bae6dd91aaf3d234c37",
         url="https://github.com/kokkos/kokkos/archive/3.3.01.tar.gz",
+        deprecated=True,
     )
     version(
         "3.3.00",
         sha256="170b9deaa1943185e928f8fcb812cd4593a07ed7d220607467e8f0419e147295",
         url="https://github.com/kokkos/kokkos/archive/3.3.00.tar.gz",
+        deprecated=True,
     )
     version(
         "3.2.01",
         sha256="9e27a3d8f81559845e190d60f277d84d6f558412a3df3301d9545e91373bcaf1",
         url="https://github.com/kokkos/kokkos/archive/3.2.01.tar.gz",
+        deprecated=True,
     )
     version(
         "3.2.00",
         sha256="05e1b4dd1ef383ca56fe577913e1ff31614764e65de6d6f2a163b2bddb60b3e9",
         url="https://github.com/kokkos/kokkos/archive/3.2.00.tar.gz",
+        deprecated=True,
     )
     version(
         "3.1.01",
         sha256="ff5024ebe8570887d00246e2793667e0d796b08c77a8227fe271127d36eec9dd",
         url="https://github.com/kokkos/kokkos/archive/3.1.01.tar.gz",
+        deprecated=True,
     )
     version(
         "3.1.00",
         sha256="b935c9b780e7330bcb80809992caa2b66fd387e3a1c261c955d622dae857d878",
         url="https://github.com/kokkos/kokkos/archive/3.1.00.tar.gz",
+        deprecated=True,
     )
     version(
         "3.0.00",
         sha256="c00613d0194a4fbd0726719bbed8b0404ed06275f310189b3493f5739042a92b",
         url="https://github.com/kokkos/kokkos/archive/3.0.00.tar.gz",
+        deprecated=True,
     )
 
     depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
@@ -75,66 +75,79 @@ class KokkosKernels(CMakePackage, CudaPackage):
         "3.7.01",
         sha256="b2060f5894bdaf7f7d4793b90444fac260460cfa80595afcbcb955518864b446",
         url="https://github.com/kokkos/kokkos-kernels/archive/3.7.01.tar.gz",
+        deprecated=True,
     )
     version(
         "3.7.00",
         sha256="51bc6db3995392065656848e2b152cfd1c3a95a951ab18a3934278113d59f32b",
         url="https://github.com/kokkos/kokkos-kernels/archive/3.7.00.tar.gz",
+        deprecated=True,
     )
     version(
         "3.6.01",
         sha256="f000b156c8c0b80e85d38587907c11d9479aaf362408b812effeda5e22b24d0d",
         url="https://github.com/kokkos/kokkos-kernels/archive/3.6.01.tar.gz",
+        deprecated=True,
     )
     version(
         "3.6.00",
         sha256="2753643fd643b9eed9f7d370e0ff5fa957211d08a91aa75398e31cbc9e5eb0a5",
         url="https://github.com/kokkos/kokkos-kernels/archive/3.6.00.tar.gz",
+        deprecated=True,
     )
     version(
         "3.5.00",
         sha256="a03a41a047d95f9f07cd1e1d30692afdb75b5c705ef524e19c1d02fe60ccf8d1",
         url="https://github.com/kokkos/kokkos-kernels/archive/3.5.00.tar.gz",
+        deprecated=True,
     )
     version(
         "3.4.01",
         sha256="f504aa4afbffb58fa7c4430d0fdb8fd5690a268823fa15eb0b7d58dab9d351e6",
         url="https://github.com/kokkos/kokkos-kernels/archive/3.4.01.tar.gz",
+        deprecated=True,
     )
     version(
         "3.4.00",
         sha256="07ba11869e686cb0d47272d1ef494ccfbcdef3f93ff1c8b64ab9e136a53a227a",
         url="https://github.com/kokkos/kokkos-kernels/archive/3.4.00.tar.gz",
+        deprecated=True,
     )
     version(
         "3.3.01",
         sha256="0f21fe6b5a8b6ae7738290e293aa990719aefe88b32f84617436bfd6074a8f77",
         url="https://github.com/kokkos/kokkos-kernels/archive/3.3.01.tar.gz",
+        deprecated=True,
     )
     version(
         "3.3.00",
         sha256="8d7f78815301afb90ddba7914dce5b718cea792ac0c7350d2f8d00bd2ef1cece",
         url="https://github.com/kokkos/kokkos-kernels/archive/3.3.00.tar.gz",
+        deprecated=True,
     )
     version(
         "3.2.01",
         sha256="c486e5cac19e354a517498c362838619435734d64b44f44ce909b0531c21d95c",
         url="https://github.com/kokkos/kokkos-kernels/archive/3.2.01.tar.gz",
+        deprecated=True,
     )
     version(
         "3.2.00",
         sha256="8ac20ee28ae7813ce1bda461918800ad57fdbac2af86ef5d1ba74e83e10956de",
         url="https://github.com/kokkos/kokkos-kernels/archive/3.2.00.tar.gz",
+        deprecated=True,
     )
     version(
         "3.1.00",
         sha256="27fea241ae92f41bd5b070b1a590ba3a56a06aca750207a98bea2f64a4a40c89",
         url="https://github.com/kokkos/kokkos-kernels/archive/3.1.00.tar.gz",
+        deprecated=True,
     )
     version(
         "3.0.00",
         sha256="e4b832aed3f8e785de24298f312af71217a26067aea2de51531e8c1e597ef0e6",
         url="https://github.com/kokkos/kokkos-kernels/archive/3.0.00.tar.gz",
+        deprecated=True,
     )
 
     variant("shared", default=True, description="Build shared libraries")

--- a/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
@@ -67,6 +67,11 @@ class KokkosKernels(CMakePackage, CudaPackage):
         url="https://github.com/kokkos/kokkos-kernels/archive/4.0.00.tar.gz",
     )
     version(
+        "3.7.02",
+        sha256="43b1d4f726bccd8d7d632ae8b81c8edc7d7afa347fbab0654f7ca0c664edf05c",
+        url="https://github.com/kokkos/kokkos-kernels/archive/3.7.02.tar.gz",
+    )
+    version(
         "3.7.01",
         sha256="b2060f5894bdaf7f7d4793b90444fac260460cfa80595afcbcb955518864b446",
         url="https://github.com/kokkos/kokkos-kernels/archive/3.7.01.tar.gz",
@@ -203,6 +208,7 @@ class KokkosKernels(CMakePackage, CudaPackage):
     depends_on("kokkos@4.1.00", when="@4.1.00")
     depends_on("kokkos@4.0.01", when="@4.0.01")
     depends_on("kokkos@4.0.00", when="@4.0.00")
+    depends_on("kokkos@3.7.02", when="@3.7.02")
     depends_on("kokkos@3.7.01", when="@3.7.01")
     depends_on("kokkos@3.7.00", when="@3.7.00")
     depends_on("kokkos@3.6.01", when="@3.6.01")

--- a/repos/spack_repo/builtin/packages/kokkos_nvcc_wrapper/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_nvcc_wrapper/package.py
@@ -76,71 +76,85 @@ class KokkosNvccWrapper(Package):
         "3.7.01",
         sha256="0481b24893d1bcc808ec68af1d56ef09b82a1138a1226d6be27c3b3c3da65ceb",
         url="https://github.com/kokkos/kokkos/archive/3.7.01.tar.gz",
+        deprecated=True,
     )
     version(
         "3.7.00",
         sha256="62e3f9f51c798998f6493ed36463f66e49723966286ef70a9dcba329b8443040",
         url="https://github.com/kokkos/kokkos/archive/3.7.00.tar.gz",
+        deprecated=True,
     )
     version(
         "3.6.01",
         sha256="1b80a70c5d641da9fefbbb652e857d7c7a76a0ebad1f477c253853e209deb8db",
         url="https://github.com/kokkos/kokkos/archive/3.6.01.tar.gz",
+        deprecated=True,
     )
     version(
         "3.6.00",
         sha256="53b11fffb53c5d48da5418893ac7bc814ca2fde9c86074bdfeaa967598c918f4",
         url="https://github.com/kokkos/kokkos/archive/3.6.00.tar.gz",
+        deprecated=True,
     )
     version(
         "3.5.00",
         sha256="748f06aed63b1e77e3653cd2f896ef0d2c64cb2e2d896d9e5a57fec3ff0244ff",
         url="https://github.com/kokkos/kokkos/archive/3.5.00.tar.gz",
+        deprecated=True,
     )
     version(
         "3.4.01",
         sha256="146d5e233228e75ef59ca497e8f5872d9b272cb93e8e9cdfe05ad34a23f483d1",
         url="https://github.com/kokkos/kokkos/archive/3.4.01.tar.gz",
+        deprecated=True,
     )
     version(
         "3.4.00",
         sha256="2e4438f9e4767442d8a55e65d000cc9cde92277d415ab4913a96cd3ad901d317",
         url="https://github.com/kokkos/kokkos/archive/3.4.00.tar.gz",
+        deprecated=True,
     )
     version(
         "3.3.01",
         sha256="4919b00bb7b6eb80f6c335a32f98ebe262229d82e72d3bae6dd91aaf3d234c37",
         url="https://github.com/kokkos/kokkos/archive/3.3.01.tar.gz",
+        deprecated=True,
     )
     version(
         "3.3.00",
         sha256="170b9deaa1943185e928f8fcb812cd4593a07ed7d220607467e8f0419e147295",
         url="https://github.com/kokkos/kokkos/archive/3.3.00.tar.gz",
+        deprecated=True,
     )
     version(
         "3.2.01",
         sha256="9e27a3d8f81559845e190d60f277d84d6f558412a3df3301d9545e91373bcaf1",
         url="https://github.com/kokkos/kokkos/archive/3.2.01.tar.gz",
+        deprecated=True,
     )
     version(
         "3.2.00",
         sha256="05e1b4dd1ef383ca56fe577913e1ff31614764e65de6d6f2a163b2bddb60b3e9",
         url="https://github.com/kokkos/kokkos/archive/3.2.00.tar.gz",
+        deprecated=True,
     )
     version(
         "3.1.01",
         sha256="ff5024ebe8570887d00246e2793667e0d796b08c77a8227fe271127d36eec9dd",
         url="https://github.com/kokkos/kokkos/archive/3.1.01.tar.gz",
+        deprecated=True,
     )
     version(
         "3.1.00",
         sha256="b935c9b780e7330bcb80809992caa2b66fd387e3a1c261c955d622dae857d878",
         url="https://github.com/kokkos/kokkos/archive/3.1.00.tar.gz",
+        deprecated=True,
     )
     version(
         "3.0.00",
         sha256="c00613d0194a4fbd0726719bbed8b0404ed06275f310189b3493f5739042a92b",
         url="https://github.com/kokkos/kokkos/archive/3.0.00.tar.gz",
+        deprecated=True,
     )
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/paraview/package.py
+++ b/repos/spack_repo/builtin/packages/paraview/package.py
@@ -312,7 +312,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("rocthrust", when="@5.13: +rocm ^cmake@3.24:")
     for target in ROCmPackage.amdgpu_targets:
         depends_on(
-            "kokkos@:3.7.01 +rocm amdgpu_target={0}".format(target),
+            "kokkos@:3.7 +rocm amdgpu_target={0}".format(target),
             when="+rocm amdgpu_target={0}".format(target),
         )
 


### PR DESCRIPTION
This PR starts to deprecate versions 3 of Kokkos, keeping only 3.7.2.