### PR TITLE
openfoam: Updating cgal version due to build failures (missing binaries)

### DIFF
--- a/repos/spack_repo/builtin/packages/openfoam/package.py
+++ b/repos/spack_repo/builtin/packages/openfoam/package.py
@@ -375,7 +375,7 @@ class Openfoam(Package):
     # Earlier versions of OpenFOAM may not work with CGAL 5.6. I do
     # not know which OpenFOAM added support for 5.x and conservatively
     # use 2312 in the check.
-    # cgal@6 needs c++17, but OpenFOAM forces c++14
+    # cgal@6 needs c++17, but until v2412 OpenFOAM forced c++14
     depends_on("cgal@:6", when="@2412:")
     depends_on("cgal@:5", when="@2312:2406")
     depends_on("cgal@:4", when="@:2306")

--- a/repos/spack_repo/builtin/packages/openfoam/package.py
+++ b/repos/spack_repo/builtin/packages/openfoam/package.py
@@ -376,7 +376,8 @@ class Openfoam(Package):
     # not know which OpenFOAM added support for 5.x and conservatively
     # use 2312 in the check.
     # cgal@6 needs c++17, but OpenFOAM forces c++14
-    depends_on("cgal@:5", when="@2312:2412")
+    depends_on("cgal@:6", when="@2412:")
+    depends_on("cgal@:5", when="@2312:2406")
     depends_on("cgal@:4", when="@:2306")
 
     # The flex restriction is ONLY to deal with a spec resolution clash


### PR DESCRIPTION
There is a problem with building 2412 with cgal version 5.
Spack reports successful build but there are errors from wmake inside build output (because of errors from wmake are not recognized as errors). This led to missing binaries in package (ex. simpleFoam, potentialFoam)

Since C++17 became minimum requirement starting with 2412 version I suggest using cgal version 6 which fixes the issue with build and missing binaries.

It would also be great to check the build status in a different way than current approach.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
