### PR TITLE
whizard: Make sure to set the LD_LIBRARY_PATH for run environment

### DIFF
--- a/repos/spack_repo/builtin/packages/whizard/package.py
+++ b/repos/spack_repo/builtin/packages/whizard/package.py
@@ -147,6 +147,12 @@ class Whizard(AutotoolsPackage):
         env.set("FC", self.compiler.fc)
         env.set("F77", self.compiler.fc)
 
+    def setup_run_environment(self, env: EnvironmentModifications) -> None:
+        # Whizard creates a whizard_setup.[c]sh script that sets the
+        # LD_LIBRARY_PATH that is necessary because whizard builds more
+        # libraries on invocation, which are usually not linked via RPATH
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["whizard"].libs.directories[0])
+
     @run_before("autoreconf")
     def prepare_whizard(self):
         # As described in the manual (SVN Repository version)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

whizard needs the `LD_LIBRARY_PATH` to be set in order to run in it without issues downstream. This is also done in the `whizard_setup.sh` script that is generated by whizard during its build. 