### PR TITLE
Gotcha 1.0.8 add commit hash

### DIFF
--- a/repos/spack_repo/builtin/packages/gotcha/package.py
+++ b/repos/spack_repo/builtin/packages/gotcha/package.py
@@ -18,7 +18,7 @@ class Gotcha(CMakePackage):
 
     version("develop", branch="develop")
     version("master", branch="master")
-    version("1.0.8", tag="1.0.8")
+    version("1.0.8", tag="1.0.8", commit="4b74402f37c28c43acb401ac63ecc20abc95d107")
     version("1.0.7", tag="1.0.7", commit="ae053b77e6b2800188e2c4ddd17057c9b15f4adb")
     version("1.0.6", tag="1.0.6", commit="81401b939c23562728a27d7678505090463e5c03")
     version("1.0.5", tag="1.0.5", commit="e28f10c45a0cda0e1ec225eaea6abfe72c8353aa")


### PR DESCRIPTION
Gotcha version 1.0.8 was added to the gotcha package.py without the corresponding commit hash.
This PR fixes that omission.
