### PR TITLE
ffmpeg: Fix aom dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/ffmpeg/package.py
+++ b/repos/spack_repo/builtin/packages/ffmpeg/package.py
@@ -105,6 +105,7 @@ class Ffmpeg(AutotoolsPackage):
 
     depends_on("pkgconfig", type="build")
 
+    depends_on("aom@2.0.0:", when="@7.1:+libaom")
     depends_on("aom", when="+libaom")
     depends_on("bzip2", when="+bzlib")
     depends_on("fontconfig", when="+drawtext")


### PR DESCRIPTION
See https://github.com/FFmpeg/FFmpeg/blob/n7.1/configure#L6868

Migrates: https://github.com/spack/spack/pull/49426
Depends on: #1029 (now merged, this PR can now be rebased on top of develop to fix CI)