### PR TITLE
ctffind: adding C language dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/ctffind/package.py
+++ b/repos/spack_repo/builtin/packages/ctffind/package.py
@@ -26,7 +26,8 @@ class Ctffind(AutotoolsPackage):
         extension="tar.gz",
     )
 
-    depends_on("c", type="build")  # the code is C++ but the configure script tests the C-compiler anyway
+    # the code is C++ but the configure script tests the C-compiler anyway
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     def url_for_version(self, version):

--- a/repos/spack_repo/builtin/packages/ctffind/package.py
+++ b/repos/spack_repo/builtin/packages/ctffind/package.py
@@ -26,6 +26,7 @@ class Ctffind(AutotoolsPackage):
         extension="tar.gz",
     )
 
+    depends_on("c", type="build")  # the code is C++ but the configure script tests the C-compiler anyway
     depends_on("cxx", type="build")  # generated
 
     def url_for_version(self, version):


### PR DESCRIPTION
The ctffind code is C++ only but the configure script tests the C-compiler anyway. So we need to add the C-language otherwise the configure script will fail.

To demonstrate the failure simply run
```
spack install ctffind
```
to produce:
```
==> No binary for ctffind-4.1.14-i3cs3rknfgiea36dwdd3zddpu6zdrsea found: installing from source
==> Installing ctffind-4.1.14-i3cs3rknfgiea36dwdd3zddpu6zdrsea [51/51]
==> Fetching https://mirror.spack.io/_source-cache/archive/db/db17b2ebeb3c3b2b3764e42b820cd50d19ccccf6956c64257bfe5d5ba6b40cb5.tar.gz
    [100%]  662.20 KB @    1.2 MB/s
==> Applied patch /lustre/hpc_home/cbm518i/spack-packages/repos/spack_repo/builtin/packages/ctffind/fix_return_types.patch
==> ctffind: Executing phase: 'autoreconf'
==> ctffind: Executing phase: 'configure'
==> Error: ProcessError: Command exited with status 77:
    '/tmp/cbm518i/spack-stage/spack-stage-ctffind-4.1.14-i3cs3rknfgiea36dwdd3zddpu6zdrsea/spack-src/configure' '--prefix=/lustre/hpc_home/cbm518i/spack/opt/spack/linux-sapphirerapids/ctffind-4.1.14-i3cs3rknfgiea36dwdd3zddpu6zdrsea' '--disable-mkl' 'CPPFLAGS=-I/lustre/hpc_home/cbm518i/spack/opt/spack/linux-sapphirerapids/fftw-3.3.10-5btu3umgsubzg5r2auvfdt5wcciz3yxu/include'

2 errors found in build log:
     15    checking for gawk... gawk
     16    checking whether make sets $(MAKE)... yes
     17    checking whether make supports nested variables... yes
     18    checking for icc... no
     19    checking for gcc... gcc
     20    checking whether the C compiler works... no
  >> 21    configure: error: in `/tmp/cbm518i/spack-stage/spack-stage-ctffind-4.1.14-i3cs3rknfgiea36dwdd3zddpu6zdrsea/spack-s
           rc':
  >> 22    configure: error: C compiler cannot create executables
     23    See `config.log' for more details
```
Adding the C-language as a build dependency to the package fixes this problem.
