### PR TITLE
Add `vir::stdx::simd` (Spack: `vir-simd`)

### DIFF
--- a/repos/spack_repo/builtin/packages/vir_simd/package.py
+++ b/repos/spack_repo/builtin/packages/vir_simd/package.py
@@ -12,7 +12,7 @@ class VirSimd(CMakePackage):
     homepage = "https://mattkretz.github.io/vir-simd/master/"
     url = "https://github.com/mattkretz/vir-simd/archive/refs/tags/v0.4.4.tar.gz"
 
-    maintainers("ax3l", "mattkretz")
+    maintainers("ax3l")
 
     license("LGPL-3.0-or-later", checked_by="ax3l")
 

--- a/repos/spack_repo/builtin/packages/vir_simd/package.py
+++ b/repos/spack_repo/builtin/packages/vir_simd/package.py
@@ -1,0 +1,21 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack.package import *
+
+
+class VirSimd(CMakePackage):
+    """A fallback std::experimental::simd (Parallelism TS 2) implementation with additional features."""
+
+    homepage = "https://mattkretz.github.io/vir-simd/master/"
+    url = "https://github.com/mattkretz/vir-simd/archive/refs/tags/v0.4.4.tar.gz"
+
+    maintainers("ax3l", "mattkretz")
+
+    license("LGPL-3.0-or-later", checked_by="ax3l")
+
+    version("0.4.4", sha256="0d2953e1219798967b156aa392de6430099d85887770e5c81aefe8fb63e9464c")
+
+    depends_on("cxx", type="build")


### PR DESCRIPTION
Add a new package for the header-only library `vir::stdx::simd` by @mattkretz .

I am adding support for SIMD in BLAST [WarpX](https://github.com/BLAST-WarpX/warpx)/[ImpactX](https://github.com/BLAST-ImpactX/impactx)/[HiPACE++](https://github.com/Hi-PACE/hipace/)/... via [AMReX](https://github.com/AMReX-Codes/amrex) and need this library as a dependency to enhance our C++17 implementations (until we can require C++26 `std::datapar`).

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
