### PR TITLE
New packages: py-tree-sitter and py-tree-sitter-c

### DIFF
--- a/repos/spack_repo/builtin/packages/py_tree_sitter/package.py
+++ b/repos/spack_repo/builtin/packages/py_tree_sitter/package.py
@@ -1,0 +1,23 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage, depends_on
+from spack.package import *
+
+class PyTreeSitter(PythonPackage):
+    """Python bindings to the tree-sitter library"""
+
+    homepage = "https://tree-sitter.github.io/py-tree-sitter/"
+    pypi = "tree-sitter/tree-sitter-0.24.0.tar.gz"
+    git = "https://github.com/tree-sitter/py-tree-sitter.git"
+    
+    maintainers("JohnGouwar")
+
+    version("master", branch="master", submodules=True)
+    version("0.25.0", commit="9c78f3b8d10f81b97fbb2181c9333323d6375480", submodules=True)
+    version("0.24.0", sha256="abd95af65ca2f4f7eca356343391ed669e764f37748b5352946f00f7fc78e734")
+
+    depends_on("python@3.10:", type=("build", "link", "run"))
+    depends_on("py-setuptools", type=("build"))
+    depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/py_tree_sitter/package.py
+++ b/repos/spack_repo/builtin/packages/py_tree_sitter/package.py
@@ -19,5 +19,5 @@ class PyTreeSitter(PythonPackage):
     version("0.24.0", sha256="abd95af65ca2f4f7eca356343391ed669e764f37748b5352946f00f7fc78e734")
 
     depends_on("python@3.10:", type=("build", "link", "run"))
-    depends_on("py-setuptools", type=("build"))
+    depends_on("py-setuptools", type="build")
     depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/py_tree_sitter_c/package.py
+++ b/repos/spack_repo/builtin/packages/py_tree_sitter_c/package.py
@@ -1,0 +1,21 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+from spack.package import *
+
+
+class PyTreeSitterC(PythonPackage):
+    """Python bindings to the C-grammar provided by tree-sitter"""
+
+    homepage = "https://tree-sitter.github.io/py-tree-sitter/"
+    pypi = "tree_sitter_c/tree_sitter_c-0.24.1.tar.gz"
+    git = "https://github.com/tree-sitter/tree-sitter-c"
+    
+    version("0.24.1", sha256="7d2d0cda0b8dda428c81440c1e94367f9f13548eedca3f49768bde66b1422ad6")
+    
+    depends_on("py-tree-sitter")
+    depends_on("python@3.10:", type=("build", "link", "run"))
+    depends_on("py-setuptools", type=("build"))
+    depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/py_tree_sitter_c/package.py
+++ b/repos/spack_repo/builtin/packages/py_tree_sitter_c/package.py
@@ -17,5 +17,5 @@ class PyTreeSitterC(PythonPackage):
     
     depends_on("py-tree-sitter")
     depends_on("python@3.10:", type=("build", "link", "run"))
-    depends_on("py-setuptools", type=("build"))
+    depends_on("py-setuptools", type="build")
     depends_on("c", type="build")


### PR DESCRIPTION
These packages are the python bindings to `tree-sitter` as a python package, as well as the python wrapper for the C grammar provided by tree-sitter.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
