### PR TITLE
yaksa: fix error when building with ROCm 6

### DIFF
--- a/repos/spack_repo/builtin/packages/yaksa/package.py
+++ b/repos/spack_repo/builtin/packages/yaksa/package.py
@@ -42,6 +42,7 @@ class Yaksa(AutotoolsPackage, CudaPackage, ROCmPackage):
     depends_on("m4", type="build")
     depends_on("python@3:", type="build")
 
+    # fix for error: no member named 'memoryType' in 'struct hipPointerAttribute_t'
     patch(
         "https://github.com/pmodels/yaksa/commit/5ebbadb7771d194f3819e3dd1ac8b5b467024afb.patch?full_index=1",
         sha256="0ae3ab6f932c1b31dde38babc181c1507e70d87e435d8fc6c82e0911fb55d560",

--- a/repos/spack_repo/builtin/packages/yaksa/package.py
+++ b/repos/spack_repo/builtin/packages/yaksa/package.py
@@ -42,6 +42,12 @@ class Yaksa(AutotoolsPackage, CudaPackage, ROCmPackage):
     depends_on("m4", type="build")
     depends_on("python@3:", type="build")
 
+    patch(
+        "https://github.com/pmodels/yaksa/commit/5ebbadb7771d194f3819e3dd1ac8b5b467024afb.patch?full_index=1",
+        sha256="0ae3ab6f932c1b31dde38babc181c1507e70d87e435d8fc6c82e0911fb55d560",
+        when="@0.3 +rocm ^hip@6:",
+    )
+
     def autoreconf(self, spec, prefix):
         sh = which("sh")
         sh("autogen.sh")


### PR DESCRIPTION
The following error can be seen when installing yaksa +rocm using ROCm 6:
```
src/backend/hip/pup/yaksuri_hipi_get_ptr_attr.c:14:15: error: no member named 'memoryType' in 'struct hipPointerAttribute_t'
   14 |     if (cattr.memoryType == hipMemoryTypeHost) {
      |         ~~~~~ ^
src/backend/hip/pup/yaksuri_hipi_get_ptr_attr.c:20:22: error: no member named 'memoryType' in 'struct hipPointerAttribute_t'
   20 |     } else if (cattr.memoryType == hipMemoryTypeDevice) {
      |                ~~~~~ ^
src/backend/hip/pup/yaksuri_hipi_get_ptr_attr.c:49:18: error: no member named 'memoryType' in 'struct hipPointerAttribute_t'
   49 |             attr.memoryType = -1;
      |             ~~~~ ^
src/backend/hip/pup/yaksuri_hipi_get_ptr_attr.c:65:18: error: no member named 'memoryType' in 'struct hipPointerAttribute_t'
   65 |             attr.memoryType = -1;
      |             ~~~~ ^
4 errors generated.
```
This PR adds a commit that fixes the error