### PR TITLE
compiler-wrapper: Fix to add extra symlink for fj

### DIFF
--- a/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
+++ b/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
@@ -141,6 +141,11 @@ class CompilerWrapper(Package):
         (cray_dir / "crayCC").symlink_to(installed_script)
         (cray_dir / "CC").symlink_to(installed_script)
 
+        # Extra symlink for Fujitsu
+        fj_dir = bin_dir / "fj" / "case-insensitive"
+        fj_dir.mkdir(exist_ok=True)
+        (fj_dir / "FCC").symlink_to(installed_script)
+
     def setup_dependent_build_environment(
         self, env: EnvironmentModifications, dependent_spec: Spec
     ) -> None:


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Fujitsu compiler needs an extra symlink of case-insensitive/FCC.