### PR TITLE
openmpi: add variant to use cray-xpmem name for package configure when cray-xpmem enabled

### DIFF
--- a/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -598,6 +598,8 @@ with '-Wl,-commons,use_dylibs' and without
 '-Wl,-flat_namespace'.""",
     )
 
+    variant("cray-xpmem", default=False, description="use cray-xpmem instead of xpmem configure flag (if fabrics=xpmem enabled)")
+
     # Patch to allow two-level namespace on a MacOS platform when building
     # openmpi. Unfortuntately, the openmpi configure command has flat namespace
     # hardwired in. In spack, this only works for openmpi up to versions 4,
@@ -1009,9 +1011,12 @@ with '-Wl,-commons,use_dylibs' and without
         return f"--with-ucc={self.spec['ucc'].prefix}"
 
     def with_or_without_xpmem(self, activated):
+        s1 = "xpmem"
+        if self.spec.satisfies("+cray-xpmem"):
+            s1 = "cray-xpmem"
         if not activated:
-            return "--without-xpmem"
-        return f"--with-xpmem={self.spec['xpmem'].prefix}"
+            return f"--without-{s1}"
+        return f"--with-{s1}={self.spec['xpmem'].prefix}"
 
     def with_or_without_knem(self, activated):
         if not activated:
@@ -1088,10 +1093,7 @@ with '-Wl,-commons,use_dylibs' and without
             config_args.extend(self.with_or_without("fabrics"))
 
         if spec.satisfies("@2.0.0:"):
-            if "fabrics=xpmem" in spec:
-                config_args.append("--with-cray-xpmem")
-            else:
-                config_args.append("--without-cray-xpmem")
+            config_args.append(self.with_or_without_xpmem("fabrics=xpmem" in spec))
 
         # Schedulers
         if "schedulers=auto" not in spec:

--- a/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -598,7 +598,7 @@ with '-Wl,-commons,use_dylibs' and without
 '-Wl,-flat_namespace'.""",
     )
 
-    variant("cray-xpmem", default=False, description="use cray-xpmem instead of xpmem configure flag (if fabrics=xpmem enabled)")
+    variant("cray-xpmem", default=False, when="fabrics=xpmem", description="use cray-xpmem instead of xpmem configure flag")
 
     # Patch to allow two-level namespace on a MacOS platform when building
     # openmpi. Unfortuntately, the openmpi configure command has flat namespace


### PR DESCRIPTION
on cray systems the xpmem package configure file is named 
```
/usr/lib64/pkgconfig/cray-xpmem.pc
```
or similar, this PR adds a avariant that changes the xpmem search from `xpmem` to `cray-xpmem` and thus allows the build to proceed