### PR TITLE
py-cython: add v3.0.12

### DIFF
--- a/repos/spack_repo/builtin/packages/py_cython/package.py
+++ b/repos/spack_repo/builtin/packages/py_cython/package.py
@@ -16,6 +16,7 @@ class PyCython(PythonPackage):
 
     license("Apache-2.0")
 
+    version("3.0.12", sha256="b988bb297ce76c671e28c97d017b95411010f7c77fa6623dd0bb47eed1aee1bc")
     version("3.0.11", sha256="7146dd2af8682b4ca61331851e6aebce9fe5158e75300343f80c07ca80b1faff")
     version("3.0.10", sha256="dcc96739331fb854dcf503f94607576cfe8488066c61ca50dfd55836f132de99")
     version("3.0.8", sha256="8333423d8fd5765e7cceea3a9985dd1e0a5dfeb2734629e1a2ed2d6233d39de6")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

I need this as a dependency for a future update of py-ray. We already have cython 3.1.X, but I can imagine this may be easier to merge.

Changelog from upstream: https://github.com/cython/cython/releases/tag/3.0.12


```
3.0.12 (2025-02-11)

===================

Bugs fixed
----------

* Release 3.0.11 introduced some incorrect ``noexcept`` warnings.
  (Github issue :issue:`6335`)

* Conditional assignments to variables using the walrus operator could crash.
  (Github issue :issue:`6094`)

* Dict assignments to struct members with reserved C names could generate invalid C code.

* Fused ctuples with the same entry types but different sizes could fail to compile.
  (Github issue :issue:`6328`)

* In Py3, `pyximport` was not searching `sys.path` when looking for importable source files.
  (Github issue :issue:`5615`)

* Using `& 0` on integers produced with `int.from_bytes()` could read invalid memory on Python 3.10.
  (Github issue :issue:`6480`)

* Modules could fail to compile in PyPy 3.11 due to missing CPython specific header files.
  Patch by Matti Picus.  (Github issue :issue:`6482`)

* Minor fix in C++ ``partial_sum()`` declaration.
```

cc @theabm 