### PR TITLE
acts-algebra-plugins: add v0.28.0

### DIFF
--- a/repos/spack_repo/builtin/packages/acts/package.py
+++ b/repos/spack_repo/builtin/packages/acts/package.py
@@ -368,7 +368,8 @@ class Acts(CMakePackage, CudaPackage):
         depends_on("actsvg@0.4.56:", when="@41.1:")
         # TODO: This should be when-constrained when the issue is fixed in ACTS.
         depends_on("actsvg@:0.4.56")
-    depends_on("acts-algebra-plugins @0.24:", when="+traccc")
+    # The version number of algebra plugins was not correct before v0.28.0.
+    depends_on("acts-algebra-plugins @0.28:", when="+traccc")
     depends_on("autodiff @0.6:", when="@17: +autodiff")
     depends_on("autodiff @0.5.11:0.5.99", when="@1.2:16 +autodiff")
     depends_on("boost @1.62:1.69 +program_options +test", when="@:0.10.3")

--- a/repos/spack_repo/builtin/packages/acts_algebra_plugins/package.py
+++ b/repos/spack_repo/builtin/packages/acts_algebra_plugins/package.py
@@ -18,6 +18,7 @@ class ActsAlgebraPlugins(CMakePackage):
 
     license("MPL-2.0", checked_by="stephenswat")
 
+    version("0.28.0", sha256="d798ba2129bf922f54627233ef947b8bb2345db9199e3868cc48bc1da86d5f15")
     version("0.27.0", sha256="c2081b399b7f4e004bebd5bf8250ed9596b113002fe445bca7fdac24d2c5932c")
     version("0.26.2", sha256="0170f22e1a75493b86464f27991117bc2c5a9d52554c75786e321d4c591990e7")
     version("0.26.1", sha256="8eb1e9e28ec2839d149b6a6bddd0f983b0cdf71c286c0aeb67ede31727c5b7d3")

--- a/repos/spack_repo/builtin/packages/detray/package.py
+++ b/repos/spack_repo/builtin/packages/detray/package.py
@@ -91,11 +91,12 @@ class Detray(CMakePackage):
     depends_on("nlohmann-json@3.11.0:", when="+json")
     depends_on("dfelibs@20211029:", when="@:0.88")
     depends_on("acts-algebra-plugins@0.18.0: +vecmem")
-    depends_on("acts-algebra-plugins@0.27.0: +vecmem", when="@0.95:")
     depends_on("acts-algebra-plugins +vc", when="+vc")
     depends_on("acts-algebra-plugins +eigen", when="+eigen")
     depends_on("acts-algebra-plugins +smatrix", when="+smatrix")
-    depends_on("acts-algebra-plugins@0.26.0:", when="@0.87:")
+    # The version number of algebra plugins was not correct before v0.28.0.
+    depends_on("acts-algebra-plugins@0.28.0:", when="@0.87:")
+    depends_on("acts-algebra-plugins@0.28.0: +vecmem", when="@0.95:")
 
     # Detray imposes requirements on the C++ standard values used by Algebra
     # Plugins.


### PR DESCRIPTION
This commit adds ACTS algebra plugins version 0.28.0.