### PR TITLE
HEP: upgrade gitlab runner image to ubuntu-24.04:v2024-09-05-v2

### DIFF
--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -689,7 +689,7 @@ ml-darwin-aarch64-mps-build:
 
 hep-generate:
   extends: [ ".hep", ".generate-x86_64"]
-  image: ghcr.io/spack/spack/ubuntu-24.04:v2024-09-05-v2
+  image: ghcr.io/spack/ubuntu-24.04:v2024-09-05-v2
 
 hep-build:
   extends: [ ".hep", ".build" ]

--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -689,7 +689,7 @@ ml-darwin-aarch64-mps-build:
 
 hep-generate:
   extends: [ ".hep", ".generate-x86_64"]
-  image: ghcr.io/spack/spack/ubuntu22.04-runner-amd64-gcc-11.4:2024.03.01
+  image: ghcr.io/spack/spack/ubuntu-24.04:v2024-09-05-v2
 
 hep-build:
   extends: [ ".hep", ".build" ]

--- a/stacks/hep/spack.yaml
+++ b/stacks/hep/spack.yaml
@@ -143,7 +143,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: ghcr.io/spack/spack/ubuntu22.04-runner-amd64-gcc-11.4:2024.03.01
+        image: ghcr.io/spack/spack/ubuntu-24.04:v2024-09-05-v2
 
   cdash:
     build-group: HEP

--- a/stacks/hep/spack.yaml
+++ b/stacks/hep/spack.yaml
@@ -143,7 +143,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: ghcr.io/spack/spack/ubuntu-24.04:v2024-09-05-v2
+        image: ghcr.io/spack/ubuntu-24.04:v2024-09-05-v2
 
   cdash:
     build-group: HEP

--- a/stacks/hep/spack.yaml
+++ b/stacks/hep/spack.yaml
@@ -36,6 +36,10 @@ spack:
       require:
       - '@5.7.1 +rocm'
       - target=x86_64_v3
+    py-iminuit:
+      require:
+      - '@2.22:'
+      - target=x86_64_v3
     rivet:
       require:
       - hepmc=3


### PR DESCRIPTION
This PR upgrades the HEP gitlab runner image from ubuntu22.04-runner-amd64-gcc-11.4:2024.03.01 to ubuntu-24.04:v2024-09-05-v2. The main motivation is a more recent system gcc that supports C++20 more fully.

Needs:
- [x] https://github.com/spack/spack/pull/50094