### PR TITLE
py-setproctitle: add v1.2.2 and v1.3.6

### DIFF
--- a/repos/spack_repo/builtin/packages/py_setproctitle/package.py
+++ b/repos/spack_repo/builtin/packages/py_setproctitle/package.py
@@ -16,6 +16,8 @@ class PySetproctitle(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.3.6", sha256="c9f32b96c700bb384f33f7cf07954bb609d35dd82752cef57fb2ee0968409169")
+    version("1.2.2", sha256="7dfb472c8852403d34007e01d6e3c68c57eb66433fb8a5c77b13b89a160d97df")
     version("1.1.10", sha256="6283b7a58477dd8478fbb9e76defb37968ee4ba47b05ec1c053cb39638bd7398")
 
     depends_on("c", type="build")  # generated


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This PR adds the latest version of py-setproctitle (1.3.6), and 1.2.2 which will be pinned by a py-ray update.

CC @theabm 