### PR TITLE
python: no recursive find in command

### DIFF
--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -930,19 +930,19 @@ class Python(Package):
         #
         # in that order if using python@3.11.0, for example.
         suffixes = [self.spec.version.up_to(2), self.spec.version.up_to(1), ""]
-        file_extension = "" if sys.platform != "win32" else ".exe"
-        patterns = [f"python{ver}{file_extension}" for ver in suffixes]
+        ext = "" if sys.platform != "win32" else ".exe"
+        filenames = [f"python{ver}{ext}" for ver in suffixes]
         root = self.prefix.bin if sys.platform != "win32" else self.prefix
-        path = find_first(root, files=patterns)
 
-        if path is not None:
-            return Executable(path)
+        for filename in filenames:
+            path = os.path.join(root, filename)
+            if is_exe(path):
+                return Executable(path)
 
-        else:
-            # Give a last try at rhel8 platform python
-            platform_python = os.path.join(self.prefix, "libexec", "platform-python")
-            if self.spec.external and self.prefix == "/usr" and is_exe(platform_python):
-                return Executable(platform_python)
+        # Give a last try at rhel8 platform python
+        platform_python = os.path.join(self.prefix, "libexec", "platform-python")
+        if self.spec.external and self.prefix == "/usr" and is_exe(platform_python):
+            return Executable(platform_python)
 
         raise RuntimeError(
             f"cannot locate the '{self.name}' command in {root} or its subdirectories"


### PR DESCRIPTION
`find_first` does not guarantee that the first pattern is returned first if multiple patterns could match files in the same directory, it just exits on the first match of *any* pattern.

I don't think recursion is necessary, so stick to testing `<prefix>/bin/pythonX.Y`, `<prefix>/bin/pythonX`, `<prefix>/bin/python` in that order.