### PR TITLE
meep: make meep depend on Fortran

### DIFF
--- a/repos/spack_repo/builtin/packages/meep/package.py
+++ b/repos/spack_repo/builtin/packages/meep/package.py
@@ -55,6 +55,7 @@ class Meep(AutotoolsPackage):
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type="build")
 
     depends_on("autoconf", type="build", when="@1.21.0:")
     depends_on("automake", type="build", when="@1.21.0:")


### PR DESCRIPTION
Meep needs Fortran to build.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
