### PR TITLE
rclone: add v1.70.2

### DIFF
--- a/repos/spack_repo/builtin/packages/rclone/package.py
+++ b/repos/spack_repo/builtin/packages/rclone/package.py
@@ -18,6 +18,7 @@ class Rclone(GoPackage):
 
     license("MIT")
 
+    version("1.70.2", sha256="982b1f09239855e7e55fb6a3b6a8146fe2ef93c8ba6e015a9c5d6ada5297ea30")
     version("1.70.0", sha256="d151d9b969dc0e000e3019c82599f53252b63fe1e63fad3c7031b718af0d0e88")
     version("1.69.3", sha256="febfd634e4eeb2e81506673debaf9af996a390dd79f215b605ac93f3d68d2b93")
     version("1.69.2", sha256="2b3fe529ad1c534db429438bad852108ff25b1df9c98a09777866b12d85b95e3")


### PR DESCRIPTION
Release notes:
- https://rclone.org/changelog/#v1-70-1-2025-06-19
- https://rclone.org/changelog/#v1-70-2-2025-06-27

Diff: https://github.com/rclone/rclone/compare/v1.70.0...v1.70.2#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6