### PR TITLE
Revert style change

### DIFF
--- a/.ci/style_check.sh
+++ b/.ci/style_check.sh
@@ -2,11 +2,9 @@
 set -x
 set -e
 
-if [ ! changed_files=$(git diff --name-only --diff-filter=ACMR HEAD^1 | grep ".*\.pyi\?") ]; then
-    exit 0  # no changed files
-fi
+changed_files=$(git diff --name-only --diff-filter=ACMR HEAD^1 | grep ".*\.pyi\?")
 
-if [ ! -z "$changed_files" ]; then
+if [ ! -z $changed_files ]; then
   echo "Detected changed..."
   for f in ${changed_files[@]}; do
     echo "  $f"

--- a/.ci/style_check.sh
+++ b/.ci/style_check.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -x
-set -e
 
 changed_files=$(git diff --name-only --diff-filter=ACMR HEAD^1 | grep ".*\.pyi\?")
 
@@ -11,6 +10,7 @@ if [ ! -z $changed_files ]; then
   done
   echo ""
 
+  set -e
   echo "Running mypy checks..."
   mypy ${changed_files[@]}
   echo ""


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Revert the previous attempt to fix this and remove `set -e` which was causing the incorrect exit code when no changed files.