### PR TITLE
Geant4-VMC: add version 6-7-p1, fix geant4 version dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/geant4_vmc/package.py
+++ b/repos/spack_repo/builtin/packages/geant4_vmc/package.py
@@ -42,6 +42,7 @@ class Geant4Vmc(CMakePackage):
     depends_on("cxx", type="build")  # generated
 
     depends_on("cmake@3.3:", type="build")
+    depends_on("cmake@3.16:", type="build", when="@6-7:")
     depends_on("geant4")
     depends_on("geant4@11.2.0:", when="@6-7:")
     depends_on("vmc")

--- a/repos/spack_repo/builtin/packages/geant4_vmc/package.py
+++ b/repos/spack_repo/builtin/packages/geant4_vmc/package.py
@@ -21,6 +21,8 @@ class Geant4Vmc(CMakePackage):
     license("GPL-3.0-only")
 
     version("master", branch="master")
+    version("6-7-p1", sha256="e1e80c78987f94d6e2f9644052a57f43946fc73309197a4c4400906d227d27ae")
+    version("6-5", sha256="e5f08ea18f52d27365c237e8866bbddbf28b82843b4e12bcd5aa832350776ed0")
     version("6-1-p1", sha256="b3115cd891192ae6cb347737854ee01a22620498f005beb7644af12461ad8b9d")
     version("5-3", sha256="22f58530963988380509a7741ad6b3dde21806f3862fb55c11cc27f25d3d3c2d")
     version("5-2", sha256="5bd0e4a4f938048b35724f06075952ecfbc8a97ffc979630cfe2788323845b13")
@@ -36,10 +38,12 @@ class Geant4Vmc(CMakePackage):
     version("4-0-p2", sha256="cdd73c499cd296f13b6c0d37e161e7d94343f85617b2a7577ded8312248f9b9b")
     version("3-6-p6", sha256="e62a62ff7075ff9afb2ffe420610374f62136094a447bbbc5f739a2238ddb0f0")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     depends_on("cmake@3.3:", type="build")
     depends_on("geant4")
+    depends_on("geant4@11.2.0:", when="@6-7:")
     depends_on("vmc")
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:


### PR DESCRIPTION
Adds version 6-7-p1 to spec for Geant4-VMC: https://github.com/vmc-project/geant4_vmc/releases/tag/v6-7-p1
Also adds an explicit version requirement for the Geant4 dependency for this version of geant4-vmc (6-7 fails to compile if concretised with earlier versions of Geant4)