### PR TITLE
Geant3: add version 4-4, fix deprecated ROOT variant dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/geant3/package.py
+++ b/repos/spack_repo/builtin/packages/geant3/package.py
@@ -41,7 +41,7 @@ class Geant3(CMakePackage):
     def cmake_args(self):
         args = []
         if self.spec.satisfies("%gcc@10:"):
-            args.append('-DCMAKE_Fortran_FLAGS="-std=legacy"')
+            args.append('-DCMAKE_Fortran_FLAGS=-fallow-argument-mismatch -fallow-invalid-boz')
         args.append(self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"))
         return args
 

--- a/repos/spack_repo/builtin/packages/geant3/package.py
+++ b/repos/spack_repo/builtin/packages/geant3/package.py
@@ -13,7 +13,8 @@ class Geant3(CMakePackage):
 
     homepage = "https://github.com/vmc-project/geant3"
     url = "https://github.com/vmc-project/geant3/archive/v3-7.tar.gz"
-
+    
+    version("4-4", sha256="31ad296d856aa282a347abcb451809e110237d8a3fd7c47458777c2c29ae47f2")
     version("4-1", sha256="a1dcab7bc7a7493e4c78d7bec22cd816e79e40992bf9db0d616e2a0125fcdf50")
     version("3-8", sha256="6ff6745eef59139d791bef043b405f6d515be1d98096cf4e82ac4c1f61f737dc")
     version("3-7", sha256="36cd57c6e5a54ff11e8687b30f54d774b676e06c55658cbc1ad787d1fadbe509")
@@ -25,7 +26,8 @@ class Geant3(CMakePackage):
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
-    depends_on("root~vmc")
+    depends_on("root")
+    depends_on("root~vmc", when="^root@:6.25")
     depends_on("vmc")
 
     variant(
@@ -39,7 +41,7 @@ class Geant3(CMakePackage):
     def cmake_args(self):
         args = []
         if self.spec.satisfies("%gcc@10:"):
-            args.append('-DCMAKE_Fortran_FLAGS="-fallow-argument-mismatch -fallow-invalid-boz"')
+            args.append('-DCMAKE_Fortran_FLAGS="-std=legacy"')
         args.append(self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"))
         return args
 

--- a/repos/spack_repo/builtin/packages/geant3/package.py
+++ b/repos/spack_repo/builtin/packages/geant3/package.py
@@ -41,7 +41,9 @@ class Geant3(CMakePackage):
     def cmake_args(self):
         args = []
         if self.spec.satisfies("%gcc@10:"):
-            args.append(self.define("CMAKE_Fortran_FLAGS", "-fallow-argument-mismatch -fallow-invalid-boz"))
+            args.append(
+                self.define("CMAKE_Fortran_FLAGS", "-fallow-argument-mismatch -fallow-invalid-boz")
+            )
         args.append(self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"))
         return args
 

--- a/repos/spack_repo/builtin/packages/geant3/package.py
+++ b/repos/spack_repo/builtin/packages/geant3/package.py
@@ -41,7 +41,7 @@ class Geant3(CMakePackage):
     def cmake_args(self):
         args = []
         if self.spec.satisfies("%gcc@10:"):
-            args.append("-DCMAKE_Fortran_FLAGS=-fallow-argument-mismatch -fallow-invalid-boz")
+            args.append(self.define("CMAKE_Fortran_FLAGS", "-fallow-argument-mismatch -fallow-invalid-boz"))
         args.append(self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"))
         return args
 

--- a/repos/spack_repo/builtin/packages/geant3/package.py
+++ b/repos/spack_repo/builtin/packages/geant3/package.py
@@ -13,7 +13,7 @@ class Geant3(CMakePackage):
 
     homepage = "https://github.com/vmc-project/geant3"
     url = "https://github.com/vmc-project/geant3/archive/v3-7.tar.gz"
-    
+
     version("4-4", sha256="31ad296d856aa282a347abcb451809e110237d8a3fd7c47458777c2c29ae47f2")
     version("4-1", sha256="a1dcab7bc7a7493e4c78d7bec22cd816e79e40992bf9db0d616e2a0125fcdf50")
     version("3-8", sha256="6ff6745eef59139d791bef043b405f6d515be1d98096cf4e82ac4c1f61f737dc")
@@ -41,7 +41,7 @@ class Geant3(CMakePackage):
     def cmake_args(self):
         args = []
         if self.spec.satisfies("%gcc@10:"):
-            args.append('-DCMAKE_Fortran_FLAGS=-fallow-argument-mismatch -fallow-invalid-boz')
+            args.append("-DCMAKE_Fortran_FLAGS=-fallow-argument-mismatch -fallow-invalid-boz")
         args.append(self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"))
         return args
 

--- a/repos/spack_repo/builtin/packages/geant3/package.py
+++ b/repos/spack_repo/builtin/packages/geant3/package.py
@@ -27,7 +27,7 @@ class Geant3(CMakePackage):
     depends_on("fortran", type="build")  # generated
 
     depends_on("root")
-    depends_on("root~vmc", when="^root@:6.25")
+    requires("^root~vmc", when="^root@:6.25")
     depends_on("vmc")
 
     variant(


### PR DESCRIPTION
Add version 4-4 to spec for Geant3: https://github.com/vmc-project/geant3/releases/tag/v4-4
Also fix reference to deprecated ROOT variant "vmc" (this variant is not defined as of ROOT 6.26, so currently specifying "root~vmc" will not allow concretisation with newer ROOT versions)