### PR TITLE
git: don't use internal API

### DIFF
--- a/repos/spack_repo/builtin/packages/git/package.py
+++ b/repos/spack_repo/builtin/packages/git/package.py
@@ -7,7 +7,6 @@ import re
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 
-import spack.fetch_strategy
 from spack.package import *
 from spack.util.environment import is_system_path
 
@@ -180,7 +179,7 @@ class Git(AutotoolsPackage):
     @classmethod
     def determine_version(cls, exe):
         output = Executable(exe)("--version", output=str, error=str)
-        match = re.search(spack.fetch_strategy.GitFetchStrategy.git_version_re, output)
+        match = re.search(r"git version (\S+)", output)
         return match.group(1) if match else None
 
     @classmethod


### PR DESCRIPTION
See https://github.com/spack/spack/issues/50388

It's not necessary to import spack.fetch_strategy

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
