### PR TITLE
Opencascade New versions and cmake argument fixes

### DIFF
--- a/repos/spack_repo/builtin/packages/opencascade/package.py
+++ b/repos/spack_repo/builtin/packages/opencascade/package.py
@@ -148,7 +148,7 @@ class Opencascade(CMakePackage):
             args.append("-DUSE_{}={}".format(feature.upper(), enabled))
             if enabled:
                 args.append(
-                    "-D3RDPARTY_{}_INCLUDE_DIR={}".format(feature.upper(), spec[depends_on].prefix)
+                    "-D3RDPARTY_{}_DIR={}".format(feature.upper(), spec[depends_on].prefix)
                 )
                 for dir in extra_dirs:
                     args.append(

--- a/repos/spack_repo/builtin/packages/opencascade/package.py
+++ b/repos/spack_repo/builtin/packages/opencascade/package.py
@@ -25,6 +25,8 @@ class Opencascade(CMakePackage):
     license("LGPL-2.1-only")
 
     with default_args(extension="tar.gz"):
+        version("7_9_1", sha256="de442298cd8860f5580b01007f67f0ecd0b8900cfa4da467fa3c823c2d1a45df")
+        version("7_9_0", sha256="151b7a522ba8220aed3009e440246abbaf2ffec42672c37e9390096f7f2c098d")
         version("7.8.1", sha256="33f2bdb67e3f6ae469f3fa816cfba34529a23a9cb736bf98a32b203d8531c523")
         version("7.8.0", sha256="b9c8f0a9d523ac1a606697f95fc39d8acf1140d3728561b8010a604431b4e9cf")
         version("7.7.2", sha256="2fb23c8d67a7b72061b4f7a6875861e17d412d524527b2a96151ead1d9cfa2c1")
@@ -118,7 +120,7 @@ class Opencascade(CMakePackage):
     conflicts("^vtk@9.2", when="@:7.7.0 +vtk")
 
     def url_for_version(self, version):
-        if self.spec.satisfies("@7.8.2:"):
+        if version > Version("7.8.1"):
             url = "https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/V{0}.tar.gz"
         else:
             url = "https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=refs/tags/V{0};sf=tgz"

--- a/repos/spack_repo/builtin/packages/opencascade/package.py
+++ b/repos/spack_repo/builtin/packages/opencascade/package.py
@@ -17,8 +17,8 @@ class Opencascade(CMakePackage):
     visualization, data exchange and rapid application development."""
 
     homepage = "https://www.opencascade.com"
-    url = "https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=refs/tags/V7_4_0;sf=tgz"
-    git = "https://git.dev.opencascade.org/repos/occt.git"
+    url = "https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/V7_4_0.tar.gz"
+    git = "https://github.com/Open-Cascade-SAS/OCCT.git"
 
     maintainers("wdconinc")
 
@@ -118,9 +118,10 @@ class Opencascade(CMakePackage):
     conflicts("^vtk@9.2", when="@:7.7.0 +vtk")
 
     def url_for_version(self, version):
-        url = (
-            "https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=refs/tags/V{0};sf=tgz"
-        )
+        if self.spec.satisfies("@7.8.2:"):
+            url = "https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/V{0}.tar.gz"
+        else:
+            url = "https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=refs/tags/V{0};sf=tgz"
         return url.format(version.underscored)
 
     def cmake_args(self):

--- a/repos/spack_repo/builtin/packages/opencascade/package.py
+++ b/repos/spack_repo/builtin/packages/opencascade/package.py
@@ -148,7 +148,7 @@ class Opencascade(CMakePackage):
             args.append("-DUSE_{}={}".format(feature.upper(), enabled))
             if enabled:
                 args.append(
-                    "-D3RDPARTY_{}_DIR={}".format(feature.upper(), spec[depends_on].prefix)
+                    "-D3RDPARTY_{}_INCLUDE_DIR={}".format(feature.upper(), spec[depends_on].prefix)
                 )
                 for dir in extra_dirs:
                     args.append(

--- a/repos/spack_repo/builtin/packages/opencascade/package.py
+++ b/repos/spack_repo/builtin/packages/opencascade/package.py
@@ -26,7 +26,7 @@ class Opencascade(CMakePackage):
 
     version("7.9.1", sha256="de442298cd8860f5580b01007f67f0ecd0b8900cfa4da467fa3c823c2d1a45df")
     version("7.9.0", sha256="151b7a522ba8220aed3009e440246abbaf2ffec42672c37e9390096f7f2c098d")
-     with default_args(extension="tar.gz"):
+    with default_args(extension="tar.gz"):
         version("7.8.1", sha256="33f2bdb67e3f6ae469f3fa816cfba34529a23a9cb736bf98a32b203d8531c523")
         version("7.8.0", sha256="b9c8f0a9d523ac1a606697f95fc39d8acf1140d3728561b8010a604431b4e9cf")
         version("7.7.2", sha256="2fb23c8d67a7b72061b4f7a6875861e17d412d524527b2a96151ead1d9cfa2c1")

--- a/repos/spack_repo/builtin/packages/opencascade/package.py
+++ b/repos/spack_repo/builtin/packages/opencascade/package.py
@@ -24,9 +24,9 @@ class Opencascade(CMakePackage):
 
     license("LGPL-2.1-only")
 
-    with default_args(extension="tar.gz"):
-        version("7_9_1", sha256="de442298cd8860f5580b01007f67f0ecd0b8900cfa4da467fa3c823c2d1a45df")
-        version("7_9_0", sha256="151b7a522ba8220aed3009e440246abbaf2ffec42672c37e9390096f7f2c098d")
+    version("7.9.1", sha256="de442298cd8860f5580b01007f67f0ecd0b8900cfa4da467fa3c823c2d1a45df")
+    version("7.9.0", sha256="151b7a522ba8220aed3009e440246abbaf2ffec42672c37e9390096f7f2c098d")
+     with default_args(extension="tar.gz"):
         version("7.8.1", sha256="33f2bdb67e3f6ae469f3fa816cfba34529a23a9cb736bf98a32b203d8531c523")
         version("7.8.0", sha256="b9c8f0a9d523ac1a606697f95fc39d8acf1140d3728561b8010a604431b4e9cf")
         version("7.7.2", sha256="2fb23c8d67a7b72061b4f7a6875861e17d412d524527b2a96151ead1d9cfa2c1")


### PR DESCRIPTION
Adjusts the git repo to point to the public GitHub mirror, rather than the official git server which requires signing a contributor license agreement.

Also fixes the CMake flags so that the 3rd party libraries are correctly found during configuration.