### PR TITLE
libogg: add v1.3.6

### DIFF
--- a/repos/spack_repo/builtin/packages/libogg/package.py
+++ b/repos/spack_repo/builtin/packages/libogg/package.py
@@ -17,16 +17,14 @@ class Libogg(CMakePackage, AutotoolsPackage, Package):
     format for the Xiph.org multimedia codecs."""
 
     homepage = "https://www.xiph.org/ogg/"
-    url = "http://downloads.xiph.org/releases/ogg/libogg-1.3.2.tar.gz"
+    url = "http://downloads.xiph.org/releases/ogg/libogg-1.3.6.tar.gz"
 
     license("BSD-3-Clause")
 
+    version("1.3.6", sha256="83e6704730683d004d20e21b8f7f55dcb3383cdf84c0daedf30bde175f774638")
     version("1.3.5", sha256="0eb4b4b9420a0f51db142ba3f9c64b333f826532dc0f48c6410ae51f4799b664")
     version("1.3.4", sha256="fe5670640bd49e828d64d2879c31cb4dde9758681bb664f9bdbf159a01b0c76e")
     version("1.3.2", sha256="e19ee34711d7af328cb26287f4137e70630e7261b17cbe3cd41011d73a654692")
-
-    depends_on("c", type="build")
-    depends_on("cxx", type="build")
 
     variant("shared", default=True, description="Build shared library", when="build_system=cmake")
     variant(
@@ -35,6 +33,11 @@ class Libogg(CMakePackage, AutotoolsPackage, Package):
         description="Produce position-independent code (for shared libs)",
         when="build_system=cmake",
     )
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build", when="@1.3.4:1.3.5")
+    depends_on("cmake@3.6:", type="build", when="@1.3.6:")
+    depends_on("cmake@2.8.12:", type="build", when="@1.3.4:1.3.5")
 
     requires("+pic", when="+shared")
 


### PR DESCRIPTION
Adding latest libogg patch release v1.3.6. Also updating some constraints.

Release notes: https://github.com/xiph/ogg/blob/main/CHANGES

C++ compiler not actually needed: https://github.com/xiph/ogg/commit/e11af601c79e642c50343c6e69dbaf03fcd6be9f