### PR TITLE
Tidyup NCCL support for aws-ofi-nccl plugin

### DIFF
--- a/repos/spack_repo/builtin/packages/aws_ofi_nccl/package.py
+++ b/repos/spack_repo/builtin/packages/aws_ofi_nccl/package.py
@@ -46,7 +46,7 @@ class AwsOfiNccl(AutotoolsPackage):
 
     depends_on("libfabric")
     depends_on("cuda")
-    depends_on("nccl")
+    depends_on("nccl fabrics=auto")
     depends_on("mpi")
     depends_on("hwloc", when="@1.7:")
     depends_on("autoconf", type="build")
@@ -62,6 +62,8 @@ class AwsOfiNccl(AutotoolsPackage):
     # To enable this plug-in to work with NCCL add it to the LD_LIBRARY_PATH
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         env.append_path("LD_LIBRARY_PATH", self.prefix.lib)
+        # Set the this network so that NCCL doesnt pick up anything else.
+        env.set("NCCL_NET", "AWS Libfabric")
 
     # To enable this plug-in to work with NCCL add it to the LD_LIBRARY_PATH
     def setup_dependent_run_environment(

--- a/repos/spack_repo/builtin/packages/aws_ofi_nccl/package.py
+++ b/repos/spack_repo/builtin/packages/aws_ofi_nccl/package.py
@@ -62,7 +62,7 @@ class AwsOfiNccl(AutotoolsPackage):
     # To enable this plug-in to work with NCCL add it to the LD_LIBRARY_PATH
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         env.append_path("LD_LIBRARY_PATH", self.prefix.lib)
-        # Set the this network so that NCCL doesnt pick up anything else.
+        # Set the network so that NCCL doesn't pick up anything else.
         env.set("NCCL_NET", "AWS Libfabric")
 
     # To enable this plug-in to work with NCCL add it to the LD_LIBRARY_PATH

--- a/repos/spack_repo/builtin/packages/nccl/package.py
+++ b/repos/spack_repo/builtin/packages/nccl/package.py
@@ -68,9 +68,11 @@ class Nccl(MakefilePackage, CudaPackage):
 
     # Make verbs default but package like aws-ofi-nccl can be used instead which loads
     # another library to use instead at runtime.
-    values=disjoint_sets(("auto",), ("verbs",))  # supported transports
-        .with_default("verbs")
-        .with_non_feature_values("auto"),
+    variant(
+        "fabrics",
+        values=disjoint_sets(("auto",), ("verbs",))  # supported transports
+            .with_default("verbs")
+            .with_non_feature_values("auto"),
         description="List of fabrics that are enabled; " "'auto' lets nccl determine at runtime",
     )
 

--- a/repos/spack_repo/builtin/packages/nccl/package.py
+++ b/repos/spack_repo/builtin/packages/nccl/package.py
@@ -71,8 +71,8 @@ class Nccl(MakefilePackage, CudaPackage):
     variant(
         "fabrics",
         values=disjoint_sets(("auto",), ("verbs",))  # supported transports
-            .with_default("verbs")
-            .with_non_feature_values("auto"),
+        .with_default("verbs")
+        .with_non_feature_values("auto"),
         description="List of fabrics that are enabled; " "'auto' lets nccl determine at runtime",
     )
 

--- a/repos/spack_repo/builtin/packages/nccl/package.py
+++ b/repos/spack_repo/builtin/packages/nccl/package.py
@@ -66,14 +66,14 @@ class Nccl(MakefilePackage, CudaPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    # Make verbs default but package like aws-ofi-nccl can be used instead which loads
+    # Make verbs default but packages like aws-ofi-nccl can be used instead which loads
     # another library to use instead at runtime.
     variant(
         "fabrics",
         values=disjoint_sets(("auto",), ("verbs",))  # supported transports
         .with_default("verbs")
         .with_non_feature_values("auto"),
-        description="List of fabrics that are enabled; " "'auto' lets nccl determine at runtime",
+        description="List of fabrics that are enabled; 'auto' lets nccl determine at runtime",
     )
 
     depends_on("rdma-core", when="fabrics=verbs", type="run")

--- a/repos/spack_repo/builtin/packages/nccl/package.py
+++ b/repos/spack_repo/builtin/packages/nccl/package.py
@@ -68,14 +68,9 @@ class Nccl(MakefilePackage, CudaPackage):
 
     # Make verbs default but package like aws-ofi-nccl can be used instead which loads
     # another library to use instead at runtime.
-    variant(
-        "fabrics",
-        values=disjoint_sets(
-            ("auto",),
-            (
-                "verbs",
-            ),  # supported transports
-        ).with_default("verbs").with_non_feature_values("auto"),
+    values=disjoint_sets(("auto",), ("verbs",))  # supported transports
+        .with_default("verbs")
+        .with_non_feature_values("auto"),
         description="List of fabrics that are enabled; " "'auto' lets nccl determine at runtime",
     )
 

--- a/repos/spack_repo/builtin/packages/nccl/package.py
+++ b/repos/spack_repo/builtin/packages/nccl/package.py
@@ -66,7 +66,20 @@ class Nccl(MakefilePackage, CudaPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    depends_on("rdma-core")
+    # Make verbs default but package like aws-ofi-nccl can be used instead which loads
+    # another library to use instead at runtime.
+    variant(
+        "fabrics",
+        values=disjoint_sets(
+            ("auto"),
+            (
+                "verbs",
+            ),  # supported transports
+        ).with_default("verbs").with_non_feature_values("auto"),
+        description="List of fabrics that are enabled; " "'auto' lets nccl determine at runtime",
+    )
+
+    depends_on("rdma-core", when="fabrics=verbs", type="run")
 
     # https://github.com/NVIDIA/nccl/issues/244
     patch("so_reuseport.patch", when="@2.3.7-1:2.4.8-1")

--- a/repos/spack_repo/builtin/packages/nccl/package.py
+++ b/repos/spack_repo/builtin/packages/nccl/package.py
@@ -71,7 +71,7 @@ class Nccl(MakefilePackage, CudaPackage):
     variant(
         "fabrics",
         values=disjoint_sets(
-            ("auto"),
+            ("auto",),
             (
                 "verbs",
             ),  # supported transports


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Following work in spack/spack#47527 these are the changes to tidyup the support for aws-ofi-nccl plugin which is used on machines such as HPE with Slingshot 11.  Tested in environment with:

```
  specs:
  - aws-ofi-nccl ^nccl+cuda cuda_arch=90
  - nccl-tests+mpi cuda_arch=90
```