### PR TITLE
root: patch handling of CMAKE_INSTALL_RPATH

### DIFF
--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -976,6 +976,10 @@ class Root(CMakePackage):
             options.append(define("FTGL_ROOT_DIR", ftgl_prefix))
             options.append(define("FTGL_INCLUDE_DIR", ftgl_prefix.include))
 
+        # Fix RPath handling with gnuinstall
+        if "+rpath" in self.spec:
+            options.append(define("CMAKE_INSTALL_RPATH", self.prefix.lib.root))
+
         return options
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:


### PR DESCRIPTION
Potential fix to address https://github.com/spack/spack-packages/issues/215 (issues installing ROOT >=6.36 library RPaths on Mac OSX).

Currently, the situation is the following:
- ROOT installs its libraries into `$prefix/lib/root` due to the "gnuinstall" install option
- Spack's CMake package builder only allows for `CMAKE_INSTALL_RPATH` values of `$prefix/lib` and `$prefix/lib64` (hardcoded)
- Prior to ROOT 6.36, ROOT overrode the `CMAKE_INSTALL_RPATH` with `@loader_path` and `@loader_path/${BINDIR_TO_LIBDIR}` in its CMake configuration. Since 6.36, these are instead _appended_ to the INSTALL_RPATH.
- At install time, `install_name_tool` sees `$prefix/lib` in both `CMAKE_INSTALL_RPATH` and in the paths already included from `CMAKE_INSTALL_RPATH_USE_LINK_PATH`, and refuses to add the `@loader_path` paths to the binary as a result. This means that the libraries don't get linked properly and ROOT fails at runtime.

This PR would override the `CMAKE_INSTALL_RPATH` with `$prefix/lib/root` by adding it to the CMake options on the RPath variant. The existing `$prefix/lib` and `/lib64` are still part of the link path directories, but since there's no longer the clash with the install RPaths, all of the correct paths get added to the installation.

Admittedly this is probably not the cleanest way of dealing with this issue, but I couldn't find a better way of overriding or adding the correct library dir to the `CMAKE_INSTALL_PATH` with the current version of the CMakePackage build system in Spack.