### PR TITLE
seacas: conjoin fixes, ioss parallel mapping error fix, catalyst2

### DIFF
--- a/repos/spack_repo/builtin/packages/seacas/package.py
+++ b/repos/spack_repo/builtin/packages/seacas/package.py
@@ -37,6 +37,9 @@ class Seacas(CMakePackage):
     # ###################### Versions ##########################
     version("master", branch="master")
     version(
+        "2025-06-27", sha256="c28f40504b2322cd69e7df6efea1e3be289a7f98a6e533c53655513d18add7bb"
+    )
+    version(
         "2025-06-07", sha256="2974705f2859e30bca48b619fda078bb771c0e94381af9e624749afb9fd72780"
     )
     version(


### PR DESCRIPTION
### Conjoin
* Each part mesh can have different variable counts and names
* Add use_all_times option
### What's Changed
* Build system can handle paths that contain regex characters (e.g. c++)
* Catalyst2 updates

See https://github.com/sandialabs/seacas/releases/tag/v2025-06-27

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
