### PR TITLE
hypre: post install may not depend on CXX

### DIFF
--- a/repos/spack_repo/builtin/packages/hypre/package.py
+++ b/repos/spack_repo/builtin/packages/hypre/package.py
@@ -402,7 +402,7 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
         makefile = join_path(install_test_root(self), self.extra_install_tests, "Makefile")
         filter_file(r"^HYPRE_DIR\s* =.*", f"HYPRE_DIR = {self.prefix}", makefile)
         filter_file(r"^CC\s*=.*", f"CC = {os.environ['CC']}", makefile)
-        if "CXX" in os.environ:
+        if "cxx" in self.spec:
             filter_file(r"^CXX\s*=.*", f"CXX = {os.environ['CXX']}", makefile)
         if self.spec.satisfies("+fortran"):
             filter_file(r"^F77\s*=.*", f"F77 = {os.environ['F77']}", makefile)

--- a/repos/spack_repo/builtin/packages/hypre/package.py
+++ b/repos/spack_repo/builtin/packages/hypre/package.py
@@ -402,7 +402,8 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
         makefile = join_path(install_test_root(self), self.extra_install_tests, "Makefile")
         filter_file(r"^HYPRE_DIR\s* =.*", f"HYPRE_DIR = {self.prefix}", makefile)
         filter_file(r"^CC\s*=.*", f"CC = {os.environ['CC']}", makefile)
-        filter_file(r"^CXX\s*=.*", f"CXX = {os.environ['CXX']}", makefile)
+        if 'CXX' in os.environ:
+            filter_file(r"^CXX\s*=.*", f"CXX = {os.environ['CXX']}", makefile)
         if self.spec.satisfies("+fortran"):
             filter_file(r"^F77\s*=.*", f"F77 = {os.environ['F77']}", makefile)
 

--- a/repos/spack_repo/builtin/packages/hypre/package.py
+++ b/repos/spack_repo/builtin/packages/hypre/package.py
@@ -402,7 +402,7 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
         makefile = join_path(install_test_root(self), self.extra_install_tests, "Makefile")
         filter_file(r"^HYPRE_DIR\s* =.*", f"HYPRE_DIR = {self.prefix}", makefile)
         filter_file(r"^CC\s*=.*", f"CC = {os.environ['CC']}", makefile)
-        if 'CXX' in os.environ:
+        if "CXX" in os.environ:
             filter_file(r"^CXX\s*=.*", f"CXX = {os.environ['CXX']}", makefile)
         if self.spec.satisfies("+fortran"):
             filter_file(r"^F77\s*=.*", f"F77 = {os.environ['F77']}", makefile)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
When package does not depend on cxx, the run after install cache_test_sources function filters CXX with a non existing variable. This PR intends to make sure os.environ['CXX'] exists.