### PR TITLE
intel-oneapi: enable determining openmp runtime

### DIFF
--- a/repos/spack_repo/builtin/build_systems/oneapi.py
+++ b/repos/spack_repo/builtin/build_systems/oneapi.py
@@ -18,6 +18,7 @@ from spack.package import (
     InstallError,
     LibraryList,
     conflicts,
+    depends_on,
     find_libraries,
     join_path,
     license,
@@ -190,8 +191,14 @@ class IntelOneApiLibraryPackage(IntelOneApiPackage):
     Contains some convenient default implementations for libraries.
     Implement the method directly in the package if something
     different is needed.
-
     """
+
+    # HFP: for the time being, this package queries
+    # - compiler for its library path
+    # - spec about C-compiler
+    # Depending on a lanaguage seem to enable above.
+    #
+    depends_on("c", type="build")
 
     def openmp_libs(self):
         """Supply LibraryList for linking OpenMP"""
@@ -285,7 +292,7 @@ class IntelOneApiLibraryPackageWithSdk(IntelOneApiLibraryPackage):
         return find_libraries("*", self.component_prefix.sdk.lib64)
 
 
-class IntelOneApiStaticLibraryList:
+class IntelOneApiStaticLibraryList(LibraryList):
     """Provides ld_flags when static linking is needed
 
     Oneapi puts static and dynamic libraries in the same directory, so

--- a/repos/spack_repo/builtin/packages/intel_oneapi_mkl/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_mkl/package.py
@@ -21,7 +21,6 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
     applications. Core math functions include BLAS, LAPACK,
     ScaLAPACK, sparse solvers, fast Fourier transforms, and vector
     math.
-
     """
 
     maintainers("rscohn2")
@@ -191,7 +190,7 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         msg="MKL with OpenMP threading requires GCC, clang, or Intel compilers",
     )
 
-    depends_on("tbb")
+    depends_on("tbb", when="threads=tbb")
     # cluster libraries need mpi
     depends_on("mpi", when="+cluster")
 
@@ -206,10 +205,9 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         requires("mpi_family=openmpi", when="^[virtuals=mpi] openmpi")
         requires("mpi_family=openmpi", when="^[virtuals=mpi] hpcx-mpi")
 
-    provides("fftw-api@3")
     provides("scalapack", when="+cluster")
-    provides("mkl")
-    provides("lapack", "blas")
+    provides("lapack", "blas", "mkl")
+    provides("fftw-api@3")
 
     @run_after("install")
     def fixup_installation(self):


### PR DESCRIPTION
- intel-oneapi-mkl: enable threads!=none (see [PR#16](https://github.com/spack/spack-packages/pull/16) and [PR#401](https://github.com/spack/spack-packages/pull/401)).
- intel-oneapi-mkl: made TBB-dependency conditional.
- Fixed missing base class (IntelOneApiStaticLibraryList).

Recent changes in Spack seem to be related to the issue. For the time being (prior to Spack 2.0?), a resolution or workaround is needed. Having a workaround like `depends_on("c", type="build")` at the level of `oneapi.py` seems reasonable (intel-oneapi-mkl package can avoid a direct dependency on the workaround).