### PR TITLE
lizard: Add version 2.1

### DIFF
--- a/repos/spack_repo/builtin/packages/lizard/package.py
+++ b/repos/spack_repo/builtin/packages/lizard/package.py
@@ -19,6 +19,7 @@ class Lizard(MakefilePackage):
     git = "https://github.com/inikep/lizard.git"
 
     version("develop", branch="lizard")
+    version("2.1", sha256="0c1a7efceeb8ae66bfa2b7b659f01dec120925d846b01ce4dfc6960ba8cd61e5")
     version("2.0", sha256="85456b7274c9f0e477ff8e3f06dbc2f8ee8619d737a73c730c8a1adacb45f6da")
     version("1.0", sha256="6f666ed699fc15dc7fdaabfaa55787b40ac251681b50c0d8df017c671a9457e6")
 


### PR DESCRIPTION
This version of lizard fixes compilation issues with gcc and clang.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
