### PR TITLE
hdfview: add new version and java usage

### DIFF
--- a/repos/spack_repo/builtin/packages/hdfview/package.py
+++ b/repos/spack_repo/builtin/packages/hdfview/package.py
@@ -59,7 +59,7 @@ class Hdfview(Package):
 
         # set the javabin to be spack's java
         filter_file(
-            r"export JAVABIN.+", f"export JAVABIN={self.spec["java"].prefix}/bin/", hdfview
+            r"export JAVABIN=.+", f"export JAVABIN={self.spec['java'].prefix}/bin", hdfview
         )
 
         mkdirp(prefix.bin)

--- a/repos/spack_repo/builtin/packages/hdfview/package.py
+++ b/repos/spack_repo/builtin/packages/hdfview/package.py
@@ -58,9 +58,9 @@ class Hdfview(Package):
         filter_file(r"/lib/app", "", hdfview)
 
         # set the javabin to be spack's java
-        filter_file(r"export JAVABIN.+", 
-            f"export JAVABIN={self.spec["java"].prefix}/bin/",
-             hdfview)
+        filter_file(r"export JAVABIN.+",
+                    f"export JAVABIN={self.spec["java"].prefix}/bin/",
+                    hdfview)
 
         mkdirp(prefix.bin)
         install(hdfview, prefix.bin.hdfview)
@@ -83,4 +83,4 @@ class Hdfview(Package):
 
         url_fmt = "https://support.hdfgroup.org/ftp/HDF5/releases/HDF-JAVA/hdfview-{0}/src/hdfview-{0}.tar.gz"
         return url_fmt.format(version)
-        
+

--- a/repos/spack_repo/builtin/packages/hdfview/package.py
+++ b/repos/spack_repo/builtin/packages/hdfview/package.py
@@ -78,7 +78,7 @@ class Hdfview(Package):
 
         # the new versions have a complex https://objects.githubusercontent.com url so use the
         # github release
-        if version >= Version("3.3.0"):
+        if version > Version("3.3.0"):
             return super().url_for_version(version)
 
         url_fmt = "https://support.hdfgroup.org/ftp/HDF5/releases/HDF-JAVA/hdfview-{0}/src/hdfview-{0}.tar.gz"

--- a/repos/spack_repo/builtin/packages/hdfview/package.py
+++ b/repos/spack_repo/builtin/packages/hdfview/package.py
@@ -50,10 +50,14 @@ class Hdfview(Package):
         path = "build/HDF_Group/HDFView/{0}/".format(dir_version)
         hdfview = "{0}/{1}".format(path, "hdfview.sh")
 
+        # set the internal dir to be the spack install prefix
         filter_file(r"\$dir", prefix, hdfview)
 
+        # the wrapper script looks for these subdirectories, however they are not
+        # in the spackk install prefix, so filter out
         filter_file(r"/lib/app", "", hdfview)
 
+        # set the javabin to be spack's java
         filter_file(r"export JAVABIN.+", 
             f"export JAVABIN={self.spec["java"].prefix}/bin/",
              hdfview)

--- a/repos/spack_repo/builtin/packages/hdfview/package.py
+++ b/repos/spack_repo/builtin/packages/hdfview/package.py
@@ -14,8 +14,9 @@ class Hdfview(Package):
     and editing HDF (HDF5 and HDF4) files."""
 
     homepage = "https://www.hdfgroup.org/downloads/hdfview/"
-    url = "https://support.hdfgroup.org/ftp/HDF5/releases/HDF-JAVA/hdfview-3.1.4/src/hdfview-3.1.4.tar.gz"
+    url = "https://github.com/HDFGroup/hdfview/releases/download/v3.3.2/HDFView-3.3.2.tar.gz"
 
+    version("3.3.2", sha256="6e83811ae98a45b82023baeca5335b9cfafd75d9f4cada93661896618b2b47aa")
     version("3.3.0", sha256="0916161861c21fa8dd354b445b48eff5a53d80a5c0b383e79eb64b7b108e2430")
     version("3.2.0", sha256="d3c0deff2cbd959508c4da9c712da72fb204ff6818a3434f00a7071f8e8cf2b8")
     version("3.1.4", sha256="898fcd5227d4e7b697efde5e5a969405f96b72517f9dfbdbdce2991290fd56a0")
@@ -30,6 +31,10 @@ class Hdfview(Package):
     patch("fix_build.patch", when="@3.1.1")
 
     depends_on("ant", type="build")
+
+    depends_on("java")
+    depends_on("java@21:", when="@3.3.2:")
+
     depends_on("hdf5 +java")
     depends_on("hdf +java -external-xdr +shared")
 
@@ -47,6 +52,12 @@ class Hdfview(Package):
 
         filter_file(r"\$dir", prefix, hdfview)
 
+        filter_file(r"/lib/app", "", hdfview)
+
+        filter_file(r"export JAVABIN.+", 
+            f"export JAVABIN={self.spec["java"].prefix}/bin/",
+             hdfview)
+
         mkdirp(prefix.bin)
         install(hdfview, prefix.bin.hdfview)
         chmod = which("chmod")
@@ -57,3 +68,15 @@ class Hdfview(Package):
         env.set("HDF5LIBS", self.spec["hdf5"].prefix)
         env.set("HDFLIBS", self.spec["hdf"].prefix)
         env.set("ANT_HOME", self.spec["ant"].prefix)
+        env.set("JAVA_HOME ", self.spec["java"].prefix)
+
+    def url_for_version(self, version):
+
+        # the new versions have a complex https://objects.githubusercontent.com url so use the
+        # github release
+        if version >= Version("3.3.0"):
+            return super().url_for_version(version)
+
+        url_fmt = "https://support.hdfgroup.org/ftp/HDF5/releases/HDF-JAVA/hdfview-{0}/src/hdfview-{0}.tar.gz"
+        return url_fmt.format(version)
+        

--- a/repos/spack_repo/builtin/packages/hdfview/package.py
+++ b/repos/spack_repo/builtin/packages/hdfview/package.py
@@ -58,9 +58,9 @@ class Hdfview(Package):
         filter_file(r"/lib/app", "", hdfview)
 
         # set the javabin to be spack's java
-        filter_file(r"export JAVABIN.+",
-                    f"export JAVABIN={self.spec["java"].prefix}/bin/",
-                    hdfview)
+        filter_file(
+            r"export JAVABIN.+", f"export JAVABIN={self.spec["java"].prefix}/bin/", hdfview
+        )
 
         mkdirp(prefix.bin)
         install(hdfview, prefix.bin.hdfview)
@@ -83,4 +83,3 @@ class Hdfview(Package):
 
         url_fmt = "https://support.hdfgroup.org/ftp/HDF5/releases/HDF-JAVA/hdfview-{0}/src/hdfview-{0}.tar.gz"
         return url_fmt.format(version)
-


### PR DESCRIPTION
This
- adds version 3.3.2
- ensure java as a direct dependency and ensure the correct version is used
- fixes how java is specified in the `hdfview.sh` wrapper script. Even with 3.3.0 I couldn't launch the GUI because the classpaths were wrong. It's not clear to me when this might have changed, or that it ever worked before as paths that don't exist are used as cps.
- fixes JAVABIN in wrapper script to point to java. Also unclear that this ever worked previously.
- The URL for 3.3.2+ has updated so now directly uses the github release source tarball
