### PR TITLE
SpFFT: append missing language dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/spfft/package.py
+++ b/repos/spack_repo/builtin/packages/spfft/package.py
@@ -52,6 +52,10 @@ class Spfft(CMakePackage, CudaPackage, ROCmPackage):
         description="CMake build type",
         values=("Debug", "Release", "RelWithDebInfo"),
     )
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build", when="+fortran")
     depends_on("fftw-api@3")
     depends_on("mpi", when="+mpi")
     depends_on("cmake@3.11:", type="build")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
SpFFT uses cxx and fortran compiler. This PR adds virtual dependencies for these compiler uses.

Maintainers:
@AdhocMan  @haampie