### PR TITLE
TexLive: add version constraint of MPFR.

### DIFF
--- a/repos/spack_repo/builtin/packages/texlive/package.py
+++ b/repos/spack_repo/builtin/packages/texlive/package.py
@@ -97,7 +97,7 @@ class Texlive(AutotoolsPackage):
     depends_on("libpng")
     depends_on("libxaw")
     depends_on("libxt")
-    depends_on("mpfr")
+    depends_on("mpfr@4:")
     depends_on("perl")
     depends_on("pixman")
     depends_on("poppler@:0.83", when="@:2019")


### PR DESCRIPTION
TeXLive uses MPFI, which uses `mpfr_erandom`, that requires a mpfr with version at least 4.0 .

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
