### PR TITLE
lhapdf: add gpu version

### DIFF
--- a/repos/spack_repo/builtin/packages/lhapdf/package.py
+++ b/repos/spack_repo/builtin/packages/lhapdf/package.py
@@ -24,6 +24,7 @@ class Lhapdf(AutotoolsPackage):
 
     license("GPL-3.0-or-later")
 
+    version("gpu", branch="kokkos_version")
     version("6.5.5", sha256="d20d8fb71936403274caec5bd584c891592b96c6319175df51d9bb69db869bd8")
     version("6.5.4", sha256="ace8913781044ad542e378697fcd95a8535d510818bb74a6665f9fd2b132ac0f")
     version("6.5.3", sha256="90fe7254d5a48a9b2d424fcbac1bf9708b0e54690efec4c78e9ad28b9203bfcd")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This adds the `gpu` version, which installs a feature branch of LHAPDF with support for usage on GPU (via CUDA and via Kokkos). This feature has not yet been integrated into an LHAPDF release, but it is very useful, e.g. to run parton-level event generators with GPU acceleration, such as [Pepper](https://gitlab.com/spice-mc/pepper). If this Pull Request is accepted, I plan to submit another one which adds a Spack package for Pepper.

This is my first contribution to `spack-packages`.