### PR TITLE
tinyxml2: fix cmake phase

### DIFF
--- a/repos/spack_repo/builtin/packages/tinyxml2/package.py
+++ b/repos/spack_repo/builtin/packages/tinyxml2/package.py
@@ -29,6 +29,7 @@ class Tinyxml2(CMakePackage):
 
     variant("shared", default=False, description="Build shared library")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     def cmake_args(self):


### PR DESCRIPTION
Error: the C compiler is not able to compile a simple test program
Fix: add depends_on 'c'

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
