### PR TITLE
omb-micro-benchmarks: add v7.5.1

### DIFF
--- a/repos/spack_repo/builtin/packages/osu_micro_benchmarks/package.py
+++ b/repos/spack_repo/builtin/packages/osu_micro_benchmarks/package.py
@@ -23,7 +23,7 @@ class OsuMicroBenchmarks(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     maintainers("natshineman", "harisubramoni", "MatthewLieber")
 
-    version("v7.5.1", sha256="b4c696b3d9ceabb8263ab24e01436871951c02272bb7afc47a25a4900b54ec6e")
+    version("7.5.1", sha256="160d0d5e3c3cb022520ecb247e9875bb0973b1d3cadccd6c17624f8407c52e22")
     version("7.5", sha256="1cf84ac5419456202757a757c5f9a4f5c6ecd05c65783c7976421cfd6020b3b3")
     version("7.4", sha256="1edd0c2efa61999409bfb28740a7f39689a5b42b1a1b4c66d1656e5637f7cefc")
     version("7.3", sha256="8fa25b8aaa34e4b07ab3a4f30b7690ab46b038b08d204a853a9b6aa7bdb02f2f")

--- a/repos/spack_repo/builtin/packages/osu_micro_benchmarks/package.py
+++ b/repos/spack_repo/builtin/packages/osu_micro_benchmarks/package.py
@@ -23,6 +23,7 @@ class OsuMicroBenchmarks(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     maintainers("natshineman", "harisubramoni", "MatthewLieber")
 
+    version("v7.5.1", sha256="b4c696b3d9ceabb8263ab24e01436871951c02272bb7afc47a25a4900b54ec6e")
     version("7.5", sha256="1cf84ac5419456202757a757c5f9a4f5c6ecd05c65783c7976421cfd6020b3b3")
     version("7.4", sha256="1edd0c2efa61999409bfb28740a7f39689a5b42b1a1b4c66d1656e5637f7cefc")
     version("7.3", sha256="8fa25b8aaa34e4b07ab3a4f30b7690ab46b038b08d204a853a9b6aa7bdb02f2f")


### PR DESCRIPTION
Adding the hash for the v7.5.1 release of OSU Mircobenchmarks
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
