### PR TITLE
dplasma: new package + required updates to parsec package

### DIFF
--- a/repos/spack_repo/builtin/packages/dplasma/package.py
+++ b/repos/spack_repo/builtin/packages/dplasma/package.py
@@ -10,11 +10,11 @@ from spack.package import *
 
 
 class Dplasma(CMakePackage, CudaPackage):
-    """"DPLASMA is a highly optimized, accelerator-aware, implementation of a
+    """DPLASMA is a highly optimized, accelerator-aware, implementation of a
     dense linear algebra package for distributed heterogeneous systems. It is
     designed to deliver sustained performance for distributed systems where each
     node featuring multiple sockets of multicore processors, and if available,
-    accelerators, using the PaRSEC runtime as a backend. """
+    accelerators, using the PaRSEC runtime as a backend."""
 
     homepage = "https://github.com/ICLDisco/dplasma"
     git = "https://github.com/ICLDisco/dplasma.git"

--- a/repos/spack_repo/builtin/packages/dplasma/package.py
+++ b/repos/spack_repo/builtin/packages/dplasma/package.py
@@ -1,0 +1,57 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+#
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems.cuda import CudaPackage
+from spack.package import *
+
+
+class Dplasma(CMakePackage, CudaPackage):
+    """"DPLASMA is a highly optimized, accelerator-aware, implementation of a
+    dense linear algebra package for distributed heterogeneous systems. It is
+    designed to deliver sustained performance for distributed systems where each
+    node featuring multiple sockets of multicore processors, and if available,
+    accelerators, using the PaRSEC runtime as a backend. """
+
+    homepage = "https://github.com/ICLDisco/dplasma"
+    git = "https://github.com/ICLDisco/dplasma.git"
+    maintainers("G-Ragghianti", "abouteiller", "bosilca", "herault")
+
+    license("BSD-3-Clause-Open-MPI")
+
+    version("develop", branch="master")
+
+    variant(
+        "build_type",
+        default="RelWithDebInfo",
+        description="CMake build type",
+        values=("Debug", "Release", "RelWithDebInfo"),
+    )
+    variant("shared", default=True, description="Build a shared library")
+    variant("cuda", default=True, description="Build with CUDA")
+    variant("internal-parsec", default="False", description="Build with internal PaRSEC")
+
+    depends_on("c", type="build")
+    depends_on("cmake@3.18:", type="build")
+    depends_on("python", type="build")
+    depends_on("flex", type="build")
+    depends_on("bison", type="build")
+    depends_on("hwloc")
+    depends_on("mpi")
+    depends_on("blas")
+    depends_on("lapack")
+    depends_on("parsec+cuda", when="~internal-parsec+cuda")
+    depends_on("parsec~cuda", when="~internal-parsec~cuda")
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("CMAKE_BUILD_TYPE", "build_type"),
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define_from_variant("DPLASMA_GPU_WITH_CUDA", "cuda"),
+            self.define("DPLASMA_GPU_WITH_HIP", "Off"),
+        ]
+        if "~internal-parsec" in self.spec:
+            args.append(self.define("PaRSEC_ROOT", self.spec["parsec"].prefix))
+        return args

--- a/repos/spack_repo/builtin/packages/dplasma/package.py
+++ b/repos/spack_repo/builtin/packages/dplasma/package.py
@@ -5,6 +5,7 @@
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
+
 from spack.package import *
 
 

--- a/repos/spack_repo/builtin/packages/parsec/apply-header.patch
+++ b/repos/spack_repo/builtin/packages/parsec/apply-header.patch
@@ -1,0 +1,14 @@
+diff --git a/parsec/data_dist/matrix/CMakeLists.txt b/parsec/data_dist/matrix/CMakeLists.txt
+index 51beffec2..597557c08 100644
+--- a/parsec/data_dist/matrix/CMakeLists.txt
++++ b/parsec/data_dist/matrix/CMakeLists.txt
+@@ -32,7 +32,7 @@ if( TARGET parsec-ptgpp )
+   target_ptg_sources(parsec PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/reduce_col.jdf;${CMAKE_CURRENT_SOURCE_DIR}/reduce_row.jdf;${CMAKE_CURRENT_SOURCE_DIR}/reduce.jdf;${CMAKE_CURRENT_SOURCE_DIR}/diag_band_to_rect.jdf;${CMAKE_CURRENT_SOURCE_DIR}/apply.jdf")
+   set_property(TARGET parsec
+                APPEND PROPERTY
+-                      PRIVATE_HEADER_H data_dist/matrix/diag_band_to_rect.h)
++                      PRIVATE_HEADER_H data_dist/matrix/diag_band_to_rect.h data_dist/matrix/apply.h)
+ endif( TARGET parsec-ptgpp )
+ 
+ target_sources(parsec PRIVATE ${sources})
+

--- a/repos/spack_repo/builtin/packages/parsec/package.py
+++ b/repos/spack_repo/builtin/packages/parsec/package.py
@@ -37,8 +37,8 @@ class Parsec(CMakePackage, CudaPackage):
         url="https://github.com/ICLDisco/parsec/archive/refs/tags/v1.1.0.tar.gz",
     )
 
-    // Add data_dist/matrix/apply.h to the list of header files to install.
-    // This is required for building against this parsec installation.
+    # Add data_dist/matrix/apply.h to the list of header files to install.
+    # This is required for building against this parsec installation.
     patch("apply-header.patch", when="@4.0.2411")
 
     variant(

--- a/repos/spack_repo/builtin/packages/parsec/package.py
+++ b/repos/spack_repo/builtin/packages/parsec/package.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 #
 
-
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 
@@ -37,6 +36,8 @@ class Parsec(CMakePackage, CudaPackage):
         sha256="d1e038713f2c1cd7db6765c891408d85648c46ee23e780fbd5e941b53c9eef85",
         url="https://github.com/ICLDisco/parsec/archive/refs/tags/v1.1.0.tar.gz",
     )
+
+    patch("apply-header.patch", when="@4.0.2411")
 
     variant(
         "build_type",
@@ -85,6 +86,7 @@ class Parsec(CMakePackage, CudaPackage):
             self.define_from_variant("PARSEC_PROF_TRACE", "profile"),
             self.define_from_variant("PARSEC_DEBUG_HISTORY", "debug_verbose"),
             self.define_from_variant("PARSEC_DEBUG_PARANOID", "debug_verbose"),
+            self.define("PARSEC_GPU_WITH_HIP", "Off"),
         ]
         return args
 

--- a/repos/spack_repo/builtin/packages/parsec/package.py
+++ b/repos/spack_repo/builtin/packages/parsec/package.py
@@ -37,6 +37,8 @@ class Parsec(CMakePackage, CudaPackage):
         url="https://github.com/ICLDisco/parsec/archive/refs/tags/v1.1.0.tar.gz",
     )
 
+    // Add data_dist/matrix/apply.h to the list of header files to install.
+    // This is required for building against this parsec installation.
     patch("apply-header.patch", when="@4.0.2411")
 
     variant(


### PR DESCRIPTION
This adds a new package to spack for the dplasma project and applies a patch to the parsec package to include a missing header file that is required for building against parsec.