### PR TITLE
BlisBase: Exposing the optional ability to target alternative build configurations

### DIFF
--- a/repos/spack_repo/builtin/packages/blis/package.py
+++ b/repos/spack_repo/builtin/packages/blis/package.py
@@ -11,6 +11,13 @@ from spack.package import *
 # https://github.com/flame/blis/issues/195
 # https://github.com/flame/blis/issues/197
 
+# Define a mapping between the selected architecture and the Blis config target
+_targets = [
+    # Arch, Target
+    ["x86_64", "x86_64"],
+    ["zen", "zen"],
+]
+
 
 class BlisBase(MakefilePackage):
     """Base class for building BLIS, shared with the AMD optimized version
@@ -83,8 +90,12 @@ class BlisBase(MakefilePackage):
         return config_args
 
     def edit(self, spec, prefix):
-        # To ensure auto should always be the last argument for base and derived class
-        config_args = self.configure_args() + ["auto"]
+        # To ensure the target should always be the last argument for base and derived class
+        target = "auto"
+        for _arch, _target in _targets:
+            if self.spec.satisfies(f"target={_target}"):
+                target = _target
+        config_args = self.configure_args() + [target]
         configure("--prefix={0}".format(prefix), *config_args)
 
     @run_after("install")

--- a/repos/spack_repo/builtin/packages/blis/package.py
+++ b/repos/spack_repo/builtin/packages/blis/package.py
@@ -11,9 +11,9 @@ from spack.package import *
 # https://github.com/flame/blis/issues/195
 # https://github.com/flame/blis/issues/197
 
-# If the spack target architecture matches one of these values, 
-# provide this target to the Blis build as the Blis config target 
-# instead of using automatic configuration detection. 
+# If the spack target architecture matches one of these values,
+# provide this target to the Blis build as the Blis config target
+# instead of using automatic configuration detection.
 _targets = ["x86_64", "zen", "zen2"]
 
 

--- a/repos/spack_repo/builtin/packages/blis/package.py
+++ b/repos/spack_repo/builtin/packages/blis/package.py
@@ -11,12 +11,10 @@ from spack.package import *
 # https://github.com/flame/blis/issues/195
 # https://github.com/flame/blis/issues/197
 
-# Define a mapping between the selected architecture and the Blis config target
-_targets = [
-    # Arch, Target
-    ["x86_64", "x86_64"],
-    ["zen", "zen"],
-]
+# If the spack target architecture matches one of these values, 
+# provide this target to the Blis build as the Blis config target 
+# instead of using automatic configuration detection. 
+_targets = ["x86_64", "zen", "zen2"]
 
 
 class BlisBase(MakefilePackage):
@@ -90,11 +88,11 @@ class BlisBase(MakefilePackage):
         return config_args
 
     def edit(self, spec, prefix):
-        # To ensure the target should always be the last argument for base and derived class
         target = "auto"
-        for _arch, _target in _targets:
+        for _target in _targets:
             if self.spec.satisfies(f"target={_target}"):
                 target = _target
+        # To ensure the target should always be the last argument for base and derived class
         config_args = self.configure_args() + [target]
         configure("--prefix={0}".format(prefix), *config_args)
 


### PR DESCRIPTION
As detailed in issue https://github.com/spack/spack/issues/49376 .  The current spack recipe forces the use of the "auto" build configuration which makes cross-compilation impossible.  This change adds a new variant which will allow the selection of alternative build configurations.  The original behavior of the package is preserved.