### PR TITLE
nvshmem: introduce cmake, add new versions 3 and libfabric variant

### DIFF
--- a/repos/spack_repo/builtin/packages/nvshmem/package.py
+++ b/repos/spack_repo/builtin/packages/nvshmem/package.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems import cmake, makefile
-from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
 from spack_repo.builtin.build_systems.cuda import CudaPackage, conflicts
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
 
@@ -54,6 +54,8 @@ class Nvshmem(MakefilePackage, CMakePackage, CudaPackage):
     )
     variant("libfabric", default=False, description="Build with Libfabric support")
 
+    generator("ninja")
+
     conflicts("~cuda")
 
     def url_for_version(self, version):
@@ -70,7 +72,9 @@ class Nvshmem(MakefilePackage, CMakePackage, CudaPackage):
 
     depends_on("cuda@11:", when="@3.2.5:")
 
-    depends_on("cmake@3.19:", when="build_system=cmake")
+    with default_args(when="build_system=cmake", type="build"):
+        depends_on("cmake@3.19:")
+        depends_on("ninja")
 
     depends_on("mpi", when="+mpi")
 

--- a/repos/spack_repo/builtin/packages/nvshmem/package.py
+++ b/repos/spack_repo/builtin/packages/nvshmem/package.py
@@ -98,7 +98,6 @@ class CMakeBuilder(cmake.CMakeBuilder):
             self.define_from_variant("NVSHMEM_USE_NCCL", "nccl"),
             self.define_from_variant("NVSHMEM_USE_GDRCOPY", "gdrcopy"),
             self.define_from_variant("NVSHMEM_SHMEM_SUPPORT", "shmem"),
-            self.define("NVSHMEM_PMIX_SUPPORT", True),
             self.define("NVSHMEM_IBRC_SUPPORT", False),
             self.define("NVSHMEM_BUILD_PYTHON_LIB", False),
             self.define("NVSHMEM_BUILD_EXAMPLES", False),

--- a/repos/spack_repo/builtin/packages/nvshmem/package.py
+++ b/repos/spack_repo/builtin/packages/nvshmem/package.py
@@ -56,7 +56,7 @@ class Nvshmem(MakefilePackage, CMakePackage, CudaPackage):
 
     generator("ninja")
 
-    conflicts("~cuda")
+    conflicts("~cuda", msg="NVSHMEM requires CUDA")
 
     def url_for_version(self, version):
         ver_str = "{0}".format(version)

--- a/repos/spack_repo/builtin/packages/nvshmem/package.py
+++ b/repos/spack_repo/builtin/packages/nvshmem/package.py
@@ -2,13 +2,15 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack_repo.builtin.build_systems.cuda import CudaPackage
+from spack_repo.builtin.build_systems import cmake, makefile
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems.cuda import CudaPackage, conflicts
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
 
 from spack.package import *
 
 
-class Nvshmem(MakefilePackage, CudaPackage):
+class Nvshmem(MakefilePackage, CMakePackage, CudaPackage):
     """NVSHMEM is a parallel programming interface based on OpenSHMEM that
     provides efficient and scalable communication for NVIDIA GPU
     clusters. NVSHMEM creates a global address space for data that spans
@@ -22,6 +24,7 @@ class Nvshmem(MakefilePackage, CudaPackage):
 
     license("BSD-3-Clause-Open-MPI")
 
+    version("3.2.5-1", sha256="eb2c8fb3b7084c2db86bd9fd905387909f1dfd483e7b45f7b3c3d5fcf5374b5a")
     version("2.7.0-6", sha256="23ed9b0187104dc87d5d2bc1394b6f5ff29e8c19138dc019d940b109ede699df")
     version("2.6.0-1", sha256="fc0e8de61b034f3a079dc231b1d0955e665a9f57b5013ee98b6743647bd60417")
     version("2.5.0-19", sha256="dd800b40f1d296e1d3ed2a9885adcfe745c3e57582bc809860e87bd32abcdc60")
@@ -29,6 +32,12 @@ class Nvshmem(MakefilePackage, CudaPackage):
     version("2.2.1-0", sha256="c8efc6cd560e0ed66d5fe4c5837c650247bec7b0dc65b5089deb8ab49658e1c3")
     version("2.1.2-0", sha256="367211808df99b4575fb901977d9f4347065c61a26642d65887f24d60342a4ec")
     version("2.0.3-0", sha256="20da93e8508511e21aaab1863cb4c372a3bec02307b932144a7d757ea5a1bad2")
+
+    build_system(
+        conditional("cmake", when="@2.9.0:"),
+        conditional("makefile", when="@:2.11"),
+        default="cmake",
+    )
 
     variant("cuda", default=True, description="Build with CUDA")
     variant("ucx", default=True, description="Build with UCX support")
@@ -53,11 +62,60 @@ class Nvshmem(MakefilePackage, CudaPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    depends_on("mpi", when="+mpi")
-    depends_on("ucx", when="+ucx")
-    depends_on("gdrcopy", when="+gdrcopy")
-    depends_on("nccl", when="+nccl")
+    depends_on("cuda@11:", when="@3.2.5:")
 
+    depends_on("cmake@3.19:", when="build_system=cmake")
+
+    depends_on("mpi", when="+mpi")
+
+    depends_on("ucx", when="+ucx")
+    depends_on("ucx@1.10.0:", when="@3: +ucx")
+
+    depends_on("gdrcopy", when="+gdrcopy")
+    conflicts("~gdrcopy", when="~ucx")
+    depends_on("gdrcopy@2.0:", when="@3: +gdrcopy")
+
+    depends_on("nccl", when="+nccl")
+    depends_on("nccl@2.0:", when="@3: +nccl")
+
+
+class CMakeBuilder(cmake.CMakeBuilder):
+    def cmake_args(self):
+        config = [
+            self.define("CMAKE_CUDA_ARCHITECTURES", self.spec.variants["cuda_arch"].value),
+            self.define_from_variant("NVSHMEM_MPI_SUPPORT", "mpi"),
+            self.define_from_variant("NVSHMEM_UCX_SUPPORT", "ucx"),
+            self.define_from_variant("NVSHMEM_USE_NCCL", "nccl"),
+            self.define_from_variant("NVSHMEM_USE_GDRCOPY", "gdrcopy"),
+            self.define_from_variant("NVSHMEM_SHMEM_SUPPORT", "shmem"),
+            self.define("NVSHMEM_PMIX_SUPPORT", True),
+            self.define("NVSHMEM_IBRC_SUPPORT", False),
+            self.define("NVSHMEM_BUILD_PYTHON_LIB", False),
+            self.define("NVSHMEM_BUILD_EXAMPLES", False),
+            self.define("NVSHMEM_BUILD_HYDRA_LAUNCHER", False),
+            self.define("NVSHMEM_BUILD_TESTS", False),
+            self.define("NVSHMEM_BUILD_TXZ_PACKAGE", False),
+        ]
+
+        if "+mpi" in self.spec:
+            config.append(self.define("MPI_HOME", self.spec["mpi"].prefix))
+
+        if "+ucx" in self.spec:
+            config.append(self.define("UCX_HOME", self.spec["ucx"].prefix))
+
+        if "+nccl" in self.spec:
+            config.append(self.define("NCCL_HOME", self.spec["nccl"].prefix))
+
+        if "+gdrcopy" in self.spec:
+            config.append(self.define("GDRCOPY_HOME", self.spec["gdrcopy"].prefix))
+
+        if "+shmem" in self.spec:
+            config.append(self.define("SHMEM_HOME", self.spec["shmem"].prefix))
+
+        return config
+
+
+class MakeBuilder(makefile.MakefileBuilder):
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         env.set("CUDA_HOME", self.spec["cuda"].prefix)
         env.set("NVSHMEM_PREFIX", self.prefix)

--- a/repos/spack_repo/builtin/packages/nvshmem/package.py
+++ b/repos/spack_repo/builtin/packages/nvshmem/package.py
@@ -24,6 +24,7 @@ class Nvshmem(MakefilePackage, CMakePackage, CudaPackage):
 
     license("BSD-3-Clause-Open-MPI")
 
+    version("3.3.9", sha256="ba41e9ad6650cf99c1a60a3e47c19d1d97d814add7d35ea72337520ae13eeb59")
     version("3.2.5-1", sha256="eb2c8fb3b7084c2db86bd9fd905387909f1dfd483e7b45f7b3c3d5fcf5374b5a")
     version("2.7.0-6", sha256="23ed9b0187104dc87d5d2bc1394b6f5ff29e8c19138dc019d940b109ede699df")
     version("2.6.0-1", sha256="fc0e8de61b034f3a079dc231b1d0955e665a9f57b5013ee98b6743647bd60417")
@@ -58,7 +59,10 @@ class Nvshmem(MakefilePackage, CMakePackage, CudaPackage):
     def url_for_version(self, version):
         ver_str = "{0}".format(version)
         directory = ver_str.split("-")[0]
-        url_fmt = "https://developer.download.nvidia.com/compute/redist/nvshmem/{0}/source/nvshmem_src_{1}.txz"
+        if version < Version("3.3.9"):
+            url_fmt = "https://developer.download.nvidia.com/compute/redist/nvshmem/{0}/source/nvshmem_src_{1}.txz"
+        else:
+            url_fmt = "https://developer.download.nvidia.com/compute/redist/nvshmem/{0}/source/nvshmem_src_cuda12-all-all-{0}.tar.gz"
         return url_fmt.format(directory, version)
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/nvshmem/package.py
+++ b/repos/spack_repo/builtin/packages/nvshmem/package.py
@@ -65,8 +65,8 @@ class Nvshmem(MakefilePackage, CMakePackage, CudaPackage):
             url_fmt = "https://developer.download.nvidia.com/compute/redist/nvshmem/{0}/source/nvshmem_src_cuda12-all-all-{0}.tar.gz"
         return url_fmt.format(directory, version)
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("cuda@11:", when="@3.2.5:")
 

--- a/repos/spack_repo/builtin/packages/nvshmem/package.py
+++ b/repos/spack_repo/builtin/packages/nvshmem/package.py
@@ -79,17 +79,17 @@ class Nvshmem(MakefilePackage, CMakePackage, CudaPackage):
     depends_on("mpi", when="+mpi")
 
     depends_on("ucx", when="+ucx")
-    depends_on("ucx@1.10.0:", when="@3: +ucx")
+    depends_on("ucx@1.10:", when="@3: +ucx")
 
     depends_on("gdrcopy", when="+gdrcopy")
     conflicts("~gdrcopy", when="~ucx")
-    depends_on("gdrcopy@2.0:", when="@3: +gdrcopy")
+    depends_on("gdrcopy@2:", when="@3: +gdrcopy")
 
     depends_on("nccl", when="+nccl")
-    depends_on("nccl@2.0:", when="@3: +nccl")
+    depends_on("nccl@2:", when="@3: +nccl")
 
     depends_on("libfabric", when="+libfabric")
-    depends_on("libfabric@1.15.0.0:", when="@3: +libfabric")
+    depends_on("libfabric@1.15:", when="@3: +libfabric")
 
 
 class CMakeBuilder(cmake.CMakeBuilder):

--- a/repos/spack_repo/builtin/packages/nvshmem/package.py
+++ b/repos/spack_repo/builtin/packages/nvshmem/package.py
@@ -95,7 +95,7 @@ class Nvshmem(MakefilePackage, CMakePackage, CudaPackage):
 class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
         config = [
-            self.define("CMAKE_CUDA_ARCHITECTURES", self.spec.variants["cuda_arch"].value),
+            self.define("CMAKE_CUDA_ARCHITECTURES", self.spec.variants["cuda_arch"].values),
             self.define_from_variant("NVSHMEM_MPI_SUPPORT", "mpi"),
             self.define_from_variant("NVSHMEM_LIBFABRIC_SUPPORT", "libfabric"),
             self.define_from_variant("NVSHMEM_UCX_SUPPORT", "ucx"),

--- a/repos/spack_repo/builtin/packages/nvshmem/package.py
+++ b/repos/spack_repo/builtin/packages/nvshmem/package.py
@@ -51,6 +51,8 @@ class Nvshmem(MakefilePackage, CMakePackage, CudaPackage):
         when="@2.6:",
         description="Build with support for GPU initiated communication",
     )
+    variant("libfabric", default=False, description="Build with Libfabric support")
+
     conflicts("~cuda")
 
     def url_for_version(self, version):
@@ -78,12 +80,16 @@ class Nvshmem(MakefilePackage, CMakePackage, CudaPackage):
     depends_on("nccl", when="+nccl")
     depends_on("nccl@2.0:", when="@3: +nccl")
 
+    depends_on("libfabric", when="+libfabric")
+    depends_on("libfabric@1.15.0.0:", when="@3: +libfabric")
+
 
 class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
         config = [
             self.define("CMAKE_CUDA_ARCHITECTURES", self.spec.variants["cuda_arch"].value),
             self.define_from_variant("NVSHMEM_MPI_SUPPORT", "mpi"),
+            self.define_from_variant("NVSHMEM_LIBFABRIC_SUPPORT", "libfabric"),
             self.define_from_variant("NVSHMEM_UCX_SUPPORT", "ucx"),
             self.define_from_variant("NVSHMEM_USE_NCCL", "nccl"),
             self.define_from_variant("NVSHMEM_USE_GDRCOPY", "gdrcopy"),
@@ -99,6 +105,9 @@ class CMakeBuilder(cmake.CMakeBuilder):
 
         if "+mpi" in self.spec:
             config.append(self.define("MPI_HOME", self.spec["mpi"].prefix))
+
+        if "+libfabric" in self.spec:
+            config.append(self.define("LIBFABRIC_HOME", self.spec["libfabric"].prefix))
 
         if "+ucx" in self.spec:
             config.append(self.define("UCX_HOME", self.spec["ucx"].prefix))


### PR DESCRIPTION
It's far from being nice and perfect, but at least it is a starting point for having newer `nvshmem` versions available, together with some of its features not currently exposed (e.g. `libfabric` support).

The ugliest thing is that, since filename has been changed from the simple  `nvshmem_src_{version}.txz"` to `nvshmem_src_cuda12-all-all-{version}.tar.gz`, I opted for an "on-spot" solution.