### PR TITLE
Disable running hipblaslt tests as they always timeout

### DIFF
--- a/.ci/gitlab/configs/ci.yaml
+++ b/.ci/gitlab/configs/ci.yaml
@@ -2,6 +2,7 @@ ci:
   target: gitlab
 
   broken-tests-packages:
+    - hipblaslt  # Timeouts
     - superlu-dist    # srun -n 4 hangs
     - papyrus
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This test is broken, so disabling for now.