### PR TITLE
py_contourpy: Adjust py-setuptools dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/py_contourpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_contourpy/package.py
@@ -31,6 +31,8 @@ class PyContourpy(PythonPackage):
 
         # Historical dependencies
         depends_on("py-setuptools@42:", when="@:1.0")
+        # not in original requirements, but pyproject.toml [project] requires py-setuptools@61:
+        depends_on("py-setuptools@61:", when="@1.0.7:1.0")
         depends_on("py-build", when="@:1.0.5")
 
     with default_args(type=("build", "link", "run")):


### PR DESCRIPTION
This dependency is not defined in contourpy itself. But starting from version 1.0.7 the [project] section is used in pyproject.toml. This requires `py-setuptools@61:`.
