### PR TITLE
netcdf-c: always depends on cxx

### DIFF
--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -142,7 +142,7 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
     variant("zstd", default=True, description="Enable Zstandard compression plugin")
 
     depends_on("c", type="build")
-    depends_on("cxx", type="build", when="build_system=cmake")
+    depends_on("cxx", type="build")
 
     with when("build_system=cmake"):
         # Based on the versions required by the root CMakeLists.txt:


### PR DESCRIPTION
Here is the PR if this is the fix for:

https://github.com/spack/spack-packages/issues/489#issuecomment-3050190481