### PR TITLE
pumi: remove MPI executable path constraint

### DIFF
--- a/repos/spack_repo/builtin/packages/pumi/package.py
+++ b/repos/spack_repo/builtin/packages/pumi/package.py
@@ -141,7 +141,7 @@ class Pumi(CMakePackage):
                 assert "mesh pipe_2_.smb written" in out
                 return
             except (Exception, ProcessError) as err:
-                    tty.info(f"Skipping {mpiexe}: {str(err)}")
+                tty.info(f"Skipping {mpiexe}: {str(err)}")
         assert False, "No MPI executable was found"
 
     def test_refine(self):

--- a/repos/spack_repo/builtin/packages/pumi/package.py
+++ b/repos/spack_repo/builtin/packages/pumi/package.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
@@ -129,9 +131,18 @@ class Pumi(CMakePackage):
             "pipe_2_.smb",
             "2",
         ]
-        exe = which(self.spec["mpi"].prefix.bin.mpiexec)
-        out = exe(*options, output=str.split, error=str.split)
-        assert "mesh pipe_2_.smb written" in out
+        mpiexe_list = ["mpirun", "mpiexec", "srun"]
+        for mpiexe in mpiexe_list:
+            tty.info(f"Attempting to build and launch with {os.path.basename(mpiexe)}")
+            try:
+                options = ["--immediate=30"] + options if mpiexe == "srun" else options
+                exe = which(mpiexe)
+                out = exe(*options, output=str.split, error=str.split)
+                assert "mesh pipe_2_.smb written" in out
+                return
+            except (Exception, ProcessError) as err:
+                    tty.info(f"Skipping {mpiexe}: {str(err)}")
+        assert False, "No MPI executable was found"
 
     def test_refine(self):
         """Testing pumi uniform mesh refinement"""


### PR DESCRIPTION
The current MPI test implementation assumes that MPI executables `mpiexec` are located in the same directory as defined. This assumption breaks in certain software environments when using a system/external MPI. Also, `mpiexec` is not always available. This PR removes such a strict path constraint.