### PR TITLE
r: guard against openblas symbol_suffix

### DIFF
--- a/repos/spack_repo/builtin/packages/r/package.py
+++ b/repos/spack_repo/builtin/packages/r/package.py
@@ -83,7 +83,7 @@ class R(AutotoolsPackage):
     depends_on("fortran", type="build")
 
     depends_on("blas")
-    requires("^openblas +symbol_suffix=none", when="^openblas")
+    requires("^openblas symbol_suffix=none", when="^openblas")
     depends_on("lapack")
 
     depends_on("bzip2")

--- a/repos/spack_repo/builtin/packages/r/package.py
+++ b/repos/spack_repo/builtin/packages/r/package.py
@@ -83,6 +83,7 @@ class R(AutotoolsPackage):
     depends_on("fortran", type="build")
 
     depends_on("blas")
+    requires("^openblas +symbol_suffix=none", when="^openblas")
     depends_on("lapack")
 
     depends_on("bzip2")


### PR DESCRIPTION
Ensures that if openblas is used to  fullfill the blas requirement of r, that no symbol_suffix is used.

Fixes #443

