### PR TITLE
sirius require cmake>=3.25 

### DIFF
--- a/repos/spack_repo/builtin/packages/sirius/package.py
+++ b/repos/spack_repo/builtin/packages/sirius/package.py
@@ -80,7 +80,7 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("c", type="build")
     depends_on("fortran", type="build")
 
-    depends_on("cmake@3.23:", type="build")
+    depends_on("cmake@3.25:", type="build")
     depends_on("mpi")
     depends_on("gsl")
     depends_on("blas")


### PR DESCRIPTION
sirus is using `CUDA::nvtx3` which has been introduced in cmake 3.25.