### PR TITLE
Checks fail on old builtin using dorny paths filter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,14 @@ jobs:
             - .ci/env
             packages:
             - repos/spack_repo/**
+            old-builtin:
+            - 'var/spack/repos/spack_repo/builtin/**'
+      - name: Detected old builtin repository
+        if: steps.filter.outputs.old-builtin == 'true'
+        run: |
+          echo "Error: Packages are not allowed in 'var/spack/repos/spack_repo/builtin'."
+          echo "       Use 'repos/spack_repo/builtin' instead."
+          exit 1
 
   unit-tests:
     # if: ${{ github.repository == 'spack/spack' && needs.changes.outputs.core == 'true' }}

--- a/.github/workflows/prechecks.yml
+++ b/.github/workflows/prechecks.yml
@@ -13,24 +13,6 @@ concurrency:
 
 
 jobs:
-  # Ensure no changes involve the old builtin repository directory
-  check-builtin-dir:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-    - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
-      id: filter
-      with:
-        filters: |
-          old:
-          - 'var/spack/repos/spack_repo/builtin/**'
-    - name: Detected old builtin repository
-      if: steps.filter.outputs.old == 'true'
-      run: |
-        echo "Error: Packages are not allowed in 'var/spack/repos/spack_repo/builtin'."
-        echo "       Use 'repos/spack_repo/builtin' instead."
-        exit 1
-
   # Validate that the code can be run on all the Python versions supported by Spack
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/prechecks.yml
+++ b/.github/workflows/prechecks.yml
@@ -13,6 +13,24 @@ concurrency:
 
 
 jobs:
+  # Ensure no changes involve the old builtin repository directory
+  check-builtin-dir:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+      id: filter
+      with:
+        filters: |
+          old:
+          - 'var/spack/repos/spack_repo/builtin/**'
+    - name: Detected old builtin repository
+      if: steps.filter.outputs.old == 'true'
+      run: |
+        echo "Error: Packages are not allowed in 'var/spack/repos/spack_repo/builtin'."
+        echo "       Use 'repos/spack_repo/builtin' instead."
+        exit 1
+
   # Validate that the code can be run on all the Python versions supported by Spack
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Alternative approach to #526 suggested by @alecbcs.

Update: Moved to CI `changes` per Alec to stop processing sooner (e.g., prevents running of style and other checks).

Example of the failure output can be found at https://github.com/spack/spack-packages/actions/runs/16181717829/job/45679606196?pr=542.

Success (i.e., no offending builtin repo packages) can be seen in https://github.com/spack/spack-packages/actions/runs/16181798079/job/45679839622?pr=542.