### PR TITLE
CI: run all style checks

### DIFF
--- a/.ci/style_check.sh
+++ b/.ci/style_check.sh
@@ -1,12 +1,27 @@
-#!/bin/sh -e
+#!/bin/sh
 ref="${1:-develop}"
 if [ ! -d "spack-core" ]; then
   printf "No 'spack-core' dir found, should be a symlink or clone of 'spack/spack'\n" >&2
   exit 1
 fi
+all_commands_successful=true
+check_command() {
+  cmd_status=$?
+  if [ $cmd_status -ne 0 ]; then
+    all_commands_successful=false
+  fi
+}
 python_files() { git diff --name-only --diff-filter=ACMR -z "$ref" | grep -zE '\.pyi?$'; }
 python_files > /dev/null || exit 0
 python_files | xargs -0 printf "%s\n"
 python_files | xargs -0 -n 100 flake8
+check_command
 python_files | xargs -0 -n 100 isort --check --diff
+check_command
 python_files | xargs -0 -n 100 black --check --diff --color
+check_command
+if $all_commands_successful; then
+  exit 0
+else
+  exit 1
+fi


### PR DESCRIPTION
Currently style checks in CI will fail fast, exiting after the first command fails This is incredibly tedious if one of the checks fails and there remain style issues, requiring multiple iterations of pushing, waiting for style checks, etc. Instead, run all the checks, tracking status, and exit based on the behavior of all commands.


Disclaimer: somewhat vibe coded
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
