### PR TITLE
remove spack.platforms.cray.slingshot_network

### DIFF
--- a/repos/spack_repo/builtin/packages/aluminum/package.py
+++ b/repos/spack_repo/builtin/packages/aluminum/package.py
@@ -13,7 +13,6 @@ from spack_repo.builtin.build_systems.cached_cmake import (
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
-import spack.platforms.cray
 from spack.package import *
 
 
@@ -56,6 +55,7 @@ class Aluminum(CachedCMakePackage, CudaPackage, ROCmPackage):
         " communication of accelerator data",
     )
     variant("nccl", default=False, description="Builds with support for NCCL communication lib")
+    variant("slingshot", default=False, when="+nccl", description="Builds with Slingshot support")
     variant("shared", default=True, description="Build Aluminum as a shared library")
 
     # Debugging features
@@ -113,8 +113,7 @@ class Aluminum(CachedCMakePackage, CudaPackage, ROCmPackage):
                     "nccl +cuda cuda_arch={0}".format(arch),
                     when="+cuda cuda_arch={0}".format(arch),
                 )
-            if spack.platforms.cray.slingshot_network():
-                depends_on("aws-ofi-nccl")  # Note: NOT a CudaPackage
+            depends_on("aws-ofi-nccl", when="+slingshot")  # Note: NOT a CudaPackage
 
     with when("+rocm"):
         for val in ROCmPackage.amdgpu_targets:
@@ -133,8 +132,7 @@ class Aluminum(CachedCMakePackage, CudaPackage, ROCmPackage):
                 "roctracer-dev +rocm amdgpu_target={0}".format(val),
                 when="+roctracer amdgpu_target={0}".format(val),
             )
-        if spack.platforms.cray.slingshot_network():
-            depends_on("aws-ofi-rccl", when="+nccl")
+        depends_on("aws-ofi-rccl", when="+nccl +slingshot")
 
     def cmake_args(self):
         args = []

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -328,12 +328,6 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         when="comm=gasnet comm_substrate=ofi",
     )
 
-    requires(
-        "^libfabric" + (" fabrics=cxi" if spack.platforms.cray.slingshot_network() else ""),
-        when="libfabric=spack",
-        msg="libfabric requires cxi fabric provider on HPE-Cray EX machines",
-    )
-
     variant(
         "llvm",
         default="spack",

--- a/repos/spack_repo/builtin/packages/lbann/package.py
+++ b/repos/spack_repo/builtin/packages/lbann/package.py
@@ -15,7 +15,6 @@ from spack_repo.builtin.build_systems.cmake import generator
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
-import spack.platforms.cray
 from spack.package import *
 
 
@@ -80,6 +79,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
         default=False,
         description="Builds with support for image processing data with OpenCV",
     )
+    variant("slingshot", default=False, description="Enable slingshot support")
     variant("vtune", default=False, description="Builds with support for Intel VTune")
     variant("onednn", default=False, description="Support for OneDNN")
     variant("onnx", default=False, description="Support for exporting models into ONNX format")
@@ -164,13 +164,8 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
     # Note that while Aluminum typically includes the dependency for the AWS OFI
     # plugins, if Aluminum is pre-built, LBANN needs to make sure that the module
     # is loaded
-    with when("+cuda"):
-        if spack.platforms.cray.slingshot_network():
-            depends_on("aws-ofi-nccl")  # Note: NOT a CudaPackage
-
-    with when("+rocm"):
-        if spack.platforms.cray.slingshot_network():
-            depends_on("aws-ofi-rccl")
+    depends_on("aws-ofi-nccl", when="+cuda +slingshot")
+    depends_on("aws-ofi-rccl", when="+rocm +slingshot")
 
     depends_on("hdf5+mpi", when="+distconv")
 


### PR DESCRIPTION
Spack packages definitions should not depend on the state of the
filesystem.

Instead of branching on `spack.platforms.cray.slingshot_network`, use a
variant `+slingshot` which users can prefer in config for particular
systems.

Further, this is private Spack API.
