### PR TITLE
ucc: use cuda_arch information

### DIFF
--- a/repos/spack_repo/builtin/packages/ucc/package.py
+++ b/repos/spack_repo/builtin/packages/ucc/package.py
@@ -58,6 +58,15 @@ class Ucc(AutotoolsPackage, CudaPackage, ROCmPackage):
         args = []
         args.extend(self.with_or_without("cuda", activation_value="prefix"))
         args.extend(self.with_or_without("nccl", activation_value="prefix"))
+
+        if "+cuda" in self.spec:
+            if self.spec.variants["cuda_arch"].values != ("none",):
+                gencode_args = [
+                    f"-gencode=arch=compute_{arch},code=sm_{arch}"
+                    for arch in self.spec.variants["cuda_arch"].values
+                ]
+                args.append(f"--with-nvcc-gencode='{' '.join(gencode_args)}'")
+
         if self.spec.satisfies("+rocm"):
             cppflags = " ".join(
                 "-I" + include_dir

--- a/repos/spack_repo/builtin/packages/ucc/package.py
+++ b/repos/spack_repo/builtin/packages/ucc/package.py
@@ -61,10 +61,7 @@ class Ucc(AutotoolsPackage, CudaPackage, ROCmPackage):
 
         if "+cuda" in self.spec:
             if self.spec.variants["cuda_arch"].values != ("none",):
-                gencode_args = [
-                    f"-gencode=arch=compute_{arch},code=sm_{arch}"
-                    for arch in self.spec.variants["cuda_arch"].values
-                ]
+                gencode_args = self.cuda_flags(self.spec.variants["cuda_arch"].values)
                 args.append(f"--with-nvcc-gencode='{' '.join(gencode_args)}'")
 
         if self.spec.satisfies("+rocm"):


### PR DESCRIPTION
According to `ucc` [FAQ](https://github-wiki-see.page/m/openucx/ucc/wiki/FAQ)

> 15. How to compile UCC for a specific GPU architecture?
>
> To compile UCC for a particular GPU architecture, you can use the "./configure" command with appropriate options and specify the "--with-nvcc-gencode" flag. For instance, if you want to compile UCC for the NVIDIA Volta architecture, you can run the following command:
>
> `./configure --with-nvcc-gencode="-gencode=arch=compute_70,code=sm_70"`
>
> You can also specify multiple GPU architectures using the "--with-nvcc-gencode" flag, as shown below:
>
> `./configure --with-nvcc-gencode="-gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_80,code=sm_80"`

It helps reducing build times.