### PR TITLE
redset: require CXX compiler for CMake

### DIFF
--- a/repos/spack_repo/builtin/packages/redset/package.py
+++ b/repos/spack_repo/builtin/packages/redset/package.py
@@ -30,6 +30,7 @@ class Redset(CMakePackage, CudaPackage):
     version("0.0.3", sha256="30ac1a960f842ae23a960a88b312af3fddc4795f2053eeeec3433a61e4666a76")
 
     depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")
 
     depends_on("mpi")
     depends_on("kvtree+mpi")


### PR DESCRIPTION
Fixes CMake configuration issue when building redset:

```
3 errors found in build log:
     16    -- Detecting C compile features
     17    -- Detecting C compile features - done
     18    -- Detecting CXX compiler ABI info
     19    -- Detecting CXX compiler ABI info - failed
     20    -- Check for working CXX compiler: /<omit>/none-none/compiler
           -wrapper-1.0-awlbxseq3p7c2a3wysdqwr3iy2v56ji5/libexec/spack/clang/clang++
     21    -- Check for working CXX compiler:  /<omit>/none-none/compiler
           -wrapper-1.0-awlbxseq3p7c2a3wysdqwr3iy2v56ji5/libexec/spack/clang/clang++ - broken
  >> 22    CMake Error at /usr/tce/backend/installations/linux-rhel8-x86_64/gcc-10.3.1/cmake-3.23.1-md
           fqd2l7c33zg7xcvqizwz25vqmp7jfw/share/cmake-3.23/Modules/CMakeTestCXXCompiler.cmake:62 (mess
           age):
     23      The C++ compiler
     24    
     25        " /<omit>/none-none/compiler-wrapper-1.0-awlbxseq3p7c2a3wy
           sdqwr3iy2v56ji5/libexec/spack/clang/clang++"
     26    
     27      is not able to compile a simple test program.
```