### PR TITLE
builtin: remove the use of `set_env`

### DIFF
--- a/repos/spack_repo/builtin/packages/arkouda/package.py
+++ b/repos/spack_repo/builtin/packages/arkouda/package.py
@@ -6,7 +6,6 @@
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
 
 from spack.package import *
-from spack.util.environment import set_env
 
 
 class Arkouda(MakefilePackage):
@@ -87,17 +86,13 @@ class Arkouda(MakefilePackage):
             f.write("$(eval $(call add-path,{0}))\n".format(spec["libiconv"].prefix))
             f.write("$(eval $(call add-path,{0}))\n".format(spec["libidn2"].prefix))
 
-    def build(self, spec, prefix):
+    def setup_build_environment(self, env):
         # Detect distributed builds and skip the dependency checks built into
         # the Arkouda Makefile. These checks will try to spawn multiple jobs which may
         # cause the build to fail in situations where the user is constrained
         # to a limited number of simultaneous jobs.
-        if spec.satisfies("+distributed"):
-            with set_env(ARKOUDA_SKIP_CHECK_DEPS="1"):
-                tty.warn("Distributed build detected. Skipping dependency checks")
-                make()
-        else:
-            make()
+        if self.spec.satisfies("+distributed"):
+            env.set("ARKOUDA_SKIP_CHECK_DEPS", "1")
 
     # Arkouda does not have an install target in its Makefile
     def install(self, spec, prefix):

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -15,7 +15,7 @@ import llnl.util.lang
 import spack.platforms
 import spack.platforms.cray
 from spack.package import *
-from spack.util.environment import is_system_path, set_env
+from spack.util.environment import is_system_path
 
 
 @llnl.util.lang.memoized
@@ -584,32 +584,24 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
             env.unset(var)
 
     def build(self, spec, prefix):
-        with set_env(CHPL_MAKE_THIRD_PARTY=join_path(self.build_directory, "third-party")):
-            make()
-            with set_env(CHPL_HOME=self.build_directory):
-                if spec.satisfies("+chpldoc"):
-                    make("chpldoc")
-                if spec.satisfies("+python-bindings"):
-                    make("chapel-py-venv")
-                    python("-m", "ensurepip", "--default-pip")
-                    python("-m", "pip", "install", "tools/chapel-py")
+        make()
+        if spec.satisfies("+chpldoc"):
+            make("chpldoc")
+        if spec.satisfies("+python-bindings"):
+            make("chapel-py-venv")
+            python("-m", "ensurepip", "--default-pip")
+            python("-m", "pip", "install", "tools/chapel-py")
 
     def install(self, spec, prefix):
-        # Needed to prevent invalidating cache on subsequent cmake runs due to
-        # env changes, likely pertaining to spack compiler wrappers.
-        with set_env(CHPL_CMAKE_USE_CC_CXX="1"):
-            make("install")
-            # We install CMakeLists.txt so we can later lookup the version number
-            # if working from a non-versioned release/branch (such as main)
-            if not self.is_versioned_release():
-                install("CMakeLists.txt", join_path(prefix.share, "chapel"))
-            install_tree(
-                "doc", join_path(prefix.share, "chapel", self._output_version_short, "doc")
-            )
-            install_tree(
-                "examples",
-                join_path(prefix.share, "chapel", self._output_version_short, "examples"),
-            )
+        make("install")
+        # We install CMakeLists.txt so we can later lookup the version number
+        # if working from a non-versioned release/branch (such as main)
+        if not self.is_versioned_release():
+            install("CMakeLists.txt", join_path(prefix.share, "chapel"))
+        install_tree("doc", join_path(prefix.share, "chapel", self._output_version_short, "doc"))
+        install_tree(
+            "examples", join_path(prefix.share, "chapel", self._output_version_short, "examples")
+        )
 
     def setup_chpl_platform(self, env):
         if self.spec.variants["host_platform"].value == "unset":
@@ -770,6 +762,11 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         self.unset_chpl_env_vars(env)
         self.setup_env_vars(env)
+        env.set("CHPL_HOME", self.build_directory)
+        env.set("CHPL_MAKE_THIRD_PARTY", join_path(self.build_directory, "third-party"))
+        # Needed to prevent invalidating cache on subsequent cmake runs due to
+        # env changes, likely pertaining to spack compiler wrappers.
+        env.set("CHPL_CMAKE_USE_CC_CXX", "1")
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         self.setup_env_vars(env)
@@ -781,6 +778,11 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         )
         with when("@2.2:2.5"):
             env.set("CHPL_HOME", chpl_home)
+
+        # Needed for standalone tests
+        env.set("CHPL_CHECK_HOME", self.test_suite.current_test_cache_dir)
+        if self.spec.satisfies("+cuda") or self.spec.satisfies("+rocm"):
+            env.set("COMP_FLAGS", "--no-checks --no-compiler-driver")
 
     def get_chpl_version_from_cmakelists(self) -> str:
         cmake_lists = None
@@ -867,17 +869,20 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     def check_chpl_install_gasnet(self):
         """Setup env to run self-test after installing the package with gasnet"""
-        with set_env(
-            GASNET_SPAWNFN="L",
-            GASNET_QUIET="yes",
-            GASNET_ROUTE_OUTPUT="0",
-            QT_AFFINITY="no",
-            CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION="1",
-            CHPL_RT_MASTERIP="127.0.0.1",
-            CHPL_RT_WORKERIP="127.0.0.0",
-            CHPL_LAUNCHER="",
-        ):
-            return subprocess.run(["util/test/checkChplInstall"])
+        env = os.environ.copy()
+        env.update(
+            {
+                "GASNET_SPAWNFN": "L",
+                "GASNET_QUIET": "yes",
+                "GASNET_ROUTE_OUTPUT": "0",
+                "QT_AFFINITY": "no",
+                "CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION": "1",
+                "CHPL_RT_MASTERIP": "127.0.0.1",
+                "CHPL_RT_WORKERIP": "127.0.0.0",
+                "CHPL_LAUNCHER": "",
+            }
+        )
+        return subprocess.run(["util/test/checkChplInstall"], env=env)
 
     def check_chpl_install(self):
         if self.spec.variants["comm"].value != "none":
@@ -888,15 +893,9 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     def test_hello(self):
         """Run the hello world test"""
         with working_dir(self.test_suite.current_test_cache_dir):
-            with set_env(CHPL_CHECK_HOME=self.test_suite.current_test_cache_dir):
-                with test_part(self, "test_hello_checkChplInstall", purpose="test hello world"):
-                    if self.spec.satisfies("+cuda") or self.spec.satisfies("+rocm"):
-                        with set_env(COMP_FLAGS="--no-checks --no-compiler-driver"):
-                            res = self.check_chpl_install()
-                            assert res and res.returncode == 0
-                    else:
-                        res = self.check_chpl_install()
-                        assert res and res.returncode == 0
+            with test_part(self, "test_hello_checkChplInstall", purpose="test hello world"):
+                res = self.check_chpl_install()
+                assert res and res.returncode == 0
 
     # TODO: This is a pain because the checkChplDoc script doesn't have the same
     # support for CHPL_CHECK_HOME and chpldoc is finicky about CHPL_HOME

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -584,16 +584,22 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
             env.unset(var)
 
     def build(self, spec, prefix):
-        make()
+        make(extra_env={"CHPL_MAKE_THIRD_PARTY": join_path(self.build_directory, "third-party")})
+        extra_env = {
+            "CHPL_MAKE_THIRD_PARTY": join_path(self.build_directory, "third-party"),
+            "CHPL_HOME": self.build_directory,
+        }
         if spec.satisfies("+chpldoc"):
-            make("chpldoc")
+            make("chpldoc", extra_env=extra_env)
         if spec.satisfies("+python-bindings"):
-            make("chapel-py-venv")
-            python("-m", "ensurepip", "--default-pip")
-            python("-m", "pip", "install", "tools/chapel-py")
+            make("chapel-py-venv", extra_env=extra_env)
+            python("-m", "ensurepip", "--default-pip", extra_env=extra_env)
+            python("-m", "pip", "install", "tools/chapel-py", extra_env=extra_env)
 
     def install(self, spec, prefix):
-        make("install")
+        # Needed to prevent invalidating cache on subsequent cmake runs due to
+        # env changes, likely pertaining to spack compiler wrappers.
+        make("install", extra_env={"CHPL_CMAKE_USE_CC_CXX": "1"})
         # We install CMakeLists.txt so we can later lookup the version number
         # if working from a non-versioned release/branch (such as main)
         if not self.is_versioned_release():
@@ -762,11 +768,6 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         self.unset_chpl_env_vars(env)
         self.setup_env_vars(env)
-        env.set("CHPL_HOME", self.build_directory)
-        env.set("CHPL_MAKE_THIRD_PARTY", join_path(self.build_directory, "third-party"))
-        # Needed to prevent invalidating cache on subsequent cmake runs due to
-        # env changes, likely pertaining to spack compiler wrappers.
-        env.set("CHPL_CMAKE_USE_CC_CXX", "1")
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         self.setup_env_vars(env)
@@ -778,11 +779,6 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         )
         with when("@2.2:2.5"):
             env.set("CHPL_HOME", chpl_home)
-
-        # Needed for standalone tests
-        env.set("CHPL_CHECK_HOME", self.test_suite.current_test_cache_dir)
-        if self.spec.satisfies("+cuda") or self.spec.satisfies("+rocm"):
-            env.set("COMP_FLAGS", "--no-checks --no-compiler-driver")
 
     def get_chpl_version_from_cmakelists(self) -> str:
         cmake_lists = None
@@ -867,7 +863,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         #       - make test is a long running operation
         pass
 
-    def check_chpl_install_gasnet(self):
+    def check_chpl_install_gasnet(self, *, env_update):
         """Setup env to run self-test after installing the package with gasnet"""
         env = os.environ.copy()
         env.update(
@@ -882,19 +878,23 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
                 "CHPL_LAUNCHER": "",
             }
         )
+        env.update(env_update)
         return subprocess.run(["util/test/checkChplInstall"], env=env)
 
-    def check_chpl_install(self):
+    def check_chpl_install(self, env_update):
         if self.spec.variants["comm"].value != "none":
-            return self.check_chpl_install_gasnet()
+            return self.check_chpl_install_gasnet(env_update=env_update)
         else:
             return subprocess.run(["util/test/checkChplInstall"])
 
     def test_hello(self):
         """Run the hello world test"""
         with working_dir(self.test_suite.current_test_cache_dir):
+            env_update = {"CHPL_CHECK_HOME": self.test_suite.current_test_cache_dir}
             with test_part(self, "test_hello_checkChplInstall", purpose="test hello world"):
-                res = self.check_chpl_install()
+                if self.spec.satisfies("+cuda") or self.spec.satisfies("+rocm"):
+                    env_update.update({"COMP_FLAGS": "--no-checks --no-compiler-driver"})
+                res = self.check_chpl_install(env_update=env_update)
                 assert res and res.returncode == 0
 
     # TODO: This is a pain because the checkChplDoc script doesn't have the same

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -864,8 +864,8 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         """Run the hello world test"""
         with working_dir(self.test_suite.current_test_cache_dir):
             checkCplInstall = Executable("util/test/checkChplInstall")
-            vars = {"CHPL_CHECK_HOME": self.test_suite.current_test_cache_dir}
             with test_part(self, "test_hello_checkChplInstall", purpose="test hello world"):
+                vars = {"CHPL_CHECK_HOME": self.test_suite.current_test_cache_dir}
                 if self.spec.satisfies("+cuda") or self.spec.satisfies("+rocm"):
                     vars["COMP_FLAGS"] = "--no-checks --no-compiler-driver"
                 if self.spec.satisfies("comm=gasnet"):

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -4,7 +4,6 @@
 
 import os
 import re
-import subprocess
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
@@ -584,22 +583,18 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
             env.unset(var)
 
     def build(self, spec, prefix):
-        make(extra_env={"CHPL_MAKE_THIRD_PARTY": join_path(self.build_directory, "third-party")})
-        extra_env = {
-            "CHPL_MAKE_THIRD_PARTY": join_path(self.build_directory, "third-party"),
-            "CHPL_HOME": self.build_directory,
-        }
+        make()
         if spec.satisfies("+chpldoc"):
-            make("chpldoc", extra_env=extra_env)
+            make("chpldoc")
         if spec.satisfies("+python-bindings"):
-            make("chapel-py-venv", extra_env=extra_env)
-            python("-m", "ensurepip", "--default-pip", extra_env=extra_env)
-            python("-m", "pip", "install", "tools/chapel-py", extra_env=extra_env)
+            make("chapel-py-venv")
+            python("-m", "ensurepip", "--default-pip")
+            python("-m", "pip", "install", "tools/chapel-py")
 
     def install(self, spec, prefix):
-        # Needed to prevent invalidating cache on subsequent cmake runs due to
-        # env changes, likely pertaining to spack compiler wrappers.
-        make("install", extra_env={"CHPL_CMAKE_USE_CC_CXX": "1"})
+        # CHPL_CMAKE_USE_CC_CXX needed to prevent invalidating cache on subsequent cmake runs due
+        # to env changes, likely pertaining to spack compiler wrappers.
+        make("install", "CHPL_CMAKE_USE_CC_CXX=1")
         # We install CMakeLists.txt so we can later lookup the version number
         # if working from a non-versioned release/branch (such as main)
         if not self.is_versioned_release():
@@ -768,6 +763,8 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         self.unset_chpl_env_vars(env)
         self.setup_env_vars(env)
+        env.set("CHPL_MAKE_THIRD_PARTY", join_path(self.build_directory, "third-party"))
+        env.set("CHPL_HOME", self.build_directory)
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         self.setup_env_vars(env)
@@ -863,39 +860,24 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         #       - make test is a long running operation
         pass
 
-    def check_chpl_install_gasnet(self, *, env_update):
-        """Setup env to run self-test after installing the package with gasnet"""
-        env = os.environ.copy()
-        env.update(
-            {
-                "GASNET_SPAWNFN": "L",
-                "GASNET_QUIET": "yes",
-                "GASNET_ROUTE_OUTPUT": "0",
-                "QT_AFFINITY": "no",
-                "CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION": "1",
-                "CHPL_RT_MASTERIP": "127.0.0.1",
-                "CHPL_RT_WORKERIP": "127.0.0.0",
-                "CHPL_LAUNCHER": "",
-            }
-        )
-        env.update(env_update)
-        return subprocess.run(["util/test/checkChplInstall"], env=env)
-
-    def check_chpl_install(self, env_update):
-        if self.spec.variants["comm"].value != "none":
-            return self.check_chpl_install_gasnet(env_update=env_update)
-        else:
-            return subprocess.run(["util/test/checkChplInstall"])
-
     def test_hello(self):
         """Run the hello world test"""
         with working_dir(self.test_suite.current_test_cache_dir):
-            env_update = {"CHPL_CHECK_HOME": self.test_suite.current_test_cache_dir}
+            checkCplInstall = Executable("util/test/checkChplInstall")
+            vars = {"CHPL_CHECK_HOME": self.test_suite.current_test_cache_dir}
             with test_part(self, "test_hello_checkChplInstall", purpose="test hello world"):
                 if self.spec.satisfies("+cuda") or self.spec.satisfies("+rocm"):
-                    env_update.update({"COMP_FLAGS": "--no-checks --no-compiler-driver"})
-                res = self.check_chpl_install(env_update=env_update)
-                assert res and res.returncode == 0
+                    vars["COMP_FLAGS"] = "--no-checks --no-compiler-driver"
+                if self.spec.satisfies("comm=gasnet"):
+                    vars["GASNET_SPAWNFN"] = "L"
+                    vars["GASNET_QUIET"] = "yes"
+                    vars["GASNET_ROUTE_OUTPUT"] = "0"
+                    vars["QT_AFFINITY"] = "no"
+                    vars["CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION"] = "1"
+                    vars["CHPL_RT_MASTERIP"] = "127.0.0.1"
+                    vars["CHPL_RT_WORKERIP"] = "127.0.0.0"
+                    vars["CHPL_LAUNCHER"] = ""
+                checkCplInstall(extra_env=vars)
 
     # TODO: This is a pain because the checkChplDoc script doesn't have the same
     # support for CHPL_CHECK_HOME and chpldoc is finicky about CHPL_HOME

--- a/repos/spack_repo/builtin/packages/cp2k/package.py
+++ b/repos/spack_repo/builtin/packages/cp2k/package.py
@@ -11,7 +11,6 @@ from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
-import spack.util.environment
 from spack.build_environment import dso_suffix
 from spack.package import *
 
@@ -935,9 +934,7 @@ class MakefileBuilder(makefile.MakefileBuilder):
             mkf.write("GPUVER = {0}\n".format(gpuver))
             mkf.write("DATA_DIR = {0}\n".format(prefix.share.data))
 
-    def setup_build_environment(
-        self, env: spack.util.environment.EnvironmentModifications
-    ) -> None:
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
         # Apparently the Makefile bases its paths on PWD
         # so we need to set PWD = self.build_directory
         env.set("PWD", self.build_directory)

--- a/repos/spack_repo/builtin/packages/cp2k/package.py
+++ b/repos/spack_repo/builtin/packages/cp2k/package.py
@@ -935,17 +935,24 @@ class MakefileBuilder(makefile.MakefileBuilder):
             mkf.write("GPUVER = {0}\n".format(gpuver))
             mkf.write("DATA_DIR = {0}\n".format(prefix.share.data))
 
+    def setup_build_environment(
+        self, env: spack.util.environment.EnvironmentModifications
+    ) -> None:
+        # Apparently the Makefile bases its paths on PWD
+        # so we need to set PWD = self.build_directory
+        env.set("PWD", self.build_directory)
+        # CP2K < 7 still uses $PWD to detect the current working dir
+        # and Makefile is in a subdir, account for both facts here:
+        data_dir = join_path(self.pkg.stage.source_path, "data")
+        env.set("CP2K_DATA_DIR", data_dir)
+
     def build(self, pkg, spec, prefix):
         if "+cuda" in spec and len(spec.variants["cuda_arch"].value) > 1:
             raise InstallError("cp2k supports only one cuda_arch at a time")
 
-        # Apparently the Makefile bases its paths on PWD
-        # so we need to set PWD = self.build_directory
-        with spack.util.environment.set_env(PWD=self.build_directory):
-            super().build(pkg, spec, prefix)
-
-            with working_dir(self.build_directory):
-                make("libcp2k", *self.build_targets)
+        super().build(pkg, spec, prefix)
+        with working_dir(self.build_directory):
+            make("libcp2k", *self.build_targets)
 
     def install(self, pkg, spec, prefix):
         exe_dir = join_path("exe", self.makefile_architecture)
@@ -994,15 +1001,6 @@ class MakefileBuilder(makefile.MakefileBuilder):
     @property
     def archive_files(self):
         return [join_path(self.pkg.stage.source_path, self.makefile)]
-
-    def check(self):
-        data_dir = join_path(self.pkg.stage.source_path, "data")
-
-        # CP2K < 7 still uses $PWD to detect the current working dir
-        # and Makefile is in a subdir, account for both facts here:
-        with spack.util.environment.set_env(CP2K_DATA_DIR=data_dir, PWD=self.build_directory):
-            with working_dir(self.build_directory):
-                make("test", *self.build_targets)
 
     @run_after("install", when="@9.1:")
     def fix_package_config(self):

--- a/repos/spack_repo/builtin/packages/magma/package.py
+++ b/repos/spack_repo/builtin/packages/magma/package.py
@@ -1,13 +1,10 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
-import spack.util.environment
 from spack.package import *
 
 
@@ -195,24 +192,22 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
         """Run C examples"""
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
         with working_dir(test_dir):
-            pkg_config_path = self.prefix.lib.pkgconfig
-            with spack.util.environment.set_env(PKG_CONFIG_PATH=pkg_config_path):
-                make = self.spec["gmake"].command
-                CC = "hipcc" if self.spec.satisfies("+rocm") else self.compiler.cc
-                make("c", f"CC={CC}")
-                tests = [
-                    ("example_sparse", "sparse solver"),
-                    ("example_sparse_operator", "sparse operator"),
-                    ("example_v1", "legacy v1 interface"),
-                    ("example_v2", "v2 interface"),
-                ]
+            make = self.spec["gmake"].command
+            CC = "hipcc" if self.spec.satisfies("+rocm") else self.compiler.cc
+            make("c", f"CC={CC}", extra_env={"PKG_CONFIG_PATH": self.prefix.lib.pkgconfig})
+            tests = [
+                ("example_sparse", "sparse solver"),
+                ("example_sparse_operator", "sparse operator"),
+                ("example_v1", "legacy v1 interface"),
+                ("example_v2", "v2 interface"),
+            ]
 
-                for test, desc in tests:
-                    with test_part(self, f"test_c_{test}", purpose=f"Run {desc} example"):
-                        exe = which(test)
-                        exe()
+            for test, desc in tests:
+                with test_part(self, f"test_c_{test}", purpose=f"Run {desc} example"):
+                    exe = which(test)
+                    exe()
 
-                make("clean")
+            make("clean")
 
     def test_fortran(self):
         """Run Fortran example"""
@@ -221,10 +216,8 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
 
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
         with working_dir(test_dir):
-            pkg_config_path = self.prefix.lib.pkgconfig
-            with spack.util.environment.set_env(PKG_CONFIG_PATH=pkg_config_path):
-                make = self.spec["gmake"].command
-                make("fortran")
-                example_f = which("example_f")
-                example_f()
-                make("clean")
+            make = self.spec["gmake"].command
+            make("fortran", extra_env={"PKG_CONFIG_PATH": self.prefix.lib.pkgconfig})
+            example_f = which("example_f")
+            example_f()
+            make("clean")

--- a/repos/spack_repo/builtin/packages/papi/package.py
+++ b/repos/spack_repo/builtin/packages/papi/package.py
@@ -1,7 +1,6 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 import glob
 import os
 import sys
@@ -9,7 +8,6 @@ import sys
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
-import spack.util.environment
 from spack.package import *
 
 
@@ -224,10 +222,9 @@ class Papi(AutotoolsPackage, ROCmPackage):
         if not os.path.exists(test_dir):
             raise SkipTest("Skipping smoke tests, directory doesn't exist")
         with working_dir(test_dir, create=False):
-            with spack.util.environment.set_env(PAPIROOT=self.prefix):
-                make = self.spec["gmake"].command
-                make()
-                exe_simple = which("simple")
-                exe_simple()
-                exe_threads = which("threads")
-                exe_threads()
+            make = self.spec["gmake"].command
+            make(extra_env={"PAPI_ROOT": self.prefix})
+            exe_simple = which("simple")
+            exe_simple(extra_env={"PAPI_ROOT": self.prefix})
+            exe_threads = which("threads")
+            exe_threads(extra_env={"PAPI_ROOT": self.prefix})

--- a/repos/spack_repo/builtin/packages/sbcl/package.py
+++ b/repos/spack_repo/builtin/packages/sbcl/package.py
@@ -1,11 +1,9 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
 
 from spack.package import *
-from spack.util.environment import set_env
 
 
 class Sbcl(MakefilePackage):
@@ -58,9 +56,7 @@ class Sbcl(MakefilePackage):
 
     def build(self, spec, prefix):
         sh = which("sh")
-
         version_str = str(spec.version)
-
         # NOTE: add any other git versions here.
         # When installing from git, the build system expects a dummy version
         # to be provided as a lisp expression.
@@ -68,15 +64,12 @@ class Sbcl(MakefilePackage):
             with open("version.lisp-expr", "w") as f:
                 f.write(f'"{version_str}"')
 
-        build_args = []
-        build_args.append("--prefix={0}".format(prefix))
-
+        build_args = ["--prefix={0}".format(prefix)]
         if "+fancy" in self.spec:
             build_args.append("--fancy")
 
         sbcl_bootstrap_prefix = self.spec["sbcl-bootstrap"].prefix.lib.sbcl
-        with set_env(SBCL_HOME=sbcl_bootstrap_prefix):
-            sh("make.sh", *build_args)
+        sh("make.sh", *build_args, extra_env={"SBCL_HOME": sbcl_bootstrap_prefix})
 
     def install(self, spec, prefix):
         sh = which("sh")

--- a/repos/spack_repo/builtin/packages/sbcl_bootstrap/package.py
+++ b/repos/spack_repo/builtin/packages/sbcl_bootstrap/package.py
@@ -1,13 +1,11 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 import platform
 
 from spack_repo.builtin.build_systems.generic import Package
 
 from spack.package import *
-from spack.util.environment import set_env
 
 
 class SbclBootstrap(Package):
@@ -112,5 +110,4 @@ class SbclBootstrap(Package):
 
     def install(self, spec, prefix):
         sh = which("sh")
-        with set_env(INSTALL_ROOT=self.spec.prefix):
-            sh("install.sh")
+        sh("install.sh", extra_env={"INSTALL_ROOT": self.spec.prefix})

--- a/repos/spack_repo/builtin/packages/strumpack/package.py
+++ b/repos/spack_repo/builtin/packages/strumpack/package.py
@@ -1,7 +1,6 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 import os
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
@@ -9,7 +8,6 @@ from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
 from spack.package import *
-from spack.util.environment import set_env
 
 
 class Strumpack(CMakePackage, CudaPackage, ROCmPackage):
@@ -231,10 +229,9 @@ class Strumpack(CMakePackage, CudaPackage, ROCmPackage):
             make = which("make")
             make(test_prog)
 
-            with set_env(OMP_NUM_THREADS="1"):
-                exe = which(test_cmd)
-                test_args = pre_args + [join_path("..", self.test_data_dir, "pde900.mtx")]
-                exe(*test_args)
+            exe = which(test_cmd)
+            test_args = pre_args + [join_path("..", self.test_data_dir, "pde900.mtx")]
+            exe(*test_args, extra_env={"OMP_NUM_THREADS": "1"})
 
     def test_sparse_seq(self):
         """Run sequential test_sparse"""


### PR DESCRIPTION
See https://github.com/spack/spack/issues/50388

`set_env` is considered internal Spack API, so remove its use from packages
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
