### PR TITLE
builtin: remove the use of `preserve_env`

### DIFF
--- a/repos/spack_repo/builtin/packages/fsl/package.py
+++ b/repos/spack_repo/builtin/packages/fsl/package.py
@@ -1,14 +1,12 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 import glob
 import os
 
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.generic import Package
 
-import spack.util.environment
 from spack.package import *
 
 
@@ -183,14 +181,12 @@ class Fsl(Package, CudaPackage):
     def postinstall(self):
         # The PYTHON  related environment variables need to be unset here so
         # the post install script does not get confused.
-        vars_to_unset = ["PYTHONPATH", "PYTHONHOME"]
+        script_env = os.environ.copy()
+        script_env.pop("PYTHONHOME", None)
+        script_env.pop("PYTHONPATH", None)
 
-        with spack.util.environment.preserve_environment(*vars_to_unset):
-            for v in vars_to_unset:
-                del os.environ[v]
-
-            script = Executable(join_path(prefix, "etc", "fslconf", "post_install.sh"))
-            script("-f", prefix)
+        script = Executable(join_path(prefix, "etc", "fslconf", "post_install.sh"))
+        script("-f", self.prefix, env=script_env)
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if not self.stage.source_path:

--- a/repos/spack_repo/builtin/packages/octave/package.py
+++ b/repos/spack_repo/builtin/packages/octave/package.py
@@ -10,7 +10,6 @@ import tempfile
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack_repo.builtin.build_systems.gnu import GNUMirrorPackage
 
-import spack.util.environment
 from spack.package import *
 
 
@@ -156,22 +155,21 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
 
         # We need to unset these variables since we are still within
         # Spack's build environment when running tests
-        vars_to_unset = ["CC", "CXX", "F77", "FC"]
+        mkoctfile_env = os.environ.copy()
+        mkoctfile_env.pop("CC", None)
+        mkoctfile_env.pop("CXX", None)
+        mkoctfile_env.pop("F77", None)
+        mkoctfile_env.pop("FC", None)
 
-        with spack.util.environment.preserve_environment(*vars_to_unset):
-            # Delete temporarily the environment variables that point
-            # to Spack compiler wrappers
-            for v in vars_to_unset:
-                del os.environ[v]
-            # Check that mkoctfile outputs the expected value for CC
-            cc = mkoctfile("-p", "CC", output=str)
-            msg = "mkoctfile didn't output the expected CC compiler"
-            assert self.compiler.cc in cc, msg
+        # Check that mkoctfile outputs the expected value for CC
+        cc = mkoctfile("-p", "CC", output=str, env=mkoctfile_env)
+        msg = "mkoctfile didn't output the expected CC compiler"
+        assert self.compiler.cc in cc, msg
 
-            # Try to compile an Octave extension
-            shutil.copy(helloworld_cc, tmp_dir)
-            with working_dir(tmp_dir):
-                mkoctfile("helloworld.cc")
+        # Try to compile an Octave extension
+        shutil.copy(helloworld_cc, tmp_dir)
+        with working_dir(tmp_dir):
+            mkoctfile("helloworld.cc", env=mkoctfile_env)
 
     def configure_args(self):
         # See


### PR DESCRIPTION
See https://github.com/spack/spack/issues/50388

`preserve_env` is considered internal Spack API, so remove its use from packages
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
