### PR TITLE
Add back slingshot network detection.

### DIFF
--- a/repos/spack_repo/builtin/packages/aluminum/package.py
+++ b/repos/spack_repo/builtin/packages/aluminum/package.py
@@ -16,6 +16,12 @@ from spack_repo.builtin.build_systems.rocm import ROCmPackage
 from spack.package import *
 
 
+def slingshot_network():
+    return os.path.exists("/opt/cray/pe") and (
+        os.path.exists("/lib64/libcxi.so") or os.path.exists("/usr/lib64/libcxi.so")
+    )
+
+
 class Aluminum(CachedCMakePackage, CudaPackage, ROCmPackage):
     """Aluminum provides a generic interface to high-performance
     communication libraries, with a focus on allreduce
@@ -55,7 +61,12 @@ class Aluminum(CachedCMakePackage, CudaPackage, ROCmPackage):
         " communication of accelerator data",
     )
     variant("nccl", default=False, description="Builds with support for NCCL communication lib")
-    variant("slingshot", default=False, when="+nccl", description="Builds with Slingshot support")
+    variant(
+        "slingshot",
+        default=slingshot_network(),
+        when="+nccl",
+        description="Builds with Slingshot support",
+    )
     variant("shared", default=True, description="Build Aluminum as a shared library")
 
     # Debugging features

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -18,6 +18,12 @@ from spack.package import *
 from spack.util.environment import is_system_path, set_env
 
 
+def slingshot_network():
+    return os.path.exists("/opt/cray/pe") and (
+        os.path.exists("/lib64/libcxi.so") or os.path.exists("/usr/lib64/libcxi.so")
+    )
+
+
 @llnl.util.lang.memoized
 def is_CrayEX():
     # Credit to upcxx package for this hpe-cray-ex detection function
@@ -326,6 +332,12 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         values=("bundled", "spack", "unset"),
         multi=False,
         when="comm=gasnet comm_substrate=ofi",
+    )
+
+    requires(
+        "^libfabric" + (" fabrics=cxi" if slingshot_network() else ""),
+        when="libfabric=spack",
+        msg="libfabric requires cxi fabric provider on HPE-Cray EX machines",
     )
 
     variant(

--- a/repos/spack_repo/builtin/packages/lbann/package.py
+++ b/repos/spack_repo/builtin/packages/lbann/package.py
@@ -18,6 +18,12 @@ from spack_repo.builtin.build_systems.rocm import ROCmPackage
 from spack.package import *
 
 
+def slingshot_network():
+    return os.path.exists("/opt/cray/pe") and (
+        os.path.exists("/lib64/libcxi.so") or os.path.exists("/usr/lib64/libcxi.so")
+    )
+
+
 class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
     """LBANN: Livermore Big Artificial Neural Network Toolkit.  A distributed
     memory, HPC-optimized, model and data parallel training toolkit for deep
@@ -79,7 +85,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
         default=False,
         description="Builds with support for image processing data with OpenCV",
     )
-    variant("slingshot", default=False, description="Enable slingshot support")
+    variant("slingshot", default=slingshot_network(), description="Enable slingshot support")
     variant("vtune", default=False, description="Builds with support for Intel VTune")
     variant("onednn", default=False, description="Support for OneDNN")
     variant("onnx", default=False, description="Support for exporting models into ONNX format")


### PR DESCRIPTION
Restore functionality lost in #544.

Packages shouldn't *silently* depend on host-based detection, as that discards build provenance. Detected options should be modeled as variants, or at least through specs metadata in some way, as #544 did.

Packages *can* use host detection to set defaults for variants, as that preserves build provenance and allows a user to override the setting if needed. It also makes it easy for users to `spack install` on a given machine and get a sensible default.

`slingshot_network()` as currently written probably shouldn't be in the Spack package API -- it isn't really detecting hardware; it's just the best way we know to test for slinghost on Cray EX. So, not importing `spack.platforms.cray.slingshot_network()` is a good idea.

However, the function is actually needed by users of several packages, so move it *into* the packages for now so as not to disrupt them.

We should have a discussion, eventually, of how best to provide hardware information to packages for configuration hints.  It should likely be something more dynamic than a hard-coded function, so that we don't have to keep functions like `slingshot_network()` around forever. e.g., we might supply a dictionary of detected hardware features to packages, or some string-based query function -- something with a small and sustainable API surface. We can leave that until after 1.0.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
