### PR TITLE
Fix relion 5.0.0 ~cuda build

### DIFF
--- a/repos/spack_repo/builtin/packages/relion/package.py
+++ b/repos/spack_repo/builtin/packages/relion/package.py
@@ -129,6 +129,10 @@ class Relion(CMakePackage, CudaPackage):
             else:
                 args += ["-DCUDA=ON", "-DCudaTexture=ON", "-DCUDA_ARCH=%s" % (carch)]
 
+        if self.spec.satisfies("@5: ~cuda"):
+            # Relion 5 defaults to CUDA=ON so it has to be explicitly disabled.
+            args.append("-DCUDA=OFF")
+
         return args
 
     def patch(self):


### PR DESCRIPTION
This fixes a build error of relion 5.0.0 if the cuda variant is disabled:

```
     35    CUDA_TOOLKIT_ROOT_DIR not found or specified
     36    -- Could NOT find CUDA (missing: CUDA_TOOLKIT_ROOT_DIR CUDA_NVCC_EXECUTABLE CUDA_INCLUDE_DIRS CUDA_CUDART_LIBRARY)
  >> 37    CMake Error at CMakeLists.txt:208 (message):
     38      CUDA enabled but unlable to locate packages...
```