### PR TITLE
cmake: Fix check to skip re-running cmake configure for develop build…

### DIFF
--- a/repos/spack_repo/builtin/build_systems/cmake.py
+++ b/repos/spack_repo/builtin/build_systems/cmake.py
@@ -468,7 +468,7 @@ class CMakeBuilder(BuilderWithDefaults):
             primary_generator = _extract_primary_generator(self.generator)
             configure_artifact = "Makefile"
             if primary_generator == "Ninja":
-                configure_artifact = "ninja.build"
+                configure_artifact = "build.ninja"
 
             if os.path.isfile(os.path.join(self.build_directory, configure_artifact)):
                 tty.msg(


### PR DESCRIPTION
…s with Ninja.

From checking for a ninja.build file instead of build.ninja

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
