### PR TITLE
chapel: change maintainers list order

### DIFF
--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -53,7 +53,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     # A list of GitHub accounts to notify when the package is updated.
     # TODO: add chapel-project github account
-    maintainers("arezaii", "bonachea", "arifthpe")
+    maintainers("arifthpe", "bonachea", "arezaii")
 
     tags = ["e4s"]
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Change order of `chapel` maintainers list so the current primary maintainers are the first two, to work around [spackbot only requesting review from the first two maintainers](https://github.com/spack/spackbot/issues/109).