### PR TITLE
[Draft] py-setuptools: Add dependency to py-packaging

### DIFF
--- a/repos/spack_repo/builtin/packages/py_setuptools/package.py
+++ b/repos/spack_repo/builtin/packages/py_setuptools/package.py
@@ -149,6 +149,8 @@ class PySetuptools(Package, PythonExtension):
         # https://github.com/pypa/setuptools/issues/3661
         depends_on("python@:3.11", when="@:67")
 
+        depends_on("py-packaging@24.2:", when="@77:")
+
     depends_on("py-pip", type="build")
 
     conflicts(


### PR DESCRIPTION
The latest version of py-setuptools depends on a recent version of py-packaging. If you fail to load a valid version of packaging, you get an error like the following.

```
  ImportError: Cannot import `packaging.licenses`.
          Setuptools>=77.0.0 requires "packaging>=24.2" to work properly.
          Please make sure you have a suitable version installed.
```

This causes other packages that use pip to install themselves to fail.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
