### PR TITLE
py-meson-python: Add dependency to ninja

### DIFF
--- a/repos/spack_repo/builtin/packages/py_meson_python/package.py
+++ b/repos/spack_repo/builtin/packages/py_meson_python/package.py
@@ -46,6 +46,7 @@ class PyMesonPython(PythonPackage):
     depends_on("py-tomli@1:", when="@0.11: ^python@:3.10", type=("build", "run"))
     depends_on("py-tomli@1:", when="@:0.10", type=("build", "run"))
     depends_on("py-setuptools@60:", when="@0.13 ^python@3.12:", type=("build", "run"))
+    depends_on("ninja", type=("build", "run"))
 
     # https://github.com/mesonbuild/meson-python/pull/111
     conflicts("platform=darwin os=ventura", when="@:0.7")


### PR DESCRIPTION
Although meson requires few dependencies, ninja is sometimes one of them. See the following documentation of meson
(at https://mesonbuild.com/Use-of-Python.html).

> The only thing you need is Python 3 (and possibly Ninja).

I had some compile failures because ninja was not available.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
