### PR TITLE
netlib-xblas: depends on fortran when +fortran

### DIFF
--- a/repos/spack_repo/builtin/packages/netlib_xblas/package.py
+++ b/repos/spack_repo/builtin/packages/netlib_xblas/package.py
@@ -34,7 +34,7 @@ class NetlibXblas(AutotoolsPackage):
     provides("blas", when="+plain_blas")
 
     depends_on("c", type="build")
-    depends_on("fortran", when="+fortran")
+    depends_on("fortran", type="build", when="+fortran")
     depends_on("m4", type="build")
 
     @property

--- a/repos/spack_repo/builtin/packages/netlib_xblas/package.py
+++ b/repos/spack_repo/builtin/packages/netlib_xblas/package.py
@@ -34,6 +34,7 @@ class NetlibXblas(AutotoolsPackage):
     provides("blas", when="+plain_blas")
 
     depends_on("c", type="build")
+    depends_on("fortran", when="+fortran")
     depends_on("m4", type="build")
 
     @property


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
netlib-xblas needs fortran compiler when `+fortran`, this PR adds this virtual dependecy to it.