### PR TITLE
git: add diffutils dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/git/package.py
+++ b/repos/spack_repo/builtin/packages/git/package.py
@@ -173,6 +173,7 @@ class Git(AutotoolsPackage):
     depends_on("openssh", type="run")
     depends_on("perl-alien-svn", type="run", when="+svn")
     depends_on("tk", type=("build", "link"), when="+tcltk")
+    depends_on("diffutils", type="build", when="@2.48:")
 
     conflicts("+svn", when="~perl")
 


### PR DESCRIPTION
Adding diffutils dependency becuase the `cmp` command was introduced in version 2.48, https://github.com/git/git/blob/master/GIT-VERSION-GEN#L100.