### PR TITLE
py-types-setuptools: add v80.9.0.20250529

### DIFF
--- a/repos/spack_repo/builtin/packages/py_types_setuptools/package.py
+++ b/repos/spack_repo/builtin/packages/py_types_setuptools/package.py
@@ -11,9 +11,19 @@ class PyTypesSetuptools(PythonPackage):
     """Typing stubs for setuptools."""
 
     homepage = "https://github.com/python/typeshed"
-    pypi = "types-setuptools/types-setuptools-65.5.0.3.tar.gz"
+    pypi = "types-setuptools/types_setuptools-80.9.0.20250529.tar.gz"
 
+    version("80.9.0.20250529", sha256="79e088ba0cba2186c8d6499cbd3e143abb142d28a44b042c28d3148b1e353c91")
     version("68.2.0.0", sha256="a4216f1e2ef29d089877b3af3ab2acf489eb869ccaf905125c69d2dc3932fd85")
     version("65.5.0.3", sha256="17769171f5f2a2dc69b25c0d3106552a5cda767bbf6b36cb6212b26dae5aa9fc")
 
+    depends_on("py-setuptools@:77.0.3", type="build", when="@:79.0.0.20250422")
     depends_on("py-setuptools", type="build")
+
+    def url_for_version(self, version):
+        url = "https://files.pythonhosted.org/packages/source/t/types-setuptools/{}-{}.tar.gz"
+        if version >= Version("75.5.0.20241121"):
+            name = "types_setuptools"
+        else:
+            name = "types-setuptools"
+        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_types_setuptools/package.py
+++ b/repos/spack_repo/builtin/packages/py_types_setuptools/package.py
@@ -15,7 +15,7 @@ class PyTypesSetuptools(PythonPackage):
 
     version(
         "80.9.0.20250529",
-        sha256="79e088ba0cba2186c8d6499cbd3e143abb142d28a44b042c28d3148b1e353c91"
+        sha256="79e088ba0cba2186c8d6499cbd3e143abb142d28a44b042c28d3148b1e353c91",
     )
     version("68.2.0.0", sha256="a4216f1e2ef29d089877b3af3ab2acf489eb869ccaf905125c69d2dc3932fd85")
     version("65.5.0.3", sha256="17769171f5f2a2dc69b25c0d3106552a5cda767bbf6b36cb6212b26dae5aa9fc")

--- a/repos/spack_repo/builtin/packages/py_types_setuptools/package.py
+++ b/repos/spack_repo/builtin/packages/py_types_setuptools/package.py
@@ -13,6 +13,8 @@ class PyTypesSetuptools(PythonPackage):
     homepage = "https://github.com/python/typeshed"
     pypi = "types-setuptools/types_setuptools-80.9.0.20250529.tar.gz"
 
+    license("Apache-2.0")
+
     version(
         "80.9.0.20250529",
         sha256="79e088ba0cba2186c8d6499cbd3e143abb142d28a44b042c28d3148b1e353c91",

--- a/repos/spack_repo/builtin/packages/py_types_setuptools/package.py
+++ b/repos/spack_repo/builtin/packages/py_types_setuptools/package.py
@@ -13,7 +13,10 @@ class PyTypesSetuptools(PythonPackage):
     homepage = "https://github.com/python/typeshed"
     pypi = "types-setuptools/types_setuptools-80.9.0.20250529.tar.gz"
 
-    version("80.9.0.20250529", sha256="79e088ba0cba2186c8d6499cbd3e143abb142d28a44b042c28d3148b1e353c91")
+    version(
+        "80.9.0.20250529",
+        sha256="79e088ba0cba2186c8d6499cbd3e143abb142d28a44b042c28d3148b1e353c91"
+    )
     version("68.2.0.0", sha256="a4216f1e2ef29d089877b3af3ab2acf489eb869ccaf905125c69d2dc3932fd85")
     version("65.5.0.3", sha256="17769171f5f2a2dc69b25c0d3106552a5cda767bbf6b36cb6212b26dae5aa9fc")
 

--- a/repos/spack_repo/builtin/packages/py_types_setuptools/package.py
+++ b/repos/spack_repo/builtin/packages/py_types_setuptools/package.py
@@ -20,7 +20,7 @@ class PyTypesSetuptools(PythonPackage):
     version("68.2.0.0", sha256="a4216f1e2ef29d089877b3af3ab2acf489eb869ccaf905125c69d2dc3932fd85")
     version("65.5.0.3", sha256="17769171f5f2a2dc69b25c0d3106552a5cda767bbf6b36cb6212b26dae5aa9fc")
 
-    depends_on("py-setuptools@:77.0.3", type="build", when="@:79.0.0.20250422")
+    depends_on("py-setuptools@77.0.3:", type="build", when="@79.0.0.20250422:")
     depends_on("py-setuptools", type="build")
 
     def url_for_version(self, version):


### PR DESCRIPTION
Add version 80.9.0.2025059 and fix tar ball name that changed on pypi from `types-setuptools` to `types_setuptools`
<https://pypi.org/project/types-setuptools/80.9.0.20250529/#files>

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
