### PR TITLE
ci / changes: also pick up an older builtin repo path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,7 @@ jobs:
             - repos/spack_repo/**
             old-builtin:
             - 'var/spack/repos/spack_repo/builtin/**'
+            - 'var/spack/repos/builtin/**'
       - name: Detected old builtin repository
         if: steps.filter.outputs.old-builtin == 'true'
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,14 +44,21 @@ jobs:
             - .ci/env
             packages:
             - repos/spack_repo/**
-            old-builtin:
+            old_builtin:
             - 'var/spack/repos/spack_repo/builtin/**'
             - 'var/spack/repos/builtin/**'
+          list-files: 'shell'
       - name: Detected old builtin repository
-        if: steps.filter.outputs.old-builtin == 'true'
+        if: steps.filter.outputs.old_builtin == 'true'
         run: |
-          echo "Error: Packages are not allowed in 'var/spack/repos/spack_repo/builtin'."
-          echo "       Use 'repos/spack_repo/builtin' instead."
+          files=${{ steps.filter.outputs.old_builtin_files }}
+          echo "Error: Builtin packages are no longer allowed under 'var/spack/repos/'."
+          echo "       The following files need to be moved to the appropriate"
+          echo "       subdirectory of 'repos/spack_repo/builtin':"
+          echo
+          for f in $files; do
+              echo "  $f"
+          done
           exit 1
 
   unit-tests:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,15 +44,14 @@ jobs:
             - .ci/env
             packages:
             - repos/spack_repo/**
-            old_builtin:
-            - 'var/spack/repos/spack_repo/builtin/**'
-            - 'var/spack/repos/builtin/**'
+            old_repos:
+            - 'var/spack/repos/**'
           list-files: 'shell'
-      - name: Detected old builtin repository
-        if: steps.filter.outputs.old_builtin == 'true'
+      - name: Detected old package repository root directory
+        if: steps.filter.outputs.old_repos == 'true'
         run: |
-          files=${{ steps.filter.outputs.old_builtin_files }}
-          echo "Error: Builtin packages are no longer allowed under 'var/spack/repos/'."
+          files=${{ steps.filter.outputs.old_repos_files }}
+          echo "Error: Packages are no longer allowed under 'var/spack/repos/'."
           echo "       The following files need to be moved to the appropriate"
           echo "       subdirectory of 'repos/spack_repo/builtin':"
           echo


### PR DESCRIPTION
Fixes #591 

https://github.com/spack/spack-packages/pull/542 added a check for one of the old `builtin` repository paths. This PR adds another that's been encountered in PRs.

An example of the new output can be seen at https://github.com/spack/spack-packages/actions/runs/16279170198/job/45965108609?pr=584.

```
...
Error: Builtin packages are no longer allowed under 'var/spack/repos/'.
       The following files need to be moved to the appropriate
       subdirectory of 'repos/spack_repo/builtin':

  var/spack/repos/builtin/remove-me/package.py
  ...
```