### PR TITLE
nvpl-fft: fix isort style issue not caught in #284

### DIFF
--- a/repos/spack_repo/builtin/packages/nvpl_fft/package.py
+++ b/repos/spack_repo/builtin/packages/nvpl_fft/package.py
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack_repo.builtin.build_systems.generic import Package
 import os
+
+from spack_repo.builtin.build_systems.generic import Package
 
 from llnl.util.symlink import symlink
 


### PR DESCRIPTION
This PR fixes the `isort` style issue not caught in the recently merged #284 .  Locally checking the style after the fix passes.

Before:
```
==> Running isort checks
--- /Users/dahlgren1/github/spack-packages/repos/spack_repo/builtin/packages/nvpl_fft/package.py:before	2025-07-14 16:49:02.475709
+++ /Users/dahlgren1/github/spack-packages/repos/spack_repo/builtin/packages/nvpl_fft/package.py:after	2025-07-14 16:49:05.644192
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack_repo.builtin.build_systems.generic import Package
-import os
 
 from llnl.util.symlink import symlink
 
ERROR: repos/spack_repo/builtin/packages/nvpl_fft/package.py Imports are incorrectly sorted and/or formatted.
  isort found errors
...
```

After:
```
$ spack style -t isort repos/spack_repo/builtin/packages/nvpl_fft/package.py
==> Running style checks on spack
  selected: isort
==> Modified files
  repos/spack_repo/builtin/packages/nvpl_fft/package.py
==> Running isort checks
  isort checks were clean
==> spack style checks were clean
```