### PR TITLE
libdwarf: fix style issues not raised in #320

### DIFF
--- a/repos/spack_repo/builtin/packages/libdwarf/package.py
+++ b/repos/spack_repo/builtin/packages/libdwarf/package.py
@@ -2,12 +2,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-import sys
-
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
+
 
 class Libdwarf(CMakePackage):
     """The DWARF Debugging Information Format is of interest to
@@ -38,9 +36,7 @@ class Libdwarf(CMakePackage):
     variant("dwarfdump", default=True, description="Build dwarfdump")
     variant("dwarfgen", default=False, description="Build dwarfgen")
     variant(
-        "decompression",
-        default=True,
-        description="Enables support for compressed debug sections",
+        "decompression", default=True, description="Enables support for compressed debug sections"
     )
 
     conflicts("+shared ~pic")


### PR DESCRIPTION
Before:

```
$  spack style repos/spack_repo/builtin/packages/libdwarf/package.py
==> Running style checks on spack
  selected: import, isort, black, flake8, mypy
==> Modified files
  repos/spack_repo/builtin/packages/libdwarf/package.py
==> Running import checks
  import checks were clean
==> Running isort checks
--- $pack-packages/repos/spack_repo/builtin/packages/libdwarf/package.py:before	2025-07-14 17:16:44.838017
+++ $spack-packages/repos/spack_repo/builtin/packages/libdwarf/package.py:after	2025-07-14 17:22:27.428801
@@ -8,6 +8,7 @@
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
+
 
 class Libdwarf(CMakePackage):
     """The DWARF Debugging Information Format is of interest to
ERROR: repos/spack_repo/builtin/packages/libdwarf/package.py Imports are incorrectly sorted and/or formatted.
  isort found errors
==> Running black checks
--- ../../spack-packages/repos/spack_repo/builtin/packages/libdwarf/package.py	2025-07-15 00:16:44.838017+00:00
+++ ../../spack-packages/repos/spack_repo/builtin/packages/libdwarf/package.py	2025-07-15 00:22:27.564611+00:00
@@ -6,10 +6,11 @@
 import sys
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
+
 
 class Libdwarf(CMakePackage):
     """The DWARF Debugging Information Format is of interest to
     programmers working on compilers and debuggers (and any one
     interested in reading or writing DWARF information). It was
@@ -36,13 +37,11 @@
     variant("examples", default=False, description="Build examples")
     variant("pic", default=True, description="Build with position independent code")
     variant("dwarfdump", default=True, description="Build dwarfdump")
     variant("dwarfgen", default=False, description="Build dwarfgen")
     variant(
-        "decompression",
-        default=True,
-        description="Enables support for compressed debug sections",
+        "decompression", default=True, description="Enables support for compressed debug sections"
     )
 
     conflicts("+shared ~pic")
 
     depends_on("c", type="build")
would reformat repos/spack_repo/builtin/packages/libdwarf/package.py
Oh no! 💥 💔 💥
1 file would be reformatted.
  black found errors
==> Running flake8 checks
...
==> Running mypy checks
Success: no issues found in 612 source files
  mypy checks were clean
==> Error: spack style found errors
```

After:

```
$ spack style -t isort -t black repos/spack_repo/builtin/packages/libdwarf/package.py
==> Running style checks on spack
  selected: isort, black
==> Modified files
  repos/spack_repo/builtin/packages/libdwarf/package.py
==> Running isort checks
  isort checks were clean
==> Running black checks
All done! ✨ 🍰 ✨
1 file would be left unchanged.
  black checks were clean
```
