### PR TITLE
boost: fix style issue not caught in #376

### DIFF
--- a/repos/spack_repo/builtin/packages/boost/package.py
+++ b/repos/spack_repo/builtin/packages/boost/package.py
@@ -325,7 +325,11 @@ class Boost(Package):
     conflicts("+clanglibcpp", when="@1.85: +stacktrace")
 
     # https://github.com/boostorg/python/issues/400
-    conflicts("@:1.80.0", when="+python ^python@3.11:", msg="Boost.python.enum has a known bug for boost@:1.80.0 and python@3.11:")
+    conflicts(
+        "@:1.80.0",
+        when="+python ^python@3.11:",
+        msg="Boost.python.enum has a known bug for boost@:1.80.0 and python@3.11:",
+    )
 
     # On Windows, the signals variant is required when building any of
     # the all_libs variants.


### PR DESCRIPTION
Fixes (thanks to `black`) the style  issue not caught by #376:

```
...
repos/spack_repo/builtin/packages/boost/package.py
repos/spack_repo/builtin/packages/boost/package.py:328: [E501] line too long (131 > 99 characters)
```
