### PR TITLE
h5hut: Update git repo location

### DIFF
--- a/repos/spack_repo/builtin/packages/h5hut/package.py
+++ b/repos/spack_repo/builtin/packages/h5hut/package.py
@@ -57,6 +57,7 @@ class H5hut(AutotoolsPackage):
     def configure_args(self):
         spec = self.spec
         config_args = ["--enable-shared"]
+        config_args.append(f"--with-hdf5={spec['hdf5'].prefix}")
 
         if spec.satisfies("+fortran"):
             config_args.append("--enable-fortran")

--- a/repos/spack_repo/builtin/packages/h5hut/package.py
+++ b/repos/spack_repo/builtin/packages/h5hut/package.py
@@ -14,7 +14,8 @@ class H5hut(AutotoolsPackage):
 
     homepage = "https://amas.psi.ch/H5hut/"
     url = "https://amas.web.psi.ch/Downloads/H5hut/H5hut-0.0.0.tar.gz"
-    git = "https://gitlab.psi.ch/H5hut/src.git"
+    git = "https://github.com/eth-cscs/h5hut.git"
+
     maintainers("biddisco")
 
     version("2.0.0rc7", sha256="bc058c4817c356b7b7acfe386c586923103b90bdfa83575db3a91754767e6fab")


### PR DESCRIPTION
The git repo location has changed.

A build error has been fixed where hdf5 was not being found by `configure` - adding the prefix to the config args fixes it