### PR TITLE
[WIP] py-opentelemetry-{api, sdk,proto,semantic-...}: init with 1.34.1

### DIFF
--- a/repos/spack_repo/builtin/packages/py_opentelemetry_api/package.py
+++ b/repos/spack_repo/builtin/packages/py_opentelemetry_api/package.py
@@ -1,0 +1,28 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+from spack.package import *
+
+
+class PyOpentelemetryApi(PythonPackage):
+    """OpenTelemetry Python API"""
+
+    homepage = "https://github.com/open-telemetry/opentelemetry-python"
+    pypi = "opentelemetry_api/opentelemetry_api-1.34.1.tar.gz"
+
+    maintainers("viperML")
+
+    license("Apache-2.0", checked_by="viperML")
+
+    version("1.34.1", sha256="64f0bd06d42824843731d05beea88d4d4b6ae59f9fe347ff7dfa2cc14233bbb3")
+
+    depends_on("python@3.9:", type=("build", "run"))
+    depends_on("py-hatchling", type="build")
+
+    with default_args(type="run"):
+        depends_on("py-typing-extensions@4.5.0:")
+        # Requires <8.8.0, but @8 is not yet on Spack
+        depends_on("py-importlib-metadata@6:8")

--- a/repos/spack_repo/builtin/packages/py_opentelemetry_exporter_prometheus/package.py
+++ b/repos/spack_repo/builtin/packages/py_opentelemetry_exporter_prometheus/package.py
@@ -1,0 +1,28 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyOpentelemetryExporterPrometheus(PythonPackage):
+    """Prometheus Metric Exporter for OpenTelemetry"""
+
+    homepage = "https://github.com/open-telemetry/opentelemetry-python"
+    pypi = "opentelemetry_exporter_prometheus/opentelemetry_exporter_prometheus-0.55b1.tar.gz"
+
+    maintainers("viperML")
+
+    license("Apache-2.0", checked_by="viperML")
+
+    version("0.55b1", sha256="d13ec0b22bf394113ff1ada5da98133a4b051779b803dae183188e26c4bd9ee0")
+
+    depends_on("python@3.9:", type=("build", "run"))
+    depends_on("py-hatchling", type="build")
+
+    with default_args(type="run"):
+        depends_on("py-opentelemetry-api@1.34.1")
+        depends_on("py-opentelemetry-sdk@1.34.1")
+        depends_on("py-prometheus-client@0.5.0:0")

--- a/repos/spack_repo/builtin/packages/py_opentelemetry_proto/package.py
+++ b/repos/spack_repo/builtin/packages/py_opentelemetry_proto/package.py
@@ -1,0 +1,25 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+from spack.package import *
+
+
+class PyOpentelemetryProto(PythonPackage):
+    """OpenTelemetry Python Proto"""
+
+    homepage = "https://github.com/open-telemetry/opentelemetry-python"
+    pypi = "opentelemetry_api/opentelemetry_api-1.34.1.tar.gz"
+
+    maintainers("viperML")
+
+    license("Apache-2.0", checked_by="viperML")
+
+    version("1.34.1", sha256="64f0bd06d42824843731d05beea88d4d4b6ae59f9fe347ff7dfa2cc14233bbb3")
+
+    depends_on("python@3.9:", type=("build", "run"))
+    depends_on("py-hatchling", type="build")
+
+    with default_args(type="run"):
+        depends_on("py-protobuf@5:6")

--- a/repos/spack_repo/builtin/packages/py_opentelemetry_sdk/package.py
+++ b/repos/spack_repo/builtin/packages/py_opentelemetry_sdk/package.py
@@ -1,0 +1,27 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyOpentelemetrySdk(PythonPackage):
+    """OpenTelemetry Python SDK"""
+
+    homepage = "https://github.com/open-telemetry/opentelemetry-python"
+    pypi = "opentelemetry_sdk/opentelemetry_sdk-1.34.1.tar.gz"
+
+    maintainers("viperML")
+
+    license("Apache-2.0", checked_by="viperML")
+
+    version("1.34.1", sha256="8091db0d763fcd6098d4781bbc80ff0971f94e260739aa6afe6fd379cdf3aa4d")
+
+    depends_on("python@3.9:", type=("build", "run"))
+    depends_on("py-hatchling", type="build")
+
+    with default_args(type="run"):
+        depends_on("py-typing-extensions@4.5.0:")
+        depends_on("py-opentelemetry-api@1.34.1", when="@1.34.1")

--- a/repos/spack_repo/builtin/packages/py_opentelemetry_semantic_conventions/package.py
+++ b/repos/spack_repo/builtin/packages/py_opentelemetry_semantic_conventions/package.py
@@ -1,0 +1,27 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyOpentelemetrySemanticConventions(PythonPackage):
+    """OpenTelemetry Semantic Conventions"""
+
+    homepage = "https://github.com/open-telemetry/opentelemetry-python"
+    pypi = "opentelemetry_semantic_conventions/opentelemetry_semantic_conventions-0.55b1.tar.gz"
+
+    maintainers("viperML")
+
+    license("Apache-2.0", checked_by="viperML")
+
+    version("0.55b1", sha256="ef95b1f009159c28d7a7849f5cbc71c4c34c845bb514d66adfdf1b3fff3598b3")
+
+    depends_on("python@3.9:", type=("build", "run"))
+    depends_on("py-hatchling", type="build")
+
+    with default_args(type="run"):
+        depends_on("py-opentelemetry-api@1.34.1")
+        depends_on("py-typing-extensions@4.5.0:")


### PR DESCRIPTION
Original PR (https://github.com/spack/spack-packages/pull/430) closed due to ownership transfer.

Simple Python packages with not too many dependencies.

Needed for a py-ray update, CC @viperML @theabm
