### PR TITLE
ignore pyrightconfig.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /spack-core
+/pyrightconfig.json
 
 ###########################
 # Python-specific ignores #


### PR DESCRIPTION
I need this to make vscode understand imports:

```json
{
    "include": ["repos"],
    "extraPaths": [
        "/home/user/spack/lib/spack",
        "/home/user/spack/lib/spack/external",
    ]
}
```
