### PR TITLE
[Draft/WIP] meep dependents: Add missing compliler-depends

### DIFF
--- a/repos/spack_repo/builtin/packages/libctl/package.py
+++ b/repos/spack_repo/builtin/packages/libctl/package.py
@@ -27,6 +27,7 @@ class Libctl(AutotoolsPackage):
     )
 
     depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
 
     depends_on("guile")
 

--- a/repos/spack_repo/builtin/packages/libgdsii/package.py
+++ b/repos/spack_repo/builtin/packages/libgdsii/package.py
@@ -20,6 +20,7 @@ class Libgdsii(AutotoolsPackage):
 
     version("0.21", sha256="1adc571c6b53df4c08d108f9ac4f4a7fd6fbefd4bc56f74e0b7b2801353671b8")
 
+    depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
     depends_on("autoconf", type="build")

--- a/repos/spack_repo/builtin/packages/mpb/package.py
+++ b/repos/spack_repo/builtin/packages/mpb/package.py
@@ -19,6 +19,7 @@ class Mpb(AutotoolsPackage):
     version("1.11.1", sha256="7311fc525214c1184cad3e0626b8540c0b53b3c31c28e61ce6ec2860088eca46")
 
     depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")


### PR DESCRIPTION
The Meep depentent packages libctl, libgdsii and mpb are missing some compiler dependency.