### PR TITLE
Patch py-kornia-rs to pin fast_image_resize

### DIFF
--- a/repos/spack_repo/builtin/packages/py_kornia_rs/package.py
+++ b/repos/spack_repo/builtin/packages/py_kornia_rs/package.py
@@ -43,6 +43,9 @@ class PyKorniaRs(PythonPackage):
     # dlpack-rs needs libclang
     depends_on("llvm+clang")
 
+    # Pin fast_image_resize to 5.1.0, >=5.2 requires rust >=1.87
+    patch("py-kornia-rs-pin-fast_image_resize.patch", when="@0.1.9")
+
     @property
     def build_directory(self):
         return "kornia-py" if self.spec.satisfies("@0.1.3:") else "py-kornia"

--- a/repos/spack_repo/builtin/packages/py_kornia_rs/package.py
+++ b/repos/spack_repo/builtin/packages/py_kornia_rs/package.py
@@ -43,7 +43,7 @@ class PyKorniaRs(PythonPackage):
     # dlpack-rs needs libclang
     depends_on("llvm+clang")
 
-    # Pin fast_image_resize to 5.1.0, >=5.2 requires rust >=1.87
+    # See https://github.com/kornia/kornia-rs/commit/93f768137814709b60767f7fc24a9b0184002aee
     patch("py-kornia-rs-pin-fast_image_resize.patch", when="@0.1.9")
 
     @property

--- a/repos/spack_repo/builtin/packages/py_kornia_rs/py-kornia-rs-pin-fast_image_resize.patch
+++ b/repos/spack_repo/builtin/packages/py_kornia_rs/py-kornia-rs-pin-fast_image_resize.patch
@@ -1,0 +1,13 @@
+diff --git a/crates/kornia-imgproc/Cargo.toml b/crates/kornia-imgproc/Cargo.toml
+index b501eb0..7950c30 100644
+--- a/crates/kornia-imgproc/Cargo.toml
++++ b/crates/kornia-imgproc/Cargo.toml
+@@ -12,7 +12,7 @@ rust-version.workspace = true
+ version.workspace = true
+ 
+ [dependencies]
+-fast_image_resize = "5.1.0"
++fast_image_resize = "=5.1.0"
+ kornia-tensor = { workspace = true }
+ kornia-image = { workspace = true }
+ num-traits = { workspace = true }

--- a/repos/spack_repo/builtin/packages/py_kornia_rs/py-kornia-rs-pin-fast_image_resize.patch
+++ b/repos/spack_repo/builtin/packages/py_kornia_rs/py-kornia-rs-pin-fast_image_resize.patch
@@ -7,7 +7,7 @@ index b501eb0..7950c30 100644
  
  [dependencies]
 -fast_image_resize = "5.1.0"
-+fast_image_resize = "=5.1.0"
++fast_image_resize = "=5.1"
  kornia-tensor = { workspace = true }
  kornia-image = { workspace = true }
  num-traits = { workspace = true }


### PR DESCRIPTION
Fixes [failure on develop](https://gitlab.spack.io/spack/spack-packages/-/jobs/17386285)

Newer versions of fast_image_resize require integer_sign_cast which was stabilized in rust 1.87. This was already done in newer releases of py-kornia-rs.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
