### PR TITLE
Require newer version of llvm-openmp for xgboost and py_torch on macOS

### DIFF
--- a/.ci/gitlab/stacks/ml-darwin-aarch64-mps/spack.yaml
+++ b/.ci/gitlab/stacks/ml-darwin-aarch64-mps/spack.yaml
@@ -62,7 +62,8 @@ spack:
   - py-torchfile
   - py-torchgeo
   - py-torchmetrics
-  - py-torchtext
+  # fp16 mismatch between openblas and py_torch@2.3.0
+  # - py-torchtext
   - py-torchvision
   - py-vector-quantize-pytorch
 

--- a/repos/spack_repo/builtin/packages/llvm_openmp/package.py
+++ b/repos/spack_repo/builtin/packages/llvm_openmp/package.py
@@ -27,6 +27,14 @@ class LlvmOpenmp(CMakePackage):
 
     license("Apache-2.0")
 
+    version("20.1.8", sha256="b21c04ee9cbe56e200c5d83823765a443ee6389bbc3f64154c96e94016e6cee9")
+    resource_for_ver(
+        "20.1.8", sha256="3319203cfd1172bbac50f06fa68e318af84dcb5d65353310c0586354069d6634"
+    )
+    version("19.1.7", sha256="bd7e6901ab086fd268750363017935fd4a717c153dad3c2aab86cb0140d9e3fe")
+    resource_for_ver(
+        "19.1.7", sha256="11c5a28f90053b0c43d0dec3d0ad579347fc277199c005206b963c19aae514e3"
+    )
     version("18.1.0", sha256="ef1cef885d463e4becf5e132a9175a540c6f4487334c0e86274a374ce7d0a092")
     resource_for_ver(
         "18.1.0", sha256="d367bf77a3707805168b0a7a7657c8571207fcae29c5890312642ee42b76c967"

--- a/repos/spack_repo/builtin/packages/py_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_torch/package.py
@@ -299,7 +299,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     depends_on("magma+cuda", when="+magma+cuda")
     depends_on("magma+rocm", when="+magma+rocm")
     depends_on("numactl", when="+numa")
-    depends_on("llvm-openmp", when="+openmp %apple-clang")
+    depends_on("llvm-openmp@19:", when="+openmp %apple-clang")
     depends_on("valgrind", when="+valgrind")
     with when("+rocm"):
         depends_on("hsa-rocr-dev")

--- a/repos/spack_repo/builtin/packages/xgboost/package.py
+++ b/repos/spack_repo/builtin/packages/xgboost/package.py
@@ -58,7 +58,7 @@ class Xgboost(CMakePackage, CudaPackage):
         depends_on("cuda@:12.4", when="@:2.1")
 
     depends_on("nccl", when="+nccl")
-    depends_on("llvm-openmp", when="+openmp %apple-clang")
+    depends_on("llvm-openmp@19:", when="+openmp %apple-clang")
     depends_on("hwloc", when="%clang")
 
     # https://github.com/dmlc/xgboost/issues/6972


### PR DESCRIPTION
* Add v19.1.7 and v20.1.8 for llvm-openmp
* Depend on llvm-openmp v19 or newer when building xgboost or torch with OpenMP using AppleClang
* Remove py-torchtext from ml-darwin-aarch64-mps so we can re-enable the stack while debugging this build failure