### PR TITLE
py-attrs: add v25.3.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_attrs/package.py
+++ b/repos/spack_repo/builtin/packages/py_attrs/package.py
@@ -16,6 +16,7 @@ class PyAttrs(PythonPackage):
 
     license("MIT")
 
+    version("25.3.0", sha256="75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b")
     version("23.1.0", sha256="6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015")
     version("22.2.0", sha256="c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99")
     version("22.1.0", sha256="29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6")
@@ -33,6 +34,7 @@ class PyAttrs(PythonPackage):
 
     depends_on("py-hatchling", when="@23.1:", type="build")
     depends_on("py-hatch-vcs", when="@23.1:", type="build")
+    depends_on("py-hatch-fancy-pypi-readme@23.2:", when="@23.2:", type="build")
     depends_on("py-hatch-fancy-pypi-readme", when="@23.1:", type="build")
 
     with when("@:22.2.0"):

--- a/repos/spack_repo/builtin/packages/py_hatch_fancy_pypi_readme/package.py
+++ b/repos/spack_repo/builtin/packages/py_hatch_fancy_pypi_readme/package.py
@@ -13,6 +13,7 @@ class PyHatchFancyPypiReadme(PythonPackage):
     homepage = "https://github.com/hynek/hatch-fancy-pypi-readme"
     pypi = "hatch_fancy_pypi_readme/hatch_fancy_pypi_readme-22.7.0.tar.gz"
 
+    version("25.1.0", sha256="9c58ed3dff90d51f43414ce37009ad1d5b0f08ffc9fc216998a06380f01c0045")
     version("23.1.0", sha256="b1df44063094af1e8248ceacd47a92c9cf313d6b9823bf66af8a927c3960287d")
     version("22.7.0", sha256="dedf2ba0b81a2975abb1deee9310b2eb85d22380fda0d52869e760b5435aa596")
 


### PR DESCRIPTION
https://github.com/python-attrs/attrs/tree/25.3.0

Also update dependency package needed to build this version:
`py-hatch-fancy-pypi-readme`: add v25.1.0
https://github.com/hynek/hatch-fancy-pypi-readme/tree/25.1.0

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
