### PR TITLE
py-bids-validator: add v1.14.7.post0 and new dependency packages

### DIFF
--- a/repos/spack_repo/builtin/packages/py_acres/package.py
+++ b/repos/spack_repo/builtin/packages/py_acres/package.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.python import PythonPackage
+
 from spack.package import *
 
 

--- a/repos/spack_repo/builtin/packages/py_acres/package.py
+++ b/repos/spack_repo/builtin/packages/py_acres/package.py
@@ -1,0 +1,22 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+from spack.package import *
+
+
+class PyAcres(PythonPackage):
+    """Access resources on your terms."""
+
+    homepage = "https://github.com/nipreps/acres"
+    pypi = "acres/acres-0.5.0.tar.gz"
+
+    license("Apache-2.0")
+
+    version("0.5.0", sha256="128b6447bf5df3b6210264feccbfa018b4ac5bd337358319aec6563f99db8f3a")
+
+    depends_on("python@3.9:", type=("build", "run"))
+    depends_on("py-pdm-backend", type="build")
+
+    depends_on("py-importlib-resources@5.7:", when="^python@:3.9", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_bids_validator/package.py
+++ b/repos/spack_repo/builtin/packages/py_bids_validator/package.py
@@ -11,8 +11,11 @@ class PyBidsValidator(PythonPackage):
     """Validator for the Brain Imaging Data Structure"""
 
     homepage = "https://github.com/bids-standard/bids-validator"
-    pypi = "bids-validator/bids-validator-1.7.2.tar.gz"
+    pypi = "bids-validator/bids_validator-1.14.6.tar.gz"
 
+    license("MIT")
+
+    version("1.14.7.post0", sha256="e6005a500b75f8a961593fb67d46085107dadb116f59a5c3b524aa0697945b66")
     version("1.13.1", sha256="7205ce4e68fba172215332c786f1ac1665025b702b6dff2b1e158f00a2df9890")
     version("1.11.0", sha256="408c56748b7cf98cf7c31822f33a8d89c5e6e7db5254c345107e8d527576ff53")
     version("1.9.8", sha256="ff39799bb205f92d6f2c322f0b8eff0d1c0288f4291a0b18fce61afa4dfd7f3e")
@@ -23,3 +26,14 @@ class PyBidsValidator(PythonPackage):
 
     depends_on("python@3.8:", when="@1.12:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
+    depends_on("py-versioneer+toml", when="@1.14:", type="build")
+
+    depends_on("py-bidsschematools@0.10:", when="@1.14.7:", type=("build", "run"))
+
+    def url_for_version(self, version):
+        url = "https://files.pythonhosted.org/packages/source/b/bids-validator/{}-{}.tar.gz"
+        if version >= Version("1.14.6"):
+            name = "bids_validator"
+        else:
+            name = "bids-validator"
+        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_bids_validator/package.py
+++ b/repos/spack_repo/builtin/packages/py_bids_validator/package.py
@@ -15,7 +15,9 @@ class PyBidsValidator(PythonPackage):
 
     license("MIT")
 
-    version("1.14.7.post0", sha256="e6005a500b75f8a961593fb67d46085107dadb116f59a5c3b524aa0697945b66")
+    version(
+        "1.14.7.post0", sha256="e6005a500b75f8a961593fb67d46085107dadb116f59a5c3b524aa0697945b66"
+    )
     version("1.13.1", sha256="7205ce4e68fba172215332c786f1ac1665025b702b6dff2b1e158f00a2df9890")
     version("1.11.0", sha256="408c56748b7cf98cf7c31822f33a8d89c5e6e7db5254c345107e8d527576ff53")
     version("1.9.8", sha256="ff39799bb205f92d6f2c322f0b8eff0d1c0288f4291a0b18fce61afa4dfd7f3e")

--- a/repos/spack_repo/builtin/packages/py_bids_validator/package.py
+++ b/repos/spack_repo/builtin/packages/py_bids_validator/package.py
@@ -11,7 +11,7 @@ class PyBidsValidator(PythonPackage):
     """Validator for the Brain Imaging Data Structure"""
 
     homepage = "https://github.com/bids-standard/bids-validator"
-    pypi = "bids-validator/bids_validator-1.14.6.tar.gz"
+    pypi = "bids-validator/bids_validator-1.14.7.post0.tar.gz"
 
     license("MIT")
 

--- a/repos/spack_repo/builtin/packages/py_bidsschematools/package.py
+++ b/repos/spack_repo/builtin/packages/py_bidsschematools/package.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.python import PythonPackage
+
 from spack.package import *
 
 

--- a/repos/spack_repo/builtin/packages/py_bidsschematools/package.py
+++ b/repos/spack_repo/builtin/packages/py_bidsschematools/package.py
@@ -1,0 +1,24 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+from spack.package import *
+
+
+class PyBidsschematools(PythonPackage):
+    """Python tools for working with the BIDS schema."""
+
+    homepage = "https://github.com/bids-standard/bids-specification"
+    pypi = "bidsschematools/bidsschematools-1.0.10.tar.gz"
+
+    license("MIT")
+
+    version("1.0.10", sha256="e241dd798cc8686d4ab8b625e4d84ef3093d472a158cccd88a850496e4a4a8b9")
+
+    depends_on("python@3.9:", type=("build", "run"))
+    depends_on("py-pdm-backend", type="build")
+
+    depends_on("py-acres", type=("build", "run"))
+    depends_on("py-click", type=("build", "run"))
+    depends_on("py-pyyaml", type=("build", "run"))


### PR DESCRIPTION
Add `py-bids-validator` version 1.14.7.post0
https://pypi.org/project/bidsschematools/#files

Add new dependency packages `py-bidsschematools` and `py-acres`
https://pypi.org/project/bidsschematools/#files
https://github.com/nipreps/acres/tree/0.5.0

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
