### PR TITLE
llvm: update description for flang variant

### DIFF
--- a/repos/spack_repo/builtin/packages/llvm/package.py
+++ b/repos/spack_repo/builtin/packages/llvm/package.py
@@ -212,12 +212,8 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
         "clang", default=True, description="Build the LLVM C/C++/Objective-C compiler frontend"
     )
 
-    variant(
-        "flang",
-        default=False,
-        description="Build the LLVM Fortran compiler frontend "
-        "(experimental - parser only, needs GCC)",
-    )
+    variant("flang", default=False, description="Build the LLVM Fortran compiler frontend ")
+
     conflicts("+flang", when="@:10")
     conflicts("+flang", when="~clang")
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Since Flang has reached a sufficient level of maturity, I am proposing to remove the part of the description that lists it as experimental.  It is no longer limited to parser support only and has been producing full executables for quite some time now.