### PR TITLE
Re-enable py-torchtext for ml-darwin-aarch64-mps stack

### DIFF
--- a/.ci/gitlab/stacks/ml-darwin-aarch64-mps/spack.yaml
+++ b/.ci/gitlab/stacks/ml-darwin-aarch64-mps/spack.yaml
@@ -62,8 +62,7 @@ spack:
   - py-torchfile
   - py-torchgeo
   - py-torchmetrics
-  # fp16 mismatch between openblas and py_torch@2.3.0
-  # - py-torchtext
+  - py-torchtext
   - py-torchvision
   - py-vector-quantize-pytorch
 

--- a/repos/spack_repo/builtin/packages/py_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_torch/package.py
@@ -298,7 +298,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     depends_on("magma+cuda", when="+magma+cuda")
     depends_on("magma+rocm", when="+magma+rocm")
     depends_on("numactl", when="+numa")
-    depends_on("llvm-openmp", when="+openmp %apple-clang")
+    depends_on("llvm-openmp@19:", when="+openmp %apple-clang")
     depends_on("valgrind", when="+valgrind")
     with when("+rocm"):
         depends_on("hsa-rocr-dev")

--- a/repos/spack_repo/builtin/packages/py_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_torch/package.py
@@ -298,7 +298,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     depends_on("magma+cuda", when="+magma+cuda")
     depends_on("magma+rocm", when="+magma+rocm")
     depends_on("numactl", when="+numa")
-    depends_on("llvm-openmp@19:", when="+openmp %apple-clang")
+    depends_on("llvm-openmp", when="+openmp %apple-clang")
     depends_on("valgrind", when="+valgrind")
     with when("+rocm"):
         depends_on("hsa-rocr-dev")


### PR DESCRIPTION
Fixed in https://github.com/spack/spack/pull/51011
