### PR TITLE
mochi-thallium: requires C compiler

### DIFF
--- a/repos/spack_repo/builtin/packages/mochi_thallium/package.py
+++ b/repos/spack_repo/builtin/packages/mochi_thallium/package.py
@@ -67,7 +67,8 @@ class MochiThallium(CMakePackage):
     )
     conflicts("~cereal", when="@0.14.0:", msg="Thallium 0.14.0 and above requires Cereal")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("pkgconfig", type=("build"))
     depends_on("mochi-margo@0.18.0:", when="@0.14.0:")


### PR DESCRIPTION
Building mochi-thallium with a fresh spack installation fails.

## Error Message
```
[...]
-- Check for working C compiler: /home/ubuntu/spack/opt/spack/linux-zen2/compiler-wrapper-1.0-uqt4a5zk6crvyotljsxax4nhy3o42jca/libexec/spack/cc - broken
CMake Error at /usr/share/cmake-3.28/Modules/CMakeTestCCompiler.cmake:67 (message):
  The C compiler

    "/home/ubuntu/spack/opt/spack/linux-zen2/compiler-wrapper-1.0-uqt4a5zk6crvyotljsxax4nhy3o42jca/libexec/spack/cc"

  is not able to compile a simple test program.

  It fails with the following output:

    Change Dir: '/tmp/root/spack-stage/spack-stage-mochi-thallium-0.15.0-42246wpyzhzdnkaukn6ttuxt2pw4zzqg/spack-build-42246wp/CMakeFiles/CMakeScratch/TryCompile-w5sSje'

    Run Build Command(s): /usr/bin/cmake -E env VERBOSE=1 /usr/bin/gmake -f Makefile cmTC_5d474/fast
    /usr/bin/gmake  -f CMakeFiles/cmTC_5d474.dir/build.make CMakeFiles/cmTC_5d474.dir/build
    gmake[1]: Entering directory '/tmp/root/spack-stage/spack-stage-mochi-thallium-0.15.0-42246wpyzhzdnkaukn6ttuxt2pw4zzqg/spack-build-42246wp/CMakeFiles/CMakeScratch/TryCompile-w5sSje'
    Building C object CMakeFiles/cmTC_5d474.dir/testCCompiler.c.o
    /home/ubuntu/spack/opt/spack/linux-zen2/compiler-wrapper-1.0-uqt4a5zk6crvyotljsxax4nhy3o42jca/libexec/spack/cc    -o CMakeFiles/cmTC_5d474.dir/testCCompiler.c.o -c /tmp/root/spack-stage/spack-stage-mochi-thallium-0.15.0-42246wpyzhzdnkaukn6ttuxt2pw4zzqg/spack-build-42246wp/CMakeFiles/CMakeScratch/TryCompile-w5sSje/testCCompiler.c
    /home/ubuntu/spack/opt/spack/linux-zen2/compiler-wrapper-1.0-uqt4a5zk6crvyotljsxax4nhy3o42jca/libexec/spack/cc: 1: eval: SPACK_CC_LINKER_ARG: ERROR: LINKER ARG WAS NOT SET, MAYBE THE PACKAGE DOES NOT DEPEND ON CC?
    gmake[1]: *** [CMakeFiles/cmTC_5d474.dir/build.make:78: CMakeFiles/cmTC_5d474.dir/testCCompiler.c.o] Error 2
    gmake[1]: Leaving directory '/tmp/root/spack-stage/spack-stage-mochi-thallium-0.15.0-42246wpyzhzdnkaukn6ttuxt2pw4zzqg/spack-build-42246wp/CMakeFiles/CMakeScratch/TryCompile-w5sSje'
    gmake: *** [Makefile:127: cmTC_5d474/fast] Error 2
[...]
```

## Fix
mochi-thallium [requires a C compiler](https://github.com/mochi-hpc/mochi-thallium/blob/9958d22abef845ea84c6039d8edaf9ea4bde1f71/CMakeLists.txt#L17). This PR adjusts the package to reflect that.