### PR TITLE
Windows: ensure correct use of "complex" in lapacke headers

### DIFF
--- a/.ci/gitlab/stacks/windows-vis/spack.yaml
+++ b/.ci/gitlab/stacks/windows-vis/spack.yaml
@@ -11,6 +11,7 @@ spack:
   specs:
   - "vtk@9: ~mpi"
   - "boost"
+  - "netlib-lapack"
 
   cdash:
     build-group: Windows Visualization (Kitware)

--- a/repos/spack_repo/builtin/packages/netlib_lapack/lapack_complex_custom.patch
+++ b/repos/spack_repo/builtin/packages/netlib_lapack/lapack_complex_custom.patch
@@ -1,0 +1,18 @@
+diff --git a/LAPACKE/include/lapack.h b/LAPACKE/include/lapack.h
+index f9a254512..f5f50f552 100644
+--- a/LAPACKE/include/lapack.h
++++ b/LAPACKE/include/lapack.h
+@@ -8,6 +8,13 @@
+ #include "lapacke_config.h"
+ #endif
+ 
++#if defined(_MSC_VER)
++#include <complex.h>
++#define LAPACK_COMPLEX_CUSTOM
++#define lapack_complex_float  _Fcomplex
++#define lapack_complex_double _Dcomplex
++#endif
++
+ #include "lapacke_mangling.h"
+ 
+ #include <stdlib.h>

--- a/repos/spack_repo/builtin/packages/netlib_lapack/package.py
+++ b/repos/spack_repo/builtin/packages/netlib_lapack/package.py
@@ -139,6 +139,10 @@ class NetlibLapack(CMakePackage):
         when="@3.12:3.12.1",
     )
 
+    # Ensures appropriate alias'ing of lapack custom complex types with MSVC
+    # e.g. MSVC float complex becomes _FComplex
+    patch("lapack_complex_custom.patch", when="@3.12: %msvc")
+
     # liblapack links to libblas, so if this package is used as a lapack
     # provider, it must also provide blas.
     provides("lapack", "blas", when="~external-blas")

--- a/repos/spack_repo/builtin/packages/netlib_lapack/package.py
+++ b/repos/spack_repo/builtin/packages/netlib_lapack/package.py
@@ -175,7 +175,7 @@ class NetlibLapack(CMakePackage):
 
         # Remove duplicate header file that gets generated during CMake shared
         # builds: https://github.com/Reference-LAPACK/lapack/issues/583
-        if self.spec.satisfies("platform=windows @0:3.9.1"):
+        if self.spec.satisfies("platform=windows @:3.9.1"):
             force_remove("LAPACKE/include/lapacke_mangling.h")
 
     def xplatform_lib_name(self, lib):


### PR DESCRIPTION
MSVC uses `_FComplex` instead of `float complex`, which lapacke's `lapack.h` header does not currently handle well when establishing type aliases.
This PR adds the requisite defines to allow the lapack custom complex type to be properly defined.

Adds lapack to Windows Gitlab CI