### PR TITLE
spack-configs-facilities: new package for DOE facility spack configs

### DIFF
--- a/repos/spack_repo/builtin/packages/spack_configs_dav_sdk/package.py
+++ b/repos/spack_repo/builtin/packages/spack_configs_dav_sdk/package.py
@@ -19,6 +19,19 @@ class SpackConfigsDavSdk(CMakePackage):
 
     version("main", branch="main")
 
+    depends_on("spack-configs-facilities")
+
+    variant(
+        "facility",
+        default="all",
+        description="Facility configs to install",
+        values=("all", "frontier"),
+    )
+
+    def cmake_args(self):
+        args = [self.define_from_variant("FACILITY", "facility")]
+        return args
+
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         env.set("SPACK_CONFIG_DAV_SDK_DIR", self.prefix.spack.configs.davsdk)
         env.set("SPACK_CONFIG_DAV_SDK_ENVIRONMENTS_DIR", self.prefix.spack.environments.davsdk)

--- a/repos/spack_repo/builtin/packages/spack_configs_facilities/package.py
+++ b/repos/spack_repo/builtin/packages/spack_configs_facilities/package.py
@@ -1,0 +1,33 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class SpackConfigsFacilities(CMakePackage):
+    """Spack configs for DOE facilities."""
+
+    git = "https://github.com/e4s-project/facility-external-spack-configs.git"
+
+    maintainers("eugeneswalker", "kwryankrattiger", "qtpowell", "vicentebolea")
+
+    license("UNKNOWN")
+
+    version("main", branch="master")
+
+    variant(
+        "facility",
+        default="all",
+        description="Facility configs to install",
+        values=("all", "frontier", "perlmutter"),
+    )
+
+    def cmake_args(self):
+        args = [self.define_from_variant("FACILITY", "facility")]
+        return args
+
+    def setup_run_environment(self, env: EnvironmentModifications) -> None:
+        env.set("SPACK_CONFIG_FACILITY_DIR", self.prefix.spack.configs.facilities)


### PR DESCRIPTION
Add a package to allow installation of Spack configs for DOE facilities. Updates `spack-configs-dav-sdk` to depend on the new package.

@kwryankrattiger 