### PR TITLE
strace: add v6.15

### DIFF
--- a/repos/spack_repo/builtin/packages/strace/package.py
+++ b/repos/spack_repo/builtin/packages/strace/package.py
@@ -20,6 +20,7 @@ class Strace(AutotoolsPackage):
 
     license("BSD-3-Clause")
 
+    version("6.15", sha256="8552dfab08abc22a0f2048c98fd9541fd4d71b6882507952780dab7c7c512f51")
     version("6.11", sha256="83262583a3529f02c3501aa8b8ac772b4cbc03dc934e98bab6e4883626e283a5")
     version("5.19", sha256="aa3dc1c8e60e4f6ff3d396514aa247f3c7bf719d8a8dc4dd4fa793be786beca3")
     version("5.17", sha256="5fb298dbd1331fd1e1bc94c5c32395860d376101b87c6cd3d1ba9f9aa15c161f")


### PR DESCRIPTION
This PR adds `strace`, v6.15, [changelog](https://github.com/strace/strace/compare/v6.11...v6.15). No changes to the configure.ac that need to be adapted.

Test build:
```
==> No binary for strace-6.15-jhe4q2mfx7unikqeussjjbygqel3iqlj found: installing from source
==> Installing strace-6.15-jhe4q2mfx7unikqeussjjbygqel3iqlj [6/6]
==> Fetching https://github.com/strace/strace/releases/download/v6.15/strace-6.15.tar.xz
    [100%]    2.66 MB @    3.4 MB/s
==> No patches needed for strace
==> strace: Executing phase: 'autoreconf'
==> strace: Executing phase: 'configure'
==> strace: Executing phase: 'build'
==> strace: Executing phase: 'install'
==> Pushed strace@6.15/jhe4q2m: sha256:5935c40d1268af81ee086dc191c27d2b775146e4c4d4f1c4be4b030f03c6a280 (2.89s, 0.76 MB/s)
==> Uploading manifests
==> Tagged strace@6.15/jhe4q2m as ghcr.io/wdconinc/spack:strace-6.15-jhe4q2mfx7unikqeussjjbygqel3iqlj.spack
==> strace: Pushed to build cache: 'ghcr-wdconinc-spack'
==> strace: Successfully installed strace-6.15-jhe4q2mfx7unikqeussjjbygqel3iqlj
  Stage: 1.78s.  Autoreconf: 0.00s.  Configure: 36.61s.  Build: 14.75s.  Install: 0.53s.  Post-install: 5.96s.  Total: 59.86s
[+] /opt/software/linux-skylake/strace-6.15-jhe4q2mfx7unikqeussjjbygqel3iqlj
```
