### PR TITLE
stow: add v2.4.1

### DIFF
--- a/repos/spack_repo/builtin/packages/stow/package.py
+++ b/repos/spack_repo/builtin/packages/stow/package.py
@@ -21,6 +21,7 @@ class Stow(AutotoolsPackage, GNUMirrorPackage):
 
     license("GPL-3.0-or-later")
 
+    version("2.4.1", sha256="0d85a8513677e7923697bce42cdbb33d2b57af915abde1d0671e7ae80b2ef0b4")
     version("2.4.0", sha256="a7bac673daa246cf54ffb48a113eadd204a615630e76b53b5f64d81a275b77b3")
     version("2.3.1", sha256="26a6cfdfdaca0eea742db5487798c15fcd01889dc86bc5aa62614ec9415a422f")
     version("2.2.2", sha256="a0022034960e47a8d23dffb822689f061f7a2d9101c9835cf11bf251597aa6fd")


### PR DESCRIPTION
Add latest version of stow

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
