### PR TITLE
eigen: add v3.4.0-44-g37248b26a

### DIFF
--- a/repos/spack_repo/builtin/packages/eigen/package.py
+++ b/repos/spack_repo/builtin/packages/eigen/package.py
@@ -23,7 +23,8 @@ class Eigen(CMakePackage, ROCmPackage):
     license("MPL-2.0")
 
     version("master", branch="master")
-    version("3.4.0", sha256="8586084f71f9bde545ee7fa6d00288b264a2b7ac3607b974e54d13e7162c1c72")
+    version("3.4.0-44-ge7248b26a", commit="e7248b26a1ed53fa030c5c459f7ea095dfd276ac")
+    version("3.4.0", sha256="8586084f71f9bde545ee7fa6d00288b264a2b7ac3607b974e54d13e7162c1c72", preferred=True)
     version("3.3.9", sha256="7985975b787340124786f092b3a07d594b2e9cd53bbfe5f3d9b1daee7d55f56f")
     version("3.3.8", sha256="146a480b8ed1fb6ac7cd33fec9eb5e8f8f62c3683b3f850094d9d5c35a92419a")
     version("3.3.7", sha256="d56fbad95abf993f8af608484729e3d87ef611dd85b3380a8bad1d5cbc373a57")

--- a/repos/spack_repo/builtin/packages/eigen/package.py
+++ b/repos/spack_repo/builtin/packages/eigen/package.py
@@ -28,7 +28,8 @@ class Eigen(CMakePackage, ROCmPackage):
         "3.4.0",
         sha256="8586084f71f9bde545ee7fa6d00288b264a2b7ac3607b974e54d13e7162c1c72",
         preferred=True,
-    )    version("3.3.9", sha256="7985975b787340124786f092b3a07d594b2e9cd53bbfe5f3d9b1daee7d55f56f")
+    )
+    version("3.3.9", sha256="7985975b787340124786f092b3a07d594b2e9cd53bbfe5f3d9b1daee7d55f56f")
     version("3.3.8", sha256="146a480b8ed1fb6ac7cd33fec9eb5e8f8f62c3683b3f850094d9d5c35a92419a")
     version("3.3.7", sha256="d56fbad95abf993f8af608484729e3d87ef611dd85b3380a8bad1d5cbc373a57")
     version("3.3.6", sha256="e7cd8c94d6516d1ada9893ccc7c9a400fcee99927c902f15adba940787104dba")

--- a/repos/spack_repo/builtin/packages/eigen/package.py
+++ b/repos/spack_repo/builtin/packages/eigen/package.py
@@ -24,8 +24,11 @@ class Eigen(CMakePackage, ROCmPackage):
 
     version("master", branch="master")
     version("3.4.0-44-ge7248b26a", commit="e7248b26a1ed53fa030c5c459f7ea095dfd276ac")
-    version("3.4.0", sha256="8586084f71f9bde545ee7fa6d00288b264a2b7ac3607b974e54d13e7162c1c72", preferred=True)
-    version("3.3.9", sha256="7985975b787340124786f092b3a07d594b2e9cd53bbfe5f3d9b1daee7d55f56f")
+    version(
+        "3.4.0",
+        sha256="8586084f71f9bde545ee7fa6d00288b264a2b7ac3607b974e54d13e7162c1c72",
+        preferred=True,
+    )    version("3.3.9", sha256="7985975b787340124786f092b3a07d594b2e9cd53bbfe5f3d9b1daee7d55f56f")
     version("3.3.8", sha256="146a480b8ed1fb6ac7cd33fec9eb5e8f8f62c3683b3f850094d9d5c35a92419a")
     version("3.3.7", sha256="d56fbad95abf993f8af608484729e3d87ef611dd85b3380a8bad1d5cbc373a57")
     version("3.3.6", sha256="e7cd8c94d6516d1ada9893ccc7c9a400fcee99927c902f15adba940787104dba")


### PR DESCRIPTION
This PR adds a newer version of `eigen` by commit since it is a requirement for `py-onnxruntime` as of 1.17.0 (https://github.com/microsoft/onnxruntime/commit/812532592e070823f0362af8c3219ca6b01eda77#diff-12c22e06cbb37ea0ed9f9eaf60cbe408dbeef04072df6a9f431c3290822ea835).

This version is added to avoid using the vendored `eigen` that is downloaded during the `py-onnxruntime` installation (and which is now broken due to changes in the checksums of the archive zip files provided on gitlab, see https://github.com/microsoft/onnxruntime/issues/24861). See also https://github.com/spack/spack-packages/pull/128.