### PR TITLE
py-cython: add v3.1.2

### DIFF
--- a/repos/spack_repo/builtin/packages/py_cython/package.py
+++ b/repos/spack_repo/builtin/packages/py_cython/package.py
@@ -16,6 +16,7 @@ class PyCython(PythonPackage):
 
     license("Apache-2.0")
 
+    version("3.1.2", sha256="6bbf7a953fa6762dfecdec015e3b054ba51c0121a45ad851fa130f63f5331381")
     version("3.0.12", sha256="b988bb297ce76c671e28c97d017b95411010f7c77fa6623dd0bb47eed1aee1bc")
     version("3.0.11", sha256="7146dd2af8682b4ca61331851e6aebce9fe5158e75300343f80c07ca80b1faff")
     version("3.0.10", sha256="dcc96739331fb854dcf503f94607576cfe8488066c61ca50dfd55836f132de99")


### PR DESCRIPTION
This PR adds `py-cython`, v3.1.2 (release notes: [3.1.2](https://github.com/cython/cython/releases/3.1.2),  [3.1.1](https://github.com/cython/cython/releases/3.1.1),  [3.1.0](https://github.com/cython/cython/releases/3.1.0), [diff](https://github.com/cython/cython/compare/3.0.12...3.1.2)). This PR skips 3.1.1 which causes failures to build numpy (https://github.com/cython/cython/issues/6859).

Test build (but this PR will also be built in CI):
```
==> No binary for py-cython-3.1.2-kidmxqc4rpuhbid2hp6a3fjyug2vklps found: installing from source
==> Installing py-cython-3.1.2-kidmxqc4rpuhbid2hp6a3fjyug2vklps [35/36]
==> Fetching https://files.pythonhosted.org/packages/source/c/cython/cython-3.1.2.tar.gz
    [100%]    3.18 MB @    9.0 MB/s
==> No patches needed for py-cython
==> py-cython: Executing phase: 'install'
==> Pushed py-cython@3.1.2/kidmxqc: sha256:363f8679e582eabfef01a82ba638edac7813a3cbbee74bc7a15a3ecd7a77210a (14.04s, 1.09 MB/s)
==> Uploading manifests
==> Tagged py-cython@3.1.2/kidmxqc as ghcr.io/wdconinc/spack:py-cython-3.1.2-kidmxqc4rpuhbid2hp6a3fjyug2vklps.spack
==> py-cython: Pushed to build cache: 'ghcr-wdconinc-spack'
==> py-cython: Successfully installed py-cython-3.1.2-kidmxqc4rpuhbid2hp6a3fjyug2vklps
  Stage: 1.24s.  Install: 2m 57.05s.  Post-install: 19.36s.  Total: 3m 17.71s
[+] /opt/software/linux-skylake/py-cython-3.1.2-kidmxqc4rpuhbid2hp6a3fjyug2vklps
```