### PR TITLE
xorg-server: avoid implicit LibraryList to str conversion warning

### DIFF
--- a/repos/spack_repo/builtin/packages/xorg_server/package.py
+++ b/repos/spack_repo/builtin/packages/xorg_server/package.py
@@ -92,8 +92,7 @@ class XorgServer(AutotoolsPackage, XorgPackage):
         # https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/406
         env.set("CPPFLAGS", "-fcommon")
 
-        gl_libs = self.spec["gl"].libs
-        env.set("GL_LIBS", gl_libs)
+        env.set("GL_LIBS", self.spec["gl"].libs.ld_flags)
         env.set("GL_CFLAGS", self.spec["gl"].headers.cpp_flags)
 
     def configure_args(self):


### PR DESCRIPTION
This PR fixes `xorg-server` by passing `spec.libs.ld_flags` instead of `spec.libs`, and avoids the following warning:
```
==> Warning: /home/wdconinc/git/spack-packages/repos/spack_repo/builtin/packages/xorg_server/package.py:96: when setting environment variable GL_LIBS=/usr/lib/x86_64-linux-gnu/libGL.so: value is of type `LibraryList`, but `str` was expected. This is deprecated and will be an error in Spack v1.0
```

This potentially affects `grads +hdf4 ^hdf ~shared`  too.