### PR TITLE
grads: avoid implicit LibraryList to str conversion warning

### DIFF
--- a/repos/spack_repo/builtin/packages/grads/package.py
+++ b/repos/spack_repo/builtin/packages/grads/package.py
@@ -92,7 +92,7 @@ class Grads(AutotoolsPackage):
         env.set("PKG_CONFIG", self.spec["pkgconfig"].prefix.bin.join("pkg-config"))
 
         if "+hdf4" in self.spec and "~shared" in self.spec["hdf"]:
-            env.set("LIBS", self.spec["hdf:transitive"].libs)
+            env.set("LIBS", self.spec["hdf:transitive"].libs.ld_flags)
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         env.set("GADDIR", self.prefix.data)

--- a/repos/spack_repo/builtin/packages/hdf/package.py
+++ b/repos/spack_repo/builtin/packages/hdf/package.py
@@ -134,7 +134,7 @@ class Hdf(AutotoolsPackage):
 
         if not shared and "transitive" in query_parameters:
             libs += self.spec["jpeg:transitive"].libs
-            libs += self.spec["zlib:transitive"].libs
+            libs += self.spec["zlib-api:transitive"].libs
             if self.spec.satisfies("+szip"):
                 libs += self.spec["szip:transitive"].libs
             if self.spec.satisfies("+external-xdr") and self.spec["rpc"].name == "libtirpc":


### PR DESCRIPTION
This PR fixes `grads` by passing `spec.libs.ld_flags` instead of `spec.libs`, and avoids the following warning:
```
==> Warning: /home/wdconinc/git/spack-packages/repos/spack_repo/builtin/packages/grads/package.py:95: when setting environment variable LIBS=/opt/software/linux-skylake/hdf-4.2.15-jrmedg3vwaopg3dtyt5zuhnrz6w4oskk/lib/libmfhdf.a /opt/software/linux-skylake/hdf-4.2.15-jrmedg3vwaopg3dtyt5zuhnrz6w4oskk/lib/libdf.a /opt/software/linux-skylake/libjpeg-turbo-3.1.0-gqtoi7ngqnbdvkmtsmuczirgbf6tpa2w/lib/libjpeg.so /opt/software/linux-skylake/zlib-ng-2.2.4-uqq2hqt3ffprd3j7z5f44oochkkdpbnu/lib/libz.so /opt/software/linux-skylake/libtirpc-1.3.3-ksztihf6z5jfuhtim3mbjgypj4s37cpu/lib/libtirpc.so: value is of type `LibraryList`, but `str` was expected. This is deprecated and will be an error in Spack v1.0
```

It also ensures that `hdf` uses the correct `zlib-api` spec, instead of hardcoding `zlib`, even when `zlib-ng` is actually used.

Test build:
```
==> No binary for grads-2.2.3-izhiprcfvucviq7guljiksofy2joxb3t found: installing from source
==> Installing grads-2.2.3-izhiprcfvucviq7guljiksofy2joxb3t [84/84]
==> Using cached archive: /opt/spack/cache/_source-cache/archive/2c/2cbb67284fe64763c589ecaf08d5bd31144554dfd82a1fccf71e1cc424695a9e.tar.gz
==> Ran patch() for grads
==> grads: Executing phase: 'autoreconf'
==> grads: Executing phase: 'configure'
==> grads: Executing phase: 'build'
==> grads: Executing phase: 'install'
==> Pushed grads@2.2.3/izhiprc: sha256:455b23f647773acec35bccf748c82be2efc59d06b21657b80ac8149874a0e423 (6.66s, 0.85 MB/s)
==> Uploading manifests
==> Tagged grads@2.2.3/izhiprc as ghcr.io/wdconinc/spack:grads-2.2.3-izhiprcfvucviq7guljiksofy2joxb3t.spack
==> grads: Pushed to build cache: 'ghcr-wdconinc-spack'
==> grads: Successfully installed grads-2.2.3-izhiprcfvucviq7guljiksofy2joxb3t
  Stage: 0.16s.  Autoreconf: 0.00s.  Configure: 11.99s.  Build: 25.22s.  Install: 0.17s.  Post-install: 10.75s.  Total: 48.50s
[+] /opt/software/linux-skylake/grads-2.2.3-izhiprcfvucviq7guljiksofy2joxb3t
```