### PR TITLE
FairROOT: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/fairroot/package.py
+++ b/repos/spack_repo/builtin/packages/fairroot/package.py
@@ -28,8 +28,11 @@ class Fairroot(CMakePackage):
     depends_on('faircmakemodules@0.2:', when='@18:')
     depends_on('fairlogger@1.4.0:')
     depends_on('fairmq@1.4.11:')
+    
     depends_on('fairsoft-bundle')
-   
+    # Version-specific fairsoft release dependencies
+    depends_on('fairsoft-bundle@may25', when='@18.8.2:')
+
     depends_on('flatbuffers')
     depends_on('geant3', when="+sim")
     depends_on('geant4', when="+sim")
@@ -40,14 +43,13 @@ class Fairroot(CMakePackage):
     depends_on('pythia6', when='+sim')
     depends_on('pythia8', when='+sim')
     depends_on('root+http+xml+gdml')
-    depends_on('root@6.18:', when='@19:')
     depends_on('vgm', when="+sim")
     depends_on('vmc', when='@18.4: ^root@6.18:')
     depends_on('yaml-cpp', when='@18.2:')
     for std in ('17','20'):
         for dep in ('root', 'fairmq'):
             depends_on('{0} cxxstd={1}'.format(dep, std),
-                       when='cxxstd={0} ^{1}'.format(std, dep))
+                       when='cxxstd={0}'.format(std))
 
     def setup_build_environment(self, env):
         super(Fairroot, self).setup_build_environment(env)

--- a/repos/spack_repo/builtin/packages/fairroot/package.py
+++ b/repos/spack_repo/builtin/packages/fairroot/package.py
@@ -15,6 +15,7 @@ class Fairroot(CMakePackage):
     git = "https://github.com/FairRootGroup/FairRoot.git"
     maintainers("dennisklein", "fuhlig1", "jezwilkinson")
 
+    tags = ["hep"]
     version("develop", branch="dev")
     version("18.8.2", sha256="0bc9bafd9583f8a4c92977647c1eb360d66f45fbc6c81a15c5a1613640934684")
 

--- a/repos/spack_repo/builtin/packages/fairroot/package.py
+++ b/repos/spack_repo/builtin/packages/fairroot/package.py
@@ -1,0 +1,88 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack.package import *
+
+class Fairroot(CMakePackage):
+    """C++ simulation, reconstruction and analysis framework for particle physics experiments"""
+
+    homepage = "http://fairroot.gsi.de"
+    url = "https://github.com/FairRootGroup/FairRoot/archive/v18.8.2.tar.gz"
+    git = "https://github.com/FairRootGroup/FairRoot.git"
+    maintainers('dennisklein', 'fuhlig1', 'jezwilkinson')
+
+    version('develop', branch='dev')
+    version('18.8.2', sha256='0bc9bafd9583f8a4c92977647c1eb360d66f45fbc6c81a15c5a1613640934684')
+
+    variant('cxxstd', default='17', values=('17', '20'), multi=False,
+            description='Use the specified C++ standard when building.')
+    variant('sim', default=True,
+            description='Enable simulation engines and event generators')
+    variant('examples', default=False,
+            description='Install examples')
+
+    depends_on('cmake@3.13.4:', type='build')
+    depends_on('boost@1.68.0: +container +serialization')
+    depends_on('faircmakemodules@0.2:', when='@18:')
+    depends_on('fairlogger@1.4.0:')
+    depends_on('fairmq@1.4.11:')
+    depends_on('fairsoft-bundle')
+   
+    depends_on('flatbuffers')
+    depends_on('geant3', when="+sim")
+    depends_on('geant4', when="+sim")
+    depends_on('geant4-vmc', when="+sim")
+    depends_on('googletest@1.7.0:')
+    depends_on('msgpack-c@3.1:', when='+examples')
+    depends_on('protobuf')
+    depends_on('pythia6', when='+sim')
+    depends_on('pythia8', when='+sim')
+    depends_on('root+http+xml+gdml')
+    depends_on('root@6.18:', when='@19:')
+    depends_on('vgm', when="+sim")
+    depends_on('vmc', when='@18.4: ^root@6.18:')
+    depends_on('yaml-cpp', when='@18.2:')
+    for std in ('17','20'):
+        for dep in ('root', 'fairmq'):
+            depends_on('{0} cxxstd={1}'.format(dep, std),
+                       when='cxxstd={0} ^{1}'.format(std, dep))
+
+    def setup_build_environment(self, env):
+        super(Fairroot, self).setup_build_environment(env)
+        env.unset('SIMPATH')
+        env.unset('FAIRSOFT_ROOT')
+
+    def cmake_args(self):
+        options = []
+        options.append('--log-level=VERBOSE')
+        if self.spec.satisfies('@18.4:'):
+            cxxstd = self.spec.variants['cxxstd'].value
+            if cxxstd != 'default':
+               options.append('-DCMAKE_CXX_STANDARD={0}'.format(cxxstd))
+        if self.spec.satisfies('@:18,develop'):
+            options.append('-DROOTSYS={0}'.format(self.spec['root'].prefix))
+            options.append('-DPYTHIA8_DIR={0}'.format(
+                self.spec['pythia8'].prefix))
+
+        options.append('-DBUILD_EXAMPLES:BOOL=%s' %
+                       ('ON' if '+examples' in self.spec else 'OFF'))
+
+        if self.spec.satisfies('^boost@:1.69.99'):
+            options.append('-DBoost_NO_BOOST_CMAKE=ON')
+        options.append('-DBUILD_PROOF_SUPPORT=OFF')
+        return options
+
+    def common_env_setup(self, env):
+        # So that root finds the shared library / rootmap
+        env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib)
+
+    def setup_run_environment(self, env):
+        self.common_env_setup(env)
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        self.common_env_setup(env)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        self.common_env_setup(env)

--- a/repos/spack_repo/builtin/packages/fairroot/package.py
+++ b/repos/spack_repo/builtin/packages/fairroot/package.py
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+
 from spack.package import *
+
 
 class Fairroot(CMakePackage):
     """C++ simulation, reconstruction and analysis framework for particle physics experiments"""
@@ -11,69 +13,69 @@ class Fairroot(CMakePackage):
     homepage = "http://fairroot.gsi.de"
     url = "https://github.com/FairRootGroup/FairRoot/archive/v18.8.2.tar.gz"
     git = "https://github.com/FairRootGroup/FairRoot.git"
-    maintainers('dennisklein', 'fuhlig1', 'jezwilkinson')
+    maintainers("dennisklein", "fuhlig1", "jezwilkinson")
 
-    version('develop', branch='dev')
-    version('18.8.2', sha256='0bc9bafd9583f8a4c92977647c1eb360d66f45fbc6c81a15c5a1613640934684')
+    version("develop", branch="dev")
+    version("18.8.2", sha256="0bc9bafd9583f8a4c92977647c1eb360d66f45fbc6c81a15c5a1613640934684")
 
-    variant('cxxstd', default='17', values=('17', '20'), multi=False,
-            description='Use the specified C++ standard when building.')
-    variant('sim', default=True,
-            description='Enable simulation engines and event generators')
-    variant('examples', default=False,
-            description='Install examples')
+    variant(
+        "cxxstd",
+        default="17",
+        values=("17", "20"),
+        multi=False,
+        description="Use the specified C++ standard when building.",
+    )
+    variant("sim", default=True, description="Enable simulation engines and event generators")
+    variant("examples", default=False, description="Install examples")
 
-    depends_on('cmake@3.13.4:', type='build')
-    depends_on('boost@1.68.0: +container +serialization')
-    depends_on('faircmakemodules@0.2:', when='@18:')
-    depends_on('fairlogger@1.4.0:')
-    depends_on('fairmq@1.4.11:')
-    
-    depends_on('fairsoft-bundle')
+    depends_on("cmake@3.13.4:", type="build")
+    depends_on("boost@1.68.0: +container +serialization")
+    depends_on("faircmakemodules@0.2:", when="@18:")
+    depends_on("fairlogger@1.4.0:")
+    depends_on("fairmq@1.4.11:")
+
     # Version-specific fairsoft release dependencies
-    depends_on('fairsoft-bundle@may25', when='@18.8.2:')
+    depends_on("fairsoft-bundle")
+    depends_on("fairsoft-bundle@may25", when="@18.8.2:")
 
-    depends_on('flatbuffers')
-    depends_on('geant3', when="+sim")
-    depends_on('geant4', when="+sim")
-    depends_on('geant4-vmc', when="+sim")
-    depends_on('googletest@1.7.0:')
-    depends_on('msgpack-c@3.1:', when='+examples')
-    depends_on('protobuf')
-    depends_on('pythia6', when='+sim')
-    depends_on('pythia8', when='+sim')
-    depends_on('root+http+xml+gdml')
-    depends_on('vgm', when="+sim")
-    depends_on('vmc', when='@18.4: ^root@6.18:')
-    depends_on('yaml-cpp', when='@18.2:')
-    for std in ('17','20'):
-        for dep in ('root', 'fairmq'):
-            depends_on('{0} cxxstd={1}'.format(dep, std),
-                       when='cxxstd={0}'.format(std))
+    depends_on("flatbuffers")
+    depends_on("geant3", when="+sim")
+    depends_on("geant4", when="+sim")
+    depends_on("geant4-vmc", when="+sim")
+    depends_on("googletest@1.7.0:")
+    depends_on("msgpack-c@3.1:", when="+examples")
+    depends_on("protobuf")
+    depends_on("pythia6", when="+sim")
+    depends_on("pythia8", when="+sim")
+    depends_on("root+http+xml+gdml")
+    depends_on("vgm", when="+sim")
+    depends_on("vmc", when="@18.4: ^root@6.18:")
+    depends_on("yaml-cpp", when="@18.2:")
+    for std in ("17", "20"):
+        for dep in ("root", "fairmq"):
+            depends_on("{0} cxxstd={1}".format(dep, std), when="cxxstd={0}".format(std))
 
     def setup_build_environment(self, env):
         super(Fairroot, self).setup_build_environment(env)
-        env.unset('SIMPATH')
-        env.unset('FAIRSOFT_ROOT')
+        env.unset("SIMPATH")
+        env.unset("FAIRSOFT_ROOT")
 
     def cmake_args(self):
         options = []
-        options.append('--log-level=VERBOSE')
-        if self.spec.satisfies('@18.4:'):
-            cxxstd = self.spec.variants['cxxstd'].value
-            if cxxstd != 'default':
-               options.append('-DCMAKE_CXX_STANDARD={0}'.format(cxxstd))
-        if self.spec.satisfies('@:18,develop'):
-            options.append('-DROOTSYS={0}'.format(self.spec['root'].prefix))
-            options.append('-DPYTHIA8_DIR={0}'.format(
-                self.spec['pythia8'].prefix))
+        options.append("--log-level=VERBOSE")
+        if self.spec.satisfies("@18.4:"):
+            cxxstd = self.spec.variants["cxxstd"].value
+            if cxxstd != "default":
+                options.append("-DCMAKE_CXX_STANDARD={0}".format(cxxstd))
+        if self.spec.satisfies("@:18,develop"):
+            options.append("-DROOTSYS={0}".format(self.spec["root"].prefix))
+            options.append("-DPYTHIA8_DIR={0}".format(self.spec["pythia8"].prefix))
 
-        options.append('-DBUILD_EXAMPLES:BOOL=%s' %
-                       ('ON' if '+examples' in self.spec else 'OFF'))
+        options.append("-DBUILD_EXAMPLES:BOOL=%s" % ("ON" if "+examples" in self.spec else "OFF"))
 
-        if self.spec.satisfies('^boost@:1.69.99'):
-            options.append('-DBoost_NO_BOOST_CMAKE=ON')
-        options.append('-DBUILD_PROOF_SUPPORT=OFF')
+        if self.spec.satisfies("^boost@:1.69.99"):
+            options.append("-DBoost_NO_BOOST_CMAKE=ON")
+        options.append("-DBUILD_PROOF_SUPPORT=OFF")
         return options
 
     def common_env_setup(self, env):

--- a/repos/spack_repo/builtin/packages/fairroot/package.py
+++ b/repos/spack_repo/builtin/packages/fairroot/package.py
@@ -36,7 +36,7 @@ class Fairroot(CMakePackage):
 
     # Version-specific fairsoft release dependencies
     depends_on("fairsoft-bundle")
-    depends_on("fairsoft-bundle@may25", when="@18.8.2:")
+    depends_on("fairsoft-bundle@2025-05", when="@18.8.2:")
 
     depends_on("flatbuffers")
     depends_on("geant3", when="+sim")
@@ -78,14 +78,17 @@ class Fairroot(CMakePackage):
         options.append("-DBUILD_PROOF_SUPPORT=OFF")
         return options
 
+    @property
+    def root_library_path(self):
+        if self.spec.satisfies("^root@:6.25"):
+            return "LD_LIBRARY_PATH"
+        return "ROOT_LIBRARY_PATH"
+
     def common_env_setup(self, env):
         # So that root finds the shared library / rootmap
-        env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib)
+        env.prepend_path(self.root_library_path, self.prefix.lib)
 
     def setup_run_environment(self, env):
-        self.common_env_setup(env)
-
-    def setup_dependent_build_environment(self, env, dependent_spec):
         self.common_env_setup(env)
 
     def setup_dependent_run_environment(self, env, dependent_spec):

--- a/repos/spack_repo/builtin/packages/fairsoft_bundle/package.py
+++ b/repos/spack_repo/builtin/packages/fairsoft_bundle/package.py
@@ -3,54 +3,54 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.bundle import BundlePackage
+
 from spack.package import *
+
 
 class FairsoftBundle(BundlePackage):
     """Bundle package providing default environment for FAIR software"""
 
     homepage = "https://github.com/FairRootGroup/FairSoft"
     maintainers("dennisklein", "fuhlig1", "jezwilkinson")
-    
-    # Releases:
-    version('may25')
 
-    variant('graphics', default=False, description="Enable graphical support in ROOT (X11 + OpenGL)")
-    variant('mt', default=False, description="Enable multithreading for GEANT4")
+    # Releases:
+    version("may25")
+
+    variant("graphics", default=False, description="Enable graphical support in ROOT")
+    variant("mt", default=False, description="Enable multithreading for GEANT4")
 
     # Some normal packages
-    depends_on('faircmakemodules')
+    depends_on("faircmakemodules")
 
     # Pin some variants:
-    depends_on('geant4 ~threads', when='~mt')
-    depends_on('geant4 +threads', when='+mt')
-    depends_on('geant4 ~qt~vecgeom~opengl~x11~motif')
+    depends_on("geant4 ~threads", when="~mt")
+    depends_on("geant4 +threads", when="+mt")
+    depends_on("geant4 ~qt~vecgeom~opengl~x11~motif")
 
-    # ensure that OpenBLAS uses CMake build system (default Makefile causes issues on some x86 Macs because of tests)
-    depends_on('openblas build_system=cmake ~dynamic_dispatch')
-    
+    # ensure that OpenBLAS uses CMake build system (default Makefile causes issues on some Macs)
+    depends_on("openblas build_system=cmake ~dynamic_dispatch")
+
     # Generic ROOT dependencies
-    depends_on('root +fortran+pythia8+vc~vdt')
+    depends_on("root +fortran+pythia8+vc~vdt")
     # Mostly for the experiments:
-    depends_on('root +python+tmva+mlp+xrootd+sqlite')
+    depends_on("root +python+tmva+mlp+xrootd+sqlite")
     # FFTW for Panda
-    depends_on('root +fftw')
-    depends_on('fftw~mpi')
-    depends_on('root +spectrum', when='@20.11:')
-    depends_on('root ~x~opengl~aqua', when='~graphics')
-    depends_on('root +x+opengl', when='+graphics')
+    depends_on("root +fftw")
+    depends_on("fftw~mpi")
+    depends_on("root +spectrum", when="@20.11:")
+    depends_on("root ~x~opengl~aqua", when="~graphics")
+    depends_on("root +x+opengl", when="+graphics")
 
-    # Using 'platform=' in a when clause gets concretized too late.
+    # Using "platform=" in a when clause gets concretized too late.
     # and our root recipe disables +aqua on non-macOS now.
-    # depends_on('root +aqua', when='+graphics platform=darwin')
-    depends_on('root +aqua', when='+graphics')
+    # depends_on("root +aqua", when="+graphics platform=darwin")
+    depends_on("root +aqua", when="+graphics")
 
     # Version-specific dependencies for FairSoft releases
-    depends_on('pythia8@8.313', when='@may25')
-    depends_on('root@6.36.00', when='@may25')
-    depends_on('vmc@2-1', when='@may25')
-    depends_on('geant3@4-4', when='@may25')
-    depends_on('vgm@5-3-1', when='@may25')
-    depends_on('geant4-vmc@6-7-p1', when='@may25')
-    depends_on('fairsoft-config@develop', when='@may25', type='run')
-
-
+    depends_on("pythia8@8.313", when="@may25")
+    depends_on("root@6.36.00", when="@may25")
+    depends_on("vmc@2-1", when="@may25")
+    depends_on("geant3@4-4", when="@may25")
+    depends_on("vgm@5-3-1", when="@may25")
+    depends_on("geant4-vmc@6-7-p1", when="@may25")
+    depends_on("fairsoft-config@develop", when="@may25", type="run")

--- a/repos/spack_repo/builtin/packages/fairsoft_bundle/package.py
+++ b/repos/spack_repo/builtin/packages/fairsoft_bundle/package.py
@@ -14,8 +14,8 @@ class FairsoftBundle(BundlePackage):
     # Releases:
     version('may25')
 
-    variant('graphics', default=False)
-    variant('mt', default=False)
+    variant('graphics', default=False, description="Enable graphical support in ROOT (X11 + OpenGL)")
+    variant('mt', default=False, description="Enable multithreading for GEANT4")
 
     # Some normal packages
     depends_on('faircmakemodules')

--- a/repos/spack_repo/builtin/packages/fairsoft_bundle/package.py
+++ b/repos/spack_repo/builtin/packages/fairsoft_bundle/package.py
@@ -1,0 +1,56 @@
+# Copyright Spack Project Developers. See COPYRIGHT for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.bundle import BundlePackage
+from spack.package import *
+
+class FairsoftBundle(BundlePackage):
+    """Bundle package providing default environment for FAIR software"""
+
+    homepage = "https://github.com/FairRootGroup/FairSoft"
+    maintainers("dennisklein", "fuhlig1", "jezwilkinson")
+    
+    # Releases:
+    version('may25')
+
+    variant('graphics', default=False)
+    variant('mt', default=False)
+
+    # Some normal packages
+    depends_on('faircmakemodules')
+
+    # Pin some variants:
+    depends_on('geant4 ~threads', when='~mt')
+    depends_on('geant4 +threads', when='+mt')
+    depends_on('geant4 ~qt~vecgeom~opengl~x11~motif')
+
+    # ensure that OpenBLAS uses CMake build system (default Makefile causes issues on some x86 Macs because of tests)
+    depends_on('openblas build_system=cmake ~dynamic_dispatch')
+    
+    # Generic ROOT dependencies
+    depends_on('root +fortran+pythia8+vc~vdt')
+    # Mostly for the experiments:
+    depends_on('root +python+tmva+mlp+xrootd+sqlite')
+    # FFTW for Panda
+    depends_on('root +fftw')
+    depends_on('fftw~mpi')
+    depends_on('root +spectrum', when='@20.11:')
+    depends_on('root ~x~opengl~aqua', when='~graphics')
+    depends_on('root +x+opengl', when='+graphics')
+
+    # Using 'platform=' in a when clause gets concretized too late.
+    # and our root recipe disables +aqua on non-macOS now.
+    # depends_on('root +aqua', when='+graphics platform=darwin')
+    depends_on('root +aqua', when='+graphics')
+
+    # Version-specific dependencies for FairSoft releases
+    depends_on('pythia8@8.313', when='@may25')
+    depends_on('root@6.36.00', when='@may25')
+    depends_on('vmc@2-1', when='@may25')
+    depends_on('geant3@4-4', when='@may25')
+    depends_on('vgm@5-3-1', when='@may25')
+    depends_on('geant4-vmc@6-7-p1', when='@may25')
+    depends_on('fairsoft-config@develop', when='@may25', type='run')
+
+

--- a/repos/spack_repo/builtin/packages/fairsoft_bundle/package.py
+++ b/repos/spack_repo/builtin/packages/fairsoft_bundle/package.py
@@ -14,7 +14,7 @@ class FairsoftBundle(BundlePackage):
     maintainers("dennisklein", "fuhlig1", "jezwilkinson")
 
     # Releases:
-    version("may25")
+    version("2025-05")
 
     variant("graphics", default=False, description="Enable graphical support in ROOT")
     variant("mt", default=False, description="Enable multithreading for GEANT4")
@@ -37,7 +37,7 @@ class FairsoftBundle(BundlePackage):
     # FFTW for Panda
     depends_on("root +fftw")
     depends_on("fftw~mpi")
-    depends_on("root +spectrum", when="@20.11:")
+    depends_on("root +spectrum", when="@2025-05:")
     depends_on("root ~x~opengl~aqua", when="~graphics")
     depends_on("root +x+opengl", when="+graphics")
 
@@ -47,10 +47,10 @@ class FairsoftBundle(BundlePackage):
     depends_on("root +aqua", when="+graphics")
 
     # Version-specific dependencies for FairSoft releases
-    depends_on("pythia8@8.313", when="@may25")
-    depends_on("root@6.36.00", when="@may25")
-    depends_on("vmc@2-1", when="@may25")
-    depends_on("geant3@4-4", when="@may25")
-    depends_on("vgm@5-3-1", when="@may25")
-    depends_on("geant4-vmc@6-7-p1", when="@may25")
-    depends_on("fairsoft-config@develop", when="@may25", type="run")
+    depends_on("pythia8@8.313", when="@2025-05")
+    depends_on("root@6.36.00", when="@2025-05")
+    depends_on("vmc@2-1", when="@2025-05")
+    depends_on("geant3@4-4", when="@2025-05")
+    depends_on("vgm@5-3-1", when="@2025-05")
+    depends_on("geant4-vmc@6-7-p1", when="@2025-05")
+    depends_on("fairsoft-config fairsoft_version=may25", when="@2025-05", type="run")

--- a/repos/spack_repo/builtin/packages/fairsoft_config/package.py
+++ b/repos/spack_repo/builtin/packages/fairsoft_config/package.py
@@ -1,0 +1,32 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack.package import *
+
+class FairsoftConfig(CMakePackage):
+    """Legacy fairsoft-config script"""
+
+    homepage = 'https://github.com/FairRootGroup/fairsoft-config'
+    git = 'https://github.com/FairRootGroup/fairsoft-config'
+    maintainers('dennisklein', 'fuhlig1', 'jezwilkinson')
+
+    version('develop')
+    version('may25')
+
+    variant('cxxstd',
+            default='17',
+            values=('17', '20'),
+            multi=False,
+            description='C++ standard reported')
+
+    depends_on('cmake@3:', type='build')
+    depends_on('root', type=('build', 'link', 'run'))
+
+    def cmake_args(self):
+        args = []
+        args.append('-DFAIRSOFT_VERSION=%s' % self.version)
+        args.append('-DCMAKE_CXX_STANDARD=%s' %
+                    self.spec.variants['cxxstd'].value)
+        return args

--- a/repos/spack_repo/builtin/packages/fairsoft_config/package.py
+++ b/repos/spack_repo/builtin/packages/fairsoft_config/package.py
@@ -3,30 +3,33 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+
 from spack.package import *
+
 
 class FairsoftConfig(CMakePackage):
     """Legacy fairsoft-config script"""
 
-    homepage = 'https://github.com/FairRootGroup/fairsoft-config'
-    git = 'https://github.com/FairRootGroup/fairsoft-config'
-    maintainers('dennisklein', 'fuhlig1', 'jezwilkinson')
+    homepage = "https://github.com/FairRootGroup/fairsoft-config"
+    git = "https://github.com/FairRootGroup/fairsoft-config"
+    maintainers("dennisklein", "fuhlig1", "jezwilkinson")
 
-    version('develop')
-    version('may25')
+    version("develop")
+    version("may25")
 
-    variant('cxxstd',
-            default='17',
-            values=('17', '20'),
-            multi=False,
-            description='C++ standard reported')
+    variant(
+        "cxxstd",
+        default="17",
+        values=("17", "20"),
+        multi=False,
+        description="C++ standard reported",
+    )
 
-    depends_on('cmake@3:', type='build')
-    depends_on('root', type=('build', 'link', 'run'))
+    depends_on("cmake@3:", type="build")
+    depends_on("root", type=("build", "link", "run"))
 
     def cmake_args(self):
         args = []
-        args.append('-DFAIRSOFT_VERSION=%s' % self.version)
-        args.append('-DCMAKE_CXX_STANDARD=%s' %
-                    self.spec.variants['cxxstd'].value)
+        args.append("-DFAIRSOFT_VERSION=%s" % self.version)
+        args.append("-DCMAKE_CXX_STANDARD=%s" % self.spec.variants["cxxstd"].value)
         return args

--- a/repos/spack_repo/builtin/packages/fairsoft_config/package.py
+++ b/repos/spack_repo/builtin/packages/fairsoft_config/package.py
@@ -14,8 +14,7 @@ class FairsoftConfig(CMakePackage):
     git = "https://github.com/FairRootGroup/fairsoft-config"
     maintainers("dennisklein", "fuhlig1", "jezwilkinson")
 
-    version("develop")
-    version("may25")
+    version("master")
 
     variant(
         "cxxstd",
@@ -25,11 +24,21 @@ class FairsoftConfig(CMakePackage):
         description="C++ standard reported",
     )
 
+    variant(
+        "fairsoft_version",
+        default="develop",
+        values=("develop", "may25"),
+        multi=False,
+        description="Installed version of fairsoft-bundle",
+    )
+
     depends_on("cmake@3:", type="build")
     depends_on("root", type=("build", "link", "run"))
 
     def cmake_args(self):
         args = []
-        args.append("-DFAIRSOFT_VERSION=%s" % self.version)
-        args.append("-DCMAKE_CXX_STANDARD=%s" % self.spec.variants["cxxstd"].value)
+        args += [
+            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
+            self.define_from_variant("FAIRSOFT_VERSION", "fairsoft_version"),
+        ]
         return args


### PR DESCRIPTION
Adds package recipe for FairROOT, along with a "FairSoft-bundle" bundle package for the default software environment for FAIR software + FairROOT dependencies.

Note: Depends on a few still-open pull requests for missing versions of dependencies and fixing a handful of build/concretisation errors that were encountered in dependency packages during testing: https://github.com/spack/spack-packages/pull/405 (VGM), https://github.com/spack/spack-packages/pull/406 (VMC), https://github.com/spack/spack-packages/pull/407 (Geant4-VMC), https://github.com/spack/spack-packages/pull/409 (Geant3).