### PR TITLE
py-jaxlib: fix runtime error due to custom cuda location

### DIFF
--- a/repos/spack_repo/builtin/packages/py_jaxlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_jaxlib/package.py
@@ -229,6 +229,11 @@ class PyJaxlib(PythonPackage, CudaPackage, ROCmPackage):
                 env.prepend_path("TF_ROCM_MULTIPLE_PATHS", spec[pkg_dep].prefix)
                 env.prune_duplicate_paths("TF_ROCM_MULTIPLE_PATHS")
 
+    def setup_run_environment(self, env: EnvironmentModifications) -> None:
+        if "+cuda" in self.spec:
+            env.prepend_path("LD_LIBRARY_PATH", join_path(self.spec['cuda'].prefix, "extras", "CUPTI", "lib64"))
+            env.set("XLA_FLAGS", f'--xla_gpu_cuda_data_dir={self.spec["cuda"].prefix}')
+
     def install(self, spec, prefix):
         # https://jax.readthedocs.io/en/latest/developer.html
         args = ["build/build.py"]

--- a/repos/spack_repo/builtin/packages/py_jaxlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_jaxlib/package.py
@@ -231,9 +231,12 @@ class PyJaxlib(PythonPackage, CudaPackage, ROCmPackage):
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         if "+cuda" in self.spec:
-            env.prepend_path(
-                "LD_LIBRARY_PATH", join_path(self.spec["cuda"].prefix, "extras", "CUPTI", "lib64")
+            libs = find_libraries(
+                "libcupti", root=self.spec["cuda"].prefix, shared=True, recursive=True
             )
+            for libdir in libs.directories:
+                env.append_path("LD_LIBRARY_PATH", libdir)
+
             env.set("XLA_FLAGS", f'--xla_gpu_cuda_data_dir={self.spec["cuda"].prefix}')
 
     def install(self, spec, prefix):

--- a/repos/spack_repo/builtin/packages/py_jaxlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_jaxlib/package.py
@@ -231,7 +231,9 @@ class PyJaxlib(PythonPackage, CudaPackage, ROCmPackage):
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         if "+cuda" in self.spec:
-            env.prepend_path("LD_LIBRARY_PATH", join_path(self.spec['cuda'].prefix, "extras", "CUPTI", "lib64"))
+            env.prepend_path(
+                "LD_LIBRARY_PATH", join_path(self.spec["cuda"].prefix, "extras", "CUPTI", "lib64")
+            )
             env.set("XLA_FLAGS", f'--xla_gpu_cuda_data_dir={self.spec["cuda"].prefix}')
 
     def install(self, spec, prefix):


### PR DESCRIPTION
Jaxlib with CUDA throws a runtime error if CUDA is installed at a custom location.
Setting `LD_LIBRARY_PATH` such that CUPTI can be found and `XLA_FLAGS` for XLA to find CUDA fixes the error.