### PR TITLE
py-numba: fix python dependency bounds

### DIFF
--- a/repos/spack_repo/builtin/packages/py_llvmlite/package.py
+++ b/repos/spack_repo/builtin/packages/py_llvmlite/package.py
@@ -47,7 +47,8 @@ class PyLlvmlite(PythonPackage):
     depends_on("cxx", type="build")  # generated
 
     depends_on("py-setuptools", type="build")
-    depends_on("python@3.9:3.12", when="@0.42:", type=("build", "run"))
+    depends_on("python@3.10:3.13", when="@0.44:", type=("build", "run"))
+    depends_on("python@3.9:3.12", when="@0.42:0.43", type=("build", "run"))
     depends_on("python@3.8:3.11", when="@0.40:0.41", type=("build", "run"))
     depends_on("python@:3.10", when="@0.38:0.39", type=("build", "run"))
     depends_on("python@:3.9", when="@0.36:0.37", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_numba/package.py
+++ b/repos/spack_repo/builtin/packages/py_numba/package.py
@@ -53,7 +53,7 @@ class PyNumba(PythonPackage):
     # Be careful that the bounds given in setup.py are exclusive on the upper bound
     # i.e., [min, max)
     depends_on("python@3.10:3.13", when="@0.61:", type=("build", "run"))
-    depends_on("python@3.9:3.12", when="@0.59:", type=("build", "run"))
+    depends_on("python@3.9:3.12", when="@0.59:0.60", type=("build", "run"))
     depends_on("python@3.8:3.11", when="@0.57:0.58", type=("build", "run"))
     depends_on("python@3.7:3.10", when="@0.55:0.56", type=("build", "run"))
     depends_on("python@3.7:3.9", when="@0.54", type=("build", "run"))


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This patch corrects inconsistencies with Numba's Python dependencies as seen in:
- https://github.com/numba/numba/blob/release0.59/setup.py
- https://github.com/numba/numba/blob/release0.61/setup.py
- https://github.com/numba/llvmlite/blob/v0.40.0/setup.py
- https://github.com/numba/llvmlite/blob/v0.42.0/setup.py
- https://github.com/numba/llvmlite/blob/v0.44.0/setup.py