### PR TITLE
openmx: fix build with latest gcc, aocc and intel-oneapi

### DIFF
--- a/repos/spack_repo/builtin/packages/openmx/package.py
+++ b/repos/spack_repo/builtin/packages/openmx/package.py
@@ -42,6 +42,8 @@ class Openmx(MakefilePackage):
 
     depends_on("mpi")
     depends_on("fftw-api@3")
+    depends_on("blas")
+    depends_on("lapack")
     depends_on("scalapack")
     depends_on("sse2neon", when="target=aarch64:")
 

--- a/repos/spack_repo/builtin/packages/openmx/package.py
+++ b/repos/spack_repo/builtin/packages/openmx/package.py
@@ -40,6 +40,17 @@ class Openmx(MakefilePackage):
         when="@3.9",
     )
 
+    # Custom patch for clang: override Set_ProExpn_VNA.c
+    # See https://www.openmx-square.org/forum/patio.cgi?mode=view&no=2955
+    resource(
+        name="set_proexpn_patch",
+        url="https://gist.githubusercontent.com/Ncmexp2717/aaffd91eb1bc15e1909b057cc2e83c1f/raw/4e7dfd4a9346b82de69ce9b1d270042bebcd1610/Set_ProExpn_VNA.c",
+        sha256="d33de4cbae9af19f39bdf880d33a487cb8fb65beb9fbaa40f4202315dc6ec87b",
+        placement="set_proexpn_patch",
+        when="@3.9",
+        expand=False,
+    )
+
     depends_on("mpi")
     depends_on("fftw-api@3")
     depends_on("blas")
@@ -61,6 +72,8 @@ class Openmx(MakefilePackage):
         # http://www.openmx-square.org/bugfixed/21Oct17/README.txt
         if spec.satisfies("@3.9"):
             copy(join_path("source", "kpoint.in"), "work")
+            if "%aocc" in spec or "%llvm" in spec:
+                copy("set_proexpn_patch/Set_ProExpn_VNA.c", "source/Set_ProExpn_VNA.c")
         makefile = FileFilter("./source/makefile")
         makefile.filter("^DESTDIR.*$", "DESTDIR = {0}/bin".format(prefix))
         mkdirp(prefix.bin)
@@ -95,6 +108,8 @@ class Openmx(MakefilePackage):
                 lib_option.append("-lgfortran")
                 if spec.satisfies("%gcc@10:"):
                     fc_option.append("-fallow-argument-mismatch")
+            if "%llvm" in spec or "%aocc" in spec:
+                lib_option.extend(["-lflang", "-lpgmath"])
 
         return [
             "CC={0} -Dscalapack {1} ".format(" ".join(cc_option), " ".join(common_option)),

--- a/repos/spack_repo/builtin/packages/openmx/package.py
+++ b/repos/spack_repo/builtin/packages/openmx/package.py
@@ -88,11 +88,13 @@ class Openmx(MakefilePackage):
             fc_option.extend([self.compiler.openmp_flag, "-Ccpp"])
         else:
             common_option.append("-O3")
+            cc_option.extend(
+                ["-Wno-error=implicit-function-declaration", "-Wno-error=implicit-int", "-fcommon"]
+            )
             if "%gcc" in spec:
                 lib_option.append("-lgfortran")
                 if spec.satisfies("%gcc@10:"):
                     fc_option.append("-fallow-argument-mismatch")
-                    cc_option.append("-fcommon")
 
         return [
             "CC={0} -Dscalapack {1} ".format(" ".join(cc_option), " ".join(common_option)),

--- a/repos/spack_repo/builtin/packages/openmx/package.py
+++ b/repos/spack_repo/builtin/packages/openmx/package.py
@@ -58,6 +58,11 @@ class Openmx(MakefilePackage):
     depends_on("scalapack")
     depends_on("sse2neon", when="target=aarch64:")
 
+    # Need OpenMP threaded BLAS libraries
+    requires("^openblas threads=openmp", when="^[virtuals=blas] openblas")
+    requires("^amdblis threads=openmp", when="^[virtuals=blas] amdblis")
+    requires("^intel-oneapi-mkl threads=openmp", when="^[virtuals=blas] intel-oneapi-mkl")
+
     patch("for_aarch64.patch", when="@3.8 target=aarch64:")
 
     parallel = False
@@ -88,8 +93,13 @@ class Openmx(MakefilePackage):
             self.compiler.openmp_flag,
             spec["fftw-api"].headers.include_flags,
         ]
-        fc_option = [spec["mpi"].mpifc]
-        lib_option = [spec["fftw-api"].libs.ld_flags, lapack_blas_libs.ld_flags, "-lmpi_mpifh"]
+        fc_option = [spec["mpi"].mpifc, self.compiler.openmp_flag]
+        lib_option = [
+            spec["fftw-api"].libs.ld_flags,
+            lapack_blas_libs.ld_flags,
+            "-lmpi_mpifh",
+            self.compiler.openmp_flag,
+        ]
         if spec.satisfies("@3.8"):
             cc_option.append("-I$(LIBERIDIR)")
         if spec.satisfies("@3.9"):
@@ -110,7 +120,9 @@ class Openmx(MakefilePackage):
                 if spec.satisfies("%gcc@10:"):
                     fc_option.append("-fallow-argument-mismatch")
             if "%llvm" in spec or "%aocc" in spec:
-                lib_option.extend(["-lflang", "-lpgmath"])
+                lib_option.extend(["-lflang", "-lpgmath", "-lflangrti"])
+            if "%oneapi" in spec:
+                lib_option.extend(["-lifcore"])
 
         return [
             "CC={0} -Dscalapack {1} ".format(" ".join(cc_option), " ".join(common_option)),

--- a/repos/spack_repo/builtin/packages/openmx/package.py
+++ b/repos/spack_repo/builtin/packages/openmx/package.py
@@ -74,6 +74,7 @@ class Openmx(MakefilePackage):
             copy(join_path("source", "kpoint.in"), "work")
             if "%aocc" in spec or "%llvm" in spec:
                 copy("set_proexpn_patch/Set_ProExpn_VNA.c", "source/Set_ProExpn_VNA.c")
+        filter_file(r"\bgcc\b", "$(CC)", "source/makefile")
         makefile = FileFilter("./source/makefile")
         makefile.filter("^DESTDIR.*$", "DESTDIR = {0}/bin".format(prefix))
         mkdirp(prefix.bin)


### PR DESCRIPTION
My first PR so please be patient.

This is mostly trying to make openmx work with latest compilers (gcc, aocc and intel-oneapi), although I did no succeeded to make vanila llvm work yet. I've tried to divide into separate patches for easier review, but can also squash if needed.

In general the issue is openmx is not written according to the C/Fortran spec too much (mostly depending on what ifort/icc was happy with historically), so there are missing definition, multiple definitions, implicit int returns, etc. So this adds some dependencies, one clang specific patch, and bunch of compiler flags to workaround the errors.

This also improves the OpenMP build, previously only C parts were build with OpenMP, enable Fortran which helps scaling in ELPA diagonalization (yes there are ELPA buildin parts, so we could in theory get rid of it and build against the proper library, but this is ELPA from 2018, so seemed like a lot of pain)
I've tried to make sure we pick threaded libraries for OpenMP, but it was not clear what would be the best approach, the best I could come up with was:
```
    # Need OpenMP threaded BLAS libraries
    requires("^openblas threads=openmp", when="^[virtuals=blas] openblas")
    requires("^amdblis threads=openmp", when="^[virtuals=blas] amdblis")
    requires("^intel-oneapi-mkl threads=openmp", when="^[virtuals=blas] intel-oneapi-mkl")

```
I have also tried 
```
    depends_on("blas threads=openmp")
    depends_on("lapack threads=openmp")
```
which seems more generic, but that breaks the oneapi build for some reason
```
==> Error: Spack concretizer internal error. Please submit a bug report and include the command, environment if applicable and the following error message.
    openmx %oneapi ^intel-oneapi-mkl+cluster ^openmpi %oneapi is unsatisfiable
```


What was tested:
spack install openmx%gcc (using system gcc 14.2.1 and openmpi 5.0.5 from Fedora 41 which picked spack openblas, netlib-scalapack and fftw)
spack install openmx+openmp%aocc ^amdfftw ^amdscalapack (aocc 5.0.0)
spack install openmx%oneapi ^openmpi%oneapi ^intel-oneapi-mkl+cluster
In each case both build and running the openmx test suite was tested.

I also tried to build with intel-oneapi-mpi, but that was for some reason picking gfrortan instead of intel fortran compiler.

BTW Is there some better way how to link against a fortran runtime instead of manually specificity for every compiler?
