### PR TITLE
gnuplot: Fix environment modifications

### DIFF
--- a/repos/spack_repo/builtin/packages/gnuplot/package.py
+++ b/repos/spack_repo/builtin/packages/gnuplot/package.py
@@ -79,6 +79,10 @@ class Gnuplot(AutotoolsPackage):
     depends_on("qt@5.7:+opengl", when="+qt")
     depends_on("qt+framework", when="+qt platform=darwin")
 
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        if self.spec.satisfies("%gcc@7:"):
+            env.set("LDFLAGS", "-Wl,--copy-dt-needed-entries")
+
     def configure_args(self):
         # see https://github.com/Homebrew/homebrew-core/blob/master/Formula/gnuplot.rb
         # and https://github.com/macports/macports-ports/blob/master/math/gnuplot/Portfile
@@ -167,8 +171,5 @@ class Gnuplot(AutotoolsPackage):
 
         # TODO: --with-aquaterm  depends_on('aquaterm')
         options.append("--without-aquaterm")
-
-        if spec.satisfies("%gcc@8:"):
-            os.environ["LDFLAGS"] = "-Wl,--copy-dt-needed-entries"
 
         return options


### PR DESCRIPTION
The `gnuplot` recipe still uses the old pre-1.0 env dictionary, instead of the new syntax. This PR updates the recipe to fix that and also drops the flag requirement from gcc@8 to gcc@7 as the fix is needed for that version as well (the minimum version for this fix was undetermined in the original PR: https://github.com/spack/spack/pull/42116).
