### PR TITLE
xnedit: add required dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/xnedit/package.py
+++ b/repos/spack_repo/builtin/packages/xnedit/package.py
@@ -47,7 +47,9 @@ class Xnedit(MakefilePackage):
     depends_on("cxx", type="build")
 
     depends_on("automake", type="build")
+    depends_on("fontconfig")
     depends_on("libx11")
+    depends_on("libxft")
     depends_on("libxt")
     depends_on("libxpm")
     depends_on("motif", when="+motif")


### PR DESCRIPTION
I suspect that two dependencies - `libxft` and `fontconfig` - are present in sufficient default OS environments that they were missed in the original creation of this package recipe. On our system, the `xnedit` build fails without each as explicit dependencies:

```
...
Package xft was not found in the pkg-config search path.
Perhaps you should add the directory containing `xft.pc'
to the PKG_CONFIG_PATH environment variable
No package 'xft' found
Package fontconfig was not found in the pkg-config search path.
Perhaps you should add the directory containing `fontconfig.pc'
to the PKG_CONFIG_PATH environment variable
No package 'fontconfig' found
cc -O -std=gnu99 -I/usr/X11R6/include -I/usr/include/X11 -DUSE_LPR_PRINT_CMD    -c -o clearcase.o clearcase.c
In file included from textfield.c:23:
textfieldP.h:26:10: fatal error: Xm/XmP.h: No such file or directory
   26 | #include <Xm/XmP.h>
      |          ^~~~~~~~~~
compilation terminated.
```

This PR adds both.