### PR TITLE
ncvis: wxwidgets dependency needs gui

### DIFF
--- a/repos/spack_repo/builtin/packages/ncvis/package.py
+++ b/repos/spack_repo/builtin/packages/ncvis/package.py
@@ -25,7 +25,7 @@ class Ncvis(CMakePackage):
 
     depends_on("cmake", type="build")
     depends_on("netcdf-c", type="link")
-    depends_on("wxwidgets+opengl", type="link")
+    depends_on("wxwidgets+opengl+gui", type="link")
 
     @run_after("install")
     def install_resources(self):


### PR DESCRIPTION
Without `+gui`, ncvis cannot detect the wxwidgets dependency via CMake:

```
CMake Error at /glade/u/apps/gust/25.07/envs/build/opt/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack/cmake/3.31.6/gcc/12.4.0/2wfa/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find wxWidgets (missing: wxWidgets_LIBRARIES)
Call Stack (most recent call first):
  /glade/u/apps/gust/25.07/envs/build/opt/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack/cmake/3.31.6/gcc/12.4.0/2wfa/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:603 (_FPHSA_FAILURE_MESSAGE)
  /glade/u/apps/gust/25.07/envs/build/opt/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack/cmake/3.31.6/gcc/12.4.0/2wfa/share/cmake-3.31/Modules/FindwxWidgets.cmake:1014 (find_package_handle_standard_args)
  CMakeLists.txt:20 (find_package)
```

I haven't been able to get it to work without `+gui`, but if this may be a side-effect of another problem, it still needs some eyes.

