### PR TITLE
zfp: fix CMake argument mistake

### DIFF
--- a/repos/spack_repo/builtin/packages/zfp/package.py
+++ b/repos/spack_repo/builtin/packages/zfp/package.py
@@ -154,7 +154,7 @@ class Zfp(CMakePackage, CudaPackage):
 
         if "round" in spec.variants:
             args.append(
-                "ZFP_ROUNDING_MODE=ZFP_ROUND_{0}".format(spec.variants["round"].value.upper())
+                "-DZFP_ROUNDING_MODE=ZFP_ROUND_{0}".format(spec.variants["round"].value.upper())
             )
 
         if "+cuda" in spec:


### PR DESCRIPTION
The current recipe has a typo for the ZFP_ROUNDING_MODE cmake argument. As is, you get this:

```
CMake Warning:
  Ignoring extra path from command line:

   "/glade/gust/scratch/csgteam/temp/spack/gust/25.07/builds/spack-stage-zfp-1.0.1-27jzy5inzutljxfyjesky6oq7nyjtapa/spack-build-27jzy5i/ZFP_ROUNDING_MODE=ZFP_ROUND_FIRST"
...
CMake Error at CMakeLists.txt:234 (message):
  ZFP_WITH_TIGHT_ERROR requires ZFP_ROUND_FIRST or ZFP_ROUND_LAST rounding
  mode
```

This PR fixes it.