### PR TITLE
tk: needs c compiler to build

### DIFF
--- a/repos/spack_repo/builtin/packages/tk/package.py
+++ b/repos/spack_repo/builtin/packages/tk/package.py
@@ -34,6 +34,8 @@ class Tk(AutotoolsPackage, SourceforgePackage):
 
     extends("tcl", type=("build", "link", "run"))
 
+    depends_on("c", type="build")
+
     depends_on("tcl@8.6:", type=("build", "link", "run"), when="@8.6:")
     depends_on("libx11")
     depends_on("libxft", when="+xft")


### PR DESCRIPTION
When compiler language dependencies were auto-added, the `tk` package did not get a C lang dependence, probably because of the source code layout. But this is required. Without it, the configure script picks up on the system GCC:

```
...
checking for gcc... gcc
...
```

and then since it isn't using the Spack wrapper, dependencies like libX11 aren't found properly.

This PR addresses this and should fix issue #328.