### PR TITLE
libdrm: version is property of spec

### DIFF
--- a/repos/spack_repo/builtin/packages/libdrm/package.py
+++ b/repos/spack_repo/builtin/packages/libdrm/package.py
@@ -87,7 +87,7 @@ class AutotoolsBuilder(autotools.AutotoolsBuilder):
     def configure_args(self):
         args = []
         args.append("--enable-static")
-        if self.version <= Version("2.4.70"):
+        if self.spec.version <= Version("2.4.70"):
             # Needed to fix build for spack/spack#1740, but breaks newer
             # builds/compilers
             args.append("LIBS=-lrt")


### PR DESCRIPTION
Perhaps this worked at one point, but in Spack vlatest this gives an error as `version` is not a valid property of `self`.

This PR corrects it to pull the version from the `spec` object of `self`.