### PR TITLE
HEP: enable acts +onnx

### DIFF
--- a/stacks/hep/spack.yaml
+++ b/stacks/hep/spack.yaml
@@ -5,8 +5,6 @@ spack:
   - $CI_PROJECT_DIR/.ci/gitlab/
 
   concretizer:
-    reuse: false
-    unify: when_possible
     static_analysis: true
 
   packages:

--- a/stacks/hep/spack.yaml
+++ b/stacks/hep/spack.yaml
@@ -22,7 +22,7 @@ spack:
       variants: +mpi
     acts:
       require:
-      - +analysis +dd4hep +edm4hep +examples +fatras +geant4 +hepmc3 +podio +pythia8 +python +svg +tgeo cxxstd=20
+      - +analysis +dd4hep +edm4hep +examples +fatras +geant4 +hepmc3 +onnx +podio +pythia8 +python +svg +tgeo cxxstd=20
       - target=x86_64_v3
     celeritas:
       require:

--- a/stacks/hep/spack.yaml
+++ b/stacks/hep/spack.yaml
@@ -40,6 +40,10 @@ spack:
       require:
       - '@2.22:'
       - target=x86_64_v3
+    py-numpy:
+      require:
+      - '@1.26:'
+      - target=x86_64_v3
     rivet:
       require:
       - hepmc=3


### PR DESCRIPTION
This PR enables `acts +onnx` in the HEP stack in CI. This will better test the HEP onnx/ort upgrades (of interest to ML as well, maybe, @adamjstewart).

