### PR TITLE
gdal: parquet support needs arrow with parquet and fs support

### DIFF
--- a/repos/spack_repo/builtin/packages/gdal/package.py
+++ b/repos/spack_repo/builtin/packages/gdal/package.py
@@ -384,7 +384,7 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
     depends_on("openjpeg", when="+openjpeg")
     depends_on("openssl", when="+openssl")
     depends_on("oracle-instant-client", when="+oracle")
-    depends_on("arrow", when="+parquet")
+    depends_on("arrow+parquet+filesystem", when="+parquet")
     # depends_on('pcidsk', when='+pcidsk')
     depends_on("pcre2", when="@3.5:+pcre2")
     depends_on("pcre", when="@:3.4+pcre2")


### PR DESCRIPTION
The GDAL support for the parquet format seems to require not just `arrow`, but `arrow` with filesystem and parquet support:

```
-- Could NOT find Parquet (missing: Parquet_DIR)
CMake Error at cmake/helpers/CheckDependentLibrariesCommon.cmake:213 (message):
  Configured to use PARQUET, but not found
Call Stack (most recent call first):
  cmake/helpers/CheckDependentLibrariesArrowParquet.cmake:3 (gdal_check_package)
  cmake/helpers/CheckDependentLibraries.cmake:493 (include)
  gdal.cmake:76 (include)
  CMakeLists.txt:264 (include)
```

And the CMake logic in GDAL:

```
if (Arrow_FOUND)
    gdal_check_package(Parquet "Apache Parquet C++ library" CONFIG PATHS ${Arrow_DIR} CAN_DISABLE)
...
```

This PR ensures that parquet support is enabled in arrow, which resolves these errors.
