### PR TITLE
spherepack: fix to avoid flags nvhpc doesnt understand

### DIFF
--- a/repos/spack_repo/builtin/packages/spherepack/package.py
+++ b/repos/spack_repo/builtin/packages/spherepack/package.py
@@ -19,7 +19,18 @@ class Spherepack(Package):
     depends_on("fortran", type="build")
     depends_on("gmake", type="build")
 
+    def flag_handler(self, name, flags):
+        spec = self.spec
+
+        if name == "fflags":
+            flags.append("-O2")
+
+            if spec.satisfies("%gcc@10:"):
+                flags.append("-fallow-argument-mismatch")
+
+        return (flags, None, None)
+
     def install(self, spec, prefix):
-        make("MAKE=make", "F90=f90 -O2 -fallow-argument-mismatch", "AR=ar", "libspherepack")
-        make("MAKE=make", "F90=f90 -O2 -fallow-argument-mismatch", "AR=ar", "testspherepack")
+        make("MAKE=make", "F90=f90", "AR=ar", "libspherepack")
+        make("MAKE=make", "F90=f90", "AR=ar", "testspherepack")
         install_tree("lib", prefix.lib)

--- a/repos/spack_repo/builtin/packages/spherepack/package.py
+++ b/repos/spack_repo/builtin/packages/spherepack/package.py
@@ -23,9 +23,7 @@ class Spherepack(Package):
         spec = self.spec
 
         if name == "fflags":
-            flags.append("-O2")
-
-            if spec.satisfies("%gcc@10:"):
+            if spec.satisfies("%fortran=gcc@10:"):
                 flags.append("-fallow-argument-mismatch")
 
         return (flags, None, None)


### PR DESCRIPTION
The current version of the package injects flags for GCC 10+ into the Makefile via environment variables, but a better approach is to use a flag handler to avoid conflicts with compilers that don't support those flags (nvhpc). This PR implements this.