### PR TITLE
Generalize Intel logic to support package names too

### DIFF
--- a/repos/spack_repo/builtin/packages/esmf/package.py
+++ b/repos/spack_repo/builtin/packages/esmf/package.py
@@ -246,7 +246,7 @@ class MakefileBuilder(makefile.MakefileBuilder):
         if spec["fortran"].name == "gcc" and spec["c"].name == "gcc":
             gfortran_major_version = int(spec["fortran"].version[0])
             env.set("ESMF_COMPILER", "gfortran")
-        elif self.pkg.compiler.name == "intel" or self.pkg.compiler.name == "oneapi":
+        elif any(comp in self.pkg.compiler.name for comp in ("intel", "oneapi")):
             env.set("ESMF_COMPILER", "intel")
         elif spec["fortran"].name == "gcc" and spec["c"].name in ["clang", "apple-clang"]:
             gfortran_major_version = int(spec["fortran"].version[0])

--- a/repos/spack_repo/builtin/packages/esmf/package.py
+++ b/repos/spack_repo/builtin/packages/esmf/package.py
@@ -246,7 +246,7 @@ class MakefileBuilder(makefile.MakefileBuilder):
         if spec["fortran"].name == "gcc" and spec["c"].name == "gcc":
             gfortran_major_version = int(spec["fortran"].version[0])
             env.set("ESMF_COMPILER", "gfortran")
-        elif any(comp in self.pkg.compiler.name for comp in ("intel", "oneapi")):
+        elif spec["fortran"].name in ["intel-oneapi-compilers", "intel-oneapi-compilers-classic"]:
             env.set("ESMF_COMPILER", "intel")
         elif spec["fortran"].name == "gcc" and spec["c"].name in ["clang", "apple-clang"]:
             gfortran_major_version = int(spec["fortran"].version[0])


### PR DESCRIPTION
The ESMF package needs to determine compiler family based on the compiler name, but instead of giving `oneapi`, the compiler.name field now gives `intel-oneapi-compilers`. In the interest of future-proofing, I generalized the logic a bit to detect any compiler with `intel` or `oneapi` in the name to be of the Intel family, but specific new packages names could be used instead if desired.