### PR TITLE
chapel: update `is_system_path` import

### DIFF
--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -13,6 +13,7 @@ from spack_repo.builtin.build_systems.rocm import ROCmPackage
 from spack.package import *
 from spack.util.environment import is_system_path
 
+
 def slingshot_network():
     return os.path.exists("/opt/cray/pe") and (
         os.path.exists("/lib64/libcxi.so") or os.path.exists("/usr/lib64/libcxi.so")

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -11,7 +11,7 @@ from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
 from spack.package import *
-
+from spack.util.environment import is_system_path
 
 def slingshot_network():
     return os.path.exists("/opt/cray/pe") and (


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Switch chapel package.py from using deprecated `spack.package.is_system_path` to its new location `spack.util.environment.is_system_path` (moved in https://github.com/spack/spack/pull/50995).

Resolves https://github.com/spack/spack-packages/issues/702.