### PR TITLE
R: A few package fixes for  gcc@14

### DIFF
--- a/repos/spack_repo/builtin/packages/r_bit/package.py
+++ b/repos/spack_repo/builtin/packages/r_bit/package.py
@@ -19,6 +19,7 @@ class RBit(RPackage):
 
     license("GPL-2.0-only OR GPL-3.0-only")
 
+    version("4.6.0", sha256="48fe21c5d04c7b724d695eeb60074395c0c631a7fb234e2075de92471445de08")
     version("4.0.5", sha256="f0f2536a8874b6a30b80baefbc68cb21f0ffbf51f3877bda8038c3f9f354bfbc")
     version("4.0.4", sha256="e404841fbe4ebefe4ecd4392effe673a8c9fa05f97952c4ce6e2f6159bd2f168")
     version("1.1-14", sha256="5cbaace1fb643a665a6ca69b90f7a6d624270de82420ca7a44f306753fcef254")
@@ -27,3 +28,4 @@ class RBit(RPackage):
     depends_on("c", type="build")  # generated
 
     depends_on("r@2.9.2:", type=("build", "run"))
+    depends_on("r@3.4.0:", type=("build", "run"), when="@4.6:")

--- a/repos/spack_repo/builtin/packages/r_bit64/package.py
+++ b/repos/spack_repo/builtin/packages/r_bit64/package.py
@@ -26,11 +26,14 @@ class RBit64(RPackage):
 
     license("GPL-2.0-only OR GPL-3.0-only")
 
+    version("4.6.0-1", sha256="fbc0ce142fc22c9a9fdcbac930a814dfb648563d4b6a77dff739c23cc81319b7")
     version("4.0.5", sha256="25df6826ea5e93241c4874cad4fa8dadc87a40f4ff74c9107aa12a9e033e1578")
     version("0.9-7", sha256="7b9aaa7f971198728c3629f9ba1a1b24d53db5c7e459498b0fdf86bbd3dff61f")
 
     depends_on("c", type="build")  # generated
 
     depends_on("r@3.0.1:", type=("build", "run"))
+    depends_on("r@3.4.0:", type=("build", "run"), when="@4.6:")
+
     depends_on("r-bit@1.1-12:", type=("build", "run"))
     depends_on("r-bit@4.0.0:", type=("build", "run"), when="@4.0.5:")

--- a/repos/spack_repo/builtin/packages/r_data_table/package.py
+++ b/repos/spack_repo/builtin/packages/r_data_table/package.py
@@ -19,6 +19,7 @@ class RDataTable(RPackage):
 
     license("MPL-2.0-no-copyleft-exception")
 
+    version("1.17.8", sha256="17f24496d548914fdac2b8ed00c7272f2e191ee32eb6bb8336f9beb6691330e0")
     version("1.15.4", sha256="ab8065ff946d59ecaaf5eaf91a975495c07c30caad97a71205c72e41a740cb53")
     version("1.14.8", sha256="14b2ce5367df9c9bb58f373555066f5dcb629c156149b5565de36d69557139fd")
     version("1.14.4", sha256="4862a7c26e8309108fd1f5296616407b9ff9e4e1be5cdedcb717f114c2e348f0")
@@ -45,6 +46,8 @@ class RDataTable(RPackage):
     depends_on("cxx", type="build")
 
     depends_on("r@3.1.0:", type=("build", "run"))
+    depends_on("r@3.3.0:", type=("build", "run"), when="@1.17:")
+
     depends_on("zlib-api")
     depends_on("llvm-openmp", when="platform=darwin %apple-clang", type=("build", "run"))
 

--- a/repos/spack_repo/builtin/packages/r_pbdzmq/package.py
+++ b/repos/spack_repo/builtin/packages/r_pbdzmq/package.py
@@ -23,6 +23,7 @@ class RPbdzmq(RPackage):
 
     license("GPL-3.0-or-later")
 
+    version("0.3-14", sha256="60154f66db9378655d7c39c8c2e02e74ac6bd801a9aac1bc73003c7eeeb23223")
     version("0.3-11", sha256="da7e204d857370201f75a05fbd808a2f409d440cc96855bb8f48f4a5dd75405b")
     version("0.3-9", sha256="d033238d0a9810581f6b40c7c75263cfc495a585653bbff98e957c37954e0fb6")
     version("0.3-8", sha256="eded4ccf6ee54a59e06061f1c6e67a8ec36e03c6ab2318af64446d8f95505465")


### PR DESCRIPTION
[In GCC 14:](https://gcc.gnu.org/gcc-14/porting_to.html)

```
[Implicit function declarations (-Werror=implicit-function-declaration)](https://gcc.gnu.org/gcc-14/porting_to.html#implicit-function-declaration)
It is no longer possible to call a function that has not been declared.
```

This change in default results in a variety of R packages failing with errors like:
```
rle.c:221:9: error: implicit declaration of function 'Calloc'; did you mean 'calloc'? [-Wimplicit-function-declaration]
  221 |   val = Calloc(n2, int);
      |         ^~~~~~
      |         calloc
```

This updates the affected packages to newer versions which have the changes required for gcc 14+. I don't think it's necessary to conflict directly on gcc@14