### PR TITLE
py-geoviews: fix depends and add v1.14.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_geoviews/package.py
+++ b/repos/spack_repo/builtin/packages/py_geoviews/package.py
@@ -39,4 +39,3 @@ class PyGeoviews(PythonPackage):
     depends_on("py-pyproj", type="run")
     depends_on("py-shapely", type="run")
     depends_on("py-xyzservices", type="run")
-

--- a/repos/spack_repo/builtin/packages/py_geoviews/package.py
+++ b/repos/spack_repo/builtin/packages/py_geoviews/package.py
@@ -16,6 +16,7 @@ class PyGeoviews(PythonPackage):
 
     license("BSD-3-Clause", checked_by="climbfuji")
 
+    version("1.14.0", sha256="3cca679a32b2c97215424a3a154e3fa343f61e2589d15e333e493bdf2f62fc6a")
     version("1.13.0", sha256="7554a1e9114995acd243546fac6c6c7f157fc28529fde6ab236a72a6e77fe0bf")
     # version("1.12.0", sha256="e2cbef0605e8fd1529bc643a31aeb61997f8f93c9b41a5aff8b2b355a76fa789")
 
@@ -23,6 +24,11 @@ class PyGeoviews(PythonPackage):
     depends_on("py-hatchling", type="build")
     depends_on("py-hatch-vcs", type="build")
     depends_on("py-bokeh@3.5", type=("build", "run"))
+
+    # nodejs and npm are not explicitly listed but to build geoviews, py-bokeh needs them.
+    # Setting as a dep in py-bokeh is not sufficient
+    depends_on("node-js@18:", type="build", when="^py-bokeh@3.5:")
+    depends_on("npm", type="build", when="^py-bokeh@3.5:")
 
     depends_on("py-cartopy@0.18:", type="run")
     depends_on("py-holoviews@1.16:", type="run")
@@ -33,3 +39,4 @@ class PyGeoviews(PythonPackage):
     depends_on("py-pyproj", type="run")
     depends_on("py-shapely", type="run")
     depends_on("py-xyzservices", type="run")
+


### PR DESCRIPTION
Geoviews needs `npm` and `node-js` to build:
```
      raise RuntimeError(f'node.js v{version_repr} or higher is needed to allow compilation of custom models ' +
  RuntimeError: node.js v18.0.0 or higher is needed to allow compilation of custom models ("conda install nodejs" or follow https://nodejs.org/en/download/)
  error: subprocess-exited-with-error
  
```

Setting the `node-js` dep in `py-bokeh` seems insufficient
