### PR TITLE
cgal: relax cmake requirement

### DIFF
--- a/repos/spack_repo/builtin/packages/cgal/package.py
+++ b/repos/spack_repo/builtin/packages/cgal/package.py
@@ -74,8 +74,7 @@ class Cgal(CMakePackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
-    # Upper bound follows CGAL's @6: CMakeLists.txt
-    depends_on("cmake@3.12:3.29", type="build", when="@6:")
+    depends_on("cmake@3.12:3", type="build", when="@6:")
     depends_on("cmake@2.8.11:", type="build", when="@:5")
 
     # Essential Third Party Libraries


### PR DESCRIPTION
This PR relaxes the upper bound version constraint matching upstream
https://github.com/CGAL/cgal/commit/e871025f364360a15671f6e825127df6207afa16