### PR TITLE
tools-sdk: update config url

### DIFF
--- a/.ci/gitlab/stacks/tools-sdk/spack.yaml
+++ b/.ci/gitlab/stacks/tools-sdk/spack.yaml
@@ -4,7 +4,7 @@ spack:
   include:
   # Include the SDK package configurations
   # TODO: Tag this with a release
-  - path: https://raw.githubusercontent.com/tools-integration/tools-sdk/refs/heads/main/spack/configs/packages.yaml
+  - path: https://raw.githubusercontent.com/tools-integration/tools-sdk/7ed3748ef8dbd91eccbfba34f86dc5174556ebaf/spack/configs/packages.yaml
     sha256: 026634f98320690230b9160ac2af54d7fe9319a001e08736b7ea900834c4982d
   - $CI_PROJECT_DIR/.ci/gitlab/
 


### PR DESCRIPTION
Use a specific commit instead of the main branch until there is a release, so that the external config can be updated without breaking this.

@kwryankrattiger