### PR TITLE
Update pmix 5.0.3 checksum

### DIFF
--- a/repos/spack_repo/builtin/packages/pmix/package.py
+++ b/repos/spack_repo/builtin/packages/pmix/package.py
@@ -41,7 +41,7 @@ class Pmix(AutotoolsPackage):
     version("master", branch="master", submodules=True)
     version("5.0.5", sha256="a12e148c8ec4b032593a2c465a762e93c43ad715f3ceb9fbc038525613b0c70d")
     version("5.0.4", sha256="f72d50a5ae9315751684ade8a8e9ac141ae5dd64a8652d594b9bee3531a91376")
-    version("5.0.3", sha256="3f779434ed59fc3d63e4f77f170605ac3a80cd40b1f324112214b0efbdc34f13")
+    version("5.0.3", sha256="474ebf5bbc420de442ab93f1b61542190ac3d39ca3b0528a19f586cf3f1cbd94")
     version("5.0.2", sha256="28227ff2ba925da2c3fece44502f23a91446017de0f5a58f5cea9370c514b83c")
     version("5.0.1", sha256="d4371792d4ba4c791e1010100b4bf9a65500ababaf5ff25d681f938527a67d4a")
     version("5.0.0", sha256="92a85c4946346816c297ac244fbaf4f723bba87fb7e4424a057c2dabd569928d")

--- a/repos/spack_repo/builtin/repo.yaml
+++ b/repos/spack_repo/builtin/repo.yaml
@@ -1,3 +1,3 @@
 repo:
-  namespace: builtin
+  namespace: mybuiltin
   api: v2.2

--- a/repos/spack_repo/builtin/repo.yaml
+++ b/repos/spack_repo/builtin/repo.yaml
@@ -1,3 +1,3 @@
 repo:
-  namespace: mybuiltin
+  namespace: builtin
   api: v2.2


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

In https://github.com/openpmix/openpmix/issues/3376 it seems pmix had an updated release for 5.0.3 which changed the checksum.  The cache in spack is still being used for the checksum in the package.  This updates the checksum to be the latest version on Github.

Apologies for the extra commits which I reverted - during testing the namespace clashes and trying to use my branch was getting confusing.  In the end disabled the builtin repo and replaced with my own which made testing easy (but had to uninstall and reinstall manually - it didnt seem to detect package checksum update).  Maybe needed `spack install -f` to freshen the install.

Output from test:

```
==> No binary for pmix-5.0.3-nmwmbvx4vcnir5rtjfffl43rwe2loxby found: installing from source
==> Installing pmix-5.0.3-nmwmbvx4vcnir5rtjfffl43rwe2loxby [14/14]
==> Fetching https://github.com/openpmix/openpmix/releases/download/v5.0.3/pmix-5.0.3.tar.bz2
    [100%]    9.96 MB @    7.6 MB/s
==> No patches needed for pmix
==> pmix: Executing phase: 'autoreconf'
==> pmix: Executing phase: 'configure'
==> pmix: Executing phase: 'build'
==> pmix: Executing phase: 'install'
==> pmix: Successfully installed pmix-5.0.3-nmwmbvx4vcnir5rtjfffl43rwe2loxby
```

Tagging in @wdconinc following Slack message.