### PR TITLE
neovim: fix build and update versions

### DIFF
--- a/repos/spack_repo/builtin/packages/neovim/package.py
+++ b/repos/spack_repo/builtin/packages/neovim/package.py
@@ -125,7 +125,7 @@ class Neovim(CMakePackage):
     # versions
     with when("@0.4:"):
         depends_on("libuv@1.28:", type="link")
-        depends_on("libluv@1.30.0:", type="link", when="@:0.9")
+        depends_on("libluv@1.30.0:", type="link")
         depends_on("libtermkey@0.18:", type="link", when="@:0.9")
         depends_on("libvterm@0.1:", type="link", when="@:0.10")
         depends_on("unibilium@2.0:", type="link")
@@ -142,7 +142,7 @@ class Neovim(CMakePackage):
         depends_on("msgpack-c@3.0.0:", type="link", when="@:0.10")
     with when("@0.7:"):
         depends_on("gettext@0.20.1:")
-        depends_on("libluv@1.43.0:", type="link", when="@:0.9")
+        depends_on("libluv@1.43.0:", type="link")
         depends_on("libuv@1.44.1:", type="link")
         depends_on("tree-sitter@0.20.6:")
     with when("@0.8:"):

--- a/repos/spack_repo/builtin/packages/neovim/package.py
+++ b/repos/spack_repo/builtin/packages/neovim/package.py
@@ -20,6 +20,9 @@ class Neovim(CMakePackage):
 
     version("master", branch="master")
     version("stable", tag="stable")
+    version("0.11.3", sha256="7f1ce3cc9fe6c93337e22a4bc16bee71e041218cc9177078bd288c4a435dbef0")
+    version("0.11.2", sha256="324759a1bcd1a80b32a7eae1516ee761ec3e566d08284a24c4c7ca59079aabfa")
+    version("0.10.1", sha256="edce96e79903adfcb3c41e9a8238511946325ea9568fde177a70a614501af689")
     version("0.11.1", sha256="ffe7f9a7633ed895ff6adb1039af7516cd6453715c8889ad844b6fa39c3df443")
     version("0.11.0", sha256="6826c4812e96995d29a98586d44fbee7c9b2045485d50d174becd6d5242b3319")
     version("0.10.4", sha256="10413265a915133f8a853dc757571334ada6e4f0aa15f4c4cc8cc48341186ca2")

--- a/repos/spack_repo/builtin/packages/neovim/package.py
+++ b/repos/spack_repo/builtin/packages/neovim/package.py
@@ -109,7 +109,7 @@ class Neovim(CMakePackage):
     depends_on("gperf", type="link")
     depends_on("jemalloc", type="link", when="platform=linux")
     depends_on("lua-lpeg")
-    depends_on("lua-mpack")
+    depends_on("lua-mpack", when="@:0.10")
     depends_on("iconv", type="link")
     depends_on("libtermkey", type="link", when="@:0.9")
     depends_on("libuv", type="link")
@@ -122,11 +122,11 @@ class Neovim(CMakePackage):
     # versions
     with when("@0.4:"):
         depends_on("libuv@1.28:", type="link")
-        depends_on("libluv@1.30.0:", type="link")
-        depends_on("libtermkey@0.18:", type="link")
-        depends_on("libvterm@0.1:", type="link")
+        depends_on("libluv@1.30.0:", type="link", when="@:0.9")
+        depends_on("libtermkey@0.18:", type="link", when="@:0.9")
+        depends_on("libvterm@0.1:", type="link", when="@:0.10")
         depends_on("unibilium@2.0:", type="link")
-        depends_on("msgpack-c@1.0.0:", type="link")
+        depends_on("msgpack-c@1.0.0:", type="link", when="@:0.10")
     with when("@0.5:"):
         depends_on("libuv@1.42:", type="link")
         depends_on("tree-sitter")
@@ -134,21 +134,21 @@ class Neovim(CMakePackage):
         depends_on("cmake@3.10:", type="build")
         depends_on("gperf@3.1:", type="link")
         conflicts("^libiconv@:1.14")
-        depends_on("libtermkey@0.22:", type="link")
-        depends_on("libvterm@0.1.4:", type="link")
-        depends_on("msgpack-c@3.0.0:", type="link")
+        depends_on("libtermkey@0.22:", type="link", when="@:0.9")
+        depends_on("libvterm@0.1.4:", type="link", when="@:0.10")
+        depends_on("msgpack-c@3.0.0:", type="link", when="@:0.10")
     with when("@0.7:"):
         depends_on("gettext@0.20.1:")
-        depends_on("libluv@1.43.0:", type="link")
+        depends_on("libluv@1.43.0:", type="link", when="@:0.9")
         depends_on("libuv@1.44.1:", type="link")
         depends_on("tree-sitter@0.20.6:")
     with when("@0.8:"):
-        depends_on("libvterm@0.3:", type="link")
+        depends_on("libvterm@0.3:", type="link", when="@:0.10")
     with when("@0.9:"):
         depends_on("tree-sitter@0.20.8:")
     with when("@0.10:"):
         depends_on("cmake@3.13:", type="build")
-        depends_on("libvterm@0.3.3:")
+        depends_on("libvterm@0.3.3:", when="@:0.10")
         depends_on("tree-sitter@0.20.9:")
     with when("@0.11:"):
         depends_on("cmake@3.16:", type="build")

--- a/repos/spack_repo/builtin/packages/unibilium/package.py
+++ b/repos/spack_repo/builtin/packages/unibilium/package.py
@@ -5,7 +5,6 @@
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 
-
 from spack.package import *
 
 

--- a/repos/spack_repo/builtin/packages/unibilium/package.py
+++ b/repos/spack_repo/builtin/packages/unibilium/package.py
@@ -8,7 +8,7 @@ from spack_repo.builtin.build_systems.makefile import MakefilePackage
 from spack.package import *
 
 
-class Unibilium(MakefilePackage, AutotoolsPackage):
+class Unibilium(CMakePackage, AutotoolsPackage):
     """A terminfo parsing library"""
 
     homepage = "https://github.com/neovim/unibilium/"
@@ -27,7 +27,8 @@ class Unibilium(MakefilePackage, AutotoolsPackage):
     build_system(
         conditional("makefile", when="@:2.1.1"),
         conditional("autotools", when="@2.1.2:"),
-        default="autotools",
+        conditional("cmake", when="@2.1.2:"),
+        default="cmake",
     )
 
     depends_on("gmake", type="build")
@@ -39,6 +40,3 @@ class Unibilium(MakefilePackage, AutotoolsPackage):
         depends_on("autoconf", when="@2.1.2:", type="build")
         depends_on("automake", when="@2.1.2:", type="build")
 
-    def install(self, spec, prefix):
-        make("PREFIX=" + prefix)
-        make("install", "PREFIX=" + prefix)

--- a/repos/spack_repo/builtin/packages/unibilium/package.py
+++ b/repos/spack_repo/builtin/packages/unibilium/package.py
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
-from spack_repo.builtin.build_systems.makefile import MakefilePackage
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
 
 from spack.package import *
 

--- a/repos/spack_repo/builtin/packages/unibilium/package.py
+++ b/repos/spack_repo/builtin/packages/unibilium/package.py
@@ -39,4 +39,3 @@ class Unibilium(CMakePackage, AutotoolsPackage):
     with when("build_system=autotools"):
         depends_on("autoconf", when="@2.1.2:", type="build")
         depends_on("automake", when="@2.1.2:", type="build")
-


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Building Neovim is broken with Spack 1.0. I has been a year or so since I built it, so I cannot pinpoint the exact causes, but this should address multiple issues. 

1. The way the `package.py` for Neovim handled dependencies was implicitly overriding "when" constraints in the "with" blocks -- resulting in the inclusion of dependencies that are either no longer required, or are vendored with Neovim itself, when concretizing the spec. For example, `libtermkey` was being included in `0.11.1` when it should not. The additions I made successfully prevent these from being required when installing modern versions, i.e. >= 0.11.0.
2. The unibilium dependency was broken, causing builds of Neovim to fail. It has something to do with autoreconf: ``` configure: error: cannot find install-sh, install.sh, or shtool in "." "./.." "./../.."```. I am by no means experienced in auto[re]conf, and I could not figure out how to patch it and get it to work. However, unibilium provides a CMakeLists.txt -- so I updated the `package.py` to accept cmake builds, and made it the default. I am happy to amend this PR if someone else can figure out how to fix the autotools build.