### PR TITLE
unittest_cpp: add c dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/unittest_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/unittest_cpp/package.py
@@ -23,4 +23,5 @@ class UnittestCpp(CMakePackage):
     version("2.0.0", sha256="74852198877dc2fdebdc4e5e9bd074018bf8ee03a13de139bfe41f4585b2f5b9")
     version("1.6.0", sha256="9fa7e797816e16669d68171418b0dc41ec6b7eaf8483f782441f5f159598c3c0")
 
+    depends_on("c", type="build") 
     depends_on("cxx", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/unittest_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/unittest_cpp/package.py
@@ -23,5 +23,5 @@ class UnittestCpp(CMakePackage):
     version("2.0.0", sha256="74852198877dc2fdebdc4e5e9bd074018bf8ee03a13de139bfe41f4585b2f5b9")
     version("1.6.0", sha256="9fa7e797816e16669d68171418b0dc41ec6b7eaf8483f782441f5f159598c3c0")
 
-    depends_on("c", type="build") 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated


### PR DESCRIPTION
add compiler dependency for unittest_cpp

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
