### PR TITLE
Kokkos Kernels: Require Kokkos PIC when building shared library

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
@@ -239,6 +239,7 @@ class KokkosKernels(CMakePackage, CudaPackage):
     depends_on("kokkos@3.2.00", when="@3.2.00")
     depends_on("kokkos@3.1.00", when="@3.1.00")
     depends_on("kokkos@3.0.00", when="@3.0.00")
+    depends_on("kokkos+pic", when="+shared")
     depends_on("kokkos+cuda", when="+execspace_cuda")
     depends_on("kokkos+openmp", when="+execspace_openmp")
     depends_on("kokkos+threads", when="+execspace_threads")


### PR DESCRIPTION
Installing the spec `kokkos-kernels ^kokkos +cuda +cuda_relocatable_device_code cuda_arch=70` I get a relocatable code error in Kokkos Kernels because Kokkos is not build with PIC (because it is static library and the Spack option is disabled by default) whereas Kokkos Kernels is built with PIC (because it is a shared library and cmake enables it by default). See the full spec below.

This PR adds a constraint to avoid this issue. An alternative could be to add a PIC option. @brian-kelley @lucbv What do you think ?

Btw I think this problem is not only related to the Kokkos ecosystem but might be present in all c,c+ and fortran-based packages ?

```
spack spec --fresh -I kokkos-kernels ^kokkos +cuda +cuda_relocatable_device_code cuda_arch=70
 -   kokkos-kernels@4.5.01%gcc@10.5.0~blas~cblas~cublas~cuda~cusolver~cusparse~ipo~lapack~lapacke~mkl~openmp~rocblas~rocsolver~rocsparse~serial+shared~superlu~threads build_system=cmake build_type=Release execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto generator=make layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double arch=linux-ubuntu20.04-icelake
[+]      ^cmake@3.30.5%gcc@10.5.0~doc+ncurses+ownlibs~qtgui build_system=generic build_type=Release patches=dbc3892 arch=linux-ubuntu20.04-icelake
[+]          ^curl@8.10.1%gcc@10.5.0~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-ubuntu20.04-icelake
[+]              ^nghttp2@1.63.0%gcc@10.5.0 build_system=autotools arch=linux-ubuntu20.04-icelake
[+]                  ^diffutils@3.10%gcc@10.5.0 build_system=autotools arch=linux-ubuntu20.04-icelake
[+]              ^openssl@3.4.0%gcc@10.5.0~docs+shared build_system=generic certs=mozilla arch=linux-ubuntu20.04-icelake
[+]                  ^ca-certificates-mozilla@2023-05-30%gcc@10.5.0 build_system=generic arch=linux-ubuntu20.04-icelake
[+]                  ^perl@5.40.0%gcc@10.5.0+cpanm+opcode+open+shared+threads build_system=generic arch=linux-ubuntu20.04-icelake
[+]                      ^berkeley-db@18.1.40%gcc@10.5.0+cxx~docs+stl build_system=autotools patches=26090f4,b231fcc arch=linux-ubuntu20.04-icelake
[+]                      ^bzip2@1.0.8%gcc@10.5.0~debug~pic+shared build_system=generic arch=linux-ubuntu20.04-icelake
[+]                      ^gdbm@1.23%gcc@10.5.0 build_system=autotools arch=linux-ubuntu20.04-icelake
[+]                          ^readline@8.2%gcc@10.5.0 build_system=autotools patches=bbf97f1 arch=linux-ubuntu20.04-icelake
[+]              ^pkgconf@2.2.0%gcc@10.5.0 build_system=autotools arch=linux-ubuntu20.04-icelake
[+]          ^ncurses@6.5%gcc@10.5.0~symlinks+termlib abi=none build_system=autotools patches=7a351bc arch=linux-ubuntu20.04-icelake
[+]          ^zlib-ng@2.2.1%gcc@10.5.0+compat+new_strategies+opt+pic+shared build_system=autotools arch=linux-ubuntu20.04-icelake
[+]      ^gcc-runtime@10.5.0%gcc@10.5.0 build_system=generic arch=linux-ubuntu20.04-icelake
[e]      ^glibc@2.31%gcc@10.5.0 build_system=autotools arch=linux-ubuntu20.04-icelake
[+]      ^gmake@4.4.1%gcc@10.5.0~guile build_system=generic arch=linux-ubuntu20.04-icelake
 -       ^kokkos@4.5.01%gcc@10.5.0~aggressive_vectorization~alloc_async~cmake_lang~compiler_warnings+complex_align+cuda~cuda_constexpr~cuda_lambda~cuda_ldg_intrinsic+cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~hip_relocatable_device_code~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl~openmp~openmptarget~pic~rocm+serial~shared~sycl~tests~threads~tuning~wrapper build_system=cmake build_type=Release cuda_arch=70 cxxstd=17 generator=make intel_gpu_arch=none arch=linux-ubuntu20.04-icelake
[+]          ^cuda@12.6.2%gcc@10.5.0~allow-unsupported-compilers~dev build_system=generic arch=linux-ubuntu20.04-icelake
[+]              ^libxml2@2.13.4%gcc@10.5.0+pic~python+shared build_system=autotools arch=linux-ubuntu20.04-icelake
[+]                  ^libiconv@1.17%gcc@10.5.0 build_system=autotools libs=shared,static arch=linux-ubuntu20.04-icelake
[+]                  ^xz@5.4.6%gcc@10.5.0~pic build_system=autotools libs=shared,static arch=linux-ubuntu20.04-icelake
```