### PR TITLE
python-venv: memoize sysconfig call

### DIFF
--- a/repos/spack_repo/builtin/packages/python_venv/package.py
+++ b/repos/spack_repo/builtin/packages/python_venv/package.py
@@ -58,6 +58,7 @@ class PythonVenv(Package):
         python_name = "python" if self.spec.satisfies("platform=windows") else "python3"
         return which(python_name, path=self.bindir, required=True)
 
+    @memoized
     def _get_path(self, name) -> str:
         return self.command(
             "-Ec", f"import sysconfig; print(sysconfig.get_path('{name}'))", output=str


### PR DESCRIPTION
This is called for every edge `py-*` to `python-venv` in `setup_dependent_package`, which is excessive.

