### PR TITLE
netcdf-c: prepare the Autotools builder for version 4.9.3

### DIFF
--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -392,8 +392,12 @@ class AutotoolsBuilder(AnyBuilder, autotools.AutotoolsBuilder):
             "--enable-utilities",
             "--enable-static",
             "--enable-largefile",
-            "--enable-netcdf-4",
         ]
+
+        if self.spec.satisfies("@4.8.0:"):
+            config_args.append("--enable-hdf5")
+        else:
+            config_args.append("--enable-netcdf-4")
 
         # NCZarr was added in version 4.8.0 as an experimental feature and became a supported one
         # in version 4.8.1:

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -263,6 +263,9 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
     # Byte-range I/O was added in version 4.7.0:
     conflicts("+byterange", when="@:4.6")
 
+    # Byte-range requires DAP starting version 4.9.3:
+    requires("+dap", when="@4.9.3:+byterange")
+
     # JNA was added in 4.3.2 and removed in 4.9.3:
     conflicts("+jna", when="@:4.3.1,4.9.3:")
 

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -508,6 +508,13 @@ class AutotoolsBuilder(AnyBuilder, autotools.AutotoolsBuilder):
             # Prevent linking to szip to disable the plugin:
             config_args.append("ac_cv_lib_sz_SZ_BufftoBuffCompress=no")
 
+        if self.spec.satisfies("@4.9.3:"):
+            # If the plugin is built (i.e. when +shared), we want to ensure that the configure
+            # scripts checks for -lbz2 delivered by the bzip2 package. If the plugin is not built,
+            # we ensure that the configure script does not pick up system bzip2 (see below), but we
+            # also want to skip the checks for -lbzip2. Therefore, we pass the following option in
+            # both cases:
+            config_args.append("--enable-filter-bz2")
         if self.spec.satisfies("@4.9.0:"):
             if "+shared" in self.spec:
                 lib_search_dirs.extend(self.spec["bzip2"].libs.directories)

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -517,7 +517,11 @@ class AutotoolsBuilder(AnyBuilder, autotools.AutotoolsBuilder):
                 config_args.append("ac_cv_lib_bz2_BZ2_bzCompress=no")
 
         if "+zstd" in self.spec:
+            if self.spec.satisfies("@4.9.3:"):
+                config_args.append("--enable-filter-zstd")
             lib_search_dirs.extend(self.spec["zstd"].libs.directories)
+        elif self.spec.satisfies("@4.9.3:"):
+            config_args.append("--disable-filter-zstd")
         elif self.spec.satisfies("@4.9.0:"):
             # Prevent linking to system zstd:
             config_args.append("ac_cv_lib_zstd_ZSTD_compress=no")

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -523,7 +523,11 @@ class AutotoolsBuilder(AnyBuilder, autotools.AutotoolsBuilder):
             config_args.append("ac_cv_lib_zstd_ZSTD_compress=no")
 
         if "+blosc" in self.spec:
+            if self.spec.satisfies("@4.9.3:"):
+                config_args.append("--enable-filter-blosc")
             lib_search_dirs.extend(self.spec["c-blosc"].libs.directories)
+        elif self.spec.satisfies("@4.9.3:"):
+            config_args.append("--disable-filter-blosc")
         elif self.spec.satisfies("@4.9.0:"):
             # Prevent linking to system c-blosc:
             config_args.append("ac_cv_lib_blosc_blosc_init=no")

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -263,6 +263,9 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
     # Byte-range I/O was added in version 4.7.0:
     conflicts("+byterange", when="@:4.6")
 
+    # JNA was added in 4.3.2 and removed in 4.9.3:
+    conflicts("+jna", when="@:4.3.1,4.9.3:")
+
     # NCZarr was added in version 4.8.0 as an experimental feature and became a supported one in
     # version 4.8.1:
     conflicts("+nczarr_zip", when="@:4.8.0")
@@ -435,7 +438,7 @@ class AutotoolsBuilder(AnyBuilder, autotools.AutotoolsBuilder):
         elif self.spec.satisfies("@4.7.0:"):
             config_args.append("--disable-byterange")
 
-        if self.spec.satisfies("@4.3.2:"):
+        if self.spec.satisfies("@4.3.2:4.9.2"):
             config_args += self.enable_or_disable("jna")
 
         config_args += self.enable_or_disable("fsync")


### PR DESCRIPTION
With these changes, we can add version 4.9.3 (see #69) and expect the package to build correctly when `build_system=autotools`.