### PR TITLE
metpy + pint: updates for numpy@2

### DIFF
--- a/repos/spack_repo/builtin/packages/eccodes/package.py
+++ b/repos/spack_repo/builtin/packages/eccodes/package.py
@@ -52,7 +52,7 @@ class Eccodes(CMakePackage):
 
     version("develop", branch="develop")
     version("2.41.0", sha256="a1467842e11ed7f62a2f5cc1982e04eec62398f4962e6ba03ace7646f32cf270")
-    version("2.40.0", sha256="f58d5d7390fce86c62b26d76b9bc3c4d7d9a6cf2e5f8145d1d598089195e51ff") 
+    version("2.40.0", sha256="f58d5d7390fce86c62b26d76b9bc3c4d7d9a6cf2e5f8145d1d598089195e51ff")
     version("2.38.0", sha256="96a21fbe8ca3aa4c31bb71bbd378b7fd130cbc0f7a477567d70e66a000ff68d9")
     version("2.34.0", sha256="3cd208c8ddad132789662cf8f67a9405514bfefcacac403c0d8c84507f303aba")
     version("2.33.0", sha256="bdcec8ce63654ec6803400c507f01220a9aa403a45fa6b5bdff7fdcc44fd7daf")

--- a/repos/spack_repo/builtin/packages/py_flexcache/package.py
+++ b/repos/spack_repo/builtin/packages/py_flexcache/package.py
@@ -1,0 +1,23 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyFlexcache(PythonPackage):
+    """A convenience wrapper for using pint with xarray"""
+
+    homepage = "https://github.com/hgrecco/flexcache"
+    pypi = "flexcache/flexcache-0.3.tar.gz"
+
+    license("BSD-3-Clause")
+
+    version("0.3", sha256="18743bd5a0621bfe2cf8d519e4c3bfdf57a269c15d1ced3fb4b64e0ff4600656")
+
+    depends_on("py-hatchling", type="build")
+    depends_on("py-hatch-vcs", type="build")
+
+    depends_on("py-typing-extensions", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_flexcache/package.py
+++ b/repos/spack_repo/builtin/packages/py_flexcache/package.py
@@ -8,7 +8,8 @@ from spack.package import *
 
 
 class PyFlexcache(PythonPackage):
-    """Flexcache is a flexible caching library for Python, providing convenient and efficient caching mechanisms."""
+    """Flexcache is a flexible caching library for Python,
+    providing convenient and efficient caching mechanisms."""
 
     homepage = "https://github.com/hgrecco/flexcache"
     pypi = "flexcache/flexcache-0.3.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_flexcache/package.py
+++ b/repos/spack_repo/builtin/packages/py_flexcache/package.py
@@ -8,7 +8,7 @@ from spack.package import *
 
 
 class PyFlexcache(PythonPackage):
-    """A convenience wrapper for using pint with xarray"""
+    """Flexcache is a flexible caching library for Python, providing convenient and efficient caching mechanisms."""
 
     homepage = "https://github.com/hgrecco/flexcache"
     pypi = "flexcache/flexcache-0.3.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_flexparser/package.py
+++ b/repos/spack_repo/builtin/packages/py_flexparser/package.py
@@ -1,0 +1,23 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyFlexparser(PythonPackage):
+    """A convenience wrapper for using pint with xarray"""
+
+    homepage = "https://github.com/hgrecco/flexparser"
+    pypi = "flexparser/flexparser-0.4.tar.gz"
+
+    license("BSD-3-Clause")
+
+    version("0.4", sha256="266d98905595be2ccc5da964fe0a2c3526fbbffdc45b65b3146d75db992ef6b2")
+
+    depends_on("py-hatchling", type="build")
+    depends_on("py-hatch-vcs", type="build")
+
+    depends_on("py-typing-extensions", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_flexparser/package.py
+++ b/repos/spack_repo/builtin/packages/py_flexparser/package.py
@@ -8,7 +8,7 @@ from spack.package import *
 
 
 class PyFlexparser(PythonPackage):
-    """A convenience wrapper for using pint with xarray"""
+    """A flexible and extensible text parsing library for Python."""
 
     homepage = "https://github.com/hgrecco/flexparser"
     pypi = "flexparser/flexparser-0.4.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_metpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_metpy/package.py
@@ -32,7 +32,6 @@ class PyMetpy(PythonPackage):
         description="Enable xarray lazy-loading and advanced plotting",
     )
 
-
     depends_on("python@3.9:", type=("build", "run"), when="@1.6.2:")
     depends_on("py-setuptools@61:", type="build", when="@1.6.2:")
     depends_on("py-setuptools-scm@3.4:", type="build", when="@1.6.2:")
@@ -67,8 +66,6 @@ class PyMetpy(PythonPackage):
     depends_on("py-dask@2020.12.0:", when="@1.6.2: +extras")
     depends_on("py-shapely@1.6.4:", when="@1.6.2: +extras")
     depends_on("py-boto3@1.26.45:", when="@1.7: +extras")
-
-
 
     with when("@1.0.1"):
         depends_on("python@3.6:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_metpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_metpy/package.py
@@ -12,7 +12,7 @@ class PyMetpy(PythonPackage):
     with weather data."""
 
     homepage = "https://github.com/Unidata/MetPy"
-    pypi = "MetPy/MetPy-1.0.1.tar.gz"
+    pypi = "MetPy/metpy-1.0.1.tar.gz"
     maintainers("dopplershift")
 
     # Importing 'metpy.io' results in downloads, so skip it.
@@ -21,6 +21,7 @@ class PyMetpy(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.7.0", sha256="aad7e03dc735cf8bfd870d16aca24920a707152de6caa24dbaf4da695c6f6ae4")
     version("1.6.2", sha256="eb065bac0d7818587fa38fa6c96dfe720d9d15b59af4e4866541894e267476bb")
     version("1.0.1", sha256="16fa9806facc24f31f454b898741ec5639a72ba9d4ff8a19ad0e94629d93cb95")
 
@@ -31,23 +32,43 @@ class PyMetpy(PythonPackage):
         description="Enable xarray lazy-loading and advanced plotting",
     )
 
-    with when("@1.6.2"):
-        depends_on("python@3.9:", type=("build", "run"))
-        depends_on("py-setuptools@61:", type="build")
-        depends_on("py-setuptools-scm@3.4:", type="build")
-        depends_on("py-matplotlib@3.5.0:", type=("build", "run"))
-        depends_on("py-numpy@1.20.0:", type=("build", "run"))
-        depends_on("py-pandas@1.4.0:", type=("build", "run"))
-        depends_on("py-pint@0.17:", type=("build", "run"))
-        depends_on("py-pooch@1.2.0:", type=("build", "run"))
-        depends_on("py-pyproj@3.0.0:", type=("build", "run"))
-        depends_on("py-scipy@1.8.0:", type=("build", "run"))
-        depends_on("py-traitlets@5.0.5:", type=("build", "run"))
-        depends_on("py-xarray@0.21.0:", type=("build", "run"))
 
-        depends_on("py-cartopy@0.12.0:", when="+extras")
-        depends_on("py-dask@2020.12.0:", when="+extras")
-        depends_on("py-shapely@1.6.4:", when="+extras")
+    depends_on("python@3.9:", type=("build", "run"), when="@1.6.2:")
+    depends_on("py-setuptools@61:", type="build", when="@1.6.2:")
+    depends_on("py-setuptools-scm@3.4:", type="build", when="@1.6.2:")
+
+    depends_on("py-matplotlib@3.5.0:", type=("build", "run"), when="@1.6.2:")
+
+    depends_on("py-numpy@1.20.0:", type=("build", "run"), when="@1.6.2:")
+    depends_on("py-numpy@1.23.0:", type=("build", "run"), when="@1.7:")
+
+    depends_on("py-pandas@1.4.0:", type=("build", "run"), when="@1.6.2:")
+
+    depends_on("py-pint +numpy +xarray +dask", when="@1.6: +extras")
+    depends_on("py-pint@0.17:", type=("build", "run"), when="@1.6.2:")
+    depends_on("py-pint@0.24:", type=("build", "run"), when="@1.6.2: ^py-numpy@2:")
+
+    depends_on("py-pooch@1.2.0:", type=("build", "run"), when="@1.6.2:")
+
+    depends_on("py-pyproj@3.0.0:", type=("build", "run"), when="@1.6.2:")
+    depends_on("py-pyproj@3.3.0:", type=("build", "run"), when="@1.7:")
+
+    depends_on("py-scipy@1.8.0:", type=("build", "run"), when="@1.6.2:")
+
+    depends_on("py-traitlets@5.0.5:", type=("build", "run"), when="@1.6.2:")
+    depends_on("py-traitlets@5.1.0:", type=("build", "run"), when="@1.7:")
+
+    depends_on("py-xarray@0.21.0:", type=("build", "run"), when="@1.6.2:")
+    depends_on("py-xarray@2022.6.0:", type=("build", "run"), when="@1.7:")
+
+    depends_on("py-cartopy@0.12.0:", when="@1.6.2: +extras")
+    depends_on("py-cartopy@0.21.0:", when="@1.7: +extras")
+
+    depends_on("py-dask@2020.12.0:", when="@1.6.2: +extras")
+    depends_on("py-shapely@1.6.4:", when="@1.6.2: +extras")
+    depends_on("py-boto3@1.26.45:", when="@1.7: +extras")
+
+
 
     with when("@1.0.1"):
         depends_on("python@3.6:", type=("build", "run"))
@@ -65,3 +86,10 @@ class PyMetpy(PythonPackage):
         depends_on("py-scipy@1.0:", type=("build", "run"))
         depends_on("py-traitlets@4.3.0:", type=("build", "run"))
         depends_on("py-xarray@0.14.1:", type=("build", "run"))
+
+    def url_for_version(self, version):
+        if version > Version("1.6.2"):
+            return super().url_for_version(version)
+
+        url = "https://files.pythonhosted.org/packages/source/m/MetPy/MetPy-{0}.tar.gz"
+        return url.format(version.dotted)

--- a/repos/spack_repo/builtin/packages/py_pint/package.py
+++ b/repos/spack_repo/builtin/packages/py_pint/package.py
@@ -12,6 +12,7 @@ class PyPint(PythonPackage):
     quantities: the product of a numerical value and a unit of measurement.
     It allows arithmetic operations between them and conversions from and
     to different units."""
+
     homepage = "https://github.com/hgrecco/pint"
     pypi = "pint/pint-0.11.tar.gz"
 
@@ -40,7 +41,7 @@ class PyPint(PythonPackage):
 
     depends_on("python@3.9:", when="@0.22:", type=("build", "run"))
     depends_on("python@3.8:", when="@0.19:0.21", type=("build", "run"))
- 
+
     depends_on("py-setuptools@61:", when="@0.21:", type="build")
     depends_on("py-setuptools@41:", when="@0.16:0.20", type="build")
     depends_on("py-setuptools@41:", when="@0.11:0.15", type=("build", "run"))
@@ -60,10 +61,9 @@ class PyPint(PythonPackage):
 
     # variant depends
     depends_on("py-numpy@1", when="@:0.22 +numpy")
-    depends_on("py-numpy@1.23:", when="@0.24: +numpy") # numpy 2 added in 0.24
+    depends_on("py-numpy@1.23:", when="@0.24: +numpy")  # numpy 2 added in 0.24
     depends_on("py-xarray", when="+xarray")
     depends_on("py-dask", when="+dask")
-
 
     def url_for_version(self, version):
         if version > Version("0.22"):

--- a/repos/spack_repo/builtin/packages/py_pint/package.py
+++ b/repos/spack_repo/builtin/packages/py_pint/package.py
@@ -12,13 +12,16 @@ class PyPint(PythonPackage):
     quantities: the product of a numerical value and a unit of measurement.
     It allows arithmetic operations between them and conversions from and
     to different units."""
+    homepage = "https://github.com/hgrecco/pint"
+    pypi = "pint/pint-0.11.tar.gz"
 
-    pypi = "pint/Pint-0.11.tar.gz"
+    license("BSD-3-Clause")
 
     # 'pint' requires 'xarray', creating a circular dependency. Don't bother attempting
     # any import tests for this package.
     import_modules = []  # type: List[str]
 
+    version("0.24.4", sha256="35275439b574837a6cd3020a5a4a73645eb125ce4152a73a2f126bf164b91b80")
     version("0.22", sha256="2d139f6abbcf3016cad7d3cec05707fe908ac4f99cf59aedfd6ee667b7a64433")
     version("0.21.1", sha256="5d5b6b518d0c5a7ab03a776175db500f1ed1523ee75fb7fafe38af8149431c8d")
     version("0.20.1", sha256="387cf04078dc7dfe4a708033baad54ab61d82ab06c4ee3d4922b1e45d5626067")
@@ -31,9 +34,13 @@ class PyPint(PythonPackage):
     version("0.9", sha256="32d8a9a9d63f4f81194c0014b3b742679dce81a26d45127d9810a68a561fe4e2")
     version("0.8.1", sha256="afcf31443a478c32bbac4b00337ee9026a13d0e2ac83d30c79151462513bb0d4")
 
+    variant("numpy", default=False, description="Optional numpy support")
+    variant("xarray", default=False, description="Optional xarray support")
+    variant("dask", default=False, description="Optional dask support")
+
     depends_on("python@3.9:", when="@0.22:", type=("build", "run"))
     depends_on("python@3.8:", when="@0.19:0.21", type=("build", "run"))
-    depends_on("py-typing-extensions", when="@0.22:", type=("build", "run"))
+ 
     depends_on("py-setuptools@61:", when="@0.21:", type="build")
     depends_on("py-setuptools@41:", when="@0.16:0.20", type="build")
     depends_on("py-setuptools@41:", when="@0.11:0.15", type=("build", "run"))
@@ -42,3 +49,25 @@ class PyPint(PythonPackage):
     depends_on("py-setuptools-scm", when="@0.10", type="build")
     depends_on("py-packaging", when="@0.13:18", type=("build", "run"))
     depends_on("py-importlib-metadata", when="@0.13:18 ^python@:3.7", type=("build", "run"))
+
+    depends_on("py-typing-extensions", when="@0.22:", type=("build", "run"))
+
+    # https://github.com/hgrecco/pint/blob/0.24.4/requirements.txt
+    depends_on("py-platformdirs@2.1.0:", when="@0.24:")
+    depends_on("py-typing-extensions@4.0.0:", when="@0.24:", type=("build", "run"))
+    depends_on("py-flexcache@0.3:", when="@0.24:")
+    depends_on("py-flexparser@0.4:", when="@0.24:")
+
+    # variant depends
+    depends_on("py-numpy@1", when="@:0.22 +numpy")
+    depends_on("py-numpy@1.23:", when="@0.24: +numpy") # numpy 2 added in 0.24
+    depends_on("py-xarray", when="+xarray")
+    depends_on("py-dask", when="+dask")
+
+
+    def url_for_version(self, version):
+        if version > Version("0.22"):
+            return super().url_for_version(version)
+
+        url = "https://files.pythonhosted.org/packages/source/p/pint/Pint-{0}.tar.gz"
+        return url.format(version.dotted)

--- a/repos/spack_repo/builtin/packages/py_pint_xarray/package.py
+++ b/repos/spack_repo/builtin/packages/py_pint_xarray/package.py
@@ -25,7 +25,7 @@ class PyPintXarray(PythonPackage):
         depends_on("python@3.9:", type=("build", "run"))
         depends_on("py-numpy@1.23:", type=("build", "run"))
         depends_on("py-xarray@2022.06.0:", type=("build", "run"))
-        depends_on("py-pint@0.21:", type=("build", "run"))
+        depends_on("py-pint@0.21: +xarray +numpy +dask", type=("build", "run"))
 
     with when("@:0.3"):
         depends_on("py-setuptools@42:", type="build")
@@ -33,7 +33,7 @@ class PyPintXarray(PythonPackage):
         depends_on("python@3.8:", type=("build", "run"))
         depends_on("py-numpy@1.17:", type=("build", "run"))
         depends_on("py-xarray@0.16.1:", type=("build", "run"))
-        depends_on("py-pint@0.16:", type=("build", "run"))
+        depends_on("py-pint@0.16:  +xarray +numpy +dask", type=("build", "run"))
         depends_on("py-importlib-metadata", when="@0.2.1 ^python@:3.7", type=("build", "run"))
 
     def url_for_version(self, version):

--- a/repos/spack_repo/builtin/packages/py_pint_xarray/package.py
+++ b/repos/spack_repo/builtin/packages/py_pint_xarray/package.py
@@ -33,7 +33,7 @@ class PyPintXarray(PythonPackage):
         depends_on("python@3.8:", type=("build", "run"))
         depends_on("py-numpy@1.17:", type=("build", "run"))
         depends_on("py-xarray@0.16.1:", type=("build", "run"))
-        depends_on("py-pint@0.16:  +xarray +numpy +dask", type=("build", "run"))
+        depends_on("py-pint@0.16: +xarray +numpy +dask", type=("build", "run"))
         depends_on("py-importlib-metadata", when="@0.2.1 ^python@:3.7", type=("build", "run"))
 
     def url_for_version(self, version):


### PR DESCRIPTION
This updates the metpy and pint stack to work with numpy@2:
- Add `py-pint` 0.24.4
- Add `py-metpy` 1.7.0
- Fix numpy version constraints
- Add new variants to `py-pint` to correct capture enabling numpy/xarray/dask to ensure correct versions (implicit before)
- Add `py-flexcache` and `py-flexparser` which are required for the new `py-pint`
- Fix url naming change

I tested the urls via browser as I otherwise kept getting spack cache URLs. I think they are right but I would appreciate a quick sanity check on the old URLs.