### PR TITLE
libmesh: add missing fortran dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/libmesh/package.py
+++ b/repos/spack_repo/builtin/packages/libmesh/package.py
@@ -137,6 +137,7 @@ class Libmesh(AutotoolsPackage):
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
 
     depends_on("boost", when="+boost")
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
