### PR TITLE
py-memray: needs debuginfod so enable it in depends on `elfutils+debuginfod`

### DIFF
--- a/repos/spack_repo/builtin/packages/py_memray/package.py
+++ b/repos/spack_repo/builtin/packages/py_memray/package.py
@@ -38,7 +38,7 @@ class PyMemray(PythonPackage):
         depends_on("py-textual@0.34:", when="@1.11:")
 
     # https://github.com/bloomberg/memray#building-from-source
-    depends_on("elfutils", when="platform=linux @1.13:")
+    depends_on("elfutils+debuginfod", when="platform=linux @1.13:")
     depends_on("libunwind", when="platform=linux")
     depends_on("lz4")
 


### PR DESCRIPTION
This requirement is document here:

https://github.com/bloomberg/memray#building-from-source

Presumably it works in some combination of Python version and memray version without this, but I've found it is needed if memray@1.15.0 and python@3.12.9.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
