### PR TITLE
pandoc: add v3.7.0.2

### DIFF
--- a/repos/spack_repo/builtin/packages/pandoc/package.py
+++ b/repos/spack_repo/builtin/packages/pandoc/package.py
@@ -25,6 +25,10 @@ class Pandoc(Package):
 
     if platform.system() == "Linux" and platform.machine() == "aarch64":
         url = "https://github.com/jgm/pandoc/releases/download/2.14.0.3/pandoc-2.14.0.3-linux-arm64.tar.gz"
+
+        version(
+            "3.7.0.2", sha256="4ef2997ff0fa7f86ada5a217722f4f732293e38518b4442ececce16628bd0e44"
+        )
         version(
             "2.19.2", sha256="43f364915b9da64905fc3f6009f5542f224e54fb24f71043ef5154540f1a3983"
         )
@@ -35,6 +39,9 @@ class Pandoc(Package):
     elif platform.system() == "Linux":
         url = "https://github.com/jgm/pandoc/releases/download/2.14.0.3/pandoc-2.14.0.3-linux-amd64.tar.gz"
 
+        version(
+            "3.7.0.2", sha256="8f8f67fdd540b6519326b0ac49d5c55c5d5d15e43920e80a086e02c8aff83268"
+        )
         version(
             "2.19.2", sha256="9d55c7afb6a244e8a615451ed9cb02e6a6f187ad4d169c6d5a123fa74adb4830"
         )
@@ -50,22 +57,43 @@ class Pandoc(Package):
             url="https://github.com/jgm/pandoc/releases/download/2.7.3/pandoc-2.7.3-linux.tar.gz",
         )
 
-    elif platform.system() == "Darwin":
-        url = "https://github.com/jgm/pandoc/releases/download/2.14.0.3/pandoc-2.14.0.3-macOS.zip"
+    elif platform.system() == "Darwin" and platform.machine() == "aarch64":
+        url = "https://github.com/jgm/pandoc/releases/download/2.14.0.3/pandoc-3.7.0.2-arm64-macOS.zip"
 
         version(
-            "2.19.2", sha256="af0cda69e31e42f01ba6adc0aa779d3e5853e6c092beeb420a4fc22712d2110b"
+            "3.7.0.2", sha256="66a579bd8aae83de0bbeba43900953b075a6a3caaa7d1bfc19173e8f95d2ea17"
+        )
+
+    elif platform.system() == "Darwin":
+        url = "https://github.com/jgm/pandoc/releases/download/2.14.0.3/pandoc-3.7.0.2-x86_64-macOS.zip"
+
+        version(
+            "3.7.0.2", sha256="5495af2c548bd49fe00c28a7f6dadaa1348e6338b92368d3d6e29fd3e16061d1"
         )
         version(
-            "2.14.0.3", sha256="c6c1addd968699733c7d597cf269cc66d692371995703c32e5262f84a125c27b"
+            "2.19.2",
+            sha256="af0cda69e31e42f01ba6adc0aa779d3e5853e6c092beeb420a4fc22712d2110b",
+            url="https://github.com/jgm/pandoc/releases/download/2.14.0.3/pandoc-2.19.2-macOS.zip",
         )
         version(
-            "2.11.4", sha256="13b8597860afa6ab802993a684b340be3f31f4d2a06c50b6601f9e726cf76f71"
+            "2.14.0.3",
+            sha256="c6c1addd968699733c7d597cf269cc66d692371995703c32e5262f84a125c27b",
+            url="https://github.com/jgm/pandoc/releases/download/2.14.0.3/pandoc-2.14.0.3-macOS.zip",
         )
-        version("2.7.3", sha256="fb93800c90f3fab05dbd418ee6180d086b619c9179b822ddfecb608874554ff0")
+        version(
+            "2.11.4",
+            sha256="13b8597860afa6ab802993a684b340be3f31f4d2a06c50b6601f9e726cf76f71",
+            url="https://github.com/jgm/pandoc/releases/download/2.14.0.3/pandoc-2.11.4-macOS.zip",
+        )
+        version(
+            "2.7.3",
+            sha256="fb93800c90f3fab05dbd418ee6180d086b619c9179b822ddfecb608874554ff0",
+            url="https://github.com/jgm/pandoc/releases/download/2.14.0.3/pandoc-2.7.3-macOS.zip",
+        )
 
     variant("texlive", default=False, description="Use TeX Live to enable PDF output")
 
+    conflicts("target=aarch64: platform=darwin", msg="aarch64 is not supported.", when="@:3.1")
     conflicts("target=aarch64:", msg="aarch64 is not supported.", when="@:2.11")
 
     depends_on("texlive", when="+texlive")

--- a/repos/spack_repo/builtin/packages/pandoc/package.py
+++ b/repos/spack_repo/builtin/packages/pandoc/package.py
@@ -58,14 +58,14 @@ class Pandoc(Package):
         )
 
     elif platform.system() == "Darwin" and platform.machine() == "aarch64":
-        url = "https://github.com/jgm/pandoc/releases/download/2.14.0.3/pandoc-3.7.0.2-arm64-macOS.zip"
+        url = "https://github.com/jgm/pandoc/releases/download/3.7.0.2/pandoc-3.7.0.2-arm64-macOS.zip"
 
         version(
             "3.7.0.2", sha256="66a579bd8aae83de0bbeba43900953b075a6a3caaa7d1bfc19173e8f95d2ea17"
         )
 
     elif platform.system() == "Darwin":
-        url = "https://github.com/jgm/pandoc/releases/download/2.14.0.3/pandoc-3.7.0.2-x86_64-macOS.zip"
+        url = "https://github.com/jgm/pandoc/releases/download/3.7.0.2/pandoc-3.7.0.2-x86_64-macOS.zip"
 
         version(
             "3.7.0.2", sha256="5495af2c548bd49fe00c28a7f6dadaa1348e6338b92368d3d6e29fd3e16061d1"
@@ -73,7 +73,7 @@ class Pandoc(Package):
         version(
             "2.19.2",
             sha256="af0cda69e31e42f01ba6adc0aa779d3e5853e6c092beeb420a4fc22712d2110b",
-            url="https://github.com/jgm/pandoc/releases/download/2.14.0.3/pandoc-2.19.2-macOS.zip",
+            url="https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-macOS.zip",
         )
         version(
             "2.14.0.3",
@@ -83,12 +83,12 @@ class Pandoc(Package):
         version(
             "2.11.4",
             sha256="13b8597860afa6ab802993a684b340be3f31f4d2a06c50b6601f9e726cf76f71",
-            url="https://github.com/jgm/pandoc/releases/download/2.14.0.3/pandoc-2.11.4-macOS.zip",
+            url="https://github.com/jgm/pandoc/releases/download/2.11.4/pandoc-2.11.4-macOS.zip",
         )
         version(
             "2.7.3",
             sha256="fb93800c90f3fab05dbd418ee6180d086b619c9179b822ddfecb608874554ff0",
-            url="https://github.com/jgm/pandoc/releases/download/2.14.0.3/pandoc-2.7.3-macOS.zip",
+            url="https://github.com/jgm/pandoc/releases/download/2.7.3/pandoc-2.7.3-macOS.zip",
         )
 
     variant("texlive", default=False, description="Use TeX Live to enable PDF output")

--- a/repos/spack_repo/builtin/packages/pandoc/package.py
+++ b/repos/spack_repo/builtin/packages/pandoc/package.py
@@ -23,7 +23,12 @@ class Pandoc(Package):
 
     skip_version_audit = ["platform=windows"]
 
-    if platform.system() == "Linux" and platform.machine() == "aarch64":
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    if machine == "arm64":
+        machine = "aarch64"
+
+    if system == "linux" and machine == "aarch64":
         url = "https://github.com/jgm/pandoc/releases/download/2.14.0.3/pandoc-2.14.0.3-linux-arm64.tar.gz"
 
         version(
@@ -36,7 +41,7 @@ class Pandoc(Package):
             "2.14.0.3", sha256="1212e528fb717e0ffa6662d4930640abdbe0c36d14d283560a9688c8403bf34c"
         )
 
-    elif platform.system() == "Linux":
+    elif system == "linux":
         url = "https://github.com/jgm/pandoc/releases/download/2.14.0.3/pandoc-2.14.0.3-linux-amd64.tar.gz"
 
         version(
@@ -57,14 +62,14 @@ class Pandoc(Package):
             url="https://github.com/jgm/pandoc/releases/download/2.7.3/pandoc-2.7.3-linux.tar.gz",
         )
 
-    elif platform.system() == "Darwin" and platform.machine() == "aarch64":
+    elif system == "darwin" and machine == "aarch64":
         url = "https://github.com/jgm/pandoc/releases/download/3.7.0.2/pandoc-3.7.0.2-arm64-macOS.zip"
 
         version(
             "3.7.0.2", sha256="66a579bd8aae83de0bbeba43900953b075a6a3caaa7d1bfc19173e8f95d2ea17"
         )
 
-    elif platform.system() == "Darwin":
+    elif system == "darwin":
         url = "https://github.com/jgm/pandoc/releases/download/3.7.0.2/pandoc-3.7.0.2-x86_64-macOS.zip"
 
         version(

--- a/repos/spack_repo/builtin/packages/pandoc/package.py
+++ b/repos/spack_repo/builtin/packages/pandoc/package.py
@@ -75,6 +75,8 @@ class Pandoc(Package):
         version(
             "3.7.0.2", sha256="5495af2c548bd49fe00c28a7f6dadaa1348e6338b92368d3d6e29fd3e16061d1"
         )
+
+    if system == "darwin":
         version(
             "2.19.2",
             sha256="af0cda69e31e42f01ba6adc0aa779d3e5853e6c092beeb420a4fc22712d2110b",


### PR DESCRIPTION
https://github.com/jgm/pandoc/releases/tag/3.7.0.2
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
