### PR TITLE
py-blinker: add v1.9.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_blinker/package.py
+++ b/repos/spack_repo/builtin/packages/py_blinker/package.py
@@ -16,8 +16,13 @@ class PyBlinker(PythonPackage):
 
     license("MIT")
 
+    version("1.9.0", sha256="b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf")
     version("1.6.2", sha256="4afd3de66ef3a9f8067559fb7a1cbe555c17dcbe15971b05d1b625c3e7abe213")
     version("1.4", sha256="471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6")
 
-    depends_on("py-setuptools@61.2:", when="@1.6:", type="build")
-    depends_on("py-setuptools", type="build")
+    depends_on("python@3.9:", type=("build", "run"), when="@1.9:")
+    depends_on("py-flit-core@:4", type="build", when="@1.6.3:")
+
+    with when("@:1.6.2"):
+        depends_on("py-setuptools@61.2:", type="build", when="@1.6:")
+        depends_on("py-setuptools", type="build")


### PR DESCRIPTION
https://github.com/pallets-eco/blinker/tree/1.9.0
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
