### PR TITLE
libdwarf: remove url for version and add v2.1.0

### DIFF
--- a/repos/spack_repo/builtin/packages/libdwarf/package.py
+++ b/repos/spack_repo/builtin/packages/libdwarf/package.py
@@ -25,6 +25,7 @@ class Libdwarf(CMakePackage):
 
     license("LGPL-2.1-only")
 
+    version("2.1.0", sha256="461bd29cbb9a41c26a25b0e527c3736c772bb7a89f6260d1edb39ab105226e06")
     version("2.0.0", sha256="c3d1db72a979e14ee60b93010f0698d30fc1bca4eb1341006783d4e9c9ec7e72")
     version("0.12.0", sha256="444dc1c5176f04d3ebc50341552a8b2ea6c334f8f1868a023a740ace0e6eae9f")
     version("0.11.0", sha256="846071fb220ac1952f9f15ebbac6c7831ef50d0369b772c07a8a8139a42e07d2")
@@ -50,11 +51,6 @@ class Libdwarf(CMakePackage):
     with when("+decompression"):
         depends_on("zlib-api")
         depends_on("zstd")
-
-    def url_for_version(self, version):
-        if version < Version("20130126"):
-            return super().url_for_version(version)
-        return f"https://www.prevanders.net/libdwarf-{version}.tar.gz"
 
     def cmake_args(self):
         args = [


### PR DESCRIPTION
Built and passes all the test on M1 Air.