### PR TITLE
qt: add v5.15.17

### DIFF
--- a/repos/spack_repo/builtin/packages/qt/package.py
+++ b/repos/spack_repo/builtin/packages/qt/package.py
@@ -30,6 +30,7 @@ class Qt(Package):
 
     license("LGPL-3.0-only")
 
+    version("5.15.17", sha256="85eb566333d6ba59be3a97c9445a6e52f2af1b52fc3c54b8a2e7f9ea040a7de4")
     version("5.15.16", sha256="efa99827027782974356aceff8a52bd3d2a8a93a54dd0db4cca41b5e35f1041c")
     version("5.15.15", sha256="b423c30fe3ace7402e5301afbb464febfb3da33d6282a37a665be1e51502335e")
     version("5.15.14", sha256="fdd3a4f197d2c800ee0085c721f4bef60951cbda9e9c46e525d1412f74264ed7")


### PR DESCRIPTION
This PR adds `qt`, v5.15.17. Bugfix release with [release notes](https://www.qt.io/blog/commercial-lts-qt-5.15.17-released). This package will be built in CI.