### PR TITLE
meshlab: add v2025.07

### DIFF
--- a/repos/spack_repo/builtin/packages/meshlab/package.py
+++ b/repos/spack_repo/builtin/packages/meshlab/package.py
@@ -19,6 +19,7 @@ class Meshlab(CMakePackage):
     license("GPL-3.0", checked_by="wdconinc")
 
     version("main", branch="main", submodules=True)
+    version("2025.07", commit="dc48b91ae562756a6988048c5d5c7f1d2b687256", submodules=True)
     version("2023.12", commit="2dbd2f4b12df3b47d8777b2b4a43cabd9e425735", submodules=True)
 
     variant("double_scalar", default=False, description="Type to use for scalars")
@@ -43,6 +44,7 @@ class Meshlab(CMakePackage):
             "LIBIGL",
             "LEVMAR",
             "LIB3DS",
+            "LIB3MF",
             "EMBREE",
             "NEXUS",
             "QHULL",


### PR DESCRIPTION
This PR adds `meshlab`, v2025.07.

Test build:
```
==> meshlab: Successfully installed meshlab-2025.07-n5tnz7wubjyv2pms4z4hmurau5lejznf
  Stage: 2.03s.  Cmake: 2.36s.  Build: 12m 17.36s.  Install: 2.39s.  Post-install: 6.80s.  Total: 12m 31.22s
[+] /opt/software/linux-skylake/meshlab-2025.07-n5tnz7wubjyv2pms4z4hmurau5lejznf
```
