### PR TITLE
arrayfire: Add version 3.9.0 with patches and dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/arrayfire/3521-fix-build-failure-with-cudnn.patch
+++ b/repos/spack_repo/builtin/packages/arrayfire/3521-fix-build-failure-with-cudnn.patch
@@ -1,0 +1,44 @@
+diff --git a/src/backend/cuda/platform.cpp b/src/backend/cuda/platform.cpp
+index 52a22cdbaf..911774d48e 100644
+--- a/src/backend/cuda/platform.cpp
++++ b/src/backend/cuda/platform.cpp
+@@ -49,6 +49,7 @@
+ #include <stdexcept>
+ #include <string>
+ #include <thread>
++#include <type_traits>
+ 
+ using std::call_once;
+ using std::make_unique;
+@@ -124,7 +125,7 @@ unique_handle<cudnnHandle_t> *nnManager(const int deviceId) {
+     });
+     if (error) {
+         string error_msg = fmt::format("Error initializing cuDNN({}): {}.",
+-                                       error, errorString(error));
++                                       static_cast<std::underlying_type<cudnnStatus_t>::type>(error), errorString(error));
+         AF_ERROR(error_msg, AF_ERR_RUNTIME);
+     }
+     CUDNN_CHECK(getCudnnPlugin().cudnnSetStream(cudnnHandles[deviceId],
+
+From 44c156a6267b89c5fd41e764b564e8d4ca8fac6e Mon Sep 17 00:00:00 2001
+From: errata-c <erratachem@gmail.com>
+Date: Sun, 5 Nov 2023 14:21:24 -0500
+Subject: [PATCH 2/2] Fixed call to dependency_check with too few arguments
+
+---
+ test/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index cf7e66255f..f019bf078e 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -20,7 +20,7 @@ if(AF_TEST_WITH_MTX_FILES)
+ endif()
+ 
+ if(AF_WITH_EXTERNAL_PACKAGES_ONLY)
+-    dependency_check(GTest_FOUND)
++    dependency_check(GTest_FOUND  "GTest not found.")
+ elseif(NOT TARGET GTest::gtest)
+   af_dep_check_and_populate(${gtest_prefix}
+     URI https://github.com/google/googletest.git

--- a/repos/spack_repo/builtin/packages/arrayfire/add-build-dir-to-cmake.patch
+++ b/repos/spack_repo/builtin/packages/arrayfire/add-build-dir-to-cmake.patch
@@ -1,0 +1,11 @@
+--- CMakeLists.txt.orig	2024-09-19 17:48:51.000000000 +0000
++++ CMakeLists.txt	2024-09-19 17:49:11.668924088 +0000
+@@ -310,7 +310,7 @@
+     URI https://github.com/martinmoene/span-lite
+     REF "ccf2351"
+     )
+-  add_subdirectory(${span-lite_SOURCE_DIR} EXCLUDE_FROM_ALL)
++  add_subdirectory(${span-lite_SOURCE_DIR} build EXCLUDE_FROM_ALL)
+   get_property(span_include_dir
+     TARGET span-lite
+     PROPERTY INTERFACE_INCLUDE_DIRECTORIES)

--- a/repos/spack_repo/builtin/packages/arrayfire/fmt-v11.patch
+++ b/repos/spack_repo/builtin/packages/arrayfire/fmt-v11.patch
@@ -1,0 +1,96 @@
+diff --git a/src/backend/common/ArrayFireTypesIO.hpp b/src/backend/common/ArrayFireTypesIO.hpp
+index e7a2e085e..5da74a9c2 100644
+--- a/src/backend/common/ArrayFireTypesIO.hpp
++++ b/src/backend/common/ArrayFireTypesIO.hpp
+@@ -21,7 +21,7 @@ struct fmt::formatter<af_seq> {
+     }
+ 
+     template<typename FormatContext>
+-    auto format(const af_seq& p, FormatContext& ctx) -> decltype(ctx.out()) {
++    auto format(const af_seq& p, FormatContext& ctx) const -> decltype(ctx.out()) {
+         // ctx.out() is an output iterator to write to.
+         if (p.begin == af_span.begin && p.end == af_span.end &&
+             p.step == af_span.step) {
+@@ -73,18 +73,16 @@ struct fmt::formatter<arrayfire::common::Version> {
+     }
+ 
+     template<typename FormatContext>
+-    auto format(const arrayfire::common::Version& ver, FormatContext& ctx)
++    auto format(const arrayfire::common::Version& ver, FormatContext& ctx) const
+         -> decltype(ctx.out()) {
+         if (ver.major() == -1) return format_to(ctx.out(), "N/A");
+-        if (ver.minor() == -1) show_minor = false;
+-        if (ver.patch() == -1) show_patch = false;
+-        if (show_major && !show_minor && !show_patch) {
++        if (show_major && (ver.minor() == -1) && (ver.patch() == -1)) {
+             return format_to(ctx.out(), "{}", ver.major());
+         }
+-        if (show_major && show_minor && !show_patch) {
++        if (show_major && (ver.minor() != -1) && (ver.patch() == -1)) {
+             return format_to(ctx.out(), "{}.{}", ver.major(), ver.minor());
+         }
+-        if (show_major && show_minor && show_patch) {
++        if (show_major && (ver.minor() != -1) && (ver.patch() != -1)) {
+             return format_to(ctx.out(), "{}.{}.{}", ver.major(), ver.minor(),
+                              ver.patch());
+         }
+diff --git a/src/backend/common/debug.hpp b/src/backend/common/debug.hpp
+index 54e74a295..07fa589ac 100644
+--- a/src/backend/common/debug.hpp
++++ b/src/backend/common/debug.hpp
+@@ -12,6 +12,7 @@
+ #include <boost/stacktrace.hpp>
+ #include <common/ArrayFireTypesIO.hpp>
+ #include <common/jit/NodeIO.hpp>
++#include <fmt/ranges.h>
+ #include <spdlog/fmt/bundled/format.h>
+ #include <iostream>
+ 
+diff --git a/src/backend/common/jit/NodeIO.hpp b/src/backend/common/jit/NodeIO.hpp
+index ac149d98d..edffdfae4 100644
+--- a/src/backend/common/jit/NodeIO.hpp
++++ b/src/backend/common/jit/NodeIO.hpp
+@@ -16,7 +16,7 @@
+ template<>
+ struct fmt::formatter<af::dtype> : fmt::formatter<char> {
+     template<typename FormatContext>
+-    auto format(const af::dtype& p, FormatContext& ctx) -> decltype(ctx.out()) {
++    auto format(const af::dtype& p, FormatContext& ctx) const -> decltype(ctx.out()) {
+         format_to(ctx.out(), "{}", arrayfire::common::getName(p));
+         return ctx.out();
+     }
+@@ -58,7 +58,7 @@ struct fmt::formatter<arrayfire::common::Node> {
+     // Formats the point p using the parsed format specification (presentation)
+     // stored in this formatter.
+     template<typename FormatContext>
+-    auto format(const arrayfire::common::Node& node, FormatContext& ctx)
++    auto format(const arrayfire::common::Node& node, FormatContext& ctx) const
+         -> decltype(ctx.out()) {
+         // ctx.out() is an output iterator to write to.
+ 
+diff --git a/src/backend/cuda/debug_cuda.hpp b/src/backend/cuda/debug_cuda.hpp
+index 555944a5e..93ebcf027 100644
+--- a/src/backend/cuda/debug_cuda.hpp
++++ b/src/backend/cuda/debug_cuda.hpp
+@@ -29,7 +29,7 @@ template<>
+ struct fmt::formatter<dim3> : fmt::formatter<std::string> {
+     // parse is inherited from formatter<string_view>.
+     template<typename FormatContext>
+-    auto format(dim3 c, FormatContext& ctx) {
++    auto format(const dim3 &c, FormatContext &ctx) const {
+         std::string name = fmt::format("{} {} {}", c.x, c.y, c.z);
+         return formatter<std::string>::format(name, ctx);
+     }
+diff --git a/src/backend/opencl/compile_module.cpp b/src/backend/opencl/compile_module.cpp
+index 89d382c9c..2c979fd5e 100644
+--- a/src/backend/opencl/compile_module.cpp
++++ b/src/backend/opencl/compile_module.cpp
+@@ -22,6 +22,8 @@
+ #include <platform.hpp>
+ #include <traits.hpp>
+ 
++#include <fmt/ranges.h>
++
+ #include <algorithm>
+ #include <cctype>
+ #include <cstdio>

--- a/repos/spack_repo/builtin/packages/arrayfire/package.py
+++ b/repos/spack_repo/builtin/packages/arrayfire/package.py
@@ -29,15 +29,30 @@ class Arrayfire(CMakePackage, CudaPackage):
 
     variant("forge", default=False, description="Enable graphics library")
     variant("opencl", default=False, description="Enable OpenCL backend")
+    variant("cuda", default=True, description="Enable CUDA backend")
+
+    conflicts("~opencl", when="@3.9:")
+    conflicts("%gcc@13:", when="@:3.8.1")
+    conflicts("%clang@14:", when="@:3.8.1")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
+    depends_on("cmake@3.18:", type="build", when="@3.9:")
     depends_on("boost@1.70:")
+    conflicts("boost@1.86", when="@3.9", msg="arrayfire@3.9.0 fails to build with boost@1.86")
+
     depends_on("fftw-api@3:")
     depends_on("blas")
-    depends_on("cuda@7.5:", when="+cuda")
+    # https://github.com/arrayfire/arrayfire/wiki/Build-Instructions-for-Linux
+    depends_on("cuda@9.1:", when="+cuda")
     depends_on("cudnn", when="+cuda")
+
+    # arrayfire@3.8.1 fails to build with spdlog and fmt:
+    depends_on("fmt@8.1.1:", when="@3.7")
+    depends_on("fmt@8.1.1:", when="@3.9:")
+    depends_on("spdlog@1.9.2:", when="@3.7")
+    depends_on("spdlog@1.9.2:", when="@3.9:")
 
     depends_on("opencl", when="+opencl")
     depends_on("pocl+icd", when="^[virtuals=opencl] pocl")
@@ -52,6 +67,10 @@ class Arrayfire(CMakePackage, CudaPackage):
     # 3.9.0 introduced a cmake bug due to absolute paths being used.
     # add_subdirectory not given a binary directory... (referencing internal build of span-lite).
     patch("add-build-dir-to-cmake.patch", level=0, when="@3.9.0:")
+    # from Arch Linux https://gitlab.archlinux.org/archlinux/packaging/packages/arrayfire/-/raw/main/fmt-v11.patch?ref_type=heads
+    patch("fmt-v11.patch", level=1, when="@3.9.0:")
+    # https://gitlab.archlinux.org/archlinux/packaging/packages/arrayfire/-/blob/6add204c734deaed234c71f2a05c3e7bcf6f73dc/3521-fix-build-failure-with-cudnn.patch
+    patch("3521-fix-build-failure-with-cudnn.patch", level=1, when="@3.9.0:")
 
     conflicts("cuda_arch=none", when="+cuda", msg="CUDA architecture is required")
 
@@ -79,6 +98,8 @@ class Arrayfire(CMakePackage, CudaPackage):
                 self.define_from_variant("AF_BUILD_FORGE", "forge"),
                 self.define_from_variant("AF_BUILD_OPENCL", "opencl"),
                 self.define("BUILD_TESTING", self.run_tests),
+                self.define("AF_WITH_SPDLOG_HEADER_ONLY", not self.spec.satisfies("@3.8")),
+                self.define("AF_WITH_FMT_HEADER_ONLY", not self.spec.satisfies("@3.8")),
             ]
         )
 

--- a/repos/spack_repo/builtin/packages/arrayfire/package.py
+++ b/repos/spack_repo/builtin/packages/arrayfire/package.py
@@ -43,6 +43,10 @@ class Arrayfire(CMakePackage, CudaPackage):
     conflicts("boost@1.86", when="@3.9", msg="arrayfire@3.9.0 fails to build with boost@1.86")
 
     depends_on("fftw-api@3:")
+
+    oneapi_conflict = "arrayfire does not detect intel-oneapi-mkl as providing FFTW"
+    conflicts("^[virtuals=fftw-api] intel-oneapi-mkl", msg=oneapi_conflict)
+
     depends_on("blas")
     # https://github.com/arrayfire/arrayfire/wiki/Build-Instructions-for-Linux
     depends_on("cuda@9.1:", when="+cuda")

--- a/repos/spack_repo/builtin/packages/arrayfire/package.py
+++ b/repos/spack_repo/builtin/packages/arrayfire/package.py
@@ -19,23 +19,19 @@ class Arrayfire(CMakePackage, CudaPackage):
 
     license("FreeImage")
 
-    version("master")
-    version("3.8.1", commit="823e8e399fe8c120c6ec7ec75f09e6106b3074ca", tag="v3.8.1")
-    version(
-        "3.7.3", commit="59ac7b980d1ae124aae914fb29cbf086c948954d", submodules=True, tag="v3.7.3"
-    )
-    version(
-        "3.7.2", commit="218dd2c99300e77496239ade76e94b0def65d032", submodules=True, tag="v3.7.2"
-    )
-    version(
-        "3.7.0", commit="fbea2aeb6f7f2d277dcb0ab425a77bb18ed22291", submodules=True, tag="v3.7.0"
-    )
+    with default_args(submodules=True, no_cache=True):
+        version("master")
+        version("3.9.0", commit="b59a1ae535da369db86451e5b28a7bc0eaf3e84a", tag="v3.9.0")
+        version("3.8.1", commit="823e8e399fe8c120c6ec7ec75f09e6106b3074ca", tag="v3.8.1")
+        version("3.7.3", commit="59ac7b980d1ae124aae914fb29cbf086c948954d", tag="v3.7.3")
+        version("3.7.2", commit="218dd2c99300e77496239ade76e94b0def65d032", tag="v3.7.2")
+        version("3.7.0", commit="fbea2aeb6f7f2d277dcb0ab425a77bb18ed22291", tag="v3.7.0")
 
     variant("forge", default=False, description="Enable graphics library")
     variant("opencl", default=False, description="Enable OpenCL backend")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("boost@1.70:")
     depends_on("fftw-api@3:")
@@ -52,6 +48,10 @@ class Arrayfire(CMakePackage, CudaPackage):
 
     depends_on("fontconfig", when="+forge")
     depends_on("glfw@3.1.4:", when="+forge")
+
+    # 3.9.0 introduced a cmake bug due to absolute paths being used.
+    # add_subdirectory not given a binary directory... (referencing internal build of span-lite).
+    patch("add-build-dir-to-cmake.patch", level=0, when="@3.9.0:")
 
     conflicts("cuda_arch=none", when="+cuda", msg="CUDA architecture is required")
 


### PR DESCRIPTION
Hi @umar456,

This is a transfer of https://github.com/spack/spack/pull/46490 by @brettviren to [spack-packages](https://github.com/spack/spack-packages):

- Adds 3.9.0 with patches and dependencies
- Fixes CMake error with CMake 3.30.2.