### PR TITLE
py-coverage: add v7.10.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_coverage/package.py
+++ b/repos/spack_repo/builtin/packages/py_coverage/package.py
@@ -15,6 +15,7 @@ class PyCoverage(PythonPackage):
 
     license("Apache-2.0")
 
+    version("7.10.0", sha256="2768885aef484b5dcde56262cbdfba559b770bfc46994fe9485dc3614c7a5867")
     version("7.2.6", sha256="2025f913f2edb0272ef15d00b1f335ff8908c921c8eb2013536fcaf61f5a683d")
     version("6.4.4", sha256="e16c45b726acb780e1e6f88b286d3c10b3914ab03438f32117c4aa52d7f30d58")
     version("6.3.1", sha256="6c3f6158b02ac403868eea390930ae64e9a9a2a5bbfafefbb920d29258d9f2f8")


### PR DESCRIPTION
https://github.com/nedbat/coveragepy/tree/7.10.0
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
