### PR TITLE
py-cryptography: add v45.0.5 and update dependency packages

### DIFF
--- a/repos/spack_repo/builtin/packages/py_cryptography/package.py
+++ b/repos/spack_repo/builtin/packages/py_cryptography/package.py
@@ -16,6 +16,7 @@ class PyCryptography(PythonPackage):
 
     license("Apache-2.0")
 
+    version("45.0.5", sha256="72e76caa004ab63accdf26023fccd1d087f6d90ec6048ff33ad0445abf7f605a")
     version("43.0.3", sha256="315b9001266a492a6ff443b61238f956b214dbec9910a081ba5b6646a055a805")
     version("43.0.1", sha256="203e92a75716d8cfb491dc47c79e17d0d9207ccffcbcb35f598fbe463ae3444d")
     version("42.0.8", sha256="8d09d05439ce7baa8e9e95b07ec5b6c886f548deb7e0f69ef25f64b3bce842f2")
@@ -46,36 +47,49 @@ class PyCryptography(PythonPackage):
     depends_on("py-setuptools@40.6:", when="@2.7:36", type="build")
     depends_on("py-setuptools@18.5:", when="@2.2:2.6", type="build")
     depends_on("py-setuptools@11.3:", when="@:2.1", type="build")
-    with when("@43:"):
-        depends_on("py-maturin@1", type="build")
-        conflicts(
-            "^py-setuptools@74.0.0,74.1.0,74.1.1,74.1.2,74.1.3,75.0.0,75.1.0,75.2.0",
-            msg="some setuptools version are incompatible",
-        )
+    depends_on("py-maturin@1.8.6:1", when="@45:", type="build")
+    depends_on("py-maturin@1", when="@43:44", type="build")
     with when("@:42"):
         depends_on("py-setuptools-rust@1.7.0:", when="@42", type=("build", "run"))
         depends_on("py-setuptools-rust@0.11.4:", when="@3.4.2:", type="build")
         depends_on("py-setuptools-rust@0.11.4:", when="@3.4:3.4.1", type=("build", "run"))
+
+    # from https://cryptography.io/en/latest/installation/#rust
+    depends_on("rust@1.74:", when="@45:", type="build")
+    depends_on("rust@1.65:", when="@43:", type="build")
+    depends_on("rust@1.63:", when="@42:", type="build")
     depends_on("rust@1.56:", when="@41:", type="build")
     depends_on("rust@1.48:", when="@38:", type="build")
     depends_on("rust@1.41:", when="@3.4.5:", type="build")
     depends_on("rust@1.45:", when="@3.4.3:3.4.4", type="build")
     depends_on("pkgconfig", when="@40:", type="build")
 
+    depends_on("py-cffi@1.14:", when="@45:", type=("build", "run"))
     depends_on("py-cffi@1.12:", when="@3.3:", type=("build", "run"))
     depends_on("py-cffi@1.8:1.11.2,1.11.4:", when="@2.5:3.2", type=("build", "run"))
     depends_on("py-cffi@1.7:1.11.2,1.11.4:", when="@1.9:2.4.2", type=("build", "run"))
     depends_on("py-cffi@1.4.1:", type=("build", "run"))
 
+    # from https://cryptography.io/en/latest/installation/
+    depends_on("openssl@3:", when="@42:")
+    depends_on("openssl@1.1.1:", when="@39:")
+    depends_on("openssl@:1.1", when="@:3.4")
+    depends_on("openssl@:1.0", when="@:1.8.1")
+    depends_on("openssl")
+
+    conflicts("^python@3.9.0,3.9.1", when="@45:")
+    conflicts("^py-setuptools@74.0.0,74.1.0,74.1.1,74.1.2", when="@44:")
+    conflicts(
+        "^py-setuptools@74.0.0,74.1.0,74.1.1,74.1.2,74.1.3,75.0.0,75.1.0,75.2.0",
+        msg="some setuptools version are incompatible",
+        when="@43",
+    )
+
+    # Historical dependencies
     depends_on("py-asn1crypto@0.21.0:", type=("build", "run"), when="@:2.7")
     depends_on("py-six@1.4.1:", type=("build", "run"), when="@:3.3")
     depends_on("py-idna@2.1:", type=("build", "run"), when="@:2.4")  # deprecated
     depends_on("py-idna@2.1:", type=("build", "run"), when="@2.5: +idna")  # deprecated
-
-    depends_on("openssl")
-    depends_on("openssl@:1.0", when="@:1.8.1")
-    depends_on("openssl@:1.1", when="@:3.4")
-    depends_on("openssl@1.1.1:", when="@39:")
 
     # To fix https://github.com/spack/spack/issues/29669
     # https://community.home-assistant.io/t/error-failed-building-wheel-for-cryptography/352020/14

--- a/repos/spack_repo/builtin/packages/py_maturin/package.py
+++ b/repos/spack_repo/builtin/packages/py_maturin/package.py
@@ -19,6 +19,7 @@ class PyMaturin(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.9.1", sha256="97b52fb19d20c1fdc70e4efdc05d79853a4c9c0051030c93a793cd5181dc4ccd")
     version("1.8.3", sha256="304762f86fd53a8031b1bf006d12572a2aa0a5235485031113195cc0152e1e12")
     version("1.8.2", sha256="e31abc70f6f93285d6e63d2f4459c079c94c259dd757370482d2d4ceb9ec1fa0")
     version("1.6.0", sha256="b955025c24c8babc808db49e0ff90db8b4b1320dcc16b14eb26132841737230d")
@@ -30,15 +31,19 @@ class PyMaturin(PythonPackage):
 
     with default_args(type="build"):
         depends_on("py-setuptools")
-        depends_on("py-wheel@0.36.2:")
+        depends_on("py-setuptools-rust@1.11:", when="@1.8.6:")
         depends_on("py-setuptools-rust@1.4:")
+
+        depends_on("py-wheel@0.36.2:", when="@:1.8.3")
 
     with default_args(type=("build", "run")):
         depends_on("py-tomli@1.1:", when="^python@:3.10")
+        # from Cargo.toml
         for rust, maturin in [
-            ("1.74", "1.8"),
+            ("1.74", "1.7.0"),
             ("1.70", "1.5.0"),
-            ("1.64", "1.0.0"),
+            ("1.67", "1.4.0"),
+            ("1.64", "0.15.0"),
             ("1.62", "0.14.3"),
             ("1.59", "0.13.3"),
         ]:

--- a/repos/spack_repo/builtin/packages/py_setuptools_rust/package.py
+++ b/repos/spack_repo/builtin/packages/py_setuptools_rust/package.py
@@ -31,13 +31,13 @@ class PySetuptoolsRust(PythonPackage):
     depends_on("py-setuptools-scm", when="@1.7.0:", type=("build", "run"))
     depends_on("py-semantic-version@2.8.2:2", when="@1.2.0:", type=("build", "run"))
     depends_on("py-semantic-version@2.6.0:", type=("build", "run"))
-    depends_on("py-tomli@1.2.1:", when="^python@:3.10", type=("build", "run"))
     depends_on("rust", type="run")
 
     # Historical dependencies
     depends_on("py-typing-extensions@3.7.4.3:", when="@1.2.0:1.7.0", type=("build", "run"))
     depends_on("py-setuptools-scm+toml@6.3.2:", when="@1.2.0:1.4.1", type="build")
     depends_on("py-setuptools-scm+toml@3.4.3:", when="@:1.1", type="build")
+    depends_on("py-tomli@1.2.1:", when="@:1.9 ^python@:3.10", type=("build", "run"))
     depends_on("py-toml@0.9.0:", type=("build", "run"), when="@0.12.1")
 
     def url_for_version(self, version):

--- a/repos/spack_repo/builtin/packages/py_setuptools_rust/package.py
+++ b/repos/spack_repo/builtin/packages/py_setuptools_rust/package.py
@@ -11,10 +11,11 @@ class PySetuptoolsRust(PythonPackage):
     """Setuptools rust extension plugin."""
 
     homepage = "https://github.com/PyO3/setuptools-rust"
-    pypi = "setuptools-rust/setuptools-rust-0.12.1.tar.gz"
+    pypi = "setuptools-rust/setuptools_rust-1.11.1.tar.gz"
 
     license("MIT")
 
+    version("1.11.1", sha256="7dabc4392252ced314b8050d63276e05fdc5d32398fc7d3cce1f6a6ac35b76c0")
     version("1.9.0", sha256="704df0948f2e4cc60c2596ad6e840ea679f4f43e58ed4ad0c1857807240eab96")
     version("1.8.1", sha256="94b1dd5d5308b3138d5b933c3a2b55e6d6927d1a22632e509fcea9ddd0f7e486")
     version("1.7.0", sha256="c7100999948235a38ae7e555fe199aa66c253dc384b125f5d85473bf81eae3a3")
@@ -38,3 +39,10 @@ class PySetuptoolsRust(PythonPackage):
     depends_on("py-setuptools-scm+toml@6.3.2:", when="@1.2.0:1.4.1", type="build")
     depends_on("py-setuptools-scm+toml@3.4.3:", when="@:1.1", type="build")
     depends_on("py-toml@0.9.0:", type=("build", "run"), when="@0.12.1")
+
+    def url_for_version(self, version):
+        if version >= Version("1.10.0"):
+            name = "setuptools_rust"
+        else:
+            name = "setuptools-rust"
+        return f"https://files.pythonhosted.org/packages/source/s/setuptools-rust/{name}-{version}.tar.gz"


### PR DESCRIPTION
https://github.com/pyca/cryptography/tree/45.0.5

py-maturin: add v1.9.1
https://github.com/PyO3/maturin/tree/v1.9.1

py-setuptools-rust: add v1.11.1
https://github.com/PyO3/setuptools-rust/tree/v1.11.1
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
