### PR TITLE
sherpa: filter_file to fix failing texinfo file

### DIFF
--- a/repos/spack_repo/builtin/packages/sherpa/package.py
+++ b/repos/spack_repo/builtin/packages/sherpa/package.py
@@ -95,6 +95,8 @@ class Sherpa(CMakePackage, AutotoolsPackage):
     depends_on("libtool", when="@:2")
     depends_on("m4", when="@:2")
     depends_on("texinfo", type="build")
+    # limit texinfo to 7.1 to avoid errors due to missing references
+    depends_on("texinfo@:7.1", type="build", when="@:2")
     depends_on("sqlite")
 
     depends_on("mpi", when="+mpi")

--- a/repos/spack_repo/builtin/packages/sherpa/package.py
+++ b/repos/spack_repo/builtin/packages/sherpa/package.py
@@ -95,8 +95,6 @@ class Sherpa(CMakePackage, AutotoolsPackage):
     depends_on("libtool", when="@:2")
     depends_on("m4", when="@:2")
     depends_on("texinfo", type="build")
-    # limit texinfo to 7.1 to avoid errors due to missing references
-    depends_on("texinfo@:7.1", type="build", when="@:2")
     depends_on("sqlite")
 
     depends_on("mpi", when="+mpi")
@@ -134,6 +132,10 @@ class Sherpa(CMakePackage, AutotoolsPackage):
             "#ifdef ARCH_DARWIN\n#include <sys/sysctl.h>\n#endif",
             "ATOOLS/Org/Run_Parameter.C",
         )
+
+        if self.spec.satisfies("@:2"):
+            # remove errant 'R' which trips up newer texinfo
+            filter_file(r"R@end", "@end", "Manual/Starting.texi", string=True)
 
         if self.spec.satisfies("^recola@2:"):
             filter_file(


### PR DESCRIPTION
This PR fixes `sherpa`, all versions `@:2`, by changing an incorrect `R@end` into `@end` in a texinfo file. See https://gitlab.com/sherpa-team/sherpa/-/blob/v2.2.16/Manual/Starting.texi?ref_type=tags#L469.

The v2 series is in maintenance mode. If this ends up getting fixed upstream anyway, and if a new version is released and added to spack, then the filter_file will become a no-op, so this is a future-proof fix.

This should fix the failing HEP GitLab CI stack.

Root cause analysis: The upgrade in #575 of `texinfo` to 7.2 (which is what now causes an error where previously it didn't cause an error, as verified for 7.1) did not trigger this issue in the PR pipeline since `texinfo` is a build dependency, and packages with updated build dependencies are not rebuilt in GitLab CI.