### PR TITLE
scorep: fix `gotcha` `prefix`

### DIFF
--- a/repos/spack_repo/builtin/packages/scorep/package.py
+++ b/repos/spack_repo/builtin/packages/scorep/package.py
@@ -253,7 +253,7 @@ class Scorep(AutotoolsPackage):
             )
         )
         config_args.extend(
-            self.with_or_without("libgotcha", activation_value="prefix", variant="gotcha")
+            self.with_or_without("libgotcha", activation_value=lambda _:self.spec["gotcha"].prefix, variant="gotcha")
         )
         config_args.extend(self.enable_or_disable("llvm-plugin"))
         config_args.extend(self.enable_or_disable("gcc-plugin"))

--- a/repos/spack_repo/builtin/packages/scorep/package.py
+++ b/repos/spack_repo/builtin/packages/scorep/package.py
@@ -253,7 +253,11 @@ class Scorep(AutotoolsPackage):
             )
         )
         config_args.extend(
-            self.with_or_without("libgotcha", activation_value=lambda _:self.spec["gotcha"].prefix, variant="gotcha")
+            self.with_or_without(
+                "libgotcha",
+                activation_value=lambda _: self.spec["gotcha"].prefix,
+                variant="gotcha",
+            )
         )
         config_args.extend(self.enable_or_disable("llvm-plugin"))
         config_args.extend(self.enable_or_disable("gcc-plugin"))


### PR DESCRIPTION
`--with-libgotcha` needs to look at the prefix for `gotcha`, which exists, not the one for `libgotcha`, which does not.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
