### PR TITLE
update fms for 2025 releases and io deprecation variant

### DIFF
--- a/repos/spack_repo/builtin/packages/eccodes/package.py
+++ b/repos/spack_repo/builtin/packages/eccodes/package.py
@@ -52,7 +52,7 @@ class Eccodes(CMakePackage):
 
     version("develop", branch="develop")
     version("2.41.0", sha256="a1467842e11ed7f62a2f5cc1982e04eec62398f4962e6ba03ace7646f32cf270")
-    version("2.40.0", sha256="f58d5d7390fce86c62b26d76b9bc3c4d7d9a6cf2e5f8145d1d598089195e51ff") 
+    version("2.40.0", sha256="f58d5d7390fce86c62b26d76b9bc3c4d7d9a6cf2e5f8145d1d598089195e51ff")
     version("2.38.0", sha256="96a21fbe8ca3aa4c31bb71bbd378b7fd130cbc0f7a477567d70e66a000ff68d9")
     version("2.34.0", sha256="3cd208c8ddad132789662cf8f67a9405514bfefcacac403c0d8c84507f303aba")
     version("2.33.0", sha256="bdcec8ce63654ec6803400c507f01220a9aa403a45fa6b5bdff7fdcc44fd7daf")

--- a/repos/spack_repo/builtin/packages/fms/package.py
+++ b/repos/spack_repo/builtin/packages/fms/package.py
@@ -20,6 +20,12 @@ class Fms(CMakePackage):
     license("LGPL-3.0-or-later")
 
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett", "rem1776", "climbfuji")
+    version("2025.03", sha256="17bdbac86bd3b1e5c1c3a5496c1495e8badcd5f671c659b17921532c990f014c")
+    version("2025.02.01", sha256="a481a0d49cf4ca06476849600c2da41fb25053e930a8fabe2add09c3d2fbee9c")
+    version("2025.02", sha256="c9bbe4dd292520bc7454db25a72ce6a8ca56201be567a7dc461601e01bbd46c5")
+    version("2025.01.02", sha256="d1f3bdda08eb3620c1ea4fec46a744bce27b852021974f2d8b5d724f4fc3e80b")
+    version("2025.01.01", sha256="aff4f0795484e47f036233d9044a4f7cc873b837f3585527ad17292a71cdb7bd")
+    version("2024.01.02", sha256="e984a5c856547d9b49fab4f5ac76985f2b4f6d3ac0d29b76b34e827433767705")
     version("2025.01", sha256="19997ef5468a06c60c1e7af3a56ab7f8a33da814a30827293ca34df5bd888d6f")
     version("2024.03", sha256="4c1e6bdfafcfec19a4a1c08770c313ab3135d47ec8319f6b07f24d2589caf44d")
     version("2024.02", sha256="47e5740bb066f5eb032e1de163eb762c7258880a2932f4cc4e34e769e0cc2b0e")
@@ -120,7 +126,7 @@ class Fms(CMakePackage):
         "deprecated_io",
         default=False,
         description="Compiles with support for deprecated io modules fms_io and mpp_io",
-        when="@2023.02:",
+        when="@2023.02:2025.02",
     )
     variant("large_file", default=False, description="Enable compiler definition -Duse_LARGEFILE.")
     variant(

--- a/repos/spack_repo/builtin/packages/fms/package.py
+++ b/repos/spack_repo/builtin/packages/fms/package.py
@@ -21,11 +21,19 @@ class Fms(CMakePackage):
 
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett", "rem1776", "climbfuji")
     version("2025.03", sha256="17bdbac86bd3b1e5c1c3a5496c1495e8badcd5f671c659b17921532c990f014c")
-    version("2025.02.01", sha256="a481a0d49cf4ca06476849600c2da41fb25053e930a8fabe2add09c3d2fbee9c")
+    version(
+        "2025.02.01", sha256="a481a0d49cf4ca06476849600c2da41fb25053e930a8fabe2add09c3d2fbee9c"
+    )
     version("2025.02", sha256="c9bbe4dd292520bc7454db25a72ce6a8ca56201be567a7dc461601e01bbd46c5")
-    version("2025.01.02", sha256="d1f3bdda08eb3620c1ea4fec46a744bce27b852021974f2d8b5d724f4fc3e80b")
-    version("2025.01.01", sha256="aff4f0795484e47f036233d9044a4f7cc873b837f3585527ad17292a71cdb7bd")
-    version("2024.01.02", sha256="e984a5c856547d9b49fab4f5ac76985f2b4f6d3ac0d29b76b34e827433767705")
+    version(
+        "2025.01.02", sha256="d1f3bdda08eb3620c1ea4fec46a744bce27b852021974f2d8b5d724f4fc3e80b"
+    )
+    version(
+        "2025.01.01", sha256="aff4f0795484e47f036233d9044a4f7cc873b837f3585527ad17292a71cdb7bd"
+    )
+    version(
+        "2024.01.02", sha256="e984a5c856547d9b49fab4f5ac76985f2b4f6d3ac0d29b76b34e827433767705"
+    )
     version("2025.01", sha256="19997ef5468a06c60c1e7af3a56ab7f8a33da814a30827293ca34df5bd888d6f")
     version("2024.03", sha256="4c1e6bdfafcfec19a4a1c08770c313ab3135d47ec8319f6b07f24d2589caf44d")
     version("2024.02", sha256="47e5740bb066f5eb032e1de163eb762c7258880a2932f4cc4e34e769e0cc2b0e")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Updates the FMS package with the most recent 2025 versions.

Also adds an ending version for the deprecated io variant, since that option was removed in the 2025.03 release.