### PR TITLE
curl: add 8.14.1

### DIFF
--- a/repos/spack_repo/builtin/packages/curl/package.py
+++ b/repos/spack_repo/builtin/packages/curl/package.py
@@ -29,9 +29,14 @@ class Curl(NMakePackage, AutotoolsPackage):
 
     license("curl")
 
-    version("8.11.1", sha256="e9773ad1dfa21aedbfe8e1ef24c9478fa780b1b3d4f763c98dd04629b5e43485")
+    version("8.14.1", sha256="5760ed3c1a6aac68793fc502114f35c3e088e8cd5c084c2d044abdf646ee48fb")
 
     # Deprecated versions due to CVEs
+    version(
+        "8.11.1",
+        sha256="e9773ad1dfa21aedbfe8e1ef24c9478fa780b1b3d4f763c98dd04629b5e43485",
+        deprecated=True,
+    )
     version(
         "8.10.1",
         sha256="3763cd97aae41dcf41950d23e87ae23b2edb2ce3a5b0cf678af058c391b6ae31",


### PR DESCRIPTION
Trying a simpler change for 2025.07.1 instead of the jump to 8.15.

8.11.1 has CVEs and triggers scanners. Update to 8.14.1 to solve that issue, but not (yet) 8.15.0.

8.15.0 removes support for secure transport and `cmake` requires a patch to work with it, so hold off on that update. This PR is meant to be backported to `v2025.07.1`. I think the 8.15.0 update will need to come later because it is more disruptive.