### PR TITLE
coin3d: add v4.0.4

### DIFF
--- a/repos/spack_repo/builtin/packages/coin3d/package.py
+++ b/repos/spack_repo/builtin/packages/coin3d/package.py
@@ -19,6 +19,7 @@ class Coin3d(AutotoolsPackage, CMakePackage):
 
     license("BSD-3-Clause")
 
+    version("4.0.4", sha256="80efd056a445050939a265db307d106ac7524105774d4be924a71b0cff23a719")  
     version("4.0.0", sha256="e4f4bd57804b8ed0e017424ad2e45c112912a928b83f86c89963df9015251476")
     version("3.1.0", sha256="70dd5ef39406e1d9e05eeadd54a5b51884a143e127530876a97744ca54173dc3")
     version("3.0.0", sha256="d5c2eb0ecaa5c83d93daf0e9e275e58a6a8dfadc74c873d51b0c939011f81bfa")
@@ -61,7 +62,9 @@ class Coin3d(AutotoolsPackage, CMakePackage):
     )
 
     def url_for_version(self, version):
-        if version >= Version("4.0.0"):
+        if version >= Version("4.0.1"):
+            url = "https://github.com/coin3d/coin/releases/download/v{0}/coin-{0}-src.tar.gz"
+        elif version >= Version("4.0.0"):
             url = "https://github.com/coin3d/coin/releases/download/Coin-{0}/coin-{0}-src.tar.gz"
         else:
             url = "https://github.com/coin3d/coin/archive/Coin-{0}.tar.gz"

--- a/repos/spack_repo/builtin/packages/coin3d/package.py
+++ b/repos/spack_repo/builtin/packages/coin3d/package.py
@@ -19,7 +19,7 @@ class Coin3d(AutotoolsPackage, CMakePackage):
 
     license("BSD-3-Clause")
 
-    version("4.0.4", sha256="80efd056a445050939a265db307d106ac7524105774d4be924a71b0cff23a719")  
+    version("4.0.4", sha256="80efd056a445050939a265db307d106ac7524105774d4be924a71b0cff23a719")
     version("4.0.0", sha256="e4f4bd57804b8ed0e017424ad2e45c112912a928b83f86c89963df9015251476")
     version("3.1.0", sha256="70dd5ef39406e1d9e05eeadd54a5b51884a143e127530876a97744ca54173dc3")
     version("3.0.0", sha256="d5c2eb0ecaa5c83d93daf0e9e275e58a6a8dfadc74c873d51b0c939011f81bfa")


### PR DESCRIPTION
This PR adds `coin3d`, v4.0.4 (bugfix, [release notes](https://github.com/coin3d/coin/releases/tag/v4.0.4), [diff](https://github.com/coin3d/coin/compare/Coin-4.0.0...v4.0.4)). No changes to the CMakeLists that need to be adapted here (asides from again a changed tag schema). This package is built in CI.

Test build:
```
==> No binary for coin3d-4.0.4-dbya2j75ualou7w3ueht2tztv6pplpst found: installing from source
==> Installing coin3d-4.0.4-dbya2j75ualou7w3ueht2tztv6pplpst [50/50]
==> Fetching https://github.com/coin3d/coin/releases/download/v4.0.4/coin-4.0.4-src.tar.gz
    [100%]   13.11 MB @   11.2 MB/s
==> No patches needed for coin3d
==> coin3d: Executing phase: 'cmake'
==> coin3d: Executing phase: 'build'
==> coin3d: Executing phase: 'install'
==> Pushed coin3d@4.0.4/dbya2j7: sha256:4f3f183fa22daf1646e59fcef0d7039e42a97292b190b9df87646a0d1d3912ef (1.91s, 2.15 MB/s)
==> Uploading manifests
==> Tagged coin3d@4.0.4/dbya2j7 as ghcr.io/wdconinc/spack:coin3d-4.0.4-dbya2j75ualou7w3ueht2tztv6pplpst.spack
==> coin3d: Pushed to build cache: 'ghcr-wdconinc-spack'
==> coin3d: Successfully installed coin3d-4.0.4-dbya2j75ualou7w3ueht2tztv6pplpst
  Stage: 1.81s.  Cmake: 7.32s.  Build: 4m 13.06s.  Install: 1.36s.  Post-install: 5.97s.  Total: 4m 29.62s
[+] /opt/software/linux-skylake/coin3d-4.0.4-dbya2j75ualou7w3ueht2tztv6pplpst
```
