### PR TITLE
sccache: fix `openssl` transitive dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/sccache/package.py
+++ b/repos/spack_repo/builtin/packages/sccache/package.py
@@ -40,7 +40,7 @@ class Sccache(CargoPackage):
     depends_on("rust@1.75:", type="build", when="@0.8.2:")
     depends_on("pkgconfig", type="build", when="platform=linux")
 
-    depends_on("openssl", when="+dist-server")
+    depends_on("openssl", when="platform=linux")
 
     @classmethod
     def determine_version(cls, exe):


### PR DESCRIPTION
`openssl` is always a transitive dependency on `linux`. Until Spack adds support for explicitly modeling Rust dependencies add a direct dependency for now. 