### PR TITLE
py-docutils: add v0.21.2

### DIFF
--- a/repos/spack_repo/builtin/packages/py_docutils/package.py
+++ b/repos/spack_repo/builtin/packages/py_docutils/package.py
@@ -21,6 +21,7 @@ class PyDocutils(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.21.2", sha256="3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f")
     version("0.20.1", sha256="f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b")
     version("0.19", sha256="33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6")
     version("0.18.1", sha256="679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06")
@@ -34,10 +35,14 @@ class PyDocutils(PythonPackage):
     version("0.12", sha256="c7db717810ab6965f66c8cf0398a98c9d8df982da39b4cd7f162911eb89596fa")
 
     depends_on("python@3.7:", when="@0.19:", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
+    depends_on("python@3.9:", when="@0.21:", type=("build", "run"))
 
-    # Uses 2to3
-    depends_on("py-setuptools@:57", when="@:0.15", type="build")
+    with when("@0.21:"):
+        depends_on("py-flit-core@3.11:3", type="build")
+    with when("@:0.20"):
+        depends_on("py-setuptools", type="build")
+        # Uses 2to3
+        depends_on("py-setuptools@:57", when="@:0.15", type="build")
 
     # Includes "longintrepr.h" instead of Python.h
     conflicts("^python@3.11:", when="@:0.15")

--- a/repos/spack_repo/builtin/packages/py_docutils/package.py
+++ b/repos/spack_repo/builtin/packages/py_docutils/package.py
@@ -38,7 +38,7 @@ class PyDocutils(PythonPackage):
     depends_on("python@3.9:", when="@0.21:", type=("build", "run"))
 
     with when("@0.21:"):
-        depends_on("py-flit-core@3.11:3", type="build")
+        depends_on("py-flit-core@3.4:3", type="build")
     with when("@:0.20"):
         depends_on("py-setuptools", type="build")
         # Uses 2to3


### PR DESCRIPTION
This PR adds `py-docutils`, v0.21.2, which switches to `flit_core` as build system (no diff on github, but https://github.com/docutils/docutils/blame/master/docutils/pyproject.toml for history).

Test build:
```
==> No binary for py-docutils-0.21.2-4iokowghuhwst6myv3xyg7vty33zmhva found: installing from source
==> Installing py-docutils-0.21.2-4iokowghuhwst6myv3xyg7vty33zmhva [28/28]
==> Using cached archive: /opt/spack/cache/_source-cache/archive/3a/3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f.tar.gz
==> No patches needed for py-docutils
==> py-docutils: Executing phase: 'install'
==> Pushed py-docutils@0.21.2/4iokowg: sha256:835c26ea2688a27c9234e0eaadaf2c9056c70cad316ab7d3c8ba756e6a6a5579 (3.15s, 0.39 MB/s)
==> Uploading manifests
==> Tagged py-docutils@0.21.2/4iokowg as ghcr.io/wdconinc/spack:py-docutils-0.21.2-4iokowghuhwst6myv3xyg7vty33zmhva.spack
==> py-docutils: Pushed to build cache: 'ghcr-wdconinc-spack'
==> py-docutils: Successfully installed py-docutils-0.21.2-4iokowghuhwst6myv3xyg7vty33zmhva
  Stage: 0.09s.  Install: 1.17s.  Post-install: 6.68s.  Total: 8.01s
[+] /opt/software/linux-skylake/py-docutils-0.21.2-4iokowghuhwst6myv3xyg7vty33zmhva
```