### PR TITLE
root: add v6.36.02

### DIFF
--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -35,6 +35,7 @@ class Root(CMakePackage):
     version("develop", branch="master")
 
     # Production release series
+    version("6.36.02", sha256="510d677b33ac7ca48aa0d712bdb88d835a1ff6a374ef86f1a1e168fa279eb470")
     version("6.36.00", sha256="94afc8def92842679a130a27521be66e2abdaa37620888e61d828a43fc4b01a2")
 
     # Supported LTS release series (note: more recent STS releases may be further down)


### PR DESCRIPTION
This PR adds `root`, v6.36.02, a bufix release ([release notes](https://github.com/root-project/root/releases/tag/v6-36-02), [diff](https://github.com/root-project/root/compare/v6-36-00...v6-36-02)). No changes to top level CMakeLists.txt that need to be adapted here. This package will be built in CI.