### PR TITLE
mlpack: add v4.6.2

### DIFF
--- a/repos/spack_repo/builtin/packages/mlpack/package.py
+++ b/repos/spack_repo/builtin/packages/mlpack/package.py
@@ -21,6 +21,7 @@ class Mlpack(CMakePackage):
 
     license("BSD-3-Clause", checked_by="wdconinc")
 
+    version("4.6.2", sha256="2fe772da383a935645ced07a07b51942ca178d38129df3bf685890bc3c1752cf")
     version("4.5.1", sha256="58059b911a78b8bda91eef4cfc6278383b24e71865263c2e0569cf5faa59dda3")
     version("4.5.0", sha256="aab70aee10c134ef3fe568843fe4b3bb5e8901af30ea666f57462ad950682317")
     version("4.4.0", sha256="61c604026d05af26c244b0e47024698bbf150dfcc9d77b64057941d7d64d6cf6")


### PR DESCRIPTION
This PR adds `mlpack`, v4.6.2 (release notes [4.6.0](https://github.com/mlpack/mlpack/releases/tag/4.6.0) [4.6.1](https://github.com/mlpack/mlpack/releases/tag/4.6.1) [4.6.2](https://github.com/mlpack/mlpack/releases/tag/4.6.2), [diff](https://github.com/mlpack/mlpack/compare/4.5.1...4.6.2)). Bugfix release primarily (now respects `CMAKE_BUILD_TYPE`). No changes needed to package recipe.
