### PR TITLE
mimalloc: add a range for when to apply a policy in CMake

### DIFF
--- a/repos/spack_repo/builtin/packages/mimalloc/package.py
+++ b/repos/spack_repo/builtin/packages/mimalloc/package.py
@@ -131,6 +131,6 @@ class Mimalloc(CMakePackage):
 
         # Use LTO also for non-Intel compilers please. This can be removed when they
         # bump cmake_minimum_required to VERSION 3.9.
-        if "+ipo" in self.spec:
+        if "+ipo" in self.spec and self.spec.satisfies("@:2.0.7"):
             args.append("-DCMAKE_POLICY_DEFAULT_CMP0069=NEW")
         return args


### PR DESCRIPTION
2.0.7 requires CMake 3.0 and 2.0.9 (the next tag) requires CMake 3.13 already and CMake 3.9 sets the policy to NEW: https://cmake.org/cmake/help/latest/policy/CMP0069.html
This will be useful when cleaning up old versions.