### PR TITLE
OpenMPI: can't build with flang 19 and older

### DIFF
--- a/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -784,6 +784,9 @@ with '-Wl,-commons,use_dylibs' and without
     conflicts("~internal-pmix", "+internal-hwloc")
     conflicts("~internal-pmix", "+internal-libevent")
 
+    # May be able to get working for LLVM 18/19 using FC=flang-new
+    conflicts("%fortran=clang %llvm@:19")
+
     filter_compiler_wrappers("openmpi/*-wrapper-data*", relative_root="share")
 
     extra_install_tests = "examples"


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Extracted out of #39 

@rbberger @hppritcha @naughtont3