### PR TITLE
py-libclang: setup.py renamed

### DIFF
--- a/repos/spack_repo/builtin/packages/py_libclang/package.py
+++ b/repos/spack_repo/builtin/packages/py_libclang/package.py
@@ -38,9 +38,14 @@ class PyLibclang(PythonPackage):
         depends_on("llvm+clang@" + ver, when="@" + ver, type="build")
 
     def patch(self):
+        if self.version >= Version("14"):
+            setup = "setup_ext.py"
+        else:
+            setup = "setup.py"
+
         filter_file(
             "source_dir = './native/'",
             "source_dir = '{0}'".format(self.spec["llvm"].libs.directories[0]),
-            "setup.py",
+            setup,
             string=True,
         )


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Extracted out of #39 

@rbberger @wdconinc @haampie @skosukhin @trws

Next problem is that the package calls `spec['llvm'].libs`, which calls `llvm-config`, which is not installed in the CI image because we only installed clang/flang. https://github.com/spack/gitlab-runners/pull/67 is one potential fix, but not very robust. Ideally, there would be some way to say that `py-libclang` requires `llvm+dev` and Spack would install it itself. Is there any variant or CMake flag that controls whether `llvm-config` or the actual library files get installed?