### PR TITLE
assimp: add v6.0.2

### DIFF
--- a/repos/spack_repo/builtin/packages/assimp/package.py
+++ b/repos/spack_repo/builtin/packages/assimp/package.py
@@ -20,6 +20,7 @@ class Assimp(CMakePackage):
     license("BSD-3-Clause", checked_by="wdconinc")
 
     version("master", branch="master")
+    version("6.0.2", sha256="d1822d9a19c9205d6e8bc533bf897174ddb360ce504680f294170cc1d6319751")
     version("5.4.3", sha256="66dfbaee288f2bc43172440a55d0235dfc7bf885dda6435c038e8000e79582cb")
     version("5.4.2", sha256="7414861a7b038e407b510e8b8c9e58d5bf8ca76c9dfe07a01d20af388ec5086a")
     version("5.4.0", sha256="a90f77b0269addb2f381b00c09ad47710f2aab6b1d904f5e9a29953c30104d3f")


### PR DESCRIPTION
This PR adds `assimp`, v6.0.2 (release notes [6.0.0](https://github.com/assimp/assimp/releases/tag/v6.0.0), [6.0.1](https://github.com/assimp/assimp/releases/tag/v6.0.1), [6.0.2](https://github.com/assimp/assimp/releases/tag/v6.0.2), [diff](https://github.com/assimp/assimp/compare/v5.4.3...v6.0.2)). No changes in CMakeLists.txt that need adapting our package recipe here. This package will be built in CI.

Test build:
```
-- linux-ubuntu25.04-skylake / %c,cxx=gcc@14.2.0 ----------------
h2ybdjc assimp@6.0.2~ipo+shared build_system=cmake build_type=Release generator=make
==> 1 installed package
```