### PR TITLE
py-hatch: add v1.14.1

### DIFF
--- a/repos/spack_repo/builtin/packages/py_hatch/package.py
+++ b/repos/spack_repo/builtin/packages/py_hatch/package.py
@@ -15,14 +15,16 @@ class PyHatch(PythonPackage):
 
     license("MIT")
 
+    version("1.14.1", sha256="ca1aff788f8596b0dd1f8f8dfe776443d2724a86b1976fabaf087406ba3d0713")
     version("1.13.0", sha256="5e1a75770cfe8f3ebae3abfded3a976238b0acefd19cdabc5245597525b8066f")
     version("1.12.0", sha256="ae80478d10312df2b44d659c93bc2ed4d33aecddce4b76378231bdf81c8bf6ad")
 
     depends_on("python@3.8:", type=("build", "run"))
 
-    depends_on("py-hatchling@1.24.2:", type="build")
+    depends_on("py-hatchling@1.24.2:", type=("build", "run"))
+    depends_on("py-hatchling@1.26.3:", type=("build", "run"), when="@1.14:")
     depends_on("py-hatch-vcs@0.3.0:", type="build")
-    depends_on("py-pyproject-hooks", type=("build"))
+    depends_on("py-pyproject-hooks", type="build")
 
     depends_on("py-click@8.0.6:", type=("build", "run"))
     depends_on("py-httpx@0.22.0:", type=("build", "run"))
@@ -37,5 +39,7 @@ class PyHatch(PythonPackage):
     depends_on("py-tomlkit@0.11.1:", type=("build", "run"))
     depends_on("py-userpath@1.7:1.7", type=("build", "run"))
     depends_on("py-uv@0.1.35:", type=("build", "run"))
+    depends_on("py-uv@0.5.23:", type=("build", "run"), when="@1.14:")
     depends_on("py-virtualenv@20.26.1:", type=("build", "run"))
-    depends_on("py-zstandard@:1", type=("build", "run"))
+    depends_on("py-virtualenv@20.26.6:", type=("build", "run"), when="@1.14:")
+    depends_on("py-zstandard@:0", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_hatch/package.py
+++ b/repos/spack_repo/builtin/packages/py_hatch/package.py
@@ -37,7 +37,7 @@ class PyHatch(PythonPackage):
     depends_on("py-shellingham@1.4.0:", type=("build", "run"))
     depends_on("py-tomli-w@1.0:", type=("build", "run"))
     depends_on("py-tomlkit@0.11.1:", type=("build", "run"))
-    depends_on("py-userpath@1.7:1.7", type=("build", "run"))
+    depends_on("py-userpath@1.7:1", type=("build", "run"))
     depends_on("py-uv@0.1.35:", type=("build", "run"))
     depends_on("py-uv@0.5.23:", type=("build", "run"), when="@1.14:")
     depends_on("py-virtualenv@20.26.1:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_virtualenv/package.py
+++ b/repos/spack_repo/builtin/packages/py_virtualenv/package.py
@@ -15,7 +15,7 @@ class PyVirtualenv(PythonPackage):
     git = "https://github.com/pypa/virtualenv.git"
 
     license("MIT")
-    version("20.26.6", sha256="280aede09a2a5c317e409a00102e7077c6432c5a38f0ef938e643805a7ad2c48")  
+    version("20.26.6", sha256="280aede09a2a5c317e409a00102e7077c6432c5a38f0ef938e643805a7ad2c48")
     version("20.26.5", sha256="ce489cac131aa58f4b25e321d6d186171f78e6cb13fafbf32a840cee67733ff4")
     version("20.26.4", sha256="c17f4e0f3e6036e9f26700446f85c76ab11df65ff6d8a9cbfad9f71aabfcf23c")
     version("20.26.3", sha256="4c43a2a236279d9ea36a0d76f98d84bd6ca94ac4e0f4a3b9d46d05e10fea542a")

--- a/repos/spack_repo/builtin/packages/py_virtualenv/package.py
+++ b/repos/spack_repo/builtin/packages/py_virtualenv/package.py
@@ -15,6 +15,7 @@ class PyVirtualenv(PythonPackage):
     git = "https://github.com/pypa/virtualenv.git"
 
     license("MIT")
+    version("20.26.6", sha256="280aede09a2a5c317e409a00102e7077c6432c5a38f0ef938e643805a7ad2c48")  
     version("20.26.5", sha256="ce489cac131aa58f4b25e321d6d186171f78e6cb13fafbf32a840cee67733ff4")
     version("20.26.4", sha256="c17f4e0f3e6036e9f26700446f85c76ab11df65ff6d8a9cbfad9f71aabfcf23c")
     version("20.26.3", sha256="4c43a2a236279d9ea36a0d76f98d84bd6ca94ac4e0f4a3b9d46d05e10fea542a")

--- a/repos/spack_repo/builtin/packages/py_virtualenv/package.py
+++ b/repos/spack_repo/builtin/packages/py_virtualenv/package.py
@@ -65,11 +65,11 @@ class PyVirtualenv(PythonPackage):
     depends_on(
         "py-importlib-metadata@0.12:3", when="@20.0.0:20.2.0 ^python@:3.7", type=("build", "run")
     )
-    depends_on("py-platformdirs@3.9.1:3", when="@20.24.1:", type=("build", "run"))
+    depends_on("py-platformdirs@3.9.1:4", when="@20.24.7:", type=("build", "run"))
+    depends_on("py-platformdirs@3.9.1:3", when="@20.24.1:20.24.6", type=("build", "run"))
     depends_on("py-platformdirs@3.2:3", when="@20.22:20.23.0", type=("build", "run"))
     depends_on("py-platformdirs@2.4:2", when="@20.16.3:20.21", type=("build", "run"))
     depends_on("py-platformdirs@2:2", when="@20.5:20.16.2", type=("build", "run"))
-
     # Historical dependencies
     with when("@:20.17"):
         # not just build-time, requires pkg_resources


### PR DESCRIPTION
This PR adds `py-hatch`, v1.14.1 ([diff](https://github.com/pypa/hatch/compare/hatch-v1.13.0...hatch-v1.14.1)). Some updated dependencies and two mistakes fixed: py-hatchling is a run dependency as well, and py-zstandard must be < 1 per pyproject.toml.