### PR TITLE
scikit-hep packages: update to latest major.minor versions

### DIFF
--- a/repos/spack_repo/builtin/packages/py_awkward/package.py
+++ b/repos/spack_repo/builtin/packages/py_awkward/package.py
@@ -10,7 +10,7 @@ from spack.package import *
 class PyAwkward(PythonPackage):
     """Manipulate JSON-like data with NumPy-like idioms."""
 
-    git = "https://github.com/scikit-hep/awkward-1.0.git"
+    git = "https://github.com/scikit-hep/awkward.git"
     pypi = "awkward/awkward-1.1.2.tar.gz"
     homepage = "https://awkward-array.org"
 
@@ -19,6 +19,9 @@ class PyAwkward(PythonPackage):
     license("BSD-3-Clause")
 
     version("main", branch="main")
+    version("2.8.5", sha256="4b9049440bb98214e05908098afd0d4f66af0b1b23c158159f9774db27447c89")
+    version("2.7.4", sha256="e79b4bfd68b2030123b4bb67d5179f92c7e9bede1dadc5a1416fce0acb6cc975")
+    version("2.6.10", sha256="3e8397e9bc4902c02d521d19552a6afb2bd94406c767bc85894bdb4ab3e9c4dc")
     version("2.6.6", sha256="6eeb426ca41b51fe3c36fbe767b90259979b08c14e3562497a71195a447c8b3c")
     version("2.1.1", sha256="fda8e1634161b8b46b151c074ff0fc631fc0feaec2ec277c4b40a2095110b0dd")
     version("2.1.0", sha256="73f7a76a1fb43e2557befee54b1381f3e6d90636983cdc54da1c2bcb9ad4c1a8")
@@ -69,15 +72,20 @@ class PyAwkward(PythonPackage):
         ("@2.0.9", "@10"),
         ("@2.0.10", "@11"),
         ("@2.1.0:2.1.1", "@12"),
-        ("@2.6.6:", "@35"),
+        ("@2.6.6", "@35"),
+        ("@2.6.10", "@40"),
+        ("@2.7.4", "@44"),
+        ("@2.8.5", "@47"),
     ]
+    depends_on("py-awkward-cpp", type=("build", "run"))
     for _awkward, _awkward_cpp in _awkward_to_awkward_cpp_map:
-        depends_on("py-awkward-cpp{}".format(_awkward_cpp), when=_awkward, type=("build", "run"))
+        depends_on(f"py-awkward-cpp{_awkward_cpp}", when=_awkward, type=("build", "run"))
 
     depends_on("python@2.7:2.8,3.5:", type=("build", "run"))
     depends_on("python@3.6:", when="@1.9:", type=("build", "run"))
     depends_on("python@3.7:", when="@1.10:", type=("build", "run"))
     depends_on("python@3.8:", when="@2.3:", type=("build", "run"))
+    depends_on("python@3.9:", when="@2.7:", type=("build", "run"))
     depends_on("py-numpy@1.13.1:", when="@:1", type=("build", "run"))
     depends_on("py-numpy@1.14.5:", when="@2.0", type=("build", "run"))
     depends_on("py-numpy@1.17.0:", when="@2.1:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_awkward_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/py_awkward_cpp/package.py
@@ -12,13 +12,16 @@ class PyAwkwardCpp(PythonPackage):
     It is not useful on its own, only as a dependency for py-awkward."""
 
     git = "https://github.com/scikit-hep/awkward.git"
-    pypi = "awkward-cpp/awkward-cpp-9.tar.gz"
+    pypi = "awkward-cpp/awkward_cpp-36.tar.gz"
     homepage = "https://awkward-array.org"
 
     maintainers("vvolkl", "wdconinc")
 
     license("BSD-3-Clause")
 
+    version("47", sha256="676cf4976810edab32187edf5a8a716af95047b9038c96d27d3be44f1331950f")
+    version("44", sha256="8dc499288d6d16b2ea20b51a27d5047e51a247b6aacfcbcb3b302cad6d3c87d8")
+    version("40", sha256="ca5658a3db04cc80e9c5d0eb9f7db41290d882c123a068bef724a879c9084367")
     version("35", sha256="1f8b112a597bd2438794e1a721a63aa61869fa9598a17ac6bd811ad6f6400d06")
     version("12", sha256="429f7fcc37a671afa67fe9680f2edc3a123d1c74d399e5889c654f9529f9f8f2")
     version("11", sha256="02d719a4da7487564b29b8e8b78925a32ac818b6f5572c2f55912b4e0e59c7a4")
@@ -36,7 +39,8 @@ class PyAwkwardCpp(PythonPackage):
 
     depends_on("python@3.7:", type=("build", "run"))
     depends_on("python@3.8:", type=("build", "run"), when="@19:")
-    depends_on("py-scikit-build-core@0.2.0:+pyproject", when="@10:", type="build")
+    depends_on("py-scikit-build-core@0.9:", when="@36:", type="build")
+    depends_on("py-scikit-build-core@0.10:", when="@38:", type="build")
     depends_on("py-pybind11", type=("build", "link"))
     depends_on("py-numpy@1.17.0:", when="@12:", type=("build", "run"))
     depends_on("py-numpy@1.18.0:", when="@19:", type=("build", "run"))
@@ -44,6 +48,13 @@ class PyAwkwardCpp(PythonPackage):
     # older versions
     depends_on("py-numpy@1.14.5:", when="@:11", type=("build", "run"))
     depends_on("py-scikit-build-core@0.1.3:+pyproject", when="@:9", type="build")
+    depends_on("py-scikit-build-core@0.2.0:+pyproject", when="@10:35", type="build")
 
     # https://github.com/scikit-hep/awkward/issues/3132#issuecomment-2136042870
     conflicts("%gcc@14:", when="@:33")
+
+    def url_for_version(self, version):
+        if version <= Version("35"):
+            return super().url_for_version(version).replace("_", "-")
+        else:
+            return super().url_for_version(version)

--- a/repos/spack_repo/builtin/packages/py_boost_histogram/package.py
+++ b/repos/spack_repo/builtin/packages/py_boost_histogram/package.py
@@ -30,7 +30,7 @@ class PyBoostHistogram(PythonPackage):
     with when("@1.5:"):
         depends_on("py-scikit-build-core@0.11:", type="build")
         depends_on("py-pybind11@2.13.3:", type="build")
-    with when("@:1.3"):
+    with when("@:1.4"):
         depends_on("py-setuptools@45:", type="build")
         depends_on("py-setuptools-scm@4.1.2:+toml", type="build")
 

--- a/repos/spack_repo/builtin/packages/py_boost_histogram/package.py
+++ b/repos/spack_repo/builtin/packages/py_boost_histogram/package.py
@@ -15,6 +15,8 @@ class PyBoostHistogram(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.5.2", sha256="51e42e830b848f08ad4d28de2ade18ded6e9a2fa4e6038becc9c72592e484e5c")
+    version("1.4.1", sha256="97146f735f467d506976a047f3f237ce59840a952fd231f5f431f897fb006cdd")
     version("1.3.2", sha256="e175efbc1054a27bc53fbbe95472cac9ea93999c91d0611840d776b99588d51a")
     version("1.3.1", sha256="31cd396656f3a37834e07d304cdb84d9906bc2172626a3d92fe577d08bcf410f")
     version("1.2.1", sha256="a27842b2f1cfecc509382da2b25b03056354696482b38ec3c0220af0fc9b7579")
@@ -22,8 +24,16 @@ class PyBoostHistogram(PythonPackage):
     depends_on("cxx", type="build")  # generated
 
     depends_on("python@3.6:", type=("build", "run"))
-    depends_on("py-setuptools@45:", type="build")
-    depends_on("py-setuptools-scm@4.1.2:+toml", type="build")
+    depends_on("python@3.7:", type=("build", "run"), when="@1.4")
+    depends_on("python@3.8:", type=("build", "run"), when="@1.5")
+
+    with when("@1.5:"):
+        depends_on("py-scikit-build-core@0.11:", type="build")
+        depends_on("py-pybind11@2.13.3:", type="build")
+    with when("@:1.3"):
+        depends_on("py-setuptools@45:", type="build")
+        depends_on("py-setuptools-scm@4.1.2:+toml", type="build")
+
     depends_on("py-numpy@1.13.3:", type=("build", "run"))
     # https://github.com/numpy/numpy/issues/26191#issuecomment-2179127999
     depends_on("py-numpy@:1", when="@:1.4.0", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_cramjam/package.py
+++ b/repos/spack_repo/builtin/packages/py_cramjam/package.py
@@ -17,4 +17,4 @@ class PyCramjam(PythonPackage):
 
     version("2.11.0", sha256="5c82500ed91605c2d9781380b378397012e25127e89d64f460fea6aeac4389b4")
 
-    depends_on("py-maturin@2.11:", type="build")
+    depends_on("py-maturin@0.14:", type="build")

--- a/repos/spack_repo/builtin/packages/py_cramjam/package.py
+++ b/repos/spack_repo/builtin/packages/py_cramjam/package.py
@@ -1,0 +1,19 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+from spack.package import *
+
+
+class PyCramjam(PythonPackage):
+    """Thin Python bindings to de/compression algorithms in Rust."""
+
+    homepage = "https://github.com/milesgranger/cramjam"
+    pypi = "cramjam/cramjam-2.11.0.tar.gz"
+
+    license("MIT", checked_by="wdconinc")
+
+    version("2.11.0", sha256="5c82500ed91605c2d9781380b378397012e25127e89d64f460fea6aeac4389b4")
+
+    depends_on("py-maturin@2.11:", type="build")

--- a/repos/spack_repo/builtin/packages/py_cramjam/package.py
+++ b/repos/spack_repo/builtin/packages/py_cramjam/package.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.python import PythonPackage
+
 from spack.package import *
 
 

--- a/repos/spack_repo/builtin/packages/py_hepunits/package.py
+++ b/repos/spack_repo/builtin/packages/py_hepunits/package.py
@@ -21,6 +21,7 @@ class PyHepunits(PythonPackage):
     license("BSD-3-Clause")
 
     version("master", branch="master")
+    version("2.3.6", sha256="cffc1c82040b15bb530542ec97f3c1f83aae6050caa4cc5c1a03097bebe34932")
     version("2.3.2", sha256="8a3366fa5d72c16af1166ed579cdaa81edd2676acb8f6a1fe7da290cefca3b08")
     version("2.3.1", sha256="b1174bba4d575b9939c01f341e24d9bdbe0e0cd4cc4ce2e7d77692da19145cfb")
     version("2.3.0", sha256="33b9ae9a8b7b3af355141a74901cb5aa557dce2e4c9992a0a30ef0443a1b2206")
@@ -35,6 +36,7 @@ class PyHepunits(PythonPackage):
     depends_on("python@2.7:2.8,3.5:", type=("build", "run"))
     depends_on("python@3.6:", when="@2.2:", type=("build", "run"))
     depends_on("python@3.7:", when="@2.3:", type=("build", "run"))
+    depends_on("python@3.8:", when="@2.3.4:", type=("build", "run"))
     depends_on("py-setuptools", when="@:2.2", type="build")
     depends_on("py-setuptools-scm +toml", when="@:2.2", type="build")
     depends_on("py-hatchling", when="@2.3:", type="build")

--- a/repos/spack_repo/builtin/packages/py_iminuit/package.py
+++ b/repos/spack_repo/builtin/packages/py_iminuit/package.py
@@ -17,6 +17,7 @@ class PyIminuit(PythonPackage):
 
     license("MIT AND LGPL-2.0-only", checked_by="wdconinc")
 
+    version("2.31.1", sha256="d5e004f1ffd83d2a076409fbf4a79691e7a17c9d73950bb63465af32e104de18")
     version("2.30.1", sha256="2815bfdeb8e7f78185f316b75e2d4b19d0f6993bdc5ff03352ed37b70a796360")
     version("2.29.1", sha256="474d10eb2f924b9320f6f7093e4c149d0a38c124d0419c12a07a3eca942de025")
     version("2.28.0", sha256="6646ae0b66a4760e02cd73711d460a6cf2375382b78ce8344141751595596aad")
@@ -55,8 +56,7 @@ class PyIminuit(PythonPackage):
     # See https://github.com/pybind/pybind11/pull/3368
     depends_on("python@:3.10", type=("build", "run"), when="@:2.21")
     with when("@2.22:"):
-        depends_on("py-scikit-build-core@0.3:+pyproject", type="build")
-        depends_on("py-scikit-build-core@0.5:+pyproject", type="build", when="@2.26:")
+        depends_on("py-scikit-build-core@0.10:", type="build", when="@2.31:")
         depends_on("py-pybind11", type="build")
         depends_on("py-pybind11@2.12:", type="build", when="@2.26:")
     with when("@:2.21"):
@@ -71,6 +71,9 @@ class PyIminuit(PythonPackage):
     depends_on("cmake@3.15:", type="build", when="@2.22:")
 
     # Historical dependencies
+    with when("@2.22:2.30"):
+        depends_on("py-scikit-build-core@0.3:+pyproject", type="build")
+        depends_on("py-scikit-build-core@0.5:+pyproject", type="build", when="@2.26:")
     with when("@:2.27"):
         depends_on("py-typing-extensions", when="@2.21: ^python@:3.8", type=("build", "run"))
         depends_on(

--- a/repos/spack_repo/builtin/packages/py_iminuit/package.py
+++ b/repos/spack_repo/builtin/packages/py_iminuit/package.py
@@ -55,12 +55,9 @@ class PyIminuit(PythonPackage):
     # Bundled pybind11@:2.92 until 2.21 fails to compile with python@3.11:
     # See https://github.com/pybind/pybind11/pull/3368
     depends_on("python@:3.10", type=("build", "run"), when="@:2.21")
-    with when("@2.22:"):
-        depends_on("py-scikit-build-core@0.10:", type="build", when="@2.31:")
-        depends_on("py-pybind11", type="build")
-        depends_on("py-pybind11@2.12:", type="build", when="@2.26:")
-    with when("@:2.21"):
-        depends_on("py-setuptools", type="build")
+    depends_on("py-scikit-build-core@0.10:", type="build", when="@2.31:")
+    depends_on("py-pybind11", type="build", when="@2.22:")
+    depends_on("py-pybind11@2.12:", type="build", when="@2.26:")
     depends_on("py-numpy", type=("build", "run"), when="@1.3:1.3.6")
     depends_on("py-numpy@1.11.3:", type=("build", "run"), when="@1.3.7:")
     # https://github.com/numpy/numpy/issues/26191#issuecomment-2179127999
@@ -71,6 +68,7 @@ class PyIminuit(PythonPackage):
     depends_on("cmake@3.15:", type="build", when="@2.22:")
 
     # Historical dependencies
+    depends_on("py-setuptools", type="build", when="@:2.21")
     with when("@2.22:2.30"):
         depends_on("py-scikit-build-core@0.3:+pyproject", type="build")
         depends_on("py-scikit-build-core@0.5:+pyproject", type="build", when="@2.26:")

--- a/repos/spack_repo/builtin/packages/py_mplhep/package.py
+++ b/repos/spack_repo/builtin/packages/py_mplhep/package.py
@@ -15,6 +15,7 @@ class PyMplhep(PythonPackage):
 
     license("MIT", checked_by="wdconinc")
 
+    version("0.4.0", sha256="485d67db2dd7a1091eee86580fe46cf32dd0b0fc34d6db6246b1ef59346a810c")
     version("0.3.59", sha256="06f4b3a799e92fe6982ed3939dd648d0f972781aca3dc814a83e5bbd970649fe")
     version("0.3.58", sha256="fed8b5d5fee92c7aa40cfe70e5b8d2b2bb8ed7aeb7a2c272d73b241279e1adba")
     version("0.3.57", sha256="3b04a91f75889e31c0d7a5e520dd092f2fd29fb6000418c26cf4e497cc977541")

--- a/repos/spack_repo/builtin/packages/py_particle/package.py
+++ b/repos/spack_repo/builtin/packages/py_particle/package.py
@@ -23,6 +23,7 @@ class PyParticle(PythonPackage):
     license("BSD-3-Clause")
 
     version("master", branch="master")
+    version("0.25.4", sha256="bfa77d8aa073e6b498f1ae2d4d4926b707662b060fb23eb986a7cdb4931f58af")
     version("0.25.3", sha256="78cf7e56e9e2118385fbfb8908d8395e7a267ab5f0596aaafebadb08cb04452b")
     version("0.25.2", sha256="1fa4bbee38bfeaef08a40b2779b4c30c5ce4fa2865a10c02acfe90679b4e61e9")
     version("0.25.1", sha256="9706748e95a706dffd49426db393298197fe1af819721c5d2c6e515764a1fb01")

--- a/repos/spack_repo/builtin/packages/py_uproot/package.py
+++ b/repos/spack_repo/builtin/packages/py_uproot/package.py
@@ -17,7 +17,7 @@ class PyUproot(PythonPackage):
     on C++ ROOT. Instead, it uses Numpy to cast blocks of data from the ROOT
     file as Numpy arrays."""
 
-    homepage = "https://github.com/scikit-hep/uproot4"
+    homepage = "https://github.com/scikit-hep/uproot5"
     pypi = "uproot/uproot-4.0.6.tar.gz"
 
     maintainers("vvolkl")
@@ -26,6 +26,13 @@ class PyUproot(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("5.6.3", sha256="47f2aefcdcae503c9a21900381ac42a7bc3274cd0c52cd0686700d282ad0f46b")
+    version("5.5.2", sha256="d765be4bea1df58cc237672fe4e8a10a2f7a40a2c7a8cf643333af48def07f5c")
+    version("5.4.2", sha256="53b245baf27067efd86fb92bd11d0efb12e8aff8b7455c85b27807e24e31d99b")
+    version("5.3.13", sha256="4af7cd874e7c1cd0703f17de70b52c9f2492cf0bca27d962c4a3f2755bb89fa9")
+    version("5.2.2", sha256="ce6abba7efaae35d891f15ad1757ece63620f0db12260403fbd0339e41951fc1")
+    version("5.1.2", sha256="f69ee9381243cb0fea58c01a94a8a7abee29de3b67cdb9c9c9cccdd2caccd934")
+    version("5.0.13", sha256="0b1a36c98a010bae5bea52f7fd98e85fee82cd7154af42a5e5a1ca6baf3dae25")
     version("5.0.5", sha256="1a2ac98d595bde7c83c7d5b716d33bb74abd44df6e8d84af62c638edb6c9abab")
     version("5.0.4", sha256="c4ea1af198e3292a4649e3fe789d11b038c1ed57c10f167fc3f52100300c2eea")
     version("5.0.3", sha256="a4ab3f2ea0b98746f601d43115a64b36f9c2145e9793da1e1cd9aaca72f311ab")
@@ -64,13 +71,21 @@ class PyUproot(PythonPackage):
 
     depends_on("python@2.6:2,3.5:", type=("build", "run"))
     depends_on("python@3.6:", type=("build", "run"), when="@4.2.0:")
+    depends_on("python@3.7:", type=("build", "run"), when="@5.0:")
+    depends_on("python@3.8:", type=("build", "run"), when="@5.1:")
+    depends_on("python@3.9:", type=("build", "run"), when="@5.5:")
     depends_on("py-hatchling", when="@5:", type="build")
+    depends_on("py-hatch-vcs", when="@5.2:", type="build")
     depends_on("py-setuptools", when="@:4", type=("build", "run"))
     depends_on("py-setuptools@42:", type=("build", "run"), when="@4.1.8:4")
     depends_on("py-awkward@2:", type=("build", "run"), when="@5:")
-    depends_on("py-importlib-metadata", when="@5: ^python@:3.7", type=("build", "run"))
+    depends_on("py-awkward@2.4.6:", type=("build", "run"), when="@5.1:")
+    depends_on("py-cramjam@2.5.0:", type=("build", "run"), when="@5.3:")
+    depends_on("py-xxhash", type=("build", "run"), when="@5.4:")
     depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-fsspec", type=("build", "run"))
     depends_on("py-packaging", when="@5:", type=("build", "run"))
+    depends_on("py-typing-extensions@4.1:", when="@5.1: ^python@:3.10", type=("build", "run"))
 
     depends_on("xrootd", when="+xrootd")
 
@@ -78,3 +93,6 @@ class PyUproot(PythonPackage):
     depends_on("xxhash", when="+lz4")
 
     depends_on("zstd", when="+zstd")
+
+    # Historical dependencies
+    depends_on("py-importlib-metadata", when="@5:5.2 ^python@:3.7", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_vector/package.py
+++ b/repos/spack_repo/builtin/packages/py_vector/package.py
@@ -19,6 +19,8 @@ class PyVector(PythonPackage):
 
     license("BSD-3-Clause", checked_by="wdconinc")
 
+    version("1.6.3", sha256="a85149a62fcaa8a4d95214ca217f3910ea6800d79d65ef1cfb1005720b4f713a")
+    version("1.5.2", sha256="42a027df219011eebab8144877b6cebcddf3113a713c23fcae2a81464454009a")
     version("1.5.1", sha256="41ec731fb67ea35af2075eb3a4d6c83ef93b580dade63010821cbc00f1b98961")
     version("1.5.0", sha256="77e48bd40b7e7d30a17bf79bb6ed0f2d6985d915fcb9bf0879836276a619a0a9")
     version("1.4.2", sha256="3805848eb9e53e9c60aa24dd5be88c842a6cd3d241e22984bfe12629b08536a9")


### PR DESCRIPTION
This PR updates the scikit-hep packages (https://github.com/scikit-hep) to their latest versions (latest patch release per major.minor series only).

- `py-awkward`: diffs [2.6.10](https://github.com/scikit-hep/awkward/compare/v2.6.6...v2.6.10) [2.7.4](https://github.com/scikit-hep/awkward/compare/v2.6.10...v2.7.4) [2.8.5](https://github.com/scikit-hep/awkward/compare/v2.7.4...v2.8.5)
  - `py-awkward-cpp`: [pyproject.toml](https://github.com/scikit-hep/awkward/blob/main/awkward-cpp/pyproject.toml) (packaged as subdirectory of `py-awkward` with no more separate tags)
- `py-boost-histogram`: [pyproject.toml](https://github.com/scikit-hep/boost-histogram/blob/main/pyproject.toml)
- `py-hepunits`: [pyproject.toml](https://github.com/scikit-hep/hepunits/blob/main/pyproject.toml)
- `py-iminuit`: [pyproject.toml](https://github.com/scikit-hep/iminuit/blob/main/pyproject.toml)
- `py-mplhep`: [pyproject.toml](https://github.com/scikit-hep/mplhep/blob/main/pyproject.toml)
- `py-particle`: [pyproject.toml](https://github.com/scikit-hep/particle/blob/main/pyproject.toml)
- `py-uproot`: diffs [5.0.13](https://github.com/scikit-hep/uproot5/compare/v5.0.5...v5.0.13) [5.1.2](https://github.com/scikit-hep/uproot5/compare/v5.0.13...v5.1.2) [5.2.2](https://github.com/scikit-hep/uproot5/compare/v5.1.2...v5.2.2) [5.3.13](https://github.com/scikit-hep/uproot5/compare/v5.2.2...v5.3.13) [5.4.2](https://github.com/scikit-hep/uproot5/compare/v5.3.13...v5.4.2) [5.5.2](https://github.com/scikit-hep/uproot5/compare/v5.4.2...v5.5.2) [5.6.3](https://github.com/scikit-hep/uproot5/compare/v5.5.2...v5.6.3)
  - `py-cramjam` is a new dependency
- `py-vector`: [pyproject.toml](https://github.com/scikit-hep/vector/blob/main/pyproject.toml)