### PR TITLE
sentencepiece: depends_on("c")

### DIFF
--- a/repos/spack_repo/builtin/packages/sentencepiece/package.py
+++ b/repos/spack_repo/builtin/packages/sentencepiece/package.py
@@ -23,6 +23,7 @@ class Sentencepiece(CMakePackage):
     version("0.1.91", sha256="acbc7ea12713cd2a8d64892f8d2033c7fd2bb4faecab39452496120ace9a4b1b")
     version("0.1.85", sha256="dd4956287a1b6af3cbdbbd499b7227a859a4e3f41c9882de5e6bdd929e219ae6")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     depends_on("cmake@3.1:", type="build")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

```plain_text
==> Installing sentencepiece-0.1.91-xx74jdcaygnijvyiepye6vxjmi22spss [87/197]
==> Using cached archive: /home/wukan/env-1.0.0/spack/var/spack/cache/_source-cache/archive/ac/acbc7ea12713cd2a8d64892f8d2033c7fd2bb4faecab39452496120ace9a4b1b.tar.gz
==> No patches needed for sentencepiece
==> sentencepiece: Executing phase: 'cmake'
==> Error: ProcessError: Command exited with status 1:
    '/home/wukan/env-1.0.0/spack/opt/spack/linux-x86_64_v3/cmake-3.31.8-naeb5h3z7vctpncvpe376wo6plvrz3do/bin/cmake' '-G' 'Unix Makefiles' '-DCMAKE_INSTALL_PREFIX:STRING=/home/wukan/env-1.0.0/spack/opt/spack/linux-x86_64_v3/sentencepiece-0.1.91-xx74jdcaygnijvyiepye6vxjmi22spss' '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=ON' '-DCMAKE_INSTALL_RPATH:STRING=/home/wukan/env-1.0.0/spack/opt/spack/linux-x86_64_v3/sentencepiece-0.1.91-xx74jdcaygnijvyiepye6vxjmi22spss/lib;/home/wukan/env-1.0.0/spack/opt/spack/linux-x86_64_v3/sentencepiece-0.1.91-xx74jdcaygnijvyiepye6vxjmi22spss/lib64' '-DCMAKE_PREFIX_PATH:STRING=/home/wukan/env-1.0.0/spack/opt/spack/linux-x86_64_v3/cmake-3.31.8-naeb5h3z7vctpncvpe376wo6plvrz3do;/home/wukan/env-1.0.0/spack/opt/spack/linux-x86_64_v3/compiler-wrapper-1.0-rwnqblirwn5aenlmsbvsieo7mzw672ee;/home/wukan/env-1.0.0/spack/opt/spack/linux-x86_64_v3/gmake-4.4.1-4rli3isyyromrvmau47aoccbs2t3yx72;/home/wukan/env-1.0.0/spack/opt/spack/linux-x86_64_v3/gperftools-2.15-4xe3oi6nh44yi4axjamyr33cu2xvkzc4;/home/wukan/env-1.0.0/spack/opt/spack/linux-x86_64_v3/libunwind-1.8.1-znnpnrbuc3szoajanhxljbhq2tazmjb7;/home/wukan/env-1.0.0/spack/opt/spack/linux-x86_64_v3/gcc-runtime-11.4.0-b2sdxxafzza7525gs6krozitcv63i2tb' '-DCMAKE_BUILD_TYPE:STRING=Release' '-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON' '-DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=OFF' '-DCMAKE_POLICY_DEFAULT_CMP0090:STRING=NEW' '-DCMAKE_FIND_USE_PACKAGE_REGISTRY:BOOL=OFF' '-DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON' '/tmp/wukan/spack-stage/spack-stage-sentencepiece-0.1.91-xx74jdcaygnijvyiepye6vxjmi22spss/spack-src'

3 errors found in build log:
     13    -- The C compiler identification is unknown
     14    -- The CXX compiler identification is GNU 11.4.0
     15    -- Detecting C compiler ABI info
     16    -- Detecting C compiler ABI info - failed
     17    -- Check for working C compiler: /home/wukan/env-1.0.0/spack/opt/spack/linux-x86_64_v3/compiler-wrapper-1.0-rwnqblirwn5aenlmsbvsieo7mzw672ee/libexec/spack/cc
     18    -- Check for working C compiler: /home/wukan/env-1.0.0/spack/opt/spack/linux-x86_64_v3/compiler-wrapper-1.0-rwnqblirwn5aenlmsbvsieo7mzw672ee/libexec/spack/cc - broken
  >> 19    CMake Error at /home/wukan/env-1.0.0/spack/opt/spack/linux-x86_64_v3/cmake-3.31.8-naeb5h3z7vctpncvpe376wo6plvrz3do/share/cmake-3.31/Modules/CMakeTestCCompiler.cmake:67 (messa
           ge):
     20      The C compiler
     21    
     22        "/home/wukan/env-1.0.0/spack/opt/spack/linux-x86_64_v3/compiler-wrapper-1.0-rwnqblirwn5aenlmsbvsieo7mzw672ee/libexec/spack/cc"
     23    
     24      is not able to compile a simple test program.
     25    

     ...

     30        Run Build Command(s): /home/wukan/env-1.0.0/spack/opt/spack/linux-x86_64_v3/cmake-3.31.8-naeb5h3z7vctpncvpe376wo6plvrz3do/bin/cmake -E env VERBOSE=1 /home/wukan/env-1.0.0
           /spack/opt/spack/linux-x86_64_v3/gmake-4.4.1-4rli3isyyromrvmau47aoccbs2t3yx72/bin/gmake -f Makefile cmTC_57769/fast
     31        /home/wukan/env-1.0.0/spack/opt/spack/linux-x86_64_v3/gmake-4.4.1-4rli3isyyromrvmau47aoccbs2t3yx72/bin/gmake  -f CMakeFiles/cmTC_57769.dir/build.make CMakeFiles/cmTC_5776
           9.dir/build
     32        gmake[1]: Entering directory '/tmp/wukan/spack-stage/spack-stage-sentencepiece-0.1.91-xx74jdcaygnijvyiepye6vxjmi22spss/spack-build-xx74jdc/CMakeFiles/CMakeScratch/TryComp
           ile-dKHURM'
     33        Building C object CMakeFiles/cmTC_57769.dir/testCCompiler.c.o
     34        /home/wukan/env-1.0.0/spack/opt/spack/linux-x86_64_v3/compiler-wrapper-1.0-rwnqblirwn5aenlmsbvsieo7mzw672ee/libexec/spack/cc    -o CMakeFiles/cmTC_57769.dir/testCCompiler
           .c.o -c /tmp/wukan/spack-stage/spack-stage-sentencepiece-0.1.91-xx74jdcaygnijvyiepye6vxjmi22spss/spack-build-xx74jdc/CMakeFiles/CMakeScratch/TryCompile-dKHURM/testCCompiler.c
     35        /home/wukan/env-1.0.0/spack/opt/spack/linux-x86_64_v3/compiler-wrapper-1.0-rwnqblirwn5aenlmsbvsieo7mzw672ee/libexec/spack/cc: 1: eval: SPACK_CC_LINKER_ARG: ERROR: LINKER 
           ARG WAS NOT SET, MAYBE THE PACKAGE DOES NOT DEPEND ON CC?
  >> 36    gmake[1]: *** [CMakeFiles/cmTC_57769.dir/build.make:81: CMakeFiles/cmTC_57769.dir/testCCompiler.c.o] Error 2
     37        gmake[1]: Leaving directory '/tmp/wukan/spack-stage/spack-stage-sentencepiece-0.1.91-xx74jdcaygnijvyiepye6vxjmi22spss/spack-build-xx74jdc/CMakeFiles/CMakeScratch/TryCompi
           le-dKHURM'
  >> 38        gmake: *** [Makefile:134: cmTC_57769/fast] Error 2
     39    
     40    
     41    
     42    
     43    
     44      CMake will not be able to correctly generate this project.

See build log for details:
  /tmp/wukan/spack-stage/spack-stage-sentencepiece-0.1.91-xx74jdcaygnijvyiepye6vxjmi22spss/spack-build-out.txt
```