### PR TITLE
gdrcopy: use `cuda_arch` information

### DIFF
--- a/repos/spack_repo/builtin/packages/gdrcopy/package.py
+++ b/repos/spack_repo/builtin/packages/gdrcopy/package.py
@@ -49,6 +49,10 @@ class Gdrcopy(MakefilePackage, CudaPackage):
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         env.set("CUDA", self.spec["cuda"].prefix)
+        env.set(
+            "NVCCFLAGS" if self.spec.satisfies("@2.4:") else "CUFLAGS",
+            "".join(self.cuda_flags(self.spec.variants["cuda_arch"].values)),
+        )
 
     def build(self, spec, prefix):
         make("lib")

--- a/repos/spack_repo/builtin/packages/gdrcopy/package.py
+++ b/repos/spack_repo/builtin/packages/gdrcopy/package.py
@@ -49,10 +49,9 @@ class Gdrcopy(MakefilePackage, CudaPackage):
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         env.set("CUDA", self.spec["cuda"].prefix)
-        env.set(
-            "NVCCFLAGS" if self.spec.satisfies("@2.4:") else "CUFLAGS",
-            "".join(self.cuda_flags(self.spec.variants["cuda_arch"].values)),
-        )
+
+        if self.spec.satisfies("@2.4:"):
+            env.set("NVCCFLAGS", "".join(self.cuda_flags(self.spec.variants["cuda_arch"].values)))
 
     def build(self, spec, prefix):
         make("lib")


### PR DESCRIPTION
Before this PR `gdrcopy` relied on an internal default, and more recently on an [internal custom script](https://github.com/NVIDIA/gdrcopy/blob/master/scripts/get_cuda_gencode.sh), to decide for which set of GPU architectures to build for.

With this change, the spack package now respects the value specified for the variant `cuda_arch`.

Not tested for older versions, but according to https://github.com/NVIDIA/gdrcopy/commit/43305764b41fe7edeb389f8a7c1d5d920085fdac the name of the variable has changed over time.