### PR TITLE
zlib-ng: disable avxvnni for gcc@:11 

### DIFF
--- a/repos/spack_repo/builtin/packages/zlib_ng/package.py
+++ b/repos/spack_repo/builtin/packages/zlib_ng/package.py
@@ -76,6 +76,12 @@ class ZlibNg(AutotoolsPackage, CMakePackage):
     def flag_handler(self, name, flags):
         if name == "cflags" and self.spec.satisfies("+pic build_system=autotools"):
             flags.append(self["c"].pic_flag)
+
+        # require gcc@12: to have an as version that support some of the avx512 calls used 
+        # https://access.redhat.com/solutions/7049696
+        if name == "cflags" and self.spec.satisfies("%gcc@:11"):
+            flags.append("-mno-avxvnni")
+
         return (flags, None, None)
 
 

--- a/repos/spack_repo/builtin/packages/zlib_ng/package.py
+++ b/repos/spack_repo/builtin/packages/zlib_ng/package.py
@@ -77,7 +77,7 @@ class ZlibNg(AutotoolsPackage, CMakePackage):
         if name == "cflags" and self.spec.satisfies("+pic build_system=autotools"):
             flags.append(self["c"].pic_flag)
 
-        # require gcc@12: to have an as version that support some of the avx512 calls used 
+        # require gcc@12: to have an as version that support some of the avx512 calls used
         # https://access.redhat.com/solutions/7049696
         if name == "cflags" and self.spec.satisfies("%gcc@:11"):
             flags.append("-mno-avxvnni")


### PR DESCRIPTION
With `gcc@:11`, `binutils@2.35` is too old to support the avx instructions emitted

```
  >> 202    /tmp/chris/374840/ccUPKedH.s:212: Error: unsupported instruction `vpdpbusd'
  >> 203    /tmp/chris/374840/ccUPKedH.s:216: Error: unsupported instruction `vpdpbusd'
  >> 204    /tmp/chris/374840/ccUPKedH.s:268: Error: unsupported instruction `vpdpbusd'
```

and so zlib-ng needs to be build with `CFLAGS="-mno-avxvnni"` (e.g., https://access.redhat.com/solutions/7049696)