### PR TITLE
netcdf-fortran: add v4.6.2

### DIFF
--- a/repos/spack_repo/builtin/packages/netcdf_fortran/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_fortran/package.py
@@ -26,6 +26,7 @@ class NetcdfFortran(AutotoolsPackage):
 
     license("Apache-2.0")
 
+    version("4.6.2", sha256="df26b99d9003c93a8bc287b58172bf1c279676f8c10d6dd0daf8bc7204877096")
     version("4.6.1", sha256="b50b0c72b8b16b140201a020936aa8aeda5c79cf265c55160986cd637807a37a")
     version("4.6.0", sha256="198bff6534cc85a121adc9e12f1c4bc53406c403bda331775a1291509e7b2f23")
     version("4.5.4", sha256="0a19b26a2b6e29fab5d29d7d7e08c24e87712d09a5cafeea90e16e0a2ab86b81")


### PR DESCRIPTION
Adds `netcdf-fortran` v4.6.2.
