### PR TITLE
tests: make spack internal deps explicit

### DIFF
--- a/tests/build_systems.py
+++ b/tests/build_systems.py
@@ -4,24 +4,21 @@
 
 import os
 import pathlib
+import platform
 import shutil
 
 import pytest
 from spack_repo.builtin.build_systems import autotools, cmake
 
-import spack
-import spack.concretize
-import spack.environment
-import spack.paths
-import spack.platforms
 import spack.platforms.test
-from spack.build_environment import ChildError, setup_package
+from spack.build_environment import setup_package
+from spack.concretize import concretize_one
+from spack.environment import Environment
 from spack.installer import PackageInstaller
 from spack.package import (
     FileList,
     InstallError,
     MakeExecutable,
-    Spec,
     create_builder,
     find,
     which,
@@ -141,7 +138,7 @@ class TestAutotoolsPackage:
 
     def test_libtool_archive_files_are_deleted_by_default(self, mutable_database):
         # Install a package that creates a mock libtool archive
-        s = spack.concretize.concretize_one("libtool-deletion")
+        s = concretize_one("libtool-deletion")
         PackageInstaller([s.package], explicit=True).install()
 
         # Assert the libtool archive is not there and we have
@@ -156,7 +153,7 @@ class TestAutotoolsPackage:
     ):
         # Install a package that creates a mock libtool archive,
         # patch its package to preserve the installation
-        s = spack.concretize.concretize_one("libtool-deletion")
+        s = concretize_one("libtool-deletion")
         monkeypatch.setattr(type(create_builder(s.package)), "install_libtool_archives", True)
         PackageInstaller([s.package], explicit=True).install()
 
@@ -168,9 +165,7 @@ class TestAutotoolsPackage:
         Tests whether only broken config.sub and config.guess are replaced with
         files from working alternatives from the gnuconfig package.
         """
-        s = spack.concretize.concretize_one(
-            Spec("autotools-config-replacement +patch_config_files +gnuconfig")
-        )
+        s = concretize_one("autotools-config-replacement +patch_config_files +gnuconfig")
         PackageInstaller([s.package]).install()
 
         with open(os.path.join(s.prefix.broken, "config.sub"), encoding="utf-8") as f:
@@ -189,9 +184,7 @@ class TestAutotoolsPackage:
         """
         Tests whether disabling patch_config_files
         """
-        s = spack.concretize.concretize_one(
-            Spec("autotools-config-replacement ~patch_config_files +gnuconfig")
-        )
+        s = concretize_one("autotools-config-replacement ~patch_config_files +gnuconfig")
         PackageInstaller([s.package]).install()
 
         with open(os.path.join(s.prefix.broken, "config.sub"), encoding="utf-8") as f:
@@ -208,8 +201,7 @@ class TestAutotoolsPackage:
 
     @pytest.mark.disable_clean_stage_check
     @pytest.mark.skipif(
-        str(spack.vendor.archspec.cpu.host().family) != "x86_64",
-        reason="test data is specific for x86_64",
+        platform.machine() not in ("AMD64", "x86_64"), reason="test data is specific for x86_64"
     )
     def test_autotools_gnuconfig_replacement_no_gnuconfig(self, mutable_database, monkeypatch):
         """
@@ -217,12 +209,10 @@ class TestAutotoolsPackage:
         enabled, but gnuconfig is not listed as a direct build dependency.
         """
         monkeypatch.setattr(spack.platforms.test.Test, "default", "x86_64")
-        s = spack.concretize.concretize_one(
-            Spec("autotools-config-replacement +patch_config_files ~gnuconfig")
-        )
+        s = concretize_one("autotools-config-replacement +patch_config_files ~gnuconfig")
 
         msg = "Cannot patch config files: missing dependencies: gnuconfig"
-        with pytest.raises(ChildError, match=msg):
+        with pytest.raises(Exception, match=msg):
             PackageInstaller([s.package]).install()
 
     @pytest.mark.disable_clean_stage_check
@@ -249,9 +239,9 @@ spack:
         )
 
         msg = "Spack could not find `config.guess`.*misconfigured as an external package"
-        with spack.environment.Environment(str(tmp_path / "env")) as e:
+        with Environment(str(tmp_path / "env")) as e:
             e.concretize()
-            with pytest.raises(ChildError, match=msg):
+            with pytest.raises(Exception, match=msg):
                 e.install_all()
 
 
@@ -292,7 +282,7 @@ class TestCMakePackage:
         assert define("SINGLE", "red") == "-DSINGLE:STRING=red"
 
     def test_define_from_variant(self):
-        s = spack.concretize.concretize_one("cmake-client multi=up,right ~truthy single=red")
+        s = concretize_one("cmake-client multi=up,right ~truthy single=red")
 
         arg = s.package.define_from_variant("MULTI")
         assert arg == "-DMULTI:STRING=right;up"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,23 +15,24 @@ import pytest
 
 import spack.bootstrap.core
 import spack.caches
-import spack.concretize
-import spack.config
-import spack.environment as ev
-import spack.error
 import spack.package_base
-import spack.paths
-import spack.platforms
-import spack.repo
-import spack.spec
 import spack.stage
-import spack.store
 import spack.subprocess_context
-import spack.vendor.archspec.cpu
+from spack.concretize import concretize_one
+from spack.config import (
+    CONFIG_DEFAULTS,
+    DirectoryConfigScope,
+    InternalConfigScope,
+    use_configuration,
+)
 from spack.enums import ConfigScopePriority
 from spack.installer import PackageInstaller
-from spack.llnl.util.filesystem import copy_tree, mkdirp, remove_linked_tree, touchp
-from spack.package import host_platform
+from spack.package import copy_tree, host_platform, mkdirp, remove_linked_tree
+from spack.platforms import Test as TestPlatform
+from spack.platforms import use_platform
+from spack.repo import from_path, use_repositories
+from spack.store import use_store
+from spack.vendor.archspec.cpu import host as host_cpu
 
 
 @pytest.fixture(autouse=True)
@@ -71,27 +72,6 @@ def record_monkeypatch_setattr():
         yield
     finally:
         _pytest.monkeypatch.MonkeyPatch.setattr = saved_setattr
-
-
-#
-# Disable any active Spack environment BEFORE all tests
-#
-@pytest.fixture(scope="session", autouse=True)
-def clean_user_environment():
-    spack_env_value = os.environ.pop(ev.spack_env_var, None)
-    with ev.no_active_environment():
-        yield
-    if spack_env_value:
-        os.environ[ev.spack_env_var] = spack_env_value
-
-
-#
-# Make sure global state of active env does not leak between tests.
-#
-@pytest.fixture(scope="function", autouse=True)
-def clean_test_environment():
-    yield
-    ev.deactivate()
 
 
 #
@@ -230,7 +210,7 @@ class MockCache:
 
 class MockCacheFetcher:
     def fetch(self):
-        raise spack.error.FetchError("Mock cache always fails for tests")
+        raise Exception("Mock cache always fails for tests")
 
     def __str__(self):
         return "[mock fetch cache]"
@@ -238,23 +218,16 @@ class MockCacheFetcher:
 
 @pytest.fixture(autouse=True)
 def mock_fetch_cache(monkeypatch):
-    """Substitutes spack.paths.FETCH_CACHE with a mock object that does nothing
-    and raises on fetch.
-    """
+    """Substitutes FETCH_CACHE that raises on fetch."""
     monkeypatch.setattr(spack.caches, "FETCH_CACHE", MockCache())
 
 
-@pytest.fixture(scope="session")
-def test_platform():
-    return spack.platforms.Test()
-
-
 @pytest.fixture(autouse=True, scope="session")
-def _use_test_platform(test_platform):
+def _use_test_platform():
     # This is the only context manager used at session scope (see note
     # below for more insight) since we want to use the test platform as
     # a default during tests.
-    with spack.platforms.use_platform(test_platform):
+    with use_platform(TestPlatform()):
         yield
 
 
@@ -286,16 +259,16 @@ def _use_test_platform(test_platform):
 #
 @pytest.fixture(scope="session")
 def mock_packages_repo():
-    yield spack.repo.from_path(
-        os.path.join(os.path.dirname(__file__), "repos", "spack_repo", "builtin_mock")
-    )
+    yield from_path(os.path.join(os.path.dirname(__file__), "repos", "spack_repo", "builtin_mock"))
 
 
 def _pkg_install_fn(pkg, spec, prefix):
     # sanity_check_prefix requires something in the install directory
     mkdirp(prefix.bin)
-    if not os.path.exists(spec.package.install_log_path):
-        touchp(spec.package.install_log_path)
+    path = Path(spec.package.install_log_path)
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
 
 
 @pytest.fixture
@@ -307,7 +280,7 @@ def mock_pkg_install(monkeypatch):
 def mock_packages(mock_packages_repo, mock_pkg_install, request):
     """Use the 'builtin_mock' repository instead of 'builtin'"""
     ensure_configuration_fixture_run_before(request)
-    with spack.repo.use_repositories(mock_packages_repo) as mock_repo:
+    with use_repositories(mock_packages_repo) as mock_repo:
         yield mock_repo
 
 
@@ -347,7 +320,7 @@ def configuration_dir(tmp_path_factory: pytest.TempPathFactory, linux_os):
     config_template = test_config / "config.yaml"
     config.write_text(config_template.read_text().format(install_tree_root, locks))
 
-    target = str(spack.vendor.archspec.cpu.host().family)
+    target = str(host_cpu().family)
     compilers = tmp_path / "site" / "packages.yaml"
     compilers_template = test_config / "packages.yaml"
     compilers.write_text(compilers_template.read_text().format(linux_os=linux_os, target=target))
@@ -358,23 +331,20 @@ def configuration_dir(tmp_path_factory: pytest.TempPathFactory, linux_os):
 def _create_mock_configuration_scopes(configuration_dir):
     """Create the configuration scopes used in `config` and `mutable_config`."""
     return [
+        (ConfigScopePriority.BUILTIN, InternalConfigScope("_builtin", CONFIG_DEFAULTS)),
         (
-            ConfigScopePriority.BUILTIN,
-            spack.config.InternalConfigScope("_builtin", spack.config.CONFIG_DEFAULTS),
+            ConfigScopePriority.CONFIG_FILES,
+            DirectoryConfigScope("site", str(configuration_dir / "site")),
         ),
         (
             ConfigScopePriority.CONFIG_FILES,
-            spack.config.DirectoryConfigScope("site", str(configuration_dir / "site")),
+            DirectoryConfigScope("system", str(configuration_dir / "system")),
         ),
         (
             ConfigScopePriority.CONFIG_FILES,
-            spack.config.DirectoryConfigScope("system", str(configuration_dir / "system")),
+            DirectoryConfigScope("user", str(configuration_dir / "user")),
         ),
-        (
-            ConfigScopePriority.CONFIG_FILES,
-            spack.config.DirectoryConfigScope("user", str(configuration_dir / "user")),
-        ),
-        (ConfigScopePriority.COMMAND_LINE, spack.config.InternalConfigScope("command_line")),
+        (ConfigScopePriority.COMMAND_LINE, InternalConfigScope("command_line")),
     ]
 
 
@@ -387,7 +357,7 @@ def mock_configuration_scopes(configuration_dir):
 @pytest.fixture(scope="function")
 def config(mock_configuration_scopes):
     """This fixture activates/deactivates the mock configuration."""
-    with spack.config.use_configuration(*mock_configuration_scopes) as config:
+    with use_configuration(*mock_configuration_scopes) as config:
         yield config
 
 
@@ -398,7 +368,7 @@ def mutable_config(tmp_path_factory: pytest.TempPathFactory, configuration_dir):
     shutil.copytree(configuration_dir, mutable_dir)
 
     scopes = _create_mock_configuration_scopes(mutable_dir)
-    with spack.config.use_configuration(*scopes) as cfg:
+    with use_configuration(*scopes) as cfg:
         yield cfg
 
 
@@ -447,7 +417,7 @@ def _populate(mock_db):
     """
 
     def _install(spec):
-        s = spack.concretize.concretize_one(spec)
+        s = concretize_one(spec)
         PackageInstaller([s.package], fake=True, explicit=True).install()
 
     _install("mpileaks ^mpich")
@@ -491,9 +461,9 @@ def mock_store(
 
     # If the cache does not exist populate the store and create it
     if not os.path.exists(str(store_cache / ".spack-db")):
-        with spack.config.use_configuration(*mock_configuration_scopes):
-            with spack.store.use_store(str(store_path)) as store:
-                with spack.repo.use_repositories(mock_packages_repo):
+        with use_configuration(*mock_configuration_scopes):
+            with use_store(str(store_path)) as store:
+                with use_repositories(mock_packages_repo):
                     # make the DB filesystem writable only while we populate it
                     _recursive_chmod(store_path, 0o755)
                     _populate(store.db)
@@ -509,7 +479,7 @@ def mock_store(
 @pytest.fixture(scope="function")
 def database_mutable_config(mock_store, mock_packages, mutable_config, monkeypatch):
     """This activates the mock store, packages, AND config."""
-    with spack.store.use_store(str(mock_store)) as store:
+    with use_store(str(mock_store)) as store:
         yield store.db
         store.db.last_seen_verifier = ""
 
@@ -554,9 +524,7 @@ def default_mock_concretization(config, mock_packages, concretized_specs_cache):
     def _func(spec_str, tests=False):
         key = spec_str, tests
         if key not in concretized_specs_cache:
-            concretized_specs_cache[key] = spack.concretize.concretize_one(
-                spack.spec.Spec(spec_str), tests=tests
-            )
+            concretized_specs_cache[key] = concretize_one(spec_str, tests=tests)
         return concretized_specs_cache[key].copy()
 
     return _func


### PR DESCRIPTION
* make the dependency of tests on `spack` modules explicit
* remove unnecessary imports of `spack` modules