### PR TITLE
py-datalad-metalad: add v0.4.22

### DIFF
--- a/repos/spack_repo/builtin/packages/py_datalad_metalad/package.py
+++ b/repos/spack_repo/builtin/packages/py_datalad_metalad/package.py
@@ -15,6 +15,7 @@ class PyDataladMetalad(PythonPackage):
 
     license("MIT")
 
+    version("0.4.22", sha256="14c48598de4fd23298ac0b326f8d9d1b215fef756d67dd4d173108cedbad1756")
     version("0.4.17", sha256="8854d5b8bc8387eff27639510f10c3cffe9cd76be018512a5d451be9708242b9")
     version("0.4.5", sha256="db1a0675e3c67fe2d9093e7098b142534f49588dea5ee048ee962422a9927fbf")
     version("0.2.1", sha256="70fe423136a168f7630b3e0ff1951e776d61e7d5f36670bddf24299ac0870285")
@@ -22,7 +23,6 @@ class PyDataladMetalad(PythonPackage):
     depends_on("py-setuptools@30.3:", type=("build"))
     depends_on("py-setuptools", type=("build"))
 
-    depends_on("py-six", when="@0.3.1:", type=("build", "run"))
     depends_on("py-datalad@0.18:", when="@0.4.11:", type=("build", "run"))
     depends_on("py-datalad@0.15.6:", when="@0.3:", type=("build", "run"))
     depends_on("py-datalad@0.12.3:", type=("build", "run"))
@@ -32,3 +32,6 @@ class PyDataladMetalad(PythonPackage):
     depends_on("py-pytest", when="@0.4.11:", type=("build", "run"))
     depends_on("py-pyyaml", when="@0.3.1:", type=("build", "run"))
     depends_on("git-annex", type=("run"))
+
+    # Historical dependencies
+    depends_on("py-six", when="@0.3.1:0.4.17", type=("build", "run"))


### PR DESCRIPTION
https://github.com/datalad/datalad-metalad/tree/0.4.22

Requires: #841

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
