### PR TITLE
gaudi: avoid build error by disallowing to build against cxxstd=17

### DIFF
--- a/repos/spack_repo/builtin/packages/gaudi/package.py
+++ b/repos/spack_repo/builtin/packages/gaudi/package.py
@@ -57,6 +57,20 @@ class Gaudi(CMakePackage, CudaPackage):
 
     maintainers("drbenmorgan", "vvolkl", "jmcarcell")
 
+    variant("cxxstd", default="20", values=(20, 23))
+    _cxxstd_values = (
+        conditional("14", when="@:39"),
+        conditional("17", when="@:39"),
+        conditional("20", when="@39:"),
+    )
+    _cxxstd_common = {
+        "values": _cxxstd_values,
+        "multi": False,
+        "description": "Use the specified C++ standard when building.",
+    }
+    variant("cxxstd", default="17", when="@:39", **_cxxstd_common)
+    variant("cxxstd", default="20", when="@39:", **_cxxstd_common)
+
     variant("aida", default=False, description="Build AIDA interfaces support")
     variant("cppunit", default=False, description="Build with CppUnit unit testing")
     variant("docs", default=False, description="Build documentation with Doxygen")
@@ -145,8 +159,12 @@ class Gaudi(CMakePackage, CudaPackage):
     depends_on("py-six", type=("build", "run"))
     depends_on("py-pyyaml", type=("build", "run", "test"))
     depends_on("range-v3")
-    depends_on("root +python +root7 +ssl +tbb")
+    depends_on("root cxxstd= +python +root7 +ssl +tbb")
     requires("^root +threads", when="^root@:6.19.01")
+    # force root to have the same cxxstd
+    for _cxxstd in _cxxstd_values:
+        for _v in _cxxstd:
+            depends_on(f"root cxxstd={_v.value}", when=f"cxxstd={_v.value}")
     depends_on("zlib-api")
     depends_on("py-pytest-cov", when="@39:")
 
@@ -203,6 +221,11 @@ class Gaudi(CMakePackage, CudaPackage):
         # Gaudi@39: needs C++ >= 20, and we need to force CMake to use C++ 20 with old gcc:
         if self.spec.satisfies("@39: %gcc@:13"):
             args.append(self.define("GAUDI_CXX_STANDARD", "20"))
+        if self.spec.satisfies("%apple-clang"):
+            args.append(self.define("GAUDI_CXX_STANDARD", "20"))
+            # fixes a build error with apple-clang
+            args.append(self.define("CMAKE_CXX_FLAGS", "-fmodules"))
+
         return args
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:

--- a/repos/spack_repo/builtin/packages/gaudi/package.py
+++ b/repos/spack_repo/builtin/packages/gaudi/package.py
@@ -67,7 +67,7 @@ class Gaudi(CMakePackage, CudaPackage):
         "multi": False,
         "description": "Use the specified C++ standard when building.",
     }
-    variant("cxxstd", default="17", when="@:39", **_cxxstd_common)
+    variant("cxxstd", default="17", when="@:38", **_cxxstd_common)
     variant("cxxstd", default="20", when="@39:", **_cxxstd_common)
 
     variant("aida", default=False, description="Build AIDA interfaces support")
@@ -218,10 +218,8 @@ class Gaudi(CMakePackage, CudaPackage):
         ]
         # Release notes for v39.0: https://gitlab.cern.ch/gaudi/Gaudi/-/releases/v39r0
         # Gaudi@39: needs C++ >= 20, and we need to force CMake to use C++ 20 with old gcc:
-        if self.spec.satisfies("@39: %gcc@:13"):
-            args.append(self.define("GAUDI_CXX_STANDARD", "20"))
+        args.append(self.define_from_variant("GAUDI_CXX_STANDARD", "cxxstd"))
         if self.spec.satisfies("%apple-clang"):
-            args.append(self.define("GAUDI_CXX_STANDARD", "20"))
             # fixes a build error with apple-clang
             args.append(self.define("CMAKE_CXX_FLAGS", "-fmodules"))
 

--- a/repos/spack_repo/builtin/packages/gaudi/package.py
+++ b/repos/spack_repo/builtin/packages/gaudi/package.py
@@ -58,9 +58,9 @@ class Gaudi(CMakePackage, CudaPackage):
     maintainers("drbenmorgan", "vvolkl", "jmcarcell")
 
     _cxxstd_values = (
-        conditional("14", when="@:39"),
-        conditional("17", when="@:39"),
-        conditional("20", when="@39:"),
+        conditional("14", when="@:38"),
+        conditional("17", when="@:38"),
+        conditional("20", when="@38:"),
     )
     _cxxstd_common = {
         "values": _cxxstd_values,

--- a/repos/spack_repo/builtin/packages/gaudi/package.py
+++ b/repos/spack_repo/builtin/packages/gaudi/package.py
@@ -159,7 +159,7 @@ class Gaudi(CMakePackage, CudaPackage):
     depends_on("py-six", type=("build", "run"))
     depends_on("py-pyyaml", type=("build", "run", "test"))
     depends_on("range-v3")
-    depends_on("root cxxstd= +python +root7 +ssl +tbb")
+    depends_on("root +python +root7 +ssl +tbb")
     requires("^root +threads", when="^root@:6.19.01")
     # force root to have the same cxxstd
     for _cxxstd in _cxxstd_values:

--- a/repos/spack_repo/builtin/packages/gaudi/package.py
+++ b/repos/spack_repo/builtin/packages/gaudi/package.py
@@ -57,7 +57,7 @@ class Gaudi(CMakePackage, CudaPackage):
 
     maintainers("drbenmorgan", "vvolkl", "jmcarcell")
 
-    variant("cxxstd", default="20", values=(20, 23))
+    variant("cxxstd", default="20", values=(20))
     _cxxstd_values = (
         conditional("14", when="@:39"),
         conditional("17", when="@:39"),

--- a/repos/spack_repo/builtin/packages/gaudi/package.py
+++ b/repos/spack_repo/builtin/packages/gaudi/package.py
@@ -57,7 +57,6 @@ class Gaudi(CMakePackage, CudaPackage):
 
     maintainers("drbenmorgan", "vvolkl", "jmcarcell")
 
-    variant("cxxstd", default="20", values=(20))
     _cxxstd_values = (
         conditional("14", when="@:39"),
         conditional("17", when="@:39"),


### PR DESCRIPTION
* also fixes macos compilation

Logic for cxxstd taken from acts, will be good to review

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
