### PR TITLE
py-datalad: fix py-setuptools restriction for old versions

### DIFF
--- a/repos/spack_repo/builtin/packages/py_datalad/package.py
+++ b/repos/spack_repo/builtin/packages/py_datalad/package.py
@@ -47,7 +47,7 @@ class PyDatalad(PythonPackage):
     # upper bound needed because otherwise the following error occurs:
     # 'extras_require' must be a dictionary whose values are strings or lists
     # of strings containing valid project/version requirement specifiers.
-    depends_on("py-setuptools@40.8.0:66", when="@:17", type="build")
+    depends_on("py-setuptools@40.8.0:66", when="@:0.17", type="build")
 
     depends_on("git", type=("build", "run"))
     depends_on("git-annex", type=("build", "run"))


### PR DESCRIPTION
Fix typo in `py-datalad` version resulting in all versions using the old `py-setuptools` version

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
