### PR TITLE
tempestextremes: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/tempestextremes/package.py
+++ b/repos/spack_repo/builtin/packages/tempestextremes/package.py
@@ -1,0 +1,44 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack.package import *
+
+
+class Tempestextremes(CMakePackage):
+    """ TempestExtremes is a growing collection of detection and
+    characterization algorithms for large climate datasets, leveraging C++ for
+    rapid throughput and a command line interface that maximizes flexibility
+    of each kernel. The tracking kernels in this package have been already
+    used for tracking and characterizing tropical cyclones (TCs), extratropical
+    cyclones (ETCs), monsoonal depressions, atmospheric blocks, atmospheric
+    rivers, and mesoscale convective systems (MCSs). By considering multiple
+    extremes within the same framework, we can study the joint characteristics
+    of extremes while minimizing the total data burden.
+    """
+
+    homepage = "https://github.com/ClimateGlobalChange/tempestextremes"
+    url = "https://github.com/ClimateGlobalChange/tempestextremes/archive/refs/tags/v2.3.tar.gz"
+
+    maintainers("andrewdnolan", "paullric", "xylar")
+
+    license("BSD-2-Clause", checked_by="andrewdnolan")
+
+    version("2.3.1", sha256="eff3564a99b0711335bd4f08e3a7dcec401c56d58fe6ef2d1ae778d7f7bf04e0")
+    version("2.3", sha256="1194a3825ce7754bda6bdfc97da5390c8e37895f2a41fb2f22a480df0b777564")
+
+    variant('mpi', default=True, description='Build with MPI support')
+
+    depends_on("cxx", type="build")
+
+    # Required dependencies
+    depends_on("cmake@3.12:", type="build")
+    depends_on('netcdf-c')
+
+    # Optional dependencies
+    depends_on('mpi', when='+mpi')
+
+    def cmake_args(self):
+        args = [self.define_from_variant("ENABLE_MPI", "mpi")]
+        return args

--- a/repos/spack_repo/builtin/packages/tempestextremes/package.py
+++ b/repos/spack_repo/builtin/packages/tempestextremes/package.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+
 from spack.package import *
 
 

--- a/repos/spack_repo/builtin/packages/tempestextremes/package.py
+++ b/repos/spack_repo/builtin/packages/tempestextremes/package.py
@@ -7,7 +7,7 @@ from spack.package import *
 
 
 class Tempestextremes(CMakePackage):
-    """ TempestExtremes is a growing collection of detection and
+    """TempestExtremes is a growing collection of detection and
     characterization algorithms for large climate datasets, leveraging C++ for
     rapid throughput and a command line interface that maximizes flexibility
     of each kernel. The tracking kernels in this package have been already
@@ -28,16 +28,16 @@ class Tempestextremes(CMakePackage):
     version("2.3.1", sha256="eff3564a99b0711335bd4f08e3a7dcec401c56d58fe6ef2d1ae778d7f7bf04e0")
     version("2.3", sha256="1194a3825ce7754bda6bdfc97da5390c8e37895f2a41fb2f22a480df0b777564")
 
-    variant('mpi', default=True, description='Build with MPI support')
+    variant("mpi", default=True, description="Build with MPI support")
 
     depends_on("cxx", type="build")
 
     # Required dependencies
     depends_on("cmake@3.12:", type="build")
-    depends_on('netcdf-c')
+    depends_on("netcdf-c")
 
     # Optional dependencies
-    depends_on('mpi', when='+mpi')
+    depends_on("mpi", when="+mpi")
 
     def cmake_args(self):
         args = [self.define_from_variant("ENABLE_MPI", "mpi")]


### PR DESCRIPTION
Adds `TempestExtremes` package, with package versions `v2.3` and `v2.3.1`, which use a `cmake` build system. Earlier package versions are not included because they use `make` based builds. @paullric if older versions are something you'd like included, I can look into supporting both `make` and `cmake` build systems. I just didn't want to wade into that unless it's something absolutely needed.  

For some context, with Spack's recent `v1.0.0` [release](https://github.com/spack/spack/releases/tag/v1.0.0) packages have been moved to their own repository. I'm working with @xylar to move some our development over from [`E3SM-Project/spack`](https://github.com/E3SM-Project/spack/) to this repo, where appropriate. This seemed like a good option to move over into the main `spack-packages` repo. 
