### PR TITLE
openmpi: Fix style issue not caught in #357

### DIFF
--- a/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -635,7 +635,12 @@ with '-Wl,-commons,use_dylibs' and without
 '-Wl,-flat_namespace'.""",
     )
 
-    variant("cray-xpmem", default=False, when="fabrics=xpmem", description="use cray-xpmem instead of xpmem configure flag")
+    variant(
+        "cray-xpmem",
+        default=False,
+        when="fabrics=xpmem",
+        description="use cray-xpmem instead of xpmem configure flag",
+    )
 
     # Patch to allow two-level namespace on a MacOS platform when building
     # openmpi. Unfortuntately, the openmpi configure command has flat namespace


### PR DESCRIPTION
This PR fixes a style issue not caught in #357 that is causing a ci-develop failure.