### PR TITLE
PRRTE: Q to @tgambin: How to don't use /usr for external packages

### DIFF
--- a/repos/spack_repo/builtin/packages/prrte/package.py
+++ b/repos/spack_repo/builtin/packages/prrte/package.py
@@ -83,11 +83,8 @@ class Prrte(AutotoolsPackage):
         spec = self.spec
         config_args = ["--enable-shared", "--enable-static", "--disable-sphinx"]
 
-        # libevent
-        config_args.append("--with-libevent={0}".format(spec["libevent"].prefix))
-        # hwloc
-        config_args.append("--with-hwloc={0}".format(spec["hwloc"].prefix))
-        # pmix
-        config_args.append("--with-pmix={0}".format(spec["pmix"].prefix))
+        for dep in ["libevent", "hwloc", "pmix"]:
+            prefix = spec[dep].prefix
+            config_args.append(f"--with-{dep}" if is_system_path(prefix) else f"--with-{dep}={prefix}")
 
         return config_args

--- a/repos/spack_repo/builtin/packages/prrte/package.py
+++ b/repos/spack_repo/builtin/packages/prrte/package.py
@@ -85,6 +85,8 @@ class Prrte(AutotoolsPackage):
 
         for dep in ["libevent", "hwloc", "pmix"]:
             prefix = spec[dep].prefix
-            config_args.append(f"--with-{dep}" if is_system_path(prefix) else f"--with-{dep}={prefix}")
+            config_args.append(
+                f"--with-{dep}" if is_system_path(prefix) else f"--with-{dep}={prefix}"
+            )
 
         return config_args


### PR DESCRIPTION
Hello @haampie and @tgamblin,

Edit by @bernhardkaindl: The first paragraph was already merged with #917:

First, according to the PRRTE [docs](https://docs.prrte.org/en/v4.0.0/install.html#minimum-pmix-version) and the configure file itself, PRRTE 4+ requires PMIx 6+. I have added the relevant dependency requirement to avoid build failures when an older PMIx is on the system.


Second, for a variety of reasons, we really prefer to build our own hwloc and libevent as externals. Unfortunately, due to Spack's external logic, the `/usr` path gets inserted for these by default. This leads to an autotools race condition where the general `/usr/lib64` path is put on the link line first, where the compiler also finds and links to an older system default PMIx. Therefore, I have added some logic to remove these spurious paths when they are not necessary. However, this is part of a broader discussion on how this should be handled in Spack as the method I use to do this is deprecated.

This has been tested as part of a broader Open MPI installation on LLNL [Matrix](https://hpc.llnl.gov/hardware/compute-platforms/matrix) and appears to work correctly with some benchmarks and smoke tests.

Please let me know what you think.

Thanks,
Nate

@spackbot fix style
