### PR TITLE
formatting: make `ruff check` pass

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ skip-magic-trailing-comma = true
 
 [tool.ruff.lint]
 extend-select = ["I"]
-ignore = ["E731", "E203"]
+ignore = ["E731", "E203", "F403", "F405", "F811"]
 
 [tool.ruff.lint.isort]
 split-on-trailing-comma = false

--- a/repos/spack_repo/builtin/build_systems/racket.py
+++ b/repos/spack_repo/builtin/build_systems/racket.py
@@ -85,7 +85,7 @@ class RacketBuilder(Builder):
         raco = Executable("raco")
         with working_dir(self.build_directory):
             parallel = pkg.parallel and (
-                not os.environ.get("SPACK_NO_PARALLEL_MAKE", "false").lower() in ("true", "1")
+                os.environ.get("SPACK_NO_PARALLEL_MAKE", "false").lower() not in ("true", "1")
             )
             name = pkg.racket_name
             assert name is not None, "Racket package name is not set"


### PR DESCRIPTION
- [x] update `pyproject.toml` so that `ruff check` passes
    * We can't do star imports yet, so this is mostly about those
- [x] fix one remaining issue in `racket`: use `not in`