### PR TITLE
netcdf-c: depends on curl

### DIFF
--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -186,9 +186,9 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
     depends_on("curl@7.18.0:", when="+byterange")
 
     # curl is supposed to only be needed when +dap or +byterange, but the check is missing
-    # this is fixed in 4.9.3
+    # this is fixed in 4.9.3. Spack autotools already protects against this
     # https://github.com/Unidata/netcdf-c/issues/3016
-    depends_on("curl@7.18.0:", when="@:4.9.2")
+    depends_on("curl@7.18.0:", when="@:4.9.2 ^build_system=cmake")
 
     # Need to include libxml2 when using DAP in 4.9.0 and newer to build
     # https://github.com/Unidata/netcdf-c/commit/53464e89635a43b812b5fec5f7abb6ff34b9be63

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -185,6 +185,11 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
     depends_on("curl@7.18.0:", when="+dap")
     depends_on("curl@7.18.0:", when="+byterange")
 
+    # curl is supposed to only be needed when +dap or +byterange, but the check is missing
+    # this is fixed in 4.9.3
+    # https://github.com/Unidata/netcdf-c/issues/3016
+    depends_on("curl@7.18.0:", when="@:4.9.2")
+
     # Need to include libxml2 when using DAP in 4.9.0 and newer to build
     # https://github.com/Unidata/netcdf-c/commit/53464e89635a43b812b5fec5f7abb6ff34b9be63
     depends_on("libxml2", when="@4.9.0:+dap")

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -188,7 +188,7 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
     # curl is supposed to only be needed when +dap or +byterange, but the check is missing
     # this is fixed in 4.9.3. Spack autotools already protects against this
     # https://github.com/Unidata/netcdf-c/issues/3016
-    depends_on("curl@7.18.0:", when="@:4.9.2 ^build_system=cmake")
+    depends_on("curl@7.18.0:", when="@:4.9.2 build_system=cmake")
 
     # Need to include libxml2 when using DAP in 4.9.0 and newer to build
     # https://github.com/Unidata/netcdf-c/commit/53464e89635a43b812b5fec5f7abb6ff34b9be63


### PR DESCRIPTION
Even though `netcdf-c` is only supposed to depend on `curl` when `+dap`, it doesn't correctly do this until 4.9.3

https://github.com/Unidata/netcdf-c/issues/3016

https://github.com/Unidata/netcdf-c/pull/2907
https://github.com/Unidata/netcdf-c/pull/3018

This looks to impact both autotools and cmake builds. 

@skosukhin @WardF 
