### PR TITLE
moab: add tempest variant

### DIFF
--- a/repos/spack_repo/builtin/packages/moab/package.py
+++ b/repos/spack_repo/builtin/packages/moab/package.py
@@ -21,7 +21,7 @@ class Moab(AutotoolsPackage):
     git = "https://bitbucket.org/fathomteam/moab.git"
     url = "https://web.cels.anl.gov/projects/sigma/downloads/moab/moab-5.5.1.tar.gz"
 
-    maintainers("vijaysm", "iulian787")
+    maintainers("vijaysm", "iulian787", "xylar", "andrewdnolan")
 
     license("LGPL-3.0-only")
 

--- a/repos/spack_repo/builtin/packages/moab/package.py
+++ b/repos/spack_repo/builtin/packages/moab/package.py
@@ -97,6 +97,7 @@ class Moab(AutotoolsPackage):
     depends_on("eigen", when="+eigen")
     # FIXME it seems that zoltan needs to be built without fortran
     depends_on("zoltan~fortran", when="+zoltan")
+    depends_on("tempestremap@2.2", when="@5.5.1+tempest")
     depends_on("tempestremap@2.2", when="@5.5.0+tempest")
     depends_on("tempestremap@2.1.6", when="@5.4.1+tempest")
     depends_on("tempestremap@2.1.6", when="@5.4.0+tempest")

--- a/repos/spack_repo/builtin/packages/moab/package.py
+++ b/repos/spack_repo/builtin/packages/moab/package.py
@@ -55,7 +55,9 @@ class Moab(AutotoolsPackage):
     variant("fbigeom", default=False, description="Enable FBiGeom interface")
     variant("coupler", default=False, description="Enable mbcoupler tool")
     variant("dagmc", default=False, description="Enable DagMC tool")
-    variant("tempest", default=False, when="@5.1: +hdf5 +netcdf", description="Enable mbtempest tool")
+    variant(
+        "tempest", default=False, when="@5.1: +hdf5 +netcdf", description="Enable mbtempest tool"
+    )
 
     variant("debug", default=False, description="Enable debug symbols in libraries")
     variant("shared", default=False, description="Enables the build of shared libraries")

--- a/repos/spack_repo/builtin/packages/moab/package.py
+++ b/repos/spack_repo/builtin/packages/moab/package.py
@@ -97,6 +97,8 @@ class Moab(AutotoolsPackage):
     depends_on("eigen", when="+eigen")
     # FIXME it seems that zoltan needs to be built without fortran
     depends_on("zoltan~fortran", when="+zoltan")
+    depends_on("tempestremap@2.1.6", when="@5.4.1+tempest")
+    depends_on("tempestremap@2.1.6", when="@5.4.0+tempest")
     depends_on("tempestremap@2.1.1", when="@5.3.1+tempest")
     depends_on("tempestremap@2.1.0", when="@5.3.0+tempest")
     depends_on("tempestremap@2.0.5", when="@5.2.1+tempest")

--- a/repos/spack_repo/builtin/packages/moab/package.py
+++ b/repos/spack_repo/builtin/packages/moab/package.py
@@ -55,6 +55,7 @@ class Moab(AutotoolsPackage):
     variant("fbigeom", default=False, description="Enable FBiGeom interface")
     variant("coupler", default=False, description="Enable mbcoupler tool")
     variant("dagmc", default=False, description="Enable DagMC tool")
+    variant("tempest", default=False, description="Enable mbtempest tool")
 
     variant("debug", default=False, description="Enable debug symbols in libraries")
     variant("shared", default=False, description="Enables the build of shared libraries")
@@ -64,6 +65,8 @@ class Moab(AutotoolsPackage):
     conflicts("+pnetcdf", when="~mpi")
     conflicts("+parmetis", when="~mpi")
     conflicts("+coupler", when="~mpi")
+    conflicts("+tempest", when="~netcdf")
+    conflicts("+tempest", when="@:5.0.2")
 
     # There are many possible variants for MOAB. Here are examples for
     # two of them:
@@ -94,6 +97,12 @@ class Moab(AutotoolsPackage):
     depends_on("eigen", when="+eigen")
     # FIXME it seems that zoltan needs to be built without fortran
     depends_on("zoltan~fortran", when="+zoltan")
+    depends_on("tempestremap@2.1.1", when="@5.3.1+tempest")
+    depends_on("tempestremap@2.1.0", when="@5.3.0+tempest")
+    depends_on("tempestremap@2.0.5", when="@5.2.1+tempest")
+    depends_on("tempestremap@2.0.3", when="@5.2.0+tempest")
+    depends_on("tempestremap@2.0.2", when="@5.1.0+tempest")
+    depends_on("eigen", when="+tempest")
 
     patch("tools-492.patch", when="@4.9.2")
 
@@ -207,6 +216,15 @@ class Moab(AutotoolsPackage):
             options.append("--disable-fortran")
         else:
             options.append("--enable-fortran")
+
+        if "+tempest" in spec:
+            options.append("--with-tempestremap={}".format(
+                spec["tempestremap"].prefix))
+            options.append("--with-eigen3={}/include/eigen3".format(
+                spec["eigen"].prefix))
+        else:
+            options.append("--without-tempestremap")
+            options.append("--without-eigen3")
 
         return options
 

--- a/repos/spack_repo/builtin/packages/moab/package.py
+++ b/repos/spack_repo/builtin/packages/moab/package.py
@@ -223,10 +223,8 @@ class Moab(AutotoolsPackage):
             options.append("--enable-fortran")
 
         if "+tempest" in spec:
-            options.append("--with-tempestremap={}".format(
-                spec["tempestremap"].prefix))
-            options.append("--with-eigen3={}/include/eigen3".format(
-                spec["eigen"].prefix))
+            options.append("--with-tempestremap={}".format(spec["tempestremap"].prefix))
+            options.append("--with-eigen3={}/include/eigen3".format(spec["eigen"].prefix))
         else:
             options.append("--without-tempestremap")
             options.append("--without-eigen3")

--- a/repos/spack_repo/builtin/packages/moab/package.py
+++ b/repos/spack_repo/builtin/packages/moab/package.py
@@ -97,6 +97,7 @@ class Moab(AutotoolsPackage):
     depends_on("eigen", when="+eigen")
     # FIXME it seems that zoltan needs to be built without fortran
     depends_on("zoltan~fortran", when="+zoltan")
+    depends_on("tempestremap@2.2", when="@master+tempest")
     depends_on("tempestremap@2.2", when="@5.5.1+tempest")
     depends_on("tempestremap@2.2", when="@5.5.0+tempest")
     depends_on("tempestremap@2.1.6", when="@5.4.1+tempest")

--- a/repos/spack_repo/builtin/packages/moab/package.py
+++ b/repos/spack_repo/builtin/packages/moab/package.py
@@ -55,7 +55,7 @@ class Moab(AutotoolsPackage):
     variant("fbigeom", default=False, description="Enable FBiGeom interface")
     variant("coupler", default=False, description="Enable mbcoupler tool")
     variant("dagmc", default=False, description="Enable DagMC tool")
-    variant("tempest", default=False, description="Enable mbtempest tool")
+    variant("tempest", default=False, when="@5.1: +hdf5 +netcdf", description="Enable mbtempest tool")
 
     variant("debug", default=False, description="Enable debug symbols in libraries")
     variant("shared", default=False, description="Enables the build of shared libraries")
@@ -65,10 +65,6 @@ class Moab(AutotoolsPackage):
     conflicts("+pnetcdf", when="~mpi")
     conflicts("+parmetis", when="~mpi")
     conflicts("+coupler", when="~mpi")
-    conflicts("+tempest", when="~netcdf")
-    conflicts("+tempest", when="~hdf5")
-    # The 'tempest' variant is only supported starting from version 5.1.0
-    conflicts("+tempest", when="@:5.0.99")
 
     # There are many possible variants for MOAB. Here are examples for
     # two of them:
@@ -99,17 +95,15 @@ class Moab(AutotoolsPackage):
     depends_on("eigen", when="+eigen")
     # FIXME it seems that zoltan needs to be built without fortran
     depends_on("zoltan~fortran", when="+zoltan")
-    depends_on("tempestremap@2.2", when="@master+tempest")
-    depends_on("tempestremap@2.2", when="@5.5.1+tempest")
-    depends_on("tempestremap@2.2", when="@5.5.0+tempest")
-    depends_on("tempestremap@2.1.6", when="@5.4.1+tempest")
-    depends_on("tempestremap@2.1.6", when="@5.4.0+tempest")
-    depends_on("tempestremap@2.1.1", when="@5.3.1+tempest")
-    depends_on("tempestremap@2.1.0", when="@5.3.0+tempest")
-    depends_on("tempestremap@2.0.5", when="@5.2.1+tempest")
-    depends_on("tempestremap@2.0.3", when="@5.2.0+tempest")
-    depends_on("tempestremap@2.0.2", when="@5.1.0+tempest")
-    depends_on("eigen", when="+tempest")
+    with when("+tempest"):
+        depends_on("tempestremap@2.2", when="@5.5:")
+        depends_on("tempestremap@2.1.6", when="@5.4")
+        depends_on("tempestremap@2.1.1", when="@5.3.1")
+        depends_on("tempestremap@2.1.0", when="@5.3.0")
+        depends_on("tempestremap@2.0.5", when="@5.2.1")
+        depends_on("tempestremap@2.0.3", when="@5.2.0")
+        depends_on("tempestremap@2.0.2", when="@5.1.0")
+        depends_on("eigen")
 
     patch("tools-492.patch", when="@4.9.2")
 
@@ -224,7 +218,7 @@ class Moab(AutotoolsPackage):
         else:
             options.append("--enable-fortran")
 
-        if "+tempest" in spec:
+        if spec.satisfies("+tempest"):
             options.append("--with-tempestremap={}".format(spec["tempestremap"].prefix))
             options.append("--with-eigen3={}/include/eigen3".format(spec["eigen"].prefix))
         else:

--- a/repos/spack_repo/builtin/packages/moab/package.py
+++ b/repos/spack_repo/builtin/packages/moab/package.py
@@ -66,7 +66,9 @@ class Moab(AutotoolsPackage):
     conflicts("+parmetis", when="~mpi")
     conflicts("+coupler", when="~mpi")
     conflicts("+tempest", when="~netcdf")
-    conflicts("+tempest", when="@:5.0.2")
+    conflicts("+tempest", when="~hdf5")
+    # The 'tempest' variant is only supported starting from version 5.1.0
+    conflicts("+tempest", when="@:5.0.99")
 
     # There are many possible variants for MOAB. Here are examples for
     # two of them:

--- a/repos/spack_repo/builtin/packages/moab/package.py
+++ b/repos/spack_repo/builtin/packages/moab/package.py
@@ -97,6 +97,7 @@ class Moab(AutotoolsPackage):
     depends_on("eigen", when="+eigen")
     # FIXME it seems that zoltan needs to be built without fortran
     depends_on("zoltan~fortran", when="+zoltan")
+    depends_on("tempestremap@2.2", when="@5.5.0+tempest")
     depends_on("tempestremap@2.1.6", when="@5.4.1+tempest")
     depends_on("tempestremap@2.1.6", when="@5.4.0+tempest")
     depends_on("tempestremap@2.1.1", when="@5.3.1+tempest")


### PR DESCRIPTION
Adds a `tempest` variant to `moab`.  Enables the `mbtempest` tool for generating remapping weights from `tempestremap` through `moab`. See here for more details: 
 >  https://sigma.mcs.anl.gov/moab/offline-remapping-workflow-with-mbtempest/

Also adds @andrewdnolan and @xylar as maintainers. 