### PR TITLE
meshlab: depends_on qt +ssl

### DIFF
--- a/repos/spack_repo/builtin/packages/meshlab/package.py
+++ b/repos/spack_repo/builtin/packages/meshlab/package.py
@@ -27,7 +27,7 @@ class Meshlab(CMakePackage):
     depends_on("eigen")
     depends_on("glew")
     depends_on("mpfr")
-    depends_on("qt@5.15: +opengl")
+    depends_on("qt@5.15: +opengl +ssl")
 
     def cmake_args(self):
         args = [


### PR DESCRIPTION
This PR fixes `meshlab`'s dependency on `qt`. There is a `QSslSocket` include somewhere in the `meshlab` codebase.