### PR TITLE
adios2: fix load when using python

### DIFF
--- a/repos/spack_repo/builtin/packages/adios2/package.py
+++ b/repos/spack_repo/builtin/packages/adios2/package.py
@@ -405,6 +405,13 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
                 exe = which(join_path(self.prefix.bin, cmd))
                 exe(*opts)
 
+    def test_python(self):
+        """Test adios2 python"""
+        if self.spec.satisfies("+python"):
+            with test_part(self, "test_python_import", purpose="import adios2 in python"):
+                python = Executable(self.spec["python"].prefix.bin.python)
+                python(*(["-c", "import adios2; print(adios2.__version__)"]))
+
     def test_install(self):
         """Build and run an install tests"""
         srcdir = self.test_suite.current_test_cache_dir.testing.install.C

--- a/repos/spack_repo/builtin/packages/adios2/package.py
+++ b/repos/spack_repo/builtin/packages/adios2/package.py
@@ -199,6 +199,7 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("python", when="+python", type=("build", "run"))
     depends_on("python@2.7:2.8,3.5:3.10", when="@:2.4.0 +python", type=("build", "run"))
     depends_on("python@3.5:3.10", when="@2.5.0:2.7 +python", type=("build", "run"))
+    depends_on("python@3.8:", when="@2.10: +python", type=("build", "run"))
 
     depends_on("python", type="test")
     depends_on("python@2.7:2.8,3.5:3.10", when="@:2.4.0", type="test")
@@ -328,6 +329,12 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
         if spec.satisfies("+rocm"):
             args.append(CMakeBuilder.define_hip_architectures(self))
 
+        if spec.satisfies("+python"):
+            py_libdir = join_path(
+                self.prefix.lib, f"python{spec['python'].version.up_to(2)}", "site-packages"
+            )
+            args.append(self.define("CMAKE_INSTALL_PYTHONDIR", py_libdir))
+
         return args
 
     @property
@@ -368,6 +375,12 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
             env.prepend_path("HDF5_PLUGIN_PATH", os.path.dirname(all_libs[idx]))
         except ValueError:
             pass
+
+        if "+python" in self.spec:
+            py_libdir = join_path(
+                self.prefix.lib, f"python{self.spec['python'].version.up_to(2)}", "site-packages"
+            )
+            env.prepend_path("PYTHONPATH", py_libdir)
 
     @run_after("install")
     def setup_install_tests(self):


### PR DESCRIPTION
This properly fixes loading the adios2 python module so that it is visible to the python interpreter when `spack load adios2+python`

This PR also bumps the python deps to 3.8 which reflects the min requirements in adios2 2.10.

This PR also adds a python smoke test to avoid regressions in the future

Related: https://github.com/spack/spack-packages/pull/873

Original issue: https://github.com/ornladios/ADIOS2/issues/4485#issuecomment-3134939062