### PR TITLE
ci: use `python -m pip install` instead of `pip install`

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -31,7 +31,7 @@ jobs:
         python-version: ${{inputs.python_version}}
     - name: Install Python packages
       run: |
-        pip install --upgrade pip setuptools pytest coverage[toml]
+        python -m pip install --upgrade pip setuptools pytest coverage[toml]
     - name: Setup for Windows run
       if: runner.os == 'Windows'
       run: |


### PR DESCRIPTION
The windows audits (at least) has started to fail with an error if we invoke pip as `pip install` and not with `python -m pip install`.

- [x] Update CI to use `python -m pip install`
