### PR TITLE
Add ajpotts as Arkouda package maintainer

### DIFF
--- a/repos/spack_repo/builtin/packages/arkouda/package.py
+++ b/repos/spack_repo/builtin/packages/arkouda/package.py
@@ -23,7 +23,7 @@ class Arkouda(MakefilePackage):
 
     # A list of GitHub accounts to notify when the package is updated.
     # TODO: add arkouda devs github account
-    maintainers("arezaii")
+    maintainers("ajpotts", "arezaii")
 
     version("master", branch="master")
 


### PR DESCRIPTION
This PR adds ajpotts as a maintainer of the arkouda package.
- Updates the maintainers() list to include my GitHub handle.
- I’m part of the Arkouda development team and will be helping maintain the Spack package going forward.
