### PR TITLE
py-tensorstore: bump version to 0.1.84 with bazel-8.7.0 to fix build

### DIFF
--- a/repos/spack_repo/builtin/packages/bazel/SPACK_INCLUDE_DIRS-0.8-code.patch
+++ b/repos/spack_repo/builtin/packages/bazel/SPACK_INCLUDE_DIRS-0.8-code.patch
@@ -1,0 +1,68 @@
+From: Bernhard Kaindl <bernhardkaindl7@gmail.com>
+Subject: [PATCH 1/2] bazel-0.8.7: Add SPACK_INCLUDE_DIRS patch
+--- a/BUILD
++++ b/BUILD
+@@ -88,6 +88,7 @@ genrule(
+         "//third_party:grpc-java-12222.patch",
+         "//third_party:rules_graalvm_fix.patch",
+         "//third_party:rules_graalvm_unicode.patch",
++        "//third_party:rules_cc_spack_include_dirs.patch",
+     ],
+     outs = ["MODULE.bazel.lock.dist"],
+     cmd = " && ".join([
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -75,6 +75,14 @@ single_version_override(
+     ],
+ )
+
++# Add SPACK_INCLUDE_DIRS support to rules_cc for spack package manager integration
++single_version_override(
++    module_name = "rules_cc",
++    patch_strip = 1,
++    patches = ["//third_party:rules_cc_spack_include_dirs.patch"],
++    version = "0.1.1",
++)
++
+ # Remove once the following PRs are available in a grpc-java release.
+ #   https://github.com/grpc/grpc-java/pull/12207
+ #   https://github.com/grpc/grpc-java/pull/12222
+--- /dev/null
++++ b/third_party/rules_cc_spack_include_dirs.patch
+@@ -0,0 +1,36 @@
++--- a/cc/private/toolchain/unix_cc_configure.bzl	2026-06-26 05:45:43.786532769 +0200
+++++ b/cc/private/toolchain/unix_cc_configure.bzl	2026-06-26 05:45:53.676473954 +0200
++@@ -99,6 +99,23 @@
++
++ _INC_DIR_MARKER_BEGIN = "#include <...>"
++
+++def _get_spack_include_directories(repository_ctx):
+++    """Get include directories from SPACK_INCLUDE_DIRS environment variable.
+++
+++    Args:
+++        repository_ctx: repository_ctx object.
+++
+++    Returns:
+++        List of include directories specified in SPACK_INCLUDE_DIRS.
+++    """
+++    spack_dirs = []
+++    if "SPACK_INCLUDE_DIRS" in repository_ctx.os.environ:
+++        for path in repository_ctx.os.environ["SPACK_INCLUDE_DIRS"].split(":"):
+++            if path:  # Skip empty strings
+++                spack_dirs.append(_prepare_include_path(repository_ctx, path))
+++    return spack_dirs
+++
+++
++ # OSX add " (framework directory)" at the end of line, strip it.
++ _OSX_FRAMEWORK_SUFFIX = " (framework directory)"
++ _OSX_FRAMEWORK_SUFFIX_LEN = len(_OSX_FRAMEWORK_SUFFIX)
++@@ -580,7 +597,8 @@
++         ) +
++         # Always included in case the user has Xcode + the CLT installed, both
++         # paths can be used interchangeably
++-        ["/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"],
+++        ["/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"] +
+++        _get_spack_include_directories(repository_ctx),
++     )
++
++     generate_modulemap = is_clang

--- a/repos/spack_repo/builtin/packages/bazel/SPACK_INCLUDE_DIRS-0.8-test.patch
+++ b/repos/spack_repo/builtin/packages/bazel/SPACK_INCLUDE_DIRS-0.8-test.patch
@@ -1,0 +1,181 @@
+From: Bernhard Kaindl <bernhardkaindl7@gmail.com>
+Subject: [PATCH 2/2] Add SPACK_INCLUDE_DIRS test suite for bazel 8.7.0
+
+- Comprehensive test scripts for verifying SPACK_INCLUDE_DIRS support
+- simple_test.sh: Minimal test suitable for spack post-build test function
+- test_spack_include_dirs.sh: Full test with setup, build, and verification
+- Example C++ program that uses custom include directories
+
+--- /dev/null
++++ b/include_test/BUILD
+@@ -0,0 +1,5 @@
++cc_binary(
++    name = "spack_test",
++    srcs = ["main.cpp", "spack_header.h"],
++    copts = ["-I."],
++)
+--- /dev/null
++++ b/include_test/MODULE.bazel
+@@ -0,0 +1,5 @@
++"""Test module for SPACK_INCLUDE_DIRS feature."""
++module(
++    name = "spack_test",
++    version = "1.0",
++)
+--- /dev/null
++++ b/include_test/README.md
+@@ -0,0 +1,16 @@
++# Manual Test
++
++```bash
++# Create a test include directory
++mkdir -p /tmp/spack_test/include
++cp include_test/spack_header.h /tmp/spack_test/include/
++
++# Set environment variable and build
++export SPACK_INCLUDE_DIRS=/tmp/spack_test/include
++cd /tmp/test_workspace
++cp -r include_test/* .
++/path/to/bazel/binary build //:spack_test
++
++# Run the binary to verify it works
++/path/to/bazel/binary run //:spack_test
++```
+--- /dev/null
++++ b/include_test/main.cpp
+@@ -0,0 +1,7 @@
++#include <iostream>
++#include "spack_header.h"
++
++int main() {
++    std::cout << get_spack_message() << std::endl;
++    return 0;
++}
+--- /dev/null
++++ b/include_test/spack_header.h
+@@ -0,0 +1,10 @@
++#ifndef SPACK_CUSTOM_HEADER_H
++#define SPACK_CUSTOM_HEADER_H
++
++#include <iostream>
++
++const char* get_spack_message() {
++    return "SPACK_INCLUDE_DIRS support is working!";
++}
++
++#endif
+--- /dev/null
++++ b/include_test/test1.sh
+@@ -0,0 +1,42 @@
++#!/bin/bash
++# Simple test for SPACK_INCLUDE_DIRS support
++# This is suitable for running in a spack post-build test
++# Usage: ./simple_test.sh /path/to/bazel/binary
++
++BAZEL_BIN="${1:?Error: bazel binary path required}"
++
++if [ ! -x "$BAZEL_BIN" ]; then
++    echo "Error: $BAZEL_BIN is not executable"
++    exit 1
++fi
++
++# Get the directory where this script is located
++SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
++WORK_DIR=$(mktemp -d)
++trap "rm -rf $WORK_DIR" EXIT
++
++# Create temporary include directory
++SPACK_INCLUDE_DIR="$WORK_DIR/spack_includes"
++mkdir -p "$SPACK_INCLUDE_DIR"
++cp "$SCRIPT_DIR/spack_header.h" "$SPACK_INCLUDE_DIR/"
++
++# Copy test files
++cp -r "$SCRIPT_DIR"/{BUILD,MODULE.bazel,main.cpp} "$WORK_DIR/"
++
++# Test 1: Build without SPACK_INCLUDE_DIRS (should fail since header is not in standard path)
++echo "Test 1: Building without SPACK_INCLUDE_DIRS..."
++cd "$WORK_DIR"
++if "$BAZEL_BIN" build //:spack_test 2>/dev/null; then
++    echo "Warning: Build unexpectedly succeeded without SPACK_INCLUDE_DIRS"
++fi
++
++# Test 2: Build with SPACK_INCLUDE_DIRS set
++echo "Test 2: Building with SPACK_INCLUDE_DIRS=$SPACK_INCLUDE_DIR..."
++export SPACK_INCLUDE_DIRS="$SPACK_INCLUDE_DIR"
++if "$BAZEL_BIN" build //:spack_test 2>&1 | grep -q "successfully"; then
++    echo "✓ Build succeeded with SPACK_INCLUDE_DIRS"
++    exit 0
++else
++    echo "✗ Build failed with SPACK_INCLUDE_DIRS"
++    exit 1
++fi
+diff --git a/include_test/test2.sh b/include_test/test2.sh
+new file mode 100755
+index 0000000000..359e9e84ec
+--- /dev/null
++++ b/include_test/test2.sh
+@@ -0,0 +1,64 @@
++#!/bin/bash
++# Test script for SPACK_INCLUDE_DIRS support in Bazel
++# Usage: ./test_spack_include_dirs.sh [bazel_binary_path] [test_dir]
++
++set -e
++
++BAZEL_BIN="${1:-.}"
++TEST_DIR="${2:-$(mktemp -d)}"
++SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
++
++cleanup() {
++    if [ -d "$TEST_DIR" ] && [ "$TEST_DIR" != "$(pwd)" ]; then
++        rm -rf "$TEST_DIR"
++    fi
++}
++
++trap cleanup EXIT
++
++echo "=== Testing SPACK_INCLUDE_DIRS Support ==="
++echo "BAZEL: $BAZEL_BIN"
++echo "TEST_DIR: $TEST_DIR"
++echo
++
++# Step 1: Create temporary include directory with test header
++echo "[1/4] Creating test include directory..."
++SPACK_INCLUDE_DIR="$TEST_DIR/spack_includes"
++mkdir -p "$SPACK_INCLUDE_DIR"
++
++# Copy the header to the spack include directory
++cp "$SCRIPT_DIR/spack_header.h" "$SPACK_INCLUDE_DIR/"
++echo "Created: $SPACK_INCLUDE_DIR"
++echo
++
++# Step 2: Set up test workspace
++echo "[2/4] Setting up test workspace..."
++mkdir -p "$TEST_DIR/workspace"
++cp -r "$SCRIPT_DIR"/* "$TEST_DIR/workspace/"
++cd "$TEST_DIR/workspace"
++echo "Copied test files to: $TEST_DIR/workspace"
++echo
++
++# Step 3: Build with SPACK_INCLUDE_DIRS set
++echo "[3/4] Building with SPACK_INCLUDE_DIRS=$SPACK_INCLUDE_DIR..."
++export SPACK_INCLUDE_DIRS="$SPACK_INCLUDE_DIR"
++
++if "$BAZEL_BIN" build //:spack_test 2>&1; then
++    echo "Build succeeded"
++else
++    echo "Build failed"
++    exit 1
++fi
++echo
++
++# Step 4: Verify the binary works
++echo "[4/4] Verifying test binary runs correctly..."
++OUTPUT=$("$BAZEL_BIN" run //:spack_test 2>/dev/null)
++if [[ "$OUTPUT" == *"SPACK_INCLUDE_DIRS support is working"* ]]; then
++    echo "Binary output: $OUTPUT"
++    echo "All tests passed!"
++    exit 0
++else
++    echo "Binary output unexpected: $OUTPUT"
++    exit 1
++fi

--- a/repos/spack_repo/builtin/packages/bazel/package.py
+++ b/repos/spack_repo/builtin/packages/bazel/package.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 import re
 
 from spack_repo.builtin.build_systems.generic import Package
@@ -25,6 +26,8 @@ class Bazel(Package):
 
     license("Apache-2.0")
 
+    version("8.7.0", sha256="75ed5aa189fd687e6e7c289ad86a3851844965a6c1479b7a5ce9b846a6e461bc")
+    version("8.5.1", sha256="bf66a1cbaaafec32e1e103d0e07343082f1f0f3f20ad4c6b66c4eda3f690ed4d")
     version("7.7.1", sha256="6181b3570c2f657d989b1141fb0c1a08eb5f08106ca577dc7dc52e7d0238379a")
     version("7.7.0", sha256="277946818c77fff70be442864cecc41faac862b6f2d0d37033e2da0b1fee7e0f")
     version("7.6.2", sha256="320582db87133c6a7b58d93b6a97bb7d67916fe7940d60fbb4ecc36c7a48da6d")
@@ -91,7 +94,9 @@ class Bazel(Package):
     patch("bazelruleclassprovider-0.25.patch")
 
     # Inject include paths
-    patch("unix_cc_configure-3.0.patch")
+    patch("unix_cc_configure-3.0.patch", when="@:7")
+    patch("SPACK_INCLUDE_DIRS-0.8-code.patch", when="@8:")
+    patch("SPACK_INCLUDE_DIRS-0.8-test.patch", when="@8:")
 
     # Set CC and CXX
     patch("compile-0.29.patch")
@@ -284,6 +289,13 @@ java_binary(
 
             exe = Executable("bazel-bin/bazel-test")
             assert exe(output=str) == "Hi!\n"
+
+            # Test SPACK_INCLUDE_DIRS support (added using spack-specific patches)
+            script1 = os.path.join(self.stage.source_path, "include_test/test1.sh")
+            script2 = os.path.join(self.stage.source_path, "include_test/test2.sh")
+            bash = which("bash", required=True)
+            bash(script1, bazel.path)
+            bash(script2, bazel.path, "tmp2.d")
 
     def setup_dependent_package(self, module, dependent_spec):
         module.bazel = Executable(self.command.path)

--- a/repos/spack_repo/builtin/packages/bazel/package.py
+++ b/repos/spack_repo/builtin/packages/bazel/package.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 import re
 
 from spack_repo.builtin.build_systems.generic import Package
@@ -25,7 +26,15 @@ class Bazel(Package):
 
     license("Apache-2.0")
 
-    version("7.7.1", sha256="6181b3570c2f657d989b1141fb0c1a08eb5f08106ca577dc7dc52e7d0238379a")
+    # Needs a special version of the 1st diff of SPACK_INCLUDE_DIRS-0.8-code.patch:
+    # version("9.2.0", sha256="81af02b33128ec1922c6b60212df3fb6150baa96bb33d32ffa020e5fed47fefc")
+    version("8.7.0", sha256="75ed5aa189fd687e6e7c289ad86a3851844965a6c1479b7a5ce9b846a6e461bc")
+    version("8.5.1", sha256="bf66a1cbaaafec32e1e103d0e07343082f1f0f3f20ad4c6b66c4eda3f690ed4d")
+    version(
+        "7.7.1",
+        sha256="6181b3570c2f657d989b1141fb0c1a08eb5f08106ca577dc7dc52e7d0238379a",
+        preferred=True,
+    )
     version("7.7.0", sha256="277946818c77fff70be442864cecc41faac862b6f2d0d37033e2da0b1fee7e0f")
     version("7.6.2", sha256="320582db87133c6a7b58d93b6a97bb7d67916fe7940d60fbb4ecc36c7a48da6d")
     version("7.4.1", sha256="83386618bc489f4da36266ef2620ec64a526c686cf07041332caff7c953afaf5")
@@ -91,7 +100,9 @@ class Bazel(Package):
     patch("bazelruleclassprovider-0.25.patch")
 
     # Inject include paths
-    patch("unix_cc_configure-3.0.patch")
+    patch("unix_cc_configure-3.0.patch", when="@:7")
+    patch("SPACK_INCLUDE_DIRS-0.8-code.patch", when="@8:")
+    patch("SPACK_INCLUDE_DIRS-0.8-test.patch", when="@8:")
 
     # Set CC and CXX
     patch("compile-0.29.patch")
@@ -284,6 +295,14 @@ java_binary(
 
             exe = Executable("bazel-bin/bazel-test")
             assert exe(output=str) == "Hi!\n"
+
+            if self.spec.satisfies("@8:") and self.spec.satisfies("platform=linux"):
+                # Test SPACK_INCLUDE_DIRS support (added using spack-specific patches)
+                script1 = os.path.join(self.stage.source_path, "include_test", "test1.sh")
+                script2 = os.path.join(self.stage.source_path, "include_test", "test2.sh")
+                bash = which("bash", required=True)
+                bash(script1, bazel.path)
+                bash(script2, bazel.path, "tmp2.d")
 
     def setup_dependent_package(self, module, dependent_spec):
         module.bazel = Executable(self.command.path)

--- a/repos/spack_repo/builtin/packages/py_tensorstore/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorstore/package.py
@@ -11,23 +11,27 @@ class PyTensorstore(PythonPackage):
     """Read and write large, multi-dimensional arrays."""
 
     homepage = "https://github.com/google/tensorstore"
-    pypi = "tensorstore/tensorstore-0.1.54.tar.gz"
+    pypi = "tensorstore/tensorstore-0.1.84.tar.gz"
 
     license("Apache-2.0")
 
-    version("0.1.54", sha256="e1a9dcb0be7c828f752375409537d4b39c658dd6c6a0873fe21a24a556ec0e2a")
+    version("0.1.84", sha256="3cb091dfde68600e6d8f03a389ccc92ffa7c0798a0c600d1013c0138d7163e6b")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
-    # .bazelversion
-    depends_on("bazel@6.4.0", type="build")
+    # .bazelversion specifies the minimum required version of Bazel.
+    # To not have to bump this every time the minimum required version of
+    # Bazel is increased and minimize the amount of bazel version churn,
+    # we depend on the most recent version which we can support in spack.
+    depends_on("bazel@8.7.0:", type="build")
 
     with default_args(type="build"):
         depends_on("py-setuptools@30.3:")
         depends_on("py-setuptools-scm")
 
     with default_args(type=("build", "run")):
-        depends_on("python@3.9:")
+        depends_on("python@3.11:")
         depends_on("py-numpy@1.16:")
         depends_on("py-ml-dtypes@0.3.1:")
 


### PR DESCRIPTION
This fixes a compilation error, similar to what was described in https://github.com/RenderKit/openvkl/issues/12,
the current tensorstore version fixed building with Python 3.13 on Ubuntu 24.04.