### PR TITLE
(py-)fenics-dolfinx: dependency fixes and improvements

### DIFF
--- a/repos/spack_repo/builtin/packages/fenics_dolfinx/package.py
+++ b/repos/spack_repo/builtin/packages/fenics_dolfinx/package.py
@@ -17,7 +17,7 @@ class FenicsDolfinx(CMakePackage):
 
     license("LGPL-3.0-or-later")
 
-    version("main", branch="main")
+    version("main", branch="main", no_cache=True)
     version("0.9.0", sha256="b266c74360c2590c5745d74768c04568c965b44739becca4cd6b5aa58cdbbbd1")
     version("0.8.0", sha256="acf3104d9ecc0380677a6faf69eabfafc58d0cce43f7777e1307b95701c7cad9")
     version("0.7.2", sha256="7d9ce1338ce66580593b376327f23ac464a4ce89ef63c105efc1a38e5eae5c0b")
@@ -32,9 +32,8 @@ class FenicsDolfinx(CMakePackage):
         multi=True,
     )
 
-    # HDF5 dependency requires C in CMake
-    depends_on("c", type="build")
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")  # HDF5 dependency requires C in CMake
+    depends_on("cxx", type="build")
 
     # Graph partitioner dependencies
     depends_on("kahip@3.12:", when="partitioners=kahip")
@@ -51,7 +50,8 @@ class FenicsDolfinx(CMakePackage):
     depends_on("pkgconfig", type="build")
     depends_on("mpi")
     depends_on("hdf5+mpi")
-    depends_on("boost@1.7.0:+filesystem+program_options+timer")
+    depends_on("boost@1.7.0")
+    depends_on("boost@1.7.0:+timer", when="@:0.9")
     depends_on("pugixml")
     depends_on("spdlog", when="@0.9:")
 

--- a/repos/spack_repo/builtin/packages/fenics_dolfinx/package.py
+++ b/repos/spack_repo/builtin/packages/fenics_dolfinx/package.py
@@ -55,8 +55,9 @@ class FenicsDolfinx(CMakePackage):
     depends_on("spdlog", when="@0.9:")
 
     depends_on("petsc+mpi+shared", when="+petsc")
-    depends_on("petsc+mpi+shared", when="+slepc")
-    depends_on("slepc", when="+slepc")
+    with when("+slepc"):
+        depends_on("petsc+mpi+shared")
+        depends_on("slepc")
 
     depends_on("adios2@2.8.1:+mpi", when="@0.9: +adios2")
     depends_on("adios2+mpi", when="+adios2")

--- a/repos/spack_repo/builtin/packages/fenics_dolfinx/package.py
+++ b/repos/spack_repo/builtin/packages/fenics_dolfinx/package.py
@@ -49,8 +49,8 @@ class FenicsDolfinx(CMakePackage):
     depends_on("pkgconfig", type="build")
     depends_on("mpi")
     depends_on("hdf5+mpi")
-    depends_on("boost@1.7.0")
-    depends_on("boost@1.7.0:+timer", when="@:0.9")
+    depends_on("boost@1.70:")
+    depends_on("boost@1.70:+timer", when="@:0.9")
     depends_on("pugixml")
     depends_on("spdlog", when="@0.9:")
 

--- a/repos/spack_repo/builtin/packages/fenics_dolfinx/package.py
+++ b/repos/spack_repo/builtin/packages/fenics_dolfinx/package.py
@@ -8,7 +8,7 @@ from spack.package import *
 
 
 class FenicsDolfinx(CMakePackage):
-    """Next generation FEniCS problem solving environment"""
+    """Next generation FEniCS problem solving environment."""
 
     homepage = "https://github.com/FEniCS/dolfinx"
     git = "https://github.com/FEniCS/dolfinx.git"
@@ -40,11 +40,10 @@ class FenicsDolfinx(CMakePackage):
     depends_on("parmetis", when="partitioners=parmetis")
     depends_on("scotch+mpi", when="partitioners=scotch")
 
-    variant("slepc", default=False, description="slepc support")
-    variant("adios2", default=False, description="adios2 support")
+    variant("slepc", default=False, description="SLEPc support")
+    variant("adios2", default=False, description="ADIOS2 support")
     variant("petsc", default=False, description="PETSc support")
 
-    depends_on("petsc", when="+slepc")
     depends_on("cmake@3.21:", when="@0.9:", type="build")
     depends_on("cmake@3.19:", when="@:0.8", type="build")
     depends_on("pkgconfig", type="build")
@@ -56,6 +55,7 @@ class FenicsDolfinx(CMakePackage):
     depends_on("spdlog", when="@0.9:")
 
     depends_on("petsc+mpi+shared", when="+petsc")
+    depends_on("petsc+mpi+shared", when="+slepc")
     depends_on("slepc", when="+slepc")
 
     depends_on("adios2@2.8.1:+mpi", when="@0.9: +adios2")

--- a/repos/spack_repo/builtin/packages/py_fenics_dolfinx/package.py
+++ b/repos/spack_repo/builtin/packages/py_fenics_dolfinx/package.py
@@ -69,16 +69,20 @@ class PyFenicsDolfinx(PythonPackage):
     depends_on("py-numpy@1.21:", type=("build", "run"))
     depends_on("py-mpi4py", type=("build", "run"))
 
-    depends_on("py-petsc4py", type=("build", "run"), when="+petsc4py")
-    depends_on("py-petsc4py", type=("build", "run"), when="+slepc4py")
-    depends_on("py-slepc4py", type=("build", "run"), when="+slepc4py")
+    with when("+petsc4py"):
+        depends_on("fenics-dolfinx +petsc")
+        depends_on("py-petsc4py", type=("build", "run"))
+    with when("+slepc4py"):
+        depends_on("fenics-dolfinx +petsc +slepc")
+        depends_on("py-petsc4py", type=("build", "run"))
+        depends_on("py-slepc4py", type=("build", "run"))
 
     depends_on("py-cffi@:1.16", type=("build", "run"))
 
     depends_on("py-nanobind@2:", when="@0.9:", type="build")
     depends_on("py-nanobind@1.8:1.9", when="@0.8", type="build")
-    depends_on("py-scikit-build-core+pyproject@0.10:", when="@0.10:", type="build")
-    depends_on("py-scikit-build-core+pyproject@0.5:", when="@0.8:0.9", type="build")
+    depends_on("py-scikit-build-core@0.10: +pyproject", when="@0.10:", type="build")
+    depends_on("py-scikit-build-core@0.5: +pyproject", when="@0.8:0.9", type="build")
 
     depends_on("py-pybind11@2.7.0:", when="@:0.7", type=("build", "run"))
     depends_on("py-setuptools@42:", when="@:0.7", type="build")

--- a/repos/spack_repo/builtin/packages/py_fenics_dolfinx/package.py
+++ b/repos/spack_repo/builtin/packages/py_fenics_dolfinx/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 
 class PyFenicsDolfinx(PythonPackage):
     """Python interface to the next generation FEniCS problem solving
-    environment"""
+    environment."""
 
     homepage = "https://github.com/FEniCS/dolfinx"
     url = "https://github.com/FEniCS/dolfinx/archive/v0.1.0.tar.gz"
@@ -18,13 +18,16 @@ class PyFenicsDolfinx(PythonPackage):
 
     license("LGPL-3.0-only")
 
-    version("main", branch="main")
+    version("main", branch="main", no_cache=True)
     version("0.9.0", sha256="b266c74360c2590c5745d74768c04568c965b44739becca4cd6b5aa58cdbbbd1")
     version("0.8.0", sha256="acf3104d9ecc0380677a6faf69eabfafc58d0cce43f7777e1307b95701c7cad9")
     version("0.7.2", sha256="7d9ce1338ce66580593b376327f23ac464a4ce89ef63c105efc1a38e5eae5c0b")
     version("0.6.0", sha256="eb8ac2bb2f032b0d393977993e1ab6b4101a84d54023a67206e3eac1a8d79b80")
 
-    depends_on("cxx", type="build")  # generated
+    variant("petsc4py", default=False, description="petsc4py support")
+    variant("slepc4py", default=False, description="slepc4py support")
+
+    depends_on("cxx", type="build")
 
     depends_on("cmake@3.21:", when="@0.9:", type="build")
     depends_on("cmake@3.19:", when="@:0.8", type="build")
@@ -65,7 +68,11 @@ class PyFenicsDolfinx(PythonPackage):
 
     depends_on("py-numpy@1.21:", type=("build", "run"))
     depends_on("py-mpi4py", type=("build", "run"))
-    depends_on("py-petsc4py", type=("build", "run"))
+
+    depends_on("py-petsc4py", type=("build", "run"), when="+petsc4py")
+    depends_on("py-petsc4py", type=("build", "run"), when="+slepc4py")
+    depends_on("py-slepc4py", type=("build", "run"), when="+slepc4py")
+
     depends_on("py-cffi@:1.16", type=("build", "run"))
 
     depends_on("py-nanobind@2:", when="@0.9:", type="build")


### PR DESCRIPTION
`py-fenics-dolfinx`
- In `fenics-dolfinx`, some variants were recently added to make some dependencies optional. Default is 'false' for the new variants.
- `py-fenics-dolfinx` made assumptions on how `fenics-dolfinx` is configured, which with the above change to `fenics-dolfinx` are no longer always true. This PR fixes `py-fenics-dolfinx` its dependency on `fenics-dolfinx`.

`fenics-dolfinx`
- Remove Boost variants that are not reuqired.