### PR TITLE
miniconda: add New Releases

### DIFF
--- a/repos/spack_repo/builtin/packages/miniconda3/package.py
+++ b/repos/spack_repo/builtin/packages/miniconda3/package.py
@@ -10,6 +10,36 @@ from spack_repo.builtin.build_systems.generic import Package
 from spack.package import *
 
 _versions = {
+    "25.5.1": {
+        "Linux-x86_64": (
+            "612af113b49db0368e2be41ac4d51b7088eebd5f31daeeb89f23fff8f920db58",
+            "https://repo.anaconda.com/miniconda/Miniconda3-py313_25.5.1-1-Linux-x86_64.sh",
+        )
+    },
+    "25.3.1": {
+        "Linux-x86_64": (
+            "2d94390e8858c72f6a28080954fd640ae4449d08d7b9d4ff8c94ad39beaf5f46",
+            "https://repo.anaconda.com/miniconda/Miniconda3-py313_25.3.1-1-Linux-x86_64.sh",
+        )
+    },
+    "25.1.1": {
+        "Linux-x86_64": (
+            "4766d85b5f7d235ce250e998ebb5a8a8210cbd4f2b0fea4d2177b3ed9ea87884",
+            "https://repo.anaconda.com/miniconda/Miniconda3-py312_25.1.1-2-Linux-x86_64.sh",
+        )
+    },
+    "24.11.1": {
+        "Linux-x86_64": (
+            "636b209b00b6673471f846581829d4b96b9c3378679925a59a584257c3fef5a3",
+            "https://repo.anaconda.com/miniconda/Miniconda3-py312_24.11.1-0-Linux-x86_64.sh",
+        )
+    },
+    "24.9.2": {
+        "Linux-x86_64": (
+            "8d936ba600300e08eca3d874dee88c61c6f39303597b2b66baee54af4f7b4122",
+            "https://repo.anaconda.com/miniconda/Miniconda3-py312_24.9.2-0-Linux-x86_64.sh",
+        )
+    },
     "24.7.1": {
         "Linux-x86_64": (
             "33442cd3813df33dcbb4a932b938ee95398be98344dff4c30f7e757cd2110e4f",

--- a/repos/spack_repo/builtin/packages/miniconda3/package.py
+++ b/repos/spack_repo/builtin/packages/miniconda3/package.py
@@ -18,7 +18,7 @@ _versions = {
     },
     "25.3.1": {
         "Linux-x86_64": (
-            "2d94390e8858c72f6a28080954fd640ae4449d08d7b9d4ff8c94ad39beaf5f46",
+            "53a86109463cfd70ba7acab396d416e623012914eee004729e1ecd6fe94e8c69",
             "https://repo.anaconda.com/miniconda/Miniconda3-py313_25.3.1-1-Linux-x86_64.sh",
         )
     },


### PR DESCRIPTION
Added versions from the last time versions were updated. Includes 24.9 -> 25.1

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
