### PR TITLE
environment-modules: add v5.6.0

### DIFF
--- a/repos/spack_repo/builtin/packages/environment_modules/package.py
+++ b/repos/spack_repo/builtin/packages/environment_modules/package.py
@@ -13,13 +13,14 @@ class EnvironmentModules(Package):
     modification of a user's environment via module files.
     """
 
-    homepage = "https://cea-hpc.github.io/modules/"
-    url = "https://github.com/cea-hpc/modules/releases/download/v5.5.0/modules-5.5.0.tar.gz"
-    git = "https://github.com/cea-hpc/modules.git"
+    homepage = "https://envmodules.github.io/modules/"
+    url = "https://github.com/envmodules/modules/releases/download/v5.6.0/modules-5.6.0.tar.gz"
+    git = "https://github.com/envmodules/modules.git"
 
     maintainers("xdelaruelle")
 
     version("main", branch="main")
+    version("5.6.0", sha256="9dd78f1543012acd3a1a14ba86dc1dca8f7d176396ea3f0027a92dcf5ff2057c")
     version("5.5.0", sha256="ad0e360c7adc2515a99836863d98499b3ad89cd7548625499b20293845b040cb")
     version("5.4.0", sha256="586245cbf9420866078d8c28fce8ef4f192530c69a0f368f51e848340dcf3b90")
     version("5.3.1", sha256="d02f9ce4f8baf6c99edceb7c73bfdd1e97d77bcc4725810b86efed9f58dda962")
@@ -93,12 +94,15 @@ class EnvironmentModules(Package):
         ]
 
         # ./configure script on version 4.5.2 breaks when specific options are
-        # set (see https://github.com/cea-hpc/modules/issues/354)
+        # set (see https://github.com/envmodules/modules/issues/354)
         if not spec.satisfies("@4.5.2"):
             config_args.extend(["--disable-dependency-tracking", "--disable-silent-rules"])
 
         if spec.satisfies("~X"):
             config_args = ["--without-x"] + config_args
+
+        if self.spec.satisfies("@5.6.0:"):
+            config_args.extend(["--enable-require-via"])
 
         if self.spec.satisfies("@5.5.0:"):
             config_args.extend(["--enable-conflict-unload"])


### PR DESCRIPTION
* add new version 5.6.0
* enable by require_via feature by default to allow hierarchical modulefiles
* update repository URL (from cea-hpc to envmodules GitHub organization)

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
