### PR TITLE
prrte: Add constraint on PMIx version

### DIFF
--- a/repos/spack_repo/builtin/packages/prrte/package.py
+++ b/repos/spack_repo/builtin/packages/prrte/package.py
@@ -45,6 +45,7 @@ class Prrte(AutotoolsPackage):
     depends_on("c", type="build")  # generated
 
     depends_on("pmix")
+    depends_on("pmix@6:", when="@4:")
     depends_on("pmix@:5", when="@:3")
     depends_on("libevent")
     depends_on("hwloc")


### PR DESCRIPTION
Otherwise

```sh
spack install hdf5 ^pmix@5
```

fails with

```
    '/tmp/user/spack-stage/spack-stage-prrte-4.0.0-dmxr27e3yyppvpc5qlhw2c2ugob3jurf/spack-src/configure' '--prefix=/home/user/dev/spack/opt/spack/linux-skylake/prrte-4.0.0-dmxr27e3yyppvpc5qlhw2c2ugob3jurf' '--enable-shared' '--enable-static' '--disable-sphinx' '--with-libevent=/home/user/dev/spack/opt/spack/linux-skylake/libevent-2.1.12-2bnitfy4orsxij6gioahodacpfcexehq' '--with-hwloc=/home/user/dev/spack/opt/spack/linux-skylake/hwloc-2.11.1-kd24ydtrjl2i3qaw4vodjmgex2vode4s' '--with-pmix=/home/user/dev/spack/opt/spack/linux-skylake/pmix-5.0.8-kj7gs6vwsbwckvc64e2vqjxolm3yux5g'

1 error found in build log:
     428    checking pmix.h usability... yes
     429    checking pmix.h presence... yes
     430    checking for pmix.h... yes
     431    checking for PMIx_Init... yes
     432    checking version at or above v6.0.0... no
     433    configure: WARNING: PRRTE requires PMIx v0x00060000 or above.
  >> 434    configure: error: Please select a supported version and configure again
```

In practice this happens when installing `slurm +hdf5`.

Added constraint reflects release notes found here https://github.com/openpmix/prrte/releases/tag/v4.0.0
> PRRTE >= v4.0 is not compatible with PMIx < v6.0 due to internal changes