### PR TITLE
OpenBlas: add constraint for required versions of CMake when compiling with MSVC

### DIFF
--- a/repos/spack_repo/builtin/build_systems/cmake.py
+++ b/repos/spack_repo/builtin/build_systems/cmake.py
@@ -228,7 +228,7 @@ class CMakePackage(PackageBase):
         # must conflict.
         # this should be updated to reflect a oneapi fortran provider
         # once oneapi is usable with fortran on Windows
-        conflicts("cmake@:4.0", when="%fortran=msvc")
+        conflicts("cmake@:4.0", when="%cxx=msvc %fortran=msvc")
 
     def flags_to_build_system_args(self, flags):
         """Return a list of all command line arguments to pass the specified

--- a/repos/spack_repo/builtin/build_systems/cmake.py
+++ b/repos/spack_repo/builtin/build_systems/cmake.py
@@ -219,7 +219,7 @@ class CMakePackage(PackageBase):
         depends_on("ninja", type="build", when="generator=ninja")
 
         # CMake earlier than 4.1 improperly handles arguments provided to
-        # the linker when using msvc as a c/cxx compiler and oneapi as a 
+        # the linker when using msvc as a c/cxx compiler and oneapi as a
         # fortran compiler https://gitlab.kitware.com/cmake/cmake/-/issues/26005
         #
         # Currently in Spack msvc is modeled as both the fortran/cxx compiler

--- a/repos/spack_repo/builtin/build_systems/cmake.py
+++ b/repos/spack_repo/builtin/build_systems/cmake.py
@@ -218,6 +218,18 @@ class CMakePackage(PackageBase):
         depends_on("gmake", type="build", when="generator=make")
         depends_on("ninja", type="build", when="generator=ninja")
 
+        # CMake earlier than 4.1 improperly handles arguments provided to
+        # the linker when using msvc as a c/cxx compiler and oneapi as a 
+        # fortran compiler https://gitlab.kitware.com/cmake/cmake/-/issues/26005
+        #
+        # Currently in Spack msvc is modeled as both the fortran/cxx compiler
+        # due to restrictions w/ oneapi on Windows, but in reality, when msvc
+        # is the fortran compiler, it is utilizing oneapi, and this
+        # must conflict.
+        # this should be updated to reflect a oneapi fortran provider
+        # once oneapi is usable with fortran on Windows
+        conflicts("cmake@:4.0", when="%fortran=msvc")
+
     def flags_to_build_system_args(self, flags):
         """Return a list of all command line arguments to pass the specified
         compiler flags to cmake. Note CMAKE does not have a cppflags option,


### PR DESCRIPTION
CMake 4.1 adds https://gitlab.kitware.com/cmake/cmake/-/merge_requests/10836 which is required to build openblas with MSVC + oneAPI

Presumably more packages will have this issue, it's not an issue with openblas' CMake, but openblas is the package that allowed us to create the fix for CMake, so it gets the constraint first as its the only one I'm currently aware of