### PR TITLE
Packages: use spack.package.symlink

### DIFF
--- a/repos/spack_repo/builtin/build_systems/oneapi.py
+++ b/repos/spack_repo/builtin/build_systems/oneapi.py
@@ -24,6 +24,7 @@ from spack.package import (
     mkdirp,
     redistribute,
     shared_library_suffix,
+    symlink,
     tty,
     variant,
 )
@@ -182,7 +183,7 @@ class IntelOneApiPackage(Package):
                 link_tree = LinkTree(src_path)
                 link_tree.merge(dest_path)
             else:
-                os.symlink(src_path, dest_path)
+                symlink(src_path, dest_path)
 
 
 class IntelOneApiLibraryPackage(IntelOneApiPackage):

--- a/repos/spack_repo/builtin/build_systems/python.py
+++ b/repos/spack_repo/builtin/build_systems/python.py
@@ -28,6 +28,7 @@ from spack.package import (
     path_contains_subdirectory,
     register_builder,
     run_after,
+    symlink,
     test_part,
     tty,
     when,
@@ -174,7 +175,7 @@ class PythonExtension(PackageBase):
             except (OSError, KeyError):
                 target = None
             if target:
-                os.symlink(os.path.relpath(target, os.path.dirname(dst)), dst)
+                symlink(os.path.relpath(target, os.path.dirname(dst)), dst)
             else:
                 view.link(src, dst, spec=self.spec)
 

--- a/repos/spack_repo/builtin/packages/amdblis/package.py
+++ b/repos/spack_repo/builtin/packages/amdblis/package.py
@@ -106,9 +106,9 @@ class Amdblis(BlisBase):
     def create_symlink(self):
         with working_dir(self.prefix.lib):
             if os.path.isfile("libblis-mt.a"):
-                os.symlink("libblis-mt.a", "libblis.a")
+                symlink("libblis-mt.a", "libblis.a")
             if os.path.isfile("libblis-mt.so"):
-                os.symlink("libblis-mt.so", "libblis.so")
+                symlink("libblis-mt.so", "libblis.so")
 
     @property
     def libs(self):

--- a/repos/spack_repo/builtin/packages/amdlibm/package.py
+++ b/repos/spack_repo/builtin/packages/amdlibm/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.scons import SConsPackage
@@ -111,8 +110,8 @@ class Amdlibm(SConsPackage, CMakePackage):
     def create_symlink(self):
         """Symbolic link for backward compatibility"""
         with working_dir(self.prefix.lib):
-            os.symlink("libalm.a", "libamdlibm.a")
-            os.symlink("libalm.so", "libamdlibm.so")
+            symlink("libalm.a", "libamdlibm.a")
+            symlink("libalm.so", "libamdlibm.so")
             if self.spec.satisfies("@4.0:"):
-                os.symlink("libalmfast.a", "libamdlibmfast.a")
-                os.symlink("libalmfast.so", "libamdlibmfast.so")
+                symlink("libalmfast.a", "libamdlibmfast.a")
+                symlink("libalmfast.so", "libamdlibmfast.so")

--- a/repos/spack_repo/builtin/packages/cosmomc/package.py
+++ b/repos/spack_repo/builtin/packages/cosmomc/package.py
@@ -69,7 +69,7 @@ class Cosmomc(Package):
         except OSError:
             pass
         if spec.satisfies("+planck"):
-            os.symlink(join_path(os.environ["CLIK_DATA"], "plc_2.0"), clikdir)
+            symlink(join_path(os.environ["CLIK_DATA"], "plc_2.0"), clikdir)
         else:
             os.environ.pop("CLIK_DATA", "")
             os.environ.pop("CLIK_PATH", "")
@@ -178,7 +178,7 @@ class Cosmomc(Package):
         cosmomc = Executable(exe)
         with working_dir("spack-check", create=True):
             for entry in ["camb", "chains", "data", "paramnames", "planck_covmats"]:
-                os.symlink(join_path(prefix.share, "cosmomc", entry), entry)
+                symlink(join_path(prefix.share, "cosmomc", entry), entry)
             inifile = join_path(prefix.share, "cosmomc", "test.ini")
             cosmomc(*(args + [inifile]))
             if spec.satisfies("+planck"):

--- a/repos/spack_repo/builtin/packages/crtm/package.py
+++ b/repos/spack_repo/builtin/packages/crtm/package.py
@@ -128,4 +128,4 @@ class Crtm(CMakePackage):
     def cmake_config_softlinks(self):
         cmake_config_files = glob.glob(join_path(self.prefix, "cmake/crtm/*"))
         for srcpath in cmake_config_files:
-            os.symlink(srcpath, join_path(self.prefix, "cmake", os.path.basename(srcpath)))
+            symlink(srcpath, join_path(self.prefix, "cmake", os.path.basename(srcpath)))

--- a/repos/spack_repo/builtin/packages/cuda/package.py
+++ b/repos/spack_repo/builtin/packages/cuda/package.py
@@ -838,7 +838,7 @@ class Cuda(Package):
             includedir = "targets/ppc64le-linux/include"
             os.makedirs(os.path.join(prefix, includedir))
             os.makedirs(os.path.join(prefix, "src"))
-            os.symlink(includedir, os.path.join(prefix, "include"))
+            symlink(includedir, os.path.join(prefix, "include"))
 
         install_shell = which("sh")
 

--- a/repos/spack_repo/builtin/packages/energyplus/package.py
+++ b/repos/spack_repo/builtin/packages/energyplus/package.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import glob
-import os
 
 from spack_repo.builtin.build_systems.generic import Package
 
@@ -52,4 +51,4 @@ class Energyplus(Package):
 
         mkdirp(prefix.bin)
         for b in ["energyplus", "EPMacro", "ExpandObjects"]:
-            os.symlink(join_path(prefix.lib.energyplus, b), join_path(prefix.bin, b))
+            symlink(join_path(prefix.lib.energyplus, b), join_path(prefix.bin, b))

--- a/repos/spack_repo/builtin/packages/esmf/package.py
+++ b/repos/spack_repo/builtin/packages/esmf/package.py
@@ -421,7 +421,7 @@ class MakefileBuilder(makefile.MakefileBuilder):
             for suffix in [shared_library_suffix(self.spec), static_library_suffix(self.spec)]:
                 library_path = os.path.join(self.prefix.lib, "libesmf.%s" % suffix)
                 if os.path.exists(library_path):
-                    os.symlink(library_path, os.path.join(self.prefix.lib, "libESMF.%s" % suffix))
+                    symlink(library_path, os.path.join(self.prefix.lib, "libESMF.%s" % suffix))
         # https://github.com/esmf-org/esmf/issues/497
         filter_file("-lmpi_cxx", "", os.path.join(self.prefix.lib, "esmf.mk"), string=True)
 

--- a/repos/spack_repo/builtin/packages/foam_extend/package.py
+++ b/repos/spack_repo/builtin/packages/foam_extend/package.py
@@ -221,7 +221,7 @@ class FoamExtend(Package):
         with working_dir(parent):
             if original != target and not os.path.lexists(target):
                 os.rename(original, target)
-                os.symlink(target, original)
+                symlink(target, original)
                 tty.info("renamed {0} -> {1}".format(original, target))
 
     def patch(self):
@@ -427,7 +427,7 @@ class FoamExtend(Package):
         """Add symlinks into bin/, lib/ (eg, for other applications)"""
         # Make build log visible - it contains OpenFOAM-specific information
         with working_dir(self.projectdir):
-            os.symlink(
+            symlink(
                 join_path(os.path.relpath(self.install_log_path)),
                 join_path("log." + str(self.foam_arch)),
             )

--- a/repos/spack_repo/builtin/packages/geant4_data/package.py
+++ b/repos/spack_repo/builtin/packages/geant4_data/package.py
@@ -227,4 +227,4 @@ class Geant4Data(BundlePackage):
                     raise InstallError(f"Dependency `{s.name}` does not expose `g4datasetname`")
 
                 d = "{0}/data/{1}".format(s.prefix.share, s.package.g4datasetname)
-                os.symlink(d, os.path.basename(d))
+                symlink(d, os.path.basename(d))

--- a/repos/spack_repo/builtin/packages/git_annex/package.py
+++ b/repos/spack_repo/builtin/packages/git_annex/package.py
@@ -130,4 +130,4 @@ class GitAnnex(Package):
             git_files = ["git", "git-receive-pack", "git-shell", "git-upload-pack"]
             for i in git_files:
                 os.remove(join_path(prefix.bin, i))
-                os.symlink(join_path(spec["git"].prefix.bin, i), join_path(prefix.bin, i))
+                symlink(join_path(spec["git"].prefix.bin, i), join_path(prefix.bin, i))

--- a/repos/spack_repo/builtin/packages/gmake/package.py
+++ b/repos/spack_repo/builtin/packages/gmake/package.py
@@ -90,7 +90,7 @@ class Gmake(Package, GNUMirrorPackage):
             Executable(build_sh)()
             os.mkdir(prefix.bin)
             install("make", prefix.bin)
-            os.symlink("make", prefix.bin.gmake)
+            symlink("make", prefix.bin.gmake)
 
     def setup_dependent_package(self, module, dspec):
         module.make = MakeExecutable(

--- a/repos/spack_repo/builtin/packages/go/package.py
+++ b/repos/spack_repo/builtin/packages/go/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
 import re
 
 from spack_repo.builtin.build_systems.generic import Package
@@ -108,7 +107,7 @@ class Go(Package):
 
     def install(self, spec, prefix):
         install_tree(".", prefix.go)
-        os.symlink(prefix.go.bin, prefix.bin)
+        symlink(prefix.go.bin, prefix.bin)
 
     def setup_dependent_package(self, module, dependent_spec):
         """Called before go modules' build(), install() methods.

--- a/repos/spack_repo/builtin/packages/hdf5/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5/package.py
@@ -671,7 +671,7 @@ class Hdf5(CMakePackage):
             with working_dir(self.prefix.lib):
                 for lib in libs:
                     libname = os.path.split(lib)[1]
-                    os.symlink(libname, libname.replace("_debug", ""))
+                    symlink(libname, libname.replace("_debug", ""))
 
     @run_after("install")
     def symlink_to_h5hl_wrappers(self):

--- a/repos/spack_repo/builtin/packages/hdf5_blosc/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5_blosc/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
 import shutil
 import sys
 
@@ -17,14 +16,14 @@ def _install_shlib(name, src, dst):
         shlib0 = name + ".0.dylib"
         shlib = name + ".dylib"
         install(join_path(src, shlib0), join_path(dst, shlib0))
-        os.symlink(shlib0, join_path(dst, shlib))
+        symlink(shlib0, join_path(dst, shlib))
     else:
         shlib000 = name + ".so.0.0.0"
         shlib0 = name + ".so.0"
         shlib = name + ".dylib"
         install(join_path(src, shlib000), join_path(dst, shlib000))
-        os.symlink(shlib000, join_path(dst, shlib0))
-        os.symlink(shlib0, join_path(dst, shlib))
+        symlink(shlib000, join_path(dst, shlib0))
+        symlink(shlib0, join_path(dst, shlib))
 
 
 class Hdf5Blosc(Package):

--- a/repos/spack_repo/builtin/packages/intel_xed/package.py
+++ b/repos/spack_repo/builtin/packages/intel_xed/package.py
@@ -100,7 +100,7 @@ class IntelXed(Package):
         # See: https://github.com/intelxed/xed/issues/300
         try:
             lname = join_path(self.stage.source_path, "..", "xed")
-            os.symlink("spack-src", lname)
+            symlink("spack-src", lname)
         except OSError:
             pass
 

--- a/repos/spack_repo/builtin/packages/ioapi/package.py
+++ b/repos/spack_repo/builtin/packages/ioapi/package.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
 
 from spack.package import *
@@ -76,7 +74,7 @@ class Ioapi(MakefilePackage):
 
     def edit(self, spec, prefix):
         # No default Makefile bundled; edit the template.
-        os.symlink("Makefile.template", "Makefile")
+        symlink("Makefile.template", "Makefile")
         # The makefile uses stubborn assignments of = instead of ?= so
         # edit the makefile instead of using environmental variables.
         makefile = FileFilter("Makefile")

--- a/repos/spack_repo/builtin/packages/liggghts/package.py
+++ b/repos/spack_repo/builtin/packages/liggghts/package.py
@@ -52,7 +52,7 @@ class Liggghts(MakefilePackage):
         # Makefile.user_default.
         makefile_default = os.path.join("src", "MAKE", "Makefile.user_default")
         makefile_user = os.path.join("src", "MAKE", "Makefile.user")
-        os.symlink(os.path.basename(makefile_default), makefile_user)
+        symlink(os.path.basename(makefile_default), makefile_user)
         makefile = FileFilter(makefile_user)
         makefile_auto = FileFilter(os.path.join("src", "MAKE", "Makefile.auto"))
 

--- a/repos/spack_repo/builtin/packages/llvm/package.py
+++ b/repos/spack_repo/builtin/packages/llvm/package.py
@@ -884,7 +884,7 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
                 sym = os.path.join(self.stage.path, "ld.lld")
                 if os.path.exists(bin) and not os.path.exists(sym):
                     mkdirp(self.stage.path)
-                    os.symlink(bin, sym)
+                    symlink(bin, sym)
             env.prepend_path("PATH", self.stage.path)
 
         if self.spec.satisfies("platform=darwin"):

--- a/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
+++ b/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
@@ -327,7 +327,7 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
                 self.prefix.amdgcn, join_path(self.prefix.lib.clang, version, "lib", "amdgcn")
             )
             shutil.rmtree(self.prefix.amdgcn)
-            os.symlink(
+            symlink(
                 join_path(self.prefix.lib.clang, version, "lib", "amdgcn"),
                 os.path.join(self.prefix, "amdgcn"),
             )

--- a/repos/spack_repo/builtin/packages/llvm_doe/package.py
+++ b/repos/spack_repo/builtin/packages/llvm_doe/package.py
@@ -385,7 +385,7 @@ class LlvmDoe(CMakePackage, CudaPackage):
                 sym = os.path.join(self.stage.path, "ld.lld")
                 if os.path.exists(bin) and not os.path.exists(sym):
                     mkdirp(self.stage.path)
-                    os.symlink(bin, sym)
+                    symlink(bin, sym)
             env.prepend_path("PATH", self.stage.path)
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:

--- a/repos/spack_repo/builtin/packages/lua/package.py
+++ b/repos/spack_repo/builtin/packages/lua/package.py
@@ -297,7 +297,7 @@ class Lua(LuaImplPackage):
                 for version_str in version_formats:
                     for joiner in ["", "-"]:
                         dest_path = "liblua{0}{1}.{2}".format(joiner, version_str, dso_suffix)
-                        os.symlink(src_path, dest_path)
+                        symlink(src_path, dest_path)
 
     @run_after("install")
     def generate_pkg_config(self):

--- a/repos/spack_repo/builtin/packages/matlab/package.py
+++ b/repos/spack_repo/builtin/packages/matlab/package.py
@@ -79,7 +79,7 @@ class Matlab(Package):
         # Fix broken link
         with working_dir(self.spec.prefix.bin.glnxa64):
             os.unlink("libSDL2.so")
-            os.symlink("libSDL2-2.0.so.0.2.1", "libSDL2.so")
+            symlink("libSDL2-2.0.so.0.2.1", "libSDL2.so")
 
         # Fix to random exceptions when changing display settings
         # https://www.mathworks.com/matlabcentral/answers/373897-external-monitor-throws-java-exception

--- a/repos/spack_repo/builtin/packages/mmv/package.py
+++ b/repos/spack_repo/builtin/packages/mmv/package.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
 
 from spack.package import *
@@ -38,11 +36,11 @@ class Mmv(MakefilePackage):
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         install("mmv", prefix.bin)
-        os.symlink(join_path(prefix.bin, "mmv"), "mad")
-        os.symlink(join_path(prefix.bin, "mmv"), "mcp")
-        os.symlink(join_path(prefix.bin, "mmv"), "mln")
+        symlink(join_path(prefix.bin, "mmv"), "mad")
+        symlink(join_path(prefix.bin, "mmv"), "mcp")
+        symlink(join_path(prefix.bin, "mmv"), "mln")
         mkdirp(prefix.man1)
         install("mmv.1", prefix.man1)
-        os.symlink(join_path(prefix.man1, "mmv.1"), "mad.1")
-        os.symlink(join_path(prefix.man1, "mmv.1"), "mcp.1")
-        os.symlink(join_path(prefix.man1, "mmv.1"), "mln.1")
+        symlink(join_path(prefix.man1, "mmv.1"), "mad.1")
+        symlink(join_path(prefix.man1, "mmv.1"), "mcp.1")
+        symlink(join_path(prefix.man1, "mmv.1"), "mln.1")

--- a/repos/spack_repo/builtin/packages/ncurses/package.py
+++ b/repos/spack_repo/builtin/packages/ncurses/package.py
@@ -196,7 +196,7 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
         headers = glob.glob(os.path.join(prefix.include, "ncursesw", "*.h"))
         for header in headers:
             h = os.path.basename(header)
-            os.symlink(os.path.join("ncursesw", h), os.path.join(prefix.include, h))
+            symlink(os.path.join("ncursesw", h), os.path.join(prefix.include, h))
 
         if spec.satisfies("@6.3:"):
             pc_stage = "{0}/lib/pkgconfig".format(self.stage.source_path)
@@ -210,7 +210,7 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
         libncurses = "{0}/libncurses.{1}".format(self.prefix.lib, soext)
         libcurses = "{0}/libcurses.{1}".format(self.prefix.lib, soext)
         if not os.path.exists(libcurses) and os.path.exists(libncurses):
-            os.symlink(libncurses, libcurses)
+            symlink(libncurses, libcurses)
 
     def query_parameter_options(self):
         """Use query parameters passed to spec (e.g., "spec[ncurses:wide]")

--- a/repos/spack_repo/builtin/packages/nekcem/package.py
+++ b/repos/spack_repo/builtin/packages/nekcem/package.py
@@ -113,6 +113,6 @@ class Nekcem(Package):
         install_tree(self.stage.source_path, prefix.bin.NekCEM)
         # Create symlinks to makenek, nek and configurenek scripts
         with working_dir(prefix.bin):
-            os.symlink(os.path.join("NekCEM", bin_dir, makenek), makenek)
-            os.symlink(os.path.join("NekCEM", bin_dir, configurenek), configurenek)
-            os.symlink(os.path.join("NekCEM", bin_dir, nek), nek)
+            symlink(os.path.join("NekCEM", bin_dir, makenek), makenek)
+            symlink(os.path.join("NekCEM", bin_dir, configurenek), configurenek)
+            symlink(os.path.join("NekCEM", bin_dir, nek), nek)

--- a/repos/spack_repo/builtin/packages/nvidia_nsight_systems/package.py
+++ b/repos/spack_repo/builtin/packages/nvidia_nsight_systems/package.py
@@ -106,23 +106,23 @@ class NvidiaNsightSystems(Package):
             shutil.copytree(join_path(base_path, ver, sd), join_path(prefix, sd))
         os.mkdir(join_path(prefix, "bin"))
         if arch == "aarch64":
-            os.symlink(
+            symlink(
                 join_path(prefix, "host-linux-armv8", "nsys-ui"),
                 join_path(prefix, "bin", "nsys-ui"),
             )
-            os.symlink(
+            symlink(
                 join_path(prefix, "target-linux-sbsa-armv8", "nsys"),
                 join_path(prefix, "bin", "nsys"),
             )
         elif arch == "ppc64le":
             # `nsys-ui` is missing in the PowerPC version of the package.
-            os.symlink(
+            symlink(
                 join_path(prefix, "target-linux-ppc64le", "nsys"), join_path(prefix, "bin", "nsys")
             )
         elif arch == "x86_64":
-            os.symlink(
+            symlink(
                 join_path(prefix, "host-linux-x64", "nsys-ui"), join_path(prefix, "bin", "nsys-ui")
             )
-            os.symlink(
+            symlink(
                 join_path(prefix, "target-linux-x64", "nsys"), join_path(prefix, "bin", "nsys")
             )

--- a/repos/spack_repo/builtin/packages/openfoam/package.py
+++ b/repos/spack_repo/builtin/packages/openfoam/package.py
@@ -590,7 +590,7 @@ class Openfoam(Package):
         projdir = "OpenFOAM-v{0}".format(self.version)
         if not os.path.exists(join_path(self.stage.path, projdir)):
             tty.info("Added directory link {0}".format(projdir))
-            os.symlink(
+            symlink(
                 os.path.relpath(self.stage.source_path, self.stage.path),
                 join_path(self.stage.path, projdir),
             )
@@ -883,7 +883,7 @@ class Openfoam(Package):
         """Add symlinks into bin/, lib/ (eg, for other applications)"""
         # Make build log visible - it contains OpenFOAM-specific information
         with working_dir(self.projectdir):
-            os.symlink(
+            symlink(
                 join_path(os.path.relpath(self.install_log_path)),
                 join_path("log." + str(self.foam_arch)),
             )
@@ -894,14 +894,14 @@ class Openfoam(Package):
         # ln -s platforms/linux64GccXXX/lib lib
         with working_dir(self.projectdir):
             if os.path.isdir(self.archlib):
-                os.symlink(self.archlib, "lib")
+                symlink(self.archlib, "lib")
 
         # (cd bin && ln -s ../platforms/linux64GccXXX/bin/* .)
         with working_dir(join_path(self.projectdir, "bin")):
             for f in [
                 f for f in glob.glob(join_path("..", self.archbin, "*")) if os.path.isfile(f)
             ]:
-                os.symlink(f, os.path.basename(f))
+                symlink(f, os.path.basename(f))
 
     # Executables like decomposePar require interface libraries for optional dependencies, but if
     # the dependency is missing, an dummy library is used and put in lib/dummy. Allow this until

--- a/repos/spack_repo/builtin/packages/openfoam_org/package.py
+++ b/repos/spack_repo/builtin/packages/openfoam_org/package.py
@@ -272,7 +272,7 @@ class OpenfoamOrg(Package):
         with working_dir(parent):
             if original != target and not os.path.lexists(target):
                 os.rename(original, target)
-                os.symlink(target, original)
+                symlink(target, original)
                 tty.info("renamed {0} -> {1}".format(original, target))
 
     def patch(self):
@@ -452,7 +452,7 @@ class OpenfoamOrg(Package):
         """Add symlinks into bin/, lib/ (eg, for other applications)"""
         # Make build log visible - it contains OpenFOAM-specific information
         with working_dir(self.projectdir):
-            os.symlink(
+            symlink(
                 join_path(os.path.relpath(self.install_log_path)),
                 join_path("log." + str(self.foam_arch)),
             )
@@ -463,14 +463,14 @@ class OpenfoamOrg(Package):
         # ln -s platforms/linux64GccXXX/lib lib
         with working_dir(self.projectdir):
             if os.path.isdir(self.archlib):
-                os.symlink(self.archlib, "lib")
+                symlink(self.archlib, "lib")
 
         # (cd bin && ln -s ../platforms/linux64GccXXX/bin/* .)
         with working_dir(join_path(self.projectdir, "bin")):
             for f in [
                 f for f in glob.glob(join_path("..", self.archbin, "*")) if os.path.isfile(f)
             ]:
-                os.symlink(f, os.path.basename(f))
+                symlink(f, os.path.basename(f))
 
 
 # -----------------------------------------------------------------------------

--- a/repos/spack_repo/builtin/packages/openjdk/package.py
+++ b/repos/spack_repo/builtin/packages/openjdk/package.py
@@ -516,7 +516,7 @@ class Openjdk(Package):
             if os.path.exists(sys_certs):
                 if os.path.exists(pkg_conf):
                     os.remove(pkg_conf)
-                os.symlink(sys_certs, pkg_conf)
+                symlink(sys_certs, pkg_conf)
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         """Set JAVA_HOME."""

--- a/repos/spack_repo/builtin/packages/openssl/package.py
+++ b/repos/spack_repo/builtin/packages/openssl/package.py
@@ -205,14 +205,14 @@ class Openssl(Package):  # Uses Fake Autotools, should subclass Package
             sys_conf = join_path(directory, "openssl.cnf")
             pkg_conf = join_path(pkg_dir, "openssl.cnf")
             if os.path.exists(sys_conf) and not os.path.exists(pkg_conf):
-                os.symlink(sys_conf, pkg_conf)
+                symlink(sys_conf, pkg_conf)
 
             sys_cert = join_path(directory, "cert.pem")
             pkg_cert = join_path(pkg_dir, "cert.pem")
             # If a bundle exists, use it. This is the preferred way on Fedora,
             # where the certs directory does not work.
             if os.path.exists(sys_cert) and not os.path.exists(pkg_cert):
-                os.symlink(sys_cert, pkg_cert)
+                symlink(sys_cert, pkg_cert)
 
             sys_certs = join_path(directory, "certs")
             pkg_certs = join_path(pkg_dir, "certs")
@@ -222,7 +222,7 @@ class Openssl(Package):  # Uses Fake Autotools, should subclass Package
             if os.path.isdir(sys_certs) and not os.path.islink(pkg_certs):
                 if os.path.isdir(pkg_certs):
                     os.rmdir(pkg_certs)
-                os.symlink(sys_certs, pkg_certs)
+                symlink(sys_certs, pkg_certs)
 
     @run_after("install")
     def copy_mozilla_certs(self):

--- a/repos/spack_repo/builtin/packages/pdt/package.py
+++ b/repos/spack_repo/builtin/packages/pdt/package.py
@@ -87,4 +87,4 @@ class Pdt(AutotoolsPackage):
                 src = join_path(path, d)
                 dst = join_path(self.prefix, d)
                 if os.path.isdir(src) and not os.path.exists(dst):
-                    os.symlink(join_path(dir, d), dst)
+                    symlink(join_path(dir, d), dst)

--- a/repos/spack_repo/builtin/packages/pocl/package.py
+++ b/repos/spack_repo/builtin/packages/pocl/package.py
@@ -110,7 +110,7 @@ class Pocl(CMakePackage):
 
     @run_after("install")
     def symlink_opencl(self):
-        os.symlink("CL", self.prefix.include.OpenCL)
+        symlink("CL", self.prefix.include.OpenCL)
 
     @run_after("install")
     @on_package_attributes(run_tests=True)

--- a/repos/spack_repo/builtin/packages/py_docutils/package.py
+++ b/repos/spack_repo/builtin/packages/py_docutils/package.py
@@ -55,4 +55,4 @@ class PyDocutils(PythonPackage):
         bin_path = self.prefix.bin
         for file in os.listdir(bin_path):
             if file.endswith(".py"):
-                os.symlink(os.path.join(bin_path, file), os.path.join(bin_path, file[:-3]))
+                symlink(os.path.join(bin_path, file), os.path.join(bin_path, file[:-3]))

--- a/repos/spack_repo/builtin/packages/py_meldmd/package.py
+++ b/repos/spack_repo/builtin/packages/py_meldmd/package.py
@@ -61,7 +61,7 @@ class PyMeldmd(CMakePackage, PythonExtension, CudaPackage):
             pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")
         for _, _, files in os.walk(self.spec["openmm"].prefix.lib.plugins):
             for f in files:
-                os.symlink(
+                symlink(
                     join_path(self.spec["openmm"].prefix.lib.plugins, f),
                     join_path(self.prefix.lib.plugins, f),
                 )

--- a/repos/spack_repo/builtin/packages/py_smartsim/package.py
+++ b/repos/spack_repo/builtin/packages/py_smartsim/package.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack_repo.builtin.build_systems.python import PythonPackage
 
 from spack.package import *
@@ -75,12 +73,12 @@ class PySmartsim(PythonPackage):
     @run_after("install")
     def symlink_bin_deps(self):
         ss_core_path = join_path(python_purelib, "smartsim", "_core")
-        os.symlink(
+        symlink(
             self.spec["redis"].prefix.bin.join("redis-server"),
             join_path(ss_core_path, "bin", "redis-server"),
         )
-        os.symlink(
+        symlink(
             self.spec["redis"].prefix.bin.join("redis-cli"),
             join_path(ss_core_path, "bin", "redis-cli"),
         )
-        os.symlink(self.spec["redis-ai"].prefix, join_path(ss_core_path, "lib"))
+        symlink(self.spec["redis-ai"].prefix, join_path(ss_core_path, "lib"))

--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -736,8 +736,8 @@ class Python(Package):
         prefix = self.prefix
 
         if spec.satisfies("+pythoncmd"):
-            os.symlink(os.path.join(prefix.bin, "python3"), os.path.join(prefix.bin, "python"))
-            os.symlink(
+            symlink(os.path.join(prefix.bin, "python3"), os.path.join(prefix.bin, "python"))
+            symlink(
                 os.path.join(prefix.bin, "python3-config"),
                 os.path.join(prefix.bin, "python-config"),
             )

--- a/repos/spack_repo/builtin/packages/rhash/package.py
+++ b/repos/spack_repo/builtin/packages/rhash/package.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
 
 from spack.package import *
@@ -87,9 +85,7 @@ class Rhash(MakefilePackage):
             install("librhash/*.dylib", prefix.lib)
         else:
             make("install-lib-shared", "DESTDIR={0}".format(prefix), "PREFIX=")
-            os.symlink(
-                join_path(prefix.lib, "librhash.so.0"), join_path(prefix.lib, "librhash.so")
-            )
+            symlink(join_path(prefix.lib, "librhash.so.0"), join_path(prefix.lib, "librhash.so"))
 
     @when("@1.3.6:")
     def install(self, spec, prefix):

--- a/repos/spack_repo/builtin/packages/rocm_openmp_extras/package.py
+++ b/repos/spack_repo/builtin/packages/rocm_openmp_extras/package.py
@@ -540,12 +540,12 @@ class RocmOpenmpExtras(Package):
                 if os.path.islink((os.path.join(bin_dir, f"flang-{legacy_or_classic}"))):
                     os.unlink(os.path.join(bin_dir, f"flang-{legacy_or_classic}"))
             if not os.path.exists(os.path.join(bin_dir, "flang1")):
-                os.symlink(os.path.join(omp_bin_dir, "flang1"), os.path.join(bin_dir, "flang1"))
+                symlink(os.path.join(omp_bin_dir, "flang1"), os.path.join(bin_dir, "flang1"))
             if not os.path.exists(os.path.join(bin_dir, "flang2")):
-                os.symlink(os.path.join(omp_bin_dir, "flang2"), os.path.join(bin_dir, "flang2"))
+                symlink(os.path.join(omp_bin_dir, "flang2"), os.path.join(bin_dir, "flang2"))
 
             if self.spec.version >= Version("6.1.0"):
-                os.symlink(
+                symlink(
                     os.path.join(omp_bin_dir, f"flang-{legacy_or_classic}"),
                     os.path.join(bin_dir, f"flang-{legacy_or_classic}"),
                 )
@@ -555,8 +555,8 @@ class RocmOpenmpExtras(Package):
                 os.unlink(os.path.join(lib_dir, "libdevice"))
             if os.path.islink((os.path.join(llvm_prefix, "lib-debug"))):
                 os.unlink(os.path.join(llvm_prefix, "lib-debug"))
-            os.symlink(os.path.join(omp_lib_dir, "libdevice"), os.path.join(lib_dir, "libdevice"))
-            os.symlink(
+            symlink(os.path.join(omp_lib_dir, "libdevice"), os.path.join(lib_dir, "libdevice"))
+            symlink(
                 os.path.join(self.prefix, "lib-debug"), os.path.join(llvm_prefix, "lib-debug")
             )
 
@@ -758,7 +758,7 @@ class RocmOpenmpExtras(Package):
                     cmake(*cmake_args)
                     make()
                     make("install")
-                    os.symlink(os.path.join(bin_dir, "clang"), os.path.join(omp_bin_dir, "clang"))
+                    symlink(os.path.join(bin_dir, "clang"), os.path.join(omp_bin_dir, "clang"))
             else:
                 with working_dir(f"spack-build-{component}", create=True):
                     # OpenMP build needs to be run twice(Release, Debug)

--- a/repos/spack_repo/builtin/packages/rocm_openmp_extras/package.py
+++ b/repos/spack_repo/builtin/packages/rocm_openmp_extras/package.py
@@ -556,9 +556,7 @@ class RocmOpenmpExtras(Package):
             if os.path.islink((os.path.join(llvm_prefix, "lib-debug"))):
                 os.unlink(os.path.join(llvm_prefix, "lib-debug"))
             symlink(os.path.join(omp_lib_dir, "libdevice"), os.path.join(lib_dir, "libdevice"))
-            symlink(
-                os.path.join(self.prefix, "lib-debug"), os.path.join(llvm_prefix, "lib-debug")
-            )
+            symlink(os.path.join(self.prefix, "lib-debug"), os.path.join(llvm_prefix, "lib-debug"))
 
         # Set cmake args
         components = dict()

--- a/repos/spack_repo/builtin/packages/rstudio/package.py
+++ b/repos/spack_repo/builtin/packages/rstudio/package.py
@@ -133,7 +133,7 @@ class Rstudio(CMakePackage):
         pandoc_dir = join_path(self.prefix.tools, "pandoc", self.spec["pandoc"].version)
         os.makedirs(pandoc_dir)
         with working_dir(pandoc_dir):
-            os.symlink(self.spec["pandoc"].prefix.bin.pandoc, "pandoc")
-            os.symlink(
+            symlink(self.spec["pandoc"].prefix.bin.pandoc, "pandoc")
+            symlink(
                 os.path.join(self.spec["pandoc"].prefix.bin, "pandoc-citeproc"), "pandoc-citeproc"
             )

--- a/repos/spack_repo/builtin/packages/s4pred/package.py
+++ b/repos/spack_repo/builtin/packages/s4pred/package.py
@@ -43,4 +43,4 @@ class S4pred(Package):
         os.chmod("run_model.py", 0o755)
         # install files and make convenience symlink
         install("*.py", prefix.bin)
-        os.symlink(join_path(prefix.bin, "run_model.py"), join_path(prefix.bin, "s4pred"))
+        symlink(join_path(prefix.bin, "run_model.py"), join_path(prefix.bin, "s4pred"))

--- a/repos/spack_repo/builtin/packages/swig/package.py
+++ b/repos/spack_repo/builtin/packages/swig/package.py
@@ -153,7 +153,7 @@ class AutotoolsBuilder(autotools.AutotoolsBuilder):
     def create_symlink(self):
         # CMake compatibility: see https://github.com/spack/spack/pull/6240
         with working_dir(self.prefix.bin):
-            os.symlink("swig", "swig{0}.0".format(self.spec.version.up_to(1)))
+            symlink("swig", "swig{0}.0".format(self.spec.version.up_to(1)))
 
     @when(Swig.AUTOCONF_VERSIONS)
     def autoreconf(self, pkg, spec, prefix):

--- a/repos/spack_repo/builtin/packages/systemd/package.py
+++ b/repos/spack_repo/builtin/packages/systemd/package.py
@@ -153,4 +153,4 @@ class Systemd(MesonPackage):
             for lib_path in glob.glob("lib*/systemd/lib*.so*"):
                 lib_name = os.path.basename(lib_path)
                 lib_dir = os.path.dirname(os.path.dirname(lib_path))
-                os.symlink(os.path.relpath(lib_path, lib_dir), os.path.join(lib_dir, lib_name))
+                symlink(os.path.relpath(lib_path, lib_dir), os.path.join(lib_dir, lib_name))

--- a/repos/spack_repo/builtin/packages/tau/package.py
+++ b/repos/spack_repo/builtin/packages/tau/package.py
@@ -524,7 +524,7 @@ class Tau(Package):
                 src = join_path(self.prefix, subdir, d)
                 dest = join_path(self.prefix, d)
                 if os.path.isdir(src) and not os.path.exists(dest):
-                    os.symlink(join_path(subdir, d), dest)
+                    symlink(join_path(subdir, d), dest)
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         pattern = join_path(self.prefix.lib, "Makefile.*")

--- a/repos/spack_repo/builtin/packages/trinotate/package.py
+++ b/repos/spack_repo/builtin/packages/trinotate/package.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import glob
-import os
 
 from spack_repo.builtin.build_systems.generic import Package
 
@@ -56,11 +55,9 @@ class Trinotate(Package):
         install_tree(".", join_path(prefix.lib, "trinotate"))
 
         mkdirp(prefix.bin)
-        os.symlink(
-            join_path(prefix.lib, "trinotate/Trinotate"), join_path(prefix.bin, "Trinotate")
-        )
+        symlink(join_path(prefix.lib, "trinotate/Trinotate"), join_path(prefix.bin, "Trinotate"))
 
-        os.symlink(
+        symlink(
             join_path(prefix.lib, "trinotate/run_TrinotateWebserver.pl"),
             join_path(prefix.bin, "run_TrinotateWebserver.pl"),
         )


### PR DESCRIPTION
os.symlink has a number of compatibility/cross platform issues. Spack has a utility explicitly to work around these issues. Packages should leverage that utility so we have more consistent x-platform behavior.

Note: `symlink` on linux/macos is still `os.symlink`, the behavior is only different for Windows.

