### PR TITLE
labels: add `remove-package` label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -21,6 +21,11 @@ update-package:
     - 'modified'
     - 'renamed'
 
+remove-package:
+  filename: '^repos/spack_repo/builtin/packages/[^/]+/package.py$'
+  status:
+    - 'removed'
+
 maintainers:
   patch: '[+-] +maintainers +='
 


### PR DESCRIPTION
Add a `remove-package` label to tag PRs that delete a package from the ecosystem.