### PR TITLE
py-hf-xet: add missing dependencies on c and cxx

### DIFF
--- a/repos/spack_repo/builtin/packages/py_hf_xet/package.py
+++ b/repos/spack_repo/builtin/packages/py_hf_xet/package.py
@@ -16,5 +16,8 @@ class PyHfXet(PythonPackage):
 
     version("1.1.5", sha256="69ebbcfd9ec44fdc2af73441619eeb06b94ee34511bbcf57cd423820090f5694")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     # https://github.com/huggingface/xet-core/blob/v1.1.5/hf_xet/pyproject.toml
     depends_on("py-maturin@1.7:1", type="build")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This was needed on my machine.