### PR TITLE
apfel: fix cmake version typo; add type=build

### DIFF
--- a/repos/spack_repo/builtin/packages/apfel/package.py
+++ b/repos/spack_repo/builtin/packages/apfel/package.py
@@ -35,7 +35,7 @@ class Apfel(AutotoolsPackage, CMakePackage):
     depends_on("fortran", type="build")
 
     with when("build_system=cmake"):
-        depends_on("cmake@03.15:")
+        depends_on("cmake@3.15:", type="build")
 
     extends("python", when="+python")
     depends_on("swig", when="+python")


### PR DESCRIPTION
This PR fixes a typo in the `apfel` build dependency on `cmake`. This causes the concretization errors in https://gitlab.spack.io/spack/spack-packages/-/jobs/17247852 (which don't actually print the offending version typo). 