### PR TITLE
gobject-introspection: restore setuptools@44: support

### DIFF
--- a/repos/spack_repo/builtin/packages/gobject_introspection/package.py
+++ b/repos/spack_repo/builtin/packages/gobject_introspection/package.py
@@ -66,7 +66,7 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
         patch(
             "https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/490/commits.patch",
             sha256="8085a21385aba2370ba0859f7d0c5f0a6d6a051ab3c0ea0b8881d567d6356299",
-            when="@:1.81.0",
+            when="@1.66:1.81.0",
         )
 
     # This package creates several scripts from

--- a/repos/spack_repo/builtin/packages/gobject_introspection/package.py
+++ b/repos/spack_repo/builtin/packages/gobject_introspection/package.py
@@ -66,9 +66,8 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
         patch(
             "https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/490/commits.patch",
             sha256="8085a21385aba2370ba0859f7d0c5f0a6d6a051ab3c0ea0b8881d567d6356299",
-            when="@:1.81.0"
+            when="@:1.81.0",
         )
-
 
     # This package creates several scripts from
     # toosl/g-ir-tool-template.in.  In their original form these

--- a/repos/spack_repo/builtin/packages/gobject_introspection/package.py
+++ b/repos/spack_repo/builtin/packages/gobject_introspection/package.py
@@ -57,10 +57,18 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
     # https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/283
     depends_on("libffi@:3.3", when="@:1.72")  # libffi 3.4 caused seg faults
     depends_on("python")
+
     with when("^python@3.12:"):
         depends_on("py-setuptools@48:", type=("build", "run"))
+
         # https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/490
-        depends_on("py-setuptools@:73", type=("build", "run"), when="@:1.81.0")
+        # restores setuptools@74: support
+        patch(
+            "https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/490/commits.patch",
+            sha256="8085a21385aba2370ba0859f7d0c5f0a6d6a051ab3c0ea0b8881d567d6356299",
+            when="@:1.81.0"
+        )
+
 
     # This package creates several scripts from
     # toosl/g-ir-tool-template.in.  In their original form these


### PR DESCRIPTION
Restores `setuptools@44:` support by applying the PR that was previously pending.

@wdconinc @michaelkuhn 