### PR TITLE
py-nvidia-nvimagecodec: new packages for CUDA 11 and 12

### DIFF
--- a/repos/spack_repo/builtin/packages/eccodes/package.py
+++ b/repos/spack_repo/builtin/packages/eccodes/package.py
@@ -52,7 +52,7 @@ class Eccodes(CMakePackage):
 
     version("develop", branch="develop")
     version("2.41.0", sha256="a1467842e11ed7f62a2f5cc1982e04eec62398f4962e6ba03ace7646f32cf270")
-    version("2.40.0", sha256="f58d5d7390fce86c62b26d76b9bc3c4d7d9a6cf2e5f8145d1d598089195e51ff") 
+    version("2.40.0", sha256="f58d5d7390fce86c62b26d76b9bc3c4d7d9a6cf2e5f8145d1d598089195e51ff")
     version("2.38.0", sha256="96a21fbe8ca3aa4c31bb71bbd378b7fd130cbc0f7a477567d70e66a000ff68d9")
     version("2.34.0", sha256="3cd208c8ddad132789662cf8f67a9405514bfefcacac403c0d8c84507f303aba")
     version("2.33.0", sha256="bdcec8ce63654ec6803400c507f01220a9aa403a45fa6b5bdff7fdcc44fd7daf")

--- a/repos/spack_repo/builtin/packages/py_nvidia_nvimagecodec/package.py
+++ b/repos/spack_repo/builtin/packages/py_nvidia_nvimagecodec/package.py
@@ -1,0 +1,63 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyNvidiaNvimagecodec(PythonPackage):
+    """A nvImageCodec library of GPU- and CPU- accelerated codecs featuring a unified interface"""
+
+    homepage = "https://docs.nvidia.com/cuda/nvimagecodec/index.html"
+    git = "https://github.com/NVIDIA/nvImageCodec.git"
+
+    skip_version_audit = ["platform=darwin", "platform=windows"]
+
+    maintainers("thomas-bouvier")
+
+    system = platform.system().lower()
+    arch = platform.machine()
+    if "linux" in system and arch == "x86_64":
+        version(
+            "0.5.0.13-cuda120",
+            sha256="24cf0a759b1b02a6c3c0aedf8bf6602643f74c4c6df68c4b1c3c4ec1d48d71b0",
+            url="https://files.pythonhosted.org/packages/f0/6d/1c9919912ee97a4f52674f1c2deec7ab80df8fdd9a8b76f8ed4d75ebf799/nvidia_nvimgcodec_cu12-0.5.0.13-py3-none-manylinux2014_x86_64.whl",
+        )
+        version(
+            "0.5.0.13-cuda110",
+            sha256="d82ccf33921a35d965e975bfcf7f64472c804cb0f734a8fe692d9dca7e1e8643",
+            url="https://files.pythonhosted.org/packages/60/69/d26efdefee269e87c034b229d94bf878ec033fca1b7cd4644395e706cf38/nvidia_nvimgcodec_cu11-0.5.0.13-py3-none-manylinux2014_x86_64.whl",
+        )
+    elif "linux" in system and arch == "aarch64":
+        version(
+            "0.5.0.13-cuda120",
+            sha256="d76fadc2ed0f9075871627e45f2592c7807a0e944a0505afc21f87ccceb75caa",
+            url="https://files.pythonhosted.org/packages/28/9a/f6c9105cb045f52af2096417ce92e7e8fba4d24ffe24d2cc82eb9bbe5534/nvidia_nvimgcodec_cu12-0.5.0.13-py3-none-manylinux2014_aarch64.whl",
+        )
+        version(
+            "0.5.0.13-cuda110",
+            sha256="0cb46e2032e2ae91afd48ba65b4a990c786927969110119a611859f6022bc417",
+            url="https://files.pythonhosted.org/packages/58/84/2ed139ffa8961549acf168a554187b3cda9820076d687ede9ed95cd458be/nvidia_nvimgcodec_cu11-0.5.0.13-py3-none-manylinux2014_aarch64.whl",
+        )
+
+    variant("nvjpeg2k", default=True, description="Enable NVJPEG2K support")
+    variant("nvtiff", default=True, description="Enable NVTIFF support")
+
+    cuda120_versions = (
+        "@0.5.0.13-cuda120",
+    )
+    cuda110_versions = (
+        "@0.5.0.13-cuda110",
+    )
+
+    for v in cuda120_versions:
+        depends_on("cuda@12", when=v, type=("build", "run"))
+    for v in cuda110_versions:
+        depends_on("cuda@11", when=v, type=("build", "run"))
+
+    depends_on("python@3.8:", when="@0.5:", type=("build", "run"))
+
+    depends_on("py-nvidia-nvjpeg2k", type=("build", "run"), when="+nvjpeg2k")
+    depends_on("py-nvidia-nvtiff", type=("build", "run"), when="+nvtiff")

--- a/repos/spack_repo/builtin/packages/py_nvidia_nvimagecodec/package.py
+++ b/repos/spack_repo/builtin/packages/py_nvidia_nvimagecodec/package.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import platform
+
 from spack_repo.builtin.build_systems.python import PythonPackage
 
 from spack.package import *

--- a/repos/spack_repo/builtin/packages/py_nvidia_nvimagecodec/package.py
+++ b/repos/spack_repo/builtin/packages/py_nvidia_nvimagecodec/package.py
@@ -47,12 +47,8 @@ class PyNvidiaNvimagecodec(PythonPackage):
     variant("nvjpeg2k", default=True, description="Enable NVJPEG2K support")
     variant("nvtiff", default=True, description="Enable NVTIFF support")
 
-    cuda120_versions = (
-        "@0.5.0.13-cuda120",
-    )
-    cuda110_versions = (
-        "@0.5.0.13-cuda110",
-    )
+    cuda120_versions = ("@0.5.0.13-cuda120",)
+    cuda110_versions = ("@0.5.0.13-cuda110",)
 
     for v in cuda120_versions:
         depends_on("cuda@12", when=v, type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_nvidia_nvjpeg2k/package.py
+++ b/repos/spack_repo/builtin/packages/py_nvidia_nvjpeg2k/package.py
@@ -43,12 +43,8 @@ class PyNvidiaNvjpeg2k(PythonPackage):
             url="https://files.pythonhosted.org/packages/4f/85/1daca97fbef54307691dde4bbd94b654a0535d3cdff1cb4a75adecc3f2be/nvidia_nvjpeg2k_cu11-0.8.1.40-py3-none-manylinux2014_aarch64.whl",
         )
 
-    cuda120_versions = (
-        "@0.8.1.40-cuda120",
-    )
-    cuda110_versions = (
-        "@0.8.1.40-cuda110",
-    )
+    cuda120_versions = ("@0.8.1.40-cuda120",)
+    cuda110_versions = ("@0.8.1.40-cuda110",)
 
     for v in cuda120_versions:
         depends_on("cuda@12", when=v, type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_nvidia_nvjpeg2k/package.py
+++ b/repos/spack_repo/builtin/packages/py_nvidia_nvjpeg2k/package.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import platform
+
 from spack_repo.builtin.build_systems.python import PythonPackage
 
 from spack.package import *

--- a/repos/spack_repo/builtin/packages/py_nvidia_nvjpeg2k/package.py
+++ b/repos/spack_repo/builtin/packages/py_nvidia_nvjpeg2k/package.py
@@ -1,0 +1,56 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyNvidiaNvjpeg2k(PythonPackage):
+    """NVIDIA nvJPEG2000 native runtime libraries"""
+
+    homepage = "https://docs.nvidia.com/cuda/nvjpeg2000/index.html"
+
+    skip_version_audit = ["platform=darwin", "platform=windows"]
+
+    maintainers("thomas-bouvier")
+
+    system = platform.system().lower()
+    arch = platform.machine()
+    if "linux" in system and arch == "x86_64":
+        version(
+            "0.8.1.40-cuda120",
+            sha256="326518da11c4b037a0ae2189ec2f7d317c8bd5ddd616413e45da0faa31bd3399",
+            url="https://files.pythonhosted.org/packages/fe/3c/7d6ba35508f5cbf6d25149076355188c8ea8303768b9a8272150a38c8063/nvidia_nvjpeg2k_cu12-0.8.1.40-py3-none-manylinux2014_x86_64.whl",
+        )
+        version(
+            "0.8.1.40-cuda110",
+            sha256="47b5f2f3217b5bf9935d013152df6e0412d11741bfee81419bdb4ad52d68aeb7",
+            url="https://files.pythonhosted.org/packages/9d/15/88dbe4f0ca93a8e5d381a993f384e7eb929d51476fcc905b848b14a2bcd7/nvidia_nvjpeg2k_cu11-0.8.1.40-py3-none-manylinux2014_x86_64.whl",
+        )
+    elif "linux" in system and arch == "aarch64":
+        version(
+            "0.8.1.40-cuda120",
+            sha256="63dd81d37b0826ad9d1086957815836a9dce45b3cbdb502b5c3566fba8cb4141",
+            url="https://files.pythonhosted.org/packages/8c/5a/8618385bb6e1d5f95f59de3a7fe22ed9b3a2c439c541589b7001345ac0aa/nvidia_nvjpeg2k_cu12-0.8.1.40-py3-none-manylinux2014_aarch64.whl",
+        )
+        version(
+            "0.8.1.40-cuda110",
+            sha256="5bc4a20f9b00097cfcbbf6d4905668717db5d381425144b06b9fce957b3a793e",
+            url="https://files.pythonhosted.org/packages/4f/85/1daca97fbef54307691dde4bbd94b654a0535d3cdff1cb4a75adecc3f2be/nvidia_nvjpeg2k_cu11-0.8.1.40-py3-none-manylinux2014_aarch64.whl",
+        )
+
+    cuda120_versions = (
+        "@0.8.1.40-cuda120",
+    )
+    cuda110_versions = (
+        "@0.8.1.40-cuda110",
+    )
+
+    for v in cuda120_versions:
+        depends_on("cuda@12", when=v, type=("build", "run"))
+    for v in cuda110_versions:
+        depends_on("cuda@11", when=v, type=("build", "run"))
+
+    depends_on("python@3.8:", when="@0.8:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_nvidia_nvtiff/package.py
+++ b/repos/spack_repo/builtin/packages/py_nvidia_nvtiff/package.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import platform
+
 from spack_repo.builtin.build_systems.python import PythonPackage
 
 from spack.package import *

--- a/repos/spack_repo/builtin/packages/py_nvidia_nvtiff/package.py
+++ b/repos/spack_repo/builtin/packages/py_nvidia_nvtiff/package.py
@@ -1,0 +1,56 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyNvidiaNvtiff(PythonPackage):
+    """NVIDIA nvTIFF native runtime libraries"""
+
+    homepage = "https://docs.nvidia.com/cuda/nvtiff/index.html"
+
+    skip_version_audit = ["platform=darwin", "platform=windows"]
+
+    maintainers("thomas-bouvier")
+
+    system = platform.system().lower()
+    arch = platform.machine()
+    if "linux" in system and arch == "x86_64":
+        version(
+            "0.5.0.67-cuda120",
+            sha256="97787f710beea7a7990b48d1dde57318e82716bdea61407db6eaced8ac511dc6",
+            url="https://files.pythonhosted.org/packages/81/67/c503df80ea3c2384bc8ed177164a1339ff49180835de01aa6597cfcad3a0/nvidia_nvtiff_cu12-0.5.0.67-py3-none-manylinux2014_x86_64.whl",
+        )
+        version(
+            "0.5.0.67-cuda110",
+            sha256="42881265c130cd62c031c154cfe108e5fb51c515b329dab627c60c46a4cbf764",
+            url="https://files.pythonhosted.org/packages/2e/13/27a18d88ed9001a98c80d3ffb1f0eec7fb77e277b7468421dc37ddebed6f/nvidia_nvtiff_cu11-0.5.0.67-py3-none-manylinux2014_x86_64.whl",
+        )
+    elif "linux" in system and arch == "aarch64":
+        version(
+            "0.5.0.67-cuda120",
+            sha256="cdaeff98d909d8ee885f1ab97da8cab06b7c1f1159f4da478f0afd21ac603155",
+            url="https://files.pythonhosted.org/packages/e9/27/d5528e059ddc6a2ae5f7df0bb602d96d0593b0c585597d04c987a5240da9/nvidia_nvtiff_cu12-0.5.0.67-py3-none-manylinux2014_aarch64.whl",
+        )
+        version(
+            "0.5.0.67-cuda110",
+            sha256="d043962a7c24085a85e93285f314a8c90bdbefef9ed48b74f943c02b3ce3f47e",
+            url="https://files.pythonhosted.org/packages/1a/b2/3b470a42ab20920f40a6138cc345379e412bfee0d58a989fb26bc6b15581/nvidia_nvtiff_cu11-0.5.0.67-py3-none-manylinux2014_aarch64.whl",
+        )
+
+    cuda120_versions = (
+        "@0.5.0.67-cuda120",
+    )
+    cuda110_versions = (
+        "@0.5.0.67-cuda110",
+    )
+
+    for v in cuda120_versions:
+        depends_on("cuda@12", when=v, type=("build", "run"))
+    for v in cuda110_versions:
+        depends_on("cuda@11", when=v, type=("build", "run"))
+
+    depends_on("python@3.8:", when="@0.5:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_nvidia_nvtiff/package.py
+++ b/repos/spack_repo/builtin/packages/py_nvidia_nvtiff/package.py
@@ -43,12 +43,8 @@ class PyNvidiaNvtiff(PythonPackage):
             url="https://files.pythonhosted.org/packages/1a/b2/3b470a42ab20920f40a6138cc345379e412bfee0d58a989fb26bc6b15581/nvidia_nvtiff_cu11-0.5.0.67-py3-none-manylinux2014_aarch64.whl",
         )
 
-    cuda120_versions = (
-        "@0.5.0.67-cuda120",
-    )
-    cuda110_versions = (
-        "@0.5.0.67-cuda110",
-    )
+    cuda120_versions = ("@0.5.0.67-cuda120",)
+    cuda110_versions = ("@0.5.0.67-cuda110",)
 
     for v in cuda120_versions:
         depends_on("cuda@12", when=v, type=("build", "run"))


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This PR add the `py-nvidia-nvimagecodec` package as well as two dependencies `py-nvidia-nvjpeg2k` and `py-nvidia-nvtiff`.