### PR TITLE
scotch: patch instead of conflict for oneAPI/FPE issue

### DIFF
--- a/repos/spack_repo/builtin/packages/scotch/package.py
+++ b/repos/spack_repo/builtin/packages/scotch/package.py
@@ -89,10 +89,6 @@ class Scotch(CMakePackage, MakefilePackage):
     conflicts("metis", when="+metis")
     conflicts("parmetis", when="+metis")
 
-    # https://github.com/ufs-community/ufs-weather-model/pull/2650
-    # https://github.com/spack/spack-packages/issues/161
-    conflicts("%oneapi")
-
     parallel = False
 
     # NOTE: Versions of Scotch up to version 6.0.0 don't include support for
@@ -126,6 +122,14 @@ class Scotch(CMakePackage, MakefilePackage):
             zlibs = self.spec["zlib-api"].libs
 
         return scotchlibs + zlibs
+
+    def patch(self):
+        if self.spec.satisfies("@:7.0.8 %oneapi"):
+            filter_file(
+                r"(actgrafptr->bbalglbval       =) (\(double\) actgrafptr->compglbload0dlt / \(double\) actgrafptr->compglbload0avg);",  # noqa: E501
+                r"\1 (actgrafptr->compglbload0avg != 0) ? \2 : 0;",
+                "src/libscotch/bdgraph.c",
+            )
 
 
 class CMakeBuilder(cmake.CMakeBuilder):

--- a/repos/spack_repo/builtin/packages/scotch/package.py
+++ b/repos/spack_repo/builtin/packages/scotch/package.py
@@ -124,6 +124,9 @@ class Scotch(CMakePackage, MakefilePackage):
         return scotchlibs + zlibs
 
     def patch(self):
+        # Add ternary operator to set 'actgrafptr->bbalglbval' to zero to avoid div by zero
+        # in the case of fewer vertices than processing elements for PT-Scotch.
+        # Solution comes from Scotch authors, and will be included in 7.0.9.
         if self.spec.satisfies("@:7.0.8 %oneapi"):
             filter_file(
                 r"(actgrafptr->bbalglbval       =) (\(double\) actgrafptr->compglbload0dlt / \(double\) actgrafptr->compglbload0avg);",  # noqa: E501


### PR DESCRIPTION
This PR eliminates the oneAPI conflict for Scotch, instead patching the file that leads to the FPE getting thrown when those flags are enabled.