### PR TITLE
parthenon: add correct language dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/parthenon/package.py
+++ b/repos/spack_repo/builtin/packages/parthenon/package.py
@@ -48,7 +48,8 @@ class Parthenon(CMakePackage):
     # Dependencies
     # ------------------------------------------------------------#
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("cmake@3.16:", type="build")
 


### PR DESCRIPTION
Parthenon declares `C CXX` in its `CMakeLists.txt` so we need to provide both.