### PR TITLE
GSL: fix configure args for external cblas

### DIFF
--- a/repos/spack_repo/builtin/packages/gsl/package.py
+++ b/repos/spack_repo/builtin/packages/gsl/package.py
@@ -65,7 +65,7 @@ class Gsl(AutotoolsPackage, GNUMirrorPackage):
     def configure_args(self):
         configure_args = []
         if self.spec.satisfies("+external-cblas"):
-            configure_args.append("--with-external-cblas")
+            configure_args.append("--with-cblas-external")
             configure_args.append("CBLAS_CFLAGS=%s" % self.spec["blas"].headers.include_flags)
             configure_args.append("CBLAS_LIBS=%s" % self.spec["blas"].libs.ld_flags)
 


### PR DESCRIPTION
Currently, the configure argument for `variant("external-cblas")` [is set as](https://github.com/jgraciahlrs/spack-packages/blob/develop/repos/spack_repo/builtin/packages/gsl/package.py#L67C1-L68C59)
```python
        if self.spec.satisfies("+external-cblas"):
            configure_args.append("--with-external-cblas")
``` 

Instead the configure argument [should be](https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/packages/gsl/gsl-2.8-cblas.patch#L66) `--with-cblas-external`.

