### PR TITLE
parmgridgen: pass  spec c/ldflags on to make command

### DIFF
--- a/repos/spack_repo/builtin/packages/parmgridgen/package.py
+++ b/repos/spack_repo/builtin/packages/parmgridgen/package.py
@@ -31,8 +31,8 @@ class Parmgridgen(Package):
     def install(self, spec, prefix):
         make_opts = [
             "make=make",
-            "COPTIONS={0}".format(self.compiler.cc_pic_flag),
-            "LDOPTIONS={0}".format(self.compiler.cc_pic_flag),
+            "COPTIONS={0} {1}".format(self.compiler.cc_pic_flag, " ".join(spec.compiler_flags["cflags"])),
+            "LDOPTIONS={0} {1}".format(self.compiler.cc_pic_flag, " ".join(spec.compiler_flags["ldflags"])),
             "CC={0}".format(self.compiler.cc),
             "LD={0}".format(self.compiler.cc),
             "LIBDIR=-L../..",

--- a/repos/spack_repo/builtin/packages/parmgridgen/package.py
+++ b/repos/spack_repo/builtin/packages/parmgridgen/package.py
@@ -31,8 +31,14 @@ class Parmgridgen(Package):
     def install(self, spec, prefix):
         make_opts = [
             "make=make",
-            "COPTIONS={0} {1}".format(self.compiler.cc_pic_flag, " ".join(spec.compiler_flags["cflags"])),
-            "LDOPTIONS={0} {1}".format(self.compiler.cc_pic_flag, " ".join(spec.compiler_flags["ldflags"])),
+            "COPTIONS={0} {1}".format(
+                self.compiler.cc_pic_flag, 
+                " ".join(spec.compiler_flags["cflags"])
+            ),
+            "LDOPTIONS={0} {1}".format(
+                self.compiler.cc_pic_flag, 
+                " ".join(spec.compiler_flags["ldflags"])
+            ),
             "CC={0}".format(self.compiler.cc),
             "LD={0}".format(self.compiler.cc),
             "LIBDIR=-L../..",


### PR DESCRIPTION
This PR takes `cflags` and `ldflags` from spec and passes those on to the make command invocation.