### PR TITLE
undeprecate gcc@12.3.0

### DIFF
--- a/.ci/gitlab/stacks/tutorial/spack.yaml
+++ b/.ci/gitlab/stacks/tutorial/spack.yaml
@@ -21,7 +21,7 @@ spack:
         - hdf5+hl+mpi ^mpich
         - trilinos
         - trilinos +hdf5 ^hdf5+hl+mpi ^mpich
-        - gcc@12
+        - gcc@12.3
         - mpileaks
         - lmod@8.7.18
         - environment-modules

--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -62,6 +62,9 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     version("4.6.4", sha256="35af16afa0b67af9b8eb15cafb76d2bc5f568540552522f5dc2c88dd45d977e8")
     version("4.5.4", sha256="eef3f0456db8c3d992cbb51d5d32558190bc14f3bc19383dd93acc27acc6befc")
 
+    # Used in the tutorial
+    version("12.3.0", sha256="949a5d4f99e786421a93b532b22ffab5578de7321369975b91aec97adfda8c3b")
+
     # Deprecated older non-final releases
     with default_args(deprecated=True):
         version(
@@ -80,9 +83,6 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
 
         version(
             "12.4.0", sha256="704f652604ccbccb14bdabf3478c9511c89788b12cb3bbffded37341916a9175"
-        )
-        version(
-            "12.3.0", sha256="949a5d4f99e786421a93b532b22ffab5578de7321369975b91aec97adfda8c3b"
         )
         version(
             "12.2.0", sha256="e549cf9cf3594a00e27b6589d4322d70e0720cdd213f39beb4181e06926230ff"


### PR DESCRIPTION
This is the default compiler of ubuntu 22.04, which is used in the tutorial.
