### PR TITLE
py-horovod: fix non-determinism issue

### DIFF
--- a/repos/spack_repo/builtin/packages/py_horovod/package.py
+++ b/repos/spack_repo/builtin/packages/py_horovod/package.py
@@ -76,7 +76,7 @@ class PyHorovod(PythonPackage, CudaPackage):
     )
     variant(
         "tensor_ops",
-        default="nccl",
+        default="mpi",
         description="Framework to use for GPU/CPU operations",
         values=("nccl", "mpi", "gloo", "ccl"),
         multi=False,


### PR DESCRIPTION
The package defines `tensor_ops=nccl`, `~cuda`, `~rocm` as variant
defaults, but also adds a conflict `tensor=nccl ~cuda ~rocm`.

This forces the concretizer to pick a solution like `tensor_ops=mpi` or
`tensor_ops=gloo`, which have an identical score, leading to
non-determinism.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
