### PR TITLE
netcdf-fortran: Make sure -fallow-argument-mismatch is added only for gfortran

### DIFF
--- a/repos/spack_repo/builtin/packages/netcdf_fortran/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_fortran/package.py
@@ -80,7 +80,7 @@ class NetcdfFortran(AutotoolsPackage):
         elif name == "fflags":
             if "+pic" in self.spec:
                 flags.append(self.compiler.f77_pic_flag)
-            if self.spec.satisfies("%gcc@10:"):
+            if self.spec.satisfies("%fortran=gcc@10:"):
                 # https://github.com/Unidata/netcdf-fortran/issues/212
                 flags.append("-fallow-argument-mismatch")
             elif self.compiler.name == "cce":


### PR DESCRIPTION
With mixed compiler toolchains, e.g. `%c,cxx=gcc %fortran=nvfortran` the current setup would wrongly add `-fallow-argument-mismatch` to the nvfortran compiler flags even though it doesn't support the flag. This PR restricts the condition to only allow `-fallow-argument-mismatch` when the fortran compiler is gcc.