### PR TITLE
environment-modules: fix X variant + fix v3.2 build + add new-features variant

### DIFF
--- a/repos/spack_repo/builtin/packages/environment_modules/package.py
+++ b/repos/spack_repo/builtin/packages/environment_modules/package.py
@@ -61,7 +61,7 @@ class EnvironmentModules(Package):
         url="http://prdownloads.sourceforge.net/modules/modules-3.2.10.tar.gz",
     )
 
-    variant("X", default=True, description="Build with X functionality")
+    variant("X", default=True, when="@:3.2", description="Build with X functionality")
 
     depends_on("c", type="build")  # generated
 
@@ -99,7 +99,7 @@ class EnvironmentModules(Package):
             config_args.extend(["--disable-dependency-tracking", "--disable-silent-rules"])
 
         if spec.satisfies("~X"):
-            config_args = ["--without-x"] + config_args
+            config_args.extend(["--without-x"])
 
         if self.spec.satisfies("@5.6.0:"):
             config_args.extend(["--enable-require-via"])

--- a/repos/spack_repo/builtin/packages/environment_modules/package.py
+++ b/repos/spack_repo/builtin/packages/environment_modules/package.py
@@ -63,6 +63,12 @@ class EnvironmentModules(Package):
 
     variant("X", default=True, when="@:3.2", description="Build with X functionality")
 
+    # Enable all new features that are disabled by default due to the substantial behavior changes
+    # see https://modules.readthedocs.io/en/latest/INSTALL.html#instopt-enable-new-features
+    variant(
+        "new-features", default=True, when="@5.0:", description="Build with new features enabled"
+    )
+
     depends_on("c", type="build")  # generated
 
     depends_on("gmake", type="build")
@@ -108,11 +114,8 @@ class EnvironmentModules(Package):
         if spec.satisfies("~X"):
             config_args.extend(["--without-x"])
 
-        if self.spec.satisfies("@5.6.0:"):
-            config_args.extend(["--enable-require-via"])
-
-        if self.spec.satisfies("@5.5.0:"):
-            config_args.extend(["--enable-conflict-unload"])
+        if spec.satisfies("+new-features"):
+            config_args.extend(["--enable-new-features"])
 
         if self.spec.satisfies("@4.4.0:4.8"):
             config_args.extend(

--- a/repos/spack_repo/builtin/packages/environment_modules/package.py
+++ b/repos/spack_repo/builtin/packages/environment_modules/package.py
@@ -83,6 +83,13 @@ class EnvironmentModules(Package):
     depends_on("tcl@8.5:8", type=("build", "link", "run"), when="@5.0.0:5.4.0")
     depends_on("tcl@8.5:", type=("build", "link", "run"), when="@5.5.0:")
 
+    def flag_handler(self, name, flags):
+        if name == "cflags":
+            if self.spec.satisfies("@:3.2"):
+                flags.append("-Wno-error=implicit-function-declaration")
+                flags.append("-Wno-error=int-conversion")
+        return (flags, None, None)
+
     def install(self, spec, prefix):
         tcl = spec["tcl"]
 


### PR DESCRIPTION
Several improvements to the environment-modules package:

### X variant only available on v3.2
    
Update X variant of environment-modules package to make it only available for 3.2 releases.

### add cflags to compile old v3.2
    
To compile nowadays 3.2 releases of environment-modules, some cflags should be added to ignore `implicit-function-declaration` and `int-conversion` errors.

### add new-features variant
    
Add "new-features" variant that enables all new features implying a substantial behavior changes. This variant is on by default.
    
When this variant is on, it adds the `--enable-new-features` argument to the list of configuration arguments. `--enable-new-features` implies `--enable-conflict-unload` and `--enable-require-via` arguments, thus it is not required anymore to add these 2 arguments separately.
