### PR TITLE
iwyu,g2,r-curl: requires(pkg) -> requires(^pkg)

### DIFF
--- a/repos/spack_repo/builtin/packages/g2/package.py
+++ b/repos/spack_repo/builtin/packages/g2/package.py
@@ -73,7 +73,7 @@ class G2(CMakePackage):
     depends_on("ip@3.3.3:", when="+utils +w3emc")
     requires("^ip precision=d", when="^ip@4.1:")
     depends_on("sp", when="+utils +w3emc ^ip@:4")
-    requires("sp precision=d", when="^sp@2.4:")
+    requires("^sp precision=d", when="^sp@2.4:")
     with when("+w3emc"):
         depends_on("w3emc")
         depends_on("w3emc precision=4", when="precision=4")

--- a/repos/spack_repo/builtin/packages/iwyu/package.py
+++ b/repos/spack_repo/builtin/packages/iwyu/package.py
@@ -60,7 +60,7 @@ class Iwyu(CMakePackage):
     depends_on("llvm+clang@8.0:8", when="@0.12")
     depends_on("llvm+clang@7.0:7", when="@0.11")
 
-    requires("llvm targets=all", "llvm targets=x86", msg="iwyu needs the X86AsmParser")
+    requires("^llvm targets=all", "^llvm targets=x86", msg="iwyu needs the X86AsmParser")
 
     patch("iwyu-013-cmake.patch", when="@0.13:0.14")
 

--- a/repos/spack_repo/builtin/packages/r_curl/package.py
+++ b/repos/spack_repo/builtin/packages/r_curl/package.py
@@ -71,7 +71,7 @@ class RCurl(RPackage):
     depends_on("curl@:7.63", when="@:4.0")
 
     # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=282908
-    requires("curl@:8.10", when="@:5.2.1")
+    requires("^curl@:8.10", when="@:5.2.1")
 
     # (Jan 2025) MacOS ships a very buggy libcurl 8.7.1 so we avoid this until apple updates it
     # See: https://github.com/jeroen/curl/issues/376


### PR DESCRIPTION
This PR fixes issues in three packages, `iwyu`, `g2`, `r-curl`, where the `requires` clause was used incorrectly, without caret to refer to dependencies.