### PR TITLE
Sandia Micro Benchmarks

### DIFF
--- a/repos/spack_repo/builtin/packages/sandia_micro_benchmarks/package.py
+++ b/repos/spack_repo/builtin/packages/sandia_micro_benchmarks/package.py
@@ -25,17 +25,15 @@ class SandiaMicroBenchmarks(MakefilePackage):
     depends_on("mpi")
     depends_on("sos", when="+shmem")
 
-    build_targets = ["mpi_overhead", "msgrate", "rma_mt_mpi"]
-    install_targets = build_targets
-
-    def build(self, spec, prefix):
-        if "+shmem" in spec:
-            self.build_targets.append("shmem_mt")
-            self.install_targets.append("shmem_mt")
-        for target in self.build_targets:
-            make(target)
+    @property
+    def build_targets(self):
+        targets = ["mpi_overhead", "msgrate", "rma_mt_mpi"]
+        if "+shmem" in self.spec:
+            targets.append("shmem_mt")
+        return targets
 
     def install(self, spec, prefix):
         mkdir(prefix.bin)
-        for target in self.install_targets:
+        for target in self.build_targets:
+            make(target)
             install(target, prefix.bin)

--- a/repos/spack_repo/builtin/packages/sandia_micro_benchmarks/package.py
+++ b/repos/spack_repo/builtin/packages/sandia_micro_benchmarks/package.py
@@ -28,7 +28,7 @@ class SandiaMicroBenchmarks(MakefilePackage):
     @property
     def build_targets(self):
         targets = ["mpi_overhead", "msgrate", "rma_mt_mpi"]
-        if "+shmem" in self.spec:
+        if self.spec.satisfies("+shmem"):
             targets.append("shmem_mt")
         return targets
 

--- a/repos/spack_repo/builtin/packages/sandia_micro_benchmarks/package.py
+++ b/repos/spack_repo/builtin/packages/sandia_micro_benchmarks/package.py
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
+
 from spack.package import *
+
 
 class SandiaMicroBenchmarks(MakefilePackage):
     """Sandia Micro Benchmarks test HPC networking, including messaging rate performance, across
@@ -18,7 +20,7 @@ class SandiaMicroBenchmarks(MakefilePackage):
     git = "https://github.com/sandialabs/SMB.git"
     version("master", branch="master")
 
-    variant(name="shmem", default=False, description="Build the SHMEM benchmark.")   
+    variant(name="shmem", default=False, description="Build the SHMEM benchmark.")
 
     depends_on("mpi")
     depends_on("sos", when="+shmem")

--- a/repos/spack_repo/builtin/packages/sandia_micro_benchmarks/package.py
+++ b/repos/spack_repo/builtin/packages/sandia_micro_benchmarks/package.py
@@ -1,0 +1,39 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
+from spack.package import *
+
+class SandiaMicroBenchmarks(MakefilePackage):
+    """Sandia Micro Benchmarks test HPC networking, including messaging rate performance, across
+    several different HPC networking protocols, including MPI, RMA, and SHMEM. There is also a test
+    for MPI implementation overhead."""
+
+    maintainers("nhanford", "mdosanjh")
+
+    license("GPL-2.0-or-later", checked_by="nhanford")
+
+    homepage = "https://github.com/sandialabs/SMB"
+    git = "https://github.com/sandialabs/SMB.git"
+    version("master", branch="master")
+
+    variant(name="shmem", default=False, description="Build the SHMEM benchmark.")   
+
+    depends_on("mpi")
+    depends_on("sos", when="+shmem")
+
+    build_targets = ["mpi_overhead", "msgrate", "rma_mt_mpi"]
+    install_targets = build_targets
+
+    def build(self, spec, prefix):
+        if "+shmem" in spec:
+            self.build_targets.append("shmem_mt")
+            self.install_targets.append("shmem_mt")
+        for target in self.build_targets:
+            make(target)
+
+    def install(self, spec, prefix):
+        mkdir(prefix.bin)
+        for target in self.install_targets:
+            install(target, prefix.bin)


### PR DESCRIPTION
This PR adds a makefile package for the Sandia Micro Benchmarks.
Future work will include making sure the SHMEM benchmark works across different implementations.