### PR TITLE
cufftmp: new package for NVIDIA cuFFTMp

### DIFF
--- a/repos/spack_repo/builtin/packages/cublasmp/package.py
+++ b/repos/spack_repo/builtin/packages/cublasmp/package.py
@@ -48,7 +48,9 @@ class Cublasmp(Package, CudaPackage):
     depends_on("nccl@2.18.5:")
 
     for cuda_arch in CudaPackage.cuda_arch_values:
-        depends_on(f"nccl cuda_arch={cuda_arch}", when=f"cuda_arch={cuda_arch}")
+        with when(f"cuda_arch={cuda_arch}"):
+            depends_on(f"nvshmem cuda_arch={cuda_arch}")
+            depends_on(f"nccl cuda_arch={cuda_arch}")
 
     def install(self, spec, prefix):
         install_tree(".", prefix)

--- a/repos/spack_repo/builtin/packages/cufftmp/package.py
+++ b/repos/spack_repo/builtin/packages/cufftmp/package.py
@@ -1,0 +1,54 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import platform
+
+from spack_repo.builtin.build_systems.cuda import CudaPackage
+from spack_repo.builtin.build_systems.generic import Package
+
+from spack.package import *
+
+_versions = {
+    "11.4.0.6": {
+        "Linux-x86_64": dict(
+            sha256="6a0597e10e698ab46ea9a607efe06f681ba6e2bf0d8eddd8a72a09c18a8f7253",
+            url="https://developer.download.nvidia.com/compute/cufftmp/redist/libcufftmp/linux-x86_64/libcufftmp-linux-x86_64-11.4.0.6_cuda12-archive.tar.xz",
+        ),
+        "Linux-aarch64": dict(
+            sha256="c0f944fd6ef2e13ef5adfd48ef2e02660f5f573a69c515580096a9eaae13be16",
+            url="https://developer.download.nvidia.com/compute/cufftmp/redist/libcufftmp/linux-sbsa/libcufftmp-linux-sbsa-11.4.0.6_cuda12-archive.tar.xz",
+        ),
+    }
+}
+
+
+class Cufftmp(Package, CudaPackage):
+    """
+    NVIDIA cuFFTMp library.
+    """
+
+    homepage = "https://docs.nvidia.com/cuda/cufftmp/"
+    url = "https://developer.download.nvidia.com/compute/cufftmp/redist/libcufftmp"
+
+    maintainers("albestro")
+
+    license("UNKNOWN")
+
+    for ver, packages in _versions.items():
+        package = packages.get(f"{platform.system()}-{platform.machine()}")
+        if package:
+            version(ver, **package)
+
+    conflicts("~cuda", msg="cuFFTMp requires CUDA")
+
+    depends_on("cuda@12:")
+    depends_on("nvshmem")
+    depends_on("nvshmem@3.1.7:", when="@11.4.0")
+
+    for cuda_arch in CudaPackage.cuda_arch_values:
+        with when(f"cuda_arch={cuda_arch}"):
+            depends_on(f"nvshmem cuda_arch={cuda_arch}")
+
+    def install(self, spec, prefix):
+        install_tree(".", prefix)

--- a/repos/spack_repo/builtin/packages/cufftmp/package.py
+++ b/repos/spack_repo/builtin/packages/cufftmp/package.py
@@ -45,6 +45,9 @@ class Cufftmp(Package, CudaPackage):
 
     depends_on("cuda@12:")
     depends_on("nvshmem")
+
+    # cuFFTMp requires a specific version of NVSHMEM
+    # https://docs.nvidia.com/cuda/cufftmp/usage/nvshmem_and_cufftmp.html#compatibility
     depends_on("nvshmem@3.1.7:", when="@11.4.0")
 
     for cuda_arch in CudaPackage.cuda_arch_values:

--- a/repos/spack_repo/builtin/packages/cufftmp/package.py
+++ b/repos/spack_repo/builtin/packages/cufftmp/package.py
@@ -33,7 +33,8 @@ class Cufftmp(Package, CudaPackage):
 
     maintainers("albestro")
 
-    license("UNKNOWN")
+    # https://docs.nvidia.com/cuda/cufftmp/license.html
+    license("NVIDIA Software License Agreement")
 
     for ver, packages in _versions.items():
         package = packages.get(f"{platform.system()}-{platform.machine()}")


### PR DESCRIPTION
Add spack package for NVIDIA cuFFTMp.

Changelog:
- `cufftmp`: new basic package
- `cublasmp`: add a missing transitive constraint on `cuda_arch` for `nvshmem`.

Added by @bernhardkaindl as an overview of the PR:

## Copilot Pull Request Overview

This PR adds a new Spack package for NVIDIA cuFFTMp, a multi-process FFT library, and fixes a missing transitive constraint in the existing cublasmp package.

- Introduces the `cufftmp` package with support for Linux x86_64 and aarch64 architectures
- Adds proper CUDA architecture constraints for NVSHMEM dependency in both packages
- Fixes missing NVSHMEM dependency constraint in the `cublasmp` package

### Reviewed Changes

Copilot reviewed 2 out of 2 changed files in this pull request and generated 2 comments.

| File | Description |
| ---- | ----------- |
| repos/spack_repo/builtin/packages/cufftmp/package.py | New package definition for NVIDIA cuFFTMp with version 11.4.0.6, platform-specific downloads, and dependency management |
| repos/spack_repo/builtin/packages/cublasmp/package.py | Adds missing NVSHMEM CUDA architecture constraint and improves dependency declaration structure |





---

<sub>**Tip:** Customize your code reviews with copilot-instructions.md. <a href="/spack/spack-packages/new/develop/.github?filename=copilot-instructions.md" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">Create the file</a> or <a href="https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">learn how to get started</a>.</sub>