### PR TITLE
scorep: set no-cross-compiler-suite to clang when compiling with llvm

### DIFF
--- a/repos/spack_repo/builtin/packages/scorep/package.py
+++ b/repos/spack_repo/builtin/packages/scorep/package.py
@@ -211,7 +211,12 @@ class Scorep(AutotoolsPackage):
     # Handle any mapping of Spack compiler names to Score-P args
     # This should continue to exist for backward compatibility
     def clean_compiler(self, compiler):
-        renames = {"cce": "cray", "rocmcc": "amdclang", "intel-oneapi-compilers": "oneapi"}
+        renames = {
+            "cce": "cray",
+            "rocmcc": "amdclang",
+            "intel-oneapi-compilers": "oneapi",
+            "llvm": "clang"
+        }
         if compiler in renames:
             return renames[compiler]
         return compiler

--- a/repos/spack_repo/builtin/packages/scorep/package.py
+++ b/repos/spack_repo/builtin/packages/scorep/package.py
@@ -215,7 +215,7 @@ class Scorep(AutotoolsPackage):
             "cce": "cray",
             "rocmcc": "amdclang",
             "intel-oneapi-compilers": "oneapi",
-            "llvm": "clang"
+            "llvm": "clang",
         }
         if compiler in renames:
             return renames[compiler]


### PR DESCRIPTION
Building `scorep %c,cxx=llvm` currently fails with this error message:

```
configure: error: compiler suite "llvm" not supported by --with-nocross-compiler-suite.
```

Apparently, `spec.compiler.name` gets set to `llvm` while Score-P expects `clang`. This change adjusts the `clean_compiler` function to address this.