### PR TITLE
sz3: add 3.3.0

### DIFF
--- a/repos/spack_repo/builtin/packages/sz3/package.py
+++ b/repos/spack_repo/builtin/packages/sz3/package.py
@@ -17,6 +17,7 @@ class Sz3(CMakePackage):
     tags = ["e4s"]
 
     version("master")
+    version("3.3.0", commit="61816ba1276a83b4f9aa3ee0f8299eb7b0b3528a")
     version("3.2.0", commit="b3dab4018425803a55d8073dc55dade7fa46b7b4")
     version("3.1.8", commit="e308ebf8528c233286874b920c72c0a6c0218fb2")
     version("3.1.7", commit="c49fd17f2d908835c41000c1286c510046c0480e")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR adds SZ3 3.3.0.

I know it just came out today, but I found that as I was [trying to build libpressio](https://github.com/robertu94/libpressio/issues/42), my mac setup seemed to need it as it didn't like compiling 3.2.0.

cc: @disheng222  @robertu94