### PR TITLE
libpressio: add blosc2 depends_on

### DIFF
--- a/repos/spack_repo/builtin/packages/libpressio/package.py
+++ b/repos/spack_repo/builtin/packages/libpressio/package.py
@@ -247,6 +247,7 @@ class Libpressio(CMakePackage, CudaPackage):
     depends_on("libstdcompat", when="@0.52.0:")
 
     depends_on("c-blosc", when="+blosc")
+    depends_on("c-blosc2", when="+blosc2")
     depends_on("fpzip", when="+fpzip")
     depends_on("hdf5", when="+hdf5")
     # this might seem excessive, but if HDF5 is external and parallel


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

In [trying to build libpressio today](https://github.com/robertu94/libpressio/issues/42), I found that because I'd added `+blosc2` to my variants, the CMake failed because it didn't find blosc2.

So, we add a `depends_on` 