### PR TITLE
py-gfal2-python: depends_on c

### DIFF
--- a/repos/spack_repo/builtin/packages/py_gfal2_python/package.py
+++ b/repos/spack_repo/builtin/packages/py_gfal2_python/package.py
@@ -19,6 +19,7 @@ class PyGfal2Python(PythonPackage):
 
     version("1.13.0", sha256="5be42cc894fa20af3d6f6dbb30dfd4d29ab49bd5f15b3e3e754aa25c5ed17997")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("python", type="build")
 


### PR DESCRIPTION
This PR adds to `py-gfal2-python` the dependency on `c` (due to generic `project` use in https://github.com/cern-fts/gfal2-python/blob/develop/CMakeLists.txt#L2).