### PR TITLE
py-exhale: add version 0.3.7

### DIFF
--- a/repos/spack_repo/builtin/packages/py_exhale/package.py
+++ b/repos/spack_repo/builtin/packages/py_exhale/package.py
@@ -18,13 +18,17 @@ class PyExhale(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.3.7", sha256="752a96d0a59456511d933311d4a81f642cd668296eacd2561905727d5ed6b0d8")
     version("0.3.6", sha256="ab41be313e1236bd4386e4696fb35f37ce8103c2059cf8d1f083da5411bb74d7")
 
-    depends_on("python@3.7:", type=("build", "run"))
+    depends_on("python@3.8:", when="@0.3.7:", type=("build", "run"))
+    depends_on("python@3.7:", when="@:0.3.6", type=("build", "run"))
     depends_on("py-setuptools@42:", type="build")
-    depends_on("py-breathe@4.32.0:", type="build")
-    depends_on("py-docutils@0.12:", type="build")
-    depends_on("py-sphinx@3:4", type="build")
+    depends_on("py-breathe@4.33.1:", when="@0.3.7:", type="build")
+    depends_on("py-breathe@4.32.0:", when="@:0.3.6", type="build")
+    depends_on("py-docutils@0.12:", when="@:0.3.6", type="build")
+    depends_on("py-sphinx@4.3.2:", when="@0.3.7:", type="build")
+    depends_on("py-sphinx@3:4", when="@:0.3.6", type="build")
     depends_on("py-beautifulsoup4", type=("build", "run"))
     depends_on("py-lxml", type=("build", "run"))
     depends_on("py-six", type=("build", "run"))


### PR DESCRIPTION
- Add version 0.3.7 with updated dependencies
- Python requirement raised to 3.8+ (3.7 reached EOL)
- Breathe minimum version increased to 4.33.1
- Sphinx minimum version raised to 4.3.2, removed upper bound
- Removed docutils dependency for 0.3.7
- Maintain backward compatibility for 0.3.6

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
