### PR TITLE
relion: Fix the build to with libx11 and deps fltk and ctffind

### DIFF
--- a/repos/spack_repo/builtin/packages/ctffind/package.py
+++ b/repos/spack_repo/builtin/packages/ctffind/package.py
@@ -26,7 +26,8 @@ class Ctffind(AutotoolsPackage):
         extension="tar.gz",
     )
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     def url_for_version(self, version):
         url = "https://grigoriefflab.umassmed.edu/system/tdf?path=ctffind-{0}.tar.gz&file=1&type=node&id=26"

--- a/repos/spack_repo/builtin/packages/fltk/package.py
+++ b/repos/spack_repo/builtin/packages/fltk/package.py
@@ -29,12 +29,13 @@ class Fltk(Package):
     version("1.3.7", sha256="019f65810fb0ea5acac14c852193e8f374e822e6a3034a3c80ed8676f6f3a090")
     version("1.3.3", sha256="186bdc4234bea74bce4d47f186d41d35bdd47d48dbe5f829513a2183fbf8f3b2")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
     depends_on("gmake", type="build")
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
+    depends_on("pkgconfig", type="build", when="@1.3.7")
 
     depends_on("libx11")
     depends_on("freetype", when="@1.4.3:")

--- a/repos/spack_repo/builtin/packages/fltk/package.py
+++ b/repos/spack_repo/builtin/packages/fltk/package.py
@@ -25,6 +25,7 @@ class Fltk(Package):
     git = "https://github.com/fltk/fltk.git"
 
     version("master", branch="master")
+    version("1.4.4", sha256="cbf5f7846af596206e8e4489e14c9981f98d7b37168110a00dcd26d8d479a669")
     version("1.4.3", sha256="6a11c0bf91b7b193a87a1928c32a953f36d7dd4b65fef3e9d0c40a51882f97a6")
     version("1.3.7", sha256="019f65810fb0ea5acac14c852193e8f374e822e6a3034a3c80ed8676f6f3a090")
     version("1.3.3", sha256="186bdc4234bea74bce4d47f186d41d35bdd47d48dbe5f829513a2183fbf8f3b2")

--- a/repos/spack_repo/builtin/packages/relion/package.py
+++ b/repos/spack_repo/builtin/packages/relion/package.py
@@ -110,8 +110,6 @@ class Relion(CMakePackage, CudaPackage):
 
     def cmake_args(self):
         args = [
-            "-DCMAKE_C_FLAGS=-g",
-            "-DCMAKE_CXX_FLAGS=-g",
             "-DGUI=%s" % ("+gui" in self.spec),
             "-DDoublePrec_CPU=%s" % ("+double" in self.spec),
             "-DDoublePrec_GPU=%s" % ("+double-gpu" in self.spec),
@@ -119,6 +117,9 @@ class Relion(CMakePackage, CudaPackage):
             "-DMKLFFT=%s" % ("+mklfft" in self.spec),
             "-DALTCPU=%s" % ("+altcpu" in self.spec),
         ]
+        if self.spec.satisfies("+gui"):
+            incs = [f"-I{self.spec[lib].prefix.include}" for lib in ["libx11", "xproto"]]
+            args += ["-DCMAKE_CXX_FLAGS=" + " ".join(incs)]
 
         if "+cuda" in self.spec:
             carch = self.spec.variants["cuda_arch"].value[0]


### PR DESCRIPTION
Fixes for building `relion` and some of its build-time dependencies:

- relion: Use spack's libx11 headers, the X11 headers of the host (if they exist).
- ctffind: Fix build failure: Add missing depends on cxx
- fltk@1.3.7: Fix build when pkgconfig is not installed on the host

Commit messages of the new commits:

- relion: Fix build failure: Use spack's libx11 includes
  To find the spack libx11 includes, we need to pass -I<path> for libx11
  and with fltk@1.3, we also need to pass -I<path> for xproto.
  `-DCMAKE_C_FLAGS=-g and -DCMAKE_CXX_FLAGS=-g`, which are not needed, are
  replaced by passing the include directories when relion is using +gui.
- ctffind: Fix build failure: Add missing depends on cxx
- fltk: Fix build when pkgconfig is not installed on the host
- fltk: Add new version fltk-1.4.4

I developed these while trying to build #263 by @snehring, who also added these to his PR now.