### PR TITLE
Fix external intel compiler

### DIFF
--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers_classic/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers_classic/package.py
@@ -90,14 +90,20 @@ class IntelOneapiCompilersClassic(Package, CompilerPackage):
            $ source {prefix}/{component}/{version}/env/vars.sh
         and from setting CC/CXX/F77/FC
         """
-        if self.spec.external:
-            return
-
-        oneapi_pkg = self.spec["intel-oneapi-compilers"].package
-
-        oneapi_pkg.setup_run_environment(env)
-
-        bin_prefix = oneapi_pkg.component_prefix.linux.bin.intel64
+        if not self.spec.external:
+            oneapi_pkg = self.spec["intel-oneapi-compilers"].package
+            oneapi_pkg.setup_run_environment(env)
+            bin_prefix = oneapi_pkg.component_prefix.linux.bin.intel64
+        else:
+            bin_prefix = self.prefix.bin
+            # External intel-oneapi-compilers-classic has no intel-oneapi-compilers
+            # dependency, so currently we skip whatever environment modifications it
+            # would do and don't try to replicate them
+            # TODO: this means there is no attempt to locate or run a vars.sh script
+            # for external instances of intel-oneapi-compilers-classic. If that is
+            # necessary, this function should include additional search logic when it
+            # is external (or check extra_attributes if a user wants to supply it
+            # manually)
         env.set("CC", bin_prefix.icc)
         env.set("CXX", bin_prefix.icpc)
         env.set("F77", bin_prefix.ifort)

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers_classic/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers_classic/package.py
@@ -90,6 +90,9 @@ class IntelOneapiCompilersClassic(Package, CompilerPackage):
            $ source {prefix}/{component}/{version}/env/vars.sh
         and from setting CC/CXX/F77/FC
         """
+        if self.spec.external:
+            return
+
         oneapi_pkg = self.spec["intel-oneapi-compilers"].package
 
         oneapi_pkg.setup_run_environment(env)


### PR DESCRIPTION
Fixes https://github.com/spack/spack-packages/issues/965 

Without this change, I can't get Spack to build a simple package (zlib) when doing `spack compiler add` for an old intel compiler.

* At a high level, this package was assuming that `intel-oneapi-compilers` was always available as a dependency (not true when this package is external)
* As for how things worked before that
  * pre-spack-1.0 one could just use the `%intel` compiler entry (so while the code in `intel-oneapi-compilers-classic` has been this way for a while, it generally wasn't used pre-spack-1.0 for doing compilations)
  * If in this prior state environment manipulations were handled in the Intel compiler logic, namely loading vars.sh, then that would be "lost" here
    * (The only two things I see `intel-oneapi-compilers` doing is running `vars.sh` and setting CC/etc.
    * ~But I don't see such scripts in the Intel classic installations I have access to~
      * Actually that logic reaches into the `intel-oneapi-compilers` prefix
    * and this wouldn't break something that wasn't already broken
    * For `intel-classic-compilers` pre-version-2021, this code would also be problematic (because there is no dependency on `intel-oneapi-compilers` in that case, but the access is unconditional)

