### PR TITLE
gnupg: add v2.5.11, fix conflicts for libassuan on macos

### DIFF
--- a/repos/spack_repo/builtin/packages/gnupg/package.py
+++ b/repos/spack_repo/builtin/packages/gnupg/package.py
@@ -19,6 +19,7 @@ class Gnupg(AutotoolsPackage):
 
     license("GPL-3.0-or-later")
 
+    version("2.5.11", sha256="5f765ec1eb605dce9e9c48679cd43b5818d4d4b84c8ea4c0c60eb5dca13c405c")
     version("2.5.6", sha256="377f9d79af0ce494c0946dbe7c92197425bb522d7edd6f54acbc9869695131a8")
     version("2.5.3", sha256="23128b136aed4e5121e793d1b6c60ee50c8007a9d926c1313e524d05386b54ac")
     version("2.5.2", sha256="7f404ccc6a58493fedc15faef59f3ae914831cff866a23f0bf9d66cfdd0fea29")

--- a/repos/spack_repo/builtin/packages/libassuan/package.py
+++ b/repos/spack_repo/builtin/packages/libassuan/package.py
@@ -31,7 +31,8 @@ class Libassuan(AutotoolsPackage):
 
     depends_on("libgpg-error@1.17:")
 
-    conflicts("platform=darwin", when="@3")
+    # error with multiple duplicate symbols in linker -- fixed in v3.0.2
+    conflicts("platform=darwin", when="@3.0.0:3.0.1")
 
     def configure_args(self):
         return [


### PR DESCRIPTION
Add gnupg v2.5.11 and update conflicts for libassuan on MacOS.