### PR TITLE
Python iconv flexibility

### DIFF
--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -316,7 +316,7 @@ class Python(Package):
         depends_on("pkgconfig@0.9.0:", type="build")
         depends_on("gettext +libxml2", when="+libxml2")
         depends_on("iconv", when="~libxml2")
-        depends_on("gettext ~libxml2", when="~libxml2 ^gettext")
+        depends_on("gettext ~libxml2", when="~libxml2 ^[virtuals=iconv]gettext")
 
         # Optional dependencies
         # See detect_modules() in setup.py for details

--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -315,7 +315,8 @@ class Python(Package):
         depends_on("gmake", type="build")
         depends_on("pkgconfig@0.9.0:", type="build")
         depends_on("gettext +libxml2", when="+libxml2")
-        depends_on("gettext ~libxml2", when="~libxml2")
+        depends_on("iconv", when="~libxml2")
+        depends_on("gettext ~libxml2", when="~libxml2 ^gettext")
 
         # Optional dependencies
         # See detect_modules() in setup.py for details


### PR DESCRIPTION

> This is a redo of  https://github.com/spack/spack/pull/39992

Currently python **always** depends on gettext, regardless what you have set for iconv preference.

This PR allows building python depending on  glibc  or libiconv instead of gettext for iconv functionality, while still allowing avoiding the libxml2 +python / python / gettext +libxml2 dependency cycle. 

With this change you can:
```
spack spec python                          # gives python +libxml2 -> gettext +libxml2 -> libxml2
spack spec python ~libxml2                 # gives python ~lixml2  -> gettext ~libxml2
spack spec python ~libxml2 ^iconv=glibc    # gives python ~libxml2 -> glibc
spack spec python ~libxml2 ^iconv=libiconv # gives python ~libxml2 -> libiconv

```
and specifying your preferred iconv in packages.yaml works for python ~libxml2