### PR TITLE
Rework `actions.yml` to use `$GITHUB_WORKSPACE`

### DIFF
--- a/.github/actions/checkout-spack/action.yml
+++ b/.github/actions/checkout-spack/action.yml
@@ -10,9 +10,9 @@ inputs:
     required: false
     default: '1'
   builtin:
-    description: Path to local clone of the builtin repository
+    description: 'Relative path under $GITHUB_WORKSPACE where the builtin repository lives'
     required: false
-    default: ${{ github.workspace }}
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -31,7 +31,12 @@ runs:
         fetch-depth: ${{ inputs.fetch-depth }}
     - name: Override builtin repository path
       shell: bash
-      run: ${{ inputs.path }}/bin/spack repo set --destination "${{ inputs.builtin }}" --scope site builtin
-    - name: Spack package repositories
-      shell: bash
-      run: ${{ inputs.path }}/bin/spack config blame repos
+      run: | 
+        REPOSITORY_PATH="$GITHUB_WORKSPACE/${{ inputs.builtin }}"        
+        ${{ inputs.path }}/bin/spack repo set --destination "$REPOSITORY_PATH" --scope site builtin
+        ${{ inputs.path }}/bin/spack config blame repos
+        ${{ inputs.path }}/bin/spack repo list
+        if [ ! -f "$REPOSITORY_PATH/spack-repo-index.yaml" ]; then
+          echo "Error: "$REPOSITORY_PATH/spack-repo-index.yaml" file not found."
+          exit 1
+        fi

--- a/.github/actions/checkout-spack/action.yml
+++ b/.github/actions/checkout-spack/action.yml
@@ -37,6 +37,6 @@ runs:
         ${{ inputs.path }}/bin/spack config blame repos
         ${{ inputs.path }}/bin/spack repo list
         if [ ! -f "$REPOSITORY_PATH/spack-repo-index.yaml" ]; then
-          echo "Error: "$REPOSITORY_PATH/spack-repo-index.yaml" file not found."
+          echo "Error: "'"'"$REPOSITORY_PATH/spack-repo-index.yaml"'"'" file not found."
           exit 1
         fi


### PR DESCRIPTION
The output of `$GITHUB_WORKSPACE` differs from that of `${{ github.workspace }}` in certain cases.

Prefer the environment variable, since it's the most correct.

References:
- https://github.com/actions/checkout/issues/785
- https://github.com/actions/actions-runner-controller/issues/3982

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
