### PR TITLE
Windows-vis: Make paraview more complicated (enable Qt)

### DIFF
--- a/stacks/windows-vis/spack.yaml
+++ b/stacks/windows-vis/spack.yaml
@@ -14,7 +14,7 @@ spack:
   - "netlib-lapack"
   - "py-beautifulsoup4"
   - "qt"
-  - "paraview@:5.13.1~mpi~qt"
+  - "paraview@:5.13.1~mpi+qt"
 
   cdash:
     build-group: Windows Visualization (Kitware)


### PR DESCRIPTION
Enables the `+qt` variant for `paraview` on the `windows-vis` stack now that both paraview and qt are stable in CI