### PR TITLE
Remove Scott as owner in ci configs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,9 +30,9 @@
 
 ###
 # CI Components maintained by Kitware
-/.ci/configs/              @kwryankrattiger @scottwittenburg @zackgalbreath
-/.ci/gitlab/configs/       @kwryankrattiger @scottwittenburg @zackgalbreath
-.ci/gitlab/.gitlab-ci.yml  @kwryankrattiger @scottwittenburg @zackgalbreath
+/.ci/configs/              @kwryankrattiger @zackgalbreath
+/.ci/gitlab/configs/       @kwryankrattiger @zackgalbreath
+.ci/gitlab/.gitlab-ci.yml  @kwryankrattiger @zackgalbreath
 
 ###
 # CI Components maintained by UO


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Scott is taking a break from Spack CI maintenance and requested to be removed from the code owners file for now. 