### PR TITLE
zsh doesn't build with 6 series ncurses

### DIFF
--- a/repos/spack_repo/builtin/packages/zsh/package.py
+++ b/repos/spack_repo/builtin/packages/zsh/package.py
@@ -41,9 +41,11 @@ class Zsh(AutotoolsPackage):
     depends_on("c", type="build")  # generated
 
     depends_on("pcre")
-    depends_on("ncurses@:5.9")
+    depends_on("ncurses")
 
     conflicts("+lmod", when="~etcdir", msg="local etc required to setup env for lmod")
+
+    patch("pointer-types.patch", when="@5.6.2:")
 
     def configure_args(self):
         args = []

--- a/repos/spack_repo/builtin/packages/zsh/package.py
+++ b/repos/spack_repo/builtin/packages/zsh/package.py
@@ -41,7 +41,7 @@ class Zsh(AutotoolsPackage):
     depends_on("c", type="build")  # generated
 
     depends_on("pcre")
-    depends_on("ncurses")
+    depends_on("ncurses@:5.9")
 
     conflicts("+lmod", when="~etcdir", msg="local etc required to setup env for lmod")
 

--- a/repos/spack_repo/builtin/packages/zsh/pointer-types.patch
+++ b/repos/spack_repo/builtin/packages/zsh/pointer-types.patch
@@ -1,0 +1,57 @@
+#
+# Original patch from: https://github.com/zsh-users/zsh/commit/4c89849c98172c951a9def3690e8647dae76308f.patch
+#
+# This patch has been modified from the original.
+#
+# Summary of modifications:
+# - Removed hunk for Changelong
+# - Removed commit hash
+#
+
+From: Florian Weimer <fweimer@redhat.com>
+Date: Fri, 8 Dec 2023 21:58:07 +0100
+Subject: [PATCH] 52383: Avoid incompatible pointer types in terminfo global
+ variable checks
+
+---
+ configure.ac | 12 ++++++------
+ 2 files changed, 9 insertions(+), 6 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 2a8221e1fb..2871dcb7c6 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1768,27 +1768,27 @@ if test x$zsh_cv_path_term_header != xnone; then
+   fi
+
+   AC_MSG_CHECKING(if boolcodes is available)
+-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = boolcodes; puts(*test);]])],[AC_DEFINE(HAVE_BOOLCODES) boolcodes=yes],[boolcodes=no])
++  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = (char **)boolcodes; puts(*test);]])],[AC_DEFINE(HAVE_BOOLCODES) boolcodes=yes],[boolcodes=no])
+   AC_MSG_RESULT($boolcodes)
+
+   AC_MSG_CHECKING(if numcodes is available)
+-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = numcodes; puts(*test);]])],[AC_DEFINE(HAVE_NUMCODES) numcodes=yes],[numcodes=no])
++  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = (char **)numcodes; puts(*test);]])],[AC_DEFINE(HAVE_NUMCODES) numcodes=yes],[numcodes=no])
+   AC_MSG_RESULT($numcodes)
+
+   AC_MSG_CHECKING(if strcodes is available)
+-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = strcodes; puts(*test);]])],[AC_DEFINE(HAVE_STRCODES) strcodes=yes],[strcodes=no])
++  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = (char **)strcodes; puts(*test);]])],[AC_DEFINE(HAVE_STRCODES) strcodes=yes],[strcodes=no])
+   AC_MSG_RESULT($strcodes)
+
+   AC_MSG_CHECKING(if boolnames is available)
+-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = boolnames; puts(*test);]])],[AC_DEFINE(HAVE_BOOLNAMES) boolnames=yes],[boolnames=no])
++  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = (char **)boolnames; puts(*test);]])],[AC_DEFINE(HAVE_BOOLNAMES) boolnames=yes],[boolnames=no])
+   AC_MSG_RESULT($boolnames)
+
+   AC_MSG_CHECKING(if numnames is available)
+-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = numnames; puts(*test);]])],[AC_DEFINE(HAVE_NUMNAMES) numnames=yes],[numnames=no])
++  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = (char **)numnames; puts(*test);]])],[AC_DEFINE(HAVE_NUMNAMES) numnames=yes],[numnames=no])
+   AC_MSG_RESULT($numnames)
+
+   AC_MSG_CHECKING(if strnames is available)
+-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = strnames; puts(*test);]])],[AC_DEFINE(HAVE_STRNAMES) strnames=yes],[strnames=no])
++  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = (char **)strnames; puts(*test);]])],[AC_DEFINE(HAVE_STRNAMES) strnames=yes],[strnames=no])
+   AC_MSG_RESULT($strnames)
+
+   dnl There are apparently defective terminal library headers on some


### PR DESCRIPTION
See: https://github.com/spack/spack-packages/issues/1024

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
