### PR TITLE
h5py: add 3.14 and fix numpy version bounds

### DIFF
--- a/repos/spack_repo/builtin/packages/py_h5py/package.py
+++ b/repos/spack_repo/builtin/packages/py_h5py/package.py
@@ -19,6 +19,7 @@ class PyH5py(PythonPackage):
     license("BSD-3-Clause")
 
     version("master", branch="master")
+    version("3.14.0", sha256="2372116b2e0d5d3e5e705b7f663f7c8d96fa79a4052d250484ef91d24d6a08f4")
     version("3.13.0", sha256="1870e46518720023da85d0895a1960ff2ce398c5671eac3b1a41ec696b7105c3")
     version("3.12.1", sha256="326d70b53d31baa61f00b8aa5f95c2fcb9621a3ee8365d770c551a13dbbcbfdf")
     # Yanked
@@ -61,8 +62,10 @@ class PyH5py(PythonPackage):
     depends_on("py-cython@0.29.14:0", type=("build"), when="@3:3.7 ^python@3.8.0:3.8")
     depends_on("py-cython@0.29:0", type=("build"), when="@3.0:3.10")
     depends_on("py-cython@0.23:0", type="build", when="@:2")
+
     depends_on("py-pkgconfig", type="build")
     depends_on("py-setuptools@61:", type="build", when="@3.8.0:")
+    depends_on("py-setuptools@77:", type="build", when="@3.14:")
     depends_on("py-setuptools", type="build")
 
     # pre-3.11 is numpy@1 only

--- a/repos/spack_repo/builtin/packages/py_h5py/package.py
+++ b/repos/spack_repo/builtin/packages/py_h5py/package.py
@@ -63,8 +63,8 @@ class PyH5py(PythonPackage):
     depends_on("py-cython@0.23:0", type="build", when="@:2")
 
     depends_on("py-pkgconfig", type="build")
-    depends_on("py-setuptools@61:", type="build", when="@3.8.0:")
     depends_on("py-setuptools@77:", type="build", when="@3.14:")
+    depends_on("py-setuptools@61:", type="build", when="@3.8.0:")
     depends_on("py-setuptools", type="build")
 
     # pre-3.11 is numpy@1 only

--- a/repos/spack_repo/builtin/packages/py_h5py/package.py
+++ b/repos/spack_repo/builtin/packages/py_h5py/package.py
@@ -59,7 +59,6 @@ class PyH5py(PythonPackage):
     depends_on("py-cython@0.29.31:3", type="build", when="@3.11:")
     depends_on("py-cython@0.29.31:0", type="build", when="@3.9:3.10")
     depends_on("py-cython@0.29.15:0", type=("build"), when="@3:3.7")
-    depends_on("py-cython@0.29.14:0", type=("build"), when="@3:3.7 ^python@3.8.0:3.8")
     depends_on("py-cython@0.29:0", type=("build"), when="@3.0:3.10")
     depends_on("py-cython@0.23:0", type="build", when="@:2")
 
@@ -94,7 +93,6 @@ class PyH5py(PythonPackage):
     depends_on("py-mpi4py", when="@:2 +mpi", type=("build", "run"))
 
     # Historical dependencies
-    depends_on("py-cached-property@1.5:", type=("build", "run"), when="@:3.6 ^python@:3.7")
     depends_on("py-six", type=("build", "run"), when="@:2")
 
     def flag_handler(self, name, flags):

--- a/repos/spack_repo/builtin/packages/py_h5py/package.py
+++ b/repos/spack_repo/builtin/packages/py_h5py/package.py
@@ -53,12 +53,7 @@ class PyH5py(PythonPackage):
 
     depends_on("c", type="build")
 
-    # Python versions
-    # python@3.9+ is required in 3.12+, but 3.11 needs python@3.9+ for numpy@2
-    # as python@3.8 is deprecated in spack, harmonized on python@3.9+
-    # https://github.com/h5py/h5py/blob/3.11.0/pyproject.toml#L5
-    depends_on("python@3.9:", type=("build", "run"), when="@3.11:")
-    depends_on("python@:3.9", type=("build", "run"), when="@:2.8")
+    depends_on("python@3.9:", type=("build", "run"))
 
     # Build dependencies
     # h5py@3.11 can build with cython@3.x

--- a/repos/spack_repo/builtin/packages/py_h5py/package.py
+++ b/repos/spack_repo/builtin/packages/py_h5py/package.py
@@ -53,8 +53,6 @@ class PyH5py(PythonPackage):
 
     depends_on("c", type="build")
 
-    depends_on("python@3.9:", type=("build", "run"))
-
     # Build dependencies
     # h5py@3.11 can build with cython@3.x
     depends_on("py-cython@0.29.31:3", type="build", when="@3.11:")

--- a/repos/spack_repo/builtin/packages/py_h5py/package.py
+++ b/repos/spack_repo/builtin/packages/py_h5py/package.py
@@ -67,16 +67,17 @@ class PyH5py(PythonPackage):
     depends_on("py-setuptools@61:", type="build", when="@3.8.0:")
     depends_on("py-setuptools", type="build")
 
-    # Build and runtime dependencies
-    depends_on("py-numpy@2", type=("build", "run"), when="@3.11:")
-
-    # https://github.com/h5py/h5py/pull/2556
-    depends_on("py-numpy@2:2.2", when="@3.11:3.12", type="build")
+    # From 3.11, the build notes numpy@2+ but
+    # https://github.com/h5py/h5py/blob/3.11.0/setup.py#L28
+    # notes that @1.17.3: is actually supported. This also follows the feedstock
+    # https://github.com/AnacondaRecipes/h5py-feedstock/pull/14
+    depends_on("py-numpy@1.17.3:", type=("build", "run"), when="@3.11:")
 
     # until 3.11.0, uses "oldest-supported-numpy" and doesn't support numpy2
     # https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
     # pre-3.11 is numpy@1 only
     # https://github.com/h5py/h5py/issues/2353
+    # https://github.com/h5py/h5py/blob/3.11.0/docs/whatsnew/3.11.rst#new-features
     depends_on("py-numpy@:1", when="@:3.10", type=("build", "run"))
     depends_on("py-numpy@1.19.3:", type=("build", "run"), when="@3:3.10")
     depends_on("py-numpy@1.7:", type=("build", "run"), when="@:2")

--- a/repos/spack_repo/builtin/packages/py_h5py/package.py
+++ b/repos/spack_repo/builtin/packages/py_h5py/package.py
@@ -65,20 +65,15 @@ class PyH5py(PythonPackage):
     depends_on("py-setuptools@61:", type="build", when="@3.8.0:")
     depends_on("py-setuptools", type="build")
 
-    # From 3.11, the build notes numpy@2+ but
-    # https://github.com/h5py/h5py/blob/3.11.0/setup.py#L28
-    # notes that @1.17.3: is actually supported. This also follows the feedstock
-    # https://github.com/AnacondaRecipes/h5py-feedstock/pull/14
-    depends_on("py-numpy@1.17.3:", type=("build", "run"), when="@3.11:")
-
-    # until 3.11.0, uses "oldest-supported-numpy" and doesn't support numpy2
-    # https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
     # pre-3.11 is numpy@1 only
     # https://github.com/h5py/h5py/issues/2353
-    # https://github.com/h5py/h5py/blob/3.11.0/docs/whatsnew/3.11.rst#new-features
     depends_on("py-numpy@:1", when="@:3.10", type=("build", "run"))
-    depends_on("py-numpy@1.19.3:", type=("build", "run"), when="@3:3.10")
-    depends_on("py-numpy@1.7:", type=("build", "run"), when="@:2")
+    depends_on("py-numpy@1.19.3:", type=("build", "run"), when="@3.12:")
+    depends_on("py-numpy@1.17.3:", type=("build", "run"), when="@3.9:")
+    depends_on("py-numpy@1.14.5:", type=("build", "run"), when="@3.2:")
+    depends_on("py-numpy@1.12:", type=("build", "run"), when="@3.0:")
+    depends_on("py-numpy@1.7:", type=("build", "run"), when="@2.7:")
+    depends_on("py-numpy@1.6.1:", type=("build", "run"), when="@2.4:")
 
     # Link dependencies (py-h5py v2 cannot build against HDF5 1.12 regardless
     # of API setting)

--- a/repos/spack_repo/builtin/packages/py_h5py/package.py
+++ b/repos/spack_repo/builtin/packages/py_h5py/package.py
@@ -84,7 +84,6 @@ class PyH5py(PythonPackage):
     # https://github.com/h5py/h5py/issues/2353
     depends_on("py-numpy@:1", when="@:3.10", type=("build", "run"))
     depends_on("py-numpy@1.19.3:", type=("build", "run"), when="@3:3.10 ^python@3.9:")
-    depends_on("py-numpy@1.17.5:", type=("build", "run"), when="@3:3.5 ^python@3.8.0:3.8")
     depends_on("py-numpy@1.7:", type=("build", "run"), when="@:2")
 
     # Link dependencies (py-h5py v2 cannot build against HDF5 1.12 regardless

--- a/repos/spack_repo/builtin/packages/py_h5py/package.py
+++ b/repos/spack_repo/builtin/packages/py_h5py/package.py
@@ -59,7 +59,7 @@ class PyH5py(PythonPackage):
     # h5py@3.11 can build with cython@3.x
     depends_on("py-cython@0.29.31:3", type="build", when="@3.11:")
     depends_on("py-cython@0.29.31:0", type="build", when="@3.9:3.10")
-    depends_on("py-cython@0.29.15:0", type=("build"), when="@3:3.7 ^python@3.9.0:")
+    depends_on("py-cython@0.29.15:0", type=("build"), when="@3:3.7")
     depends_on("py-cython@0.29.14:0", type=("build"), when="@3:3.7 ^python@3.8.0:3.8")
     depends_on("py-cython@0.29:0", type=("build"), when="@3.0:3.10")
     depends_on("py-cython@0.23:0", type="build", when="@:2")
@@ -68,7 +68,7 @@ class PyH5py(PythonPackage):
     depends_on("py-setuptools", type="build")
 
     # Build and runtime dependencies
-    depends_on("py-numpy@2", type=("build", "run"), when="@3.11: ^python@3.9:")
+    depends_on("py-numpy@2", type=("build", "run"), when="@3.11:")
 
     # https://github.com/h5py/h5py/pull/2556
     depends_on("py-numpy@2:2.2", when="@3.11:3.12", type="build")
@@ -78,7 +78,7 @@ class PyH5py(PythonPackage):
     # pre-3.11 is numpy@1 only
     # https://github.com/h5py/h5py/issues/2353
     depends_on("py-numpy@:1", when="@:3.10", type=("build", "run"))
-    depends_on("py-numpy@1.19.3:", type=("build", "run"), when="@3:3.10 ^python@3.9:")
+    depends_on("py-numpy@1.19.3:", type=("build", "run"), when="@3:3.10")
     depends_on("py-numpy@1.7:", type=("build", "run"), when="@:2")
 
     # Link dependencies (py-h5py v2 cannot build against HDF5 1.12 regardless

--- a/repos/spack_repo/builtin/packages/py_h5py/package.py
+++ b/repos/spack_repo/builtin/packages/py_h5py/package.py
@@ -70,6 +70,9 @@ class PyH5py(PythonPackage):
     # pre-3.11 is numpy@1 only
     # https://github.com/h5py/h5py/issues/2353
     depends_on("py-numpy@:1", when="@:3.10", type=("build", "run"))
+
+    # https://github.com/h5py/h5py/issues/2644
+    depends_on("py-numpy@2:", type=("build", "run"), when="@3.14:")
     depends_on("py-numpy@1.19.3:", type=("build", "run"), when="@3.12:")
     depends_on("py-numpy@1.17.3:", type=("build", "run"), when="@3.9:")
     depends_on("py-numpy@1.14.5:", type=("build", "run"), when="@3.2:")


### PR DESCRIPTION
Fixes the numpy version bounds introduced in https://github.com/spack/spack-packages/commit/4aaf3853c3b6e4937101c7c3a684faaab949e733#r161610115

Despite the confusing notes, 3.11 doesn't require numpy2 to build 