### PR TITLE
rust: Add rust-1.89 and improve url_for_version() for spack checksum use

### DIFF
--- a/repos/spack_repo/builtin/packages/rust/package.py
+++ b/repos/spack_repo/builtin/packages/rust/package.py
@@ -14,7 +14,7 @@ class Rust(Package):
     """The Rust programming language toolchain."""
 
     homepage = "https://www.rust-lang.org"
-    url = "https://static.rust-lang.org/dist/rustc-1.42.0-src.tar.gz"
+    url = "https://static.rust-lang.org/dist/rustc-1.89.0-src.tar.gz"
     git = "https://github.com/rust-lang/rust.git"
 
     maintainers("alecbcs")
@@ -36,6 +36,7 @@ class Rust(Package):
     version("nightly")
 
     # Stable versions.
+    version("1.89.0", sha256="2576f9f440dd99b0151bd28f59aa0ac6102d5c4f3ed4ef8a810c8dd05057250d")
     version("1.85.0", sha256="2f4f3142ffb7c8402139cfa0796e24baaac8b9fd3f96b2deec3b94b4045c6a8a")
     version("1.83.0", sha256="722d773bd4eab2d828d7dd35b59f0b017ddf9a97ee2b46c1b7f7fac5c8841c6e")
     version("1.81.0", sha256="872448febdff32e50c3c90a7e15f9bb2db131d13c588fe9071b0ed88837ccfa7")
@@ -84,6 +85,7 @@ class Rust(Package):
     depends_on("rust-bootstrap@nightly", type="build", when="@nightly")
 
     # Stable version dependencies
+    depends_on("rust-bootstrap@1.88:1.89", type="build", when="@1.89")
     depends_on("rust-bootstrap@1.84:1.85", type="build", when="@1.85")
     depends_on("rust-bootstrap@1.82:1.83", type="build", when="@1.83")
     depends_on("rust-bootstrap@1.80:1.81", type="build", when="@1.81")

--- a/repos/spack_repo/builtin/packages/rust_bootstrap/package.py
+++ b/repos/spack_repo/builtin/packages/rust_bootstrap/package.py
@@ -13,7 +13,7 @@ class RustBootstrap(Package):
     """Binary bootstrap Rust compiler."""
 
     homepage = "https://www.rust-lang.org"
-    url = "https://static.rust-lang.org/dist/rust-1.65.0-aarch64-apple-darwin.tar.gz"
+    url = "https://static.rust-lang.org/dist/rust-1.89.0-aarch64-apple-darwin.tar.gz"
 
     maintainers("alecbcs")
 
@@ -24,6 +24,17 @@ class RustBootstrap(Package):
     # should update these binary releases as bootstrapping requirements are
     # modified by new releases of Rust.
     rust_releases = {
+        "1.89.0": {
+            "darwin": {
+                "x86_64": "8590528cade978ecb5249184112887489c9d77ae846539e3ef4d04214a6d8663",
+                "aarch64": "87baeb57fb29339744ac5f99857f0077b12fa463217fc165dfd8f77412f38118",
+            },
+            "linux": {
+                "x86_64": "542f517d0624cbee516627221482b166bf0ffe5fd560ec32beb778c01f5c99b6",
+                "aarch64": "26d6de84ac59da702aa8c2f903e3c344e3259da02e02ce92ad1c735916b29a4a",
+                "powerpc64le": "80db8e203357a050780fb8a2cdc027b81d5ae1634fa999c3be69cf8a2e10bbf6",
+            },
+        },
         "1.85.0": {
             "darwin": {
                 "x86_64": "69a36d239e38cc08c6366d1d85071847406645346c6f2d2e0dfaf64b58050d3d",
@@ -176,19 +187,27 @@ class RustBootstrap(Package):
         if self.os not in ("linux", "darwin"):
             return None
 
-        # Allow maintainers to checksum multiple architectures via
-        # `spack checksum rust-bootstrap@1.70.0-darwin-aarch64`.
-        match = re.search(r"(\S+)-(\S+)-(\S+)", str(version))
+        # Allow spack recipe developers to get checksums of all provided architectures via
+        # spack checksum -b rust-bootstrap 1.89.0-{aarch64,x86_64,ppc64le}-{darwin,linux}
+        # (When the <os> or <arch-os> is not added, the current spack target and os are used)
+        given_version = str(version)
+        if given_version:
+            tty.info(f"Looking for a download matching version {version}")
+        version_str = given_version.split("-")[0]
+        match = re.search(r"(\S+)-(\S+)-", given_version)
         if match:
-            version = match.group(1)
-            os = self.rust_os[match.group(2)]
-            target = self.rust_targets[match.group(3)]
+            arch = self.rust_targets[match.group(2)].split("-")[0]
         else:
-            os = self.rust_os[self.os]
-            target = self.target
+            arch = self.target  # Use the architecture spack target as the moment
+        match = re.search(r"(\S+)-(\S+)-(\S+)", given_version)
+        if match:
+            os = self.rust_os[match.group(3)]
+        else:
+            os = self.rust_os[self.os]  # Use the os running spack targets at the moment
 
-        url = "https://static.rust-lang.org/dist/rust-{0}-{1}-{2}.tar.gz"
-        return url.format(version, target, os)
+        url = f"https://static.rust-lang.org/dist/rust-{version_str}-{arch}-{os}.tar.gz"
+        tty.debug(f"Attempting {url}")
+        return url
 
     @run_before("install", when="platform=linux")
     def fixup_rpaths(self):


### PR DESCRIPTION
Add rust-1.89 and improve url_for_version() for spack checksum use

Updated the description in rust-bootstrap on generating checksums for developers to:

> Allow spack recipe developers to get checksums of all provided architectures via
> `spack checksum -b rust-bootstrap 1.89.0-{aarch64,x86_64,ppc64le}-{darwin,linux}`
> (When the <os> or <arch-os> is not added, the current spack target and os are used)

Updated its url_for_version() to use the established format of `<architecture>` before `<os>` and allow omitting the os, e.g. using `spack checksum rust-bootstrap 1.89.0-aarch64`.

Updated the description as well as the syntax is `spack checksum <recipe> <versions>` (without @)

PS: The GitLab CI failures look unrelated. I'll let @alecbcs review the PR next:
https://gitlab.spack.io/spack/spack-packages/-/pipelines/1191853/failures