### PR TITLE
aom: add v3.12.1

### DIFF
--- a/repos/spack_repo/builtin/packages/aom/package.py
+++ b/repos/spack_repo/builtin/packages/aom/package.py
@@ -15,11 +15,17 @@ class Aom(CMakePackage):
 
     license("BSD-2-Clause AND AOM-Patent-License-1.0", checked_by="tgamblin")
 
-    version("v1.0.0-errata1", commit="29d8ce4836630df5cc7ab58f1afc4836765fc212")
+    version("3.12.1", tag="v3.12.1", commit="10aece4157eb79315da205f39e19bf6ab3ee30d0")
+    version(
+        "1.0.0-errata1",
+        tag="v1.0.0-errata1",
+        commit="add4b15580e410c00c927ee366fa65545045a5d9",
+        deprecated=True,
+    )
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("yasm")
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("nasm", type="build")
 
     def cmake_args(self):
         args = []


### PR DESCRIPTION
This also makes the following changes:
- Use nasm instead of yasm, since the latter seems to be unmaintained
- Update v1.0.0-errata1's checksum, which seems to have been wrong all along (see https://aomedia.googlesource.com/aom/+/refs/tags/v1.0.0-errata1)
- Deprecate v1.0.0-errata1