### PR TITLE
ffmpeg: use nasm

### DIFF
--- a/repos/spack_repo/builtin/packages/ffmpeg/package.py
+++ b/repos/spack_repo/builtin/packages/ffmpeg/package.py
@@ -95,12 +95,12 @@ class Ffmpeg(AutotoolsPackage):
 
     conflicts("@1", when="platform=darwin target=aarch64:", msg="requires gas-preprocessor")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("alsa-lib", when="platform=linux")
     depends_on("iconv")
-    depends_on("yasm@1.2.0:")
+    depends_on("nasm", type="build")
     depends_on("zlib-api")
 
     depends_on("pkgconfig", type="build")


### PR DESCRIPTION
yasm seems to be unmaintained, see e.g. https://fedoraproject.org/wiki/Changes/DeprecateYASM