### PR TITLE
ioapi: add 3.2.20200828

### DIFF
--- a/repos/spack_repo/builtin/packages/ioapi/package.py
+++ b/repos/spack_repo/builtin/packages/ioapi/package.py
@@ -13,20 +13,79 @@ class Ioapi(MakefilePackage):
     """Models-3/EDSS Input/Output Applications Programming Interface."""
 
     homepage = "https://www.cmascenter.org/ioapi/"
-    url = "https://www.cmascenter.org/ioapi/download/ioapi-3.2.tar.gz"
-    maintainers("omsai")
-    # This checksum is somewhat meaningless because upstream updates the tarball
-    # without incrementing the version despite requests no to do this.
-    # Therefore the checksum fails everytime upstream silently updates the
-    # source tarball (#28247).  This also means that one must test for breaking
-    # changes when updating the checksum and avoid #22633.
-    version("3.2", sha256="0a3cbf236ffbd9fb5f6509e35308c3353f1f53096efe0c51b84883d2da86924b")
+    git = "https://github.com/cjcoats/ioapi-3.2.git"
 
-    depends_on("c", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
-    depends_on("netcdf-c@4:")
-    depends_on("netcdf-fortran@4:")
+    maintainers("omsai")
+
+    license("GPL-2.0-or-later", checked_by="omsai")
+
+    # The two -develop versions below without date suffixes are "rolling
+    # releases":
+    # https://www.cmascenter.org/ioapi/documentation/all_versions/html/AVAIL.html#build
+    # If you installed ioapi@3.2 previously it was a rolling release that
+    # caused checksums to fail (#22633, #28247).  Until recently, upstream did
+    # not freeze tarballs and now freezes them with a date suffix.
+    version("4.0-develop", branch="ioapi-4.0")
+    version("3.2-develop", branch="master")
+    # Dated suffix versions are now pulled from GitHub.  The dates below are
+    # based on the, the GitHub tag release date, because there is no other
+    # reliable version:
+    # 1. Most of upstream's tagged versions are missing a leading zero and are
+    #    therefore not in ascending numerical order which break versioning
+    #    relationships.
+    # 2. The tarball VERSION.txt is not reliably updated.
+    version(
+        "3.2.20200828",
+        commit="ef5d5f4e112c249b593b19426421f25d79ae094b",
+        preferred=True,
+    )
+    version(
+        "3.2.20200714",
+        commit="6ebb47e96db3b641af63ee5f853c943b596a1268",
+    )
+    version(
+        "3.2.20200420",
+        commit="4017280cc656993a5be50f0da9287a56166da22b",
+    )
+
+    # MPI support is not yet well supported in this spack package and
+    # may fail to build.
+    variant("mpi", default=False, description="Enable MPI support")
+
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
     depends_on("sed", type="build")
+
+    depends_on("mpi", when="+mpi")
+    depends_on("netcdf-c@4.4.2: ~mpi +parallel-netcdf", when="+mpi")
+    depends_on("netcdf-c@4.4.2: ~mpi", when="~mpi")
+    depends_on("netcdf-fortran@4.4.2:")
+
+    # Supporting compilers by mapping to their Makeinclude files
+    # requires additional work and testing; the package naming scheme
+    # is inconsistent perhaps because it's meant more for human
+    # editing.
+    conflicts(
+        "^intel-oneapi-compilers",
+        msg="Update this spack package to support oneapi",
+    )
+    conflicts("%nvhpc", msg="Update this spack package to support pgi")
+    # There is no evidence of support for LLVM even on macOS.
+    conflicts("%llvm", msg="IOAPI does not support LLVM")
+
+    # Parallel build will fail with this error:
+    #
+    # Fatal Error: Cannot open module file 'm3utilio.mod' for reading at (1):
+    # No such file or directory
+    parallel = False
+
+    def setup_build_environment(self, env):
+        # The BIN environmental variables needs to be set in addition
+        # to being written into the top-level Makefile.
+        BIN = "Linux2_x86_64gfort"
+        if self.spec.satisfies("+mpi"):
+            BIN += "mpi"
+        env.set("BIN", BIN)
 
     def edit(self, spec, prefix):
         # No default Makefile bundled; edit the template.
@@ -41,6 +100,9 @@ CPLMODE = nocpl
 \\1
         """.strip(),
         )
+        BIN = "Linux2_x86_64gfort"
+        if self.spec.satisfies("+mpi"):
+            BIN += "mpi"
         makefile.filter(
             "^BASEDIR.*",
             (
@@ -56,15 +118,25 @@ BININST = """
                 + """
 LIBINST = """
                 + prefix.lib
-                + """
-BIN = Linux2_x86_64
+                + f"""
+BIN = {BIN}
         """
             ).strip(),
         )
         # Fix circular dependency bug for generating subdirectory Makefiles.
         makefile.filter("^configure:.*", "configure:")
+        # Fix hard-coded fortran mpi compiler.
+        if self.spec.satisfies("+mpi"):
+            makeinclude = FileFilter(f"ioapi/Makeinclude.{BIN}")
+            makeinclude.filter("mpicc", f"{self.spec['mpi'].mpicc}")
+            makeinclude.filter("mpif90", f"{self.spec['mpi'].mpifc}")
         # Generate the subdirectory Makefiles.
         make("configure")
+
+    def flag_handler(self, name: str, flags: List[str]):
+        if name == "fflags" and self.spec.satisfies("%fortran=gcc@10:"):
+            flags.append("-fallow-argument-mismatch")
+        return (flags, None, None)
 
     def install(self, spec, prefix):
         make("install")

--- a/repos/spack_repo/builtin/packages/ioapi/package.py
+++ b/repos/spack_repo/builtin/packages/ioapi/package.py
@@ -34,19 +34,9 @@ class Ioapi(MakefilePackage):
     #    therefore not in ascending numerical order which break versioning
     #    relationships.
     # 2. The tarball VERSION.txt is not reliably updated.
-    version(
-        "3.2.20200828",
-        commit="ef5d5f4e112c249b593b19426421f25d79ae094b",
-        preferred=True,
-    )
-    version(
-        "3.2.20200714",
-        commit="6ebb47e96db3b641af63ee5f853c943b596a1268",
-    )
-    version(
-        "3.2.20200420",
-        commit="4017280cc656993a5be50f0da9287a56166da22b",
-    )
+    version("3.2.20200828", commit="ef5d5f4e112c249b593b19426421f25d79ae094b", preferred=True)
+    version("3.2.20200714", commit="6ebb47e96db3b641af63ee5f853c943b596a1268")
+    version("3.2.20200420", commit="4017280cc656993a5be50f0da9287a56166da22b")
 
     # MPI support is not yet well supported in this spack package and
     # may fail to build.
@@ -65,10 +55,7 @@ class Ioapi(MakefilePackage):
     # requires additional work and testing; the package naming scheme
     # is inconsistent perhaps because it's meant more for human
     # editing.
-    conflicts(
-        "^intel-oneapi-compilers",
-        msg="Update this spack package to support oneapi",
-    )
+    conflicts("^intel-oneapi-compilers", msg="Update this spack package to support oneapi")
     conflicts("%nvhpc", msg="Update this spack package to support pgi")
     # There is no evidence of support for LLVM even on macOS.
     conflicts("%llvm", msg="IOAPI does not support LLVM")


### PR DESCRIPTION
Finally fixes spack/spack#22633 and fixes spack/spack#28247 by migrating away from the rolling release tarballs to specific git commits.

Fixes argument mismatch build error with newer versions of gfortran. Although IOAPI supports other compilers, so far only gcc/gfortran is implemented with conflicts set for other compilers that will not work unless mapped to the relevant Makeinclude files.  I can support other compilers if asked, but it took most of the day just to get gcc/gfortran working again and should at least get people up and running.

MPI was never well supported and it's made more complicated by upstream wanting to use the non-default parallel-netcdf API.  Can look at MPI if asked.  I never personally used this package and created it to help another researcher when I was a grad student.  Strangely, upstream's test cshell script is interactive and might take some time figuring out how to run it after installing it in to the spack prefix rather than upstream's non-hier(7) installation.