### PR TITLE
py-boost-histogram: depends_on py-setuptools-scm type build

### DIFF
--- a/repos/spack_repo/builtin/packages/py_boost_histogram/package.py
+++ b/repos/spack_repo/builtin/packages/py_boost_histogram/package.py
@@ -30,6 +30,10 @@ class PyBoostHistogram(PythonPackage):
     with when("@1.5:"):
         depends_on("py-scikit-build-core@0.11:", type="build")
         depends_on("py-pybind11@2.13.3:", type="build")
+        # pyproject.toml:
+        # [tool.scikit-build]
+        # metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
+        depends_on("py-setuptools-scm", type="build")
     with when("@:1.4"):
         depends_on("py-setuptools@45:", type="build")
         depends_on("py-setuptools-scm@4.1.2:+toml", type="build")


### PR DESCRIPTION
This PR adds to `py-boost-histogram` the build dependency on `py-setuptools-scm`, which is kind of hidden in the [`pyproject.toml`](https://github.com/scikit-hep/boost-histogram/blob/v1.6.0/pyproject.toml#L112-L114):
```toml
[tool.scikit-build]
minimum-version = "build-system.requires"
metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
```
