### PR TITLE
llvm: add `utils` variant for LLVM_INSTALL_UTILS

### DIFF
--- a/repos/spack_repo/builtin/packages/llvm/package.py
+++ b/repos/spack_repo/builtin/packages/llvm/package.py
@@ -376,6 +376,8 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
         description="Enable zstd support for static analyzer / lld",
     )
 
+    variant("utils", default=False, description="Install utility binaries (FileCheck, etc.)")
+
     provides("libllvm@20", when="@20.0.0:20")
     provides("libllvm@19", when="@19.0.0:19")
     provides("libllvm@18", when="@18.0.0:18")
@@ -1136,6 +1138,10 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
         if spec.satisfies("+polly"):
             projects.append("polly")
             cmake_args.append(define("LINK_POLLY_INTO_TOOLS", True))
+        if spec.satisfies("+utils"):
+            cmake_args.extend(
+                [define("LLVM_BUILD_UTILS", True), define("LLVM_INSTALL_UTILS", True)]
+            )
 
         cmake_args.extend(
             [


### PR DESCRIPTION
With this PR, I propose to add a ~~`utilities`~~ `utils` variant which can be used to enable building and installing the LLVM utils (e.g., FileCheck, etc.). I'm not sure on the name of the variant ~~(`utils` is shorter, maybe?)~~ and whether it should be enabled by default.

CC maintainers: @trws @haampie @skosukhin 