### PR TITLE
elfutils: add version 0.193

### DIFF
--- a/repos/spack_repo/builtin/packages/elfutils/package.py
+++ b/repos/spack_repo/builtin/packages/elfutils/package.py
@@ -28,6 +28,7 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
 
     license("GPL-3.0-or-later AND ( GPL-2.0-or-later OR LGPL-3.0-or-later )")
 
+    version("0.193", sha256="7857f44b624f4d8d421df851aaae7b1402cfe6bcdd2d8049f15fc07d3dde7635")
     version("0.192", sha256="616099beae24aba11f9b63d86ca6cc8d566d968b802391334c91df54eab416b4")
     version("0.191", sha256="df76db71366d1d708365fc7a6c60ca48398f14367eb2b8954efc8897147ad871")
     version("0.190", sha256="8e00a3a9b5f04bc1dc273ae86281d2d26ed412020b391ffcc23198f10231d692")

--- a/repos/spack_repo/builtin/packages/hpctoolkit/package.py
+++ b/repos/spack_repo/builtin/packages/hpctoolkit/package.py
@@ -242,7 +242,7 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
 
     # https://gitlab.com/hpctoolkit/hpctoolkit/-/issues/831
     conflicts(
-        "^elfutils@0.191:",
+        "^elfutils@0.191",
         msg="avoid elfutils 0.191 (known critical errors in hpcstruct for CUDA binaries)",
     )
 


### PR DESCRIPTION
Relax conflict in hpctoolkit to 0.191 only.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
