### PR TITLE
py-greenlet: add v3.2.2

### DIFF
--- a/repos/spack_repo/builtin/packages/py_greenlet/package.py
+++ b/repos/spack_repo/builtin/packages/py_greenlet/package.py
@@ -18,6 +18,7 @@ class PyGreenlet(PythonPackage):
 
     license("MIT AND PSF-2.0", checked_by="tgamblin")
 
+    version("3.2.2", sha256="ad053d34421a2debba45aa3cc39acf454acbcd025b3fc1a9f8a0dee237abd485")
     version("3.1.1", sha256="4ce3ac6cdb6adf7946475d7ef31777c26d94bccc377e070a7986bd2d5c515467")
     version("3.0.3", sha256="43374442353259554ce33599da8b692d5aa96f8976d567d4badf263371fbe491")
     version("3.0.0a1", sha256="1bd4ea36f0aeb14ca335e0c9594a5aaefa1ac4e2db7d86ba38f0be96166b3102")
@@ -32,11 +33,12 @@ class PyGreenlet(PythonPackage):
     depends_on("cxx", type="build")
 
     with default_args(type=("build", "link", "run")):
-        depends_on("python")
-        depends_on("python@:3.11", when="@:2")
+        depends_on("python@3.9:", when="@3.2:")
         depends_on("python@:3.12", when="@:3.0")
+        depends_on("python@:3.11", when="@:2")
+        depends_on("python")
 
+    depends_on("py-setuptools@40.8:", type="build", when="@3.0.2:")
     depends_on("py-setuptools", type="build")
-    depends_on("py-setuptools@40.8.0:", type="build", when="@3.0.2:")
 
     conflicts("%gcc@:7", when="@3.1.1:", msg="GCC-8 required as of 3.1.1")


### PR DESCRIPTION
This is a new version is holding up #134 and I don't see any other PRs for it.

I confirmed and updated the dependencies for the new version.