### PR TITLE
quandary: add version and update variants

### DIFF
--- a/repos/spack_repo/builtin/packages/quandary/package.py
+++ b/repos/spack_repo/builtin/packages/quandary/package.py
@@ -2,7 +2,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack_repo.builtin.build_systems.cached_cmake import CachedCMakePackage, cmake_cache_path, cmake_cache_option
+from spack_repo.builtin.build_systems.cached_cmake import (
+    CachedCMakePackage,
+    cmake_cache_option,
+    cmake_cache_path,
+)
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 

--- a/repos/spack_repo/builtin/packages/quandary/package.py
+++ b/repos/spack_repo/builtin/packages/quandary/package.py
@@ -20,6 +20,7 @@ class Quandary(CachedCMakePackage, CudaPackage, ROCmPackage):
     license("MIT", checked_by="tdrwenski")
 
     version("main", branch="main", preferred=True)
+    version("4.2", tag="v4.2", commit="557675fd76daf9fd0be7ebd6321bf2afcb6a6b9c")
     version("learning", branch="learning")
 
     variant("slepc", default=False, description="Build with SLEPc library")

--- a/repos/spack_repo/builtin/packages/quandary/package.py
+++ b/repos/spack_repo/builtin/packages/quandary/package.py
@@ -23,14 +23,19 @@ class Quandary(CachedCMakePackage, CudaPackage, ROCmPackage):
     version("learning", branch="learning")
 
     variant("slepc", default=False, description="Build with SLEPc library")
-    variant("debug", default=False, description="Debug mode")
+    variant("int64", default=False, description="Use 64 bit ints for PetscInts")
     variant("test", default=False, description="Add dependencies needed for testing")
 
     depends_on("cxx", type="build")
     depends_on("c", type="build")
 
     depends_on("petsc~hypre~metis~fortran")
-    depends_on("petsc+debug", when="+debug")
+    depends_on("petsc+debug", when="build_type=Debug")
+    depends_on("petsc~debug", when="build_type=Release")
+    depends_on("petsc~debug", when="build_type=RelWithDebInfo")
+    depends_on("petsc+int64", when="+int64")
+    depends_on("petsc~int64", when="~int64")
+
     depends_on("slepc", when="+slepc")
     depends_on("mpi", type=("build", "link", "run"))
 

--- a/repos/spack_repo/builtin/packages/quandary/package.py
+++ b/repos/spack_repo/builtin/packages/quandary/package.py
@@ -30,6 +30,7 @@ class Quandary(CachedCMakePackage, CudaPackage, ROCmPackage):
     variant("slepc", default=False, description="Build with SLEPc library")
     variant("int64", default=False, description="Use 64 bit ints for PetscInts")
     variant("test", default=False, description="Add dependencies needed for testing")
+    variant("werror", default=False, description="Enable warnings as errors")
 
     depends_on("cxx", type="build")
     depends_on("c", type="build")
@@ -67,5 +68,6 @@ class Quandary(CachedCMakePackage, CudaPackage, ROCmPackage):
 
         entries.append(cmake_cache_path("BLT_SOURCE_DIR", spec["blt"].prefix))
         entries.append(cmake_cache_option("WITH_SLEPC", spec.satisfies("+slepc")))
+        entries.append(cmake_cache_option("ENABLE_WARNINGS_AS_ERRORS", spec.satisfies("+werror")))
 
         return entries

--- a/repos/spack_repo/builtin/packages/quandary/package.py
+++ b/repos/spack_repo/builtin/packages/quandary/package.py
@@ -19,7 +19,7 @@ class Quandary(CachedCMakePackage, CudaPackage, ROCmPackage):
     homepage = "https://github.com/LLNL/quandary"
     git = "https://github.com/LLNL/quandary.git"
 
-    maintainers("steffi7574", "tdrwenski")
+    maintainers("steffi7574", "tdrwenski", "adrienbernede")
 
     license("MIT", checked_by="tdrwenski")
 

--- a/repos/spack_repo/builtin/packages/quandary/package.py
+++ b/repos/spack_repo/builtin/packages/quandary/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack_repo.builtin.build_systems.cached_cmake import CachedCMakePackage, cmake_cache_path
+from spack_repo.builtin.build_systems.cached_cmake import CachedCMakePackage, cmake_cache_path, cmake_cache_option
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
@@ -61,9 +61,6 @@ class Quandary(CachedCMakePackage, CudaPackage, ROCmPackage):
         entries = []
 
         entries.append(cmake_cache_path("BLT_SOURCE_DIR", spec["blt"].prefix))
+        entries.append(cmake_cache_option("WITH_SLEPC", spec.satisfies("+slepc")))
 
         return entries
-
-    def cmake_args(self):
-        args = [self.define_from_variant("WITH_SLEPC", "slepc")]
-        return args


### PR DESCRIPTION
- add version 4.2 from tag
- add int64 variant that uses Petsc's int64 variant
- remove debug variant and instead use cmake build type
- put slepc variable in cmake cache
- add warnings as errors variant
- add @adrienbernede as maintainer