### PR TITLE
Curl: add CMake build system

### DIFF
--- a/repos/spack_repo/builtin/packages/curl/package.py
+++ b/repos/spack_repo/builtin/packages/curl/package.py
@@ -431,9 +431,9 @@ class CMakeBuilder(CMakeBuilder):
             )
             if self.spec.satisfies("+ldap"):
                 args.append(self.define("USE_WIN32_LDAP", True))
-
-        if "shared" in self.spec.variants["libs"]:
+            
+        if self.spec.satisfies("libs=shared"):
             args.append(self.define("BUILD_SHARED_LIBS", True))
-        if "static" in self.spec.variants["libs"]:
+        if self.spec.satisfies("libs=static"):
             args.append(self.define("BUILD_STATIC_LIBS", True))
         return args

--- a/repos/spack_repo/builtin/packages/curl/package.py
+++ b/repos/spack_repo/builtin/packages/curl/package.py
@@ -8,8 +8,8 @@ import re
 import sys
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsBuilder, AutotoolsPackage
-from spack_repo.builtin.build_systems.nmake import NMakeBuilder, NMakePackage
 from spack_repo.builtin.build_systems.cmake import CMakeBuilder, CMakePackage
+from spack_repo.builtin.build_systems.nmake import NMakeBuilder, NMakePackage
 
 from spack.package import *
 
@@ -146,7 +146,6 @@ class Curl(NMakePackage, AutotoolsPackage, CMakePackage):
     # 3.0, which curl@7.63 requires
     depends_on("cmake@:3", when="build_system=cmake @:7.63")
 
-
     depends_on("gnutls", when="tls=gnutls")
 
     with when("tls=mbedtls"):
@@ -182,7 +181,9 @@ class Curl(NMakePackage, AutotoolsPackage, CMakePackage):
     # https://github.com/curl/curl/pull/9054
     patch("easy-lock-sched-header.patch", when="@7.84.0")
 
-    build_system("autotools", "cmake", conditional("nmake", when="@:8.11 platform=windows"), default="cmake")
+    build_system(
+        "autotools", "cmake", conditional("nmake", when="@:8.11 platform=windows"), default="cmake"
+    )
 
     @classmethod
     def determine_version(cls, exe):
@@ -385,6 +386,7 @@ class NMakeBuilder(BuildEnvironment, NMakeBuilder):
             if os.path.exists(libcurl_a) and not os.path.exists(libcurl):
                 symlink(libcurl_a, libcurl)
 
+
 class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):
         args = [
@@ -419,17 +421,17 @@ class CMakeBuilder(CMakeBuilder):
             self.define("CURL_USE_MBEDTLS", True)
         if self.spec.satisfies("tls=openssl"):
             self.define("CURL_USE_OPENSSL", True)
-        
+
         if self.spec.satisfies("platform=windows"):
             args.extend(
                 [
                     self.define_from_variant("ENABLE_UNICODE", "unicode"),
-                    self.define_from_variant("CURL_STATIC_CRT", "static-crt")
+                    self.define_from_variant("CURL_STATIC_CRT", "static-crt"),
                 ]
             )
             if self.spec.satisfies("+ldap"):
                 args.append(self.define("USE_WIN32_LDAP", True))
-            
+
         if "shared" in self.spec.variants["libs"]:
             args.append(self.define("BUILD_SHARED_LIBS", True))
         if "static" in self.spec.variants["libs"]:

--- a/repos/spack_repo/builtin/packages/curl/package.py
+++ b/repos/spack_repo/builtin/packages/curl/package.py
@@ -181,8 +181,9 @@ class Curl(NMakePackage, AutotoolsPackage, CMakePackage):
     # https://github.com/curl/curl/pull/9054
     patch("easy-lock-sched-header.patch", when="@7.84.0")
 
+    platform_default = "cmake" if sys.platform =="win32" else "autotools"
     build_system(
-        "autotools", "cmake", conditional("nmake", when="@:8.11 platform=windows"), default="cmake"
+        "autotools", "cmake", conditional("nmake", when="@:8.11 platform=windows"), default=platform_default
     )
 
     @classmethod

--- a/repos/spack_repo/builtin/packages/curl/package.py
+++ b/repos/spack_repo/builtin/packages/curl/package.py
@@ -9,13 +9,14 @@ import sys
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsBuilder, AutotoolsPackage
 from spack_repo.builtin.build_systems.nmake import NMakeBuilder, NMakePackage
+from spack_repo.builtin.build_systems.cmake import CMakeBuilder, CMakePackage
 
 from spack.package import *
 
 is_windows = sys.platform == "win32"
 
 
-class Curl(NMakePackage, AutotoolsPackage):
+class Curl(NMakePackage, AutotoolsPackage, CMakePackage):
     """cURL is an open source command line tool and library for
     transferring data with URL syntax"""
 
@@ -137,6 +138,11 @@ class Curl(NMakePackage, AutotoolsPackage):
     depends_on("pkgconfig", type="build", when="platform=linux")
     depends_on("pkgconfig", type="build", when="platform=freebsd")
 
+    # CMake 4.0: is not compatible with CMake systems requiring
+    # 3.0, which curl@7.63 requires
+    depends_on("cmake@:3", when="build_system=cmake @:7.63")
+
+
     depends_on("gnutls", when="tls=gnutls")
 
     with when("tls=mbedtls"):
@@ -172,7 +178,7 @@ class Curl(NMakePackage, AutotoolsPackage):
     # https://github.com/curl/curl/pull/9054
     patch("easy-lock-sched-header.patch", when="@7.84.0")
 
-    build_system("autotools", conditional("nmake", when="platform=windows"), default="autotools")
+    build_system("autotools", "cmake", conditional("nmake", when="platform=windows"), default="cmake")
 
     @classmethod
     def determine_version(cls, exe):
@@ -374,3 +380,13 @@ class NMakeBuilder(BuildEnvironment, NMakeBuilder):
             # safeguard against future curl releases that do this for us
             if os.path.exists(libcurl_a) and not os.path.exists(libcurl):
                 symlink(libcurl_a, libcurl)
+
+class CMakeBuilder(CMakeBuilder):
+    def cmake_args(self):
+        args = [
+            self.define("BUILD_TESTING", False),
+            self.define_from_variant("CMAKE_USE_LIBSSH2", "libssh2"),
+            self.define_from_variant("CMAKE_USE_OPENSSL", "openssl"),
+            self.define_from_variant("CMAKE_USE_OPENLDAP", "ldap"),
+            
+        ]

--- a/repos/spack_repo/builtin/packages/curl/package.py
+++ b/repos/spack_repo/builtin/packages/curl/package.py
@@ -403,7 +403,6 @@ class CMakeBuilder(CMakeBuilder):
             self.define("ENABLE_CURL_MANUAL", False),
             self.define_from_variant("CURL_USE_LIBSSH2", "libssh2"),
             self.define_from_variant("CURL_USE_LIBSSH", "libssh"),
-            self.define_from_variant("CURL_USE_OPENSSL", "openssl"),
             self.define_from_variant("CURL_USE_OPENLDAP", "ldap"),
             self.define_from_variant("CURL_DISABLE_LDAP", "ldap"),
             self.define_from_variant("USE_NGHTTP2", "nghttp2"),
@@ -431,8 +430,8 @@ class CMakeBuilder(CMakeBuilder):
             if self.spec.satisfies("+ldap"):
                 args.append(self.define("USE_WIN32_LDAP", True))
             
-        if "shared" in self.spec["libs"]:
+        if "shared" in self.spec.variants["libs"]:
             args.append(self.define("BUILD_SHARED_LIBS", True))
-        if "static" in self.spec["libs"]:
+        if "static" in self.spec.variants["libs"]:
             args.append(self.define("BUILD_STATIC_LIBS", True))
         return args

--- a/repos/spack_repo/builtin/packages/curl/package.py
+++ b/repos/spack_repo/builtin/packages/curl/package.py
@@ -414,14 +414,14 @@ class CMakeBuilder(CMakeBuilder):
         ]
 
         if self.spec.satisfies("tls=sspi"):
-            self.define("CURL_WINDOWS_SSPI", True)
+            args.append(self.define("CURL_WINDOWS_SSPI", True))
         if self.spec.satisfies("tls=gnutls"):
-            self.define("CURL_USE_GNUTLS", True)
+            args.append(self.define("CURL_USE_GNUTLS", True))
         if self.spec.satisfies("tls=mbedtls"):
-            self.define("CURL_USE_MBEDTLS", True)
+            args.append(self.define("CURL_USE_MBEDTLS", True))
         if self.spec.satisfies("tls=openssl"):
-            self.define("CURL_USE_OPENSSL", True)
-
+            args.append(self.define("CURL_USE_OPENSSL", True))
+        
         if self.spec.satisfies("platform=windows"):
             args.extend(
                 [

--- a/repos/spack_repo/builtin/packages/curl/package.py
+++ b/repos/spack_repo/builtin/packages/curl/package.py
@@ -181,9 +181,12 @@ class Curl(NMakePackage, AutotoolsPackage, CMakePackage):
     # https://github.com/curl/curl/pull/9054
     patch("easy-lock-sched-header.patch", when="@7.84.0")
 
-    platform_default = "cmake" if sys.platform =="win32" else "autotools"
+    platform_default = "cmake" if sys.platform == "win32" else "autotools"
     build_system(
-        "autotools", "cmake", conditional("nmake", when="@:8.11 platform=windows"), default=platform_default
+        "autotools",
+        "cmake",
+        conditional("nmake", when="@:8.11 platform=windows"),
+        default=platform_default,
     )
 
     @classmethod
@@ -422,7 +425,7 @@ class CMakeBuilder(CMakeBuilder):
             args.append(self.define("CURL_USE_MBEDTLS", True))
         if self.spec.satisfies("tls=openssl"):
             args.append(self.define("CURL_USE_OPENSSL", True))
-        
+
         if self.spec.satisfies("platform=windows"):
             args.extend(
                 [
@@ -432,7 +435,7 @@ class CMakeBuilder(CMakeBuilder):
             )
             if self.spec.satisfies("+ldap"):
                 args.append(self.define("USE_WIN32_LDAP", True))
-            
+
         if self.spec.satisfies("libs=shared"):
             args.append(self.define("BUILD_SHARED_LIBS", True))
         if self.spec.satisfies("libs=static"):

--- a/repos/spack_repo/builtin/packages/curl/package.py
+++ b/repos/spack_repo/builtin/packages/curl/package.py
@@ -13,7 +13,7 @@ from spack_repo.builtin.build_systems.nmake import NMakeBuilder, NMakePackage
 
 from spack.package import *
 
-is_windows = sys.platform == "win32"
+IS_WINDOWS = sys.platform == "win32"
 
 
 class Curl(NMakePackage, AutotoolsPackage, CMakePackage):
@@ -123,9 +123,9 @@ class Curl(NMakePackage, AutotoolsPackage, CMakePackage):
     variant("libidn2", default=False, description="enable libidn2 support")
     variant(
         "libs",
-        default="shared,static" if not is_windows else "shared",
+        default="shared,static" if not IS_WINDOWS else "shared",
         values=("shared", "static"),
-        multi=not is_windows,
+        multi=not IS_WINDOWS,
         description="Build shared libs, static libs or both",
     )
 
@@ -181,12 +181,11 @@ class Curl(NMakePackage, AutotoolsPackage, CMakePackage):
     # https://github.com/curl/curl/pull/9054
     patch("easy-lock-sched-header.patch", when="@7.84.0")
 
-    platform_default = "cmake" if sys.platform == "win32" else "autotools"
     build_system(
         "autotools",
         "cmake",
         conditional("nmake", when="@:8.11 platform=windows"),
-        default=platform_default,
+        default="cmake" if IS_WINDOWS else "autotools",
     )
 
     @classmethod

--- a/repos/spack_repo/builtin/packages/curl/package.py
+++ b/repos/spack_repo/builtin/packages/curl/package.py
@@ -129,6 +129,10 @@ class Curl(NMakePackage, AutotoolsPackage, CMakePackage):
         description="Build shared libs, static libs or both",
     )
 
+    with when("platform=windows build_system=cmake"):
+        variant("static-crt", default=False, description="Link to static CRT")
+        variant("unicode", default=False, description="Use the unicode version of Windows API")
+
     conflicts("platform=linux", when="tls=secure_transport", msg="Only supported on macOS")
 
     depends_on("c", type="build")  # generated
@@ -178,7 +182,7 @@ class Curl(NMakePackage, AutotoolsPackage, CMakePackage):
     # https://github.com/curl/curl/pull/9054
     patch("easy-lock-sched-header.patch", when="@7.84.0")
 
-    build_system("autotools", "cmake", conditional("nmake", when="platform=windows"), default="cmake")
+    build_system("autotools", "cmake", conditional("nmake", when="@:8.11 platform=windows"), default="cmake")
 
     @classmethod
     def determine_version(cls, exe):
@@ -385,8 +389,50 @@ class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):
         args = [
             self.define("BUILD_TESTING", False),
-            self.define_from_variant("CMAKE_USE_LIBSSH2", "libssh2"),
-            self.define_from_variant("CMAKE_USE_OPENSSL", "openssl"),
-            self.define_from_variant("CMAKE_USE_OPENLDAP", "ldap"),
-            
+            self.define("CURL_USE_LIBPSL", False),
+            # Curl's CMake will turn this off if not building static libcurl
+            self.define("BUILD_STATIC_CURL", True),
+            # enables install from cmake
+            self.define("CURL_DISABLE_INSTALL", False),
+            self.define("BUILD_MISC_DOCS", False),
+            self.define("BUILD_LIBCURL_DOCS", False),
+            self.define("BUILD_EXAMPLES", False),
+            self.define("CURL_BROTLI", False),
+            self.define("CURL_USE_GSASL", False),
+            self.define("CURL_ZSTD", False),
+            self.define("ENABLE_CURL_MANUAL", False),
+            self.define_from_variant("CURL_USE_LIBSSH2", "libssh2"),
+            self.define_from_variant("CURL_USE_LIBSSH", "libssh"),
+            self.define_from_variant("CURL_USE_OPENSSL", "openssl"),
+            self.define_from_variant("CURL_USE_OPENLDAP", "ldap"),
+            self.define_from_variant("CURL_DISABLE_LDAP", "ldap"),
+            self.define_from_variant("USE_NGHTTP2", "nghttp2"),
+            self.define_from_variant("CURL_USE_GSSAPI", "gssapi"),
+            self.define_from_variant("USE_LIBRTMP", "librtmp"),
+            self.define_from_variant("USE_LIBIDN2", "libidn2"),
         ]
+
+        if self.spec.satisfies("tls=sspi"):
+            self.define("CURL_WINDOWS_SSPI", True)
+        if self.spec.satisfies("tls=gnutls"):
+            self.define("CURL_USE_GNUTLS", True)
+        if self.spec.satisfies("tls=mbedtls"):
+            self.define("CURL_USE_MBEDTLS", True)
+        if self.spec.satisfies("tls=openssl"):
+            self.define("CURL_USE_OPENSSL", True)
+        
+        if self.spec.satisfies("platform=windows"):
+            args.extend(
+                [
+                    self.define_from_variant("ENABLE_UNICODE", "unicode"),
+                    self.define_from_variant("CURL_STATIC_CRT", "static-crt")
+                ]
+            )
+            if self.spec.satisfies("+ldap"):
+                args.append(self.define("USE_WIN32_LDAP", True))
+            
+        if "shared" in self.spec["libs"]:
+            args.append(self.define("BUILD_SHARED_LIBS", True))
+        if "static" in self.spec["libs"]:
+            args.append(self.define("BUILD_STATIC_LIBS", True))
+        return args


### PR DESCRIPTION
Curl added a CMake build system a while back, finally port it to Spack's recipe.

Adds appropriate cutover from NMake (being removed in a month (sept 2025) to CMake on Windows
