### PR TITLE
py-fenics-ufl: Fix test stage

### DIFF
--- a/repos/spack_repo/builtin/packages/py_fenics_ufl/package.py
+++ b/repos/spack_repo/builtin/packages/py_fenics_ufl/package.py
@@ -56,5 +56,5 @@ class PyFenicsUfl(PythonPackage):
     @run_after("install")
     @on_package_attributes(run_tests=True)
     def check_build(self):
-        with working_dir("test"):
-            Executable("py.test")()
+        with working_dir(self.stage.source_path):
+            python("-m", "pytest")


### PR DESCRIPTION
Working dir was not set up correctly and favour `python` over `py.test`.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
