### PR TITLE
xsdk: add compiler dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/xsdk/package.py
+++ b/repos/spack_repo/builtin/packages/xsdk/package.py
@@ -114,6 +114,10 @@ class Xsdk(BundlePackage, CudaPackage, ROCmPackage):
     variant("raja", default=(sys.platform != "darwin"), description="Enable raja for hiop, exago")
     variant("pflotran", default=True, when="@:1.0.0", description="Enable pflotran package build")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
+
     xsdk_depends_on(
         "hypre@2.32.0+superlu-dist+shared", when="@1.1.0", cuda_var="cuda", rocm_var="rocm"
     )


### PR DESCRIPTION
Without this change - spack fails with:
```
svcpetsc@petsc-gpu-02:/scratch/svcpetsc/spack$ ./bin/spack spec xsdk%intel-oneapi-compilers@2024.0.2
==> Error: 'xsdk %oneapi@2024.0.2' cannot depend on intel-oneapi-compilers
```
```
balay@pj01:~/spack$ ./bin/spack spec xsdk%llvm@20.1.6
==> Error: 'xsdk %clang@20.1.6' cannot depend on llvm
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
