### PR TITLE
Win: Numpy in CI

### DIFF
--- a/repos/spack_repo/builtin/packages/netlib_lapack/package.py
+++ b/repos/spack_repo/builtin/packages/netlib_lapack/package.py
@@ -210,9 +210,8 @@ class NetlibLapack(CMakePackage):
         # this method is used for establishing link interfaces
         # so we want to be searching for import not runtime libs
         # no op elsewhere
-        runtime = False
         return find_libraries(
-            libraries, root=self.prefix, shared=shared, runtime=runtime, recursive=True
+            libraries, root=self.prefix, shared=shared, runtime=False, recursive=True
         )
 
     @property
@@ -232,9 +231,8 @@ class NetlibLapack(CMakePackage):
         libraries = query2libraries[key]
         # see comment in blas_libs for explanation of
         # runtime
-        runtime = False
         return find_libraries(
-            libraries, root=self.prefix, shared=shared, runtime=runtime, recursive=True
+            libraries, root=self.prefix, shared=shared, runtime=False, recursive=True
         )
 
     @property

--- a/repos/spack_repo/builtin/packages/netlib_lapack/package.py
+++ b/repos/spack_repo/builtin/packages/netlib_lapack/package.py
@@ -211,7 +211,9 @@ class NetlibLapack(CMakePackage):
         # so we want to be searching for import not runtime libs
         # no op elsewhere
         runtime = False
-        return find_libraries(libraries, root=self.prefix, shared=shared, runtime=runtime, recursive=True)
+        return find_libraries(
+            libraries, root=self.prefix, shared=shared, runtime=runtime, recursive=True
+        )
 
     @property
     def lapack_libs(self):
@@ -228,10 +230,12 @@ class NetlibLapack(CMakePackage):
         }
         key = tuple(sorted(query_parameters))
         libraries = query2libraries[key]
-        # see comment in blas_libs for explanation of 
+        # see comment in blas_libs for explanation of
         # runtime
-        runtime=False
-        return find_libraries(libraries, root=self.prefix, shared=shared, runtime=runtime, recursive=True)
+        runtime = False
+        return find_libraries(
+            libraries, root=self.prefix, shared=shared, runtime=runtime, recursive=True
+        )
 
     @property
     def headers(self):

--- a/repos/spack_repo/builtin/packages/netlib_lapack/package.py
+++ b/repos/spack_repo/builtin/packages/netlib_lapack/package.py
@@ -206,7 +206,12 @@ class NetlibLapack(CMakePackage):
         }
         key = tuple(sorted(query_parameters))
         libraries = query2libraries[key]
-        return find_libraries(libraries, root=self.prefix, shared=shared, recursive=True)
+        # set search option for runtime libraries on win
+        # this method is used for establishing link interfaces
+        # so we want to be searching for import not runtime libs
+        # no op elsewhere
+        runtime = False
+        return find_libraries(libraries, root=self.prefix, shared=shared, runtime=runtime, recursive=True)
 
     @property
     def lapack_libs(self):
@@ -223,7 +228,10 @@ class NetlibLapack(CMakePackage):
         }
         key = tuple(sorted(query_parameters))
         libraries = query2libraries[key]
-        return find_libraries(libraries, root=self.prefix, shared=shared, recursive=True)
+        # see comment in blas_libs for explanation of 
+        # runtime
+        runtime=False
+        return find_libraries(libraries, root=self.prefix, shared=shared, runtime=runtime, recursive=True)
 
     @property
     def headers(self):

--- a/repos/spack_repo/builtin/packages/netlib_lapack/package.py
+++ b/repos/spack_repo/builtin/packages/netlib_lapack/package.py
@@ -206,10 +206,7 @@ class NetlibLapack(CMakePackage):
         }
         key = tuple(sorted(query_parameters))
         libraries = query2libraries[key]
-        # set search option for runtime libraries on win
-        # this method is used for establishing link interfaces
-        # so we want to be searching for import not runtime libs
-        # no op elsewhere
+
         return find_libraries(
             libraries, root=self.prefix, shared=shared, runtime=False, recursive=True
         )
@@ -229,8 +226,7 @@ class NetlibLapack(CMakePackage):
         }
         key = tuple(sorted(query_parameters))
         libraries = query2libraries[key]
-        # see comment in blas_libs for explanation of
-        # runtime
+
         return find_libraries(
             libraries, root=self.prefix, shared=shared, runtime=False, recursive=True
         )

--- a/stacks/windows-vis/spack.yaml
+++ b/stacks/windows-vis/spack.yaml
@@ -11,9 +11,8 @@ spack:
   specs:
   - "vtk@9: +mpi"
   - "boost"
-  - "netlib-lapack"
-  - "py-beautifulsoup4"
   - "paraview@:5.13.1+mpi+qt"
+  - "py-numpy"
 
   cdash:
     build-group: Windows Visualization (Kitware)

--- a/stacks/windows-vis/spack.yaml
+++ b/stacks/windows-vis/spack.yaml
@@ -12,7 +12,7 @@ spack:
   - "vtk@9: +mpi"
   - "boost"
   - "paraview@:5.13.1+mpi+qt"
-  - "py-numpy"
+  - "py-numpy ^netlib-lapack"
 
   cdash:
     build-group: Windows Visualization (Kitware)


### PR DESCRIPTION
Adds Numpy to Gitlab CI

Numpy allows us to validate a blas provider and python with one root package, and is a high value/traffic package

Puts us one step closer to testing AI stacks on Windows

Removes:

* b4s
* netlib-lapack

Adds:

* py-numpy


Modifies `netlib-lapack` to search for non runtime libraries in it's `libs` methods on Windows (sets runtime for all platforms but its a no-op everywhere else)