### PR TITLE
cprnc: add hash for genf90 resource

### DIFF
--- a/repos/spack_repo/builtin/packages/cprnc/package.py
+++ b/repos/spack_repo/builtin/packages/cprnc/package.py
@@ -35,6 +35,7 @@ class Cprnc(CMakePackage):
         name="genf90",
         git="https://github.com/PARALLELIO/genf90",
         tag="genf90_200608",
+        commit="4816965ba946731352bad195b7d946a5fe682ff5",
         destination="genf90-resource",
     )
 


### PR DESCRIPTION
This PR adds a commit hash for cprnc's genf90 resource.