### PR TITLE
Elpa: Add new version and a fix for aocc

### DIFF
--- a/repos/spack_repo/builtin/packages/elpa/package.py
+++ b/repos/spack_repo/builtin/packages/elpa/package.py
@@ -28,6 +28,9 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
     version("master", branch="master")
 
     version(
+        "2025.01.002", sha256="8febe408c590ba9b44bd8bce04605fd1b7da964afcd8fd5f1ce9edecb3d0b65d"
+    )
+    version(
         "2025.01.001", sha256="3ef0c6aed9a3e05db6efafe6e14d66eb88b2a1354d61e765b7cde0d3d5f3951e"
     )
     version(
@@ -246,3 +249,10 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
         options.append("--without-threading-support-check-during-build")
 
         return options
+
+    def flag_handler(self, name, flags):
+        if name == "ldflags":
+            if self.spec.satisfies("@2024.05.001,2025.01.001 %aocc"):
+                # fix an issue where main library and test suite containing duplicate symbols
+                flags.append("-Wl,--allow-multiple-definition")
+        return (flags, None, None)


### PR DESCRIPTION
This PR has two changes:
- Adding a new elpa version `v2025.01.002`
- Solving a link time issue caused by duplicate symbols in both the main library and the test suite. The latest release `v2025.01.002` contains a fix to the issue.