### PR TITLE
seacas: allow to compile older versions with recent GCC

### DIFF
--- a/repos/spack_repo/builtin/packages/seacas/package.py
+++ b/repos/spack_repo/builtin/packages/seacas/package.py
@@ -338,6 +338,12 @@ class Seacas(CMakePackage):
     # Based on install-tpl.sh script, cereal seems to only be used when faodel enabled
     depends_on("cereal", when="@2021-04-02: +faodel")
 
+    def flag_handler(self, name: str, flags: List[str]):
+        if name == "fflags" and self.spec.satisfies("@2022:2022-03 %fortran=gcc@10:"):
+            # Required for recent GCC compilers, flag exists since GCC 10
+            flags.append("-fallow-argument-mismatch")
+        return (flags, None, None)
+
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         env.prepend_path("PYTHONPATH", self.prefix.lib)
 


### PR DESCRIPTION
Allows seacas 2022-01, 2022-02 and 2022-03 to compile correctly with recent GCC compilers. Tested with GCC 13.2. The flag exists since GCC 10 so it should be safe to add it as soon as GCC is sufficiently recent.
