### PR TITLE
ml ci: use latest ROCm

### DIFF
--- a/repos/spack_repo/builtin/packages/hipsparse/package.py
+++ b/repos/spack_repo/builtin/packages/hipsparse/package.py
@@ -100,6 +100,13 @@ class Hipsparse(CMakePackage, CudaPackage, ROCmPackage):
     for tgt in ROCmPackage.amdgpu_targets:
         depends_on(f"rocsparse amdgpu_target={tgt}", when=f"+rocm amdgpu_target={tgt}")
 
+    # Add c++17 to hipsparse to fix error with std::filesystem
+    patch(
+        "https://github.com/ROCm/hipSPARSE/commit/037b54ecc129edaaff59d3df149a3f071466ba29.patch?full_index=1",
+        sha256="02f44a3bac6f9983648afeb606aa43b7329547218e0f13b9d31b685acb8b198e",
+        when="@6.3",
+    )
+
     @classmethod
     def determine_version(cls, lib):
         match = re.search(r"lib\S*\.so\.\d+\.\d+\.(\d)(\d\d)(\d\d)", lib)

--- a/stacks/ml-linux-x86_64-rocm/spack.yaml
+++ b/stacks/ml-linux-x86_64-rocm/spack.yaml
@@ -24,6 +24,8 @@ spack:
       - ~flash_attention
     miopen-hip:
       require: ~ck
+    eigen:
+      require: ~rocm
 
   specs:
     # Horovod


### PR DESCRIPTION
The ml-linux-x86_64-rocm stack is currently installing ROCm 6.2.4 in ci despite ROCm 6.4.2 being the latest. I suspect this has do with the ci avoiding eigen after: https://github.com/spack/spack/pull/49398.

I can concretize locally with 6.4.2 but it uses eigen@master+rocm. Note in the eigen recipe: https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/packages/eigen/package.py#L54