### PR TITLE
py-jupyterlab-server: add the "build-tools" tag

### DIFF
--- a/repos/spack_repo/builtin/packages/py_jupyterlab_server/package.py
+++ b/repos/spack_repo/builtin/packages/py_jupyterlab_server/package.py
@@ -17,6 +17,8 @@ class PyJupyterlabServer(PythonPackage):
 
     license("BSD-3-Clause")
 
+    tags = ["build-tools"]
+    
     version("2.27.3", sha256="eb36caca59e74471988f0ae25c77945610b887f777255aa21f8065def9e51ed4")
     version("2.27.2", sha256="15cbb349dc45e954e09bacf81b9f9bcb10815ff660fb2034ecd7417db3a7ea27")
     version("2.27.1", sha256="097b5ac709b676c7284ac9c5e373f11930a561f52cd5a86e4fc7e5a9c8a8631d")

--- a/repos/spack_repo/builtin/packages/py_jupyterlab_server/package.py
+++ b/repos/spack_repo/builtin/packages/py_jupyterlab_server/package.py
@@ -18,7 +18,7 @@ class PyJupyterlabServer(PythonPackage):
     license("BSD-3-Clause")
 
     tags = ["build-tools"]
-    
+
     version("2.27.3", sha256="eb36caca59e74471988f0ae25c77945610b887f777255aa21f8065def9e51ed4")
     version("2.27.2", sha256="15cbb349dc45e954e09bacf81b9f9bcb10815ff660fb2034ecd7417db3a7ea27")
     version("2.27.1", sha256="097b5ac709b676c7284ac9c5e373f11930a561f52cd5a86e4fc7e5a9c8a8631d")


### PR DESCRIPTION
refers https://github.com/spack/spack/issues/51134

This identifies the package as possibly needing more than one node in a DAG, due to conflicting build constraints of other packages

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
