### PR TITLE
py-uproot: depends_on py-numpy@:1 when @:5.3.2

### DIFF
--- a/repos/spack_repo/builtin/packages/py_uproot/package.py
+++ b/repos/spack_repo/builtin/packages/py_uproot/package.py
@@ -83,6 +83,7 @@ class PyUproot(PythonPackage):
     depends_on("py-cramjam@2.5.0:", type=("build", "run"), when="@5.3:")
     depends_on("py-xxhash", type=("build", "run"), when="@5.4:")
     depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-numpy@:1", type=("build", "run"), when="@:5.3.2")
     depends_on("py-fsspec", type=("build", "run"))
     depends_on("py-packaging", when="@5:", type=("build", "run"))
     depends_on("py-typing-extensions@4.1:", when="@5.1: ^python@:3.10", type=("build", "run"))


### PR DESCRIPTION
This PR adds to `py-uproot` the correct upper limit for `py-numpy@:1`. See https://github.com/scikit-hep/uproot5/releases/tag/v5.3.3 for first version with declared `py-numpy@2` support (but no requirement).