### PR TITLE
podio: Add latest tag 1.4 and 1.4.1

### DIFF
--- a/repos/spack_repo/builtin/packages/podio/package.py
+++ b/repos/spack_repo/builtin/packages/podio/package.py
@@ -21,6 +21,7 @@ class Podio(CMakePackage):
     tags = ["hep", "key4hep"]
 
     version("master", branch="master")
+    version("1.4", sha256="f8b7f5ba965ff58270d617f50f168a4683a98fbcd643b66f1852bec960e02bbd")
     version("1.3", sha256="7efdf049822f171f4da5e83a7101096c066679904e59e741f3c2833ccda5e363")
     version("1.2", sha256="bc97ba09ce908e55d4c5faa78d9739dde7daefd9337ae98351813b13708d0685")
     version("1.1", sha256="2cb5040761f3da4383e1f126da25d68e99ecd8398e0ff12e7475a3745a7030a6")

--- a/repos/spack_repo/builtin/packages/podio/package.py
+++ b/repos/spack_repo/builtin/packages/podio/package.py
@@ -21,6 +21,7 @@ class Podio(CMakePackage):
     tags = ["hep", "key4hep"]
 
     version("master", branch="master")
+    version("1.4.1", sha256="d70dad214ac683e76c6e1093804c0f1ec4e7133a704173e2f1777a1279eb1535")
     version("1.4", sha256="f8b7f5ba965ff58270d617f50f168a4683a98fbcd643b66f1852bec960e02bbd")
     version("1.3", sha256="7efdf049822f171f4da5e83a7101096c066679904e59e741f3c2833ccda5e363")
     version("1.2", sha256="bc97ba09ce908e55d4c5faa78d9739dde7daefd9337ae98351813b13708d0685")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Add the latest tag of podio: https://github.com/AIDASoft/podio/releases/tag/v01-04