### PR TITLE
Update stale bot messages in GitHub Actions workflow

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -12,22 +12,36 @@ jobs:
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639
         with:
           # Issues configuration
-          stale-issue-message: |
-            This issue has been automatically marked as stale because it has not had 
-            recent activity in the last 6 months. It will be closed if no further activity occurs.
-            Thank you for your contributions.
-          close-issue-message: |
-            This issue was closed because it has been stalled for 30 days with no activity.
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had any activity in the last 6 months.
+            It will be closed in 30 days if there is no further activity.
+            
+            If the issue is waiting for a reply from maintainers, feel free to ping them as a reminder.
+            If it is waiting and has no comments yet, feel free to ping `@spack/spack-releasers` or simply leave a comment saying this should not be marked stale.
+            This will also reset the issue's stale state.
+            
+            Thank you for your contributions!
+          close-issue-message: >
+            This issue was closed because it had no activity for 30 days after being marked stale.
+            If you feel this is in error, please feel free to reopen this issue.
           stale-issue-label: 'stale'
           exempt-issue-labels: 'pinned,bug'
 
           # Pull requests configuration
-          stale-pr-message: |
-            This pull request has been automatically marked as stale because it has not had 
-            recent activity in the last 6 months. It will be closed if no further activity occurs.
-            Thank you for your contributions.
-          close-pr-message: |
-            This pull request was closed because it has been stalled for 30 days with no activity.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had any activity in the last 6 months. 
+            It will be closed in 30 days if there is no further activity.
+            
+            If the pull request is waiting for a reply from reviewers, feel free to ping them as a reminder.
+            If it is waiting and has no assigned reviewer, feel free to ping `@spack/spack-releasers` or simply leave a comment saying this should not be marked stale.
+            This will reset the pull request's stale state.
+            
+            To get more eyes on your pull request, you can post a link in the #pull-requests channel of the Spack Slack.
+            
+            Thank you for your contributions!
+          close-pr-message: >
+            This pull request was closed because it had no activity for 30 days after being marked stale.
+            If you feel this is in error, please feel free to reopen this pull request.
           stale-pr-label: 'stale'
           exempt-pr-labels: 'pinned'
 


### PR DESCRIPTION
Refine issue and PR stale/close messages for better clarity and guidance, ensuring contributors have clear steps to avoid automatic closure.

Same as https://github.com/spack/spack/pull/51156

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
