### PR TITLE
Add new version for all AOCL libs and update aocl_libmem and amdlibm

### DIFF
--- a/repos/spack_repo/builtin/packages/amd_aocl/package.py
+++ b/repos/spack_repo/builtin/packages/amd_aocl/package.py
@@ -25,7 +25,8 @@ class AmdAocl(BundlePackage):
 
     maintainers("amd-toolchain-support")
 
-    version("5.0", preferred=True)
+    version("5.1", preferred=True)
+    version("5.0")
     version("4.2")
     version("4.1")
     version("4.0")
@@ -63,7 +64,7 @@ class AmdAocl(BundlePackage):
         depends_on("aocl-da ~openmp")
         depends_on("aocl-compression ~openmp")
 
-    for vers in ["2.2", "3.0", "3.1", "3.2", "4.0", "4.1", "4.2", "5.0"]:
+    for vers in ["2.2", "3.0", "3.1", "3.2", "4.0", "4.1", "4.2", "5.0", "5.1"]:
         with when(f"@={vers}"):
             depends_on(f"amdblis@={vers}")
             depends_on(f"amdfftw@={vers}")

--- a/repos/spack_repo/builtin/packages/amd_aocl/package.py
+++ b/repos/spack_repo/builtin/packages/amd_aocl/package.py
@@ -25,7 +25,7 @@ class AmdAocl(BundlePackage):
 
     maintainers("amd-toolchain-support")
 
-    version("5.1", preferred=True)
+    version("5.1")
     version("5.0")
     version("4.2")
     version("4.1")

--- a/repos/spack_repo/builtin/packages/amdblis/package.py
+++ b/repos/spack_repo/builtin/packages/amdblis/package.py
@@ -36,11 +36,7 @@ class Amdblis(BlisBase):
 
     license("BSD-3-Clause")
 
-    version(
-        "5.1",
-        sha256="4ab210cea8753f4be9646a3ad8e6b42c7d19380084a66312497c97278b8c76a4",
-        preferred=True,
-    )
+    version("5.1", sha256="4ab210cea8753f4be9646a3ad8e6b42c7d19380084a66312497c97278b8c76a4")
     version("5.0", sha256="5abb34972b88b2839709d0af8785662bc651c7806ccfa41d386d93c900169bc2")
     version("4.2", sha256="0e1baf850ba0e6f99e79f64bbb0a59fcb838ddb5028e24527f52b407c3c62963")
     version("4.1", sha256="a05c6c7d359232580d1d599696053ad0beeedf50f3b88d5d22ee7d34375ab577")

--- a/repos/spack_repo/builtin/packages/amdblis/package.py
+++ b/repos/spack_repo/builtin/packages/amdblis/package.py
@@ -37,10 +37,11 @@ class Amdblis(BlisBase):
     license("BSD-3-Clause")
 
     version(
-        "5.0",
-        sha256="5abb34972b88b2839709d0af8785662bc651c7806ccfa41d386d93c900169bc2",
+        "5.1",
+        sha256="4ab210cea8753f4be9646a3ad8e6b42c7d19380084a66312497c97278b8c76a4",
         preferred=True,
     )
+    version("5.0", sha256="5abb34972b88b2839709d0af8785662bc651c7806ccfa41d386d93c900169bc2")
     version("4.2", sha256="0e1baf850ba0e6f99e79f64bbb0a59fcb838ddb5028e24527f52b407c3c62963")
     version("4.1", sha256="a05c6c7d359232580d1d599696053ad0beeedf50f3b88d5d22ee7d34375ab577")
     version("4.0", sha256="cddd31176834a932753ac0fc4c76332868feab3e9ac607fa197d8b44c1e74a41")

--- a/repos/spack_repo/builtin/packages/amdfftw/package.py
+++ b/repos/spack_repo/builtin/packages/amdfftw/package.py
@@ -39,11 +39,7 @@ class Amdfftw(FftwBase):
 
     license("GPL-2.0-only")
 
-    version(
-        "5.1",
-        sha256="4cc0d6985afc5ce14cafc195ad46d9876ac4f35b959861b41a3b681385d7320d",
-        preferred=True,
-    )
+    version("5.1", sha256="4cc0d6985afc5ce14cafc195ad46d9876ac4f35b959861b41a3b681385d7320d")
     version("5.0", sha256="bead6c08309a206f8a6258971272affcca07f11eb57b5ecd8496e2e7e3ead877")
     version("4.2", sha256="391ef7d933e696762e3547a35b58ab18d22a6cf3e199c74889bcf25a1d1fc89b")
     version("4.1", sha256="f1cfecfcc0729f96a5bd61c6b26f3fa43bb0662d3fff370d4f73490c60cf4e59")

--- a/repos/spack_repo/builtin/packages/amdfftw/package.py
+++ b/repos/spack_repo/builtin/packages/amdfftw/package.py
@@ -40,10 +40,11 @@ class Amdfftw(FftwBase):
     license("GPL-2.0-only")
 
     version(
-        "5.0",
-        sha256="bead6c08309a206f8a6258971272affcca07f11eb57b5ecd8496e2e7e3ead877",
+        "5.1",
+        sha256="4cc0d6985afc5ce14cafc195ad46d9876ac4f35b959861b41a3b681385d7320d",
         preferred=True,
     )
+    version("5.0", sha256="bead6c08309a206f8a6258971272affcca07f11eb57b5ecd8496e2e7e3ead877")
     version("4.2", sha256="391ef7d933e696762e3547a35b58ab18d22a6cf3e199c74889bcf25a1d1fc89b")
     version("4.1", sha256="f1cfecfcc0729f96a5bd61c6b26f3fa43bb0662d3fff370d4f73490c60cf4e59")
     version("4.0", sha256="5f02cb05f224bd86bd88ec6272b294c26dba3b1d22c7fb298745fd7b9d2271c0")

--- a/repos/spack_repo/builtin/packages/amdlibflame/package.py
+++ b/repos/spack_repo/builtin/packages/amdlibflame/package.py
@@ -81,7 +81,7 @@ class Amdlibflame(CMakePackage, LibflameBase):
     with when("build_system=cmake"):
         generator("make")
         depends_on("cmake@3.22:", when="@:5.0", type="build")
-        depends_on("cmake@3.26:", when="@5.1:",type="build")
+        depends_on("cmake@3.26:", when="@5.1:", type="build")
 
     conflicts("threads=pthreads", msg="pthread is not supported")
     conflicts("threads=openmp", when="@:3", msg="openmp is not supported by amdlibflame < 4.0")

--- a/repos/spack_repo/builtin/packages/amdlibflame/package.py
+++ b/repos/spack_repo/builtin/packages/amdlibflame/package.py
@@ -49,10 +49,11 @@ class Amdlibflame(CMakePackage, LibflameBase):
     license("BSD-3-Clause")
 
     version(
-        "5.0",
-        sha256="3bee3712459a8c5bd728a521d8a4c8f46735730bf35d48c878d2fc45fc000918",
+        "5.1",
+        sha256="25524ba78b5952303369fa0859d217e44071144fd122a9dc3f72ed0bd73e3b2d",
         preferred=True,
     )
+    version("5.0", sha256="3bee3712459a8c5bd728a521d8a4c8f46735730bf35d48c878d2fc45fc000918")
     version("4.2", sha256="93a433c169528ffba74a99df0ba3ce3d5b1fab9bf06ce8d2fd72ee84768ed84c")
     version("4.1", sha256="8aed69c60d11cc17e058cabcb8a931cee4f343064ade3e73d3392b7214624b61")
     version("4.0", sha256="bcb05763aa1df1e88f0da5e43ff86d956826cbea1d9c5ff591d78a3e091c66a4")
@@ -83,7 +84,7 @@ class Amdlibflame(CMakePackage, LibflameBase):
     # Required dependencies
     with when("build_system=cmake"):
         generator("make")
-        depends_on("cmake@3.22:", type="build")
+        depends_on("cmake@3.26:", type="build")
 
     conflicts("threads=pthreads", msg="pthread is not supported")
     conflicts("threads=openmp", when="@:3", msg="openmp is not supported by amdlibflame < 4.0")
@@ -103,7 +104,7 @@ class Amdlibflame(CMakePackage, LibflameBase):
     depends_on("python+pythoncmd", type="build")
     depends_on("gmake@4:", when="@3.0.1,3.1:", type="build")
 
-    for vers in ["4.1", "4.2", "5.0"]:
+    for vers in ["4.1", "4.2", "5.0", "5.1"]:
         with when(f"@{vers}"):
             depends_on(f"aocl-utils@{vers}")
 

--- a/repos/spack_repo/builtin/packages/amdlibflame/package.py
+++ b/repos/spack_repo/builtin/packages/amdlibflame/package.py
@@ -81,7 +81,7 @@ class Amdlibflame(CMakePackage, LibflameBase):
     with when("build_system=cmake"):
         generator("make")
         depends_on("cmake@3.22:", when="@:5.0", type="build")
-        depends_on("cmake@3.26:", when="@5.1",type="build")
+        depends_on("cmake@3.26:", when="@5.1:",type="build")
 
     conflicts("threads=pthreads", msg="pthread is not supported")
     conflicts("threads=openmp", when="@:3", msg="openmp is not supported by amdlibflame < 4.0")

--- a/repos/spack_repo/builtin/packages/amdlibflame/package.py
+++ b/repos/spack_repo/builtin/packages/amdlibflame/package.py
@@ -48,11 +48,7 @@ class Amdlibflame(CMakePackage, LibflameBase):
 
     license("BSD-3-Clause")
 
-    version(
-        "5.1",
-        sha256="25524ba78b5952303369fa0859d217e44071144fd122a9dc3f72ed0bd73e3b2d",
-        preferred=True,
-    )
+    version("5.1", sha256="25524ba78b5952303369fa0859d217e44071144fd122a9dc3f72ed0bd73e3b2d")
     version("5.0", sha256="3bee3712459a8c5bd728a521d8a4c8f46735730bf35d48c878d2fc45fc000918")
     version("4.2", sha256="93a433c169528ffba74a99df0ba3ce3d5b1fab9bf06ce8d2fd72ee84768ed84c")
     version("4.1", sha256="8aed69c60d11cc17e058cabcb8a931cee4f343064ade3e73d3392b7214624b61")

--- a/repos/spack_repo/builtin/packages/amdlibflame/package.py
+++ b/repos/spack_repo/builtin/packages/amdlibflame/package.py
@@ -80,7 +80,8 @@ class Amdlibflame(CMakePackage, LibflameBase):
     # Required dependencies
     with when("build_system=cmake"):
         generator("make")
-        depends_on("cmake@3.26:", type="build")
+        depends_on("cmake@3.22:", when="@:5.0", type="build")
+        depends_on("cmake@3.26:", when="@5.1",type="build")
 
     conflicts("threads=pthreads", msg="pthread is not supported")
     conflicts("threads=openmp", when="@:3", msg="openmp is not supported by amdlibflame < 4.0")

--- a/repos/spack_repo/builtin/packages/amdlibm/package.py
+++ b/repos/spack_repo/builtin/packages/amdlibm/package.py
@@ -33,11 +33,7 @@ class Amdlibm(SConsPackage, CMakePackage):
 
     license("BSD-3-Clause")
 
-    version(
-        "5.1",
-        sha256="7acf2c98469353b60a59fad167a98e1ae689055a3faf8352a254832145c9d59e",
-        preferred=True,
-    )
+    version("5.1", sha256="7acf2c98469353b60a59fad167a98e1ae689055a3faf8352a254832145c9d59e")
     version("5.0", sha256="ba1d50c068938c9a927e37e5630f683b6149d7d5a95efffeb76e7c9a8bcb2b5e")
     version("4.2", sha256="58847b942e998b3f52eb41ae26403c7392d244fcafa707cbf23165aac24edd9e")
     version("4.1", sha256="5bbbbc6bc721d9a775822eab60fbc11eb245e77d9f105b4fcb26a54d01456122")

--- a/repos/spack_repo/builtin/packages/amdlibm/package.py
+++ b/repos/spack_repo/builtin/packages/amdlibm/package.py
@@ -46,7 +46,7 @@ class Amdlibm(SConsPackage, CMakePackage):
     variant("verbose", default=False, description="Building with verbosity", when="@:4.1")
 
     # Build system
-    build_system(conditional("cmake", when="@5.1"), "scons", default="scons")
+    build_system(conditional("cmake", when="@5.1:"), "scons", default="scons")
     # Mandatory dependencies
     depends_on("c", type="build")
     depends_on("cxx", type="build")

--- a/repos/spack_repo/builtin/packages/amdlibm/package.py
+++ b/repos/spack_repo/builtin/packages/amdlibm/package.py
@@ -4,12 +4,13 @@
 
 import os
 
+from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.scons import SConsPackage
 
 from spack.package import *
 
 
-class Amdlibm(SConsPackage):
+class Amdlibm(SConsPackage, CMakePackage):
     """AMD LibM is a software library containing a collection of basic math
     functions optimized for x86-64 processor-based machines. It provides
     many routines from the list of standard C99 math functions.
@@ -33,10 +34,11 @@ class Amdlibm(SConsPackage):
     license("BSD-3-Clause")
 
     version(
-        "5.0",
-        sha256="ba1d50c068938c9a927e37e5630f683b6149d7d5a95efffeb76e7c9a8bcb2b5e",
+        "5.1",
+        sha256="7acf2c98469353b60a59fad167a98e1ae689055a3faf8352a254832145c9d59e",
         preferred=True,
     )
+    version("5.0", sha256="ba1d50c068938c9a927e37e5630f683b6149d7d5a95efffeb76e7c9a8bcb2b5e")
     version("4.2", sha256="58847b942e998b3f52eb41ae26403c7392d244fcafa707cbf23165aac24edd9e")
     version("4.1", sha256="5bbbbc6bc721d9a775822eab60fbc11eb245e77d9f105b4fcb26a54d01456122")
     version("4.0", sha256="038c1eab544be77598eccda791b26553d3b9e2ee4ab3f5ad85fdd2a77d015a7d")
@@ -47,14 +49,17 @@ class Amdlibm(SConsPackage):
 
     variant("verbose", default=False, description="Building with verbosity", when="@:4.1")
 
+    # Build system
+    build_system(conditional("cmake", when="@5.1"), "scons", default="scons")
     # Mandatory dependencies
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
     depends_on("python@3.6.1:", type=("build", "run"))
     depends_on("scons@3.1.2:4.8.1", type=("build"))
+    depends_on("cmake@3.26:3.30.6", type="build", when="build_system=cmake")
     depends_on("mpfr", type=("link"))
-    for vers in ["4.1", "4.2", "5.0"]:
+    for vers in ["4.1", "4.2", "5.0", "5.1"]:
         with when(f"@{vers}"):
             depends_on(f"aocl-utils@{vers}")
 
@@ -63,12 +68,10 @@ class Amdlibm(SConsPackage):
     # Patch to update the SCons environment with newly introduced
     # Spack build environment variables.
     patch("libm-ose-SconsSpack.patch", when="@3.1:4.2")
-    patch("libm-ose-SconsSpack-5.patch", when="@5.0")
+    patch("libm-ose-SconsSpack-5.patch", when="@5.0:")
 
     conflicts("%gcc@:9.1.0", msg="Minimum supported GCC version is 9.2.0")
-    conflicts("%clang@:9.0", msg="Minimum supported Clang version is 9")
-    conflicts("%clang@17.0.0:", msg="Maximum supported Clang version is 17.0.0")
-    conflicts("%gcc@14.3.0:", msg="Maximum supported GCC version is 14.2.0")
+    conflicts("%clang@:11.1", msg="Minimum supported Clang version is 12.0")
     conflicts("%aocc@3.2.0", msg="dependency on python@3.6.2")
 
     def patch(self):
@@ -97,6 +100,16 @@ class Amdlibm(SConsPackage):
         return args
 
     install_args = build_args
+
+    def cmake_args(self):
+        """Setting build arguments for amdlibm when using CMake"""
+        spec = self.spec
+
+        args = [
+            self.define("LIBAOCLUTILS_INCLUDE_PATH", spec["aocl-utils"].prefix.include),
+            f"-DLIBAOCLUTILS_LIBRARY_PATH={spec['aocl-utils'].libs}",
+        ]
+        return args
 
     @run_after("install")
     def create_symlink(self):

--- a/repos/spack_repo/builtin/packages/amdscalapack/package.py
+++ b/repos/spack_repo/builtin/packages/amdscalapack/package.py
@@ -34,11 +34,7 @@ class Amdscalapack(ScalapackBase):
 
     license("BSD-3-Clause-Open-MPI")
 
-    version(
-        "5.1",
-        sha256="92f6f6b2081e27731c8b9e96c742203777cc7f2a848b96ca7511f4d259142b37",
-        preferred=True,
-    )
+    version("5.1", sha256="92f6f6b2081e27731c8b9e96c742203777cc7f2a848b96ca7511f4d259142b37")
     version("5.0", sha256="a33cf16c51cfd65c7acb5fbdb8884a5c147cdefea73931b07863c56d54f812cc")
     version("4.2", sha256="c6e9a846c05cdc05252b0b5f264164329812800bf13f9d97c77114dc138e6ccb")
     version("4.1", sha256="b2e51c3604e5869d1faaef2e52c92071fcb3de1345aebb2ea172206622067ad9")

--- a/repos/spack_repo/builtin/packages/amdscalapack/package.py
+++ b/repos/spack_repo/builtin/packages/amdscalapack/package.py
@@ -33,11 +33,13 @@ class Amdscalapack(ScalapackBase):
     tags = ["e4s"]
 
     license("BSD-3-Clause-Open-MPI")
+
     version(
-        "5.0",
-        sha256="a33cf16c51cfd65c7acb5fbdb8884a5c147cdefea73931b07863c56d54f812cc",
+        "5.1",
+        sha256="92f6f6b2081e27731c8b9e96c742203777cc7f2a848b96ca7511f4d259142b37",
         preferred=True,
     )
+    version("5.0", sha256="a33cf16c51cfd65c7acb5fbdb8884a5c147cdefea73931b07863c56d54f812cc")
     version("4.2", sha256="c6e9a846c05cdc05252b0b5f264164329812800bf13f9d97c77114dc138e6ccb")
     version("4.1", sha256="b2e51c3604e5869d1faaef2e52c92071fcb3de1345aebb2ea172206622067ad9")
     version("4.0", sha256="f02913b5984597b22cdb9a36198ed61039a1bf130308e778dc31b2a7eb88b33b")

--- a/repos/spack_repo/builtin/packages/aocl_compression/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_compression/package.py
@@ -74,7 +74,7 @@ class AoclCompression(CMakePackage):
     depends_on("cxx", type="build")  # generated
 
     depends_on("cmake@3.22:", when="@:5.0", type="build")
-    depends_on("cmake@3.26:", when="@5.1",type="build")
+    depends_on("cmake@3.26:", when="@5.1:",type="build")
 
     def cmake_args(self):
         """Runs ``cmake`` in the build directory"""

--- a/repos/spack_repo/builtin/packages/aocl_compression/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_compression/package.py
@@ -73,7 +73,8 @@ class AoclCompression(CMakePackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    depends_on("cmake@3.26:", type="build")
+    depends_on("cmake@3.22:", when="@:5.0", type="build")
+    depends_on("cmake@3.26:", when="@5.1",type="build")
 
     def cmake_args(self):
         """Runs ``cmake`` in the build directory"""

--- a/repos/spack_repo/builtin/packages/aocl_compression/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_compression/package.py
@@ -44,11 +44,7 @@ class AoclCompression(CMakePackage):
 
     maintainers("amd-toolchain-support")
 
-    version(
-        "5.1",
-        sha256="9462c6898350d66a5d9ce0236c432c94b4c9393b638ddf6511628b784eb02720",
-        preferred=True,
-    )
+    version("5.1", sha256="9462c6898350d66a5d9ce0236c432c94b4c9393b638ddf6511628b784eb02720")
     version("5.0", sha256="50bfb2c4a4738b96ed6d45627062b17bb9d0e1787c7d83ead2841da520327fa4")
     version("4.2", sha256="a18b3e7f64a8105c1500dda7b4c343e974b5e26bfe3dd838a1c1acf82a969c6f")
 

--- a/repos/spack_repo/builtin/packages/aocl_compression/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_compression/package.py
@@ -45,10 +45,11 @@ class AoclCompression(CMakePackage):
     maintainers("amd-toolchain-support")
 
     version(
-        "5.0",
-        sha256="50bfb2c4a4738b96ed6d45627062b17bb9d0e1787c7d83ead2841da520327fa4",
+        "5.1",
+        sha256="9462c6898350d66a5d9ce0236c432c94b4c9393b638ddf6511628b784eb02720",
         preferred=True,
     )
+    version("5.0", sha256="50bfb2c4a4738b96ed6d45627062b17bb9d0e1787c7d83ead2841da520327fa4")
     version("4.2", sha256="a18b3e7f64a8105c1500dda7b4c343e974b5e26bfe3dd838a1c1acf82a969c6f")
 
     variant("shared", default=True, description="Build shared library")
@@ -76,7 +77,7 @@ class AoclCompression(CMakePackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    depends_on("cmake@3.22:", type="build")
+    depends_on("cmake@3.26:", type="build")
 
     def cmake_args(self):
         """Runs ``cmake`` in the build directory"""

--- a/repos/spack_repo/builtin/packages/aocl_compression/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_compression/package.py
@@ -74,7 +74,7 @@ class AoclCompression(CMakePackage):
     depends_on("cxx", type="build")  # generated
 
     depends_on("cmake@3.22:", when="@:5.0", type="build")
-    depends_on("cmake@3.26:", when="@5.1:",type="build")
+    depends_on("cmake@3.26:", when="@5.1:", type="build")
 
     def cmake_args(self):
         """Runs ``cmake`` in the build directory"""

--- a/repos/spack_repo/builtin/packages/aocl_crypto/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_crypto/package.py
@@ -54,7 +54,8 @@ class AoclCrypto(CMakePackage):
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
-    depends_on("cmake@3.26:", type="build")
+    depends_on("cmake@3.22:", when="@:5.0", type="build")
+    depends_on("cmake@3.26:", when="@5.1",type="build")
     depends_on("openssl@3.1.5:")
     depends_on("intel-oneapi-ippcp@2021.12.0:", when="+ipp")
     depends_on("p7zip", type="build")

--- a/repos/spack_repo/builtin/packages/aocl_crypto/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_crypto/package.py
@@ -39,10 +39,11 @@ class AoclCrypto(CMakePackage):
     maintainers("amd-toolchain-support")
 
     version(
-        "5.0",
-        sha256="b15e609943f9977e13f2d5839195bb7411c843839a09f0ad47f78f57e8821c23",
+        "5.1",
+        sha256="a2f768b7d37516c5c29cca0034aba90b91d02e477c762f2fa0fe4b1c30613973",
         preferred=True,
     )
+    version("5.0", sha256="b15e609943f9977e13f2d5839195bb7411c843839a09f0ad47f78f57e8821c23")
     version("4.2", sha256="2bdbedd8ab1b28632cadff237f4abd776e809940ad3633ad90fc52ce225911fe")
 
     variant("examples", default=False, description="Build examples")
@@ -57,11 +58,11 @@ class AoclCrypto(CMakePackage):
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
-    depends_on("cmake@3.22:", type="build")
+    depends_on("cmake@3.26:", type="build")
     depends_on("openssl@3.1.5:")
     depends_on("intel-oneapi-ippcp@2021.12.0:", when="+ipp")
     depends_on("p7zip", type="build")
-    for vers in ["4.2", "5.0"]:
+    for vers in ["4.2", "5.0", "5.1"]:
         with when(f"@={vers}"):
             depends_on(f"aocl-utils@={vers}")
 

--- a/repos/spack_repo/builtin/packages/aocl_crypto/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_crypto/package.py
@@ -55,7 +55,7 @@ class AoclCrypto(CMakePackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
     depends_on("cmake@3.22:", when="@:5.0", type="build")
-    depends_on("cmake@3.26:", when="@5.1:",type="build")
+    depends_on("cmake@3.26:", when="@5.1:", type="build")
     depends_on("openssl@3.1.5:")
     depends_on("intel-oneapi-ippcp@2021.12.0:", when="+ipp")
     depends_on("p7zip", type="build")

--- a/repos/spack_repo/builtin/packages/aocl_crypto/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_crypto/package.py
@@ -38,11 +38,7 @@ class AoclCrypto(CMakePackage):
 
     maintainers("amd-toolchain-support")
 
-    version(
-        "5.1",
-        sha256="a2f768b7d37516c5c29cca0034aba90b91d02e477c762f2fa0fe4b1c30613973",
-        preferred=True,
-    )
+    version("5.1", sha256="a2f768b7d37516c5c29cca0034aba90b91d02e477c762f2fa0fe4b1c30613973")
     version("5.0", sha256="b15e609943f9977e13f2d5839195bb7411c843839a09f0ad47f78f57e8821c23")
     version("4.2", sha256="2bdbedd8ab1b28632cadff237f4abd776e809940ad3633ad90fc52ce225911fe")
 

--- a/repos/spack_repo/builtin/packages/aocl_crypto/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_crypto/package.py
@@ -55,7 +55,7 @@ class AoclCrypto(CMakePackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
     depends_on("cmake@3.22:", when="@:5.0", type="build")
-    depends_on("cmake@3.26:", when="@5.1",type="build")
+    depends_on("cmake@3.26:", when="@5.1:",type="build")
     depends_on("openssl@3.1.5:")
     depends_on("intel-oneapi-ippcp@2021.12.0:", when="+ipp")
     depends_on("p7zip", type="build")

--- a/repos/spack_repo/builtin/packages/aocl_da/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_da/package.py
@@ -59,7 +59,7 @@ class AoclDa(CMakePackage):
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
     depends_on("cmake@3.22:", when="@:5.0", type="build")
-    depends_on("cmake@3.26:", when="@5.1:",type="build")
+    depends_on("cmake@3.26:", when="@5.1:", type="build")
     depends_on("boost@1.66.0:", when="@5.1:", type="build")
     for vers in ["5.0", "5.1"]:
         with when(f"@={vers}"):

--- a/repos/spack_repo/builtin/packages/aocl_da/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_da/package.py
@@ -58,7 +58,8 @@ class AoclDa(CMakePackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
-    depends_on("cmake@3.26:", type="build")
+    depends_on("cmake@3.22:", when="@:5.0", type="build")
+    depends_on("cmake@3.26:", when="@5.1",type="build")
     depends_on("boost@1.66.0:", when="@5.1:", type="build")
     for vers in ["5.0", "5.1"]:
         with when(f"@={vers}"):

--- a/repos/spack_repo/builtin/packages/aocl_da/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_da/package.py
@@ -59,7 +59,7 @@ class AoclDa(CMakePackage):
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
     depends_on("cmake@3.22:", when="@:5.0", type="build")
-    depends_on("cmake@3.26:", when="@5.1",type="build")
+    depends_on("cmake@3.26:", when="@5.1:",type="build")
     depends_on("boost@1.66.0:", when="@5.1:", type="build")
     for vers in ["5.0", "5.1"]:
         with when(f"@={vers}"):

--- a/repos/spack_repo/builtin/packages/aocl_da/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_da/package.py
@@ -34,6 +34,7 @@ class AoclDa(CMakePackage):
 
     maintainers("amd-toolchain-support")
 
+    version("5.1", sha256="93cdb789c948bf750e531f95618bae4370d53eddc88960744ff02c9acbfe9ef5")
     version("5.0", sha256="3458adc7be39c78a08232c887f32838633149df0a69ccea024327c3edc5a5c1d")
 
     variant("examples", default=True, description="Build examples")
@@ -57,9 +58,9 @@ class AoclDa(CMakePackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
-
-    depends_on("cmake@3.22:", type="build")
-    for vers in ["5.0"]:
+    depends_on("cmake@3.26:", type="build")
+    depends_on("boost@1.66.0:", when="@5.1:", type="build")
+    for vers in ["5.0", "5.1"]:
         with when(f"@={vers}"):
             depends_on(f"aocl-utils@={vers} +shared", when="+shared")
             depends_on(f"aocl-utils@={vers} ~shared", when="~shared")
@@ -116,6 +117,8 @@ class AoclDa(CMakePackage):
         args.append(self.define_from_variant("BUILD_SMP", "openmp"))
         args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
         args.append(self.define_from_variant("BUILD_PYTHON", "python"))
+        if self.spec.satisfies("@5.1:"):
+            args.append(self.define("Boost_INCLUDE_DIRS", self.spec["boost"].prefix.include))
 
         return args
 

--- a/repos/spack_repo/builtin/packages/aocl_libmem/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_libmem/package.py
@@ -96,7 +96,7 @@ class AoclLibmem(CMakePackage):
     depends_on("cxx", type="build")  # generated
 
     depends_on("cmake@3.22:", when="@:5.0", type="build")
-    depends_on("cmake@3.26:", when="@5.1",type="build")
+    depends_on("cmake@3.26:", when="@5.1:",type="build")
 
     @property
     def libs(self):

--- a/repos/spack_repo/builtin/packages/aocl_libmem/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_libmem/package.py
@@ -96,7 +96,7 @@ class AoclLibmem(CMakePackage):
     depends_on("cxx", type="build")  # generated
 
     depends_on("cmake@3.22:", when="@:5.0", type="build")
-    depends_on("cmake@3.26:", when="@5.1:",type="build")
+    depends_on("cmake@3.26:", when="@5.1:", type="build")
 
     @property
     def libs(self):

--- a/repos/spack_repo/builtin/packages/aocl_libmem/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_libmem/package.py
@@ -82,12 +82,18 @@ class AoclLibmem(CMakePackage):
     requires(
         "vectorization=none",
         when="+dynamic-dispatch",
-        msg="Error: +dynamic-dispatch requires vectorization=none. Please set vectorization to 'none' when enabling dynamic-dispatch.",
+        msg=(
+            "+dynamic-dispatch requires vectorization=none. Set vectorization to 'none' "
+            "when enabling dynamic-dispatch."
+        ),
     )
     requires(
         "vectorization=none",
         when="+tunables",
-        msg="Error: +tunables requires vectorization=none. Please set vectorization to 'none' when enabling tunables.",
+        msg=(
+            "+tunables requires vectorization=none. Set vectorization to 'none' when "
+            "enabling tunables."
+        ),
     )
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/aocl_libmem/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_libmem/package.py
@@ -95,7 +95,8 @@ class AoclLibmem(CMakePackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    depends_on("cmake@3.26:", type="build")
+    depends_on("cmake@3.22:", when="@:5.0", type="build")
+    depends_on("cmake@3.26:", when="@5.1",type="build")
 
     @property
     def libs(self):

--- a/repos/spack_repo/builtin/packages/aocl_libmem/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_libmem/package.py
@@ -34,11 +34,7 @@ class AoclLibmem(CMakePackage):
 
     maintainers("amd-toolchain-support")
 
-    version(
-        "5.1",
-        sha256="e03bc712a576b3e14ae433a696558e121dc67aac7fc1b4dca9b727605784e994",
-        preferred=True,
-    )
+    version("5.1", sha256="e03bc712a576b3e14ae433a696558e121dc67aac7fc1b4dca9b727605784e994")
     version("5.0", sha256="d3148db1a57fec4f3468332c775cade356e8133bf88385991964edd7534b7e22")
     version("4.2", sha256="4ff5bd8002e94cc2029ef1aeda72e7cf944b797c7f07383656caa93bcb447569")
 

--- a/repos/spack_repo/builtin/packages/aocl_libmem/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_libmem/package.py
@@ -35,10 +35,11 @@ class AoclLibmem(CMakePackage):
     maintainers("amd-toolchain-support")
 
     version(
-        "5.0",
-        sha256="d3148db1a57fec4f3468332c775cade356e8133bf88385991964edd7534b7e22",
+        "5.1",
+        sha256="e03bc712a576b3e14ae433a696558e121dc67aac7fc1b4dca9b727605784e994",
         preferred=True,
     )
+    version("5.0", sha256="d3148db1a57fec4f3468332c775cade356e8133bf88385991964edd7534b7e22")
     version("4.2", sha256="4ff5bd8002e94cc2029ef1aeda72e7cf944b797c7f07383656caa93bcb447569")
 
     variant("logging", default=False, description="Enable/Disable logger")
@@ -47,8 +48,26 @@ class AoclLibmem(CMakePackage):
     variant(
         "vectorization",
         default="auto",
+        when="@:5.0",
         description="Use hardware vectorization support",
         values=("avx2", "avx512", "auto"),
+        multi=False,
+    )
+
+    # Add new variant for dynamic dispatcher support
+    variant(
+        "dynamic-dispatch",
+        default=False,
+        when="@5.1:",
+        description="Single portable optimized library"
+        " to execute on different x86 CPU architectures",
+    )
+    variant(
+        "vectorization",
+        default="none",
+        when="@5.1:",
+        description="Use hardware vectorization support",
+        values=("avx2", "avx512", "auto", "none"),
         multi=False,
     )
 
@@ -59,10 +78,22 @@ class AoclLibmem(CMakePackage):
         when="@5.0",
     )
 
+    # vectorization or ISA has precedence over +dynamic-dispatch and tunables
+    requires(
+        "vectorization=none",
+        when="+dynamic-dispatch",
+        msg="Error: +dynamic-dispatch requires vectorization=none. Please set vectorization to 'none' when enabling dynamic-dispatch.",
+    )
+    requires(
+        "vectorization=none",
+        when="+tunables",
+        msg="Error: +tunables requires vectorization=none. Please set vectorization to 'none' when enabling tunables.",
+    )
+
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    depends_on("cmake@3.22:", type="build")
+    depends_on("cmake@3.26:", type="build")
 
     @property
     def libs(self):
@@ -79,13 +110,31 @@ class AoclLibmem(CMakePackage):
         args.append(self.define_from_variant("ENABLE_TUNABLES", "tunables"))
         args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
 
-        if spec.satisfies("vectorisation=auto"):
-            if "avx512" in self.spec.target:
-                args.append("-ALMEM_ARCH=avx512")
-            elif "avx2" in self.spec.target:
-                args.append("-ALMEM_ARCH=avx2")
+        if spec.satisfies("@:5.0"):
+            vectorization = spec.variants["vectorization"].value
+            if vectorization == "auto":
+                target = spec.target
+                if "avx512" in target:
+                    args.append("-DALMEM_ARCH=avx512")
+                elif "avx2" in target:
+                    args.append("-DALMEM_ARCH=avx2")
+                else:
+                    args.append("-DALMEM_ARCH=none")
             else:
-                args.append("-ALMEM_ARCH=none")
-        else:
-            args.append(self.define("ALMEM_ARCH", spec.variants["vectorization"].value))
+                args.append(self.define("ALMEM_ARCH", vectorization))
+
+        # Managing Renamed CMake Option Values
+        if self.spec.satisfies("@5.1:"):
+            args.append(self.define_from_variant("ALMEM_LOGGING", "logging"))
+            args.append(self.define_from_variant("ALMEM_TUNABLES", "tunables"))
+            args.append(self.define_from_variant("ALMEM_DYN_DISPATCH", "dynamic-dispatch"))
+
+            if self.spec.satisfies("vectorisation=auto"):
+                if "avx512" in self.spec.target:
+                    args.append("-DALMEM_ISA=avx512")
+                elif "avx2" in self.spec.target:
+                    args.append("-DALMEM_ISA=avx2")
+            else:
+                args.append(self.define("ALMEM_ISA", self.spec.variants["vectorization"].value))
+
         return args

--- a/repos/spack_repo/builtin/packages/aocl_sparse/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_sparse/package.py
@@ -71,7 +71,7 @@ class AoclSparse(CMakePackage):
     depends_on("boost", when="+benchmarks")
     depends_on("boost", when="@2.2")
     depends_on("cmake@3.22:", when="@:5.0", type="build")
-    depends_on("cmake@3.26:", when="@5.1",type="build")
+    depends_on("cmake@3.26:", when="@5.1:",type="build")
 
     @property
     def libs(self):

--- a/repos/spack_repo/builtin/packages/aocl_sparse/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_sparse/package.py
@@ -31,11 +31,7 @@ class AoclSparse(CMakePackage):
 
     license("MIT")
 
-    version(
-        "5.1",
-        sha256="a5fff94f9144cb5e5e0f4702cc0d48a20215ccccd06cbed915e566e5d901fa0a",
-        preferred=True,
-    )
+    version("5.1", sha256="a5fff94f9144cb5e5e0f4702cc0d48a20215ccccd06cbed915e566e5d901fa0a")
     version("5.0", sha256="7528970f41ae60563df9fe1f8cc74a435be1566c01868a603ab894e9956c3c94")
     version("4.2", sha256="03cd67adcfea4a574fece98b60b4aba0a6e5a9c8f608ff1ccc1fb324a7185538")
     version("4.1", sha256="35ef437210bc25fdd802b462eaca830bfd928f962569b91b592f2866033ef2bb")

--- a/repos/spack_repo/builtin/packages/aocl_sparse/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_sparse/package.py
@@ -32,10 +32,11 @@ class AoclSparse(CMakePackage):
     license("MIT")
 
     version(
-        "5.0",
-        sha256="7528970f41ae60563df9fe1f8cc74a435be1566c01868a603ab894e9956c3c94",
+        "5.1",
+        sha256="a5fff94f9144cb5e5e0f4702cc0d48a20215ccccd06cbed915e566e5d901fa0a",
         preferred=True,
     )
+    version("5.0", sha256="7528970f41ae60563df9fe1f8cc74a435be1566c01868a603ab894e9956c3c94")
     version("4.2", sha256="03cd67adcfea4a574fece98b60b4aba0a6e5a9c8f608ff1ccc1fb324a7185538")
     version("4.1", sha256="35ef437210bc25fdd802b462eaca830bfd928f962569b91b592f2866033ef2bb")
     version("4.0", sha256="68524e441fdc7bb923333b98151005bed39154d9f4b5e8310b5c37de1d69c2c3")
@@ -43,6 +44,9 @@ class AoclSparse(CMakePackage):
     version("3.1", sha256="8536f06095c95074d4297a3d2910654085dd91bce82e116c10368a9f87e9c7b9")
     version("3.0", sha256="1d04ba16e04c065051af916b1ed9afce50296edfa9b1513211a7378e1d6b952e")
     version("2.2", sha256="33c2ed6622cda61d2613ee63ff12c116a6cd209c62e54307b8fde986cd65f664")
+
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
 
     variant("shared", default=True, description="Build shared library")
     variant("ilp64", default=False, description="Build with ILP64 support")
@@ -57,10 +61,7 @@ class AoclSparse(CMakePackage):
     )
     variant("openmp", default=True, when="@4.2:", description="Enable OpenMP support")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-
-    for vers in ["4.1", "4.2", "5.0"]:
+    for vers in ["4.1", "4.2", "5.0", "5.1"]:
         with when(f"@={vers}"):
             depends_on(f"amdblis@={vers}")
             depends_on(f"amdlibflame@={vers}")
@@ -73,7 +74,7 @@ class AoclSparse(CMakePackage):
     depends_on("amdlibflame threads=none", when="~openmp")
     depends_on("boost", when="+benchmarks")
     depends_on("boost", when="@2.2")
-    depends_on("cmake@3.22:", type="build")
+    depends_on("cmake@3.26:", type="build")
 
     @property
     def libs(self):

--- a/repos/spack_repo/builtin/packages/aocl_sparse/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_sparse/package.py
@@ -71,7 +71,7 @@ class AoclSparse(CMakePackage):
     depends_on("boost", when="+benchmarks")
     depends_on("boost", when="@2.2")
     depends_on("cmake@3.22:", when="@:5.0", type="build")
-    depends_on("cmake@3.26:", when="@5.1:",type="build")
+    depends_on("cmake@3.26:", when="@5.1:", type="build")
 
     @property
     def libs(self):

--- a/repos/spack_repo/builtin/packages/aocl_sparse/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_sparse/package.py
@@ -70,7 +70,8 @@ class AoclSparse(CMakePackage):
     depends_on("amdlibflame threads=none", when="~openmp")
     depends_on("boost", when="+benchmarks")
     depends_on("boost", when="@2.2")
-    depends_on("cmake@3.26:", type="build")
+    depends_on("cmake@3.22:", when="@:5.0", type="build")
+    depends_on("cmake@3.26:", when="@5.1",type="build")
 
     @property
     def libs(self):

--- a/repos/spack_repo/builtin/packages/aocl_utils/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_utils/package.py
@@ -37,10 +37,11 @@ class AoclUtils(CMakePackage):
     license("BSD-3-Clause")
 
     version(
-        "5.0",
-        sha256="ee2e5d47f33a3f673b3b6fcb88a7ef1a28648f407485ad07b6e9bf1b86159c59",
+        "5.1",
+        sha256="68d75e04013abe90ea8308a9bc99b99532233b6c7f937f35381563f4124c20a5",
         preferred=True,
     )
+    version("5.0", sha256="ee2e5d47f33a3f673b3b6fcb88a7ef1a28648f407485ad07b6e9bf1b86159c59")
     version("4.2", sha256="1294cdf275de44d3a22fea6fc4cd5bf66260d0a19abb2e488b898aaf632486bd")
     version("4.1", sha256="660746e7770dd195059ec25e124759b126ee9f060f43302d13354560ca76c02c")
 
@@ -52,7 +53,7 @@ class AoclUtils(CMakePackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
-    depends_on("cmake@3.22:", type="build")
+    depends_on("cmake@3.26:", type="build")
     depends_on("doxygen", when="+doc")
 
     @property

--- a/repos/spack_repo/builtin/packages/aocl_utils/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_utils/package.py
@@ -36,11 +36,7 @@ class AoclUtils(CMakePackage):
 
     license("BSD-3-Clause")
 
-    version(
-        "5.1",
-        sha256="68d75e04013abe90ea8308a9bc99b99532233b6c7f937f35381563f4124c20a5",
-        preferred=True,
-    )
+    version("5.1", sha256="68d75e04013abe90ea8308a9bc99b99532233b6c7f937f35381563f4124c20a5")
     version("5.0", sha256="ee2e5d47f33a3f673b3b6fcb88a7ef1a28648f407485ad07b6e9bf1b86159c59")
     version("4.2", sha256="1294cdf275de44d3a22fea6fc4cd5bf66260d0a19abb2e488b898aaf632486bd")
     version("4.1", sha256="660746e7770dd195059ec25e124759b126ee9f060f43302d13354560ca76c02c")

--- a/repos/spack_repo/builtin/packages/aocl_utils/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_utils/package.py
@@ -50,7 +50,7 @@ class AoclUtils(CMakePackage):
     depends_on("cxx", type="build")
 
     depends_on("cmake@3.22:", when="@:5.0", type="build")
-    depends_on("cmake@3.26:", when="@5.1:",type="build")
+    depends_on("cmake@3.26:", when="@5.1:", type="build")
     depends_on("doxygen", when="+doc")
 
     @property

--- a/repos/spack_repo/builtin/packages/aocl_utils/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_utils/package.py
@@ -50,7 +50,7 @@ class AoclUtils(CMakePackage):
     depends_on("cxx", type="build")
 
     depends_on("cmake@3.22:", when="@:5.0", type="build")
-    depends_on("cmake@3.26:", when="@5.1",type="build")
+    depends_on("cmake@3.26:", when="@5.1:",type="build")
     depends_on("doxygen", when="+doc")
 
     @property

--- a/repos/spack_repo/builtin/packages/aocl_utils/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_utils/package.py
@@ -49,7 +49,8 @@ class AoclUtils(CMakePackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
-    depends_on("cmake@3.26:", type="build")
+    depends_on("cmake@3.22:", when="@:5.0", type="build")
+    depends_on("cmake@3.26:", when="@5.1",type="build")
     depends_on("doxygen", when="+doc")
 
     @property


### PR DESCRIPTION
This PR includes below main changes in addition to few minor supporting changes:
- Adding new version 5.1 for AOCL libraries: 
`amdblis` `amdfftw` `amdlibflame` `amdlibm` `amdscalapack` `aocl-compression` `aocl-crypto` `aocl-da` `aocl-libmem` `aocl-sparse` `aocl-utils` and corresponding bundle package `amd-aocl`
- Adding `CMake` support for `amdlibm` with version `5.1`
- Update compiler dependency for `amdlibm`
- Update `aocl-libmem` recipe to include new variants `dynamic-dispatch` and update existing variant `vectorization` specific to version `5.1`
- Align the CMake version dependency for all libraries.