### PR TITLE
Add new version for amduprof 5.1.701

### DIFF
--- a/repos/spack_repo/builtin/packages/amduprof/package.py
+++ b/repos/spack_repo/builtin/packages/amduprof/package.py
@@ -23,10 +23,15 @@ class Amduprof(Package):
     maintainers("amd-toolchain-support")
 
     version(
+        "5.1.701",
+        sha256="8fd83170170883a6617391609545dffd557d6ca4a8f8f00a7a8a2d6cdee08189",
+        url="file://{0}/AMDuProf_Linux_x64_5.1.701.tar.bz2".format(os.getcwd()),
+        preferred=True,
+    )
+    version(
         "5.0.1479",
         sha256="065d24d9b84d2ef94ae8a360bf55c74a0f3fe9250b01cc7fb2642495028130d5",
         url="file://{0}/AMDuProf_Linux_x64_5.0.1479.tar.bz2".format(os.getcwd()),
-        preferred=True,
     )
     version(
         "4.2.850",

--- a/repos/spack_repo/builtin/packages/amduprof/package.py
+++ b/repos/spack_repo/builtin/packages/amduprof/package.py
@@ -26,7 +26,6 @@ class Amduprof(Package):
         "5.1.701",
         sha256="8fd83170170883a6617391609545dffd557d6ca4a8f8f00a7a8a2d6cdee08189",
         url="file://{0}/AMDuProf_Linux_x64_5.1.701.tar.bz2".format(os.getcwd()),
-        preferred=True,
     )
     version(
         "5.0.1479",


### PR DESCRIPTION
This PR adds a new version `5.1.701` for `amduprof`