### PR TITLE
compiler-wrapper: improve error message when no dep on c, cxx, fortran

### DIFF
--- a/repos/spack_repo/builtin/packages/compiler_wrapper/cc.sh
+++ b/repos/spack_repo/builtin/packages/compiler_wrapper/cc.sh
@@ -64,7 +64,7 @@ SPACK_MANAGED_DIRS"
 # die MESSAGE
 # Print a message and exit with error code 1.
 die() {
-    echo "[spack cc] ERROR: $*"
+    echo "[spack cc]: Error: $*"
     exit 1
 }
 

--- a/repos/spack_repo/builtin/packages/compiler_wrapper/cc.sh
+++ b/repos/spack_repo/builtin/packages/compiler_wrapper/cc.sh
@@ -618,7 +618,7 @@ categorize_arguments() {
                 # library. Filter it out.
                 # TODO: generalize filtering of args with an env var, so that
                 # TODO: we do not have to special case this here.
-                if { [ "$mode" = "ccld" ] || [ $mode = "ld" ]; } \
+                if { [ "$mode" = "ccld" ] || [ "$mode" = "ld" ]; } \
                     && [ "$1" != "${1#-loopopt}" ]; then
                     shift
                     continue

--- a/repos/spack_repo/builtin/packages/compiler_wrapper/cc.sh
+++ b/repos/spack_repo/builtin/packages/compiler_wrapper/cc.sh
@@ -282,7 +282,6 @@ fi
 # Figure out the type of compiler, the language, and the mode so that
 # the compiler script knows what to do.
 #
-# Possible languages are C, C++, Fortran 77, and Fortran 90.
 # 'command' is set based on the input command to $SPACK_[CC|CXX|F77|F90]
 #
 # 'mode' is set to one of:
@@ -307,7 +306,7 @@ case "$command" in
         ;;
     cc|c89|c99|gcc|clang|armclang|icc|icx|pgcc|nvc|xlc|xlc_r|fcc|amdclang|cl.exe|craycc)
         command="$SPACK_CC"
-        language="C"
+        vdep=c
         comp="CC"
         lang_flags=C
         debug_flags="-g"
@@ -315,7 +314,7 @@ case "$command" in
         ;;
     c++|CC|g++|clang++|armclang++|icpc|icpx|pgc++|nvc++|xlc++|xlc++_r|FCC|amdclang++|crayCC)
         command="$SPACK_CXX"
-        language="C++"
+        vdep=cxx
         comp="CXX"
         lang_flags=CXX
         debug_flags="-g"
@@ -323,7 +322,7 @@ case "$command" in
         ;;
     ftn|f90|fc|f95|gfortran|flang|armflang|ifort|ifx|pgfortran|nvfortran|xlf90|xlf90_r|nagfor|frt|amdflang|crayftn)
         command="$SPACK_FC"
-        language="Fortran 90"
+        vdep=fortran
         comp="FC"
         lang_flags=F
         debug_flags="-g"
@@ -331,7 +330,7 @@ case "$command" in
         ;;
     f77|xlf|xlf_r|pgf77)
         command="$SPACK_F77"
-        language="Fortran 77"
+        vdep=fortran
         comp="F77"
         lang_flags=F
         debug_flags="-g"
@@ -397,12 +396,11 @@ fi
 dtags_to_add="${SPACK_DTAGS_TO_ADD}"
 dtags_to_strip="${SPACK_DTAGS_TO_STRIP}"
 
-linker_arg="ERROR: LINKER ARG WAS NOT SET, MAYBE THE PACKAGE DOES NOT DEPEND ON ${comp}?"
-eval "linker_arg=\${SPACK_${comp}_LINKER_ARG:?${linker_arg}}"
-
-# Set up rpath variable according to language.
-rpath="ERROR: RPATH ARG WAS NOT SET, MAYBE THE PACKAGE DOES NOT DEPEND ON ${comp}?"
-eval "rpath=\${SPACK_${comp}_RPATH_ARG:?${rpath}}"
+eval "linker_arg=\"\$SPACK_${comp}_LINKER_ARG\""
+eval "rpath=\"\$SPACK_${comp}_RPATH_ARG\""
+if [ -z "$linker_arg" ] || [ -z "$rpath" ]; then
+    die "SPACK_${comp}_* variables not set: this usually means a missing \`depends_on(\"$vdep\", type=\"build\")\` in package.py"
+fi
 
 # Dump the mode and exit if the command is dump-mode.
 if [ "$SPACK_TEST_COMMAND" = "dump-mode" ]; then

--- a/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
+++ b/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
@@ -38,7 +38,7 @@ class CompilerWrapper(Package):
     if sys.platform != "win32":
         version(
             "1.0",
-            sha256="c65a9d2b2d4eef67ab5cb0684d706bb9f005bb2be94f53d82683d7055bdb837c",
+            sha256="a5ff4fcdbeda284a7993b87f294b6338434cffc84ced31e4d04008ed5ea389bf",
             expand=False,
         )
     else:


### PR DESCRIPTION
* show the missing `depends_on` statement when language specific environment variables are not set, to help users troubleshoot the issue:
   ```
   SPACK_CC_* variables not set: this usually means a missing `depends_on("c", type="build")` in package.py
   ```
* ensure that `die` outputs errors that are recognized by `spack log-parse`.
