### PR TITLE
Updated e2fsprogs to v1.47.3

### DIFF
--- a/repos/spack_repo/builtin/packages/e2fsprogs/package.py
+++ b/repos/spack_repo/builtin/packages/e2fsprogs/package.py
@@ -12,10 +12,11 @@ class E2fsprogs(AutotoolsPackage):
     It also supports the ext3 and ext4 filesystems."""
 
     homepage = "https://github.com/tytso/e2fsprogs"
-    url = "https://github.com/tytso/e2fsprogs/archive/v1.45.6.tar.gz"
+    url = "https://github.com/tytso/e2fsprogs/archive/v1.47.3.tar.gz"
 
     license("GPL-2.0-or-later AND LGPL-2.0-or-later AND BSD-3-Clause AND MIT")
 
+    version("1.47.3", sha256="9286ee5471a8a5339a61eb952739e4614a5b1dbed79ca73a78f014885ce2ad53")
     version("1.47.1", sha256="db95ff1cb6ef741c9aa8875d9f3f52a34168360febba765b6377b80bada09a8c")
     version("1.47.0", sha256="74c8ea97c73294edc6c11dc5e7fbb4324f86c28efd66ad0ba50be4eec8a48be2")
     version("1.45.6", sha256="d785164a2977cd88758cb0cac5c29add3fe491562a60040cfb193abcd0f9609b")


### PR DESCRIPTION
This bumps e2fsprogs to version 1.47.3 which helps with compilation using gcc@15 by adding an additional check before declaring a typedef.

https://github.com/tytso/e2fsprogs/blob/a5da316e5b54e12da000c60191c6220692c00f0f/lib/ext2fs/tdb.c#L113-L115

Prior to this, when attempting to install e2fsprogs@1.47.1 using gcc@15, a compilation error would occur as the typedef did not have any checks.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
