### PR TITLE
go and rust: allow multiple versions in concretized specs

### DIFF
--- a/repos/spack_repo/builtin/packages/go/package.py
+++ b/repos/spack_repo/builtin/packages/go/package.py
@@ -36,6 +36,7 @@ class Go(Package):
     extendable = True
     executables = ["^go$"]
     unresolved_libraries = ["libtiff.so.*"]  # go/src/debug/elf/testdata/libtiffxx.so_
+    tags = ["build-tools"]
 
     maintainers("alecbcs")
 

--- a/repos/spack_repo/builtin/packages/rust/package.py
+++ b/repos/spack_repo/builtin/packages/rust/package.py
@@ -17,6 +17,8 @@ class Rust(Package):
     url = "https://static.rust-lang.org/dist/rustc-1.42.0-src.tar.gz"
     git = "https://github.com/rust-lang/rust.git"
 
+    tags = ["build-tools"]
+
     maintainers("alecbcs")
 
     license("Apache-2.0 OR MIT")


### PR DESCRIPTION
Tag `go` and `rust` as build-tools so they can occur multiple times in a concretization.