### PR TITLE
Updated iq_tree 2.4.0

### DIFF
--- a/repos/spack_repo/builtin/packages/iq_tree/package.py
+++ b/repos/spack_repo/builtin/packages/iq_tree/package.py
@@ -18,6 +18,9 @@ class IqTree(CMakePackage):
     license("GPL-2.0-or-later")
 
     version(
+        "2.4.0", tag="v2.4.0", commit="977cc4324234b36fbfb80b326b8e43b73952e365", submodules=True
+    )
+    version(
         "2.3.2", tag="v2.3.1", commit="60f1aa68646ab84cc96b55a7548707adde15f47a", submodules=True
     )
     version(


### PR DESCRIPTION
Updated iq_tree package to version 2.4.0.

When attempting to install iq_tree 2.3.2 using the latest version of boost (1.88.0), iq_tree would complain that C++14 was required. Bumping to 2.4.0 also bumps the C++ requirement up to 14 or 17
https://github.com/iqtree/iqtree2/blob/v2.4.0/CMakeLists.txt#L280-L284

Since @ilbiondo is marked as the maintainer, I figure it might be appropriate/required to get their approval as well?