### PR TITLE
Rolling back OpenBLAS llvm conflict

### DIFF
--- a/repos/spack_repo/builtin/packages/openblas/package.py
+++ b/repos/spack_repo/builtin/packages/openblas/package.py
@@ -250,7 +250,7 @@ class Openblas(CMakePackage, MakefilePackage):
     )
 
     # Requires support for -mtune=generic
-    conflicts("%fortran=clang %llvm@:18")
+    conflicts("%fortran=clang %llvm@18.0:18.99")
 
     # See https://github.com/spack/spack/issues/19932#issuecomment-733452619
     # Notice: fixed on Amazon Linux GCC 7.3.1 (which is an unofficial version

--- a/repos/spack_repo/builtin/packages/openblas/package.py
+++ b/repos/spack_repo/builtin/packages/openblas/package.py
@@ -250,7 +250,7 @@ class Openblas(CMakePackage, MakefilePackage):
     )
 
     # Requires support for -mtune=generic
-    conflicts("%fortran=clang %llvm@18.0:18.99")
+    conflicts("%fortran=clang %llvm@18")
 
     # See https://github.com/spack/spack/issues/19932#issuecomment-733452619
     # Notice: fixed on Amazon Linux GCC 7.3.1 (which is an unofficial version

--- a/repos/spack_repo/builtin/packages/openblas/package.py
+++ b/repos/spack_repo/builtin/packages/openblas/package.py
@@ -249,9 +249,6 @@ class Openblas(CMakePackage, MakefilePackage):
         when="@0.3.27 %oneapi",
     )
 
-    # Requires support for -mtune=generic
-    conflicts("%fortran=clang %llvm@:18")
-
     # See https://github.com/spack/spack/issues/19932#issuecomment-733452619
     # Notice: fixed on Amazon Linux GCC 7.3.1 (which is an unofficial version
     # as GCC only has major.minor releases. But the bound :7.3.0 doesn't hurt)

--- a/repos/spack_repo/builtin/packages/openblas/package.py
+++ b/repos/spack_repo/builtin/packages/openblas/package.py
@@ -249,6 +249,9 @@ class Openblas(CMakePackage, MakefilePackage):
         when="@0.3.27 %oneapi",
     )
 
+    # Requires support for -mtune=generic
+    conflicts("%fortran=clang %llvm@:18")
+
     # See https://github.com/spack/spack/issues/19932#issuecomment-733452619
     # Notice: fixed on Amazon Linux GCC 7.3.1 (which is an unofficial version
     # as GCC only has major.minor releases. But the bound :7.3.0 doesn't hurt)


### PR DESCRIPTION
In reference to #805.

Something's not right here, as mtune is supported all the way back to LLVM 12.0. I recognized this because I have long had a stack using LLVM 17.0, and I just did a successful test install of OpenBLAS using LLVM 13.0.1.

@psakievich FYI, this was hit when building for a Vanguard software stack.