### PR TITLE
poppler: update test resource url

### DIFF
--- a/repos/spack_repo/builtin/packages/poppler/package.py
+++ b/repos/spack_repo/builtin/packages/poppler/package.py
@@ -83,7 +83,7 @@ class Poppler(CMakePackage):
 
     # Only needed to run `make test`
     resource(
-        name="test", git="git://git.freedesktop.org/git/poppler/test.git", placement="testdata"
+        name="test", git="https://gitlab.freedesktop.org/poppler/test.git", placement="testdata"
     )
 
     def cmake_args(self):


### PR DESCRIPTION
Avoids deprecated git url for test data. Main repo url was already migrated some time ago.