### PR TITLE
intel-oneapi-compilers-classic updates

### DIFF
--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers_classic/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers_classic/package.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
+import pathlib
 import sys
 
 from spack_repo.builtin.build_systems.compiler import CompilerPackage

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers_classic/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers_classic/package.py
@@ -93,10 +93,6 @@ class IntelOneapiCompilersClassic(Package, CompilerPackage):
            $ source {prefix}/{component}/{version}/env/vars.sh
         and from setting CC/CXX/F77/FC
         """
-        _link_path = pathlib.Path(os.readlink(self.prefix.bin.icc))
-        vars_path = _link_path.parent.parent / "env" / "vars.sh"
-        env.extend(EnvironmentModifications.from_sourcing_file(vars_path))
-
         env.set("CC", self.prefix.bin.icc)
         env.set("CXX", self.prefix.bin.icpc)
         env.set("F77", self.prefix.bin.ifort)

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers_classic/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers_classic/package.py
@@ -117,12 +117,30 @@ class IntelOneapiCompilersClassic(Package, CompilerPackage):
             env.append_flags("SPACK_ALWAYS_FFLAGS", "-diag-disable=10448")
 
     def install(self, spec, prefix):
-        # If we use symlinks, we create a run dependency on oneapi compilers
-        # preventing ifort use with a different version of icx
+        # List of all binaries from intel-oneapi-compilers related to ifort
+        binaries = [
+            "codecov",
+            "fortcom",
+            "fpp",
+            "ifort",
+            "ifort.cfg",
+            "map_opts",
+            "profdcg",
+            "profmerge",
+            "profmergesampling",
+            "proforder",
+            "tselect",
+            "xiar",
+            "xiar.cfg",
+            "xild",
+            "xild.cfg",
+        ]
+
+        # We do a full copy (not symlinks) to avoid a run dependency on intel-oneapi-compilers
+        # which would prevent mixing versions in a DAG
         mkdirp(prefix.bin)
-        install(self.oneapi_compiler_prefix.bin.ifort, prefix.bin)
-        install(self.oneapi_compiler_prefix.bin.fortcom, prefix.bin)
-        install(self.oneapi_compiler_prefix.bin.join("ifort.cfg"), prefix.bin)
+        for binary in binaries:
+            install(self.oneapi_compiler_prefix.bin.join(binary), prefix.bin)
         install_tree(self.oneapi_compiler_prefix.lib, prefix.lib)
         install_tree(self.oneapi_compiler_prefix.opt, prefix.opt)
         install_tree(self.oneapi_compiler_prefix.etc, prefix.etc)
@@ -130,8 +148,8 @@ class IntelOneapiCompilersClassic(Package, CompilerPackage):
 
     @when("@:2021.10")
     def install(self, spec, prefix):
-        # If we use symlinks, we create a run dependency on oneapi compilers
-        # preventing ifort use with a different version of icx
+        # We do a full copy (not symlinks) to avoid a run dependency on intel-oneapi-compilers
+        # which would prevent mixing versions in a DAG
         install_tree(self.oneapi_compiler_prefix.linux.bin.intel64, prefix.bin)
         install_tree(self.oneapi_compiler_prefix.linux.lib, prefix.lib)
         install_tree(self.oneapi_compiler_prefix.linux.include, prefix.include)

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers_classic/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers_classic/package.py
@@ -52,7 +52,7 @@ class IntelOneapiCompilersClassic(Package, CompilerPackage):
 
     stdcxx_libs = ("-cxxlib",)
 
-    provides("c", "cxx")
+    provides("c", "cxx", when="@:2021.10")
     provides("fortran")
 
     version_map = {
@@ -67,7 +67,11 @@ class IntelOneapiCompilersClassic(Package, CompilerPackage):
         "2021.8.0": "2023.0.0",
         "2021.9.0": "2023.1.0",
         "2021.10.0": "2023.2.4",
-        "2021.11.1": "2024.0.2",
+        "2021.11.0": "2024.0.0",
+        "2021.11.1": "2024.0.1:2024.0.2",
+        "2021.12.0": "2024.1.0",
+        "2021.13.0": "2024.2.0",
+        "2021.13.1": "2024.2.1",
     }
 
     # Versions before 2021 are in the `intel` package
@@ -75,15 +79,14 @@ class IntelOneapiCompilersClassic(Package, CompilerPackage):
     for ver, oneapi_ver in version_map.items():
         # prefer 2021.10.0 because it is the last one that has a C compiler
         version(ver, preferred=(ver == "2021.10.0"))
-        depends_on("intel-oneapi-compilers@" + oneapi_ver, when="@" + ver, type="run")
+        depends_on("intel-oneapi-compilers@" + oneapi_ver, when="@" + ver, type="build")
 
     # icc@2021.6.0 does not support gcc@12 headers
     conflicts("%gcc@12:", when="@:2021.6.0")
 
     @property
     def oneapi_compiler_prefix(self):
-        oneapi_version = self.spec["intel-oneapi-compilers"].version
-        return self.spec["intel-oneapi-compilers"].prefix.compiler.join(str(oneapi_version))
+        return self["intel-oneapi-compilers"].component_prefix
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         """Adds environment variables to the generated module file.
@@ -114,28 +117,27 @@ class IntelOneapiCompilersClassic(Package, CompilerPackage):
         if dependent_spec.satisfies("^[virtuals=fortran] intel-oneapi-compilers-classic"):
             env.append_flags("SPACK_ALWAYS_FFLAGS", "-diag-disable=10448")
 
+    @when("@:2021.10")
     def install(self, spec, prefix):
-        # If we symlink top-level directories directly, files won't show up in views
-        # Create real dirs and symlink files instead
-        self.symlink_dir(self.oneapi_compiler_prefix.linux.bin.intel64, prefix.bin)
-        self.symlink_dir(self.oneapi_compiler_prefix.linux.lib, prefix.lib)
-        self.symlink_dir(self.oneapi_compiler_prefix.linux.include, prefix.include)
-        self.symlink_dir(self.oneapi_compiler_prefix.linux.compiler, prefix.compiler)
-        self.symlink_dir(self.oneapi_compiler_prefix.documentation.en.man, prefix.man)
+        # If we use symlinks, we create a run dependency on oneapi compilers
+        # preventing ifort use with a different version of icx
+        install_tree(self.oneapi_compiler_prefix.linux.bin.intel64, prefix.bin)
+        install_tree(self.oneapi_compiler_prefix.linux.lib, prefix.lib)
+        install_tree(self.oneapi_compiler_prefix.linux.include, prefix.include)
+        install_tree(self.oneapi_compiler_prefix.linux.compiler, prefix.compiler)
+        install_tree(self.oneapi_compiler_prefix.documentation.en.man, prefix.man)
 
-    def symlink_dir(self, src, dest):
-        # Create a real directory at dest
-        mkdirp(dest)
-
-        # Symlink all files in src to dest keeping directories as dirs
-        for entry in os.listdir(src):
-            src_path = os.path.join(src, entry)
-            dest_path = os.path.join(dest, entry)
-            if os.path.isdir(src_path) and os.access(src_path, os.X_OK):
-                link_tree = LinkTree(src_path)
-                link_tree.merge(dest_path)
-            else:
-                os.symlink(src_path, dest_path)
+    def install(self, spec, prefix):
+        # If we use symlinks, we create a run dependency on oneapi compilers
+        # preventing ifort use with a different version of icx
+        mkdirp(prefix.bin)
+        install(self.oneapi_compiler_prefix.bin.ifort, prefix.bin)
+        install(self.oneapi_compiler_prefix.bin.fortcom, prefix.bin)
+        install(self.oneapi_compiler_prefix.bin.join("ifort.cfg"), prefix.bin)
+        install_tree(self.oneapi_compiler_prefix.lib, prefix.lib)
+        install_tree(self.oneapi_compiler_prefix.opt, prefix.opt)
+        install_tree(self.oneapi_compiler_prefix.etc, prefix.etc)
+        install_tree(self.oneapi_compiler_prefix.share, prefix.share)
 
     def _cc_path(self):
         return str(self.prefix.bin.icc)

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers_classic/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers_classic/package.py
@@ -116,16 +116,6 @@ class IntelOneapiCompilersClassic(Package, CompilerPackage):
         if dependent_spec.satisfies("^[virtuals=fortran] intel-oneapi-compilers-classic"):
             env.append_flags("SPACK_ALWAYS_FFLAGS", "-diag-disable=10448")
 
-    @when("@:2021.10")
-    def install(self, spec, prefix):
-        # If we use symlinks, we create a run dependency on oneapi compilers
-        # preventing ifort use with a different version of icx
-        install_tree(self.oneapi_compiler_prefix.linux.bin.intel64, prefix.bin)
-        install_tree(self.oneapi_compiler_prefix.linux.lib, prefix.lib)
-        install_tree(self.oneapi_compiler_prefix.linux.include, prefix.include)
-        install_tree(self.oneapi_compiler_prefix.linux.compiler, prefix.compiler)
-        install_tree(self.oneapi_compiler_prefix.documentation.en.man, prefix.man)
-
     def install(self, spec, prefix):
         # If we use symlinks, we create a run dependency on oneapi compilers
         # preventing ifort use with a different version of icx
@@ -137,6 +127,16 @@ class IntelOneapiCompilersClassic(Package, CompilerPackage):
         install_tree(self.oneapi_compiler_prefix.opt, prefix.opt)
         install_tree(self.oneapi_compiler_prefix.etc, prefix.etc)
         install_tree(self.oneapi_compiler_prefix.share, prefix.share)
+
+    @when("@:2021.10")
+    def install(self, spec, prefix):
+        # If we use symlinks, we create a run dependency on oneapi compilers
+        # preventing ifort use with a different version of icx
+        install_tree(self.oneapi_compiler_prefix.linux.bin.intel64, prefix.bin)
+        install_tree(self.oneapi_compiler_prefix.linux.lib, prefix.lib)
+        install_tree(self.oneapi_compiler_prefix.linux.include, prefix.include)
+        install_tree(self.oneapi_compiler_prefix.linux.compiler, prefix.compiler)
+        install_tree(self.oneapi_compiler_prefix.documentation.en.man, prefix.man)
 
     def _cc_path(self):
         return str(self.prefix.bin.icc)

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers_classic/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers_classic/package.py
@@ -94,7 +94,7 @@ class IntelOneapiCompilersClassic(Package, CompilerPackage):
         and from setting CC/CXX/F77/FC
         """
         _link_path = pathlib.Path(os.readlink(self.prefix.bin.icc))
-        vars_path = _link_path.parent.parent.parent / "env" / "vars.sh"
+        vars_path = _link_path.parent.parent / "env" / "vars.sh"
         env.extend(EnvironmentModifications.from_sourcing_file(vars_path))
 
         env.set("CC", self.prefix.bin.icc)

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers_classic/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers_classic/package.py
@@ -54,9 +54,7 @@ class IntelOneapiCompilersClassic(Package, CompilerPackage):
     provides("c", "cxx")
     provides("fortran")
 
-    # Versions before 2021 are in the `intel` package
-    # intel-oneapi versions before 2022 use intel@19.0.4
-    for ver, oneapi_ver in {
+    version_map = {
         "2021.1.2": "2021.1.2",
         "2021.2.0": "2021.2.0",
         "2021.3.0": "2021.3.0",
@@ -69,7 +67,11 @@ class IntelOneapiCompilersClassic(Package, CompilerPackage):
         "2021.9.0": "2023.1.0",
         "2021.10.0": "2023.2.4",
         "2021.11.1": "2024.0.2",
-    }.items():
+    }
+
+    # Versions before 2021 are in the `intel` package
+    # intel-oneapi versions before 2022 use intel@19.0.4
+    for ver, oneapi_ver in version_map.items():
         # prefer 2021.10.0 because it is the last one that has a C compiler
         version(ver, preferred=(ver == "2021.10.0"))
         depends_on("intel-oneapi-compilers@" + oneapi_ver, when="@" + ver, type="run")
@@ -90,24 +92,14 @@ class IntelOneapiCompilersClassic(Package, CompilerPackage):
            $ source {prefix}/{component}/{version}/env/vars.sh
         and from setting CC/CXX/F77/FC
         """
-        if not self.spec.external:
-            oneapi_pkg = self.spec["intel-oneapi-compilers"].package
-            oneapi_pkg.setup_run_environment(env)
-            bin_prefix = oneapi_pkg.component_prefix.linux.bin.intel64
-        else:
-            bin_prefix = self.prefix.bin
-            # External intel-oneapi-compilers-classic has no intel-oneapi-compilers
-            # dependency, so currently we skip whatever environment modifications it
-            # would do and don't try to replicate them
-            # TODO: this means there is no attempt to locate or run a vars.sh script
-            # for external instances of intel-oneapi-compilers-classic. If that is
-            # necessary, this function should include additional search logic when it
-            # is external (or check extra_attributes if a user wants to supply it
-            # manually)
-        env.set("CC", bin_prefix.icc)
-        env.set("CXX", bin_prefix.icpc)
-        env.set("F77", bin_prefix.ifort)
-        env.set("FC", bin_prefix.ifort)
+        _link_path = pathlib.Path(os.readlink(self.prefix.bin.icc))
+        vars_path = _link_path.parent.parent.parent / "env" / "vars.sh"
+        env.extend(EnvironmentModifications.from_sourcing_file(vars_path))
+
+        env.set("CC", self.prefix.bin.icc)
+        env.set("CXX", self.prefix.bin.icpc)
+        env.set("F77", self.prefix.bin.ifort)
+        env.set("FC", self.prefix.bin.ifort)
 
     def setup_dependent_build_environment(
         self, env: EnvironmentModifications, dependent_spec: Spec

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers_classic/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers_classic/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
-import pathlib
 import sys
 
 from spack_repo.builtin.build_systems.compiler import CompilerPackage


### PR DESCRIPTION
This PR addresses three issues:

1. external packages for `intel-oneapi-compilers-classic` currently fail because they need to query their `intel-oneapi-compilers` dependency. This is fixed by changing which paths are used in `setup_run_environment`.
2. fortran compilers from `intel-oneapi-compilers-classic` are not currently usable with C/C++ compilers from a version of `intel-oneapi-compilers` other than the one the fortran was built with. This is fixed by changing the dependency type from `run` to `build`, and by changing from symlinks to copies to ensure that the "build" dependency type is accurate.
3. newer fortran compilers for `intel-oneapi-compilers-classic` need to be added, but their locations within `intel-oneapi-compilers` are different from previous versions. This is fixed by adding special logic for versions `2021.11.0:` as those versions only include `ifort`
