### PR TITLE
yafyaml: conflict ifx 2025.2

### DIFF
--- a/repos/spack_repo/builtin/packages/yafyaml/package.py
+++ b/repos/spack_repo/builtin/packages/yafyaml/package.py
@@ -69,6 +69,11 @@ class Yafyaml(CMakePackage):
 
     conflicts("%gcc@13.3:", when="@:1.3.0", msg="GCC 13.3+ only works with yafyaml 1.4.0 onwards")
 
+    # ifx (or rather fpp) 2025.2 has a bug that prevents yafyaml from compiling
+    # This bug is still in 2025.2.1
+    # https://community.intel.com/t5/Intel-Fortran-Compiler/Regression-with-fpp-2025-2-0/m-p/1703735
+    conflicts("oneapi@2025.2:", msg="yaFyaml does not compile with ifx 2025.2 due to a bug in fpp")
+
     variant(
         "build_type",
         default="Release",

--- a/repos/spack_repo/builtin/packages/yafyaml/package.py
+++ b/repos/spack_repo/builtin/packages/yafyaml/package.py
@@ -72,7 +72,9 @@ class Yafyaml(CMakePackage):
     # ifx (or rather fpp) 2025.2 has a bug that prevents yafyaml from compiling
     # This bug is still in 2025.2.1
     # https://community.intel.com/t5/Intel-Fortran-Compiler/Regression-with-fpp-2025-2-0/m-p/1703735
-    conflicts("%oneapi@2025.2:", msg="yaFyaml does not compile with ifx 2025.2 due to a bug in fpp")
+    conflicts(
+        "%oneapi@2025.2:", msg="yaFyaml does not compile with ifx 2025.2 due to a bug in fpp"
+    )
 
     variant(
         "build_type",

--- a/repos/spack_repo/builtin/packages/yafyaml/package.py
+++ b/repos/spack_repo/builtin/packages/yafyaml/package.py
@@ -73,7 +73,8 @@ class Yafyaml(CMakePackage):
     # This bug is still in 2025.2.1
     # https://community.intel.com/t5/Intel-Fortran-Compiler/Regression-with-fpp-2025-2-0/m-p/1703735
     conflicts(
-        "%oneapi@2025.2:", msg="yaFyaml does not compile with ifx 2025.2 due to a bug in fpp"
+        "^[virtuals=fortran] intel-oneapi-compilers@2025.2:",
+        msg="yaFyaml does not compile with ifx 2025.2 due to a bug in fpp",
     )
 
     variant(

--- a/repos/spack_repo/builtin/packages/yafyaml/package.py
+++ b/repos/spack_repo/builtin/packages/yafyaml/package.py
@@ -72,7 +72,7 @@ class Yafyaml(CMakePackage):
     # ifx (or rather fpp) 2025.2 has a bug that prevents yafyaml from compiling
     # This bug is still in 2025.2.1
     # https://community.intel.com/t5/Intel-Fortran-Compiler/Regression-with-fpp-2025-2-0/m-p/1703735
-    conflicts("oneapi@2025.2:", msg="yaFyaml does not compile with ifx 2025.2 due to a bug in fpp")
+    conflicts("%oneapi@2025.2:", msg="yaFyaml does not compile with ifx 2025.2 due to a bug in fpp")
 
     variant(
         "build_type",


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Intel oneAPI has an `fpp` bug that is exposed in yafyaml, see https://community.intel.com/t5/Intel-Fortran-Compiler/Regression-with-fpp-2025-2-0/m-p/1703735

Until Intel can fix this (or we can somehow find a workaround), we have to conflict out ifx 2025.2.

NOTE: I have tested the newly released 2025.2.1 and it still has the bug.

cc: @climbfuji @rickgrubin-noaa 