### PR TITLE
mapl: Allow ifx 2025

### DIFF
--- a/repos/spack_repo/builtin/packages/mapl/package.py
+++ b/repos/spack_repo/builtin/packages/mapl/package.py
@@ -277,7 +277,6 @@ class Mapl(CMakePackage):
     # MAPL can use ifx only from MAPL 2.51 onwards and only supports
     # ifx 2025.0 and newer due to bugs in ifx.
     conflicts("%oneapi@2025:", when="@:2.50")
-    conflicts("^[virtuals=fortran] intel-oneapi-compilers")
 
     variant("flap", default=False, description="Build with FLAP support", when="@:2.39")
     variant("pflogger", default=True, description="Build with pFlogger support")

--- a/repos/spack_repo/builtin/packages/mapl/package.py
+++ b/repos/spack_repo/builtin/packages/mapl/package.py
@@ -276,7 +276,7 @@ class Mapl(CMakePackage):
 
     # MAPL can use ifx only from MAPL 2.51 onwards and only supports
     # ifx 2025.0 and newer due to bugs in ifx.
-    conflicts("%oneapi@2025:", when="@:2.50")
+    conflicts("^[virtuals=fortran] intel-oneapi-compilers@2025:", when="@:2.50")
 
     variant("flap", default=False, description="Build with FLAP support", when="@:2.39")
     variant("pflogger", default=True, description="Build with pFlogger support")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

At some point this:
```python
conflicts("^[virtuals=fortran] intel-oneapi-compilers")
```
was added to the MAPL package. However, MAPL does work with ifx 2025.0 and 2025.1 (I just tested them).

This PR updates it to use:
```python
    conflicts("^[virtuals=fortran] intel-oneapi-compilers@2025:", when="@:2.50")
```
which seems to be the spack v1 way of doing this for ifx.

NOTE: I am not sure if MAPL builds with 2025.2 yet. The main issue is the default way we run (with `+pflogger`) is broken at the moment as ifx (or rather fpp) 2025.2 does not compile a library needed by `pflogger` (see https://github.com/spack/spack-packages/pull/1124). I'm going to try and test to see if the fpp bug hits the MAPL code.