### PR TITLE
Swap "if ... in self.spec" with "self.spec.satisfies(...)" in ICON package

### DIFF
--- a/repos/spack_repo/builtin/packages/icon/package.py
+++ b/repos/spack_repo/builtin/packages/icon/package.py
@@ -216,7 +216,7 @@ class Icon(AutotoolsPackage):
         else:
             args.append("--disable-gpu")
 
-        if gpu in self.nvidia_targets or "+comin" in self.spec:
+        if gpu in self.nvidia_targets or self.spec.satisfies("+comin"):
             flags["ICON_LDFLAGS"].extend(self.compiler.stdcxx_libs)
 
         if self.compiler.name == "gcc":


### PR DESCRIPTION
There was still a line in the ICON package using the syntax `if ... in self.spec` instead of `self.spec.satisfies(...)`.

Judging from old commits, there was quite an effort to change all `if ... in self.spec` to `self.spec.satisfies(...)` some months ago, so I thought it would be good to change [line 219](https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/packages/icon/package.py#L219) in *repos/spack_repo/builtin/packages/icon/package.py* accordingly.
