### PR TITLE
otf2: Lift requirement on Python <= 3.11 for newer versions

### DIFF
--- a/repos/spack_repo/builtin/packages/otf2/package.py
+++ b/repos/spack_repo/builtin/packages/otf2/package.py
@@ -74,7 +74,8 @@ class Otf2(AutotoolsPackage):
     extends("python")
 
     # `imp` module required
-    depends_on("python@:3.11", type=("build", "run"))
+    depends_on("python@3", type=("build", "run"), when="@3.1:")
+    depends_on("python@:3.11", type=("build", "run"), when="@:3.0")
 
     with when("@2.2 %cce"):
         depends_on("autoconf", type="build")


### PR DESCRIPTION
If I'm not mistaken, `otf2` no longer depends on Python's `imp` module since version 3.1. Maybe @wrwilliams can confirm?