### PR TITLE
JAX: add v0.7.1+

### DIFF
--- a/repos/spack_repo/builtin/packages/py_jax/package.py
+++ b/repos/spack_repo/builtin/packages/py_jax/package.py
@@ -23,6 +23,7 @@ class PyJax(PythonPackage):
 
     tags = ["e4s"]
 
+    version("0.7.1", sha256="118f56338c503361d2791f069d24339d8d44a8db442ed851d2e591222fb7a56d")
     version("0.7.0", sha256="4dd8924f171ed73a4f1a6191e2f800ae1745069989b69fabc45593d6b6504003")
     version("0.6.2", sha256="a437d29038cbc8300334119692744704ca7941490867b9665406b7f90665cd96")
     version("0.6.1", sha256="c4dcb93e1d34f80cf7adfa81f3fdab62a5068b69107b7a6117f8742ab37b6779")
@@ -99,6 +100,7 @@ class PyJax(PythonPackage):
         # jax/_src/lib/__init__.py
         # https://github.com/google/jax/commit/8be057de1f50756fe7522f7e98b2f30fad56f7e4
         for v in [
+            "0.7.1",
             "0.7.0",
             "0.6.2",
             "0.6.1",
@@ -147,6 +149,7 @@ class PyJax(PythonPackage):
             depends_on(f"py-jaxlib@:{v}", when=f"@{v}")
 
         # See _minimum_jaxlib_version in jax/version.py
+        depends_on("py-jaxlib@0.7.1:", when="@0.7.1:")
         depends_on("py-jaxlib@0.7.0:", when="@0.7.0:")
         depends_on("py-jaxlib@0.6.2:", when="@0.6.2:")
         depends_on("py-jaxlib@0.6.1:", when="@0.6.1:")

--- a/repos/spack_repo/builtin/packages/py_jax/package.py
+++ b/repos/spack_repo/builtin/packages/py_jax/package.py
@@ -23,6 +23,7 @@ class PyJax(PythonPackage):
 
     tags = ["e4s"]
 
+    version("0.8.0", sha256="0ea5a7be7068c25934450dfd87d7d80a18a5d30e0a53454e7aade525b23accd5")
     version("0.7.2", sha256="71a42b964bc6d52e819311429e6c0f5742e2a4650226dab1a1dd26fd986ca70d")
     version("0.7.1", sha256="118f56338c503361d2791f069d24339d8d44a8db442ed851d2e591222fb7a56d")
     version("0.7.0", sha256="4dd8924f171ed73a4f1a6191e2f800ae1745069989b69fabc45593d6b6504003")
@@ -103,6 +104,7 @@ class PyJax(PythonPackage):
         # jax/_src/lib/__init__.py
         # https://github.com/google/jax/commit/8be057de1f50756fe7522f7e98b2f30fad56f7e4
         for v in [
+            "0.8.0",
             "0.7.2",
             "0.7.1",
             "0.7.0",
@@ -153,6 +155,7 @@ class PyJax(PythonPackage):
             depends_on(f"py-jaxlib@:{v}", when=f"@{v}")
 
         # See _minimum_jaxlib_version in jax/version.py
+        depends_on("py-jaxlib@0.8.0:", when="@0.8.0:")
         depends_on("py-jaxlib@0.7.2:", when="@0.7.2:")
         depends_on("py-jaxlib@0.7.1:", when="@0.7.1:")
         depends_on("py-jaxlib@0.7.0:", when="@0.7.0:")

--- a/repos/spack_repo/builtin/packages/py_jax/package.py
+++ b/repos/spack_repo/builtin/packages/py_jax/package.py
@@ -23,6 +23,7 @@ class PyJax(PythonPackage):
 
     tags = ["e4s"]
 
+    version("0.7.2", sha256="71a42b964bc6d52e819311429e6c0f5742e2a4650226dab1a1dd26fd986ca70d")
     version("0.7.1", sha256="118f56338c503361d2791f069d24339d8d44a8db442ed851d2e591222fb7a56d")
     version("0.7.0", sha256="4dd8924f171ed73a4f1a6191e2f800ae1745069989b69fabc45593d6b6504003")
     version("0.6.2", sha256="a437d29038cbc8300334119692744704ca7941490867b9665406b7f90665cd96")
@@ -81,6 +82,7 @@ class PyJax(PythonPackage):
         depends_on("py-ml-dtypes@0.2:", when="@0.4.14:")
         depends_on("py-ml-dtypes@0.1:", when="@0.4.9:")
         depends_on("py-ml-dtypes@0.0.3:", when="@0.4.7:")
+        depends_on("py-numpy@2:", when="@0.7.2:")
         depends_on("py-numpy@1.26:", when="@0.6.2:")
         depends_on("py-numpy@1.25:", when="@0.5:")
         depends_on("py-numpy@1.24:", when="@0.4.31:")
@@ -90,6 +92,7 @@ class PyJax(PythonPackage):
         # https://github.com/google/jax/issues/19246
         depends_on("py-numpy@:1", when="@:0.4.25")
         depends_on("py-opt-einsum")
+        depends_on("py-scipy@1.13:", when="@0.7.2:")
         depends_on("py-scipy@1.12:", when="@0.6.2:")
         depends_on("py-scipy@1.11.1:", when="@0.5:")
         depends_on("py-scipy@1.10:", when="@0.4.31:")
@@ -100,6 +103,7 @@ class PyJax(PythonPackage):
         # jax/_src/lib/__init__.py
         # https://github.com/google/jax/commit/8be057de1f50756fe7522f7e98b2f30fad56f7e4
         for v in [
+            "0.7.2",
             "0.7.1",
             "0.7.0",
             "0.6.2",
@@ -149,6 +153,7 @@ class PyJax(PythonPackage):
             depends_on(f"py-jaxlib@:{v}", when=f"@{v}")
 
         # See _minimum_jaxlib_version in jax/version.py
+        depends_on("py-jaxlib@0.7.2:", when="@0.7.2:")
         depends_on("py-jaxlib@0.7.1:", when="@0.7.1:")
         depends_on("py-jaxlib@0.7.0:", when="@0.7.0:")
         depends_on("py-jaxlib@0.6.2:", when="@0.6.2:")

--- a/repos/spack_repo/builtin/packages/py_jaxlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_jaxlib/package.py
@@ -272,7 +272,7 @@ class PyJaxlib(PythonPackage, CudaPackage, ROCmPackage):
         if spec.satisfies("@0.7.1:"):
             args.append(f"--clang_path={spack_cc}")
         elif spec.satisfies("@0.4.32:0.7.0"):
-            if spec.satisfies("%c,cxx=clang"):
+            if spec.satisfies("%c,cxx=llvm") or spec.satisfies("%c,cxx=apple-clang"):
                 args.append("--use_clang=true")
             else:
                 args.append("--use_clang=false")

--- a/repos/spack_repo/builtin/packages/py_jaxlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_jaxlib/package.py
@@ -49,6 +49,7 @@ class PyJaxlib(PythonPackage, CudaPackage, ROCmPackage):
     license("Apache-2.0")
     maintainers("adamjstewart", "jonas-eschle")
 
+    version("0.8.0", sha256="864aa46b5a4475c70195bd3728d32224f5b5ae1c7dd9c70646ef1387b4b0b04b")
     version("0.7.2", sha256="56d92604f1bb60bb3dbd7dc7c7dc21502d10b3474b8b905ce29ce06db6a26e45")
     version("0.7.1", sha256="8b866b775106c712a0c5532775a00941d293a4807cffae8dbcca1e03f54ce1ff")
     version("0.7.0", sha256="518966801e4402667e77915c2dc7cf1a178a80e22ff253204a837f207a87fcde")

--- a/repos/spack_repo/builtin/packages/py_jaxlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_jaxlib/package.py
@@ -189,6 +189,13 @@ class PyJaxlib(PythonPackage, CudaPackage, ROCmPackage):
     # backports https://github.com/abseil/abseil-cpp/pull/1732
     patch("jaxxlatsl.patch", when="@0.4.28:0.4.32 target=aarch64:")
 
+    requires(
+        "%c,cxx=llvm",
+        "%c,cxx=apple-clang",
+        when="@0.7.1:",
+        msg="Clang is the only acceptable compiler.",
+    )
+
     conflicts(
         "cuda_arch=none",
         when="+cuda",

--- a/repos/spack_repo/builtin/packages/py_jaxlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_jaxlib/package.py
@@ -49,6 +49,7 @@ class PyJaxlib(PythonPackage, CudaPackage, ROCmPackage):
     license("Apache-2.0")
     maintainers("adamjstewart", "jonas-eschle")
 
+    version("0.7.2", sha256="56d92604f1bb60bb3dbd7dc7c7dc21502d10b3474b8b905ce29ce06db6a26e45")
     version("0.7.1", sha256="8b866b775106c712a0c5532775a00941d293a4807cffae8dbcca1e03f54ce1ff")
     version("0.7.0", sha256="518966801e4402667e77915c2dc7cf1a178a80e22ff253204a837f207a87fcde")
     version("0.6.2", sha256="d46cb98795f2c1ccdf2b081e02d9d74b659063679a80beb001ad17d482a60e17")
@@ -96,7 +97,8 @@ class PyJaxlib(PythonPackage, CudaPackage, ROCmPackage):
         depends_on("cuda@12.1:", when="@0.4.26:")
         depends_on("cuda@11.8:", when="@0.4.11:")
         depends_on("cuda@11.4:", when="@0.4.0:0.4.7")
-        depends_on("cudnn@9.1:9", when="@0.4.31:")
+        depends_on("cudnn@9.8:9", when="@0.7.1:")
+        depends_on("cudnn@9.1:9", when="@0.4.31:0.7.0")
         depends_on("cudnn@9", when="@0.4.29:0.4.30")
         depends_on("cudnn@8.9:8", when="@0.4.26:0.4.28")
         depends_on("cudnn@8.8:8", when="@0.4.11:0.4.25")
@@ -144,12 +146,14 @@ class PyJaxlib(PythonPackage, CudaPackage, ROCmPackage):
         depends_on("python@:3.12", when="+rocm")
 
         # jaxlib/setup.py
+        depends_on("py-scipy@1.13:", when="@0.7.2:")
         depends_on("py-scipy@1.12:", when="@0.6.2:")
         depends_on("py-scipy@1.11.1:", when="@0.5:")
         depends_on("py-scipy@1.10:", when="@0.4.31:")
         depends_on("py-scipy@1.9:", when="@0.4.19:")
         depends_on("py-scipy@1.7:", when="@0.4.7:")
         depends_on("py-scipy@1.5:")
+        depends_on("py-numpy@2:", when="@0.7.2:")
         depends_on("py-numpy@1.26:", when="@0.6.2:")
         depends_on("py-numpy@1.25:", when="@0.5:")
         depends_on("py-numpy@1.24:", when="@0.4.31:")

--- a/repos/spack_repo/builtin/packages/py_jaxlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_jaxlib/package.py
@@ -49,6 +49,7 @@ class PyJaxlib(PythonPackage, CudaPackage, ROCmPackage):
     license("Apache-2.0")
     maintainers("adamjstewart", "jonas-eschle")
 
+    version("0.7.1", sha256="8b866b775106c712a0c5532775a00941d293a4807cffae8dbcca1e03f54ce1ff")
     version("0.7.0", sha256="518966801e4402667e77915c2dc7cf1a178a80e22ff253204a837f207a87fcde")
     version("0.6.2", sha256="d46cb98795f2c1ccdf2b081e02d9d74b659063679a80beb001ad17d482a60e17")
     version("0.6.1", sha256="af179a4047d473059beebc4b9d09763e80d8f7dcf4ae75670bc3dd912c92d6f5")
@@ -136,10 +137,11 @@ class PyJaxlib(PythonPackage, CudaPackage, ROCmPackage):
         depends_on("python@3.10:", when="@0.4.31:")
         depends_on("python@3.9:", when="@0.4.14:")
         depends_on("python@3.8:", when="@0.4.6:")
-        depends_on("python@:3.13")
-        depends_on("python@:3.12", when="+rocm")
+        depends_on("python@:3.14")
+        depends_on("python@:3.13", when="@:0.7.0")
         depends_on("python@:3.12", when="@:0.4.33")
         depends_on("python@:3.11", when="@:0.4.16")
+        depends_on("python@:3.12", when="+rocm")
 
         # jaxlib/setup.py
         depends_on("py-scipy@1.12:", when="@0.6.2:")

--- a/repos/spack_repo/builtin/packages/py_jaxlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_jaxlib/package.py
@@ -262,7 +262,9 @@ class PyJaxlib(PythonPackage, CudaPackage, ROCmPackage):
             else:
                 args.append("--wheels=jaxlib")
 
-        if spec.satisfies("@0.4.32:"):
+        if spec.satisfies("@0.7.1:"):
+            args.append(f"--clang_path={spack_cc}")
+        elif spec.satisfies("@0.4.32:0.7.0"):
             if spec.satisfies("%c,cxx=clang"):
                 args.append("--use_clang=true")
             else:


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Python 3.14 support 🙂 

* https://github.com/jax-ml/jax/releases/tag/jax-v0.7.1
* https://github.com/jax-ml/jax/releases/tag/jax-v0.7.2
* https://github.com/jax-ml/jax/releases/tag/jax-v0.8.0