### PR TITLE
openmpi: fix schedulers= variant propagation to external prrte

### DIFF
--- a/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -621,7 +621,7 @@ class Openmpi(AutotoolsPackage, CudaPackage, ROCmPackage):
     )
     # Variants to use internal packages
     variant("internal-hwloc", default=False, description="Use internal hwloc")
-    variant("internal-pmix", default=False, description="Use internal pmix")
+    variant("internal-pmix", default=False, description="Use internal pmix and prrte")
     variant("internal-libevent", default=False, description="Use internal libevent")
     variant("openshmem", default=False, description="Enable building OpenSHMEM")
     variant("debug", default=False, description="Make debug build", when="build_system=autotools")
@@ -737,6 +737,11 @@ with '-Wl,-commons,use_dylibs' and without
         # https://github.com/open-mpi/ompi/issues/13275#issuecomment-2907903468
         depends_on("prrte")
 
+        for scheduler in [s for s in SCHEDULERS if s not in ("none", "auto", "loadleveler")]:
+            depends_on(f"prrte schedulers={scheduler}", when=f"schedulers={scheduler}")
+            depends_on(f"pmix schedulers={scheduler}", when=f"schedulers={scheduler}")
+
+
     # Libevent is required when *vendored* PMIx is used
     depends_on("libevent@2:", when="~internal-libevent")
 
@@ -776,6 +781,12 @@ with '-Wl,-commons,use_dylibs' and without
         "schedulers=loadleveler",
         when="@3:",
         msg="The loadleveler scheduler is not supported with openmpi(>=3).",
+    )
+
+    conflicts(
+        "schedulers=auto",
+        when="~internal-pmix",
+        msg="External pmix and prrte requires specifying schedulers explicitly.",
     )
 
     # According to this comment on github:

--- a/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -737,7 +737,7 @@ with '-Wl,-commons,use_dylibs' and without
         # https://github.com/open-mpi/ompi/issues/13275#issuecomment-2907903468
         depends_on("prrte")
 
-        for scheduler in [s for s in SCHEDULERS if s not in ("none", "auto", "loadleveler")]:
+        for scheduler in [s for s in SCHEDULERS if s not in ("loadleveler")] + ["none"]:
             depends_on(f"prrte schedulers={scheduler}", when=f"schedulers={scheduler}")
             depends_on(f"pmix schedulers={scheduler}", when=f"schedulers={scheduler}")
 
@@ -785,7 +785,7 @@ with '-Wl,-commons,use_dylibs' and without
     conflicts(
         "schedulers=auto",
         when="~internal-pmix",
-        msg="External pmix and prrte requires specifying schedulers explicitly.",
+        msg="External pmix and prrte requires specifying schedulers explicitly (including 'none').",
     )
 
     # According to this comment on github:

--- a/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -733,13 +733,17 @@ with '-Wl,-commons,use_dylibs' and without
         # See https://www.mail-archive.com/announce@lists.open-mpi.org//msg00158.html
         depends_on("pmix@:4.2.2", when="@:4.1.5")
 
-        # When an external PMIx is used, also an external PRRTE should be used
-        # https://github.com/open-mpi/ompi/issues/13275#issuecomment-2907903468
-        depends_on("prrte")
+        # @:4 does not depend on prrte and used orte
+        with when("@5"):
 
-        for scheduler in [s for s in SCHEDULERS if s not in ("loadleveler")] + ["none"]:
-            depends_on(f"prrte schedulers={scheduler}", when=f"schedulers={scheduler}")
-            depends_on(f"pmix schedulers={scheduler}", when=f"schedulers={scheduler}")
+            # When an external PMIx is used, also an external PRRTE should be used
+            # https://github.com/open-mpi/ompi/issues/13275#issuecomment-2907903468
+            depends_on("prrte")
+
+            # only prrte knows about schedulers
+            # https://github.com/spack/spack-packages/pull/1145#issuecomment-3208378366
+            for scheduler in [s for s in SCHEDULERS if s not in ("loadleveler")] + ["none"]:
+                depends_on(f"prrte schedulers={scheduler}", when=f"schedulers={scheduler}")
 
     # Libevent is required when *vendored* PMIx is used
     depends_on("libevent@2:", when="~internal-libevent")

--- a/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -741,7 +741,6 @@ with '-Wl,-commons,use_dylibs' and without
             depends_on(f"prrte schedulers={scheduler}", when=f"schedulers={scheduler}")
             depends_on(f"pmix schedulers={scheduler}", when=f"schedulers={scheduler}")
 
-
     # Libevent is required when *vendored* PMIx is used
     depends_on("libevent@2:", when="~internal-libevent")
 

--- a/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -785,7 +785,7 @@ with '-Wl,-commons,use_dylibs' and without
     conflicts(
         "schedulers=auto",
         when="~internal-pmix",
-        msg="External pmix and prrte requires specifying schedulers explicitly (including 'none').",
+        msg="External pmix/prrte requires specifying schedulers explicitly (including 'none').",
     )
 
     # According to this comment on github:

--- a/repos/spack_repo/builtin/packages/pmix/package.py
+++ b/repos/spack_repo/builtin/packages/pmix/package.py
@@ -200,13 +200,12 @@ class Pmix(AutotoolsPackage):
     depends_on("py-setuptools", when="+python")
     depends_on("munge", when="+munge")
 
-
     SCHEDULERS = ("alps", "lsf", "tm", "slurm", "sge")
 
     variant(
         "schedulers",
         values=disjoint_sets(SCHEDULERS),
-        description="List of schedulers for which support is enabled"
+        description="List of schedulers for which support is enabled",
     )
     depends_on("lsf", when="schedulers=lsf")
     depends_on("pbs", when="schedulers=tm")
@@ -301,6 +300,5 @@ class Pmix(AutotoolsPackage):
 
         if spec.satisfies("schedulers=alps"):
             config_args.append("--with-alps")
-
 
         return config_args

--- a/repos/spack_repo/builtin/packages/pmix/package.py
+++ b/repos/spack_repo/builtin/packages/pmix/package.py
@@ -204,9 +204,7 @@ class Pmix(AutotoolsPackage):
 
     variant(
         "schedulers",
-        values=disjoint_sets(("none"), SCHEDULERS).with_non_feature_values(
-            "none"
-        ),
+        values=disjoint_sets(("none"), SCHEDULERS).with_non_feature_values("none"),
         description="List of schedulers for which support is enabled",
     )
     depends_on("lsf", when="schedulers=lsf")

--- a/repos/spack_repo/builtin/packages/pmix/package.py
+++ b/repos/spack_repo/builtin/packages/pmix/package.py
@@ -200,17 +200,6 @@ class Pmix(AutotoolsPackage):
     depends_on("py-setuptools", when="+python")
     depends_on("munge", when="+munge")
 
-    SCHEDULERS = ("alps", "lsf", "tm", "slurm", "sge")
-
-    variant(
-        "schedulers",
-        values=disjoint_sets(("none"), SCHEDULERS).with_non_feature_values("none"),
-        description="List of schedulers for which support is enabled",
-    )
-    depends_on("lsf", when="schedulers=lsf")
-    depends_on("pbs", when="schedulers=tm")
-    depends_on("slurm", when="schedulers=slurm")
-
     def autoreconf(self, spec, prefix):
         """Only needed when building from git checkout"""
         # If configure exists nothing needs to be done
@@ -281,24 +270,5 @@ class Pmix(AutotoolsPackage):
         # aarch64.  Work-around is to just not build the test code.
         if spec.satisfies("@:2.1.0 target=aarch64:"):
             config_args.append("--without-tests-examples")
-
-        # schedulers
-        # listed in https://github.com/openpmix/prrte/tree/master/config
-        # in the prte_check_X.m4 files
-        if spec.satisfies("schedulers=lsf"):
-            config_args.append(f"--with-lsf={self.spec['lsf'].prefix}")
-            config_args.append("--with-lsf-libdir={0}".format(spec["lsf"].libs.directories[0]))
-
-        if spec.satisfies("schedulers=tm"):
-            config_args.append(f"--with-tm={self.spec['pbs'].prefix}")
-
-        if spec.satisfies("schedulers=slurm"):
-            config_args.append("--with-slurm")
-
-        if spec.satisfies("schedulers=sge"):
-            config_args.append("--with-sge")
-
-        if spec.satisfies("schedulers=alps"):
-            config_args.append("--with-alps")
 
         return config_args

--- a/repos/spack_repo/builtin/packages/pmix/package.py
+++ b/repos/spack_repo/builtin/packages/pmix/package.py
@@ -204,7 +204,9 @@ class Pmix(AutotoolsPackage):
 
     variant(
         "schedulers",
-        values=disjoint_sets(SCHEDULERS),
+        values=disjoint_sets(("none"), SCHEDULERS).with_non_feature_values(
+            "none"
+        ),
         description="List of schedulers for which support is enabled",
     )
     depends_on("lsf", when="schedulers=lsf")

--- a/repos/spack_repo/builtin/packages/pmix/package.py
+++ b/repos/spack_repo/builtin/packages/pmix/package.py
@@ -200,6 +200,18 @@ class Pmix(AutotoolsPackage):
     depends_on("py-setuptools", when="+python")
     depends_on("munge", when="+munge")
 
+
+    SCHEDULERS = ("alps", "lsf", "tm", "slurm", "sge")
+
+    variant(
+        "schedulers",
+        values=disjoint_sets(SCHEDULERS),
+        description="List of schedulers for which support is enabled"
+    )
+    depends_on("lsf", when="schedulers=lsf")
+    depends_on("pbs", when="schedulers=tm")
+    depends_on("slurm", when="schedulers=slurm")
+
     def autoreconf(self, spec, prefix):
         """Only needed when building from git checkout"""
         # If configure exists nothing needs to be done
@@ -270,5 +282,25 @@ class Pmix(AutotoolsPackage):
         # aarch64.  Work-around is to just not build the test code.
         if spec.satisfies("@:2.1.0 target=aarch64:"):
             config_args.append("--without-tests-examples")
+
+        # schedulers
+        # listed in https://github.com/openpmix/prrte/tree/master/config
+        # in the prte_check_X.m4 files
+        if spec.satisfies("schedulers=lsf"):
+            config_args.append(f"--with-lsf={self.spec['lsf'].prefix}")
+            config_args.append("--with-lsf-libdir={0}".format(spec["lsf"].libs.directories[0]))
+
+        if spec.satisfies("schedulers=tm"):
+            config_args.append(f"--with-tm={self.spec['pbs'].prefix}")
+
+        if spec.satisfies("schedulers=slurm"):
+            config_args.append("--with-slurm")
+
+        if spec.satisfies("schedulers=sge"):
+            config_args.append("--with-sge")
+
+        if spec.satisfies("schedulers=alps"):
+            config_args.append("--with-alps")
+
 
         return config_args

--- a/repos/spack_repo/builtin/packages/prrte/package.py
+++ b/repos/spack_repo/builtin/packages/prrte/package.py
@@ -64,6 +64,18 @@ class Prrte(AutotoolsPackage):
     depends_on("pkgconfig", type="build")
     depends_on("python@3.7:", type="build", when="@develop")
 
+    # https://github.com/openpmix/openpmix/blob/master/docs/installing-pmix/configure-cli-options/runtime.rst
+    SCHEDULERS = ("alps", "lsf", "tm", "slurm", "sge")
+
+    variant(
+        "schedulers",
+        values=disjoint_sets(SCHEDULERS),
+        description="List of schedulers for which support is enabled"
+    )
+    depends_on("lsf", when="schedulers=lsf")
+    depends_on("pbs", when="schedulers=tm")
+    depends_on("slurm", when="schedulers=slurm")
+
     def url_for_version(self, version):
         if version <= Version("3"):
             # tarballs have a single 'r'
@@ -89,5 +101,23 @@ class Prrte(AutotoolsPackage):
         config_args.append("--with-hwloc={0}".format(spec["hwloc"].prefix))
         # pmix
         config_args.append("--with-pmix={0}".format(spec["pmix"].prefix))
+
+        # schedulers
+        # https://github.com/openpmix/openpmix/blob/master/docs/installing-pmix/configure-cli-options/runtime.rst
+        if spec.satisfies("schedulers=alps"):
+            config_args.append("--with-alps")
+
+        if spec.satisfies("schedulers=lsf"):
+            config_args.append(f"--with-lsf={self.spec['lsf'].prefix}")
+            config_args.append("--with-lsf-libdir={0}".format(spec["lsf"].libs.directories[0]))
+
+        if spec.satisfies("schedulers=sge"):
+            config_args.append("--with-sge")
+
+        if spec.satisfies("schedulers=tm"):
+            config_args.append(f"--with-tm={self.spec['pbs'].prefix}")
+
+        if spec.satisfies("schedulers=slurm"):
+            config_args.append("--with-slurm")
 
         return config_args

--- a/repos/spack_repo/builtin/packages/prrte/package.py
+++ b/repos/spack_repo/builtin/packages/prrte/package.py
@@ -69,7 +69,9 @@ class Prrte(AutotoolsPackage):
 
     variant(
         "schedulers",
-        values=disjoint_sets(SCHEDULERS),
+        values=disjoint_sets(("none"), SCHEDULERS).with_non_feature_values(
+            "none"
+        ),
         description="List of schedulers for which support is enabled",
     )
     depends_on("lsf", when="schedulers=lsf")

--- a/repos/spack_repo/builtin/packages/prrte/package.py
+++ b/repos/spack_repo/builtin/packages/prrte/package.py
@@ -70,7 +70,7 @@ class Prrte(AutotoolsPackage):
     variant(
         "schedulers",
         values=disjoint_sets(SCHEDULERS),
-        description="List of schedulers for which support is enabled"
+        description="List of schedulers for which support is enabled",
     )
     depends_on("lsf", when="schedulers=lsf")
     depends_on("pbs", when="schedulers=tm")

--- a/repos/spack_repo/builtin/packages/prrte/package.py
+++ b/repos/spack_repo/builtin/packages/prrte/package.py
@@ -69,9 +69,7 @@ class Prrte(AutotoolsPackage):
 
     variant(
         "schedulers",
-        values=disjoint_sets(("none"), SCHEDULERS).with_non_feature_values(
-            "none"
-        ),
+        values=disjoint_sets(("none"), SCHEDULERS).with_non_feature_values("none"),
         description="List of schedulers for which support is enabled",
     )
     depends_on("lsf", when="schedulers=lsf")

--- a/repos/spack_repo/builtin/packages/prrte/package.py
+++ b/repos/spack_repo/builtin/packages/prrte/package.py
@@ -110,7 +110,7 @@ class Prrte(AutotoolsPackage):
 
         if spec.satisfies("schedulers=lsf"):
             config_args.append(f"--with-lsf={self.spec['lsf'].prefix}")
-            config_args.append("--with-lsf-libdir={0}".format(spec["lsf"].libs.directories[0]))
+            config_args.append(f"--with-lsf-libdir={spec['lsf'].libs.directories[0]}")
 
         if spec.satisfies("schedulers=sge"):
             config_args.append("--with-sge")

--- a/repos/spack_repo/builtin/packages/prrte/package.py
+++ b/repos/spack_repo/builtin/packages/prrte/package.py
@@ -103,7 +103,8 @@ class Prrte(AutotoolsPackage):
         config_args.append("--with-pmix={0}".format(spec["pmix"].prefix))
 
         # schedulers
-        # https://github.com/openpmix/openpmix/blob/master/docs/installing-pmix/configure-cli-options/runtime.rst
+        # see prte_check_X.m4 files in
+        # https://github.com/openpmix/prrte/tree/master/config
         if spec.satisfies("schedulers=alps"):
             config_args.append("--with-alps")
 


### PR DESCRIPTION
Fixes: https://github.com/spack/spack-packages/issues/1144
Closes: https://github.com/spack/spack-packages/issues/670

As described in https://github.com/spack/spack-packages/issues/1144, the changes in https://github.com/spack/spack-packages/pull/241 around `~internal-pmix` does not correctly propagate scheduler selection down to `pmix` or `prrte`. As a result, running mpi jobs would fail (for me) after trying to fall back to ssh (which may mask this issue).

With these changes:
```
prte_info | grep tm
                          '--with-tm=/opt/pbs/'
                 MCA ess: tm (MCA v2.1.0, API v3.0.0, Component v4.0.0)
                 MCA plm: tm (MCA v2.1.0, API v2.0.0, Component v4.0.0)
```

It is not 100% clear to me that `--with-alps` is the correct way to [configure `prrte`](https://github.com/search?q=repo%3Aopenpmix%2Fprrte%20--with-alps&type=code). 
I am hoping @rhc54 might have a moment to lend his expertise.



**maintainers:**
@wdconinc 
`openmpi`: @naughtont3 @hppritcha