### PR TITLE
mesa-glu: update to current release url

### DIFF
--- a/repos/spack_repo/builtin/packages/mesa_glu/package.py
+++ b/repos/spack_repo/builtin/packages/mesa_glu/package.py
@@ -10,7 +10,7 @@ class MesaGlu(AutotoolsPackage):
     """This package provides the Mesa OpenGL Utility library."""
 
     homepage = "https://www.mesa3d.org"
-    url = "https://www.mesa3d.org/archive/glu/glu-9.0.0.tar.gz"
+    url = "https://archive.mesa3d.org/glu/glu-9.0.0.tar.gz"
 
     version("9.0.2", sha256="24effdfb952453cc00e275e1c82ca9787506aba0282145fff054498e60e19a65")
     version("9.0.1", sha256="f6f484cfcd51e489afe88031afdea1e173aa652697e4c19ddbcb8260579a10f7")


### PR DESCRIPTION
The existing spack url is giving 404, but the url in the PR exists, includes old versions, and seems stable.

checksums are unchanged.
