### PR TITLE
Always disable xpu to avoid torch build from auto-finding it on system

### DIFF
--- a/repos/spack_repo/builtin/packages/py_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_torch/package.py
@@ -627,6 +627,9 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
         # Spack logs have trouble handling colored output
         env.set("COLORIZE_OUTPUT", "OFF")
 
+        # Currently there are no variants/dependencies for Intel GPU support
+        env.set("USE_XPU", "OFF")
+
         enable_or_disable("test", keyword="BUILD")
         enable_or_disable("caffe2", keyword="BUILD")
 


### PR DESCRIPTION
A build of `py-torch` failed for me because it auto-determined `USE_XPU=ON` based on the presence of system artifacts, then failed.

Right now there are no variants/dependencies for Intel GPU support. Until those are added, it is safest to turn it off.