### PR TITLE
precice: update boost compatibility

### DIFF
--- a/repos/spack_repo/builtin/packages/precice/package.py
+++ b/repos/spack_repo/builtin/packages/precice/package.py
@@ -97,6 +97,7 @@ class Precice(CMakePackage):
     depends_on("boost@:1.74", when="@:2.1.1")
     depends_on("boost@:1.78", when="@:2.3.0")
     depends_on("boost@:1.86", when="@:3.1.2")
+    depends_on("boost@:1.89", when="@:3.2.0")
 
     depends_on("eigen@3.2:")
     depends_on("eigen@3.4:", when="@3.2:")


### PR DESCRIPTION
This PR prevents the latest release from building against boost 1.89
