### PR TITLE
Added mariadb 11.8.3 and 12.1.1

### DIFF
--- a/repos/spack_repo/builtin/packages/mariadb/package.py
+++ b/repos/spack_repo/builtin/packages/mariadb/package.py
@@ -73,6 +73,8 @@ class Mariadb(CMakePackage):
     depends_on("openssl")
     depends_on("openssl@:1.0", when="@:10.1")
     depends_on("krb5")
+    depends_on("snappy", when="@11.8.3: platform=darwin")
+    depends_on("pcre2", when="@11.8.3: platform=darwin")
 
     conflicts("%gcc@9.1.0:", when="@:5.5")
     conflicts("%gcc@13:", when="@:10.8.7")  # https://github.com/spack/spack/issues/41377

--- a/repos/spack_repo/builtin/packages/mariadb/package.py
+++ b/repos/spack_repo/builtin/packages/mariadb/package.py
@@ -73,8 +73,9 @@ class Mariadb(CMakePackage):
     depends_on("openssl")
     depends_on("openssl@:1.0", when="@:10.1")
     depends_on("krb5")
-    depends_on("snappy", when="@11.8.3: platform=darwin")
-    depends_on("pcre2", when="@11.8.3: platform=darwin")
+    depends_on("snappy", when="@11.8.3:")
+    depends_on("pcre2", when="@11.8.3:")
+    depends_on("fmt", when="@11.8.3:")
 
     conflicts("%gcc@9.1.0:", when="@:5.5")
     conflicts("%gcc@13:", when="@:10.8.7")  # https://github.com/spack/spack/issues/41377

--- a/repos/spack_repo/builtin/packages/mariadb/package.py
+++ b/repos/spack_repo/builtin/packages/mariadb/package.py
@@ -20,10 +20,12 @@ class Mariadb(CMakePackage):
     """
 
     homepage = "https://mariadb.org/about/"
-    url = "http://ftp.hosteurope.de/mirror/archive.mariadb.org/mariadb-10.2.8/source/mariadb-10.2.8.tar.gz"
+    url = "https://archive.mariadb.org/mariadb-12.1.1/source/mariadb-12.1.1.tar.gz"
 
     license("GPL-2.0-or-later")
 
+    version("12.1.1", sha256="ac5359c7361a5fffd9a6df769a694d3c832dacf94003debc2926fff77db12248")
+    version("11.8.3", sha256="1014a85c768de8f9e9c6d4bf0b42617f3b1588be1ad371f71674ea32b87119c0")
     version("11.3.2", sha256="5570778f0a2c27af726c751cda1a943f3f8de96d11d107791be5b44a0ce3fb5c")
     version("10.9.6", sha256="fe6f5287fccc6a65b8bbccae09e841e05dc076fcc13017078854ca387eab8ae9")
     version("10.8.8", sha256="8de1a151842976a492d6331b543d0ed87259febbbc03b9ebce07c80d754d6361")


### PR DESCRIPTION
Added mariadb versions 11.8.3 (latest 11.x version) and 12.1.1 (latest 12.x).

I also updated the URL to not be a (seemingly) arbitrary mirror and to use https.

Update was motivated by the inability to compile mariadb 11.3.2 using gcc@15.2.0