### PR TITLE
osu-micro-benchmarks: Add cray-mpich GTL support

### DIFF
--- a/repos/spack_repo/builtin/packages/osu_micro_benchmarks/package.py
+++ b/repos/spack_repo/builtin/packages/osu_micro_benchmarks/package.py
@@ -59,6 +59,22 @@ class OsuMicroBenchmarks(AutotoolsPackage, CudaPackage, ROCmPackage):
     depends_on("gnuplot", when="+graphing")
     depends_on("imagemagick", when="+graphing")
 
+    def flag_handler(self, name, flags):
+        wrapper_flags = []
+        build_system_flags = []
+
+        if self.spec.satisfies("+cuda") or self.spec.satisfies("+rocm"):
+            if self.spec.satisfies("^[virtuals=mpi] cray-mpich"):
+                gtl_lib = self.spec["cray-mpich"].package.gtl_lib
+                build_system_flags.extend(gtl_lib.get(name) or [])
+            # hipcc is not wrapped, we need to pass the flags via the build
+            # system.
+            build_system_flags.extend(flags)
+        else:
+            wrapper_flags.extend(flags)
+
+        return (wrapper_flags, [], build_system_flags)
+
     def configure_args(self):
         spec = self.spec
         config_args = ["CC=%s" % spec["mpi"].mpicc, "CXX=%s" % spec["mpi"].mpicxx]

--- a/repos/spack_repo/builtin/packages/osu_micro_benchmarks/package.py
+++ b/repos/spack_repo/builtin/packages/osu_micro_benchmarks/package.py
@@ -63,17 +63,20 @@ class OsuMicroBenchmarks(AutotoolsPackage, CudaPackage, ROCmPackage):
         wrapper_flags = []
         build_system_flags = []
 
-        if self.spec.satisfies("+cuda") or self.spec.satisfies("+rocm"):
-            if self.spec.satisfies("^[virtuals=mpi] cray-mpich"):
-                gtl_lib = self.spec["cray-mpich"].package.gtl_lib
-                build_system_flags.extend(gtl_lib.get(name) or [])
-            # hipcc is not wrapped, we need to pass the flags via the build
-            # system.
-            build_system_flags.extend(flags)
-        else:
-            wrapper_flags.extend(flags)
+        if name == "ldlibs":
+            # librt not available on darwin (and not required)
+            if not sys.platform == "darwin":
+                build_system_flags.append("-lrt")
 
-        return (wrapper_flags, [], build_system_flags)
+        if (self.spec.satisfies("+cuda") or self.spec.satisfies("+rocm")) and self.spec.satisfies(
+            "^[virtuals=mpi] cray-mpich"
+        ):
+            # hipcc is not wrapped, we need to pass GPU flags via the build system.
+            gtl_lib = self.spec["cray-mpich"].package.gtl_lib
+            build_system_flags.extend(gtl_lib.get(name) or [])
+
+        wrapper_flags.extend(flags)
+        return (wrapper_flags, None, build_system_flags)
 
     def configure_args(self):
         spec = self.spec
@@ -101,9 +104,6 @@ class OsuMicroBenchmarks(AutotoolsPackage, CudaPackage, ROCmPackage):
                 ]
             )
 
-        # librt not available on darwin (and not required)
-        if not sys.platform == "darwin":
-            config_args.append("LDFLAGS=-lrt")
         return config_args
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:


### PR DESCRIPTION
This PR adds GTL support to the `osu-micro-benchmarks` package, so that the `cray-mpich` MPI provided by the Cray Programming Environment can be used to build the package with either `+cuda` or `+rocm` support. Without this change, the "gtl" library is not linked into the OSU executables and they fail at runtime.

The code was borrowed and slightly modified from the `lammps` package.
