### PR TITLE
Remove false fortran dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/adios2/package.py
+++ b/repos/spack_repo/builtin/packages/adios2/package.py
@@ -120,7 +120,7 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
-    depends_on("fortran", type="build")
+    depends_on("fortran", type="build", when="fortran")
 
     depends_on("cmake@3.12.0:", type="build")
 

--- a/repos/spack_repo/builtin/packages/adios2/package.py
+++ b/repos/spack_repo/builtin/packages/adios2/package.py
@@ -120,7 +120,7 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
-    depends_on("fortran", type="build", when="fortran")
+    depends_on("fortran", type="build", when="+fortran")
 
     depends_on("cmake@3.12.0:", type="build")
 

--- a/repos/spack_repo/builtin/packages/doxygen/package.py
+++ b/repos/spack_repo/builtin/packages/doxygen/package.py
@@ -46,9 +46,8 @@ class Doxygen(CMakePackage):
     version("1.8.11", sha256="86263cb4ce1caa41937465f73f644651bd73128d685d35f18dea3046c7c42c12")
     version("1.8.10", sha256="0ac08900e5dc3ab5b65976991bf197623a7cc33ec3b32fe29360fb55d0c16b60")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     # graphviz appears to be a run-time optional dependency
     variant("graphviz", default=False, description="Build with dot command support from Graphviz.")

--- a/repos/spack_repo/builtin/packages/hepmc3/package.py
+++ b/repos/spack_repo/builtin/packages/hepmc3/package.py
@@ -46,6 +46,7 @@ class Hepmc3(CMakePackage):
         description="Install interfaces for some Monte-Carlo Event Gens",
     )
 
+    depends_on("c", type="build", when="@:3.2")
     depends_on("cxx", type="build")
 
     depends_on("cmake@2.8.9:", type="build")
@@ -56,6 +57,7 @@ class Hepmc3(CMakePackage):
     depends_on("python", when="+python")
 
     conflicts("%gcc@9.3.0", when="@:3.1.1")
+    # See https://gitlab.cern.ch/hepmc/HepMC3/-/merge_requests/58.diff
     patch("ba38f14d8f56c16cc4105d98f6d4540c928c6150.patch", when="@3.1.2:3.2.1 %gcc@9.3.0")
 
     extends("python", when="+python")

--- a/repos/spack_repo/builtin/packages/hepmc3/package.py
+++ b/repos/spack_repo/builtin/packages/hepmc3/package.py
@@ -46,9 +46,7 @@ class Hepmc3(CMakePackage):
         description="Install interfaces for some Monte-Carlo Event Gens",
     )
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("cxx", type="build")
 
     depends_on("cmake@2.8.9:", type="build")
     with when("+rootio"):

--- a/repos/spack_repo/builtin/packages/profugusmc/package.py
+++ b/repos/spack_repo/builtin/packages/profugusmc/package.py
@@ -23,8 +23,7 @@ class Profugusmc(CMakePackage, CudaPackage):
     variant("cuda", default=False, description="Enable CUDA")
 
     depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("cxx", type="build")
 
     depends_on("blas")
     depends_on("lapack")

--- a/repos/spack_repo/builtin/packages/spack/package.py
+++ b/repos/spack_repo/builtin/packages/spack/package.py
@@ -65,10 +65,6 @@ class Spack(Package):
     # This should be read as "require at least curl", not "require curl".
     requires("fetchers=curl", when="@:0.16", msg="Curl is required for Spack < 0.17")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
-
     # Python
     depends_on("python@2.6.0:2.7,3.5:", type="run")
     depends_on("python@2.7.0:2.7,3.5:", type="run", when="@0.18.0:")


### PR DESCRIPTION
The 'generated' compiler languages have a number of false positives, especially for Fortran, which is bad because macOS doesn't include a fortran compiler by default, leading to concretization errors like:
```
==> Error: failed to concretize `py-sphinxcontrib-bibtex`, `python@3.6:`, `git`, `geant4@11`, ..., `py-breathe` for the following reasons:
     1. Only external, or concrete, compilers are allowed for the fortran language. You could consider setting `concretizer:unify` to `when_possible` or `false` to allow multiple versions of some packages.
```

Many packages have Fortran as an optional target, or use Fortran as example files, etc. I've manually verified a few packages that definitely do not use Fortran. I also removed the other languages from "spack/package.yaml" since those are obviously fake too...