### PR TITLE
MFEM: fix `+strumpack` error

### DIFF
--- a/repos/spack_repo/builtin/packages/mfem/package.py
+++ b/repos/spack_repo/builtin/packages/mfem/package.py
@@ -295,7 +295,8 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     # See https://github.com/mfem/mfem/issues/2957
     conflicts("^mpich@4:", when="@:4.3+mpi")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build", when="+strumpack")
     depends_on("gmake", type="build")
 
     depends_on("mpi", when="+mpi")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This fixes the following error:

```
==> mfem: Executing phase: 'configure'
==> Error: KeyError: 'FC'

package_repos/fncqgg4/repos/spack_repo/builtin/packages/mfem/package.py:807, in get_make_config_options:
        804            # Parts of STRUMPACK use fortran, so we need to link with the
        805            # fortran library and also the MPI fortran library:
        806            if "~shared" in strumpack:
  >>    807                if os.path.basename(env["FC"]) == "gfortran":
        808                    gfortran = Executable(env["FC"])
        809                    libext = "dylib" if sys.platform == "darwin" else "so"
        810                    libfile = os.path.abspath(
```

