### PR TITLE
mcl: update and addition of cimfomfa dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/cimfomfa/package.py
+++ b/repos/spack_repo/builtin/packages/cimfomfa/package.py
@@ -18,7 +18,7 @@ class Cimfomfa(AutotoolsPackage):
     homepage = "https://github.com/micans/cimfomfa"
     url = "https://github.com/micans/cimfomfa/archive/refs/tags/21-361.tar.gz"
 
-    license("GPL-2.0-only", checked_by="emwjacobson")
+    license("GPL-2.0-or-later", checked_by="emwjacobson")
 
     version("21-361", sha256="e554f7838a16dfee79999b28133abf58dce01ac9a18f99c38c4183805b5b19d4")
 

--- a/repos/spack_repo/builtin/packages/cimfomfa/package.py
+++ b/repos/spack_repo/builtin/packages/cimfomfa/package.py
@@ -2,27 +2,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install cimfomfa
-#
-# You can edit this file again by typing:
-#
-#     spack edit cimfomfa
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack.package import *
 import shutil
-
 
 class Cimfomfa(AutotoolsPackage):
     """This library supports both MCL, a cluster algorithm for graphs, and zoem, a macro/DSL language.
@@ -42,16 +24,8 @@ class Cimfomfa(AutotoolsPackage):
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
 
-    # FIXME: Add additional dependencies if required.
-    # depends_on("foo")
-
     def autoreconf(self, spec, prefix):
         # The configure file isn't named properly
         shutil.move("configure.ac.in", "configure.ac")
         autoreconf("--install", "--verbose", "--force")
 
-    def configure_args(self):
-        # FIXME: Add arguments other than --prefix
-        # FIXME: If not needed delete this function
-        args = []
-        return args

--- a/repos/spack_repo/builtin/packages/cimfomfa/package.py
+++ b/repos/spack_repo/builtin/packages/cimfomfa/package.py
@@ -2,13 +2,18 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
-from spack.package import *
 import shutil
 
+from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+
+from spack.package import *
+
+
 class Cimfomfa(AutotoolsPackage):
-    """This library supports both MCL, a cluster algorithm for graphs, and zoem, a macro/DSL language.
-    It supplies abstractions for memory management, I/O, associative arrays, strings, heaps, and a few other things."""
+    """This library supports both MCL, a cluster algorithm for graphs, and zoem, a macro/DSL
+    language. It supplies abstractions for memory management, I/O, associative arrays, strings,
+    heaps, and a few other things.
+    """
 
     homepage = "https://github.com/micans/cimfomfa"
     url = "https://github.com/micans/cimfomfa/archive/refs/tags/21-361.tar.gz"
@@ -28,4 +33,3 @@ class Cimfomfa(AutotoolsPackage):
         # The configure file isn't named properly
         shutil.move("configure.ac.in", "configure.ac")
         autoreconf("--install", "--verbose", "--force")
-

--- a/repos/spack_repo/builtin/packages/cimfomfa/package.py
+++ b/repos/spack_repo/builtin/packages/cimfomfa/package.py
@@ -1,0 +1,57 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install cimfomfa
+#
+# You can edit this file again by typing:
+#
+#     spack edit cimfomfa
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack.package import *
+import shutil
+
+
+class Cimfomfa(AutotoolsPackage):
+    """This library supports both MCL, a cluster algorithm for graphs, and zoem, a macro/DSL language.
+    It supplies abstractions for memory management, I/O, associative arrays, strings, heaps, and a few other things."""
+
+    homepage = "https://github.com/micans/cimfomfa"
+    url = "https://github.com/micans/cimfomfa/archive/refs/tags/21-361.tar.gz"
+
+    license("GPL-2.0-only", checked_by="emwjacobson")
+
+    version("21-361", sha256="e554f7838a16dfee79999b28133abf58dce01ac9a18f99c38c4183805b5b19d4")
+
+    depends_on("c", type="build")
+
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+    depends_on("m4", type="build")
+
+    # FIXME: Add additional dependencies if required.
+    # depends_on("foo")
+
+    def autoreconf(self, spec, prefix):
+        # The configure file isn't named properly
+        shutil.move("configure.ac.in", "configure.ac")
+        autoreconf("--install", "--verbose", "--force")
+
+    def configure_args(self):
+        # FIXME: Add arguments other than --prefix
+        # FIXME: If not needed delete this function
+        args = []
+        return args

--- a/repos/spack_repo/builtin/packages/mcl/package.py
+++ b/repos/spack_repo/builtin/packages/mcl/package.py
@@ -17,6 +17,7 @@ class Mcl(AutotoolsPackage):
 
     license("GPL-3.0-or-later")
 
+    version("22-282", sha256="291f35837b6e852743bd87e499c5a46936125dcdf334f7747af92e88ac902183")
     version("14-137", sha256="b5786897a8a8ca119eb355a5630806a4da72ea84243dba85b19a86f14757b497")
 
     @when("%gcc@10:")
@@ -27,6 +28,9 @@ class Mcl(AutotoolsPackage):
     depends_on("c", type="build")  # generated
 
     depends_on("perl", type="run")
+
+    # 22-282 and later depend on cimfomfa
+    depends_on("cimfomfa", when="@22-282:")
 
     variant("blast", default=False, description="Build bio-informatics tools.")
 


### PR DESCRIPTION
Was working on updating mcl, prompted due to a problematic import, and found that newer versions depend on [cimfomfa](https://github.com/micans/cimfomfa).

One concern/question about this would be the license on cimfomfa. It has a GPLv2 license in the repo, and I'm not sure if this would qualify for a `GPL-2.0-only` or `GPL-2.0-or-later` license.

In the cimfomfa repo there is a "configure.ac.in" file to use for configuration. This isn't auto-detected by `autoreconf`, but renaming it resolves things. I'm not sure if a `shutil.move` is standard practice, though I found it also used in some other packages. Any recommendations here would be appreciated!