### PR TITLE
Add package py-dolfinx-mpc

### DIFF
--- a/repos/spack_repo/builtin/packages/dolfinx_mpc/package.py
+++ b/repos/spack_repo/builtin/packages/dolfinx_mpc/package.py
@@ -22,7 +22,6 @@ class DolfinxMpc(CMakePackage):
     version("main", branch="main")
     version("0.9.3", sha256="efa312cc498e428aab44acccc9bb0c74c200eda005742de7778c8e68fa84e8df")
     version("0.8.1", sha256="e0254b4a1c9c1456583c1415821946b11b0b2e48dbfee6558da2bbedfe78b461")
-    version("0.7.2", sha256="decf73dac8688ed235b8ee357b763d80a0d477110f35757117c1de649930c71a")
 
     # HDF5 dependency requires C in CMake
     depends_on("c", type="build")
@@ -31,7 +30,6 @@ class DolfinxMpc(CMakePackage):
     depends_on("fenics-dolfinx@main+petsc", when="@main")
     depends_on("fenics-dolfinx@0.9+petsc", when="@0.9")
     depends_on("fenics-dolfinx@0.8+petsc", when="@0.8")
-    depends_on("fenics-dolfinx@0.7+petsc", when="@0.7")
     depends_on("boost@1.70:+timer+filesystem", when="@:0.9")
     depends_on("cmake@3.21:", when="@0.9:", type="build")
     depends_on("cmake@3.19:", when="@:0.8", type="build")

--- a/repos/spack_repo/builtin/packages/dolfinx_mpc/package.py
+++ b/repos/spack_repo/builtin/packages/dolfinx_mpc/package.py
@@ -32,7 +32,7 @@ class DolfinxMpc(CMakePackage):
     depends_on("fenics-dolfinx@0.9+petsc", when="@0.9")
     depends_on("fenics-dolfinx@0.8+petsc", when="@0.8")
     depends_on("fenics-dolfinx@0.7+petsc", when="@0.7")
-
+    depends_on("boost@1.70:+timer+filesystem", when="@:0.9")
     depends_on("cmake@3.21:", when="@0.9:", type="build")
     depends_on("cmake@3.19:", when="@:0.8", type="build")
 

--- a/repos/spack_repo/builtin/packages/py_dolfinx_mpc/package.py
+++ b/repos/spack_repo/builtin/packages/py_dolfinx_mpc/package.py
@@ -26,6 +26,7 @@ class PyDolfinxMpc(PythonPackage):
     depends_on("cmake@3.19:", when="@:0.8", type="build")
     depends_on("py-packaging")
 
+    depends_on("python@3.9:", when="@main:", type=("build", "run"))
     depends_on("python@3.8:", when="@0.8:", type=("build", "run"))
 
     depends_on("py-cffi@:1.16", type=("build", "run"))
@@ -37,7 +38,7 @@ class PyDolfinxMpc(PythonPackage):
     depends_on("dolfinx-mpc@0.8.1", when="@0.8.1", type=("build"))
 
     depends_on("py-fenics-dolfinx@main+petsc4py", when="@main")
-    depends_on("py-fenics-dolfinx@0.9+petsc4py", when="@0.9")
+    depends_on("py-fenics-dolfinx@0.9:+petsc4py", when="@0.9")
     depends_on("py-fenics-dolfinx@0.8+petsc4py", when="@0.8")
 
     depends_on("py-nanobind@2:", when="@0.9:", type="build")

--- a/repos/spack_repo/builtin/packages/py_dolfinx_mpc/package.py
+++ b/repos/spack_repo/builtin/packages/py_dolfinx_mpc/package.py
@@ -26,8 +26,12 @@ class PyDolfinxMpc(PythonPackage):
     depends_on("cmake@3.19:", when="@:0.8", type="build")
     depends_on("py-packaging")
 
-    depends_on("python@3.9:", when="@0.8:", type=("build", "run"))
+    depends_on("python@3.8:", when="@0.8:", type=("build", "run"))
 
+    depends_on("py-cffi@:1.16", type=("build", "run"))
+    depends_on("py-numpy@1.21:", type=("build", "run"))
+    depends_on("py-mpi4py", type=("build", "run"))
+    
     depends_on("dolfinx-mpc@main", when="@main", type=("build"))
     depends_on("dolfinx-mpc@0.9.3", when="@0.9.3", type=("build"))
     depends_on("dolfinx-mpc@0.8.1", when="@0.8.1", type=("build"))

--- a/repos/spack_repo/builtin/packages/py_dolfinx_mpc/package.py
+++ b/repos/spack_repo/builtin/packages/py_dolfinx_mpc/package.py
@@ -31,7 +31,7 @@ class PyDolfinxMpc(PythonPackage):
     depends_on("py-cffi@:1.16", type=("build", "run"))
     depends_on("py-numpy@1.21:", type=("build", "run"))
     depends_on("py-mpi4py", type=("build", "run"))
-    
+
     depends_on("dolfinx-mpc@main", when="@main", type=("build"))
     depends_on("dolfinx-mpc@0.9.3", when="@0.9.3", type=("build"))
     depends_on("dolfinx-mpc@0.8.1", when="@0.8.1", type=("build"))

--- a/repos/spack_repo/builtin/packages/py_dolfinx_mpc/package.py
+++ b/repos/spack_repo/builtin/packages/py_dolfinx_mpc/package.py
@@ -1,3 +1,8 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
 from spack_repo.builtin.build_systems.python import PythonPackage
 
 from spack.package import *

--- a/repos/spack_repo/builtin/packages/py_dolfinx_mpc/package.py
+++ b/repos/spack_repo/builtin/packages/py_dolfinx_mpc/package.py
@@ -26,7 +26,7 @@ class PyDolfinxMpc(PythonPackage):
     depends_on("cmake@3.19:", when="@:0.8", type="build")
     depends_on("py-packaging")
 
-    depends_on("python@3.9:", when="@main", type=("build", "run"))
+    depends_on("python@3.10:", when="@main:", type=("build", "run"))
     depends_on("python@3.8:", when="@0.8:", type=("build", "run"))
 
     depends_on("py-cffi@:1.16", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_dolfinx_mpc/package.py
+++ b/repos/spack_repo/builtin/packages/py_dolfinx_mpc/package.py
@@ -1,0 +1,50 @@
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyDolfinxMpc(PythonPackage):
+    """Python interface of DOLFINx-MPC, an extension of DOLFINx for multipoint constraints."""
+
+    homepage = "https://www.jsdokken.com/dolfinx_mpc"
+    url = "https://github.com/jorgensd/dolfinx_mpc/archive/v0.9.3.tar.gz"
+    git = "https://github.com/jorgensd/dolfinx_mpc.git"
+
+    maintainers("jorgensd")
+
+    license("MIT", checked_by="jorgensd")
+
+    version("main", branch="main")
+    version("0.9.3", sha256="efa312cc498e428aab44acccc9bb0c74c200eda005742de7778c8e68fa84e8df")
+    version("0.8.1", sha256="e0254b4a1c9c1456583c1415821946b11b0b2e48dbfee6558da2bbedfe78b461")
+    version("0.7.2", sha256="decf73dac8688ed235b8ee357b763d80a0d477110f35757117c1de649930c71a")
+
+    variant("numba", default=False, description="numba support")
+
+    depends_on("cxx", type="build")
+    depends_on("cmake@3.21:", when="@0.9:", type="build")
+    depends_on("py-packaging")
+
+    depends_on("python@3.9:", when="@0.8:", type=("build", "run"))
+    depends_on("python@3.8:", when="@0.7", type=("build", "run"))
+
+    depends_on("dolfinx-mpc@main", when="@main", type=("build"))
+    depends_on("dolfinx-mpc@0.9.3", when="@0.9.3", type=("build"))
+    depends_on("dolfinx-mpc@0.8.1", when="@0.8.1", type=("build"))
+    depends_on("dolfinx-mpc@0.7.2", when="@0.7.2", type=("build"))
+
+    depends_on("py-fenics-dolfinx@main+petsc4py", when="@main")
+    depends_on("py-fenics-dolfinx@0.9+petsc4py", when="@0.9")
+    depends_on("py-fenics-dolfinx@0.8+petsc4py", when="@0.8")
+
+    depends_on("py-nanobind@2:", when="@0.9:", type="build")
+    depends_on("py-nanobind@1.8:1.9", when="@0.8", type="build")
+    depends_on("py-scikit-build-core@0.10: +pyproject", when="@0.10:", type="build")
+    depends_on("py-scikit-build-core@0.5: +pyproject", when="@0.8:0.9", type="build")
+    depends_on("py-pybind11@2.7.0:", when="@:0.7", type=("build", "run"))
+    depends_on("py-setuptools@42:", when="@:0.7", type="build")
+
+    depends_on("py-petsc4py", type=("build", "run"))
+    depends_on("py-numba", when="+numba", type="run")
+
+    build_directory = "python"

--- a/repos/spack_repo/builtin/packages/py_dolfinx_mpc/package.py
+++ b/repos/spack_repo/builtin/packages/py_dolfinx_mpc/package.py
@@ -17,21 +17,20 @@ class PyDolfinxMpc(PythonPackage):
     version("main", branch="main")
     version("0.9.3", sha256="efa312cc498e428aab44acccc9bb0c74c200eda005742de7778c8e68fa84e8df")
     version("0.8.1", sha256="e0254b4a1c9c1456583c1415821946b11b0b2e48dbfee6558da2bbedfe78b461")
-    version("0.7.2", sha256="decf73dac8688ed235b8ee357b763d80a0d477110f35757117c1de649930c71a")
 
     variant("numba", default=False, description="numba support")
 
     depends_on("cxx", type="build")
+
     depends_on("cmake@3.21:", when="@0.9:", type="build")
+    depends_on("cmake@3.19:", when="@:0.8", type="build")
     depends_on("py-packaging")
 
     depends_on("python@3.9:", when="@0.8:", type=("build", "run"))
-    depends_on("python@3.8:", when="@0.7", type=("build", "run"))
 
     depends_on("dolfinx-mpc@main", when="@main", type=("build"))
     depends_on("dolfinx-mpc@0.9.3", when="@0.9.3", type=("build"))
     depends_on("dolfinx-mpc@0.8.1", when="@0.8.1", type=("build"))
-    depends_on("dolfinx-mpc@0.7.2", when="@0.7.2", type=("build"))
 
     depends_on("py-fenics-dolfinx@main+petsc4py", when="@main")
     depends_on("py-fenics-dolfinx@0.9+petsc4py", when="@0.9")
@@ -41,8 +40,6 @@ class PyDolfinxMpc(PythonPackage):
     depends_on("py-nanobind@1.8:1.9", when="@0.8", type="build")
     depends_on("py-scikit-build-core@0.10: +pyproject", when="@0.10:", type="build")
     depends_on("py-scikit-build-core@0.5: +pyproject", when="@0.8:0.9", type="build")
-    depends_on("py-pybind11@2.7.0:", when="@:0.7", type=("build", "run"))
-    depends_on("py-setuptools@42:", when="@:0.7", type="build")
 
     depends_on("py-petsc4py", type=("build", "run"))
     depends_on("py-numba", when="+numba", type="run")

--- a/repos/spack_repo/builtin/packages/py_dolfinx_mpc/package.py
+++ b/repos/spack_repo/builtin/packages/py_dolfinx_mpc/package.py
@@ -26,7 +26,7 @@ class PyDolfinxMpc(PythonPackage):
     depends_on("cmake@3.19:", when="@:0.8", type="build")
     depends_on("py-packaging")
 
-    depends_on("python@3.9:", when="@main:", type=("build", "run"))
+    depends_on("python@3.9:", when="@main", type=("build", "run"))
     depends_on("python@3.8:", when="@0.8:", type=("build", "run"))
 
     depends_on("py-cffi@:1.16", type=("build", "run"))


### PR DESCRIPTION
Package depends on `dolfinx-mpc`.
I've removed the 0.7 release of `dolfinx-mpc`, as it seems like `py-fenics-dolfinx@v0.7` doesn't install correctly, which means that `py-dolfinx-mpc` would work. 
I believe it is better for me to maintain a sync of versions to avoid confusion.

All supported versions (0.8, 0.9 and main) has been tested locally.