### PR TITLE
gdrcopy: fix nvcc flags for multiple cuda_arch

### DIFF
--- a/repos/spack_repo/builtin/packages/gdrcopy/package.py
+++ b/repos/spack_repo/builtin/packages/gdrcopy/package.py
@@ -51,7 +51,7 @@ class Gdrcopy(MakefilePackage, CudaPackage):
         env.set("CUDA", self.spec["cuda"].prefix)
 
         if self.spec.satisfies("@2.4:"):
-            env.set("NVCCFLAGS", "".join(self.cuda_flags(self.spec.variants["cuda_arch"].values)))
+            env.set("NVCCFLAGS", " ".join(self.cuda_flags(self.spec.variants["cuda_arch"].values)))
 
     def build(self, spec, prefix):
         make("lib")


### PR DESCRIPTION
Small fix to nvcc flags creation in gdrcopy to allow supplying multiple `cuda_arch` variants. 

Was causing build errors due to missing space between flags.

#830 original PR adding explicit `cuda_arch` support.