### PR TITLE
nccl: added v2.27.6-1, v2.27.7-1

### DIFF
--- a/repos/spack_repo/builtin/packages/nccl/package.py
+++ b/repos/spack_repo/builtin/packages/nccl/package.py
@@ -19,6 +19,8 @@ class Nccl(MakefilePackage, CudaPackage):
     maintainers("adamjstewart")
     libraries = ["libnccl.so"]
 
+    version("2.27.7-1", sha256="98e6262bd55932c51e7c8ffc50cc764f019e4b94a8fd6694d839ae828ec8d128")
+    version("2.27.6-1", sha256="be322d358891c48acf34ac23655e7ebdce27bcfa83d67d09483c335d3b5021cc")
     version("2.27.5-1", sha256="e8a8972fc7f7517703510ef23608d41f6484db5331fca37827b4af3f66995344")
     version("2.27.3-1", sha256="97cde99265d0b76004b96e258deea6365df18ff9a292b8588f648e59c3ce1f2e")
     version("2.26.6-1", sha256="2a4f86198510e1f0764c116b33ff70e082240f87d158b2017d7f34c7c3768ac6")


### PR DESCRIPTION
Update nccl to v2.27.7-1.

Notably, v2.27.6-1 included a fix for building with gcc14 ([nccl issue#1743](https://github.com/NVIDIA/nccl/issues/1743#issuecomment-3062606775), [nccl issue#1751](https://github.com/NVIDIA/nccl/pull/1751#issuecomment-3001133613)).