### PR TITLE
Update arkouda/package.py to inculde recent versions up to v2025.08.20

### DIFF
--- a/repos/spack_repo/builtin/packages/arkouda/package.py
+++ b/repos/spack_repo/builtin/packages/arkouda/package.py
@@ -16,10 +16,8 @@ class Arkouda(MakefilePackage):
 
     # Arkouda does not have a current PyPI package, so we use the GitHub tarball
     list_url = "https://github.com/Bears-R-Us/arkouda/tags"
+    url = "https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2025.08.20.tar.gz"
     git = "https://github.com/Bears-R-Us/arkouda.git"
-
-    def url_for_version(self, version):
-        return f"https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v{version}.tar.gz"
 
     # See https://spdx.org/licenses/ for a list.
     license("MIT")

--- a/repos/spack_repo/builtin/packages/arkouda/package.py
+++ b/repos/spack_repo/builtin/packages/arkouda/package.py
@@ -15,23 +15,35 @@ class Arkouda(MakefilePackage):
     homepage = "https://github.com/Bears-R-Us/arkouda"
 
     # Arkouda does not have a current PyPI package, so we use the GitHub tarball
-    url = "https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2024.10.02.tar.gz"
+    list_url = "https://github.com/Bears-R-Us/arkouda/tags"
     git = "https://github.com/Bears-R-Us/arkouda.git"
+
+    def url_for_version(self, version):
+        return f"https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v{version}.tar.gz"
 
     # See https://spdx.org/licenses/ for a list.
     license("MIT")
 
     # A list of GitHub accounts to notify when the package is updated.
-    # TODO: add arkouda devs github account
-    maintainers("ajpotts", "arezaii")
+    maintainers("1RyanK", "ajpotts", "arezaii", "drculhane", "jaketrookman")
 
-    version("master", branch="master")
+    version("main", branch="main")
 
     version(
-        "2024.10.02", sha256="00671a89a08be57ff90a94052f69bfc6fe793f7b50cf9195dd7ee794d6d13f23"
+        "2025.08.20", sha256="3e305930905397ff3a7a28a5d8cc2c9adca4194ca7f6ee51f749f427a2dea92c"
     )
     version(
-        "2024.06.21", sha256="ab7f753befb3a0b8e27a3d28f3c83332d2c6ae49678877a7456f0fcfe42df51c"
+        "2025.07.03", sha256="eb888fac7b0eec6b4f3bfa0bfe14e5c8f15b449286e84c45ba95c44d8cd3917a"
+    )
+    version(
+        "2024.10.02",
+        sha256="00671a89a08be57ff90a94052f69bfc6fe793f7b50cf9195dd7ee794d6d13f23",
+        deprecated=True,
+    )
+    version(
+        "2024.06.21",
+        sha256="ab7f753befb3a0b8e27a3d28f3c83332d2c6ae49678877a7456f0fcfe42df51c",
+        deprecated=True,
     )
 
     variant(
@@ -40,17 +52,25 @@ class Arkouda(MakefilePackage):
         description="Build Arkouda for multi-locale execution on a cluster or supercomputer",
     )
 
-    depends_on("chapel@2.1: +hdf5 +zmq", type=("build", "link", "run", "test"))
+    depends_on(
+        "chapel@2.0:2.4 +hdf5 +zmq",
+        when="@2025.07.03:2025.08.20",
+        type=("build", "link", "run", "test"),
+    )
+    depends_on(
+        "chapel@2.1: +hdf5 +zmq", when="@:2025.01.13", type=("build", "link", "run", "test")
+    )
+
     depends_on("cmake@3.13.4:", type="build")
     depends_on("python@3.9:", type=("build", "link", "run", "test"))
     depends_on("libzmq@4.2.5:", type=("build", "link", "run", "test"))
     depends_on("hdf5+hl~mpi", type=("build", "link", "run", "test"))
     depends_on("libiconv", type=("build", "link", "run", "test"))
     depends_on("libidn2", type=("build", "link", "run", "test"))
-    depends_on(
-        "arrow +parquet +snappy +zlib +brotli +bz2 +lz4 +zstd",
-        type=("build", "link", "run", "test"),
-    )
+    depends_on("arrow@:19+brotli+bz2+lz4+parquet+snappy+zlib+zstd", type=("build", "link", "run"))
+
+    # force lz4 to use cmake (add as a direct dep to control its variant)
+    depends_on("lz4 build_system=cmake", type="build")
 
     requires("^chapel comm=none", when="~distributed")
     requires("^chapel +python-bindings", when="@2024.10.02:")

--- a/repos/spack_repo/builtin/packages/py_arkouda/package.py
+++ b/repos/spack_repo/builtin/packages/py_arkouda/package.py
@@ -14,10 +14,8 @@ class PyArkouda(PythonPackage):
 
     # Updating the arkouda PyPI package is future work
     list_url = "https://github.com/Bears-R-Us/arkouda/tags"
+    url = "https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2025.08.20.tar.gz"
     git = "https://github.com/Bears-R-Us/arkouda.git"
-
-    def url_for_version(self, version):
-        return f"https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v{version}.tar.gz"
 
     # See https://spdx.org/licenses/ for a list.
     license("MIT")

--- a/repos/spack_repo/builtin/packages/py_arkouda/package.py
+++ b/repos/spack_repo/builtin/packages/py_arkouda/package.py
@@ -13,8 +13,11 @@ class PyArkouda(PythonPackage):
     homepage = "https://github.com/Bears-R-Us/arkouda"
 
     # Updating the arkouda PyPI package is future work
-    url = "https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2024.10.02.tar.gz"
+    list_url = "https://github.com/Bears-R-Us/arkouda/tags"
     git = "https://github.com/Bears-R-Us/arkouda.git"
+
+    def url_for_version(self, version):
+        return f"https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v{version}.tar.gz"
 
     # See https://spdx.org/licenses/ for a list.
     license("MIT")
@@ -22,34 +25,50 @@ class PyArkouda(PythonPackage):
     test_requires_compiler = True
 
     # A list of GitHub accounts to notify when the package is updated.
-    # TODO: add arkouda devs github account
-    maintainers("arezaii")
+    maintainers("1RyanK", "ajpotts", "arezaii", "drculhane", "jaketrookman")
 
-    version("master", branch="master")
+    version("main", branch="main")
 
     version(
-        "2024.10.02", sha256="00671a89a08be57ff90a94052f69bfc6fe793f7b50cf9195dd7ee794d6d13f23"
+        "2025.08.20", sha256="3e305930905397ff3a7a28a5d8cc2c9adca4194ca7f6ee51f749f427a2dea92c"
     )
     version(
-        "2024.06.21", sha256="ab7f753befb3a0b8e27a3d28f3c83332d2c6ae49678877a7456f0fcfe42df51c"
+        "2025.07.03", sha256="eb888fac7b0eec6b4f3bfa0bfe14e5c8f15b449286e84c45ba95c44d8cd3917a"
+    )
+    version(
+        "2024.10.02",
+        sha256="00671a89a08be57ff90a94052f69bfc6fe793f7b50cf9195dd7ee794d6d13f23",
+        deprecated=True,
+    )
+    version(
+        "2024.06.21",
+        sha256="ab7f753befb3a0b8e27a3d28f3c83332d2c6ae49678877a7456f0fcfe42df51c",
+        deprecated=True,
     )
 
     variant("dev", default=False, description="Include arkouda developer extras")
 
-    depends_on("python@3.8:", type=("build", "run"), when="@:2024.06.21")
-    depends_on("python@3.9:3.12.3", type=("build", "run"), when="@2024.10.02:")
+    depends_on("python@3.9:3.12.3", type=("build", "run"), when="@:2025.01.13")
+    depends_on("python@3.9:3.13", type=("build", "run"), when="@2025.07.03:")
     depends_on("py-setuptools", type="build")
-    depends_on("py-numpy@1.24.1:1.99", type=("build", "run"))
+    depends_on("py-numpy@1.25:1", when="@:2025.01.13", type=("build", "run"))
+    depends_on("py-numpy@2", when="@2025.07.03:", type=("build", "run"))
+    depends_on("py-pandas@2.2.3:", when="@2025.07.03:")
     depends_on("py-pandas@1.4.0:", type=("build", "run"))
     conflicts("^py-pandas@2.2.0", msg="arkouda client not compatible with pandas 2.2.0")
-
-    depends_on("py-pyarrow", type=("build", "run"))
+    depends_on("py-pyarrow@:19", type=("build", "run"))
+    depends_on("py-pyarrow@15:19", when="@2025.07.03:")
     depends_on("py-pyzmq@20:", type=("build", "run"))
-    depends_on("py-scipy@:1.13.1", type=("build", "run"), when="@2024.06.21:")
-    depends_on("py-tables@3.7.0: +lzo +bzip2", type=("build", "run"), when="@:2024.06.21")
-    depends_on("py-tables@3.8.0: +lzo +bzip2", type=("build", "run"), when="@2024.10.02:")
+    depends_on("py-scipy@:1.13.1", type=("build", "run"), when="@:2025.01.13")
+    depends_on("py-scipy@1.14:", when="@2025.07.03:")
+    depends_on("py-tables@3.8: +lzo +bzip2", type=("build", "run"))
+    depends_on("py-tables@3.10: +lzo +bzip2", when="@2025.07.03:")
+    depends_on("py-cloudpickle@2:", when="@2025.07.03:", type=("build", "run"))
     depends_on("py-h5py@3.7.0:", type=("build", "run"))
+    depends_on("py-h5py@3.11:", when="@2025.07.03:")
+    depends_on("py-matplotlib@3.9:", when="@2025.07.03:")
     depends_on("py-matplotlib@3.3.2:", type=("build", "run"))
+    depends_on("py-contourpy@1.3:", when="@2025.07.03:")
     depends_on("py-versioneer", type=("build"))
     depends_on("py-pyfiglet", type=("build", "run"))
     depends_on("py-typeguard@2.10:2.12", type=("build", "run"))


### PR DESCRIPTION
## Summary

Adds Arkouda and Py-Arkouda versions **2025.07.03** and **2025.08.20**.
Deprecates **2024.10.02** and **2024.06.21**, which are no longer actively supported.

Arkouda and Py-Arkouda function as a server/client pair and must be updated and tested together, so both packages are updated in this PR.

## Testing

The new versions were validated end-to-end using a unified Spack environment:

```
source /opt/spack-develop/share/spack/setup-env.sh
spack env create ark-env
spack env activate -p ark-env

# Unify dependencies across both roots
spack config add concretizer:unify:true

# Add matching server/client roots
spack add arkouda@2025.08.20
spack add py-arkouda@2025.08.20

# Concretize and verify the solve
spack concretize -f
spack spec -Il
spack install

```
Runtime validation was performed by cloning the Arkouda GitHub repo and running the full unit test suite:
```
python3 -m pytest -c pytest.ini --size=100 --skip_doctest=True
```
## Changes

- **Branch rename**: Updated default branch from `master` → `main` to match the upstream project.
- **Chapel dependency**:  Updated upper bound to 2.4, consistent with Arkouda’s current support for 2025.07.03–2025.08.20.
`depends_on("chapel@2.0:2.4 +hdf5 +zmq",when="@2025.07.03:2025.08.20", type=("build","link","run","test"))`
- **Arrow / LZ4**: Added lz4 explicitly to ensure Parquet I/O support.  I confirmed that building Arrow (and its compression stack, including LZ4) using the CMake build system works correctly with Arkouda’s Parquet I/O path.
```
depends_on("arrow@:19+brotli+bz2+lz4+parquet+snappy+zlib+zstd", type=("build", "link", "run"))
depends_on("lz4 build_system=cmake", type="build")
```
- **Python versions**: Updated to match currently supported versions in the Arkouda project.
```
depends_on("python@3.9:3.12.3", when="@:2025.01.13", type=("build","run"))
depends_on("python@3.9:3.13", when="@2025.07.03:", type=("build","run"))
```
- **Updated dependency ranges**:  Adjusted for better alignment with Arkouda’s supported stack:
`py-pyarrow`, `py-scipy`, `py-tables`, and `py-h5py`.
- **New dependencies (required since 2025.07.03)**:  `py-cloudpickle`, `py-contourpy`.