### PR TITLE
libtirpc: Updated to 1.3.7

### DIFF
--- a/repos/spack_repo/builtin/packages/libtirpc/package.py
+++ b/repos/spack_repo/builtin/packages/libtirpc/package.py
@@ -15,6 +15,7 @@ class Libtirpc(AutotoolsPackage):
 
     license("BSD-3-Clause")
 
+    version("1.3.7", sha256="b47d3ac19d3549e54a05d0019a6c400674da716123858cfdb6d3bdd70a66c702")
     version("1.3.3", sha256="6474e98851d9f6f33871957ddee9714fdcd9d8a5ee9abb5a98d63ea2e60e12f3")
     version("1.2.6", sha256="4278e9a5181d5af9cd7885322fdecebc444f9a3da87c526e7d47f7a12a37d1cc")
     version("1.1.4", sha256="2ca529f02292e10c158562295a1ffd95d2ce8af97820e3534fe1b0e3aec7561d")


### PR DESCRIPTION
Updated libtirpc to 1.3.7.

Version 1.3.7, surprisingly released only a couple of hours before I ran into compilation errors, implements a fix for a couple of extern functions (eg. xdr_opaque_auth).