### PR TITLE
Skip ParaView tests for e4s-rocm-external stack

### DIFF
--- a/stacks/e4s-rocm-external/spack.yaml
+++ b/stacks/e4s-rocm-external/spack.yaml
@@ -320,6 +320,8 @@ spack:
     pipeline-gen:
     - build-job:
         image: ghcr.io/spack/spack/ubuntu22.04-runner-amd64-gcc-11.4-rocm6.2.1:2024.10.08
+    broken-tests-packages:
+    - paraview
 
   cdash:
     build-group: E4S ROCm External


### PR DESCRIPTION
The motivation behind this commit is to resolve the GitLab job timeouts for ParaView in the e4s-rocm-external stack.