### PR TITLE
Patch ispc 1.19 to make it compile

### DIFF
--- a/repos/spack_repo/builtin/packages/ispc/ispc-1.19-regexp.patch
+++ b/repos/spack_repo/builtin/packages/ispc/ispc-1.19-regexp.patch
@@ -1,0 +1,13 @@
+--- a/bitcode2cpp.py	2023-02-28 08:53:24.000000000 +0100
++++ b/bitcode2cpp.py.fixed	2025-08-26 17:37:16.373912000 +0200
+@@ -22,8 +22,8 @@
+ target = re.sub(r".*builtins\\target-", "", target)
+ target = re.sub(".*builtins/", "", target)
+ target = re.sub(r".*builtins\\", "", target)
+-target = re.sub("\.ll$", "", target)
+-target = re.sub("\.c$", "", target)
++target = re.sub(r"\.ll$", "", target)
++target = re.sub(r"\.c$", "", target)
+ target = re.sub("-", "_", target)
+ 
+ llvm_as="llvm-as"

--- a/repos/spack_repo/builtin/packages/ispc/package.py
+++ b/repos/spack_repo/builtin/packages/ispc/package.py
@@ -81,12 +81,17 @@ class Ispc(CMakePackage):
         sha256="d3ccf547d3ba59779fd375e10417a436318f2200d160febb9f830a26f0daefdc",
     )
 
+    # Turn a few regexp literals into raw strings, as otherwise some escape sequence fail
+    # to parse (shows warning). Patch based on ispc 1.22 version of bitcode2cpp.py
+    # in ispc github repo.
     patch(
         "ispc-1.19-regexp.patch",
         when="@1.19",
         sha256="dc5e5492442df91ba17877d84f062bc364140ee5620ed55b7beef87257030b74",
     )
 
+    # Adds missing <cstdint> include, as otherwise uint32_t and friends aren't found
+    # and the build fails. Patch based on 1.19 -> 1.20 diff of ispc github repo
     patch(
         "stdint-fix.patch",
         when="@1.19",

--- a/repos/spack_repo/builtin/packages/ispc/package.py
+++ b/repos/spack_repo/builtin/packages/ispc/package.py
@@ -81,6 +81,18 @@ class Ispc(CMakePackage):
         sha256="d3ccf547d3ba59779fd375e10417a436318f2200d160febb9f830a26f0daefdc",
     )
 
+    patch(
+        "ispc-1.19-regexp.patch",
+        when="@1.19",
+        sha256="dc5e5492442df91ba17877d84f062bc364140ee5620ed55b7beef87257030b74",
+    )
+
+    patch(
+        "stdint-fix.patch",
+        when="@1.19",
+        sha256="03303b2407718e340bfc574511f736ae0f6678e60db33f68147db29bdd806a1a",
+    )
+
     # Fix build with Apple clang 15
     patch(
         "https://github.com/ispc/ispc/commit/a25cbdcdb86cb35ea40dcddeba03564128f83eca.patch?full_index=1",

--- a/repos/spack_repo/builtin/packages/ispc/stdint-fix.patch
+++ b/repos/spack_repo/builtin/packages/ispc/stdint-fix.patch
@@ -1,0 +1,10 @@
+--- a/src/target_registry.h	2023-02-28 08:53:24.000000000 +0100
++++ b/src/target_registry.h.fixed	2025-08-26 17:43:23.338298000 +0200
+@@ -40,6 +40,7 @@
+ #include "bitcode_lib.h"
+ 
+ #include <bitset>
++#include <cstdint>
+ #include <map>
+ #include <vector>
+ 


### PR DESCRIPTION
I screwed up the merge/rebase on https://github.com/spack/spack-packages/pull/1091. And rather than try to figure out if it can still be salvaged, I made this new clean PR, which only concerns ispc (and not openvkl)