### PR TITLE
netcdf-c: fix build with autotools

### DIFF
--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -472,8 +472,9 @@ class AutotoolsBuilder(AnyBuilder, autotools.AutotoolsBuilder):
 
         # In general, we rely on the compiler wrapper to inject the required CPPFLAGS and LDFLAGS.
         # However, the injected LDFLAGS are invisible for the configure script and are added
-        # neither to the pkg-config nor to the nc-config files. Therefore, we generate LDFLAGS
+        # neither to the pkg-config nor to the nc-config files. Therefore, we generate CPPFLAGS and LDFLAGS
         # based on the contents of the following list and pass them to the configure script:
+        headers_include_flags = []
         lib_search_dirs = []
 
         # In general, we rely on the configure script to generate the required linker flags in the
@@ -500,6 +501,7 @@ class AutotoolsBuilder(AnyBuilder, autotools.AutotoolsBuilder):
                 extra_libs.append(hdf["zlib-api"].libs)
 
         hdf5 = self.spec["hdf5:hl"]
+        headers_include_flags.append(self.spec["hdf5"].headers.include_flags)
         lib_search_dirs.extend(hdf5.libs.directories)
         if "~shared" in hdf5:
             if "+szip" in hdf5:
@@ -522,6 +524,7 @@ class AutotoolsBuilder(AnyBuilder, autotools.AutotoolsBuilder):
             config_args.append("ac_cv_lib_zip_zip_open=no")
 
         if "+szip" in self.spec:
+            headers_include_flags.append(self.spec["szip"].headers.include_flags)
             lib_search_dirs.extend(self.spec["szip"].libs.directories)
         elif self.spec.satisfies("@4.9.0:"):
             # Prevent linking to szip to disable the plugin:
@@ -555,6 +558,7 @@ class AutotoolsBuilder(AnyBuilder, autotools.AutotoolsBuilder):
         if "+blosc" in self.spec:
             if self.spec.satisfies("@4.9.3:"):
                 config_args.append("--enable-filter-blosc")
+            headers_include_flags.append(self.spec["c-blosc"].headers.include_flags)
             lib_search_dirs.extend(self.spec["c-blosc"].libs.directories)
         elif self.spec.satisfies("@4.9.3:"):
             config_args.append("--disable-filter-blosc")
@@ -579,6 +583,8 @@ class AutotoolsBuilder(AnyBuilder, autotools.AutotoolsBuilder):
         if not self.spec.satisfies("@:4.4,main"):
             # Suppress the redundant check for m4:
             config_args.append("ac_cv_prog_NC_M4=false")
+
+        config_args.append("CPPFLAGS={}".format(" ".join(headers_include_flags)))
 
         lib_search_dirs.extend(d for libs in extra_libs for d in libs.directories)
         # Remove duplicates and system prefixes:

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -472,8 +472,9 @@ class AutotoolsBuilder(AnyBuilder, autotools.AutotoolsBuilder):
 
         # In general, we rely on the compiler wrapper to inject the required CPPFLAGS and LDFLAGS.
         # However, the injected LDFLAGS are invisible for the configure script and are added
-        # neither to the pkg-config nor to the nc-config files. Therefore, we generate CPPFLAGS and LDFLAGS
-        # based on the contents of the following list and pass them to the configure script:
+        # neither to the pkg-config nor to the nc-config files.
+        # Therefore, we generate CPPFLAGS and LDFLAGS based on the contents of the following list
+        # and pass them to the configure script:
         headers_include_flags = []
         lib_search_dirs = []
 


### PR DESCRIPTION
Trying to build `netcdf-c` with `build_system=autotools` and `hdf5` support, I ended up with configure errors like the following one

```
==> Error: ProcessError: Command exited with status 1:
    '/tmp/jfavre/spack-stage/spack-stage-netcdf-c-4.9.2-qhs4nvljm3ocedfh4zmrf6tyvougsxee/spack-src/configure' '--prefix=/capstor/store/cscs/cscs/csstaff/jfavre/spack-eiger/opt/spack/linux-zen2/netcdf-c-4.9.2-qhs4nvljm3ocedfh4zmrf6tyvougsxee' '--enable-v2' '--enable-utilities' '--enable-static' '--enable-largefile' '--enable-netcdf-4' '--enable-nczarr' '--enable-plugins' '--with-plugin-dir=/capstor/store/cscs/cscs/csstaff/jfavre/spack-eiger/opt/spack/linux-zen2/netcdf-c-4.9.2-qhs4nvljm3ocedfh4zmrf6tyvougsxee/plugins' '--enable-parallel4' '--enable-pnetcdf' '--disable-hdf4' '--enable-shared' '--disable-dap' '--disable-libxml2' '--disable-byterange' '--disable-jna' '--disable-fsync' '--disable-logging' 'CC=/user-environment/linux-zen2/cray-mpich-8.1.32-xhpgnxp5i7q6uro5h3vlesibcgw6dp5q/bin/mpicc' 'ac_cv_search_zip_open=no' 'ac_cv_lib_curl_curl_easy_setopt=no' 'ac_cv_prog_NC_M4=false' 'LDFLAGS=-L/capstor/store/cscs/cscs/csstaff/jfavre/spack-eiger/opt/spack/linux-zen2/parallel-netcdf-1.14.0-mtrr3hlqkippd4vn7poenoi6diy356yx/lib -L/user-environment/linux-zen2/hdf5-1.14.6-tqpmpebrmshudh6yj2yjv72yo6jxjkog/lib -L/user-environment/linux-zen2/zlib-ng-2.2.4-lzh5igelvufqwpqmuskgzltwhifknigq/lib -L/user-environment/linux-zen2/libaec-1.0.6-bae6vby2xqhwf6dalh2ysdnxjgvlb7da/lib64 -L/user-environment/linux-zen2/bzip2-1.0.8-vl42sqc7urf2girjk3zs2ytdhhtbodcy/lib -L/user-environment/linux-zen2/zstd-1.5.7-onjtcgvd6env5kbb3uhf7guljxlnx7jx/lib -L/user-environment/linux-zen2/c-blosc-1.21.6-qdeoq76fqev335zspx65t2igqbchyhjr/lib64' 'LIBS='

1 error found in build log:
     324    checking size of void*... 8
     325    checking for library containing deflate... -lz
     326    checking for floor in -lm... yes
     327    checking for library containing H5Fflush... -lhdf5
     328    checking for library containing H5DSis_scale... -lhdf5_hl
     329    checking for hdf5.h... no
  >> 330    configure: error: Compiling a test with HDF5 failed.  Either hdf5.h cannot be found, or config.log should be checked for other reason.
```

After some digging I found out that include flags were not passed at all apparently.

I'm an absolute newbie regarding `autotools`, but from a quick search and investigation (for instance see [netcdf-c/4.9.2 doc](https://docs.unidata.ucar.edu/netcdf-c/4.9.2/building_netcdf_fortran.html#building_fortran_with_static_libraries)), I ended up setting `CPPFLAGS`, along the already "managed" `LDFLAGS`.

Looking forward for comments from who know if this is the proper way to fix it or if there is any better way to do it.

Thanks in advance!

EDIT: I wouldn't be surprised if in spack there is a utility that loops through all build dependencies and add CPPFLAGS/LDFLAGS/...