### PR TITLE
comgr: needs CMAKE_MODULE_PATH for llvm-amdgpu

### DIFF
--- a/repos/spack_repo/builtin/packages/comgr/package.py
+++ b/repos/spack_repo/builtin/packages/comgr/package.py
@@ -105,6 +105,7 @@ class Comgr(CMakePackage):
         return args
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        env.prepend_path("CMAKE_MODULE_PATH", self.spec["llvm-amdgpu"].prefix.lib.cmake.clang)
         if self.spec.satisfies("@5.7: +asan"):
             env.set("CC", f"{self.spec['llvm-amdgpu'].prefix}/bin/clang")
             env.set("CXX", f"{self.spec['llvm-amdgpu'].prefix}/bin/clang++")


### PR DESCRIPTION
fixes the missing CMAKE_MODULE_PATH during build time which causes comgr to not pick up ClangConfig.cmake.
