### PR TITLE
kokkos: deprecate master branch

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -26,7 +26,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
 
     license("Apache-2.0 WITH LLVM-exception")
 
-    version("master", branch="master")
+    version("master", branch="master", deprecated=True)
     version("develop", branch="develop")
 
     version("4.7.00", sha256="126b774a24dde8c1085c4aede7564c0b7492d6a07d85380f2b387a712cea1ff5")

--- a/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
@@ -24,7 +24,7 @@ class KokkosKernels(CMakePackage, CudaPackage):
     license("Apache-2.0 WITH LLVM-exception")
 
     version("develop", branch="develop")
-    version("master", branch="master")
+    version("master", branch="master", deprecated=True)
     version("4.7.00", sha256="5c7c8c8f91817ab22dbc50ea72f02292bbd6c5b412d6f1588b27574600c478ef")
     version("4.6.02", sha256="a953f445660ed5aaab10e18fc4a90c4c178291e9d9d97d20abd4e6027f1193ec")
     version("4.6.01", sha256="95b9357f37ab3b9c3913c00741acb2501831c28ea8664de67818ae79c69c5908")

--- a/repos/spack_repo/builtin/packages/kokkos_nvcc_wrapper/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_nvcc_wrapper/package.py
@@ -22,7 +22,7 @@ class KokkosNvccWrapper(Package):
 
     license("BSD-3-Clause")
 
-    version("master", branch="master")
+    version("master", branch="master", deprecated=True)
     version("develop", branch="develop")
 
     version("4.7.00", sha256="126b774a24dde8c1085c4aede7564c0b7492d6a07d85380f2b387a712cea1ff5")


### PR DESCRIPTION
The default branch is now `develop`. The `master` branch has been deprecated since release 4.3.