### PR TITLE
Pressio: add 0.16.0 and 0.17.0

### DIFF
--- a/repos/spack_repo/builtin/packages/pressio_log/package.py
+++ b/repos/spack_repo/builtin/packages/pressio_log/package.py
@@ -22,6 +22,7 @@ class PressioLog(Package):
 
     version("main", branch="main")
     version("0.15.0", branch="0.15.0")
+    version("0.16.0", branch="0.16.0")
 
     def install(self, spec, prefix):
         install_tree("include", prefix.include)

--- a/repos/spack_repo/builtin/packages/pressio_log/package.py
+++ b/repos/spack_repo/builtin/packages/pressio_log/package.py
@@ -23,6 +23,7 @@ class PressioLog(Package):
     version("main", branch="main")
     version("0.15.0", branch="0.15.0")
     version("0.16.0", branch="0.16.0")
+    version("0.17.0", branch="0.17.0")
 
     def install(self, spec, prefix):
         install_tree("include", prefix.include)

--- a/repos/spack_repo/builtin/packages/pressio_ops/package.py
+++ b/repos/spack_repo/builtin/packages/pressio_ops/package.py
@@ -23,6 +23,7 @@ class PressioOps(Package):
     version("main", branch="main")
     version("0.15.0", branch="0.15.0")
     version("0.16.0", branch="0.16.0")
+    version("0.17.0", branch="0.17.0")
 
     def install(self, spec, prefix):
         install_tree("include", prefix.include)

--- a/repos/spack_repo/builtin/packages/pressio_ops/package.py
+++ b/repos/spack_repo/builtin/packages/pressio_ops/package.py
@@ -22,6 +22,7 @@ class PressioOps(Package):
 
     version("main", branch="main")
     version("0.15.0", branch="0.15.0")
+    version("0.16.0", branch="0.16.0")
 
     def install(self, spec, prefix):
         install_tree("include", prefix.include)

--- a/repos/spack_repo/builtin/packages/pressio_rom/package.py
+++ b/repos/spack_repo/builtin/packages/pressio_rom/package.py
@@ -26,7 +26,7 @@ class PressioRom(Package):
     license("BSD-3-Clause")
     maintainers("fnrizzi", "cwschilly")
 
-    supported_versions = ["main", "0.15.0"]
+    supported_versions = ["main", "0.15.0", "0.16.0"]
 
     # For now, assume each repo is compatible only with the same version of the other repos
     for supported_version in supported_versions:

--- a/repos/spack_repo/builtin/packages/pressio_rom/package.py
+++ b/repos/spack_repo/builtin/packages/pressio_rom/package.py
@@ -26,7 +26,7 @@ class PressioRom(Package):
     license("BSD-3-Clause")
     maintainers("fnrizzi", "cwschilly")
 
-    supported_versions = ["main", "0.15.0", "0.16.0"]
+    supported_versions = ["main", "0.15.0", "0.16.0", "0.17.0"]
 
     # For now, assume each repo is compatible only with the same version of the other repos
     for supported_version in supported_versions:


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Adds version 0.16.0 and 0.17.0 of all Pressio ecosystem packages.

cc @fnrizzi 
