### PR TITLE
py-pyvista: fix dependency and add v0.46.3

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pyvista/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyvista/package.py
@@ -20,6 +20,7 @@ class PyPyvista(PythonPackage):
 
     license("MIT")
 
+    version("0.46.3", sha256="1f8e6e39516d24d93bc227f278841a0d72ec3722959f612cf4616d2720a8afe1")
     version("0.45.3", sha256="bca39f5ea17e45f40070ab45423dfd2c4fc81c33e0fb565bafded81c024fd04f")
     version("0.44.1", sha256="63976f5d57d151b3f7e1616dde40dcf56a66d1f37f6db067087fa9cc9667f512")
     version("0.42.3", sha256="00159cf0dea05c1ecfd1695c8c6ccfcfff71b0744c9997fc0276e661dc052351")
@@ -44,6 +45,7 @@ class PyPyvista(PythonPackage):
     # https://github.com/pyvista/pyvista/issues/6731
     depends_on("vtk@:9.3,9.4.2:9.6+python", type=("build", "run"), when="@0.45.3:")
 
+    depends_on("py-typing-extensions@4.10:", when="@0.46.1:", type=("build", "run"))
     depends_on("py-typing-extensions", when="^python@:3.7", type=("build", "run"))
 
     # Historical dependencies


### PR DESCRIPTION
- Fix error for `py-typing-extensions` dependency, see https://github.com/pyvista/pyvista/blob/a6fa92498a9896bdba7d495b39273151c6e68cfa/pyproject.toml#L26
- Add v0.46.3