### PR TITLE
vtk-h: add missing C compiler dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/vtk_h/package.py
+++ b/repos/spack_repo/builtin/packages/vtk_h/package.py
@@ -68,6 +68,7 @@ class VtkH(CMakePackage, CudaPackage):
     variant("logging", default=False, description="Build vtk-h with logging enabled")
     variant("contourtree", default=False, description="Enable contour tree support")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
The package later tries to use `SPACK_CC`, which isn't defined unless a compiler dependency is added.