### PR TITLE
py-pyamg: dependency update and add v5.3.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pyamg/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyamg/package.py
@@ -31,7 +31,6 @@ class PyPyamg(PythonPackage):
     depends_on("py-setuptools@42:", type="build", when="@4.2.0:")
     # Later version required due to
     # https://github.com/pypa/setuptools_scm/issues/758
-    # depends_on("py-setuptools-scm@8.3.0+toml", type="build", when="@5.3.0:")
     depends_on("py-setuptools-scm@7.1:+toml", type="build", when="@5.0.0:")
     depends_on("py-setuptools-scm@5:+toml", type="build", when="@4.2.0:")
     depends_on("py-pybind11@2.8.0:", type=("build", "link"), when="@4.2.0:")

--- a/repos/spack_repo/builtin/packages/py_pyamg/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyamg/package.py
@@ -18,6 +18,7 @@ class PyPyamg(PythonPackage):
 
     license("MIT")
 
+    version("5.3.0", sha256="c83e745f93e60a3fc1598ca6369049387403be1db4f6ac887866259c853f6364")
     version("5.0.0", sha256="088be4b38203e708905fa45295593c1336b127a28391486d4f5917cf0b96f5f2")
     version("4.2.3", sha256="dcf23808e0e8edf177fc4f71a6b36e0823ffb117137a33a9eee14b391ddbb733")
     version("4.1.0", sha256="9e340aef5da11280a1e28f28deeaac390f408e38ee0357d0fdbb77503747bbc4")
@@ -26,9 +27,11 @@ class PyPyamg(PythonPackage):
     depends_on("python", type=("build", "link", "run"))
     depends_on("py-numpy@1.7:", type=("build", "run"))
     depends_on("py-scipy@0.12:", type=("build", "run"))
+    depends_on("py-scipy@0.12:1.15", type=("build", "run"), when="@:5.2")
     depends_on("py-setuptools@42:", type="build", when="@4.2.0:")
     # Later version required due to
     # https://github.com/pypa/setuptools_scm/issues/758
+    # depends_on("py-setuptools-scm@8.3.0+toml", type="build", when="@5.3.0:")
     depends_on("py-setuptools-scm@7.1:+toml", type="build", when="@5.0.0:")
     depends_on("py-setuptools-scm@5:+toml", type="build", when="@4.2.0:")
     depends_on("py-pybind11@2.8.0:", type=("build", "link"), when="@4.2.0:")


### PR DESCRIPTION
- pyamg version <= 5.2 fails with scipy version >=1.16 due to Scipy change. Update dependency to reflect this.
- Add pyamg v5.3.0 