### PR TITLE
Added gcc conflict for py-numpy

### DIFF
--- a/repos/spack_repo/builtin/packages/py_numpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_numpy/package.py
@@ -178,6 +178,7 @@ class PyNumpy(PythonPackage):
 
     # meson.build
     # https://docs.scipy.org/doc/scipy/dev/toolchain.html#compilers
+    conflicts("%gcc@:9.2", when="@2.3:", msg="NumPy requires GCC >= 9.3")
     conflicts("%gcc@:8.3", when="@1.26:", msg="NumPy requires GCC >= 8.4")
     conflicts("%gcc@:6.4", when="@1.23:", msg="NumPy requires GCC >= 6.5")
     conflicts("%gcc@:4.7", msg="NumPy requires GCC >= 4.8")


### PR DESCRIPTION
Numpy >=2.3.0 now requires GCC >= 9.3.0
https://numpy.org/doc/stable/release/2.3.0-notes.html#the-minimum-supported-gcc-version-is-now-9-3-0

Also mentioning @rgommers and @adamjstewart as they are the listed maintainers.