### PR TITLE
go-sh: add sh package (includes shfmt and gosh)

### DIFF
--- a/repos/spack_repo/builtin/packages/go_sh/package.py
+++ b/repos/spack_repo/builtin/packages/go_sh/package.py
@@ -7,7 +7,7 @@ from spack_repo.builtin.build_systems.go import GoPackage
 from spack.package import *
 
 
-class Sh(GoPackage):
+class GoSh(GoPackage):
     """A shell parser, formatter, and interpreter. Supports POSIX
     Shell, Bash, and mksh. Requires Go 1.23 or later."""
 

--- a/repos/spack_repo/builtin/packages/go_sh/package.py
+++ b/repos/spack_repo/builtin/packages/go_sh/package.py
@@ -25,11 +25,14 @@ class GoSh(GoPackage):
     variant("gosh", default=False, description="Build and install gosh")
     conflicts("~shfmt~gosh", msg="One of shfmt or gosh must be specified")
 
-    sanity_check_is_file = []
-    with when("+shfmt"):
-        sanity_check_is_file.append(join_path("bin", "shfmt"))
-    with when("+gosh"):
-        sanity_check_is_file.append(join_path("bin", "gosh"))
+    @property
+    def sanity_check_is_file(self):
+        files = []
+        if self.spec.satisfies("+shfmt"):
+            files.append(join_path("bin", "shfmt"))
+        if self.spec.satisfies("+gosh"):
+            files.append(join_path("bin", "gosh"))
+        return files
 
     def build(self, spec: Spec, prefix: Prefix) -> None:
         """Runs ``go build`` in the source directory for the specified

--- a/repos/spack_repo/builtin/packages/sh/package.py
+++ b/repos/spack_repo/builtin/packages/sh/package.py
@@ -1,0 +1,57 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.go import GoPackage
+
+from spack.package import *
+
+
+class Sh(GoPackage):
+    """A shell parser, formatter, and interpreter. Supports POSIX
+    Shell, Bash, and mksh. Requires Go 1.23 or later."""
+
+    homepage = "https://github.com/mvdan/sh"
+    url = "https://github.com/mvdan/sh/archive/refs/tags/v3.12.0.tar.gz"
+
+    maintainers("mcmehrtens")
+    license("BSD-3-Clause", checked_by="mcmehrtens")
+
+    version("3.12.0", sha256="ac15f42feeba55af29bd07698a881deebed1cd07e937effe140d9300e79d5ceb")
+
+    depends_on("go@1.23:", type="build", when="@3.12.0:")
+
+    variant("shfmt", default=True, description="Build and install shfmt")
+    variant("gosh", default=False, description="Build and install gosh")
+    conflicts("~shfmt~gosh", msg="One of shfmt or gosh must be specified")
+
+    sanity_check_is_file = []
+    with when("+shfmt"):
+        sanity_check_is_file.append(join_path("bin", "shfmt"))
+    with when("+gosh"):
+        sanity_check_is_file.append(join_path("bin", "gosh"))
+
+    def build(self, spec: Spec, prefix: Prefix) -> None:
+        """Runs ``go build`` in the source directory for the specified
+        variants."""
+        common_flags = (
+            "-p",
+            str(make_jobs),
+            "-modcacherw",
+            "-ldflags",
+            f"-s -w -X main.version={spec.version}",
+        )
+        with working_dir(self.build_directory):
+            if spec.satisfies("+shfmt"):
+                go("build", "-o", "shfmt", *common_flags, "cmd/shfmt/main.go")
+            if spec.satisfies("+gosh"):
+                go("build", "-o", "gosh", *common_flags, "cmd/gosh/main.go")
+
+    def install(self, spec: Spec, prefix: Prefix) -> None:
+        """Install built binaries into prefix bin."""
+        with working_dir(self.build_directory):
+            mkdirp(prefix.bin)
+            if spec.satisfies("+shfmt"):
+                install("shfmt", prefix.bin)
+            if spec.satisfies("+gosh"):
+                install("gosh", prefix.bin)


### PR DESCRIPTION
* adds a package for [sh](https://github.com/mvdan/sh), the software package housing `shfmt` and `gosh`
* package is named `go-sh` to avoid potential confusion with the Bourne shell
* `go-sh` creates two possible binaries: `shfmt` and `gosh`. I've dealt with this by adding variants for each.
  * To try and set sensible defaults, I've set the `shfmt` variant to default to true, since this seems to be the more widely used tool

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
