### PR TITLE
hpctoolkit: add 2025.0.0 and update docs dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/hpctoolkit/package.py
+++ b/repos/spack_repo/builtin/packages/hpctoolkit/package.py
@@ -34,6 +34,7 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
 
     version("develop", branch="develop")
     version("2025.0.stable", branch="release/2025.0")
+    version("2025.0.0", tag="2025.0.0", commit="9d0878a37ff3273ebebd1559780557de7a8a05cb")
     version("2024.01.stable", branch="release/2024.01")
     version("2024.01.1", tag="2024.01.1", commit="0672b9a9a2a1e3846c5e2059fb73a07a129f22cd")
     version("2023.08.stable", branch="release/2023.08")

--- a/repos/spack_repo/builtin/packages/hpctoolkit/package.py
+++ b/repos/spack_repo/builtin/packages/hpctoolkit/package.py
@@ -203,8 +203,9 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
     depends_on("zlib+shared", when="^[virtuals=zlib-api] zlib")
 
     depends_on("py-docutils", type="build", when="@2025:")
-    depends_on("py-sphinx", type="build", when="+docs")
-    depends_on("py-myst-parser@0.19:", type="build", when="+docs")
+    depends_on("py-sphinx@6:8", type="build", when="+docs")
+    depends_on("py-myst-parser@3:4", type="build", when="+docs")
+    depends_on("py-sphinx-book-theme@1", type="build", when="+docs")
 
     depends_on("cuda", when="+cuda")
     depends_on("oneapi-level-zero", when="+level_zero")


### PR DESCRIPTION
- Add `@2025.0.0`: https://gitlab.com/hpctoolkit/hpctoolkit/-/releases/2025.0.0
- Update `+docs` dependencies to match accepted versions and add `py-sphinx-book-theme`

CC maintainer: @mwkrentel 