### PR TITLE
py-gosam: Depend on setuptools since distutils is removed in python 3.13

### DIFF
--- a/repos/spack_repo/builtin/packages/py_gosam/package.py
+++ b/repos/spack_repo/builtin/packages/py_gosam/package.py
@@ -40,6 +40,7 @@ class PyGosam(Package):
     depends_on("qgraf", type="run")
     depends_on("gosam-contrib", type="link")
     depends_on("python@3:", type=("build", "run"))
+    depends_on("py-setuptools", type="build", when="^python@3.12:")
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         gosam_contrib_lib_dir = self.spec["gosam-contrib"].prefix.lib

--- a/repos/spack_repo/builtin/packages/py_gosam/package.py
+++ b/repos/spack_repo/builtin/packages/py_gosam/package.py
@@ -40,7 +40,7 @@ class PyGosam(PythonPackage):
     depends_on("qgraf", type="run")
     depends_on("gosam-contrib", type="link")
     depends_on("python@3:", type=("build", "run"))
-    depends_on("py-setuptools", type="build", when="^python@3.12:")
+    depends_on("py-setuptools", type="build")
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         gosam_contrib_lib_dir = self.spec["gosam-contrib"].prefix.lib

--- a/repos/spack_repo/builtin/packages/py_gosam/package.py
+++ b/repos/spack_repo/builtin/packages/py_gosam/package.py
@@ -2,12 +2,12 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack_repo.builtin.build_systems.generic import Package
+from spack_repo.builtin.build_systems.python import PythonPackage
 
 from spack.package import *
 
 
-class PyGosam(Package):
+class PyGosam(PythonPackage):
     """The package GoSam allows for the automated calculation of
     one-loop amplitudes for multi-particle processes in renormalizable
     quantum field theories."""
@@ -45,7 +45,3 @@ class PyGosam(Package):
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         gosam_contrib_lib_dir = self.spec["gosam-contrib"].prefix.lib
         env.prepend_path("LD_LIBRARY_PATH", gosam_contrib_lib_dir)
-
-    def install(self, spec, prefix):
-        python("-s", "setup.py", "--no-user-cfg", "build")
-        python("-s", "setup.py", "--no-user-cfg", "install", "--prefix=" + prefix)


### PR DESCRIPTION
By default this builds with distutils, but that has been removed in python 3.12. If that doesn't work it falls back to setuptools, but that needs to be in the build dependencies for that to work.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Without these changes, I run into the following build error:

```
==> py-gosam: Executing phase: 'install'
==> [2025-08-29-21:18:05.277776] '/home/madlener/work/.spack/spackages/skylake-ubuntu24.04-nonenone/python-venv/1.0-hkozj5/bin/python3' '-s' 'setup.py' '--no-user-cfg' 'build'
Traceback (most recent call last):
  File "/home/madlener/work/.spack/spack-stage/spack-stage-py-gosam-2.1.2-oxngbfo426op5vg3knokjv3oht4gmemp/spack-src/setup.py", line 5, in <module>
    from distutils.core import setup
ModuleNotFoundError: No module named 'distutils'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/madlener/work/.spack/spack-stage/spack-stage-py-gosam-2.1.2-oxngbfo426op5vg3knokjv3oht4gmemp/spack-src/setup.py", line 14, in <module>
    from setuptools import setup
ModuleNotFoundError: No module named 'setuptools'
```