### PR TITLE
oneapi: only download resources for variants when variant enabled

### DIFF
--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
@@ -431,7 +431,7 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
             resource(
                 name="nvidia-plugin-installer",
                 placement="nvidia-plugin-installer",
-                when="@{0}".format(v["version"]),
+                when="@{0}+nvidia".format(v["version"]),
                 expand=False,
                 **v["nvidia-plugin"],
             )
@@ -439,7 +439,7 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
             resource(
                 name="amd-plugin-installer",
                 placement="amd-plugin-installer",
-                when="@{0}".format(v["version"]),
+                when="@{0}+amd".format(v["version"]),
                 expand=False,
                 **v["amd-plugin"],
             )


### PR DESCRIPTION
Currently, `intel-oneapi-compilers` unconditionally requires resources for the nvidia and amd plugins, despite the fact that those are variants on the package.

This PR fixes this by making the resource specifications conditional on the variants.