### PR TITLE
Fix build error with `rdkit@2022_09_5` and python>=3.12

### DIFF
--- a/repos/spack_repo/builtin/packages/rdkit/package.py
+++ b/repos/spack_repo/builtin/packages/rdkit/package.py
@@ -73,7 +73,7 @@ class Rdkit(CMakePackage):
         depends_on("coordgen", when="+coordgen")
         depends_on("maeparser", when="+maeparser")
         depends_on("eigen@3:", when="+descriptors3d")
-        depends_on("python@3.11:", when="+python")
+        depends_on("python@:3.11", when="+python")
         depends_on("py-numpy", when="+python")
         # https://github.com/rdkit/rdkit/issues/7477
         depends_on("py-numpy@:1", when="@:2024.03.3+python")

--- a/repos/spack_repo/builtin/packages/rdkit/package.py
+++ b/repos/spack_repo/builtin/packages/rdkit/package.py
@@ -73,7 +73,7 @@ class Rdkit(CMakePackage):
         depends_on("coordgen", when="+coordgen")
         depends_on("maeparser", when="+maeparser")
         depends_on("eigen@3:", when="+descriptors3d")
-        depends_on("python@3:", when="+python")
+        depends_on("python@3.11:", when="+python")
         depends_on("py-numpy", when="+python")
         # https://github.com/rdkit/rdkit/issues/7477
         depends_on("py-numpy@:1", when="@:2024.03.3+python")
@@ -82,7 +82,7 @@ class Rdkit(CMakePackage):
 
         conflicts("+xyz2mol", when="~yaehmop", msg="XY2MOL requires YAeHMOP")
 
-    depends_on("boost@1.53.0: +python +serialization +iostreams +system")
+    depends_on("boost@1.53.0: +python +serialization +iostreams +system +numeric_conversion")
     depends_on("sqlite")
     depends_on("freetype", when="@2020_09_1: +freetype")
 

--- a/repos/spack_repo/builtin/packages/rdkit/package.py
+++ b/repos/spack_repo/builtin/packages/rdkit/package.py
@@ -82,7 +82,7 @@ class Rdkit(CMakePackage):
 
         conflicts("+xyz2mol", when="~yaehmop", msg="XY2MOL requires YAeHMOP")
 
-    depends_on("boost@1.53.0: +python +serialization +iostreams +system +numeric_conversion")
+    depends_on("boost@1.53.0: +python +serialization +iostreams +system +conversion")
     depends_on("sqlite")
     depends_on("freetype", when="@2020_09_1: +freetype")
 

--- a/repos/spack_repo/builtin/packages/shellcheck/package.py
+++ b/repos/spack_repo/builtin/packages/shellcheck/package.py
@@ -28,7 +28,7 @@ _versions = {
         "linux-armv6hf": "8afc50b302d5feeac9381ea114d563f0150d061520042b254d6eb715797c8223",
         "linux-riscv64": "693c987777e7b524dd311d9b8c704885a39c889c9804bb1ef1fd29b48567b0b3",
         "linux-x86_64": "8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198",
-    }
+    },
 }
 
 

--- a/repos/spack_repo/builtin/packages/shellcheck/package.py
+++ b/repos/spack_repo/builtin/packages/shellcheck/package.py
@@ -14,6 +14,20 @@ _versions = {
         "linux-aarch64": "179c579ef3481317d130adebede74a34dbbc2df961a70916dd4039ebf0735fae",
         "linux-armv6hf": "03deed9ded9dd66434ccf9649815bcde7d275d6c9f6dcf665b83391673512c75",
         "linux-x86_64": "700324c6dd0ebea0117591c6cc9d7350d9c7c5c287acbad7630fa17b1d4d9e2f",
+    },
+    "0.10.0": {
+        "darwin-aarch64": "bbd2f14826328eee7679da7221f2bc3afb011f6a928b848c80c321f6046ddf81",
+        "linux-aarch64": "324a7e89de8fa2aed0d0c28f3dab59cf84c6d74264022c00c22af665ed1a09bb",
+        "linux-armv6hf": "1c89cb51e1412b580d7ba8aac240251ffb0b829788f83d2daa4a82da42d275e4",
+        "linux-riscv64": "be1f2028951783424c7a5dc744ac0bab8d5b181189e80f640cc56f481f1e371e",
+        "linux-x86_64": "6c881ab0698e4e6ea235245f22832860544f17ba386442fe7e9d629f8cbedf87",
+    },
+    "0.11.0": {
+        "darwin-aarch64": "56affdd8de5527894dca6dc3d7e0a99a873b0f004d7aabc30ae407d3f48b0a79",
+        "linux-aarch64": "12b331c1d2db6b9eb13cfca64306b1b157a86eb69db83023e261eaa7e7c14588",
+        "linux-armv6hf": "8afc50b302d5feeac9381ea114d563f0150d061520042b254d6eb715797c8223",
+        "linux-riscv64": "693c987777e7b524dd311d9b8c704885a39c889c9804bb1ef1fd29b48567b0b3",
+        "linux-x86_64": "8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198",
     }
 }
 


### PR DESCRIPTION
When building rdkit with `rdkit@2022_09_5 ~freetype` and python 3.12 or 3.13, this error pops up.
```
2 errors found in build log:
     70     This warning is for project developers.  Use -Wno-dev to suppress it.
     71     
     72     Traceback (most recent call last):
     73       File "<string>", line 1, in <module>
     74     ModuleNotFoundError: No module named 'distutils'
     75     Python Install directory
  >> 76     CMake Error at CMakeLists.txt:341 (install):
     77       install DIRECTORY given no DESTINATION!
     78     
     79     
     80     Traceback (most recent call last):
     81       File "<string>", line 1, in <module>
     82     ModuleNotFoundError: No module named 'distutils'
```

By forcing the python version with `rdkit@2022_09_5 ~freetype ^python@:3.11` the error disappears. So, the first fix of this PR is to add 3.11 as maximum version when installing rdkit 2022_09_5.

The second fix is about specifying correctly what boost libraries are needed, in particular `conversion` which I added in [this pending PR](https://github.com/spack/spack-packages/pull/1253).

@RMeli @bvanessen 

EDIT: added maintainers.