### PR TITLE
Add m4 as build-time dependency for flint (required by configure)

### DIFF
--- a/repos/spack_repo/builtin/packages/flint/package.py
+++ b/repos/spack_repo/builtin/packages/flint/package.py
@@ -36,6 +36,8 @@ class Flint(AutotoolsPackage):
     depends_on("gmp")  # mpir is a drop-in replacement for this
     depends_on("mpfr")  # Could also be built against mpir
 
+    depends_on("m4", type="build")
+
     def configure_args(self):
         spec = self.spec
         return [f"--with-gmp={spec['gmp'].prefix}", f"--with-mpfr={spec['mpfr'].prefix}"]


### PR DESCRIPTION
Currently, the flint build fails with the following error:

```
  >> 133    checking for suitable m4... configure: error: No usable m4 in $PA
            TH or /usr/5bin (see config.log for reasons).
```

Adding m4 as a build dependency fixes the issue.