### PR TITLE
fplll: Add C compiler as a dependency (otherwise configure fails)

### DIFF
--- a/repos/spack_repo/builtin/packages/fplll/package.py
+++ b/repos/spack_repo/builtin/packages/fplll/package.py
@@ -17,6 +17,7 @@ class Fplll(AutotoolsPackage):
 
     license("LGPL-2.1-or-later")
 
+    version("5.5.0", sha256="f0af6bdd0ebd5871e87ff3ef7737cb5360b1e38181a4e5a8c1236f3476fec3b2")
     version("5.4.4", sha256="0fd9d378f04ff886d8864728baf5d90b8b0b82c1e541e92550644fb54f75691d")
     version("5.4.1", sha256="7bd887957173aa592091772c1c36f6aa606b3b2ace0d14e2c26c7463dcf2deb7")
     version("5.4.0", sha256="fe192a65a56439b098e26e3b7ee224dda7c2c73a58f36ef2cc6f9185ae8c482b")
@@ -29,6 +30,7 @@ class Fplll(AutotoolsPackage):
     version("5.1.0", sha256="58175c54cc92752576a64361c73e4ea7797fc18fb703b3f22c7570a09075486f")
     version("5.0.3", sha256="d2b11b7dcb26c30ac1aab9ff75aca9b3dd6e0b0b40c382af16017a717dfe05c2")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     depends_on("gmp")

--- a/repos/spack_repo/builtin/packages/fplll/package.py
+++ b/repos/spack_repo/builtin/packages/fplll/package.py
@@ -31,7 +31,7 @@ class Fplll(AutotoolsPackage):
     version("5.0.3", sha256="d2b11b7dcb26c30ac1aab9ff75aca9b3dd6e0b0b40c382af16017a717dfe05c2")
 
     depends_on("c", type="build")
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
 
     depends_on("gmp")
     depends_on("mpfr")


### PR DESCRIPTION
Without this dependency, we get (from `config.log`):

```
configure:4631: checking whether the C compiler works
configure:4653: gcc    conftest.c  >&5
[spack cc]: Error: SPACK_CC_* variables not set: this usually means a missing `depends_on("c", type="build")` in package.py
configure:4657: $? = 1
configure:4697: result: no
```

Also add latest version (5.5.0).
