### PR TITLE
(py-)fenics-dolfinx: build and dependency updates

### DIFF
--- a/repos/spack_repo/builtin/packages/fenics_dolfinx/package.py
+++ b/repos/spack_repo/builtin/packages/fenics_dolfinx/package.py
@@ -23,6 +23,14 @@ class FenicsDolfinx(CMakePackage):
     version("0.7.2", sha256="7d9ce1338ce66580593b376327f23ac464a4ce89ef63c105efc1a38e5eae5c0b")
     version("0.6.0", sha256="eb8ac2bb2f032b0d393977993e1ab6b4101a84d54023a67206e3eac1a8d79b80")
 
+    # CMake build types
+    variant(
+        "build_type",
+        default="RelWithDebInfo",
+        description="CMake build type",
+        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel", "Developer"),
+    )
+
     # Graph partitioner variants
     variant(
         "partitioners",
@@ -32,7 +40,7 @@ class FenicsDolfinx(CMakePackage):
         multi=True,
     )
 
-    depends_on("c", type="build")  # HDF5 dependency requires C in CMake
+    depends_on("c", type="build")  # HDF5 dependency requires C in CMake config
     depends_on("cxx", type="build")
 
     # Graph partitioner dependencies
@@ -61,21 +69,11 @@ class FenicsDolfinx(CMakePackage):
 
     depends_on("adios2@2.8.1:+mpi", when="@0.9: +adios2")
     depends_on("adios2+mpi", when="+adios2")
-
-    depends_on("fenics-ufcx@main", when="@main")
-    depends_on("fenics-ufcx@0.9", when="@0.9")
-    depends_on("fenics-ufcx@0.8", when="@0.8")
-    depends_on("fenics-ufcx@0.7", when="@0.7")
-    depends_on("fenics-ufcx@0.6", when="@0.6")
-
-    depends_on("fenics-basix@main", when="@main")
-    depends_on("fenics-basix@0.9", when="@0.9")
-    depends_on("fenics-basix@0.8", when="@0.8")
-    depends_on("fenics-basix@0.7", when="@0.7")
-    depends_on("fenics-basix@0.6", when="@0.6")
-
-    conflicts("%gcc@:9.10", msg="fenics-dolfinx requires GCC-10 or newer for C++20 support")
-    conflicts("%clang@:9.10", msg="fenics-dolfinx requires Clang-10 or newer for C++20 support")
+    for ver in ("main", "0.9", "0.8", "0.7", "0.6"):
+        depends_on(f"fenics-ufcx@{ver}", when=f"@{ver}")
+        depends_on(f"fenics-basix@{ver}", when=f"@{ver}")
+        depends_on(f"py-fenics-ffcx@{ver}", when=f"@{ver}", type="test")
+    depends_on("catch2", type="test")
 
     root_cmakelists_dir = "cpp"
 

--- a/repos/spack_repo/builtin/packages/py_fenics_dolfinx/package.py
+++ b/repos/spack_repo/builtin/packages/py_fenics_dolfinx/package.py
@@ -24,9 +24,22 @@ class PyFenicsDolfinx(PythonPackage):
     version("0.7.2", sha256="7d9ce1338ce66580593b376327f23ac464a4ce89ef63c105efc1a38e5eae5c0b")
     version("0.6.0", sha256="eb8ac2bb2f032b0d393977993e1ab6b4101a84d54023a67206e3eac1a8d79b80")
 
+    # CMake build type
+    variant(
+        "build_type",
+        default="RelWithDebInfo",
+        description="CMake build type",
+        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel", "Developer"),
+    )
+
     variant("petsc4py", default=False, description="petsc4py support")
     variant("slepc4py", default=False, description="slepc4py support")
 
+    # py-fenics-dolfinx does not require a C compiler, but does depend
+    # on DOLFINXConfig.cmake which in turn includes hdf5-config.cmake.
+    # When HDF5 has MPI support, hdf5-config.cmake calls
+    # enable_language(c).
+    depends_on("c", type="build")
     depends_on("cxx", type="build")
 
     depends_on("cmake@3.21:", when="@0.9:", type="build")
@@ -38,33 +51,24 @@ class PyFenicsDolfinx(PythonPackage):
     depends_on("python@3.8:", when="@0.7", type=("build", "run"))
     depends_on("python@3.8:3.10", when="@0.6.0", type=("build", "run"))
 
-    depends_on("fenics-dolfinx@main", when="@main")
-    depends_on("fenics-dolfinx@0.9.0", when="@0.9.0")
-    depends_on("fenics-dolfinx@0.8.0", when="@0.8.0")
-    depends_on("fenics-dolfinx@0.7.2", when="@0.7.2")
-    depends_on("fenics-dolfinx@0.6.0", when="@0.6.0")
+    for ver in ["main", "0.9.0", "0.8.0", "0.7.2", "0.6.0"]:
+        depends_on(f"fenics-dolfinx@{ver}", when=f"@{ver}")
 
-    depends_on("py-fenics-basix@main", type=("build", "run"), when="@main")
-    depends_on("py-fenics-basix@0.9", type=("build", "link"), when="@0.9")
-    depends_on("py-fenics-basix@0.8", type=("build", "link"), when="@0.8")
+    for ver in ["main", "0.9", "0.8"]:
+        depends_on(f"py-fenics-basix@{ver}", type=("build", "run"), when=f"@{ver}")
 
-    depends_on("fenics-basix@main", type=("build", "link"), when="@main")
-    depends_on("fenics-basix@0.9", type=("build", "link"), when="@0.9")
-    depends_on("fenics-basix@0.8", type=("build", "link"), when="@0.8")
-    depends_on("fenics-basix@0.7", type=("build", "link"), when="@0.7")
-    depends_on("fenics-basix@0.6", type=("build", "link"), when="@0.6")
+    for ver in ["main", "0.9", "0.8", "0.7", "0.6"]:
+        depends_on(f"fenics-basix@{ver}", type=("build", "link"), when=f"@{ver}")
+        depends_on(f"py-fenics-ffcx@{ver}", type=("build", "link"), when=f"@{ver}")
 
-    depends_on("py-fenics-ffcx@main", type=("build", "run"), when="@main")
-    depends_on("py-fenics-ffcx@0.9", type=("build", "run"), when="@0.9")
-    depends_on("py-fenics-ffcx@0.8", type=("build", "run"), when="@0.8")
-    depends_on("py-fenics-ffcx@0.7", type=("build", "run"), when="@0.7")
-    depends_on("py-fenics-ffcx@0.6", type=("build", "run"), when="@0.6")
-
-    depends_on("py-fenics-ufl@main", type=("build", "run"), when="@main")
-    depends_on("py-fenics-ufl@2024.2", type=("build", "run"), when="@0.9")
-    depends_on("py-fenics-ufl@2024.1", type=("build", "run"), when="@0.8")
-    depends_on("py-fenics-ufl@2023.2", type=("build", "run"), when="@0.7")
-    depends_on("py-fenics-ufl@2023.1", type=("build", "run"), when="@0.6")
+    for ufl_ver, ver in [
+        ("main", "main"),
+        ("2024.2", "0.9"),
+        ("2024.1", "0.8"),
+        ("2023.2", "0.7"),
+        ("2023.1", "0.6"),
+    ]:
+        depends_on(f"py-fenics-ufl@{ufl_ver}", type=("build", "run"), when=f"@{ver}")
 
     depends_on("py-numpy@1.21:", type=("build", "run"))
     depends_on("py-mpi4py", type=("build", "run"))
@@ -86,5 +90,11 @@ class PyFenicsDolfinx(PythonPackage):
 
     depends_on("py-pybind11@2.7.0:", when="@:0.7", type=("build", "run"))
     depends_on("py-setuptools@42:", when="@:0.7", type="build")
+
+    def config_settings(self, spec, prefix):
+        return {
+            "build.tool-args": f"-j{make_jobs}",
+            "cmake.build-type": spec.variants["build_type"].value,
+        }
 
     build_directory = "python"

--- a/repos/spack_repo/builtin/packages/py_fenics_dolfinx/package.py
+++ b/repos/spack_repo/builtin/packages/py_fenics_dolfinx/package.py
@@ -94,6 +94,7 @@ class PyFenicsDolfinx(PythonPackage):
     def config_settings(self, spec, prefix):
         return {
             "build.tool-args": f"-j{make_jobs}",
+            "build.verbose": "true",
             "cmake.build-type": spec.variants["build_type"].value,
         }
 

--- a/repos/spack_repo/builtin/packages/py_pyamg/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyamg/package.py
@@ -31,7 +31,6 @@ class PyPyamg(PythonPackage):
     depends_on("py-setuptools@42:", type="build", when="@4.2.0:")
     # Later version required due to
     # https://github.com/pypa/setuptools_scm/issues/758
-    # depends_on("py-setuptools-scm@8.3.0+toml", type="build", when="@5.3.0:")
     depends_on("py-setuptools-scm@7.1:+toml", type="build", when="@5.0.0:")
     depends_on("py-setuptools-scm@5:+toml", type="build", when="@4.2.0:")
     depends_on("py-pybind11@2.8.0:", type=("build", "link"), when="@4.2.0:")

--- a/repos/spack_repo/builtin/packages/py_pyamg/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyamg/package.py
@@ -18,6 +18,7 @@ class PyPyamg(PythonPackage):
 
     license("MIT")
 
+    version("5.3.0", sha256="c83e745f93e60a3fc1598ca6369049387403be1db4f6ac887866259c853f6364")
     version("5.0.0", sha256="088be4b38203e708905fa45295593c1336b127a28391486d4f5917cf0b96f5f2")
     version("4.2.3", sha256="dcf23808e0e8edf177fc4f71a6b36e0823ffb117137a33a9eee14b391ddbb733")
     version("4.1.0", sha256="9e340aef5da11280a1e28f28deeaac390f408e38ee0357d0fdbb77503747bbc4")
@@ -26,9 +27,11 @@ class PyPyamg(PythonPackage):
     depends_on("python", type=("build", "link", "run"))
     depends_on("py-numpy@1.7:", type=("build", "run"))
     depends_on("py-scipy@0.12:", type=("build", "run"))
+    depends_on("py-scipy@0.12:1.15", type=("build", "run"), when="@:5.2")
     depends_on("py-setuptools@42:", type="build", when="@4.2.0:")
     # Later version required due to
     # https://github.com/pypa/setuptools_scm/issues/758
+    # depends_on("py-setuptools-scm@8.3.0+toml", type="build", when="@5.3.0:")
     depends_on("py-setuptools-scm@7.1:+toml", type="build", when="@5.0.0:")
     depends_on("py-setuptools-scm@5:+toml", type="build", when="@4.2.0:")
     depends_on("py-pybind11@2.8.0:", type=("build", "link"), when="@4.2.0:")

--- a/repos/spack_repo/builtin/packages/py_pyamg/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyamg/package.py
@@ -18,7 +18,6 @@ class PyPyamg(PythonPackage):
 
     license("MIT")
 
-    version("5.3.0", sha256="c83e745f93e60a3fc1598ca6369049387403be1db4f6ac887866259c853f6364")
     version("5.0.0", sha256="088be4b38203e708905fa45295593c1336b127a28391486d4f5917cf0b96f5f2")
     version("4.2.3", sha256="dcf23808e0e8edf177fc4f71a6b36e0823ffb117137a33a9eee14b391ddbb733")
     version("4.1.0", sha256="9e340aef5da11280a1e28f28deeaac390f408e38ee0357d0fdbb77503747bbc4")
@@ -27,7 +26,6 @@ class PyPyamg(PythonPackage):
     depends_on("python", type=("build", "link", "run"))
     depends_on("py-numpy@1.7:", type=("build", "run"))
     depends_on("py-scipy@0.12:", type=("build", "run"))
-    depends_on("py-scipy@0.12:1.15", type=("build", "run"), when="@:5.2")
     depends_on("py-setuptools@42:", type="build", when="@4.2.0:")
     # Later version required due to
     # https://github.com/pypa/setuptools_scm/issues/758


### PR DESCRIPTION
- Add dependency on C compiler to py-fenics-dolfinx. This is because HDF5 and ADIOS2 use a C compiler in their CMake config files. Fixes a configure stage failure.
- Expose custom (py)-fenics-dolfinx CMake build type variants.
- Parallel build of py-fenics-dolfinx using `make_jobs` processes.
- Verbose build of C++ bindings for py-fenics-dolfinx.
