### PR TITLE
(py-)-fenics-*: build updates

### DIFF
--- a/repos/spack_repo/builtin/packages/fenics_basix/package.py
+++ b/repos/spack_repo/builtin/packages/fenics_basix/package.py
@@ -17,13 +17,20 @@ class FenicsBasix(CMakePackage):
 
     license("MIT")
 
-    version("main", branch="main")
+    version("main", branch="main", no_cache=True)
     version("0.9.0", sha256="60e96b2393084729b261cb10370f0e44d12735ab3dbd1f15890dec23b9e85329")
     version("0.8.0", sha256="b299af82daf8fa3e4845e17f202491fe71b313bf6ab64c767a5287190b3dd7fe")
     version("0.7.0", sha256="9bee81b396ee452eec8d9735f278cb44cb6994c6bc30aec8ed9bb4b12d83fa7f")
     version("0.6.0", sha256="687ae53153c98facac4080dcdc7081701db1dcea8c5e7ae3feb72aec17f83304")
 
-    depends_on("cxx", type="build")  # generated
+    variant(
+        "build_type",
+        default="RelWithDebInfo",
+        description="CMake build type",
+        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel", "Developer"),
+    )
+
+    depends_on("cxx", type="build")
 
     depends_on("cmake@3.21:", when="@0.9:", type="build")
     depends_on("cmake@3.19:", when="@:0.8", type="build")

--- a/repos/spack_repo/builtin/packages/fenics_ufcx/package.py
+++ b/repos/spack_repo/builtin/packages/fenics_ufcx/package.py
@@ -19,7 +19,7 @@ class FenicsUfcx(CMakePackage):
 
     license("LGPL-3.0-or-later")
 
-    version("main", branch="main")
+    version("main", branch="main", no_cache=True)
     version("0.9.0", sha256="afa517272a3d2249f513cb711c50b77cf8368dd0b8f5ea4b759142229204a448")
     version("0.8.0", sha256="8a854782dbd119ec1c23c4522a2134d5281e7f1bd2f37d64489f75da055282e3")
     version("0.7.0", sha256="7f3c3ca91d63ce7831d37799cc19d0551bdcd275bdfa4c099711679533dd1c71")

--- a/repos/spack_repo/builtin/packages/py_fenics_basix/package.py
+++ b/repos/spack_repo/builtin/packages/py_fenics_basix/package.py
@@ -45,6 +45,9 @@ class PyFenicsBasix(PythonPackage):
     depends_on("py-scikit-build-core+pyproject@0.5.0:", when="@0.8:0.9", type="build")
 
     def config_settings(self, spec, prefix):
-        return {"build.tool-args": f"-j{make_jobs}"}
+        return {
+            "build.tool-args": f"-j{make_jobs}",
+            "build.verbose": "true",
+        }
 
     build_directory = "python"

--- a/repos/spack_repo/builtin/packages/py_fenics_basix/package.py
+++ b/repos/spack_repo/builtin/packages/py_fenics_basix/package.py
@@ -17,19 +17,16 @@ class PyFenicsBasix(PythonPackage):
 
     license("MIT")
 
-    version("main", branch="main")
+    version("main", branch="main", no_cache=True)
     version("0.9.0", sha256="60e96b2393084729b261cb10370f0e44d12735ab3dbd1f15890dec23b9e85329")
     version("0.8.0", sha256="b299af82daf8fa3e4845e17f202491fe71b313bf6ab64c767a5287190b3dd7fe")
     version("0.7.0", sha256="9bee81b396ee452eec8d9735f278cb44cb6994c6bc30aec8ed9bb4b12d83fa7f")
     version("0.6.0", sha256="687ae53153c98facac4080dcdc7081701db1dcea8c5e7ae3feb72aec17f83304")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
 
-    depends_on("fenics-basix@main", type=("build", "run"), when="@main")
-    depends_on("fenics-basix@0.9.0", type=("build", "run"), when="@0.9.0")
-    depends_on("fenics-basix@0.8.0", type=("build", "run"), when="@0.8.0")
-    depends_on("fenics-basix@0.7.0", type=("build", "run"), when="@0.7.0")
-    depends_on("fenics-basix@0.6.0", type=("build", "run"), when="@0.6.0")
+    for ver in ("main", "0.9.0", "0.8.0", "0.7.0", "0.6.0"):
+        depends_on(f"fenics-basix@{ver}", type=("build", "run"), when=f"@{ver}")
 
     # See python/CMakeLists.txt
     depends_on("cmake@3.21:", when="@0.9:", type="build")
@@ -46,5 +43,8 @@ class PyFenicsBasix(PythonPackage):
     depends_on("py-nanobind@1.6.0:", when="@0.8:0.9", type="build")
     depends_on("py-scikit-build-core+pyproject@0.10:", when="@0.10:", type="build")
     depends_on("py-scikit-build-core+pyproject@0.5.0:", when="@0.8:0.9", type="build")
+
+    def config_settings(self, spec, prefix):
+        return {"build.tool-args": f"-j{make_jobs}"}
 
     build_directory = "python"

--- a/repos/spack_repo/builtin/packages/py_fenics_basix/package.py
+++ b/repos/spack_repo/builtin/packages/py_fenics_basix/package.py
@@ -45,9 +45,6 @@ class PyFenicsBasix(PythonPackage):
     depends_on("py-scikit-build-core+pyproject@0.5.0:", when="@0.8:0.9", type="build")
 
     def config_settings(self, spec, prefix):
-        return {
-            "build.tool-args": f"-j{make_jobs}",
-            "build.verbose": "true",
-        }
+        return {"build.tool-args": f"-j{make_jobs}", "build.verbose": "true"}
 
     build_directory = "python"

--- a/repos/spack_repo/builtin/packages/py_fenics_ffcx/package.py
+++ b/repos/spack_repo/builtin/packages/py_fenics_ffcx/package.py
@@ -17,7 +17,7 @@ class PyFenicsFfcx(PythonPackage):
 
     license("LGPL-3.0-or-later")
 
-    version("main", branch="main")
+    version("main", branch="main", no_cache=True)
     version("0.9.0", sha256="afa517272a3d2249f513cb711c50b77cf8368dd0b8f5ea4b759142229204a448")
     version("0.8.0", sha256="8a854782dbd119ec1c23c4522a2134d5281e7f1bd2f37d64489f75da055282e3")
     version("0.7.0", sha256="7f3c3ca91d63ce7831d37799cc19d0551bdcd275bdfa4c099711679533dd1c71")

--- a/repos/spack_repo/builtin/packages/py_fenics_ufl/package.py
+++ b/repos/spack_repo/builtin/packages/py_fenics_ufl/package.py
@@ -21,7 +21,7 @@ class PyFenicsUfl(PythonPackage):
 
     license("LGPL-3.0-or-later")
 
-    version("main", branch="main")
+    version("main", branch="main", no_cache=True)
     version("2024.2.0", sha256="d9353d23ccbdd9887f8d6edab74c04fe06d818da972072081dbf0c25bc86f5a7")
     version(
         "2024.1.0.post1", sha256="6e38e93a2c8417271c9fb316e0d0ea5fe1101c6a37b2496fff8290e7ea7ead74"


### PR DESCRIPTION
- Expose custom CMake build type variants.
- Add support for parallel builds of the C++/Python binding code.
- Make builds of C++ code managed by scikit-core-build verbose.
- Refactor some tight dependencies into loops over versions.
