### PR TITLE
rocm: add missing rocm tags and improve external detection

### DIFF
--- a/repos/spack_repo/builtin/packages/aqlprofile/package.py
+++ b/repos/spack_repo/builtin/packages/aqlprofile/package.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import re
 
 from spack_repo.builtin.build_systems.generic import Package
 
@@ -270,7 +271,11 @@ class Aqlprofile(Package):
     Provides AQL packets helper methods for perfcounters (PMC) and SQ threadtraces (SQTT).
     """
 
+    tags = ["rocm"]
+
     maintainers("afzpatel", "srekolam", "renjithravindrankannath")
+
+    libraries = ["libhsa-amd-aqlprofile64"]
 
     spack_os = host_platform().default_os
     if "rhel" in spack_os or "centos" in spack_os:
@@ -322,6 +327,17 @@ class Aqlprofile(Package):
 
         install_tree(f"opt/rocm-{spec.version}/share/", prefix.share)
         install_tree(f"opt/rocm-{spec.version}/lib/", prefix.lib)
+
+    @classmethod
+    def determine_version(cls, lib):
+        match = re.search(r"lib\S*\.so\.\d+\.\d+\.(\d)(\d\d)(\d\d)", lib)
+        if match:
+            ver = "{0}.{1}.{2}".format(
+                int(match.group(1)), int(match.group(2)), int(match.group(3))
+            )
+        else:
+            ver = None
+        return ver
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         if not self.spec.external:

--- a/repos/spack_repo/builtin/packages/composable_kernel/package.py
+++ b/repos/spack_repo/builtin/packages/composable_kernel/package.py
@@ -16,6 +16,7 @@ class ComposableKernel(CMakePackage):
     homepage = "https://github.com/ROCm/composable_kernel"
     git = "https://github.com/ROCm/composable_kernel.git"
     url = "https://github.com/ROCm/composable_kernel/archive/refs/tags/rocm-6.4.3.tar.gz"
+    tags = ["rocm"]
     maintainers("srekolam", "afzpatel")
 
     license("MIT")

--- a/repos/spack_repo/builtin/packages/hip_tensor/package.py
+++ b/repos/spack_repo/builtin/packages/hip_tensor/package.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
+
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
@@ -15,6 +17,8 @@ class HipTensor(CMakePackage, ROCmPackage):
     git = "https://github.com/ROCm/hipTensor.git"
     url = "https://github.com/ROCm/hipTensor/archive/refs/tags/rocm-6.4.2.tar.gz"
     tags = ["rocm"]
+
+    libraries = ["libhiptensor"]
 
     maintainers("srekolam", "afzpatel")
 
@@ -65,6 +69,17 @@ class HipTensor(CMakePackage, ROCmPackage):
         depends_on(f"composable-kernel@{ver}", when=f"@{ver}")
         depends_on(f"rocm-cmake@{ver}", when=f"@{ver}")
         depends_on(f"hipcc@{ver}", when=f"@{ver}")
+
+    @classmethod
+    def determine_version(cls, lib):
+        match = re.search(r"lib\S*\.so\.\d+\.\d+\.(\d)(\d\d)(\d\d)", lib)
+        if match:
+            ver = "{0}.{1}.{2}".format(
+                int(match.group(1)), int(match.group(2)), int(match.group(3))
+            )
+        else:
+            ver = None
+        return ver
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("@6.1"):

--- a/repos/spack_repo/builtin/packages/hipblas_common/package.py
+++ b/repos/spack_repo/builtin/packages/hipblas_common/package.py
@@ -12,6 +12,7 @@ class HipblasCommon(CMakePackage):
 
     homepage = "https://github.com/ROCm/hipBLAS-common"
     url = "https://github.com/ROCm/hipBLAS-common/archive/refs/tags/rocm-6.3.0.tar.gz"
+    tags = ["rocm"]
 
     maintainers("srekolam", "renjithravindrankannath", "afzpatel")
 

--- a/repos/spack_repo/builtin/packages/hipblaslt/package.py
+++ b/repos/spack_repo/builtin/packages/hipblaslt/package.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
+
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
@@ -18,6 +20,7 @@ class Hipblaslt(CMakePackage):
 
     maintainers("srekolam", "afzpatel", "renjithravindrankannath")
     tags = ["rocm"]
+    libraries = ["libhipblaslt"]
 
     license("MIT")
     version("6.4.3", sha256="64252588faf8a9089838e8f427e911617916fd6905a8cc65370e8d25fafdf0e4")
@@ -139,6 +142,17 @@ class Hipblaslt(CMakePackage):
                 "tensilelite/Tensile/Ops/gen_assembly.sh",
                 string=True,
             )
+
+    @classmethod
+    def determine_version(cls, lib):
+        match = re.search(r"lib\S*\.so\.\d+\.\d+\.(\d)(\d\d)(\d\d)", lib)
+        if match:
+            ver = "{0}.{1}.{2}".format(
+                int(match.group(1)), int(match.group(2)), int(match.group(3))
+            )
+        else:
+            ver = None
+        return ver
 
     def cmake_args(self):
         args = [

--- a/repos/spack_repo/builtin/packages/hipcc/package.py
+++ b/repos/spack_repo/builtin/packages/hipcc/package.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 
@@ -23,6 +24,7 @@ class Hipcc(CMakePackage):
 
     maintainers("srekolam", "renjithravindrankannath", "afzpatel")
     tags = ["rocm"]
+    executables = ["hipcc"]
 
     license("MIT")
     version("6.4.3", sha256="7a484b621d568eef000ee8c4d2d46d589e5682b950f1f410ce7215031f1f3ad7")
@@ -60,6 +62,12 @@ class Hipcc(CMakePackage):
             return "."
         else:
             return join_path("amd", "hipcc")
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)("--version", output=str, error=str)
+        match = re.search(r"roc-(\S+)", output)
+        return match.group(1) if match else None
 
     def patch(self):
         numactl = self.spec["numactl"].prefix.lib

--- a/repos/spack_repo/builtin/packages/hipfft/package.py
+++ b/repos/spack_repo/builtin/packages/hipfft/package.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
@@ -21,6 +22,7 @@ class Hipfft(CMakePackage, CudaPackage, ROCmPackage):
     git = "https://github.com/ROCm/hipFFT.git"
     url = "https://github.com/ROCm/hipfft/archive/rocm-6.4.3.tar.gz"
     tags = ["rocm"]
+    libraries = ["libhipfft"]
 
     maintainers("renjithravindrankannath", "srekolam", "afzpatel")
 
@@ -96,6 +98,17 @@ class Hipfft(CMakePackage, CudaPackage, ROCmPackage):
         depends_on(f"rocfft amdgpu_target={tgt}", when=f"+rocm amdgpu_target={tgt}")
     # https://github.com/ROCm/rocFFT/pull/85)
     patch("001-remove-submodule-and-sync-shared-files-from-rocFFT.patch", when="@6.0.0")
+
+    @classmethod
+    def determine_version(cls, lib):
+        match = re.search(r"lib\S*\.so\.\d+\.\d+\.(\d)(\d\d)(\d\d)", lib)
+        if match:
+            ver = "{0}.{1}.{2}".format(
+                int(match.group(1)), int(match.group(2)), int(match.group(3))
+            )
+        else:
+            ver = None
+        return ver
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("+asan"):

--- a/repos/spack_repo/builtin/packages/hipify_clang/package.py
+++ b/repos/spack_repo/builtin/packages/hipify_clang/package.py
@@ -19,7 +19,7 @@ class HipifyClang(CMakePackage):
     tags = ["rocm"]
 
     maintainers("srekolam", "renjithravindrankannath", "afzpatel")
-    executables=["hipify-perl"]
+    executables = ["hipify-perl"]
 
     license("MIT")
 

--- a/repos/spack_repo/builtin/packages/hipify_clang/package.py
+++ b/repos/spack_repo/builtin/packages/hipify_clang/package.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
+
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
@@ -17,6 +19,7 @@ class HipifyClang(CMakePackage):
     tags = ["rocm"]
 
     maintainers("srekolam", "renjithravindrankannath", "afzpatel")
+    executables=["hipify-perl"]
 
     license("MIT")
 
@@ -74,6 +77,12 @@ class HipifyClang(CMakePackage):
     ]:
         depends_on(f"llvm-amdgpu@{ver}", when=f"@{ver}")
         depends_on(f"rocm-core@{ver}", when=f"@{ver}")
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)("--version", output=str, error=str)
+        match = re.search(r"HIP version (\S+)", output)
+        return match.group(1) if match else "None"
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         # The installer puts the binaries directly into the prefix

--- a/repos/spack_repo/builtin/packages/hipsparselt/package.py
+++ b/repos/spack_repo/builtin/packages/hipsparselt/package.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
@@ -19,8 +20,11 @@ class Hipsparselt(CMakePackage, ROCmPackage):
     homepage = "https://github.com/ROCm/hipsparselt"
     url = "https://github.com/ROCm/hipSPARSELt/archive/refs/tags/rocm-6.4.3.tar.gz"
     git = "https://github.com/ROCm/hipsparseLt.git"
+    tags = ["rocm"]
 
     maintainers("srekolam", "afzpatel", "renjithravindrankannath")
+
+    libraries = ["libhipsparselt"]
 
     license("MIT")
 
@@ -103,6 +107,17 @@ class Hipsparselt(CMakePackage, ROCmPackage):
     patch("0001-update-llvm-path-add-hipsparse-include-dir-for-spack-6.2.patch", when="@6.2")
     patch("0001-update-llvm-path-add-hipsparse-include-dir-for-spack-6.3.patch", when="@6.3")
     patch("0002-add-hipsparse-include.patch", when="@6.4")
+
+    @classmethod
+    def determine_version(cls, lib):
+        match = re.search(r"lib\S*\.so\.\d+\.\d+\.(\d)(\d\d)(\d\d)", lib)
+        if match:
+            ver = "{0}.{1}.{2}".format(
+                int(match.group(1)), int(match.group(2)), int(match.group(3))
+            )
+        else:
+            ver = None
+        return ver
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         env.set("CXX", self.spec["hip"].hipcc)

--- a/repos/spack_repo/builtin/packages/rocal/package.py
+++ b/repos/spack_repo/builtin/packages/rocal/package.py
@@ -13,7 +13,7 @@ class Rocal(CMakePackage):
 
     homepage = "https://github.com/ROCm/rocAL"
     url = "https://github.com/ROCm/rocAL/archive/refs/tags/rocm-6.4.3.tar.gz"
-    tag=["rocm"]
+    tag = ["rocm"]
 
     maintainers("afzpatel", "srekolam", "renjithravindrankannath")
 

--- a/repos/spack_repo/builtin/packages/rocal/package.py
+++ b/repos/spack_repo/builtin/packages/rocal/package.py
@@ -13,7 +13,7 @@ class Rocal(CMakePackage):
 
     homepage = "https://github.com/ROCm/rocAL"
     url = "https://github.com/ROCm/rocAL/archive/refs/tags/rocm-6.4.3.tar.gz"
-    tag = ["rocm"]
+    tags = ["rocm"]
 
     maintainers("afzpatel", "srekolam", "renjithravindrankannath")
 

--- a/repos/spack_repo/builtin/packages/rocal/package.py
+++ b/repos/spack_repo/builtin/packages/rocal/package.py
@@ -13,6 +13,7 @@ class Rocal(CMakePackage):
 
     homepage = "https://github.com/ROCm/rocAL"
     url = "https://github.com/ROCm/rocAL/archive/refs/tags/rocm-6.4.3.tar.gz"
+    tag=["rocm"]
 
     maintainers("afzpatel", "srekolam", "renjithravindrankannath")
 

--- a/repos/spack_repo/builtin/packages/rocalution/package.py
+++ b/repos/spack_repo/builtin/packages/rocalution/package.py
@@ -25,7 +25,7 @@ class Rocalution(CMakePackage):
     tags = ["rocm"]
 
     maintainers("cgmb", "srekolam", "renjithravindrankannath", "afzpatel")
-    libraries = ["librocalution_hip"]
+    libraries = ["librocalution"]
 
     license("MIT")
 

--- a/repos/spack_repo/builtin/packages/rocm_core/package.py
+++ b/repos/spack_repo/builtin/packages/rocm_core/package.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 
@@ -65,6 +66,17 @@ class RocmCore(CMakePackage):
         "6.4.3",
     ]:
         depends_on("llvm-amdgpu", when=f"@{ver}+asan")
+
+    @classmethod
+    def determine_version(cls, lib):
+        match = re.search(r"lib\S*\.so\.\d+\.\d+\.(\d)(\d\d)(\d\d)", lib)
+        if match:
+            ver = "{0}.{1}.{2}".format(
+                int(match.group(1)), int(match.group(2)), int(match.group(3))
+            )
+        else:
+            ver = None
+        return ver
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("+asan"):

--- a/repos/spack_repo/builtin/packages/rocm_gdb/package.py
+++ b/repos/spack_repo/builtin/packages/rocm_gdb/package.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 
@@ -15,6 +16,7 @@ class RocmGdb(AutotoolsPackage):
     homepage = "https://github.com/ROCm/ROCgdb"
     url = "https://github.com/ROCm/ROCgdb/archive/rocm-6.4.3.tar.gz"
     tags = ["rocm"]
+    executables = ["rocgdb"]
 
     license("LGPL-2.0-or-later")
 
@@ -108,3 +110,13 @@ class RocmGdb(AutotoolsPackage):
             "--disable-gprofng",
         ]
         return options
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)("--version", output=str, error=str)
+        match = re.search(r"rocm-rel-(\d+)\.(\d+)", output)
+        if match:
+            ver = "{0}.{1}".format(int(match.group(1)), int(match.group(2)))
+        else:
+            ver = None
+        return ver

--- a/repos/spack_repo/builtin/packages/rocm_opencl/package.py
+++ b/repos/spack_repo/builtin/packages/rocm_opencl/package.py
@@ -20,7 +20,7 @@ class RocmOpencl(CMakePackage):
     tags = ["rocm"]
 
     maintainers("srekolam", "renjithravindrankannath", "afzpatel")
-    libraries = ["libOpenCL"]
+    libraries = ["libamdocl64"]
 
     license("MIT")
 
@@ -123,7 +123,9 @@ class RocmOpencl(CMakePackage):
             return "{0}.{1}.{2}".format(
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
-        return None
+        else:
+            ver = None
+        return ver
 
     def cmake_args(self):
         args = ["-DUSE_COMGR_LIBRARY=yes", "-DBUILD_TESTS=ON"]

--- a/repos/spack_repo/builtin/packages/rocprofiler_systems/package.py
+++ b/repos/spack_repo/builtin/packages/rocprofiler_systems/package.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
+
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
@@ -13,6 +15,8 @@ class RocprofilerSystems(CMakePackage):
     homepage = "https://github.com/ROCm/rocprofiler-systems"
     git = "https://github.com/ROCm/rocprofiler-systems.git"
     url = "https://github.com/ROCm/rocprofiler-systems/archive/refs/tags/rocm-6.3.1.tar.gz"
+    executables = ["rocprof-sys-sample"]
+    tags = ["rocm"]
 
     maintainers("dgaliffiAMD", "afzpatel", "srekolam", "renjithravindrankannath")
 
@@ -218,6 +222,16 @@ class RocprofilerSystems(CMakePackage):
             if name == "ldflags":
                 flags.append("-lintl")
         return (flags, None, None)
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)("--version", output=str, error=str)
+        match = re.search(r"rocm: v(\d+)\.(\d+)", output)
+        if match:
+            ver = "{0}.{1}".format(int(match.group(1)), int(match.group(2)))
+        else:
+            ver = None
+        return ver
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if "+tau" in self.spec:

--- a/repos/spack_repo/builtin/packages/rocpydecode/package.py
+++ b/repos/spack_repo/builtin/packages/rocpydecode/package.py
@@ -13,6 +13,7 @@ class Rocpydecode(CMakePackage):
 
     homepage = "https://github.com/ROCm/rocPyDecode"
     url = "https://github.com/ROCm/rocPyDecode/archive/refs/tags/rocm-6.4.3.tar.gz"
+    tags = ["rocm"]
 
     maintainers("afzpatel", "srekolam", "renjithravindrankannath")
 

--- a/repos/spack_repo/builtin/packages/transferbench/package.py
+++ b/repos/spack_repo/builtin/packages/transferbench/package.py
@@ -15,6 +15,7 @@ class Transferbench(CMakePackage):
     url = "https://github.com/ROCm/TransferBench/archive/refs/tags/rocm-6.4.0.tar.gz"
 
     maintainers("afzpatel", "srekolam", "renjithravindrankannath")
+    tags = ["rocm"]
 
     license("MIT")
 


### PR DESCRIPTION
Add `rocm` tags wherever missing.
Add `determine_version` methods to various packages so they can be found externally.