### PR TITLE
ci: add spack-reviewers to add maintainers to PRs

### DIFF
--- a/.github/workflows/bin/spack-reviewers.py
+++ b/.github/workflows/bin/spack-reviewers.py
@@ -8,7 +8,7 @@ import subprocess
 
 import requests
 
-IS_PACKAGE = re.compile(r"repos/spack_repo/builtin/packages/([^/]+)/package.py$")
+IS_PACKAGE_CHANGE = re.compile(r"repos/spack_repo/builtin/packages/([^/]+)/.*$")
 
 
 def main():
@@ -29,7 +29,7 @@ def main():
     maintainers = set()
 
     for file in pull_request_files.json():
-        if match := IS_PACKAGE.match(file["filename"]):
+        if match := IS_PACKAGE_CHANGE.match(file["filename"]):
             package = match.group(1)
 
             # add maintainers from packages here
@@ -47,7 +47,9 @@ def main():
 
     added_reviewers = reviewers - existing_reviewers
     if added_reviewers:
-        print(f"[PR #{pr_number}]: adding reviewer(s): @{' @'.join(added_reviewers)}")
+        print(f"[PR #{pr_number}]: adding reviewer(s):")
+        for reviewer in sorted(added_reviewers):
+            print(f"    @{reviewer}")
 
     if token:
         resp = requests.post(

--- a/.github/workflows/bin/spack-reviewers.py
+++ b/.github/workflows/bin/spack-reviewers.py
@@ -42,12 +42,12 @@ def main():
     reviewers = (maintainers | existing_reviewers) - {author}
 
     if existing_reviewers == reviewers:
-        print(f"[PR #{pr_number}]: labels already up-to-date")
+        print(f"[PR #{pr_number}]: reviewers already up-to-date")
         return
 
     added_reviewers = reviewers - existing_reviewers
     if added_reviewers:
-        print(f"[PR #{pr_number}]: Adding reviewer(s): @{' @'.join(added_reviewers)}")
+        print(f"[PR #{pr_number}]: adding reviewer(s): @{' @'.join(added_reviewers)}")
 
     if token:
         resp = requests.post(

--- a/.github/workflows/bin/spack-reviewers.py
+++ b/.github/workflows/bin/spack-reviewers.py
@@ -51,9 +51,7 @@ def main():
 
     if token:
         resp = requests.post(
-            f"{base_url}/requested_reviewers",
-            json={"reviewers": list(reviewers)},
-            headers=headers,
+            f"{base_url}/requested_reviewers", json={"reviewers": list(reviewers)}, headers=headers
         )
         # https://docs.github.com/en/rest/pulls/review-requests
         # endpoint may return status code 422 for users who are not collaborators

--- a/.github/workflows/bin/spack-reviewers.py
+++ b/.github/workflows/bin/spack-reviewers.py
@@ -1,0 +1,66 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+import re
+import subprocess
+
+import requests
+
+IS_PACKAGE = re.compile(r"repos/spack_repo/builtin/packages/([^/]+)/package.py$")
+
+
+def main():
+    repository = os.environ["GH_REPO"]
+    pr_number = os.environ["GH_PR_NUMBER"]
+    token = os.environ["GH_TOKEN"]
+
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    base_url = f"https://api.github.com/repos/{repository}/pulls/{pr_number}"
+    pull_request = requests.get(base_url, headers=headers).json()
+
+    pull_request_files = requests.get(f"{base_url}/files", headers=headers)
+
+    existing_reviewers = {reviewer["login"] for reviewer in pull_request["requested_reviewers"]}
+    maintainers = set()
+
+    for file in pull_request_files.json():
+        if match := IS_PACKAGE.match(file["filename"]):
+            package = match.group(1)
+
+            # add maintainers from packages here
+            result = subprocess.run(
+                ["spack", "maintainers", package], capture_output=True, text=True, check=False
+            )
+            maintainers.update(result.stdout.split())
+
+    author = pull_request["user"]["login"]
+    reviewers = (maintainers | existing_reviewers) - {author}
+
+    if existing_reviewers == reviewers:
+        print(f"[PR #{pr_number}]: labels already up-to-date")
+        return
+
+    added_reviewers = reviewers - existing_reviewers
+    if added_reviewers:
+        print(f"[PR #{pr_number}]: Adding reviewer(s): @{' @'.join(added_reviewers)}")
+
+    if token:
+        resp = requests.post(
+            f"{base_url}/requested_reviewers",
+            json={"reviewers": list(reviewers)},
+            headers=headers,
+        )
+        # https://docs.github.com/en/rest/pulls/review-requests
+        # endpoint may return status code 422 for users who are not collaborators
+        # or have not accepted their invites to the organization yet
+        if resp.status_code != 422:
+            resp.raise_for_status()
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -24,11 +24,14 @@ jobs:
           ref: develop # DO NOT CHANGE
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: ./.github/actions/checkout-spack
 
       - name: Install Python dependencies
         run: pip install -r .github/workflows/requirements/triage/requirements.txt
 
-      - run: python3 .github/workflows/bin/spack-labeler.py
+      - run: |
+          python3 .github/workflows/bin/spack-labeler.py
+          python3 .github/workflows/bin/spack-reviewers.py
         env:
           GH_PR_NUMBER: ${{ github.event.number }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: Tag Maintainers on PR
         run: |
+          . spack-core/share/spack/setup-env.sh
           python3 .github/workflows/bin/spack-reviewers.py
         env:
           GH_PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -24,9 +24,7 @@ jobs:
           ref: develop # DO NOT CHANGE
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
-      - uses: spack/setup-spack@5ab3c91bdefffffad9a7e45d1d156146afebb3a7
-        with:
-          ref: develop # DO NOT CHANGE
+      - uses: ./.github/actions/checkout-spack
 
       - name: Install Python dependencies
         run: pip install -r .github/workflows/requirements/triage/requirements.txt

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -24,16 +24,26 @@ jobs:
           ref: develop # DO NOT CHANGE
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
-      - uses: ./.github/actions/checkout-spack
+      - uses: spack/setup-spack@5ab3c91bdefffffad9a7e45d1d156146afebb3a7
+        with:
+          ref: develop # DO NOT CHANGE
 
       - name: Install Python dependencies
         run: pip install -r .github/workflows/requirements/triage/requirements.txt
 
-      - run: |
+      - name: Label PR
+        run: |
           python3 .github/workflows/bin/spack-labeler.py
-          python3 .github/workflows/bin/spack-reviewers.py
         env:
           GH_PR_NUMBER: ${{ github.event.number }}
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           LABELS_CONFIG: .github/labels.yml
+
+      - name: Tag Maintainers on PR
+        run: |
+          python3 .github/workflows/bin/spack-reviewers.py
+        env:
+          GH_PR_NUMBER: ${{ github.event.number }}
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Building on the labeler work, this PR adds an extensible script to automatically add package maintainers as reviewers to pull requests. 

This PR is left very minimal to allow this to merge quickly before adding additional advanced functionality. 
(E.g. adding the users to the org on merge to develop, adding build system maintainers on `new-package` pull requests, etc...)