### PR TITLE
py-filelock: add v3.19.1 and py-hatch-vcs: add v0.5

### DIFF
--- a/repos/spack_repo/builtin/packages/py_filelock/package.py
+++ b/repos/spack_repo/builtin/packages/py_filelock/package.py
@@ -19,6 +19,7 @@ class PyFilelock(PythonPackage):
 
     license("Unlicense")
 
+    version("3.19.1", sha256="66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58")
     version("3.12.4", sha256="2e6f249f1f3654291606e046b09f1fd5eac39b360664c27f5aad072012f8bcbd")
     version("3.12.0", sha256="fc03ae43288c013d2ea83c8597001b1129db351aad9c57fe2409327916b8e718")
     version("3.8.0", sha256="55447caa666f2198c5b6b13a26d2084d26fa5b115c00d065664b2124680c4edc")
@@ -35,9 +36,12 @@ class PyFilelock(PythonPackage):
     version("2.0.9", sha256="0f91dce339c9f25d6f2e0733a17e4f9a47b139dffda52619a0e61e013e5c6782")
     version("2.0.8", sha256="7e48e4906de3c9a5d64d8f235eb3ae1050dfefa63fd65eaf318cc915c935212b")
 
+    depends_on("python@3.9:", when="@3.17:", type=("build", "run"))
     depends_on("python@3.8:", when="@3.12.3:", type=("build", "run"))
 
+    depends_on("py-hatch-vcs@0.5:", when="@3.19:", type="build")
     depends_on("py-hatch-vcs@0.3:", when="@3.8:", type="build")
+    depends_on("py-hatchling@1.27:", when="@3.17:", type="build")
     depends_on("py-hatchling@1.18:", when="@3.12.3:", type="build")
     depends_on("py-hatchling@1.14:", when="@3.8:", type="build")
 

--- a/repos/spack_repo/builtin/packages/py_hatch_vcs/package.py
+++ b/repos/spack_repo/builtin/packages/py_hatch_vcs/package.py
@@ -15,11 +15,13 @@ class PyHatchVcs(PythonPackage):
 
     license("MIT")
 
+    version("0.5.0", sha256="0395fa126940340215090c344a2bf4e2a77bcbe7daab16f41b37b98c95809ff9")
     version("0.4.0", sha256="093810748fe01db0d451fabcf2c1ac2688caefd232d4ede967090b1c1b07d9f7")
     version("0.3.0", sha256="cec5107cfce482c67f8bc96f18bbc320c9aa0d068180e14ad317bbee5a153fee")
     version("0.2.0", sha256="9913d733b34eec9bb0345d0626ca32165a4ad2de15d1ce643c36d09ca908abff")
 
-    depends_on("py-hatchling@1.24.2:", when="@0.4:", type=("build", "run"))
+    depends_on("python@3.9:", when="@0.5:", type=("build", "run"))
     depends_on("python@3.8:", when="@0.4:", type=("build", "run"))
     depends_on("py-hatchling@1.1:", when="@0.3:", type=("build", "run"))
+    depends_on("py-setuptools-scm@8.2.0:", when="@0.5:", type=("build", "run"))
     depends_on("py-setuptools-scm@6.4.0:", type=("build", "run"))


### PR DESCRIPTION
https://github.com/tox-dev/filelock/tree/3.19.1

`py-filelock` needs a newer version of `py-hatch-vcs`, so this updated as well.
`py-hatch-vcs` had a dependency to `py-hatchling@1.24.2:` in the recipe but no information where this came from. According to the [py-project.toml](https://github.com/ofek/hatch-vcs/blob/v0.5.0/pyproject.toml) it only depends on `py-hatchling@1.1`, so I removed the other one.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
