### PR TITLE
py-flask: add v3.1.2 and py-itsdangerous: add 2.2.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_flask/package.py
+++ b/repos/spack_repo/builtin/packages/py_flask/package.py
@@ -16,19 +16,27 @@ class PyFlask(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("3.1.2", sha256="bf656c15c80190ed628ad08cdfd3aaa35beb087855e2f494910aa3774cc4fd87")
     version("3.0.3", sha256="ceb27b0af3823ea2737928a4d99d125a06175b8512c445cbd9a9ce200ef76842")
     version("2.3.2", sha256="8c2f9abd47a9e8df7f0c3f091ce9497d011dc3b31effcf4c85a6e2b50f4114ef")
 
-    depends_on("py-setuptools", type=("build", "run"), when="@:2")
+    depends_on("python@3.9:", type=("build", "run"), when="@3.1:")
     depends_on("py-flit-core@:3", type=("build", "run"), when="@3:")
 
-    depends_on("py-werkzeug@3:", when="@3:", type=("build", "run"))
-    depends_on("py-werkzeug@2.3.3:", when="@2.3.2:", type=("build", "run"))
-    depends_on("py-jinja2@3.1.2:", when="@3:", type=("build", "run"))
-    depends_on("py-jinja2@3:", when="@2:", type=("build", "run"))
-    depends_on("py-itsdangerous@2.1.2:", when="@3:", type=("build", "run"))
-    depends_on("py-itsdangerous@2:", when="@2:", type=("build", "run"))
+    depends_on("py-blinker@1.9:", when="@3.1:", type=("build", "run"))
+    depends_on("py-blinker@1.6.2:", when="@2.3:", type=("build", "run"))
     depends_on("py-click@8.1.3:", when="@3:", type=("build", "run"))
     depends_on("py-click@8:", when="@2.1:", type=("build", "run"))
-    depends_on("py-blinker@1.6.2:", when="@2.3:", type=("build", "run"))
     depends_on("py-importlib-metadata@3.6:", when="@2.1: ^python@:3.9", type=("build", "run"))
+    depends_on("py-itsdangerous@2.2:", when="@3.1:", type=("build", "run"))
+    depends_on("py-itsdangerous@2.1.2:", when="@3:", type=("build", "run"))
+    depends_on("py-itsdangerous@2:", when="@2:", type=("build", "run"))
+    depends_on("py-jinja2@3.1.2:", when="@3:", type=("build", "run"))
+    depends_on("py-jinja2@3:", when="@2:", type=("build", "run"))
+    depends_on("py-markupsafe@2.1.1:", when="@3.1.1:", type=("build", "run"))
+    depends_on("py-werkzeug@3.1:", when="@3.1:", type=("build", "run"))
+    depends_on("py-werkzeug@3:", when="@3:", type=("build", "run"))
+    depends_on("py-werkzeug@2.3.3:", when="@2.3.2:", type=("build", "run"))
+
+    # Historical dependencies
+    depends_on("py-setuptools", type=("build", "run"), when="@:2")

--- a/repos/spack_repo/builtin/packages/py_itsdangerous/package.py
+++ b/repos/spack_repo/builtin/packages/py_itsdangerous/package.py
@@ -15,12 +15,17 @@ class PyItsdangerous(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("2.2.0", sha256="e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173")
     version("2.1.2", sha256="5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a")
     version("2.0.1", sha256="9e724d68fc22902a1435351f84c3fb8623f303fffcc566a4cb952df8c572cff0")
     version("1.1.0", sha256="321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19")
     version("0.24", sha256="cbb3fcf8d3e33df861709ecaf89d9e6629cff0a217bc2848f1b41cd30d360519")
 
+    depends_on("python@3.8:", when="@2.2:", type=("build", "run"))
     depends_on("python@3.7:", when="@2.1:", type=("build", "run"))
     depends_on("python@3.6:", when="@2:", type=("build", "run"))
     depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
+    depends_on("py-flit-core@:3", type="build")
+
+    # Historical dependencies
+    depends_on("py-setuptools", when="@:2.1", type="build")

--- a/repos/spack_repo/builtin/packages/py_itsdangerous/package.py
+++ b/repos/spack_repo/builtin/packages/py_itsdangerous/package.py
@@ -25,7 +25,7 @@ class PyItsdangerous(PythonPackage):
     depends_on("python@3.7:", when="@2.1:", type=("build", "run"))
     depends_on("python@3.6:", when="@2:", type=("build", "run"))
     depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
-    depends_on("py-flit-core@:3", type="build")
+    depends_on("py-flit-core@:3", when="@2.2:", type="build")
 
     # Historical dependencies
     depends_on("py-setuptools", when="@:2.1", type="build")


### PR DESCRIPTION
https://github.com/pallets/flask/tree/3.1.2
Reorder dependencies to match [pyproject.toml](https://github.com/pallets/flask/blob/3.1.2/pyproject.toml)

`py-flask` needs a newer version of `py-itsdangerous`, so this is updated as well
https://github.com/pallets/itsdangerous/tree/2.2.0

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
