### PR TITLE
amd-aocl: remove virtual providers

### DIFF
--- a/repos/spack_repo/builtin/packages/amd_aocl/package.py
+++ b/repos/spack_repo/builtin/packages/amd_aocl/package.py
@@ -40,13 +40,10 @@ class AmdAocl(BundlePackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
-    depends_on("scalapack")
-    depends_on("lapack")
-    depends_on("blas")
 
-    requires("^[virtuals=scalapack] amdscalapack")
-    requires("^[virtuals=lapack] amdlibflame")
-    requires("^[virtuals=blas] amdblis")
+    requires("amdscalapack")
+    requires("amdlibflame")
+    requires("amdblis")
 
     with when("+openmp"):
         depends_on("amdblis threads=openmp")


### PR DESCRIPTION
The amd-aocl package requests the virtual providers blas, lapack, and scalapack, but the providers are hard-coded to be satisfied by the amd implementations of these libraries.  If the provider is hard-coded to a specific package, then the virtual provider (e.g. "blas") shouldn't be used.  One reason to remove the virtuals is that is prevents the use of some other virtual provider for blas by other packages within a unified environment.