### PR TITLE
babeltrace: add elfutils dep

### DIFF
--- a/repos/spack_repo/builtin/packages/babeltrace/package.py
+++ b/repos/spack_repo/builtin/packages/babeltrace/package.py
@@ -26,3 +26,4 @@ class Babeltrace(AutotoolsPackage):
     depends_on("glib@2.22:", type=("build", "link"))
     depends_on("uuid")
     depends_on("popt")
+    depends_on("elfutils")


### PR DESCRIPTION
Configure would fail in my environment without elfutils (complains about missing libdw).