### PR TITLE
Revert "vtk: add v9.5.1 release"

### DIFF
--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -26,11 +26,11 @@ class Vtk(CMakePackage):
     license("BSD-3-Clause")
 
     version(
-        "9.5.1",
-        sha256="14443661c7b095d05b4e376fb3f40613f173e34fc9d4658234e9ec1d624a618f",
+        "9.5.0",
+        sha256="04ae86246b9557c6b61afbc534a6df099244fbc8f3937f82e6bc0570953af87d",
         preferred=True,
     )
-    version("9.5.0", sha256="04ae86246b9557c6b61afbc534a6df099244fbc8f3937f82e6bc0570953af87d")
+
     version("9.4.1", sha256="c253b0c8d002aaf98871c6d0cb76afc4936c301b72358a08d5f3f72ef8bc4529")
     version("9.3.1", sha256="8354ec084ea0d2dc3d23dbe4243823c4bfc270382d0ce8d658939fd50061cab8")
     version("9.2.6", sha256="06fc8d49c4e56f498c40fcb38a563ed8d4ec31358d0101e8988f0bb4d539dd12")


### PR DESCRIPTION
Reverts spack/spack-packages#1234 to attempt quick fix of [failing CI on develop](https://gitlab.spack.io/spack/spack-packages/-/jobs/17993003#L1000).