### PR TITLE
gettext: provide additional linking information

### DIFF
--- a/repos/spack_repo/builtin/packages/gettext/package.py
+++ b/repos/spack_repo/builtin/packages/gettext/package.py
@@ -170,10 +170,32 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
         )
         return libs
 
-    # gettext doesn't produce a pkg-config
     def setup_dependent_build_environment(self, env, dependent_spec):
-        env.append_flags(
-            "LDFLAGS",
-            "-L{0} ".format(dependent_spec["gettext"].prefix.lib)
-            + dependent_spec["gettext"].libs.link_flags,
-        )
+        # gettext doesn't produce a pkg-config, which means that static dependencies are not
+        # propagated to dependent packages
+
+        # either gettext is built static (~shared), in which case we gather all dependencies
+        # otherwise, we are building shared and only require static dependencies
+        if dependent_spec.satisfies("^gettext+shared"):
+            link_deps = dependent_spec["gettext"].dependencies(deptype="link")
+            for link_dep in link_deps:
+                if not (dependent_spec["gettext"].satisfies(fr"^{link_dep.name}+shared") or \
+                        dependent_spec["gettext"].satisfies(fr"^{link_dep.name} libs=shared")):
+                    env.append_flags(
+                        "LDFLAGS",
+                        "-L{0} ".format(dependent_spec[link_dep.name].prefix.lib)
+                        + dependent_spec[link_dep.name].libs.link_flags,
+                    )
+        else:
+            env.append_flags(
+                "LDFLAGS",
+                "-L{0} ".format(dependent_spec["gettext"].prefix.lib)
+                + dependent_spec["gettext"].libs.link_flags,
+            )
+            link_deps = dependent_spec["gettext"].dependencies(deptype="link")
+            for link_dep in link_deps:
+                env.append_flags(
+                    "LDFLAGS",
+                    "-L{0} ".format(dependent_spec[link_dep.name].prefix.lib)
+                    + dependent_spec[link_dep.name].libs.link_flags,
+                    )

--- a/repos/spack_repo/builtin/packages/gettext/package.py
+++ b/repos/spack_repo/builtin/packages/gettext/package.py
@@ -97,7 +97,10 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
     def flag_handler(self, name, flags):
         # this goes together with gl_cv_libxml_force_included=no
         if name == "ldflags" and self.spec.satisfies("+libxml2"):
-            flags.append("-lxml2")
+            flags.append(self.spec["libxml2"].libs.link_flags)
+        # gettext ignores libxml2's pkg-config
+        if name == "ldflags" and self.spec.satisfies("+libxml2^libxml2~shared"):
+            flags.append(self.spec["xz"].libs.link_flags)
         return (flags, None, None)
 
     @classmethod
@@ -166,3 +169,7 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
             shared=True if not shared_variant else shared_variant.value,
         )
         return libs
+
+    # gettext doesn't produce a pkg-config
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.append_flags("LDFLAGS", "-L{0} ".format(dependent_spec["gettext"].prefix.lib) + dependent_spec["gettext"].libs.link_flags)

--- a/repos/spack_repo/builtin/packages/gettext/package.py
+++ b/repos/spack_repo/builtin/packages/gettext/package.py
@@ -179,8 +179,10 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
         if dependent_spec.satisfies("^gettext+shared"):
             link_deps = dependent_spec["gettext"].dependencies(deptype="link")
             for link_dep in link_deps:
-                if not (dependent_spec["gettext"].satisfies(fr"^{link_dep.name}+shared") or \
-                        dependent_spec["gettext"].satisfies(fr"^{link_dep.name} libs=shared")):
+                if not (
+                    dependent_spec["gettext"].satisfies(rf"^{link_dep.name}+shared")
+                    or dependent_spec["gettext"].satisfies(rf"^{link_dep.name} libs=shared")
+                ):
                     env.append_flags(
                         "LDFLAGS",
                         "-L{0} ".format(dependent_spec[link_dep.name].prefix.lib)
@@ -198,4 +200,4 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
                     "LDFLAGS",
                     "-L{0} ".format(dependent_spec[link_dep.name].prefix.lib)
                     + dependent_spec[link_dep.name].libs.link_flags,
-                    )
+                )

--- a/repos/spack_repo/builtin/packages/gettext/package.py
+++ b/repos/spack_repo/builtin/packages/gettext/package.py
@@ -185,8 +185,8 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
                 ):
                     env.append_flags(
                         "LDFLAGS",
-                        "-L{0} ".format(dependent_spec[link_dep.name].prefix.lib)
-                        + dependent_spec[link_dep.name].libs.link_flags,
+                        "-L{0} ".format(dependent_spec["gettext"][link_dep.name].prefix.lib)
+                        + dependent_spec["gettext"][link_dep.name].libs.link_flags,
                     )
         else:
             env.append_flags(
@@ -198,6 +198,6 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
             for link_dep in link_deps:
                 env.append_flags(
                     "LDFLAGS",
-                    "-L{0} ".format(dependent_spec[link_dep.name].prefix.lib)
-                    + dependent_spec[link_dep.name].libs.link_flags,
+                    "-L{0} ".format(dependent_spec["gettext"][link_dep.name].prefix.lib)
+                    + dependent_spec["gettext"][link_dep.name].libs.link_flags,
                 )

--- a/repos/spack_repo/builtin/packages/gettext/package.py
+++ b/repos/spack_repo/builtin/packages/gettext/package.py
@@ -172,4 +172,8 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
 
     # gettext doesn't produce a pkg-config
     def setup_dependent_build_environment(self, env, dependent_spec):
-        env.append_flags("LDFLAGS", "-L{0} ".format(dependent_spec["gettext"].prefix.lib) + dependent_spec["gettext"].libs.link_flags)
+        env.append_flags(
+            "LDFLAGS",
+            "-L{0} ".format(dependent_spec["gettext"].prefix.lib)
+            + dependent_spec["gettext"].libs.link_flags,
+        )

--- a/repos/spack_repo/builtin/packages/libiconv/package.py
+++ b/repos/spack_repo/builtin/packages/libiconv/package.py
@@ -74,3 +74,7 @@ class Libiconv(AutotoolsPackage, GNUMirrorPackage):
     def libs(self):
         shared = self.spec.satisfies("libs=shared")
         return find_libraries(["libiconv"], root=self.prefix, recursive=True, shared=shared)
+
+    # libiconv doesn't produce a pkg-config
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.append_flags("LDFLAGS", "-L{0} ".format(dependent_spec["libiconv"].prefix.lib) + dependent_spec["libiconv"].libs.link_flags)

--- a/repos/spack_repo/builtin/packages/libiconv/package.py
+++ b/repos/spack_repo/builtin/packages/libiconv/package.py
@@ -74,11 +74,3 @@ class Libiconv(AutotoolsPackage, GNUMirrorPackage):
     def libs(self):
         shared = self.spec.satisfies("libs=shared")
         return find_libraries(["libiconv"], root=self.prefix, recursive=True, shared=shared)
-
-    # libiconv doesn't produce a pkg-config
-    def setup_dependent_build_environment(self, env, dependent_spec):
-        env.append_flags(
-            "LDFLAGS",
-            "-L{0} ".format(dependent_spec["libiconv"].prefix.lib)
-            + dependent_spec["libiconv"].libs.link_flags,
-        )

--- a/repos/spack_repo/builtin/packages/libiconv/package.py
+++ b/repos/spack_repo/builtin/packages/libiconv/package.py
@@ -77,4 +77,8 @@ class Libiconv(AutotoolsPackage, GNUMirrorPackage):
 
     # libiconv doesn't produce a pkg-config
     def setup_dependent_build_environment(self, env, dependent_spec):
-        env.append_flags("LDFLAGS", "-L{0} ".format(dependent_spec["libiconv"].prefix.lib) + dependent_spec["libiconv"].libs.link_flags)
+        env.append_flags(
+            "LDFLAGS",
+            "-L{0} ".format(dependent_spec["libiconv"].prefix.lib)
+            + dependent_spec["libiconv"].libs.link_flags,
+        )

--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -176,7 +176,7 @@ class Python(Package):
         depends_on("gdbm", when="+dbm")  # alternatively ndbm or berkeley-db
         depends_on("zlib-api", when="+zlib")
         depends_on("bzip2", when="+bz2")
-        depends_on("xz libs=shared", when="+lzma")
+        depends_on("xz", when="+lzma")
         depends_on("expat", when="+pyexpat")
         depends_on("libffi", when="+ctypes")
         # https://docs.python.org/3/whatsnew/3.11.html#build-changes


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

- Adds `setup_dependent_build_environment` for gettext, which does not produce a pkgconfig file. 
- Adds to `ldflags` when using `+libxml2` in gettext, as gettext ignores libxml2's pkgconfig.
- Make python's dependency on xz consistent.

With these changes, it is possible to build `gettext` and all dependencies statically (`spack install gettext~~shared`)