### PR TITLE
py-flask-restful: add v0.3.10

### DIFF
--- a/repos/spack_repo/builtin/packages/py_flask_restful/package.py
+++ b/repos/spack_repo/builtin/packages/py_flask_restful/package.py
@@ -15,6 +15,7 @@ class PyFlaskRestful(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.3.10", sha256="fe4af2ef0027df8f9b4f797aba20c5566801b6ade995ac63b588abf1a59cec37")
     version("0.3.9", sha256="ccec650b835d48192138c85329ae03735e6ced58e9b2d9c2146d6c84c06fa53e")
 
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
https://github.com/flask-restful/flask-restful/tree/0.3.10
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
