### PR TITLE
compiler dependency: gxsview depends on cxx

### DIFF
--- a/repos/spack_repo/builtin/packages/gxsview/package.py
+++ b/repos/spack_repo/builtin/packages/gxsview/package.py
@@ -41,6 +41,7 @@ class Gxsview(QMakePackage):
         "2021.07.01", sha256="000f9b4721d4ee03b02730dbbfe83947f96a60a183342b127f0b6b63b03e8f9a"
     )
 
+    depends_on("cxx", type="build")
     depends_on("fontconfig")
     depends_on("qt@5.14.0:+opengl+gui")
     depends_on("vtk@8.0:+qt+opengl2")  # +mpi+python are optional


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Strangely gxsview did not get the C++ compiler dependency for spack 1.0.
Gxsview requires C++17 compiler support.