### PR TITLE
py-formulaic: add v1.2.0 and py-wrapt: add v1.17.3

### DIFF
--- a/repos/spack_repo/builtin/packages/py_formulaic/package.py
+++ b/repos/spack_repo/builtin/packages/py_formulaic/package.py
@@ -14,27 +14,35 @@ class PyFormulaic(PythonPackage):
     homepage = "https://github.com/matthewwardrop/formulaic"
     pypi = "formulaic/formulaic-0.2.4.tar.gz"
 
+    version("1.2.0", sha256="ab5c43a5b107d1b1e87f55cf0a01245531cce793d3dcab433dae12053c3cb2d6")
     version("0.6.1", sha256="5b20b2130436dc8bf5ea604e69d88d44b3be4d8ea20bfea96d982fa1f6bb762b")
     version("0.5.2", sha256="25b1e1c8dff73f0b11c0028a6ab350222de6bbc47b316ccb770cec16189cef53")
     version("0.2.4", sha256="15b71ea8972fb451f80684203cddd49620fc9ed5c2e35f31e0874e9c41910d1a")
 
-    depends_on("python@3.7.2:", when="@5:", type=("build", "run"))
+    depends_on("python@3.9:", when="@1.2:", type=("build", "run"))
+    depends_on("python@3.7.2:", when="@0.5:", type=("build", "run"))
     depends_on("py-hatchling", when="@0.5:", type="build")
     depends_on("py-hatch-vcs", when="@0.5:", type="build")
-    depends_on("py-setuptools", when="@:0.3.2", type="build")
-    depends_on("py-setupmeta", when="@:0.3.2", type="build")
 
-    depends_on("py-astor@0.8:", when="@0.3.4:", type=("build", "run"))
-    depends_on("py-astor", type=("build", "run"))
-    depends_on("py-cached-property@1.3:", when="@0.4: ^python@:3.7", type=("build", "run"))
-    depends_on("py-graphlib-backport@1:", when="@0.5: ^python@:3.8", type=("build", "run"))
     depends_on("py-interface-meta@1.2:", type=("build", "run"))
+    depends_on("py-narwhals@1.17:", when="@1.2:", type=("build", "run"))
+    depends_on("py-numpy@1.20:", when="@1.2:", type=("build", "run"))
     depends_on("py-numpy@1.16.5:", when="@0.5:", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-pandas@1.3:", when="@1.2:", type=("build", "run"))
     depends_on("py-pandas@1:", when="@0.4:", type=("build", "run"))
     depends_on("py-pandas", type=("build", "run"))
     depends_on("py-scipy@1.6:", when="@0.3:", type=("build", "run"))
     depends_on("py-scipy", type=("build", "run"))
-    depends_on("py-wrapt@1:", when="@0.3:", type=("build", "run"))
+    depends_on("py-wrapt@1.17:", when="@1.1: ^python@3.13:", type=("build", "run"))
+    depends_on("py-wrapt@1:", when="@0.3: ^python@:3.12", type=("build", "run"))
     depends_on("py-wrapt", type=("build", "run"))
     depends_on("py-typing-extensions@4.2:", when="@0.5:", type=("build", "run"))
+
+    # Historical dependencies
+    depends_on("py-setuptools", when="@:0.3.2", type="build")
+    depends_on("py-setupmeta", when="@:0.3.2", type="build")
+    depends_on("py-astor@0.8:", when="@0.3.4:1.1", type=("build", "run"))
+    depends_on("py-astor", when="@:1.1", type=("build", "run"))
+    depends_on("py-cached-property@1.3:", when="@0.4:1.1 ^python@:3.7", type=("build", "run"))
+    depends_on("py-graphlib-backport@1:", when="@0.5:1.1 ^python@:3.8", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_wrapt/package.py
+++ b/repos/spack_repo/builtin/packages/py_wrapt/package.py
@@ -15,6 +15,7 @@ class PyWrapt(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("1.17.3", sha256="f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0")
     version("1.15.0", sha256="d06730c6aed78cee4126234cf2d071e01b44b915e725a6cb439a879ec9754a3a")
     version("1.14.1", sha256="380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d")
     version("1.13.3", sha256="1fea9cd438686e6682271d36f3481a9f3636195578bab9ca3382e2f5f01fc185")
@@ -25,4 +26,5 @@ class PyWrapt(PythonPackage):
 
     depends_on("c", type="build")  # generated
 
+    depends_on("python@3.8:", type=("build", "run"), when="@1.17:")
     depends_on("py-setuptools@38.3:", type="build")


### PR DESCRIPTION
https://github.com/matthewwardrop/formulaic/tree/v1.2.0

`py-formulaic` needs a newer versions of `py-wrapt`, so this was updated as well
https://github.com/GrahamDumpleton/wrapt/tree/1.17.3

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
