### PR TITLE
llvm: add conflict for gcc@15 and older llvm versions

### DIFF
--- a/repos/spack_repo/builtin/packages/llvm/package.py
+++ b/repos/spack_repo/builtin/packages/llvm/package.py
@@ -471,6 +471,7 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
     conflicts("%gcc@:5.0", when="@8:")
     # Internal compiler error on gcc 8.4 on aarch64 https://bugzilla.redhat.com/show_bug.cgi?id=1958295
     conflicts("%gcc@8.4:8.4.9", when="@12: target=aarch64:")
+    conflicts("%gcc@15:", when="@:18")
 
     # libcxx=project imposes compiler conflicts
     # see https://libcxx.llvm.org/#platform-and-compiler-support for the latest release

--- a/repos/spack_repo/builtin/packages/llvm/package.py
+++ b/repos/spack_repo/builtin/packages/llvm/package.py
@@ -471,7 +471,7 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
     conflicts("%gcc@:5.0", when="@8:")
     # Internal compiler error on gcc 8.4 on aarch64 https://bugzilla.redhat.com/show_bug.cgi?id=1958295
     conflicts("%gcc@8.4:8.4.9", when="@12: target=aarch64:")
-    # Compiler will through errors like e.g. "no type named 'iterator'" or "class has no member"
+    # Compiler will throw errors like e.g. "no type named 'iterator'" or "class has no member"
     conflicts("%gcc@15:", when="@:18")
 
     # libcxx=project imposes compiler conflicts

--- a/repos/spack_repo/builtin/packages/llvm/package.py
+++ b/repos/spack_repo/builtin/packages/llvm/package.py
@@ -471,6 +471,7 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
     conflicts("%gcc@:5.0", when="@8:")
     # Internal compiler error on gcc 8.4 on aarch64 https://bugzilla.redhat.com/show_bug.cgi?id=1958295
     conflicts("%gcc@8.4:8.4.9", when="@12: target=aarch64:")
+    # Compiler will through errors like e.g. "no type named 'iterator'" or "class has no member"
     conflicts("%gcc@15:", when="@:18")
 
     # libcxx=project imposes compiler conflicts


### PR DESCRIPTION
Add conflicts because older llvm versions do not build with `gcc@15`
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
