### PR TITLE
ci: use internal Spack SDK to satisfy @haampie's need for speed

### DIFF
--- a/.github/workflows/bin/spack-reviewers.py
+++ b/.github/workflows/bin/spack-reviewers.py
@@ -8,7 +8,7 @@ import subprocess
 
 import requests
 
-import spack
+import spack.repo
 
 IS_PACKAGE_CHANGE = re.compile(r"repos/spack_repo/builtin/packages/([^/]+)/.*$")
 

--- a/.github/workflows/bin/spack-reviewers.py
+++ b/.github/workflows/bin/spack-reviewers.py
@@ -4,7 +4,6 @@
 
 import os
 import re
-import subprocess
 
 import requests
 

--- a/.github/workflows/bin/spack-reviewers.py
+++ b/.github/workflows/bin/spack-reviewers.py
@@ -8,6 +8,8 @@ import subprocess
 
 import requests
 
+import spack
+
 IS_PACKAGE_CHANGE = re.compile(r"repos/spack_repo/builtin/packages/([^/]+)/.*$")
 
 
@@ -33,10 +35,8 @@ def main():
             package = match.group(1)
 
             # add maintainers from packages here
-            result = subprocess.run(
-                ["spack", "maintainers", package], capture_output=True, text=True, check=False
-            )
-            maintainers.update(result.stdout.split())
+            pkg_maintainers = spack.repo.PATH.get_pkg_class(package).maintainers
+            maintainers.update(pkg_maintainers)
 
     author = pull_request["user"]["login"]
     reviewers = (maintainers | existing_reviewers) - {author}

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Tag Maintainers on PR
         run: |
           . spack-core/share/spack/setup-env.sh
-          python3 .github/workflows/bin/spack-reviewers.py
+          spack-python .github/workflows/bin/spack-reviewers.py
         env:
           GH_PR_NUMBER: ${{ github.event.number }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
I'd originally opted to use Spack's CLI since it's more stable and unlikely to change. However, @haampie brought up a decent point regarding PRs with bulk package updates and the overhead of each being in a python process.