### PR TITLE
NCCL: remove maintainer

### DIFF
--- a/repos/spack_repo/builtin/packages/nccl/package.py
+++ b/repos/spack_repo/builtin/packages/nccl/package.py
@@ -16,7 +16,6 @@ class Nccl(MakefilePackage, CudaPackage):
     homepage = "https://github.com/NVIDIA/nccl"
     url = "https://github.com/NVIDIA/nccl/archive/v2.7.3-1.tar.gz"
 
-    maintainers("adamjstewart")
     libraries = ["libnccl.so"]
 
     version("2.27.7-1", sha256="98e6262bd55932c51e7c8ffc50cc764f019e4b94a8fd6694d839ae828ec8d128")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
I'm really not qualified to maintain this package. I only added myself because it was needed by much of the ML ecosystem. Any other volunteers want to take over?