### PR TITLE
kokkos_fft: fix rocm compiler definition

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos_fft/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_fft/package.py
@@ -72,6 +72,6 @@ class KokkosFft(CMakePackage):
         if self.spec.satisfies("^kokkos+rocm"):
             args.append(self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc))
         else:
-            args.append(self.define("CMAKE_CXX_COMPILER", self.spec["kokkos"].kokkos_cxx))
+            args.append(self.define("CMAKE_CXX_COMPILER", self["kokkos"].kokkos_cxx))
 
         return args

--- a/repos/spack_repo/builtin/packages/kokkos_fft/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_fft/package.py
@@ -70,8 +70,8 @@ class KokkosFft(CMakePackage):
         ]
 
         if self.spec.satisfies("^kokkos+rocm"):
-            args.append(self.define("CMAKE_CXX_COMPILER", self["hip"].hipcc))
+            args.append(self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc))
         else:
-            args.append(self.define("CMAKE_CXX_COMPILER", self["kokkos"].kokkos_cxx))
+            args.append(self.define("CMAKE_CXX_COMPILER", self.spec["kokkos"].kokkos_cxx))
 
         return args


### PR DESCRIPTION
This PR resolves the error from incorrect setting of hipcc compiler in kokkos-fft recipe.
The following error will be resolved by this PR.

```
The 'kokkos-fft' package cannot find an attribute while trying to build from sources. You can fix this by updating the build recipe, and you can also report the issue as a build-error or a bug at https://github.com/spack/spack/issues
/root/.spack/package_repos/fncqgg4/repos/spack_repo/builtin/packages/kokkos_fft/package.py:73, in cmake_args:
         70        ]
         71
         72        if self.spec.satisfies("^kokkos+rocm"):
  >>     73            args.append(self.define("CMAKE_CXX_COMPILER", self["hip"].hipcc))
         74        else:
         75            args.append(self.define("CMAKE_CXX_COMPILER", self["kokkos"].kokkos_cxx))
         76
See build log for details:
  /tmp/root/spack-stage/spack-stage-kokkos-fft-0.3.0-ugwucen4g6fzndmgvm5dfi4jjhhdtf5t/spack-build-out.txt
```