### PR TITLE
remove unused `D` provider

### DIFF
--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -319,11 +319,6 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     conflicts("languages=jit", when="@:4")
 
     with when("languages=d"):
-        # The very first version of GDC that became part of GCC already supported version 2.076 of
-        # the language and runtime.
-        # See https://wiki.dlang.org/GDC#Status
-        provides("d-lang@2")
-
         # Support for the D programming language has been added to GCC 9.
         # See https://gcc.gnu.org/gcc-9/changes.html#d
         conflicts("@:8", msg="support for D has been added in GCC 9.1")

--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -322,7 +322,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         # The very first version of GDC that became part of GCC already supported version 2.076 of
         # the language and runtime.
         # See https://wiki.dlang.org/GDC#Status
-        provides("D@2")
+        provides("d-lang@2")
 
         # Support for the D programming language has been added to GCC 9.
         # See https://gcc.gnu.org/gcc-9/changes.html#d

--- a/repos/spack_repo/builtin/packages/ldc/package.py
+++ b/repos/spack_repo/builtin/packages/ldc/package.py
@@ -37,7 +37,7 @@ class Ldc(CMakePackage):
     depends_on("binutils", type=("build", "link", "run"))
     depends_on("ldc-bootstrap", type=("build", "link"))
 
-    provides("D@2")
+    provides("d-lang@2")
 
     def cmake_args(self):
         ldmd2 = self.spec["ldc-bootstrap"].prefix.bin.ldmd2

--- a/repos/spack_repo/builtin/packages/ldc/package.py
+++ b/repos/spack_repo/builtin/packages/ldc/package.py
@@ -37,8 +37,6 @@ class Ldc(CMakePackage):
     depends_on("binutils", type=("build", "link", "run"))
     depends_on("ldc-bootstrap", type=("build", "link"))
 
-    provides("d-lang@2")
-
     def cmake_args(self):
         ldmd2 = self.spec["ldc-bootstrap"].prefix.bin.ldmd2
 


### PR DESCRIPTION
~Depends on https://github.com/spack/spack/pull/51274~: no longer the case after removal.

`D` is not a valid package name, so I don't see why it should be used as a
virtual name. And `d` is probably too short, so use `d-lang`?

The `ldc` package hasn't been updated in half a decade, so I guess this is
not controversial. Nobody uses it :)


