### PR TITLE
ELPA: new version 2025.06.001

### DIFF
--- a/repos/spack_repo/builtin/packages/elpa/package.py
+++ b/repos/spack_repo/builtin/packages/elpa/package.py
@@ -185,7 +185,7 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
                 flags.append(spec["mpi"].headers.include_flags)
             if name == "fflags":
                 flags.append(f'-I{spec["mpi"].prefix.lib}')
-            if name == "ldflags":# or name == "fflags":
+            if name == "ldflags":
                 flags.append(spec["mpi"].libs.search_flags)
                 flags.append(spec["mpi"].libs.link_flags)
                 if spec["mpi"].name == "openmpi":
@@ -272,9 +272,6 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
 
         if self.spec.satisfies("+mpi"):
             options += [
-                #"CC={0}".format(spec["mpi"].mpicc),
-                #"CXX={0}".format(spec["mpi"].mpicxx),
-                #"FC={0}".format(spec["mpi"].mpifc),
                 "SCALAPACK_LDFLAGS={0}".format(spec["scalapack"].libs.joined()),
             ]
 

--- a/repos/spack_repo/builtin/packages/elpa/package.py
+++ b/repos/spack_repo/builtin/packages/elpa/package.py
@@ -265,7 +265,7 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
                 "CC={0}".format(spec["mpi"].mpicc),
                 "CXX={0}".format(spec["mpi"].mpicxx),
                 "FC={0}".format(spec["mpi"].mpifc),
-                "SCALAPACK_LDFLAGS={0}".format(spec["scalapack"].libs.joined())
+                "SCALAPACK_LDFLAGS={0}".format(spec["scalapack"].libs.joined()),
             ]
 
         if self.spec.satisfies("+autotune"):

--- a/repos/spack_repo/builtin/packages/elpa/package.py
+++ b/repos/spack_repo/builtin/packages/elpa/package.py
@@ -180,7 +180,7 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
             if self.spec.satisfies("@2024.05.001,2025.01.001 %aocc"):
                 # fix an issue where main library and test suite containing duplicate symbols
                 flags.append("-Wl,--allow-multiple-definition")
-        if spec.satisfies("+mpi"): # Use spack's compiler wrapper instead of mpi's wrapper
+        if spec.satisfies("+mpi"):  # Use spack's compiler wrapper instead of mpi's wrapper
             if name == "cflags" or name == "cxxflags" or name == "fflags":
                 flags.append(spec["mpi"].headers.include_flags)
             if name == "fflags":
@@ -271,9 +271,7 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
         options += self.enable_or_disable("openmp")
 
         if self.spec.satisfies("+mpi"):
-            options += [
-                "SCALAPACK_LDFLAGS={0}".format(spec["scalapack"].libs.joined()),
-            ]
+            options += ["SCALAPACK_LDFLAGS={0}".format(spec["scalapack"].libs.joined())]
 
         if self.spec.satisfies("+autotune"):
             options.append("--enable-autotune-redistribute-matrix")

--- a/repos/spack_repo/builtin/packages/elpa/package.py
+++ b/repos/spack_repo/builtin/packages/elpa/package.py
@@ -28,6 +28,9 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
     version("master", branch="master")
 
     version(
+        "2025.06.001", sha256="feeb1fea1ab4a8670b8d3240765ef0ada828062ef7ec9b735eecba2848515c94"
+    )
+    version(
         "2025.01.002", sha256="8febe408c590ba9b44bd8bce04605fd1b7da964afcd8fd5f1ce9edecb3d0b65d"
     )
     version(
@@ -82,7 +85,7 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
         sha256="90f18c84e740a35d726e44078a111fac3b6278a0e750ce1f3ea154ee78e93298",
         when="@:2025.01.001",
     )
-    patch("hipcc.patch", when="+rocm @2025.01.001")
+    patch("hipcc.patch", when="+rocm @2025.01.001:2025.06.001")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
@@ -177,6 +180,17 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
             if self.spec.satisfies("@2024.05.001,2025.01.001 %aocc"):
                 # fix an issue where main library and test suite containing duplicate symbols
                 flags.append("-Wl,--allow-multiple-definition")
+        if spec.satisfies("+mpi"): # Use spack's compiler wrapper instead of mpi's wrapper
+            if name == "cflags" or name == "cxxflags" or name == "fflags":
+                flags.append(spec["mpi"].headers.include_flags)
+            if name == "fflags":
+                flags.append(f'-I{spec["mpi"].prefix.lib}')
+            if name == "ldflags":# or name == "fflags":
+                flags.append(spec["mpi"].libs.search_flags)
+                flags.append(spec["mpi"].libs.link_flags)
+                if spec["mpi"].name == "openmpi":
+                    flags.append("-lmpi_mpifh")
+
         return (flags, None, None)
 
     def configure_args(self):
@@ -237,12 +251,12 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
             # Can't yet be changed to the new option --enable-amd-gpu-kernels
             # https://github.com/marekandreas/elpa/issues/55
             options.append("--enable-amd-gpu")
-            if spec.satisfies("@2025.01.001"):
+            if spec.satisfies("@2025.01.001:"):
                 options.append(
-                    "HIPCC={0} -I{1} -I{2}".format(
+                    "HIPCC={0} {1} {2}".format(
                         spec["hip"].hipcc,
-                        spec["rocblas"].prefix.include,
-                        spec["rocsolver"].prefix.include,
+                        spec["rocblas"].headers.include_flags,
+                        spec["rocsolver"].headers.include_flags,
                     )
                 )
             else:
@@ -258,9 +272,9 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
 
         if self.spec.satisfies("+mpi"):
             options += [
-                "CC={0}".format(spec["mpi"].mpicc),
-                "CXX={0}".format(spec["mpi"].mpicxx),
-                "FC={0}".format(spec["mpi"].mpifc),
+                #"CC={0}".format(spec["mpi"].mpicc),
+                #"CXX={0}".format(spec["mpi"].mpicxx),
+                #"FC={0}".format(spec["mpi"].mpifc),
                 "SCALAPACK_LDFLAGS={0}".format(spec["scalapack"].libs.joined()),
             ]
 

--- a/repos/spack_repo/builtin/packages/elpa/package.py
+++ b/repos/spack_repo/builtin/packages/elpa/package.py
@@ -180,16 +180,6 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
             if self.spec.satisfies("@2024.05.001,2025.01.001 %aocc"):
                 # fix an issue where main library and test suite containing duplicate symbols
                 flags.append("-Wl,--allow-multiple-definition")
-        if spec.satisfies("+mpi"):  # Use spack's compiler wrapper instead of mpi's wrapper
-            if name == "cflags" or name == "cxxflags" or name == "fflags":
-                flags.append(spec["mpi"].headers.include_flags)
-            if name == "fflags":
-                flags.append(f'-I{spec["mpi"].prefix.lib}')
-            if name == "ldflags":
-                flags.append(spec["mpi"].libs.search_flags)
-                flags.append(spec["mpi"].libs.link_flags)
-                if spec["mpi"].name == "openmpi":
-                    flags.append("-lmpi_mpifh")
 
         return (flags, None, None)
 
@@ -271,7 +261,12 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
         options += self.enable_or_disable("openmp")
 
         if self.spec.satisfies("+mpi"):
-            options += ["SCALAPACK_LDFLAGS={0}".format(spec["scalapack"].libs.joined())]
+            options += [
+                "CC={0}".format(spec["mpi"].mpicc),
+                "CXX={0}".format(spec["mpi"].mpicxx),
+                "FC={0}".format(spec["mpi"].mpifc),
+                "SCALAPACK_LDFLAGS={0}".format(spec["scalapack"].libs.joined())
+            ]
 
         if self.spec.satisfies("+autotune"):
             options.append("--enable-autotune-redistribute-matrix")


### PR DESCRIPTION
Add new version 2025.06.001 of package elpa.
<del>
Previous commit 621ec78 moved configure cmdline options to flag_handler, which caused conflicts against using mpi's compiler wrappers: </del>
<del> - flag_handler produces `SPACK_*FLAGS` </del>
<del>   -> which cannot be used by mpi's wrappers
<del>   -> causing configure test about BLAS fails for not founding dynlib at run time(i.e. missing rpath) on some machines. 

<del>This commit turns to use spack's compiler wrappers and add mpi's flags manually.

<del>A special case is about openmpi: openmpi's `libs()` method only returns the C-side dynlib `libmpi.so`, and elpa requires both C-side and Fortran-side. To avoid interference of other packages, openmpi stays unchanged and only elpa was edited. Should this be reported in a seperate issue?
</del>

**EDIT**: Due to unable to reproduce the configure problem, changes about MPI are reverted.

The range to apply `hipcc.patch` was set to `:2025.06.001` due to marekandreas/elpa#68.


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
