### PR TITLE
ninja: depends on python@:3.12 when @:1.11

### DIFF
--- a/repos/spack_repo/builtin/packages/ninja/package.py
+++ b/repos/spack_repo/builtin/packages/ninja/package.py
@@ -66,6 +66,7 @@ class Ninja(Package):
     depends_on("cxx", type="build")  # generated
 
     depends_on("python", type="build")
+    # Python 3.13 added in https://github.com/ninja-build/ninja/pull/2340
     depends_on("python@:3.12", type="build", when="@:1.11")
     depends_on("re2c@0.11.3:", type="build", when="+re2c")
 

--- a/repos/spack_repo/builtin/packages/ninja/package.py
+++ b/repos/spack_repo/builtin/packages/ninja/package.py
@@ -66,6 +66,7 @@ class Ninja(Package):
     depends_on("cxx", type="build")  # generated
 
     depends_on("python", type="build")
+    depends_on("python@:3.12", type="build", when="@:1.11")
     depends_on("re2c@0.11.3:", type="build", when="+re2c")
 
     phases = ["configure", "install"]


### PR DESCRIPTION
This PR fixes older ninja with newer python, since `pipes` was replaced by `shlex` in python 3.13. Ref: https://github.com/ninja-build/ninja/commit/9cf13cd1ecb7ae649394f4133d121a01e191560b 

Addresses failure in https://gitlab.spack.io/spack/spack-packages/-/jobs/18016648.