### PR TITLE
fastani, py_macs2, tophat: Fixed compilation, dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/fastani/package.py
+++ b/repos/spack_repo/builtin/packages/fastani/package.py
@@ -32,3 +32,10 @@ class Fastani(CMakePackage, AutotoolsPackage):
     depends_on("m4", type="build", when="build_system=autotools")
     depends_on("gsl", type=("build", "link"))
     depends_on("zlib-api", type=("build", "link"))
+
+    def cmake_args(self):
+        args = [
+            "-DBUILD_TESTING=OFF",
+        ]
+
+        return args

--- a/repos/spack_repo/builtin/packages/fastani/package.py
+++ b/repos/spack_repo/builtin/packages/fastani/package.py
@@ -34,8 +34,4 @@ class Fastani(CMakePackage, AutotoolsPackage):
     depends_on("zlib-api", type=("build", "link"))
 
     def cmake_args(self):
-        args = [
-            "-DBUILD_TESTING=OFF",
-        ]
-
-        return args
+        return ["-DBUILD_TESTING=OFF"]

--- a/repos/spack_repo/builtin/packages/py_macs2/package.py
+++ b/repos/spack_repo/builtin/packages/py_macs2/package.py
@@ -38,7 +38,7 @@ class PyMacs2(PythonPackage):
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools@41.2:", when="@2.2.4:", type="build")
     depends_on("py-numpy@1.17:", when="@2.2.4:", type=("build", "run"))
-    depends_on("py-cython@0.29.24:", when="@2.2.8:", type="build")
+    depends_on("py-cython@0.29.24:0.29.36", when="@2.2.8:", type="build")
     depends_on("py-cython@0.29:", when="@2.2.4:2.2.7.1", type="build")
 
     def patch(self):

--- a/repos/spack_repo/builtin/packages/tophat/package.py
+++ b/repos/spack_repo/builtin/packages/tophat/package.py
@@ -30,7 +30,7 @@ class Tophat(AutotoolsPackage):
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
 
-    depends_on("boost@1.47:+exception+chrono+system+random+atomic+thread")
+    depends_on("boost@1.47:+exception+chrono+system+random+atomic+thread cxxstd=98")
     depends_on("bowtie2", type="run")
 
     parallel = False


### PR DESCRIPTION
3 fixes/updates here...

## fastani
When building fastani, building tests is enabled by default (https://github.com/ParBLiSS/FastANI/blob/master/CMakeLists.txt#L13). Disabling testing stops the need from requiring the Catch2 project from being required (https://github.com/ParBLiSS/FastANI/blob/master/CMakeLists.txt#L58-L82)

@snehring is the listed maintainer for fastani


## py_macs2
For MACS2, cython 3+ breaks the installation, so capping cython at 0.29.36 allows it to build. MACS3 allows for cython 3+, but py_macs3 is it's own spack package.


## tophat
When building tophat, we need boost compiled with cxxstd=98 as tophat itself is built with c++98. This will cap the version that boost will compile with, as boost 1.84 drops support for 98/03 (https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/packages/boost/package.py#L216), but attempting to compile tophat using boost compiled with >= c++11 fails.