### PR TITLE
py-torchgeo: fix minimum supported rasterio version

### DIFF
--- a/repos/spack_repo/builtin/packages/py_torchgeo/package.py
+++ b/repos/spack_repo/builtin/packages/py_torchgeo/package.py
@@ -89,7 +89,7 @@ class PyTorchgeo(PythonPackage):
         depends_on("py-pyproj@3.3:", when="@0.6:")
         depends_on("py-pyproj@3:", when="@0.5:")
         depends_on("py-pyproj@2.2:")
-        depends_on("py-rasterio@1.3.3:", when="@0.7:")
+        depends_on("py-rasterio@1.3.11:", when="@0.7:")
         depends_on("py-rasterio@1.3:", when="@0.6:")
         depends_on("py-rasterio@1.2:", when="@0.5:")
         depends_on("py-rasterio@1.0.20:", when="@0.3:")

--- a/repos/spack_repo/builtin/packages/py_torchgeo/package.py
+++ b/repos/spack_repo/builtin/packages/py_torchgeo/package.py
@@ -89,6 +89,7 @@ class PyTorchgeo(PythonPackage):
         depends_on("py-pyproj@3.3:", when="@0.6:")
         depends_on("py-pyproj@3:", when="@0.5:")
         depends_on("py-pyproj@2.2:")
+        # https://github.com/torchgeo/torchgeo/pull/2969
         depends_on("py-rasterio@1.3.11:", when="@0.7:")
         depends_on("py-rasterio@1.3:", when="@0.6:")
         depends_on("py-rasterio@1.2:", when="@0.5:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
1.3.3 mostly works, except for non-square pixels, one of the features added in 0.7.