### PR TITLE
gtkplus: add v3.24.43, v3.24.50 (last old stable); default meson; fix url

### DIFF
--- a/repos/spack_repo/builtin/packages/gtkplus/package.py
+++ b/repos/spack_repo/builtin/packages/gtkplus/package.py
@@ -21,7 +21,7 @@ class Gtkplus(AutotoolsPackage, MesonPackage):
     build_system(
         conditional("autotools", when="@:3.24.35"),
         conditional("meson", when="@3.24.9:"),
-        default="autotools",
+        default="meson",
     )
 
     version("3.24.50", sha256="399118a5699314622165a11b769ea9b6ed68e037b6d46d57cfcf4851dec07529")

--- a/repos/spack_repo/builtin/packages/gtkplus/package.py
+++ b/repos/spack_repo/builtin/packages/gtkplus/package.py
@@ -14,7 +14,7 @@ class Gtkplus(AutotoolsPackage, MesonPackage):
     interfaces for applications."""
 
     homepage = "https://www.gtk.org/"
-    url = "https://download.gnome.org/sources/gtk+/3.24/gtk+-3.24.26.tar.xz"
+    url = "https://download.gnome.org/sources/gtk/3.24/gtk-3.24.50.tar.xz"
 
     license("LGPL-2.0-or-later")
 
@@ -24,6 +24,8 @@ class Gtkplus(AutotoolsPackage, MesonPackage):
         default="autotools",
     )
 
+    version("3.24.50", sha256="399118a5699314622165a11b769ea9b6ed68e037b6d46d57cfcf4851dec07529")  
+    version("3.24.43", sha256="7e04f0648515034b806b74ae5d774d87cffb1a2a96c468cb5be476d51bf2f3c7")  
     version("3.24.41", sha256="47da61487af3087a94bc49296fd025ca0bc02f96ef06c556e7c8988bd651b6fa")
     version("3.24.29", sha256="f57ec4ade8f15cab0c23a80dcaee85b876e70a8823d9105f067ce335a8268caa")
     version("3.24.26", sha256="2cc1b2dc5cad15d25b6abd115c55ffd8331e8d4677745dd3ce6db725b4fff1e9")
@@ -95,7 +97,10 @@ class Gtkplus(AutotoolsPackage, MesonPackage):
     patch("no-demos.patch", when="@2.0:2")
 
     def url_for_version(self, version):
-        url = "https://download.gnome.org/sources/gtk+/{0}/gtk+-{1}.tar.xz"
+        if self.spec.satisfies("@:3.24.43"):
+            url = "https://download.gnome.org/sources/gtk+/{0}/gtk+-{1}.tar.xz"
+        else:
+            url = "https://download.gnome.org/sources/gtk/{0}/gtk-{1}.tar.xz"
         return url.format(version.up_to(2), version)
 
     def patch(self):

--- a/repos/spack_repo/builtin/packages/gtkplus/package.py
+++ b/repos/spack_repo/builtin/packages/gtkplus/package.py
@@ -24,8 +24,8 @@ class Gtkplus(AutotoolsPackage, MesonPackage):
         default="autotools",
     )
 
-    version("3.24.50", sha256="399118a5699314622165a11b769ea9b6ed68e037b6d46d57cfcf4851dec07529")  
-    version("3.24.43", sha256="7e04f0648515034b806b74ae5d774d87cffb1a2a96c468cb5be476d51bf2f3c7")  
+    version("3.24.50", sha256="399118a5699314622165a11b769ea9b6ed68e037b6d46d57cfcf4851dec07529")
+    version("3.24.43", sha256="7e04f0648515034b806b74ae5d774d87cffb1a2a96c468cb5be476d51bf2f3c7")
     version("3.24.41", sha256="47da61487af3087a94bc49296fd025ca0bc02f96ef06c556e7c8988bd651b6fa")
     version("3.24.29", sha256="f57ec4ade8f15cab0c23a80dcaee85b876e70a8823d9105f067ce335a8268caa")
     version("3.24.26", sha256="2cc1b2dc5cad15d25b6abd115c55ffd8331e8d4677745dd3ce6db725b4fff1e9")


### PR DESCRIPTION
This PR adds `gtkplus`, v3.24.43, v3.24.50, the last two versions of the so-called "old stable" series. [Diff 3.24.41...3.24.50](https://gitlab.gnome.org/GNOME/gtk/-/compare/3.24.41...3.24.50)

v3.24.43 is the last version in the current url scheme (with `gtk+`), and  v3.24.50 is the last version in the new url scheme (with `gtk`), and the versions from v3.24.44 to v3.24.47 are nowhere to be found... (Note that version up to 4.20.0 are available, but that's for a different PR.)

The newer versions, with the `gtk` url scheme also defines the meson project name as `gtk` instead of `gtk+`. I am not sure if this affects the ability of dependents to find the package if they use `gtk+` as name.

This package is build in CI, but it falls back to the `autotools` version, so the most recent versions are not built. That's something I'll look into just to make sure we build newer versions as they are added, but may become a different PR.
> EDIT: Even after changing the default to `meson`, this doesn't trigger a rebuild. It may be that this package used to get built in CI, but doesn't anymore.