### PR TITLE
py-iso8601: add v2.1.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_iso8601/package.py
+++ b/repos/spack_repo/builtin/packages/py_iso8601/package.py
@@ -15,10 +15,12 @@ class PyIso8601(PythonPackage):
 
     license("MIT")
 
+    version("2.1.0", sha256="6b1d3829ee8921c4301998c909f7829fa9ed3cbdac0d3b16af2d743aed1ba8df")
     version("1.1.0", sha256="32811e7b81deee2063ea6d2e94f8819a86d1f3811e49d23623a41fa832bef03f")
     version("1.0.2", sha256="27f503220e6845d9db954fb212b95b0362d8b7e6c1b2326a87061c3de93594b1")
     version("0.1.14", sha256="8aafd56fa0290496c5edbb13c311f78fa3a241f0853540da09d9363eae3ebd79")
 
+    depends_on("python@3.7:3", when="@2:", type=("build", "run"))
     depends_on("python@3.6.2:3", when="@1:", type=("build", "run"))
     depends_on("py-poetry-core@1:", when="@1:", type="build")
 


### PR DESCRIPTION
https://github.com/micktwomey/pyiso8601/tree/2.1.0
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
