### PR TITLE
py-zarr: add new version, fix deps

### DIFF
--- a/repos/spack_repo/builtin/packages/py_crc32c/package.py
+++ b/repos/spack_repo/builtin/packages/py_crc32c/package.py
@@ -1,0 +1,23 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+from spack.package import *
+
+
+class PyCrc32c(PythonPackage):
+    """A python package implementing the crc32c algorithm in hardware and software."""
+
+    homepage = "https://github.com/ICRAR/crc32c"
+    pypi = "crc32c/crc32c-2.7.1.tar.gz"
+
+    license("LGPL-2.1-or-later")
+
+    version("2.7.1", sha256="f91b144a21eef834d64178e01982bb9179c354b3e9e5f4c803b0e5096384968c")
+
+    depends_on("python@3.7:", type=("build", "link", "run"))
+
+    with default_args(type="build"):
+        depends_on("c")
+        depends_on("py-setuptools")

--- a/repos/spack_repo/builtin/packages/py_crc32c/package.py
+++ b/repos/spack_repo/builtin/packages/py_crc32c/package.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.python import PythonPackage
+
 from spack.package import *
 
 

--- a/repos/spack_repo/builtin/packages/py_numcodecs/package.py
+++ b/repos/spack_repo/builtin/packages/py_numcodecs/package.py
@@ -17,13 +17,13 @@ class PyNumcodecs(PythonPackage):
     pypi = "numcodecs/numcodecs-0.6.4.tar.gz"
     git = "https://github.com/zarr-developers/numcodecs.git"
 
-    # 'numcodecs.tests' excluded from 'import_modules' because it requires
-    # an additional dependency on 'pytest'
-    import_modules = ["numcodecs"]
+    # Requires pytest
+    skip_modules = ["numcodecs.tests"]
 
     license("MIT")
 
     version("main", branch="main", submodules=True)
+    version("0.16.2", sha256="9922dae0c3b01b5bed3b4bae239f4787e891daa3262c27971298669d029d10e9")
     version("0.15.0", sha256="52fb0c20d99845ef600eb3f8c8ad3e22fe2cb4f2a53394d331210af7cc3375ca")
     version("0.13.0", sha256="ba4fac7036ea5a078c7afe1d4dffeb9685080d42f19c9c16b12dad866703aa2e")
     version("0.12.1", sha256="05d91a433733e7eef268d7e80ec226a0232da244289614a8f3826901aec1098e")
@@ -32,24 +32,39 @@ class PyNumcodecs(PythonPackage):
     version("0.7.3", sha256="022b12ad83eb623ec53f154859d49f6ec43b15c36052fa864eaf2d9ee786dd85")
     version("0.6.4", sha256="ef4843d5db4d074e607e9b85156835c10d006afc10e175bda62ff5412fca6e4d")
 
-    variant("msgpack", default=False, description="Codec to encode data as msgpacked bytes.")
+    variant("crc32c", default=False, description="CRC32C codec", when="@0.14:")
+    variant("msgpack", default=False, description="Codec to encode data as msgpacked bytes")
 
-    depends_on("c", type="build")  # generated
+    with default_args(type=("build", "link", "run")):
+        depends_on("python@3.11:", when="@0.14:")
+        depends_on("python@3.10:", when="@0.13:")
+        depends_on("python@3.8:", when="@0.11:0.12")
+        depends_on("python@3.6:3", when="@0.7:0.10")
+        depends_on("py-numpy@1.24:", when="@0.14:")
+        depends_on("py-numpy@1.7:")
+        # https://github.com/zarr-developers/numcodecs/issues/521
+        depends_on("py-numpy@:1", when="@:0.12.0")
 
-    depends_on("python@3.10:", when="@0.13:", type=("build", "link", "run"))
-    depends_on("python@3.8:", when="@0.11:0.12", type=("build", "link", "run"))
-    depends_on("python@3.6:3", when="@0.7:0.10", type=("build", "link", "run"))
-    depends_on("py-setuptools@64:", when="@0.11:", type="build")
-    depends_on("py-setuptools@18.1:", type="build")
-    depends_on("py-setuptools-scm@6.2: +toml", when="@0.11:", type="build")
-    depends_on("py-setuptools-scm@1.5.5: +toml", type="build")
-    depends_on("py-cython", type="build")
-    depends_on("py-numpy@1.7:", type=("build", "run"))
-    # https://github.com/zarr-developers/numcodecs/issues/521
-    depends_on("py-numpy@:1", when="@:0.12.0", type=("build", "run"))
-    depends_on("py-py-cpuinfo", when="@0.11:", type="build")
-    depends_on("py-entrypoints", when="@0.10.1:0.11", type=("build", "run"))
-    depends_on("py-msgpack", type=("build", "run"), when="+msgpack")
+    with default_args(type="build"):
+        depends_on("c")
+        depends_on("py-setuptools@77:", when="@0.16.1:")
+        depends_on("py-setuptools@64:", when="@0.11:")
+        depends_on("py-setuptools@18.1:")
+        depends_on("py-setuptools-scm@6.2: +toml", when="@0.11:")
+        depends_on("py-setuptools-scm@1.5.5: +toml")
+        depends_on("py-cython")
+        depends_on("py-py-cpuinfo", when="@0.11:")
+
+    with default_args(type=("build", "run")):
+        depends_on("py-typing-extensions", when="@0.16:")
+
+        # Historical dependencies
+        depends_on("py-deprecated", when="@0.15")
+        depends_on("py-entrypoints", when="@0.10.1:0.11")
+
+    with default_args(type="run"):
+        depends_on("py-crc32c@2.7:", when="+crc32c")
+        depends_on("py-msgpack", when="+msgpack")
 
     patch("apple-clang-12.patch", when="@:0.13 %apple-clang@12:")
 

--- a/repos/spack_repo/builtin/packages/py_zarr/package.py
+++ b/repos/spack_repo/builtin/packages/py_zarr/package.py
@@ -16,6 +16,7 @@ class PyZarr(PythonPackage):
 
     license("MIT")
 
+    version("3.1.2", sha256="688e4eb79045c110128cd16f301f2f58fa19507b1803dcbea0ea894e66e06274")
     version("3.0.6", sha256="6ef23c740e34917a2a1099471361537732942e49f0cabe95c9b7124cd0d6d84f")
     version("3.0.1", sha256="033859c5603dc9c29e53af494ede24b42f1b761d2bb625466990a3b8a9afb792")
     version("2.17.0", sha256="6390a2b8af31babaab4c963efc45bf1da7f9500c9aafac193f84cf019a7c66b0")
@@ -25,35 +26,47 @@ class PyZarr(PythonPackage):
     version("2.4.0", sha256="53aa21b989a47ddc5e916eaff6115b824c0864444b1c6f3aaf4f6cf9a51ed608")
     version("2.3.2", sha256="c62d0158fb287151c978904935a177b3d2d318dea3057cfbeac8541915dfa105")
 
-    with when("@:2"):
-        depends_on("python@3.9:", type=("build", "run"), when="@2.17:")
-        depends_on("python@3.7:3", type=("build", "run"), when="@2.10")
-        depends_on("py-setuptools@64:", type="build", when="@2.17:")
-        depends_on("py-setuptools@38.6.0:", type="build", when="@2.4.0:")
-        depends_on("py-setuptools@18.0:", type="build")
-        depends_on("py-setuptools-scm@1.5.5:", type="build")
-
-        depends_on("py-asciitree", type=("build", "run"))
-        depends_on("py-numpy@1.21.1:", type=("build", "run"), when="@2.17:")
-        depends_on("py-numpy@1.7:", type=("build", "run"))
-        # https://github.com/zarr-developers/zarr-python/issues/1818
-        depends_on("py-numpy@:1", when="@:2.17", type=("build", "run"))
-        depends_on("py-fasteners", type=("build", "run"))
-        depends_on("py-numcodecs@0.10:", type=("build", "run"), when="@2.17:")
-        depends_on("py-numcodecs@0.6.4:", type=("build", "run"), when="@2.4.0:")
-        depends_on("py-numcodecs@0.6.2:", type=("build", "run"))
+    with default_args(type="build"):
+        depends_on("py-hatchling@1.27:", when="@3.1.1:")
+        depends_on("py-hatchling", when="@3:")
+        depends_on("py-hatch-vcs", when="@3:")
 
         # Historical dependencies
-        depends_on("py-msgpack", type=("build", "run"), when="@:2.3.2")
+        depends_on("py-setuptools@64:", when="@2.13.4:2")
+        depends_on("py-setuptools@40.8:", when="@2.5:2")
+        depends_on("py-setuptools@38.6:", when="@2.4:2")
+        depends_on("py-setuptools@18.1:", when="@:2")
+        depends_on("py-setuptools-scm@8.1:", when="@2.18.4:2")
+        depends_on("py-setuptools-scm@1.5.5:", when="@:2")
 
-    with when("@3:"):
-        depends_on("python@3.11:", type=("build", "run"))
-        depends_on("py-hatchling", type="build")
-        depends_on("py-hatch-vcs", type="build")
-        depends_on("py-packaging@22:", type=("build", "run"), when="@3.0:")
-        # numpy@2: compatible
+    with default_args(type=("build", "run")):
+        depends_on("python@3.11:", when="@2.18.4:")
+        depends_on("python@3.10:", when="@2.18.3:")
+        depends_on("python@3.9:", when="@2.17:")
+        depends_on("python@3.8:", when="@2.13.4:")
+        depends_on("python@3.8:3", when="@2.13.0:2.13.3")
+        depends_on("python@3.7:3", when="@2.9:2.12")
+        depends_on("python@3.6:3", when="@2.6:2.8")
+        depends_on("python@3.5:", when="@2.4:2.5")
+        depends_on("py-packaging@22:", when="@3:")
+        depends_on("py-numpy@1.26:", when="@3.1:")
+        depends_on("py-numpy@1.25:", when="@3:")
+        depends_on("py-numpy@1.24:", when="@2.18.3:")
+        depends_on("py-numpy@1.23:", when="@2.17.2:")
+        depends_on("py-numpy@1.21.1:", when="@2.16.1:")
+        depends_on("py-numpy@1.20,1.21.1:", when="@2.13.4:")
+        depends_on("py-numpy@1.7:")
         # https://github.com/zarr-developers/zarr-python/issues/1818
-        depends_on("py-numpy@1.25:2", type=("build", "run"))
-        depends_on("py-numcodecs@0.14:", type=("build", "run"))
-        depends_on("py-typing-extensions@4.9:", type=("build", "run"))
-        depends_on("py-donfig@0.8:", type=("build", "run"))
+        depends_on("py-numpy@:1", when="@:2.17")
+        depends_on("py-numcodecs@0.14:+crc32c", when="@3:")
+        depends_on("py-numcodecs@0.10:0.13,0.14.2:0.15", when="@2.18.7")
+        depends_on("py-numcodecs@0.10:0.13,0.14.2:", when="@2.18.4:2.18.6")
+        depends_on("py-numcodecs@0.10:", when="@2.13:")
+        depends_on("py-numcodecs@0.6.4:", when="@2.4:")
+        depends_on("py-numcodecs@0.6.2:")
+        depends_on("py-typing-extensions@4.9:", when="@3:")
+        depends_on("py-donfig@0.8:", when="@3:")
+
+        # Historical dependencies
+        depends_on("py-asciitree", when="@:2")
+        depends_on("py-fasteners", when="@:2")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Previous versions of py-zarr and py-numcodecs had a bunch of missing or incorrect dependencies that prevented either package from being imported.