### PR TITLE
kokkos-fft: Add kokkos-fft to the e4s stack

### DIFF
--- a/stacks/e4s-cray-rhel/spack.yaml
+++ b/stacks/e4s-cray-rhel/spack.yaml
@@ -116,6 +116,7 @@ spack:
   - hypre
   - kokkos +openmp
   - kokkos-kernels +openmp
+  - kokkos-fft host_backend=fftw-openmp +tests
   - legion
   - libnrm
   - libquo

--- a/stacks/e4s-cray-sles/spack.yaml
+++ b/stacks/e4s-cray-sles/spack.yaml
@@ -91,6 +91,7 @@ spack:
   - hypre
   - kokkos +openmp
   - kokkos-kernels +openmp
+  - kokkos-fft host_backend=fftw-openmp +tests
   - lammps
   - legion
   - libnrm

--- a/stacks/e4s-neoverse-v2/spack.yaml
+++ b/stacks/e4s-neoverse-v2/spack.yaml
@@ -203,7 +203,7 @@ spack:
   - hpx +cuda cuda_arch=90
   - kokkos +wrapper +cuda cuda_arch=90
   - kokkos-kernels +cuda cuda_arch=90 ^kokkos +wrapper +cuda cuda_arch=90
-  - kokkos-fft device_backend=cufft +tests
+  - kokkos-fft device_backend=cufft +tests ^kokkos +wrapper +cuda cuda_arch=90
   - libceed +cuda cuda_arch=90
   - magma +cuda cuda_arch=90
   - mfem +cuda cuda_arch=90

--- a/stacks/e4s-neoverse-v2/spack.yaml
+++ b/stacks/e4s-neoverse-v2/spack.yaml
@@ -90,6 +90,7 @@ spack:
   - hypre
   - kokkos +openmp
   - kokkos-kernels +openmp
+  - kokkos-fft host_backend=fftw-openmp +tests
   - lammps
   - lbann
   - legion
@@ -202,6 +203,7 @@ spack:
   - hpx +cuda cuda_arch=90
   - kokkos +wrapper +cuda cuda_arch=90
   - kokkos-kernels +cuda cuda_arch=90 ^kokkos +wrapper +cuda cuda_arch=90
+  - kokkos-fft device_backend=cufft +tests
   - libceed +cuda cuda_arch=90
   - magma +cuda cuda_arch=90
   - mfem +cuda cuda_arch=90

--- a/stacks/e4s-oneapi/spack.yaml
+++ b/stacks/e4s-oneapi/spack.yaml
@@ -223,6 +223,7 @@ spack:
   - cabana +sycl ^kokkos +sycl +openmp cxxstd=17
   - ginkgo +sycl
   - kokkos +sycl +openmp cxxstd=17
+  - kokkos-fft host_backend=fftw-openmp device_backend=onemkl +tests ^kokkos +sycl +openmp cxxstd=17
   - sundials +sycl +examples-install cxxstd=17
   - tau +mpi +opencl +level_zero +syscall
   - upcxx +level_zero

--- a/stacks/e4s-oneapi/spack.yaml
+++ b/stacks/e4s-oneapi/spack.yaml
@@ -98,6 +98,7 @@ spack:
   - hypre
   - kokkos +openmp
   - kokkos-kernels +openmp
+  - kokkos-fft host_backend=fftw-openmp +tests
   - laghos ^mfem~cuda
   - lammps +amoeba +asphere +bocs +body +bpm +brownian +cg-dna +cg-spica +class2 +colloid +colvars +compress +coreshell +dielectric +diffraction +dipole +dpd-basic +dpd-meso +dpd-react +dpd-smooth +drude +eff +electrode +extra-compute +extra-dump +extra-fix +extra-molecule +extra-pair +fep +granular +interlayer +kspace +lepton +machdyn +manybody +mc +meam +mesont +misc +ml-iap +ml-pod +ml-snap +mofff +molecule +openmp-package +opt +orient +peri +phonon +plugin +poems +qeq +reaction +reaxff +replica +rigid +shock +sph +spin +srd +tally +uef +voronoi +yaff
   - legion
@@ -222,6 +223,7 @@ spack:
   - cabana +sycl ^kokkos +sycl +openmp cxxstd=17
   - ginkgo +sycl
   - kokkos +sycl +openmp cxxstd=17
+  - kokkos-fft host_backend=fftw-openmp device_backend=onemkl +tests
   - sundials +sycl +examples-install cxxstd=17
   - tau +mpi +opencl +level_zero +syscall
   - upcxx +level_zero

--- a/stacks/e4s-oneapi/spack.yaml
+++ b/stacks/e4s-oneapi/spack.yaml
@@ -223,7 +223,6 @@ spack:
   - cabana +sycl ^kokkos +sycl +openmp cxxstd=17
   - ginkgo +sycl
   - kokkos +sycl +openmp cxxstd=17
-  - kokkos-fft host_backend=fftw-openmp device_backend=onemkl +tests ^kokkos +sycl +openmp cxxstd=17
   - sundials +sycl +examples-install cxxstd=17
   - tau +mpi +opencl +level_zero +syscall
   - upcxx +level_zero
@@ -233,6 +232,7 @@ spack:
   # - hypre +sycl                                     # hypre-2.32.0: gpu/intel/level0/level0-command-process.c:94:61: error: illegal initializer type 'atomic_int' (aka '_Atomic(int)')
   # - kokkos-kernels ^kokkos +sycl +openmp cxxstd=17  # kokkos-kernels-4.5.01: /opt/intel/oneapi/compiler/2025.1/bin/compiler/../../include/sycl/group_algorithm.hpp:598:31: error: SYCL kernel cannot call an undefined function without SYCL_EXTERNAL attribute
   # - petsc +sycl                                     # kokkos-kernels-4.4.01: /opt/intel/oneapi/compiler/2025.1/bin/compiler/../../include/sycl/group_algorithm.hpp:598:31: error: SYCL kernel cannot call an undefined function without SYCL_EXTERNAL attribute
+  # - kokkos-fft host_backend=fftw-openmp device_backend=onemkl +tests ^kokkos +sycl +openmp cxxstd=17
   # - slate +sycl                                     # blaspp-2024.10.26: blas/device.hh:46:14: fatal error: 'sycl.hpp' file not found
 
   ci:

--- a/stacks/e4s-oneapi/spack.yaml
+++ b/stacks/e4s-oneapi/spack.yaml
@@ -223,7 +223,7 @@ spack:
   - cabana +sycl ^kokkos +sycl +openmp cxxstd=17
   - ginkgo +sycl
   - kokkos +sycl +openmp cxxstd=17
-  - kokkos-fft host_backend=fftw-openmp device_backend=onemkl +tests
+  - kokkos-fft host_backend=fftw-openmp device_backend=onemkl +tests ^kokkos +sycl +openmp cxxstd=17
   - sundials +sycl +examples-install cxxstd=17
   - tau +mpi +opencl +level_zero +syscall
   - upcxx +level_zero

--- a/stacks/e4s-oneapi/spack.yaml
+++ b/stacks/e4s-oneapi/spack.yaml
@@ -98,7 +98,6 @@ spack:
   - hypre
   - kokkos +openmp
   - kokkos-kernels +openmp
-  - kokkos-fft host_backend=fftw-openmp +tests
   - laghos ^mfem~cuda
   - lammps +amoeba +asphere +bocs +body +bpm +brownian +cg-dna +cg-spica +class2 +colloid +colvars +compress +coreshell +dielectric +diffraction +dipole +dpd-basic +dpd-meso +dpd-react +dpd-smooth +drude +eff +electrode +extra-compute +extra-dump +extra-fix +extra-molecule +extra-pair +fep +granular +interlayer +kspace +lepton +machdyn +manybody +mc +meam +mesont +misc +ml-iap +ml-pod +ml-snap +mofff +molecule +openmp-package +opt +orient +peri +phonon +plugin +poems +qeq +reaction +reaxff +replica +rigid +shock +sph +spin +srd +tally +uef +voronoi +yaff
   - legion
@@ -191,6 +190,7 @@ spack:
   # - geopm-runtime                 # concretize: c-blosc2: conflicts with '%oneapi';
   - glvis                         # llvm-17.0.6: https://github.com/spack/spack/issues/49625
   # - gptune ~mpispawn              # py-maturin-1.8.3: rust-lld: error: undefined symbol: __intel_cpu_feature_indicator_x
+  # - kokkos-fft host_backend=fftw-openmp +tests # commenting out until build error is resolved
   # - lbann                         # lbann-0.104: https://github.com/spack/spack/issues/49619
   # - libpressio +bitgrooming +bzip2 ~cuda ~cusz +fpzip +hdf5 +libdistributed +lua +openmp +python +sz +sz3 +unix +zfp # concretize: c-blosc2: conflicts with '%oneapi';
   # - nek5000 +mpi ~visit           # nek5000-19.0: RuntimeError: Cannot build example: short_tests/eddy.

--- a/stacks/e4s-oneapi/spack.yaml
+++ b/stacks/e4s-oneapi/spack.yaml
@@ -223,7 +223,6 @@ spack:
   - cabana +sycl ^kokkos +sycl +openmp cxxstd=17
   - ginkgo +sycl
   - kokkos +sycl +openmp cxxstd=17
-  - kokkos-fft host_backend=fftw-openmp device_backend=onemkl +tests ^kokkos +sycl +openmp cxxstd=17
   - sundials +sycl +examples-install cxxstd=17
   - tau +mpi +opencl +level_zero +syscall
   - upcxx +level_zero

--- a/stacks/e4s-rocm-external/spack.yaml
+++ b/stacks/e4s-rocm-external/spack.yaml
@@ -239,7 +239,7 @@ spack:
   - hpx +rocm amdgpu_target=gfx908
   - hypre +rocm amdgpu_target=gfx908
   - kokkos +rocm amdgpu_target=gfx908
-  - kokkos-fft device_backend=hipfft
+  - kokkos-fft device_backend=hipfft ^kokkos +rocm amdgpu_target=gfx908
   - lammps +rocm amdgpu_target=gfx908
   - legion +rocm amdgpu_target=gfx908
   - libceed +rocm amdgpu_target=gfx908
@@ -286,7 +286,7 @@ spack:
   - hpx +rocm amdgpu_target=gfx90a
   - hypre +rocm amdgpu_target=gfx90a
   - kokkos +rocm amdgpu_target=gfx90a
-  - kokkos-fft device_backend=hipfft
+  - kokkos-fft device_backend=hipfft ^kokkos +rocm amdgpu_target=gfx90a
   - lammps +rocm amdgpu_target=gfx90a
   - legion +rocm amdgpu_target=gfx90a
   - libceed +rocm amdgpu_target=gfx90a

--- a/stacks/e4s-rocm-external/spack.yaml
+++ b/stacks/e4s-rocm-external/spack.yaml
@@ -239,7 +239,7 @@ spack:
   - hpx +rocm amdgpu_target=gfx908
   - hypre +rocm amdgpu_target=gfx908
   - kokkos +rocm amdgpu_target=gfx908
-  - kokkos-fft device_backend=hipfft ^kokkos +rocm amdgpu_target=gfx908
+  - kokkos-fft device_backend=hipfft +tests ^kokkos +rocm amdgpu_target=gfx908
   - lammps +rocm amdgpu_target=gfx908
   - legion +rocm amdgpu_target=gfx908
   - libceed +rocm amdgpu_target=gfx908
@@ -286,7 +286,7 @@ spack:
   - hpx +rocm amdgpu_target=gfx90a
   - hypre +rocm amdgpu_target=gfx90a
   - kokkos +rocm amdgpu_target=gfx90a
-  - kokkos-fft device_backend=hipfft ^kokkos +rocm amdgpu_target=gfx90a
+  - kokkos-fft device_backend=hipfft +tests ^kokkos +rocm amdgpu_target=gfx90a
   - lammps +rocm amdgpu_target=gfx90a
   - legion +rocm amdgpu_target=gfx90a
   - libceed +rocm amdgpu_target=gfx90a

--- a/stacks/e4s-rocm-external/spack.yaml
+++ b/stacks/e4s-rocm-external/spack.yaml
@@ -239,6 +239,7 @@ spack:
   - hpx +rocm amdgpu_target=gfx908
   - hypre +rocm amdgpu_target=gfx908
   - kokkos +rocm amdgpu_target=gfx908
+  - kokkos-fft device_backend=hipfft
   - lammps +rocm amdgpu_target=gfx908
   - legion +rocm amdgpu_target=gfx908
   - libceed +rocm amdgpu_target=gfx908
@@ -285,6 +286,7 @@ spack:
   - hpx +rocm amdgpu_target=gfx90a
   - hypre +rocm amdgpu_target=gfx90a
   - kokkos +rocm amdgpu_target=gfx90a
+  - kokkos-fft device_backend=hipfft
   - lammps +rocm amdgpu_target=gfx90a
   - legion +rocm amdgpu_target=gfx90a
   - libceed +rocm amdgpu_target=gfx90a

--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -273,7 +273,7 @@ spack:
   - hypre +cuda cuda_arch=80
   - kokkos +wrapper +cuda cuda_arch=80
   - kokkos-kernels +cuda cuda_arch=80 ^kokkos +wrapper +cuda cuda_arch=80
-  - kokkos-fft device_backend=cufft +tests
+  - kokkos-fft device_backend=cufft +tests ^kokkos +wrapper +cuda cuda_arch=80
   - libceed +cuda cuda_arch=80
   - libpressio +bitgrooming +bzip2 +fpzip +hdf5 +libdistributed +lua +openmp +python +sz +sz3 +unix +zfp +json +remote +netcdf +cusz +mgard +cuda cuda_arch=80 ^cusz +cuda cuda_arch=80
   - magma +cuda cuda_arch=80
@@ -322,6 +322,7 @@ spack:
   - hypre +cuda cuda_arch=90
   - kokkos +wrapper +cuda cuda_arch=90
   - kokkos-kernels +cuda cuda_arch=90 ^kokkos +wrapper +cuda cuda_arch=90
+  - kokkos-fft device_backend=cufft +tests ^kokkos +wrapper +cuda cuda_arch=90
   - libceed +cuda cuda_arch=90
   - libpressio +bitgrooming +bzip2 +fpzip +hdf5 +libdistributed +lua +openmp +python +sz +sz3 +unix +zfp +json +remote +netcdf +cusz +mgard +cuda cuda_arch=90 ^cusz +cuda cuda_arch=90
   - magma +cuda cuda_arch=90

--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -130,6 +130,7 @@ spack:
   - julia ^llvm ~clang ~gold ~polly targets=amdgpu,bpf,nvptx,webassembly
   - kokkos +openmp
   - kokkos-kernels +openmp
+  - kokkos-fft host_backend=fftw-openmp +tests
   - laghos
   - lammps +amoeba +asphere +bocs +body +bpm +brownian +cg-dna +cg-spica +class2 +colloid +colvars +compress +coreshell +dielectric +diffraction +dipole +dpd-basic +dpd-meso +dpd-react +dpd-smooth +drude +eff +electrode +extra-compute +extra-dump +extra-fix +extra-molecule +extra-pair +fep +granular +interlayer +kspace +lepton +machdyn +manybody +mc +meam +mesont +misc +ml-iap +ml-pod +ml-snap +mofff +molecule +openmp-package +opt +orient +peri +phonon +plugin +poems +qeq +reaction +reaxff +replica +rigid +shock +sph +spin +srd +tally +uef +voronoi +yaff
   - lbann
@@ -272,6 +273,7 @@ spack:
   - hypre +cuda cuda_arch=80
   - kokkos +wrapper +cuda cuda_arch=80
   - kokkos-kernels +cuda cuda_arch=80 ^kokkos +wrapper +cuda cuda_arch=80
+  - kokkos-fft device_backend=cufft +tests
   - libceed +cuda cuda_arch=80
   - libpressio +bitgrooming +bzip2 +fpzip +hdf5 +libdistributed +lua +openmp +python +sz +sz3 +unix +zfp +json +remote +netcdf +cusz +mgard +cuda cuda_arch=80 ^cusz +cuda cuda_arch=80
   - magma +cuda cuda_arch=80


### PR DESCRIPTION
The kokkos-fft library is header-only, I chose to add `+tests` to actually compile some source code.