### PR TITLE
py-snoop: add v0.6.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_snoop/package.py
+++ b/repos/spack_repo/builtin/packages/py_snoop/package.py
@@ -11,15 +11,17 @@ class PySnoop(PythonPackage):
     to be a more featureful and refined version of PySnooper. It also includes
     its own version of icecream and some other nifty stuff."""
 
-    pypi = "snoop/snoop-0.4.3.tar.gz"
+    pypi = "snoop/snoop-0.6.0.tar.gz"
 
     license("MIT", checked_by="jmlapre")
 
+    version("0.6.0", sha256="c615eddf84d8907f893dec7fde38768aa4b1d88d92d63055b6cfc07e5cde37ec")
     version("0.4.3", sha256="2e0930bb19ff0dbdaa6f5933f88e89ed5984210ea9f9de0e1d8231fa5c1c1f25")
 
+    depends_on("python@3.8:", when="@0.6:")
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools-scm+toml", type="build")
-    depends_on("py-six", type=("build", "run"))
+    depends_on("py-six", when="@:0.5", type=("build", "run"))
     depends_on("py-cheap-repr@0.4.0:", type=("build", "run"))
     depends_on("py-executing", type=("build", "run"))
     depends_on("py-asttokens", type=("build", "run"))


### PR DESCRIPTION
Add py-snoop v0.6.0.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
