### PR TITLE
tcl/tk: Add versions 8.6.17 and 9.0.2.

### DIFF
--- a/repos/spack_repo/builtin/packages/tcl/package.py
+++ b/repos/spack_repo/builtin/packages/tcl/package.py
@@ -41,6 +41,8 @@ class Tcl(AutotoolsPackage, NMakePackage, SourceforgePackage):
 
     license("TCL")
 
+    version("9.0.2", sha256="e074c6a8d9ba2cddf914ba97b6677a552d7a52a3ca102924389a05ccb249b520")
+    version("8.6.17", sha256="a3903371efcce8a405c5c245d029e9f6850258a60fa3761c4d58995610949b31")
     version("8.6.12", sha256="26c995dd0f167e48b11961d891ee555f680c175f7173ff8cb829f4ebcde4c1a6")
     version("8.6.11", sha256="8c0486668586672c5693d7d95817cb05a18c5ecca2f40e2836b9578064088258")
     version("8.6.10", sha256="5196dbf6638e3df8d5c87b5815c8c2b758496eb6f0e41446596c9a4e638d87ed")

--- a/repos/spack_repo/builtin/packages/tcl/package.py
+++ b/repos/spack_repo/builtin/packages/tcl/package.py
@@ -42,7 +42,11 @@ class Tcl(AutotoolsPackage, NMakePackage, SourceforgePackage):
     license("TCL")
 
     version("9.0.2", sha256="e074c6a8d9ba2cddf914ba97b6677a552d7a52a3ca102924389a05ccb249b520")
-    version("8.6.17", sha256="a3903371efcce8a405c5c245d029e9f6850258a60fa3761c4d58995610949b31")
+    version(
+        "8.6.17",
+        sha256="a3903371efcce8a405c5c245d029e9f6850258a60fa3761c4d58995610949b31",
+        peferred=True
+    )
     version("8.6.12", sha256="26c995dd0f167e48b11961d891ee555f680c175f7173ff8cb829f4ebcde4c1a6")
     version("8.6.11", sha256="8c0486668586672c5693d7d95817cb05a18c5ecca2f40e2836b9578064088258")
     version("8.6.10", sha256="5196dbf6638e3df8d5c87b5815c8c2b758496eb6f0e41446596c9a4e638d87ed")

--- a/repos/spack_repo/builtin/packages/tcl/package.py
+++ b/repos/spack_repo/builtin/packages/tcl/package.py
@@ -45,7 +45,7 @@ class Tcl(AutotoolsPackage, NMakePackage, SourceforgePackage):
     version(
         "8.6.17",
         sha256="a3903371efcce8a405c5c245d029e9f6850258a60fa3761c4d58995610949b31",
-        peferred=True
+        preferred=True,
     )
     version("8.6.12", sha256="26c995dd0f167e48b11961d891ee555f680c175f7173ff8cb829f4ebcde4c1a6")
     version("8.6.11", sha256="8c0486668586672c5693d7d95817cb05a18c5ecca2f40e2836b9578064088258")

--- a/repos/spack_repo/builtin/packages/tk/package.py
+++ b/repos/spack_repo/builtin/packages/tk/package.py
@@ -25,7 +25,7 @@ class Tk(AutotoolsPackage, SourceforgePackage):
     version(
         "8.6.17",
         sha256="e4982df6f969c08bf9dd858a6891059b4a3f50dc6c87c10abadbbe2fc4838946",
-        preferred=True
+        preferred=True,
     )
     version("8.6.11", sha256="5228a8187a7f70fa0791ef0f975270f068ba9557f57456f51eb02d9d4ea31282")
     version("8.6.10", sha256="63df418a859d0a463347f95ded5cd88a3dd3aaa1ceecaeee362194bc30f3e386")

--- a/repos/spack_repo/builtin/packages/tk/package.py
+++ b/repos/spack_repo/builtin/packages/tk/package.py
@@ -22,7 +22,11 @@ class Tk(AutotoolsPackage, SourceforgePackage):
     license("TCL")
 
     version("9.0.2", sha256="76fb852b2f167592fe8b41aa6549ce4e486dbf3b259a269646600e3894517c76")
-    version("8.6.17", sha256="e4982df6f969c08bf9dd858a6891059b4a3f50dc6c87c10abadbbe2fc4838946")
+    version(
+        "8.6.17",
+        sha256="e4982df6f969c08bf9dd858a6891059b4a3f50dc6c87c10abadbbe2fc4838946",
+        preferred=True
+    )
     version("8.6.11", sha256="5228a8187a7f70fa0791ef0f975270f068ba9557f57456f51eb02d9d4ea31282")
     version("8.6.10", sha256="63df418a859d0a463347f95ded5cd88a3dd3aaa1ceecaeee362194bc30f3e386")
     version("8.6.8", sha256="49e7bca08dde95195a27f594f7c850b088be357a7c7096e44e1158c7a5fd7b33")

--- a/repos/spack_repo/builtin/packages/tk/package.py
+++ b/repos/spack_repo/builtin/packages/tk/package.py
@@ -21,6 +21,8 @@ class Tk(AutotoolsPackage, SourceforgePackage):
 
     license("TCL")
 
+    version("9.0.2", sha256="76fb852b2f167592fe8b41aa6549ce4e486dbf3b259a269646600e3894517c76")
+    version("8.6.17", sha256="e4982df6f969c08bf9dd858a6891059b4a3f50dc6c87c10abadbbe2fc4838946")
     version("8.6.11", sha256="5228a8187a7f70fa0791ef0f975270f068ba9557f57456f51eb02d9d4ea31282")
     version("8.6.10", sha256="63df418a859d0a463347f95ded5cd88a3dd3aaa1ceecaeee362194bc30f3e386")
     version("8.6.8", sha256="49e7bca08dde95195a27f594f7c850b088be357a7c7096e44e1158c7a5fd7b33")

--- a/repos/spack_repo/builtin/packages/turbine/package.py
+++ b/repos/spack_repo/builtin/packages/turbine/package.py
@@ -30,6 +30,7 @@ class Turbine(AutotoolsPackage):
     depends_on("adlbx@master", when="@master")
     depends_on("adlbx@:0.9.2", when="@1.2.3:1.2.99")
     depends_on("tcl", type=("build", "run"))
+    depends_on("tcl@:8.6", when="@:1.3.0", type=("build", "run"))
     depends_on("zsh", type=("build", "run"))
     depends_on("swig", type="build")
     depends_on("python", when="+python")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Adding 2 newer versions of `tcl` and `tk`.