### PR TITLE
py-jupyter-events: add v0.12.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_jupyter_events/package.py
+++ b/repos/spack_repo/builtin/packages/py_jupyter_events/package.py
@@ -13,9 +13,12 @@ class PyJupyterEvents(PythonPackage):
     homepage = "https://github.com/jupyter/jupyter_events"
     pypi = "jupyter_events/jupyter_events-0.6.3.tar.gz"
 
+    version("0.12.0", sha256="fc3fce98865f6784c9cd0a56a20644fc6098f21c8c33834a8d9fe383c17e554b")
     version("0.10.0", sha256="670b8229d3cc882ec782144ed22e0d29e1c2d639263f92ca8383e66682845e22")
     version("0.6.3", sha256="9a6e9995f75d1b7146b436ea24d696ce3a35bfa8bfe45e0c33c334c79464d0b3")
 
+    depends_on("python@3.9:", type=("build", "run"), when="@0.11:")
+    depends_on("python@3.8:", type=("build", "run"), when="@0.7:")
     depends_on("py-hatchling@1.5:", type="build")
 
     depends_on("py-referencing", type=("build", "run"), when="@0.7:")
@@ -24,5 +27,6 @@ class PyJupyterEvents(PythonPackage):
     depends_on("py-python-json-logger@2.0.4:", type=("build", "run"))
     depends_on("py-pyyaml@5.3:", type=("build", "run"))
     depends_on("py-traitlets@5.3:", type=("build", "run"))
+    depends_on("py-packaging", type=("build", "run"), when="@0.12:")
     depends_on("py-rfc3339-validator", type=("build", "run"))
     depends_on("py-rfc3986-validator@0.1.1:", type=("build", "run"))


### PR DESCRIPTION
https://github.com/jupyter/jupyter_events/tree/v0.12.0
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
