### PR TITLE
Kokkos: Add conflict for debug_dualview_modify_check

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -217,7 +217,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     }
 
     conflicts("~debug_dualview_modify_check", when="@4.7:")  # always enable from 4.7.00
-    
+
     spack_micro_arch_map = {
         "thunderx2": "THUNDERX2",
         "zen": "ZEN",

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -216,6 +216,8 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         "tests": [False, None, "Build for tests"],
     }
 
+    conflicts("~debug_dualview_modify_check", when="@4.7:")  # always enable from 4.7.00
+    
     spack_micro_arch_map = {
         "thunderx2": "THUNDERX2",
         "zen": "ZEN",


### PR DESCRIPTION
Newer versions of Kokkos always check dual view usage.

Should fix Kokkos nightly tests.