### PR TITLE
add versions 0.20.0 and 0.21.0 of mochi-margo

### DIFF
--- a/repos/spack_repo/builtin/packages/mochi_margo/package.py
+++ b/repos/spack_repo/builtin/packages/mochi_margo/package.py
@@ -18,6 +18,8 @@ class MochiMargo(AutotoolsPackage):
     maintainers("carns", "mdorier", "fbudin69500")
 
     version("main", branch="main")
+    version("0.21.0", sha256="d0a527cd0dcbeb9a8f04d090140cdedb66d9a90c6794a046d48d6bc2d11fc278")
+    version("0.20.0", sha256="ed19f65c3c0dda42b285904f64508d1997f4b0fcef81cddb011aa9c42381eb2a")
     version("0.19.2", sha256="cfd20117744631779f0e99a0bc0668a1ca4d6d3c89fce5e9926961f830491689")
     version("0.19.1", sha256="77422156be5d1e24b16f6d65109ada29a2276c9d6fdd9a5392c23f1fbe370b98")
     version("0.19.0", sha256="269e3b52228fb59a8ab502b8fac4761fc15440817455bb006f311093bd4c02f3")
@@ -69,6 +71,8 @@ class MochiMargo(AutotoolsPackage):
     version("0.4.3", sha256="61a634d6983bee2ffa06e1e2da4c541cb8f56ddd9dd9f8e04e8044fb38657475")
     version("0.4.2", sha256="91085e28f50e373b9616e1ae5c3c8d40a19a7d3776259592d8f361766890bcaa")
 
+    variant('hwloc', default=True, when="@0.21:", description="use hwloc to help select network cards when possible")
+
     depends_on("c", type="build")
 
     depends_on("json-c", when="@0.9:")
@@ -82,6 +86,7 @@ class MochiMargo(AutotoolsPackage):
     # "breadcrumb" support not available in mercury-1.0
     depends_on("mercury@1.0.0:", type=("build", "link", "run"), when="@:0.5.1")
     depends_on("mercury@2.0.0:", type=("build", "link", "run"), when="@0.5.2:")
+    depends_on('hwloc', when='+hwloc')
 
     # Fix pthread detection
     # https://github.com/mochi-hpc/mochi-margo/pull/177


### PR DESCRIPTION
* adds two new versions of mochi-margo
* adds an hwloc dependency that can be optionally disabled by setting the `hwloc` variant to false