### PR TITLE
hpctoolkit: add dependency on patchelf

### DIFF
--- a/repos/spack_repo/builtin/packages/hpctoolkit/package.py
+++ b/repos/spack_repo/builtin/packages/hpctoolkit/package.py
@@ -178,6 +178,7 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
     depends_on("dyninst@12.1.0:12", when="@2022:2023.08")
     depends_on("dyninst@10.2.0:12", when="@2021")
     depends_on("dyninst@9.3.2:12", when="@:2020")
+    depends_on("patchelf", type="build")
     depends_on("elfutils~nls", type="link")
     depends_on("gotcha@1.0.3:", when="@:2020.09")
     depends_on("tbb")


### PR DESCRIPTION
This change fixes a dependency error related to patchelf, which likely emerged after [044de4a3](https://gitlab.com/hpctoolkit/hpctoolkit/-/commit/044de4a35d2ffbabeb781c4c305ac773bec946f6).

```
1 error found in build log:
     102    Found git repository at spack-stage-hpctoolkit-develop-7djbwi2gykmhsxqgo5xpvl3biw54gwdz/spack-src
     103    Checking if "Linux >= 4.3" compiles: YES
     104    Program patchelf found: NO
     105    Fallback to subproject patchelf which provides program patchelf
     106    ERROR: Subproject patchelf is buildable: NO
     107    
  >> 108    ../spack-src/src/hpcrun/meson.build:549:11: ERROR: Automatic wrap-based subproject downloading is disabled
  ```
  
  CC: @cameronrutherford 