### PR TITLE
fflas-ffpack: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/fflas_ffpack/package.py
+++ b/repos/spack_repo/builtin/packages/fflas_ffpack/package.py
@@ -1,0 +1,31 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+
+from spack.package import *
+
+
+class FflasFfpack(AutotoolsPackage):
+    """FFLAS-FFPACK is a library for dense linear algebra over finite
+    fields, providing high-performance implementations of classical
+    and fast matrix algorithms (e.g., Gaussian elimination, rank,
+    determinant, minimal/characteristic polynomials) using Givaro for
+    finite field arithmetic."""
+
+    homepage = "https://linbox-team.github.io/fflas-ffpack/"
+    url = "https://github.com/linbox-team/fflas-ffpack/releases/download/v2.5.0/fflas-ffpack-2.5.0.tar.gz"
+
+    maintainers("d-torrance")
+
+    license("LGPL-2.1-or-later", checked_by="d-torrance")
+
+    version("2.5.0", sha256="dafb4c0835824d28e4f823748579be6e4c8889c9570c6ce9cce1e186c3ebbb23")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    depends_on("blas")
+    depends_on("givaro")
+    depends_on("lapack")


### PR DESCRIPTION
[FFLAS-FFPACK](https://linbox-team.github.io/fflas-ffpack/) is a header-only library for linear algebra over finite fields.  It's a dependency of software such as LinBox and Macaulay2.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
