### PR TITLE
qgis: fix building

### DIFF
--- a/repos/spack_repo/builtin/packages/libspatialite/package.py
+++ b/repos/spack_repo/builtin/packages/libspatialite/package.py
@@ -45,10 +45,11 @@ class Libspatialite(AutotoolsPackage):
     depends_on("iconv")
     depends_on("librttopo", when="@5.0.1:")
 
-    # in libxml2 2.15+ http support is completely removed
+    # in libxml2 2.15+ http support is completely removed, so this will need
+    # to be refined when libspatiallite is updated
     # https://www.gaia-gis.it/fossil/libspatialite/tktview?name=e8f33aa9d8
     # https://www.gaia-gis.it/fossil/libspatialite/tktview?name=ac85f0fca3
-    depends_on("libxml2@:2.14 +http", when="@:5.1.0")
+    depends_on("libxml2 +http")
     depends_on("minizip", when="@5.0.0:")
     depends_on("proj")
     depends_on("proj@:5", when="@:4")

--- a/repos/spack_repo/builtin/packages/libspatialite/package.py
+++ b/repos/spack_repo/builtin/packages/libspatialite/package.py
@@ -44,7 +44,11 @@ class Libspatialite(AutotoolsPackage):
     depends_on("geos@:3.9", when="@:5.0.0")
     depends_on("iconv")
     depends_on("librttopo", when="@5.0.1:")
-    depends_on("libxml2+http")
+
+    # in libxml2 2.15+ http support is completely removed
+    # https://www.gaia-gis.it/fossil/libspatialite/tktview?name=e8f33aa9d8
+    # https://www.gaia-gis.it/fossil/libspatialite/tktview?name=ac85f0fca3
+    depends_on("libxml2@:2.14 +http", when="@:5.1.0")
     depends_on("minizip", when="@5.0.0:")
     depends_on("proj")
     depends_on("proj@:5", when="@:4")

--- a/repos/spack_repo/builtin/packages/libxml2/package.py
+++ b/repos/spack_repo/builtin/packages/libxml2/package.py
@@ -66,7 +66,9 @@ class Libxml2(AutotoolsPackage, CMakePackage, NMakePackage):
         version("2.9.2", sha256="5178c30b151d044aefb1b08bf54c3003a0ac55c59c866763997529d60770d5bc")
         version("2.7.8", sha256="cda23bc9ebd26474ca8f3d67e7d1c4a1f1e7106364b690d822e009fdc3c417ec")
 
-    variant("http", default=False, description="Enable HTTP support")
+    # http support was deprecated in 2.13 and removed in 2.15
+    # https://github.com/GNOME/libxml2/commit/b85d77d156476bcb910b2a25b21a091957d10de6
+    variant("http", default=False, description="Enable HTTP support", when="@:2.14")
     variant("python", default=False, description="Enable Python support")
     variant("shared", default=True, description="Build shared library")
     variant("pic", default=True, description="Enable position-independent code (PIC)")
@@ -274,6 +276,7 @@ class CMakeBuilder(AnyBuilder, cmake.CMakeBuilder):
         args = [
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant("LIBXML2_WITH_PYTHON", "python"),
+            self.define_from_variant("LIBXML2_WITH_HTTP", "http"),
             self.define("LIBXML2_WITH_LZMA", True),
             self.define("LIBXML2_WITH_ZLIB", True),
             self.define("LIBXML2_WITH_TESTS", True),

--- a/repos/spack_repo/builtin/packages/py_pyqt5/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyqt5/package.py
@@ -18,6 +18,7 @@ class PyPyqt5(SIPPackage):
 
     license("GPL-3.0-only")
 
+    version("5.15.11", sha256="fda45743ebb4a27b4b1a51c6d8ef455c4c1b5d610c90d2934c7802b5c1557c52")
     version("5.15.9", sha256="dc41e8401a90dc3e2b692b411bd5492ab559ae27a27424eed4bd3915564ec4c0")
 
     depends_on("cxx", type="build")  # generated
@@ -25,10 +26,12 @@ class PyPyqt5(SIPPackage):
 
     # pyproject.toml
     depends_on("py-sip@6.6.2:6", type="build")
+    depends_on("py-sip@6.8.6:6", type="build", when="@5.15.11:")
     depends_on("py-pyqt-builder@1.14.1:1", type="build")
 
     # PKG-INFO
     depends_on("py-pyqt5-sip@12.11:12", type=("build", "run"))
+    depends_on("py-pyqt5-sip@12.15:12", type=("build", "run"), when="@5.15.11:")
 
     # README
     depends_on("qt@5+opengl")

--- a/repos/spack_repo/builtin/packages/py_pyqt5_sip/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyqt5_sip/package.py
@@ -11,10 +11,11 @@ class PyPyqt5Sip(PythonPackage):
     """The sip module support for PyQt5."""
 
     homepage = "https://www.riverbankcomputing.com/software/sip/"
-    pypi = "PyQt5-sip/PyQt5_sip-12.9.0.tar.gz"
+    pypi = "PyQt5-sip/pyqt5_sip-12.9.0.tar.gz"
 
     license("GPL-2.0-only")
 
+    version("12.17.0", sha256="682dadcdbd2239af9fdc0c0628e2776b820e128bec88b49b8d692fe682f90b4f")
     version("12.13.0", sha256="7f321daf84b9c9dbca61b80e1ef37bdaffc0e93312edae2cd7da25b953971d91")
     version("12.12.1", sha256="8fdc6e0148abd12d977a1d3828e7b79aae958e83c6cb5adae614916d888a6b10")
     version("12.9.0", sha256="d3e4489d7c2b0ece9d203ae66e573939f7f60d4d29e089c9f11daa17cfeaae32")
@@ -27,5 +28,13 @@ class PyPyqt5Sip(PythonPackage):
     patch(
         "https://src.fedoraproject.org/rpms/python-pyqt5-sip/raw/841f58ce66df4dfcf11713e7adb6bd301403d5a8/f/afc99fa84d0d.patch",
         sha256="82a326749b145b30eda3f0040cd7099c4c06a57a5e9626687b0a983de1ebfc3e",
-        when="@12.12: %gcc@14:",
+        when="@12.12:12.13 %gcc@14:",
     )
+
+
+    def url_for_version(self, version):
+        if version >= Version("12.17.0"):
+            name = "pyqt5-sip"
+        else:
+            name = "PyQt5-sip"
+        return f"https://files.pythonhosted.org/packages/source/P/PyQt5-sip/{name}-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_pyqt5_sip/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyqt5_sip/package.py
@@ -31,10 +31,11 @@ class PyPyqt5Sip(PythonPackage):
         when="@12.12:12.13 %gcc@14:",
     )
 
-
     def url_for_version(self, version):
         if version >= Version("12.17.0"):
             name = "pyqt5-sip"
         else:
             name = "PyQt5-sip"
-        return f"https://files.pythonhosted.org/packages/source/P/PyQt5-sip/{name}-{version}.tar.gz"
+        return (
+            f"https://files.pythonhosted.org/packages/source/P/PyQt5-sip/{name}-{version}.tar.gz"
+        )

--- a/repos/spack_repo/builtin/packages/qgis/package.py
+++ b/repos/spack_repo/builtin/packages/qgis/package.py
@@ -195,9 +195,11 @@ class Qgis(CMakePackage):
     patch("pyqt5_322x.patch", when="@3.22: ^qt@5 ^py-sip@4")
 
     # https://github.com/qgis/QGIS/pull/62142
-    patch("https://patch-diff.githubusercontent.com/raw/qgis/QGIS/pull/62142.patch?full_index=1",
-          when="@3.40 ^py-sip@6.11:",
-          sha256="edb2c149f88c1adfee3791f1928c5119301900541cb40a6d1cc5b68d8aa3b688")
+    patch(
+        "https://patch-diff.githubusercontent.com/raw/qgis/QGIS/pull/62142.patch?full_index=1",
+        when="@3.40 ^py-sip@6.11:",
+        sha256="edb2c149f88c1adfee3791f1928c5119301900541cb40a6d1cc5b68d8aa3b688",
+    )
 
     @run_before("cmake", when="^py-pyqt5")
     def fix_pyqt5_cmake(self):

--- a/repos/spack_repo/builtin/packages/qgis/package.py
+++ b/repos/spack_repo/builtin/packages/qgis/package.py
@@ -16,7 +16,7 @@ class Qgis(CMakePackage):
     homepage = "https://qgis.org"
     url = "https://qgis.org/downloads/qgis-3.8.1.tar.bz2"
 
-    maintainers("adamjstewart", "Sinan81")
+    maintainers("adamjstewart", "Sinan81", "Chrismarsh")
 
     license("GPL-2.0-or-later")
 

--- a/repos/spack_repo/builtin/packages/qgis/package.py
+++ b/repos/spack_repo/builtin/packages/qgis/package.py
@@ -194,6 +194,11 @@ class Qgis(CMakePackage):
     patch("pyqt5_3165x.patch", when="@3.16.5:3.21 ^qt@5 ^py-sip@4")
     patch("pyqt5_322x.patch", when="@3.22: ^qt@5 ^py-sip@4")
 
+    # https://github.com/qgis/QGIS/pull/62142
+    patch("https://patch-diff.githubusercontent.com/raw/qgis/QGIS/pull/62142.patch?full_index=1",
+          when="@3.40 ^py-sip@6.11:",
+          sha256="edb2c149f88c1adfee3791f1928c5119301900541cb40a6d1cc5b68d8aa3b688")
+
     @run_before("cmake", when="^py-pyqt5")
     def fix_pyqt5_cmake(self):
         cmfile = FileFilter(join_path("cmake", "FindPyQt5.cmake"))

--- a/repos/spack_repo/builtin/packages/qscintilla/package.py
+++ b/repos/spack_repo/builtin/packages/qscintilla/package.py
@@ -78,9 +78,10 @@ class Qscintilla(QMakePackage):
         )
         # if prefix includes symlinks, the realpath is what was written to the make file
         makefile.filter(
-            "$(INSTALL_ROOT)" + os.path.realpath(self.spec["qmake"].prefix), "$(INSTALL_ROOT)", string=True
+            "$(INSTALL_ROOT)" + os.path.realpath(self.spec["qmake"].prefix),
+            "$(INSTALL_ROOT)",
+            string=True,
         )
-
 
     @run_after("install", when="+designer")
     def make_designer(self):
@@ -95,7 +96,9 @@ class Qscintilla(QMakePackage):
             )
             # if prefix includes symlinks, the realpath is what was written to the make file
             makefile.filter(
-                "$(INSTALL_ROOT)" + os.path.realpath(self.spec["qmake"].prefix), "$(INSTALL_ROOT)", string=True
+                "$(INSTALL_ROOT)" + os.path.realpath(self.spec["qmake"].prefix),
+                "$(INSTALL_ROOT)",
+                string=True,
             )
             make("install")
 
@@ -122,7 +125,13 @@ class Qscintilla(QMakePackage):
                 # add widgets and printsupport to Qsci.pro
                 # also add link statement to fix "undefined symbol _Z...Qsciprinter...
                 # without no-as-needed this can be dropped from linking stage
-                link_qscilibs = "LIBS += -Wl,--no-as-needed -L" + self.prefix.lib + " -lqscintilla2_" + qtx + " -Wl,--as-needed"
+                link_qscilibs = (
+                    "LIBS += -Wl,--no-as-needed -L"
+                    + self.prefix.lib
+                    + " -lqscintilla2_"
+                    + qtx
+                    + " -Wl,--as-needed"
+                )
                 tomlfile.write(
                     f"""
 [tool.sip.builder]

--- a/repos/spack_repo/builtin/packages/qscintilla/package.py
+++ b/repos/spack_repo/builtin/packages/qscintilla/package.py
@@ -41,7 +41,7 @@ class Qscintilla(QMakePackage):
     depends_on("py-pyqt-builder", type="build", when="+python")
     depends_on("py-pyqt5", type=("build", "run"), when="+python ^qt@5")
     depends_on("python", type=("build", "run"), when="+python")
-    # adter install inquires py-sip variant : so we need to have it
+    # after install inquires py-sip variant : so we need to have it
     depends_on("py-sip", type="build", when="+python")
 
     extends("python", when="+python")
@@ -76,6 +76,11 @@ class Qscintilla(QMakePackage):
         makefile.filter(
             "$(INSTALL_ROOT)" + self.spec["qmake"].prefix, "$(INSTALL_ROOT)", string=True
         )
+        # if prefix includes symlinks, the realpath is what was written to the make file
+        makefile.filter(
+            "$(INSTALL_ROOT)" + os.path.realpath(self.spec["qmake"].prefix), "$(INSTALL_ROOT)", string=True
+        )
+
 
     @run_after("install", when="+designer")
     def make_designer(self):
@@ -87,6 +92,10 @@ class Qscintilla(QMakePackage):
             makefile = FileFilter("Makefile")
             makefile.filter(
                 "$(INSTALL_ROOT)" + self.spec["qmake"].prefix, "$(INSTALL_ROOT)", string=True
+            )
+            # if prefix includes symlinks, the realpath is what was written to the make file
+            makefile.filter(
+                "$(INSTALL_ROOT)" + os.path.realpath(self.spec["qmake"].prefix), "$(INSTALL_ROOT)", string=True
             )
             make("install")
 
@@ -112,7 +121,8 @@ class Qscintilla(QMakePackage):
                 tomlfile.write(f'\n[tool.sip.project]\nsip-include-dirs = ["{sip_inc_dir}"]\n')
                 # add widgets and printsupport to Qsci.pro
                 # also add link statement to fix "undefined symbol _Z...Qsciprinter...
-                link_qscilibs = "LIBS += -L" + self.prefix.lib + " -lqscintilla2_" + qtx
+                # without no-as-needed this can be dropped from linking stage
+                link_qscilibs = "LIBS += -Wl,--no-as-needed -L" + self.prefix.lib + " -lqscintilla2_" + qtx + " -Wl,--as-needed"
                 tomlfile.write(
                     f"""
 [tool.sip.builder]


### PR DESCRIPTION
Fixes building qgis due to a few issues:
-  `libxml` had a missing a define for `+http` when building with cmake
- `libxml` has deprecated the `http` feature, so this tidies up the `libxml` depend in `libspatiallite`
- `qscintilla`'s complex post-install patching fails when paths are internally symlinked but are written to the file as realpaths. This now tries to patch out both
- there is a complex interaction of `py-sip` and `py-pyqt5-sip` and `py-pyqt5` such that with the versions in spack currently, `qscintialla` does not import cleanly due to an ABI mismatch. Error below for anyone searching:

```
 python -c "from PyQt5.Qsci import QSCINTILLA_VERSION_STR; print(QSCINTILLA_VERSION_STR)"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    from PyQt5.Qsci import QSCINTILLA_VERSION_STR; print(QSCINTILLA_VERSION_STR)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: the sip module implements API v12.0 to v12.13 but the PyQt5.Qsci module requires API v12.15
```
Updating all the various `*-sip` dependencies resolves this problem.
- qgis needs a patch to work with newish `py-sip` versions and this applies the back-ported patch

Maintainers:
@adamjstewart @Sinan81 @AlexanderRichert-NOAA