### PR TITLE
py-fenics-dolfinx: remove unnecessary dependency (hdf5)

### DIFF
--- a/repos/spack_repo/builtin/packages/py_fenics_dolfinx/package.py
+++ b/repos/spack_repo/builtin/packages/py_fenics_dolfinx/package.py
@@ -44,7 +44,6 @@ class PyFenicsDolfinx(PythonPackage):
 
     depends_on("cmake@3.21:", when="@0.9:", type="build")
     depends_on("cmake@3.19:", when="@:0.8", type="build")
-    depends_on("hdf5", type="build")
     depends_on("pkgconfig", type="build")
 
     depends_on("python@3.9:", when="@0.8:", type=("build", "run"))


### PR DESCRIPTION
Package doesn't depend on HDF5.