### PR TITLE
py-keyrings-alt: add v5.0.2 and add new dep packages

### DIFF
--- a/repos/spack_repo/builtin/packages/py_backports_tarfile/package.py
+++ b/repos/spack_repo/builtin/packages/py_backports_tarfile/package.py
@@ -1,0 +1,22 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyBackportsTarfile(PythonPackage):
+    """Backport of CPython tarfile module."""
+
+    homepage = "https://github.com/jaraco/backports.tarfile"
+    pypi = "backports_tarfile/backports_tarfile-1.2.0.tar.gz"
+
+    license("MIT")
+
+    version("1.2.0", sha256="d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991")
+
+    depends_on("python@3.8:", type=("build", "run"))
+    depends_on("py-setuptools@61.2:", type="build")
+    depends_on("py-setuptools-scm+toml@3.4.1:", type="build")

--- a/repos/spack_repo/builtin/packages/py_jaraco_context/package.py
+++ b/repos/spack_repo/builtin/packages/py_jaraco_context/package.py
@@ -1,0 +1,24 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyJaracoContext(PythonPackage):
+    """Useful decorators and context managers."""
+
+    homepage = "https://github.com/jaraco/jaraco.context"
+    pypi = "jaraco_context/jaraco_context-6.0.1.tar.gz"
+
+    license("MIT")
+
+    version("6.0.1", sha256="9bae4ea555cf0b14938dc0aee7c9f32ed303aa20a3b73e7dc80111628792d1b3")
+
+    depends_on("python@3.8:", type=("build", "run"))
+    depends_on("py-setuptools@61.2:", type="build")
+    depends_on("py-setuptools-scm+toml@3.4.1:", type="build")
+
+    depends_on("py-backports-tarfile", type=("build", "run"), when="^python@:3.11")

--- a/repos/spack_repo/builtin/packages/py_keyrings_alt/package.py
+++ b/repos/spack_repo/builtin/packages/py_keyrings_alt/package.py
@@ -11,18 +11,29 @@ class PyKeyringsAlt(PythonPackage):
     """Alternate keyring implementations"""
 
     homepage = "https://github.com/jaraco/keyrings.alt"
-    pypi = "keyrings.alt/keyrings.alt-4.0.2.tar.gz"
+    pypi = "keyrings.alt/keyrings_alt-5.0.2.tar.gz"
 
     license("MIT")
 
+    version("5.0.2", sha256="8f097ebe9dc8b185106502b8cdb066c926d2180e13b4689fd4771a3eab7d69fb")
     version("4.2.0", sha256="2ba3d56441ba0637f5f9c096068f67010ac0453f9d0b626de2aa3019353b6431")
     version("4.1.0", sha256="52ccb61d6f16c10f32f30d38cceef7811ed48e086d73e3bae86f0854352c4ab2")
     version("4.0.2", sha256="cc475635099d6edd7e475c5a479e5b4da5e811a3af04495a1e9ada488d16fe25")
 
+    depends_on("python@3.8:", when="@5:", type=("build", "run"))
     depends_on("python@3.7:", when="@4.2:", type=("build", "run"))
     depends_on("python@3.6:", type=("build", "run"))
+    depends_on("py-setuptools@61.2:", when="@5.0.2:", type="build")
     depends_on("py-setuptools@56:", when="@4.2:", type="build")
     depends_on("py-setuptools@42:", type="build")
     depends_on("py-setuptools-scm+toml@3.4.1:", type="build")
 
     depends_on("py-jaraco-classes", when="@4.1.2:", type=("build", "run"))
+    depends_on("py-jaraco-context", when="@5.0.1:", type=("build", "run"))
+
+    def url_for_version(self, version):
+        if version >= Version("5.0.2"):
+            name = "keyrings_alt"
+        else:
+            name = "keyrings.alt"
+        return f"https://files.pythonhosted.org/packages/source/k/keyrings.alt/{name}-{version}.tar.gz"


### PR DESCRIPTION
https://github.com/jaraco/keyrings.alt/tree/v5.0.2

`py-keyrings-alt` has a new dependency on `py-jaraco-context` which again depends on `py-backports-tarfile`. So these 2 new packages were added as well.
https://github.com/jaraco/jaraco.context/tree/v6.0.1
https://github.com/jaraco/backports.tarfile/tree/v1.2.0

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
