### PR TITLE
compiler dependency: octave_io depends on cxx

### DIFF
--- a/repos/spack_repo/builtin/packages/octave_io/package.py
+++ b/repos/spack_repo/builtin/packages/octave_io/package.py
@@ -17,10 +17,13 @@ class OctaveIo(OctavePackage, SourceforgePackage):
 
     license("GPL-3.0-only")
 
+    version("2.7.0", sha256="4aa48468b3697934bf8c854e27dbab8827605e9dd4fe37e56834265e6130ba6f")
     version("2.6.3", sha256="6bc63c6498d79cada01a6c4446f793536e0bb416ddec2a5201dd8d741d459e10")
     version("2.6.2", sha256="01dbf8885a8011e76c919e271727c1d44f625bf6b217948b79438039ba368ceb")
     version("2.6.1", sha256="83253561f883c96ca3021a771223d23795122dc4cb800766e9cb893c6f8262dd")
     version("2.6.0", sha256="27f26273ced0b42c098e900136bb0ab2e542baf98d02bc0176cf47edbd0e6d7f")
     version("2.2.7", sha256="4eed2ee4c89b49ab160546c77ed66a384598f3bbb1c6e3833529c2c55aa479b6")
+
+    depends_on("cxx", type="build")
 
     extends("octave@4.2.0:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
- octave_io depends on cxx
- added new version 2.7.0