### PR TITLE
lmod: depends on pkgconf

### DIFF
--- a/repos/spack_repo/builtin/packages/lmod/package.py
+++ b/repos/spack_repo/builtin/packages/lmod/package.py
@@ -66,6 +66,8 @@ class Lmod(AutotoolsPackage):
 
     depends_on("bc", type="build", when="@8.7.10:")
 
+    depends_on("pkgconf", type="build")
+
     # GNU sed is required instead of bsd sed on macOS
     depends_on("sed", type="build", when="platform=darwin")
 

--- a/repos/spack_repo/builtin/packages/lmod/package.py
+++ b/repos/spack_repo/builtin/packages/lmod/package.py
@@ -66,7 +66,7 @@ class Lmod(AutotoolsPackage):
 
     depends_on("bc", type="build", when="@8.7.10:")
 
-    depends_on("pkgconf", type="build")
+    depends_on("pkgconfig", type="build")
 
     # GNU sed is required instead of bsd sed on macOS
     depends_on("sed", type="build", when="platform=darwin")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Lmod's configure script explicitly looks for `pkg-config` executable , so I added an explicit build-time dependency on `pkgconf` to ensure the configuration phase succeeds.

Fixes: spack/spack#50348