### PR TITLE
py-mne: add v1.10.1 and py-h5io: add v0.2.5

### DIFF
--- a/repos/spack_repo/builtin/packages/py_h5io/package.py
+++ b/repos/spack_repo/builtin/packages/py_h5io/package.py
@@ -16,10 +16,15 @@ class PyH5io(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.2.5", sha256="265bc9c24508b30575e8a8806b19cd4440643ff26f8b82b51d0280444807eed8")
     version("0.1.7", sha256="be2684e678a28a5d59140de838f0165f095af865e48b8e498a279a3c2b89303e")
 
+    depends_on("python@3.8:", type=("build", "run"), when="@0.2.4:")
     depends_on("python@3.7:", type=("build", "run"))
+
+    depends_on("py-setuptools@64:", type="build", when="@0.2.4:")
     depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools-scm@8:", type="build", when="@0.2.4:")
 
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-h5py", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_mne/package.py
+++ b/repos/spack_repo/builtin/packages/py_mne/package.py
@@ -18,6 +18,7 @@ class PyMne(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.10.1", sha256="a93e3d772d551e43ec5ddcd3495fffe0f98e3e384045bcd96497636e86a32a0b")
     version("1.7.1", sha256="a87bbc998b792532d2c87add8b0f7bbf28a4d8cf5db1bdfb6d6e260791754498")
     version("1.6.1", sha256="e4f5683d01cef675eddad788bdb6b44cc015dff0fb1ddfca3c4105edfb757ef8")
     version("1.4.2", sha256="dd2bf35a90d951bef15ff3a651045b0373eff26018a821667109c727d55c7d63")
@@ -32,34 +33,40 @@ class PyMne(PythonPackage):
     variant("full", default=False, when="@:0.23", description="Enable full functionality.")
     variant("hdf5", default=False, when="@1:", description="Enable hdf5 functionality.")
 
+    depends_on("python@3.10:", when="@1.9:", type=("build", "run"))
     depends_on("python@3.9:", when="@1.7:", type=("build", "run"))
     depends_on("python@3.8:", when="@1.4:", type=("build", "run"))
     depends_on("py-hatchling", when="@1.7:", type="build")
     depends_on("py-hatch-vcs", when="@1.7:", type="build")
 
-    # requirements_base.txt with versions specified in README.rst (marked with *)
-    depends_on("py-numpy@1.21.2:", when="@1.6.1:", type=("build", "run"))
-    depends_on("py-numpy@1.20.2:", when="@1.4:", type=("build", "run"))  # *
-    depends_on("py-numpy@1.18.1:", when="@1:", type=("build", "run"))  # *
-    depends_on("py-numpy@1.15.4:", when="@0.23:", type=("build", "run"))
-    depends_on("py-numpy@1.11.3:", type=("build", "run"))
+    # dependencies for @:1.5 can be found in requirements_base.txt with versions
+    # specified in README.rst (marked with *)
+    depends_on("py-decorator", when="@1:", type=("build", "run"))
+    depends_on("py-jinja2", when="@1:", type=("build", "run"))
+    depends_on("py-lazy-loader@0.3:", when="@1.6.1:", type=("build", "run"))
+    depends_on("py-matplotlib@3.7:", when="@1.10:", type=("build", "run"))
+    depends_on("py-matplotlib@3.5:", when="@1.6.1:", type=("build", "run"))
+    depends_on("py-matplotlib@3.4:", when="@1:", type=("build", "run"))  # *
+    depends_on("py-matplotlib@3.1:", when="@1:", type=("build", "run"))  # *
+    depends_on("py-numpy@1.25:2", when="@1.6.1:", type=("build", "run"))
+    depends_on("py-numpy@1.21.2:", when="@1.6.1:1.7", type=("build", "run"))
+    depends_on("py-numpy@1.20.2:", when="@1.4:1.7", type=("build", "run"))  # *
+    depends_on("py-numpy@1.18.1:", when="@1:1.7", type=("build", "run"))  # *
+    depends_on("py-numpy@1.15.4:", when="@0.23:1.7", type=("build", "run"))
+    depends_on("py-numpy@1.11.3:", when="@:1.7", type=("build", "run"))
     depends_on("py-numpy@:1", when="@:1.6", type=("build", "run"))
+    depends_on("py-packaging", when="@1:", type=("build", "run"))
+    depends_on("py-pooch@1.5:", when="@1:", type=("build", "run"))
+    depends_on("py-scipy@1.11:", when="@1.10:", type=("build", "run"))
     depends_on("py-scipy@1.7.1:", when="@1.6.1:", type=("build", "run"))
     depends_on("py-scipy@1.6.3:", when="@1.4:", type=("build", "run"))
     depends_on("py-scipy@1.4.1:", when="@1:", type=("build", "run"))  # *
     depends_on("py-scipy@1.1.0:", when="@0.23:", type=("build", "run"))
     depends_on("py-scipy@0.17.1:", type=("build", "run"))
-    depends_on("py-matplotlib@3.5:", when="@1.6.1:", type=("build", "run"))
-    depends_on("py-matplotlib@3.4:", when="@1:", type=("build", "run"))  # *
-    depends_on("py-matplotlib@3.1:", when="@1:", type=("build", "run"))  # *
     depends_on("py-tqdm", when="@1:", type=("build", "run"))
-    depends_on("py-pooch@1.5:", when="@1:", type=("build", "run"))
-    depends_on("py-decorator", when="@1:", type=("build", "run"))
-    depends_on("py-packaging", when="@1:", type=("build", "run"))
-    depends_on("py-jinja2", when="@1:", type=("build", "run"))
-    depends_on("py-lazy-loader@0.3:", when="@1.6.1:", type=("build", "run"))
 
     with when("+hdf5"):
+        depends_on("py-h5io@0.2.4:", when="@1.8:", type=("build", "run"))
         depends_on("py-h5io", type=("build", "run"))
         depends_on("py-pymatreader", type=("build", "run"))
 


### PR DESCRIPTION
https://github.com/mne-tools/mne-python/tree/v1.10.1
Reordered dependency to match `pyproject.toml` for easier reviewing

`py-mne+hdf5` also needs a newer version of `py-h5io`, so this is updated as well.
https://github.com/h5io/h5io/tree/h5io-0.2.5

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
