### PR TITLE
py-pygrib: patch required for Cython >= 3.1 support

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pygrib/fix-cython-3.1.patch
+++ b/repos/spack_repo/builtin/packages/py_pygrib/fix-cython-3.1.patch
@@ -1,0 +1,25 @@
+From: Thomas Bouvier <contact@thomas-bouvier.io>
+Subject: Fix build with Cython 3.1
+
+--- a/src/pygrib/_pygrib.pyx
++++ b/src/pygrib/_pygrib.pyx
+@@ -420,7 +419,7 @@ cdef class open(object):
+             grbs = [self.message(n) for n in xrange(beg,end,inc)]
+             self.seek(msg) # put iterator back in original position
+             return grbs
+-        elif type(key) == int or type(key) == long:
++        elif type(key) == int:
+             # for an integer, return a single grib message.
+             msg = self.tell()
+             grb = self.message(key)
+@@ -1925,8 +1924,8 @@ Example usage:
+             # if there are no matches for this key, just skip it
+             if not size:
+                 continue
+-            if typ == 'l' or (type(v) == int or type(v) == long):
+-                longval = long(v)
++            if typ == 'l' or (type(v) == int):
++                longval = int(v)
+                 err = grib_index_select_long(self._gi, key, longval)
+                 if err:
+                     raise RuntimeError(_get_error_message(err))

--- a/repos/spack_repo/builtin/packages/py_pygrib/package.py
+++ b/repos/spack_repo/builtin/packages/py_pygrib/package.py
@@ -27,5 +27,8 @@ class PyPygrib(PythonPackage):
     depends_on("py-numpy@2:", type=("build", "run"))
     depends_on("eccodes", type=("build", "run"))
 
+    # See: https://github.com/jswhit/pygrib/pull/269
+    patch("fix-cython-3.1.patch", when="@2.1.6 ^py-cython@3.1:")
+
     def setup_build_environment(self, env):
         env.set("ECCODES_DIR", self.spec["eccodes"].prefix)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
`py-pygrib` can't be built using Cython >= 3.1

Relevant PR:
- https://github.com/jswhit/pygrib/pull/269

Relevant issues:
- https://github.com/jswhit/pygrib/issues/265
- https://github.com/jswhit/pygrib/issues/238