### PR TITLE
kokkos: support clang as CMake CUDA/HIP compiler

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -423,21 +423,39 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
             options.append(self.define("CMAKE_CXX_COMPILER", self.kokkos_cxx))
         elif "+rocm" in self.spec:
             if "+cmake_lang" in self.spec:
+                if self.spec.satisfies("%cxx=clang"):
+                    options.append(self.define("CMAKE_HIP_COMPILER", self.compiler.cxx))
+                else:
+                    options.append(
+                        self.define(
+                            "CMAKE_HIP_COMPILER",
+                            join_path(self.spec["llvm-amdgpu"].prefix.bin, "amdclang++"),
+                        )
+                    )
+                options.append(from_variant("CMAKE_HIP_STANDARD", "cxxstd"))
                 options.append(
                     self.define(
-                        "CMAKE_HIP_COMPILER",
-                        join_path(self.spec["llvm-amdgpu"].prefix.bin, "amdclang++"),
+                        "CMAKE_HIP_ARCHITECTURES", self.spec.variants["amdgpu_target"].value
                     )
                 )
-                options.append(from_variant("CMAKE_HIP_STANDARD", "cxxstd"))
+                options.append(self.define("CMAKE_HIP_EXTENSIONS", False))
             else:
                 options.append(self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc))
             options.append(self.define("Kokkos_ENABLE_ROCTHRUST", True))
         elif "+cuda" in self.spec and "+cmake_lang" in self.spec:
+            if self.spec.satisfies("%cxx=clang"):
+                options.append(self.define("CMAKE_CUDA_COMPILER", self.compiler.cxx))
+            else:
+                options.append(
+                    self.define(
+                        "CMAKE_CUDA_COMPILER", join_path(self.spec["cuda"].prefix.bin, "nvcc")
+                    )
+                )
             options.append(
-                self.define("CMAKE_CUDA_COMPILER", join_path(self.spec["cuda"].prefix.bin, "nvcc"))
+                self.define("CMAKE_CUDA_ARCHITECTURES", self.spec.variants["cuda_arch"].value)
             )
             options.append(from_variant("CMAKE_CUDA_STANDARD", "cxxstd"))
+            options.append(self.define("CMAKE_CUDA_EXTENSIONS", False))
 
         if self.spec.satisfies("%oneapi") or self.spec.satisfies("%intel"):
             options.append(self.define("CMAKE_CXX_FLAGS", "-fp-model=precise"))


### PR DESCRIPTION
So far `nvcc`/`amdclang++` have been set as `CMAKE_CUDA_COMPILER`and `CMAKE_HIP_COMPILER` if CMake Language support is enabled (+cuda_lang).

However, some projects require both CMake language support and need to use Clang as CUDA/HIP compiler. This still doesn't cover all the cases (such as clang+nvcc), which will hopefully be possible once Spack learns about CUDA and HIP language requirements.

~Due to how the CMake CUDA compiler detection logic operates, we need to add CMAKE_CUDA_FLAGS to make sure we are building for a new enough C++ and for the right target device to pass the initial checks.~

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
