### PR TITLE
mpt: fix for build environment

### DIFF
--- a/repos/spack_repo/builtin/packages/mpt/package.py
+++ b/repos/spack_repo/builtin/packages/mpt/package.py
@@ -40,9 +40,13 @@ class Mpt(BundlePackage):
     ) -> None:
         # use the Spack compiler wrappers under MPI
         dependent_module = dependent_spec.package.module
-        env.set("MPICC_CC", dependent_module.spack_cc)
-        env.set("MPICXX_CXX", dependent_module.spack_cxx)
-        env.set("MPIF90_F90", dependent_module.spack_fc)
+        for var_name, attr_name in (
+            ("MPICC_CC", "spack_cc"),
+            ("MPICXX_CXX", "spack_cxx"),
+            ("MPIF90_F90", "spack_fc"),
+        ):
+            if hasattr(dependent_module, attr_name):
+                env.set(var_name, getattr(dependent_module, attr_name))
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         # Because MPI is both runtime and compiler, we have to setup the mpi


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Testing at NASA NAS (which uses MPT) found that the `mpt` module needed an update for `setup_dependent_build_environment`. This PR "borrows" what is being done in `openmpi` and applies to `mpt`. It seems to allow builds 