### PR TITLE
enzyme: Add v0.0.196

### DIFF
--- a/repos/spack_repo/builtin/packages/enzyme/package.py
+++ b/repos/spack_repo/builtin/packages/enzyme/package.py
@@ -25,6 +25,7 @@ class Enzyme(CMakePackage):
     root_cmakelists_dir = "enzyme"
 
     version("main", branch="main")
+    version("0.0.196", sha256="2b9cfcb7c34e56fc8191423042df06241cf32928eefbb113ac3c5199e3361cb2")
     version("0.0.186", sha256="125e612df0b6b82b07e1e13218c515bc54e04aa1407e57f4f31d3abe995f4714")
     version("0.0.173", sha256="b8477fb5bead9e9ece76d450ebd0afee99914235c6e1a6ef8c05bf288e3c0478")
     version("0.0.172", sha256="688200164787d543641cb446cff20f6a8e8b5c92bb7032ebe7f867efa67ceafb")
@@ -94,4 +95,4 @@ class Enzyme(CMakePackage):
 
         if self.version >= Version("0.0.32"):  # TODO actual lower bound
             lld = find_libraries("LLDEnzyme-{0}".format(ver), root=self.prefix, recursive=True)
-            env.set("LLDMENZYME", lld.joined(";"))
+            env.set("LLDENZYME", lld.joined(";"))

--- a/repos/spack_repo/builtin/packages/enzyme/package.py
+++ b/repos/spack_repo/builtin/packages/enzyme/package.py
@@ -88,11 +88,11 @@ class Enzyme(CMakePackage):
         ver = self.llvm_version.up_to(1)
 
         llvm = find_libraries("LLVMEnzyme-{0}".format(ver), root=self.prefix, recursive=True)
-        env.set("LLVMENZYME", llvm.joined(";"))
+        env.set("LLVMENZYME", ";".join(llvm))
 
         clang = find_libraries("ClangEnzyme-{0}".format(ver), root=self.prefix, recursive=True)
-        env.set("CLANGENZYME", clang.joined(";"))
+        env.set("CLANGENZYME", ";".join(clang))
 
         if self.version >= Version("0.0.32"):  # TODO actual lower bound
             lld = find_libraries("LLDEnzyme-{0}".format(ver), root=self.prefix, recursive=True)
-            env.set("LLDENZYME", lld.joined(";"))
+            env.set("LLDENZYME", ";".join(lld))


### PR DESCRIPTION
This adds [enzyme@0.0.196](https://github.com/EnzymeAD/Enzyme/releases/tag/v0.0.196) and fixes some typos and warnings generated by `env.set` on the generated libraries.
