### PR TITLE
py-more-itertools: add v10.8.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_more_itertools/package.py
+++ b/repos/spack_repo/builtin/packages/py_more_itertools/package.py
@@ -11,10 +11,11 @@ class PyMoreItertools(PythonPackage):
     """Additions to the standard Python itertools package."""
 
     homepage = "https://github.com/erikrose/more-itertools"
-    pypi = "more-itertools/more-itertools-7.2.0.tar.gz"
+    pypi = "more-itertools/more_itertools-10.8.0.tar.gz"
 
     license("MIT")
 
+    version("10.8.0", sha256="f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd")
     version("9.1.0", sha256="cabaa341ad0389ea83c17a94566a53ae4c9d07349861ecb14dc6d0345cf9ac5d")
     version("8.14.0", sha256="c09443cd3d5438b8dafccd867a6bc1cb0894389e90cb53d227456b0b0bccb750")
     version("8.12.0", sha256="7dc6ad46f05f545f900dd59e8dfb4e84a4827b97b3cfecb175ea0c7d247f6064")
@@ -27,8 +28,19 @@ class PyMoreItertools(PythonPackage):
     version("4.1.0", sha256="c9ce7eccdcb901a2c75d326ea134e0886abfbea5f93e91cc95de9507c0816c44")
     version("2.2", sha256="93e62e05c7ad3da1a233def6731e8285156701e3419a5fe279017c429ec67ce0")
 
-    depends_on("py-flit-core@3.2:3", when="@8.14.0:", type="build")
+    depends_on("python@3.9:", when="@10.6:", type=("build", "run"))
+    depends_on("python@3.8:", when="@10:", type=("build", "run"))
+    depends_on("python@3.7:", when="@9:", type=("build", "run"))
+    depends_on("py-flit-core@3.12:3", when="@10.8:", type="build")
+    depends_on("py-flit-core@3.2:3", when="@8.14.0:10.7", type="build")
 
     # Historical dependencies
     depends_on("py-setuptools", when="@:8.12.0", type="build")
     depends_on("py-six@1.0.0:1", when="@:5", type=("build", "run"))
+
+    def url_for_version(self, version):
+        if version >= Version("10.7.0"):
+            name = "more_itertools"
+        else:
+            name = "more-itertools"
+        return f"https://files.pythonhosted.org/packages/source/m/more-itertools/{name}-{version}.tar.gz"


### PR DESCRIPTION
https://github.com/more-itertools/more-itertools/tree/v10.8.0

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
