### PR TITLE
Fix build failure for cgl and coinutils.

### DIFF
--- a/repos/spack_repo/builtin/packages/cgl/package.py
+++ b/repos/spack_repo/builtin/packages/cgl/package.py
@@ -25,6 +25,7 @@ class Cgl(AutotoolsPackage):
     version("0.60.6", sha256="9e2c51ffad816ab408763d6b931e2a3060482ee4bf1983148969de96d4b2c9ce")
     version("0.60.3", sha256="cfeeedd68feab7c0ce377eb9c7b61715120478f12c4dd0064b05ad640e20f3fb")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     depends_on("coinutils")

--- a/repos/spack_repo/builtin/packages/coinutils/package.py
+++ b/repos/spack_repo/builtin/packages/coinutils/package.py
@@ -22,6 +22,8 @@ class Coinutils(AutotoolsPackage):
     version("2.11.6", sha256="6ea31d5214f7eb27fa3ffb2bdad7ec96499dd2aaaeb4a7d0abd90ef852fc79ca")
     version("2.11.4", sha256="d4effff4452e73356eed9f889efd9c44fe9cd68bd37b608a5ebb2c58bd45ef81")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type="build")
 
     build_directory = "spack-build"


### PR DESCRIPTION
Both packages are missing language declarations. This patch fixes the issue and make the two packages buildable again.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
