### PR TITLE
hdf5: set MPI_CXX_COMPILER only when +cxx

### DIFF
--- a/repos/spack_repo/builtin/packages/hdf5/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5/package.py
@@ -560,12 +560,9 @@ class Hdf5(CMakePackage):
         # and pointing these variables at the MSVC compilers
         # breaks CMake's mpi detection for MSMPI.
         if spec.satisfies("+mpi") and "msmpi" not in spec:
-            args.extend(
-                [
-                    "-DMPI_CXX_COMPILER:PATH=%s" % spec["mpi"].mpicxx,
-                    "-DMPI_C_COMPILER:PATH=%s" % spec["mpi"].mpicc,
-                ]
-            )
+            if spec.satisfies("+cxx"):
+                args.append("-DMPI_CXX_COMPILER:PATH=%s" % spec["mpi"].mpicxx)
+            args.append("-DMPI_C_COMPILER:PATH=%s" % spec["mpi"].mpicc)
 
             if spec.satisfies("+fortran"):
                 args.extend(["-DMPI_Fortran_COMPILER:PATH=%s" % spec["mpi"].mpifc])


### PR DESCRIPTION
This PR modifies the hdf5 recipe to set MPI_CXX_COMPILER only when +cxx.