### PR TITLE
osqp: fix build dependency for C++

### DIFF
--- a/repos/spack_repo/builtin/packages/osqp/package.py
+++ b/repos/spack_repo/builtin/packages/osqp/package.py
@@ -24,4 +24,5 @@ class Osqp(CMakePackage):
     version("0.6.0", commit="0baddd36bd57ec1cace0a52c6dd9663e8f16df0a", submodules=True)
     version("0.5.0", commit="97050184aa2cbebe446ae02d1f8b811243e180d6", submodules=True)
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")


### PR DESCRIPTION
The OSQP package fails when installed with GCC 13.3.0 with the following message:

```log
3 errors found in build log:
     8     -- Detecting C compile features
     9     -- Detecting C compile features - done
     10    -- Detecting CXX compiler ABI info
     11    -- Detecting CXX compiler ABI info - failed
     12    -- Check for working CXX compiler: /<<<REDACTED>>>/projects/spack/opt/spack/linux-skylake/compil
           er-wrapper-1.0-7jwusgfgu3whgccg6col46kp7qmvxsho/libexec/spack/gcc/g++
     13    -- Check for working CXX compiler: /<<<REDACTED>>>/projects/spack/opt/spack/linux-skylake/compil
           er-wrapper-1.0-7jwusgfgu3whgccg6col46kp7qmvxsho/libexec/spack/gcc/g++ - broken
  >> 14    CMake Error at /usr/share/cmake-3.28/Modules/CMakeTestCXXCompiler.cmake:60 (message):
     15      The C++ compiler
     16    
     17        "/<<<REDACTED>>>/projects/spack/opt/spack/linux-skylake/compiler-wrapper-1.0-7jwusgfgu3whgcc
           g6col46kp7qmvxsho/libexec/spack/gcc/g++"
     18    
     19      is not able to compile a simple test program.
     20    

     ...

     25        Run Build Command(s): /usr/bin/cmake -E env VERBOSE=1 /usr/bin/gmake -f Makefile cmTC_6fdeb/fast
     26        /usr/bin/gmake  -f CMakeFiles/cmTC_6fdeb.dir/build.make CMakeFiles/cmTC_6fdeb.dir/build
     27        gmake[1]: Entering directory '/tmp/<<<REDACTED>>>/spack-stage/spack-stage-osqp-master-ri6jy3bzpzvtzzzc4a2g
           wlw6gtt5qtcb/spack-build-ri6jy3b/CMakeFiles/CMakeScratch/TryCompile-0ivPi8'
     28        Building CXX object CMakeFiles/cmTC_6fdeb.dir/testCXXCompiler.cxx.o
     29        /<<<REDACTED>>>/projects/spack/opt/spack/linux-skylake/compiler-wrapper-1.0-7jwusgfgu3whgccg
           6col46kp7qmvxsho/libexec/spack/gcc/g++    -o CMakeFiles/cmTC_6fdeb.dir/testCXXCompiler.cxx.o -c /tmp/pz2
           77238/spack-stage/spack-stage-osqp-master-ri6jy3bzpzvtzzzc4a2gwlw6gtt5qtcb/spack-build-ri6jy3b/CMakeFile
           s/CMakeScratch/TryCompile-0ivPi8/testCXXCompiler.cxx
     30        /<<<REDACTED>>>/projects/spack/opt/spack/linux-skylake/compiler-wrapper-1.0-7jwusgfgu3whgccg
           6col46kp7qmvxsho/libexec/spack/gcc/g++: 1: eval: SPACK_CXX_LINKER_ARG: ERROR: LINKER ARG WAS NOT SET, MA
           YBE THE PACKAGE DOES NOT DEPEND ON CXX?
  >> 31    gmake[1]: *** [CMakeFiles/cmTC_6fdeb.dir/build.make:78: CMakeFiles/cmTC_6fdeb.dir/testCXXCompiler.cxx.o]
            Error 2
     32        gmake[1]: Leaving directory '/tmp/<<<REDACTED>>>/spack-stage/spack-stage-osqp-master-ri6jy3bzpzvtzzzc4a2gw
           lw6gtt5qtcb/spack-build-ri6jy3b/CMakeFiles/CMakeScratch/TryCompile-0ivPi8'
  >> 33        gmake: *** [Makefile:127: cmTC_6fdeb/fast] Error 2
     34    
     35    
     36    
     37    
     38    
     39      CMake will not be able to correctly generate this project.
```

Given that OSQP is a C and C++ project, adding a build dependency to C++ solved the issue.