### PR TITLE
ninja: update and un-deprecate kitware version

### DIFF
--- a/repos/spack_repo/builtin/packages/ninja/package.py
+++ b/repos/spack_repo/builtin/packages/ninja/package.py
@@ -38,10 +38,7 @@ class Ninja(Package):
     version("1.7.2", sha256="2edda0a5421ace3cf428309211270772dd35a91af60c96f93f90df6bc41b16d9")
     version("1.6.0", sha256="b43e88fb068fe4d92a3dfd9eb4d19755dae5c33415db2e9b7b61b4659009cde7")
     version(
-        "kitware",
-        branch="features-for-fortran",
-        git="https://github.com/Kitware/ninja.git",
-        deprecated=True,
+        "kitware", branch="kitware-staged-features", git="https://github.com/Kitware/ninja.git"
     )
 
     # ninja@1.12: needs googletest source, but 1.12 itself needs a patch to use it


### PR DESCRIPTION
Use the default branch (kitware-staged-features) for the Kitware fork of ninja.
