### PR TITLE
libpng: make stdio variant conditional for version 1.2.57

### DIFF
--- a/repos/spack_repo/builtin/packages/libpng/package.py
+++ b/repos/spack_repo/builtin/packages/libpng/package.py
@@ -50,6 +50,10 @@ class Libpng(CMakePackage):
     )
     variant("pic", default=False, description="PIC")
 
+#MOD
+    variant("stdio", default=False, description="Enable/disable stdio support", when="@1.2.57")
+#MOD
+
     # Tries but fails to include fp.h, removed in libpng 1.6.45
     conflicts("@:1.6.44", when="%apple-clang@17:")
 
@@ -72,6 +76,12 @@ class CMakeBuilder(CMakeBuilder):
             self.define("PNG_STATIC", "static" in self.spec.variants["libs"].value),
             self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
         ]
+
+#MOD
+        if self.spec.satisfies("@1.2.57"):
+            args.append(self.define("PNG_NO_STDIO", not self.spec.satisfies("+stdio")))
+#MOD
+
         zlib_lib = self.spec["zlib-api"].libs
         if zlib_lib:
             args.append(self.define("ZLIB_LIBRARY", zlib_lib[0]))

--- a/repos/spack_repo/builtin/packages/libpng/package.py
+++ b/repos/spack_repo/builtin/packages/libpng/package.py
@@ -50,9 +50,7 @@ class Libpng(CMakePackage):
     )
     variant("pic", default=False, description="PIC")
 
-#MOD
     variant("stdio", default=False, description="Enable/disable stdio support", when="@1.2.57")
-#MOD
 
     # Tries but fails to include fp.h, removed in libpng 1.6.45
     conflicts("@:1.6.44", when="%apple-clang@17:")
@@ -77,10 +75,8 @@ class CMakeBuilder(CMakeBuilder):
             self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
         ]
 
-#MOD
         if self.spec.satisfies("@1.2.57"):
             args.append(self.define("PNG_NO_STDIO", not self.spec.satisfies("+stdio")))
-#MOD
 
         zlib_lib = self.spec["zlib-api"].libs
         if zlib_lib:


### PR DESCRIPTION
I modified packages.py and used "spack install pixman ^libpng@1.2 +stdio" to resolve this issue: https://github.com/spack/spack-packages/issues/1041

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
