### PR TITLE
protobuf: Bump protobuf version to support or-tools required for OpenROAD

### DIFF
--- a/repos/spack_repo/builtin/packages/protobuf/package.py
+++ b/repos/spack_repo/builtin/packages/protobuf/package.py
@@ -16,6 +16,11 @@ class Protobuf(CMakePackage):
 
     license("BSD-3-Clause")
 
+    version("31.1", preferred=True, sha256="c3a0a9ece8932e31c3b736e2db18b1c42e7070cd9b881388b26d01aa71e24ca2")
+    version("31.0", sha256="2b695cb1eaef8e173f884235ee6d55f57186e95d89ebb31361ee55cb5fd1b996")
+    version("31.0-rc2", sha256="61a948c028574647fe8426ef8e1063b583364c727fbd089c848e505c9bea029f")
+    version("31.0-rc1", sha256="5bd5a5f6a2dd75aeff85a21362de2944f1a7226d3e100bcb92bed1c90178454c")
+
     version("3.29.3", sha256="c8d0ed0085f559444f70311791cf7aef414246b9942441443963184b534dbf9e")
     version("3.28.2", sha256="1b6b6a7a7894f509f099c4469b5d4df525c2f3c9e4009e5b2db5b0f66cb8ee0e")
     version("3.27.5", sha256="a4aa92d0a207298149bf553d9a3192f3562eb91740086f50fa52331e60fa480c")
@@ -92,6 +97,7 @@ class Protobuf(CMakePackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
+    depends_on("abseil-cpp@20250127.0 cxxstd=17", when="@31.0:")
     depends_on("abseil-cpp@20230125.3:", when="@3.22.5:")
     # https://github.com/protocolbuffers/protobuf/issues/11828#issuecomment-1433557509
     depends_on("abseil-cpp@20230125:", when="@3.22:")
@@ -143,11 +149,11 @@ class Protobuf(CMakePackage):
     def cmake_args(self):
         args = [
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
-            self.define("protobuf_BUILD_TESTS", False),
             self.define("CMAKE_POSITION_INDEPENDENT_CODE", True),
+            self.define("protobuf_BUILD_TESTS", False),
         ]
 
-        if self.spec.satisfies("@3.22:"):
+        if self.spec.satisfies("@3.22:") or self.spec.satisfies("@31.0:"):
             cxxstd = self.spec["abseil-cpp"].variants["cxxstd"].value
             args.extend(
                 [


### PR DESCRIPTION


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
