### PR TITLE
Fix: Replace PyEval_CallObject by PyObject_CallObject

### DIFF
--- a/repos/spack_repo/builtin/packages/med/package.py
+++ b/repos/spack_repo/builtin/packages/med/package.py
@@ -118,4 +118,7 @@ class Med(CMakePackage):
         if "+mpi" in spec:
             options.extend(["-DMEDFILE_USE_MPI=YES", "-DMPI_ROOT_DIR=%s" % spec["mpi"].prefix])
 
+        if "+python" in spec and spec['python'].version >= Version('3.9'):
+            options.extend(["-DCMAKE_CXX_FLAGS=-DPyEval_CallObject=PyObject_CallObject"])
+
         return options


### PR DESCRIPTION
I change the flag of cmake to using flag to define macro. It replace the new PyObject_CallObject function instead of the deprecated PyEval_CallObject macro function.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
