### PR TITLE
termcap: Fix no implicit function decl error for termcap at gcc@14:

### DIFF
--- a/repos/spack_repo/builtin/packages/termcap/package.py
+++ b/repos/spack_repo/builtin/packages/termcap/package.py
@@ -22,3 +22,12 @@ class Termcap(AutotoolsPackage, GNUMirrorPackage):
     version("1.3", sha256="3eb4b98ae08408ca65dd9275f3c8e56e2feac1261fae914a9b21273db51cf000")
 
     depends_on("c", type="build")  # generated
+
+    def flag_handler(self, name, flags):
+        if name == "cflags":
+            if (
+                self.spec.satisfies("%gcc@14:")
+            ):
+                flags.append("-Wno-error=implicit-function-declaration")
+        return (flags, None, None)
+    

--- a/repos/spack_repo/builtin/packages/termcap/package.py
+++ b/repos/spack_repo/builtin/packages/termcap/package.py
@@ -25,9 +25,6 @@ class Termcap(AutotoolsPackage, GNUMirrorPackage):
 
     def flag_handler(self, name, flags):
         if name == "cflags":
-            if (
-                self.spec.satisfies("%gcc@14:")
-            ):
+            if self.spec.satisfies("%gcc@14:"):
                 flags.append("-Wno-error=implicit-function-declaration")
         return (flags, None, None)
-    


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
