### PR TITLE
ghostscript: add fontconfig as a link dependent

### DIFF
--- a/repos/spack_repo/builtin/packages/ghostscript/package.py
+++ b/repos/spack_repo/builtin/packages/ghostscript/package.py
@@ -70,6 +70,7 @@ class Ghostscript(AutotoolsPackage):
     depends_on("krb5", type="link")
 
     depends_on("freetype@2.4.2:")
+    depends_on("fontconfig", type="link")
     depends_on("jpeg")
     depends_on("lcms")
     depends_on("libpng")


### PR DESCRIPTION
GhostScript uses fontconfig as a optional dependent. The `configure` script would try to search for fontconfig through pkgconfig, and can be cancelled with `--disable-fontconfig`. To keep consistency with the behavior before 20c945a (#125), this PR adds fontconfig as a link dependent of ghostscript.

<details><summary>More on why depend on fontconfig explicitly instead of leave it a non-denendency</summary>
<p>

TLDR: The dependening relation would be undetermined if fontconfig is not clamed as a dependent of ghostscript and no more declare on configure command-line was done; the produced ghostscript may depend on or not depend on fontconfig, relying on the build environment.

In spack's build environment, non-default paths, pkgconfig paths, etc. should be filtered out, making them only prepared on behalf of requirements from the spec tree, so that one spec produces one product. In situation of this PR, that can be break by building in a spack env:
 - build `ghostscript~gtk` alone
   - the product does't link to fontconfig
 - build `ghostscript~gtk` in a spack env containing `fontconfig` (e.g. a env uses `texlive` as the only root spec) and view enabled
   - the product link to fontconfig
   - or fails to be compiled.

**What happened**: in such a spack env, fontconfig's pkgconfig file appears in the env's view's `lib/pkgconfig`, visible to ghostsscript's `configure` script, making it be found and linked to mid-products like `obj/aux/echogs`. If no `libfontconfig.so` in any system-visible ld library path, the mid-product fails to be executed and compile fails; otherwise fontconfig was linked. To eliminate the undetermined behavior, there should be either:
 - forcing fontconfig be a dependent of ghostscript;
 - explicitly add `--disable-fontconfig` configure option while `~gtk`;
 - make fontconfig a variant when `~gtk`.

To keep consistency with `+gtk`'s behavior, the first was choosed in this PR.

</p>
</details> 
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
