### PR TITLE
Revert "lzo: ensure #include <lzo/lzo1x.h> works with pkgconf cflags `-I${includedir}/lzo`"

### DIFF
--- a/repos/spack_repo/builtin/packages/lzo/package.py
+++ b/repos/spack_repo/builtin/packages/lzo/package.py
@@ -36,10 +36,3 @@ class Lzo(AutotoolsPackage):
         args = ["--disable-dependency-tracking"]
         args += self.enable_or_disable("libs")
         return args
-
-    @run_after("install")
-    def postinstall(self):
-        # ensure e.g. #include <lzo/lzo1x.h> works with Cflags: -I${includedir}/lzo in pkgconf
-        # by creating symlink ${includedir}/lzo/lzo -> ${includedir}/lzo
-        with working_dir(self.prefix.include.lzo):
-            symlink(".", "lzo")


### PR DESCRIPTION
Reverts spack/spack-packages#75

Symlink results in infinite filesystem recursion, resulting in failures in our gitlab-runners repo: https://github.com/spack/gitlab-runners/actions/runs/17732188924/job/50385553346?pr=67

A better solution would be to either patch lzo/cairo/squashfuse or to symlink all `*.h` files instead of symlinking the directory. This can be done in a follow-up PR.