### PR TITLE
libfabric: fix missing deps for CXI

### DIFF
--- a/repos/spack_repo/builtin/packages/libfabric/package.py
+++ b/repos/spack_repo/builtin/packages/libfabric/package.py
@@ -135,6 +135,8 @@ class Libfabric(AutotoolsPackage, CudaPackage):
     depends_on("liburing@2.1:", when="+uring")
     depends_on("oneapi-level-zero", when="+level_zero")
     depends_on("libcxi", when="fabrics=cxi")
+    depends_on("cassini-headers", when="fabrics=cxi")
+    depends_on("cxi-driver", when="fabrics=cxi")
     depends_on("xpmem", when="fabrics=xpmem")
 
     depends_on("m4", when="@main", type="build")


### PR DESCRIPTION
When building libfabric from source for the Slingshot interconnect, it fails with the following
error:

```
==> Error: KeyError: 'No spec with name cassini-headers in libfabric@2.2.0/nx5ukr3wlewlop3bg5ixqfuyzw7irlr3'

/p/vast1/nhanford/github/spack-packages/repos/spack_repo/builtin/packages/libfabric/package.py:221, in configure_args:
        218        if self.spec.satisfies("fabrics=cxi"):
        219            args.append(f"--with-json-c={self.spec['json-c'].prefix}")
        220            args.append(f"--with-curl={self.spec['curl'].prefix}")
  >>    221            args.append(f"--with-cassini-headers={self.spec['cassini-headers'].prefix.include}")
        222            args.append(f"--with-cxi-uapi-headers={self.spec['cxi-driver'].prefix.include}")
        223            args.append(f"--enable-cxi={self.spec['libcxi'].prefix}")
        224
```

This is caused by the `cassini-headers` and `cxi-driver` dependencies not being correctly
represented for the `package.py` module. I have added in the dependencies explicitly earlier in the package.
However, I am unsure in what version of SHS/libfabric these became necessary. Regardless, with the
dependencies added, the build appears to succeed.