### PR TITLE
Workaround for py-numpy@1.26 for compiler regression with Intel oneAPI 2025.2

### DIFF
--- a/repos/spack_repo/builtin/packages/py_numpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_numpy/package.py
@@ -176,6 +176,16 @@ class PyNumpy(PythonPackage):
             when="@1.26:1.26.3",
         )
 
+    # https://github.com/spack/spack-packages/issues/1477
+    @when("@1.26 ^intel-oneapi-compilers@2025.2")
+    def patch(self):
+        filter_file(
+            ".get(compiler_id, ['-O3'])",
+            ".get(compiler_id, ['-O1'])",
+            "./numpy/core/meson.build",
+            string=True
+        )
+
     # meson.build
     # https://docs.scipy.org/doc/scipy/dev/toolchain.html#compilers
     conflicts("%gcc@:9.2", when="@2.3:", msg="NumPy requires GCC >= 9.3")

--- a/repos/spack_repo/builtin/packages/py_numpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_numpy/package.py
@@ -183,7 +183,7 @@ class PyNumpy(PythonPackage):
             ".get(compiler_id, ['-O3'])",
             ".get(compiler_id, ['-O1'])",
             "./numpy/core/meson.build",
-            string=True
+            string=True,
         )
 
     # meson.build


### PR DESCRIPTION
## Description

Workaround for py-numpy@1.26 for compiler regression with Intel oneAPI 2025.2: lower optimization for auto-generated dispatch code from -O3 to -O1

Note. I checked the range of numpy versions for which the patch applies. The offending code is only in 1.26.x, not in 1.25 or earlier, and also not in versions 2.x.y.

Closes #1477 