### PR TITLE
at_spi2_atk: Remove max version allowed for depends_on(at-spi2-core)

### DIFF
--- a/repos/spack_repo/builtin/packages/at_spi2_atk/package.py
+++ b/repos/spack_repo/builtin/packages/at_spi2_atk/package.py
@@ -26,7 +26,7 @@ class AtSpi2Atk(MesonPackage):
     depends_on("c", type="build")  # generated
 
     depends_on("pkgconfig", type="build")
-    depends_on("at-spi2-core@2.28.0:2.45.1")
+    depends_on("at-spi2-core@2.28.0:")
     depends_on("atk@2.28.1:")
 
     def url_for_version(self, version):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

# Summary

* I'm trying to develop some new spack packages that require a newer version of `at-spi2-core`.  This requires the removal of the upper limit in the command `depends_on("at-spi2-core@2.28.0:2.45.1")`.
* Does anyone know why the upper limit was listed previously?
* I didn't experience any negative side effects of removing this upper limit, but my testing is far from exhaustive.

