### PR TITLE
py-aiohttp: add v3.12.15

### DIFF
--- a/repos/spack_repo/builtin/packages/py_aiohttp/package.py
+++ b/repos/spack_repo/builtin/packages/py_aiohttp/package.py
@@ -19,6 +19,7 @@ class PyAiohttp(PythonPackage):
 
     license("Apache-2.0")
 
+    version("3.12.15", sha256="4fc61385e9c98d72fcdf47e6dd81833f47b2f77c114c29cd64a361be57a763a2")
     version("3.11.16", sha256="16f8a2c9538c14a557b4d309ed4d0a7c60f0253e8ed7b6c9a2859a7582f8b1b8")
     version("3.9.5", sha256="edea7d15772ceeb29db4aff55e482d4bcfb6ae160ce144f2682de02f6d693551")
     version("3.9.4", sha256="6ff71ede6d9a5a58cfb7b6fffc83ab5d4a63138276c771ac91ceaaddf5459644")
@@ -35,20 +36,22 @@ class PyAiohttp(PythonPackage):
     depends_on("py-setuptools@46.4:", type="build")
 
     with default_args(type=("build", "run")):
+        depends_on("py-aiohappyeyeballs@2.5.0:", when="@3.12:")
         depends_on("py-aiohappyeyeballs@2.3:", when="@3.10:")
         depends_on("py-propcache@0.2.0:", when="@3.11:")
         depends_on("py-attrs@17.3.0:")
         depends_on("py-charset-normalizer@2:3", when="@3.8.4:")
         depends_on("py-charset-normalizer@2", when="@3.8.0:3.8.3")
         depends_on("py-multidict@4.5:6", when="@3.6.3:")
-        depends_on("py-async-timeout@4:", when="@3.8.0 ^python@:3.10")
+        depends_on("py-async-timeout@4:5", when="@3.8: ^python@:3.10")
         depends_on("py-async-timeout@3", when="@:3.7.4 ^python@:3.10")
         depends_on("py-asynctest@0.13.0", when="@3.8.0: ^python@:3.7")
-        depends_on("py-yarl@1.17:", when="@3.11:")
+        depends_on("py-yarl@1.17:1", when="@3.11:")
         depends_on("py-yarl@1")
         depends_on("py-typing-extensions@3.7.4:", when="@3.8: ^python@:3.7")
         depends_on("py-typing-extensions@3.6.5:", when="@3.7")
         depends_on("py-frozenlist@1.1.1:", when="@3.8.1:")
+        depends_on("py-aiosignal@1.4.0:", when="@3.12:")
         depends_on("py-aiosignal@1.1.2:", when="@3.8.1:")
 
     # Historical dependencies

--- a/repos/spack_repo/builtin/packages/py_aiohttp/package.py
+++ b/repos/spack_repo/builtin/packages/py_aiohttp/package.py
@@ -46,7 +46,7 @@ class PyAiohttp(PythonPackage):
         depends_on("py-async-timeout@4:5", when="@3.8: ^python@:3.10")
         depends_on("py-async-timeout@3", when="@:3.7.4 ^python@:3.10")
         depends_on("py-asynctest@0.13.0", when="@3.8.0: ^python@:3.7")
-        depends_on("py-yarl@1.17:1", when="@3.11:")
+        depends_on("py-yarl@1.17:", when="@3.11:")
         depends_on("py-yarl@1")
         depends_on("py-typing-extensions@3.7.4:", when="@3.8: ^python@:3.7")
         depends_on("py-typing-extensions@3.6.5:", when="@3.7")

--- a/repos/spack_repo/builtin/packages/py_aiosignal/package.py
+++ b/repos/spack_repo/builtin/packages/py_aiosignal/package.py
@@ -16,8 +16,10 @@ class PyAiosignal(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.4.0", sha256="f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7")
     version("1.2.0", sha256="78ed67db6c7b7ced4f98e495e572106d5c432a93e1ddd1bf475e1dc05f5b7df2")
 
+    depends_on("python@3.9:", type=("build", "run"), when="@1.4:")
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-frozenlist@1.1.0:", type=("build", "run"))


### PR DESCRIPTION
adds new constraints found in https://github.com/aio-libs/aiohttp/blob/v3.12.15/setup.cfg and fixes a couple others that were missed in previous recipes.

also adds a new version of dependency py-aiosignal

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
