### PR TITLE
Add cmake dependency for Python 3.12+ support

### DIFF
--- a/repos/spack_repo/builtin/packages/tau/package.py
+++ b/repos/spack_repo/builtin/packages/tau/package.py
@@ -149,6 +149,7 @@ class Tau(Package):
     depends_on("gmake", type="build")
     depends_on("cmake@3.14:", type="build", when="%clang")
     depends_on("cmake@3.14:", type="build", when="%aocc")
+    depends_on("cmake@3.14:", type="build", when="+python ^python@3.12:")
     depends_on("zlib-api", type="link")
     depends_on("pdt", when="+pdt")  # Required for TAU instrumentation
     depends_on("scorep", when="+scorep")

--- a/repos/spack_repo/builtin/packages/tau/package.py
+++ b/repos/spack_repo/builtin/packages/tau/package.py
@@ -149,7 +149,7 @@ class Tau(Package):
     depends_on("gmake", type="build")
     depends_on("cmake@3.14:", type="build", when="%clang")
     depends_on("cmake@3.14:", type="build", when="%aocc")
-    depends_on("cmake@3.14:", type="build", when="+python ^python@3.12:")
+    depends_on("cmake@3.20:", type="build", when="+python ^python@3.12:")
     depends_on("zlib-api", type="link")
     depends_on("pdt", when="+pdt")  # Required for TAU instrumentation
     depends_on("scorep", when="+scorep")


### PR DESCRIPTION
TAU needs to build its internal perfstubs library to support python instrumentation for python@3.12:. This requires cmake.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
