### PR TITLE
py-kaleido: add 1.1.0 and new dependency packages

### DIFF
--- a/repos/spack_repo/builtin/packages/py_choreographer/package.py
+++ b/repos/spack_repo/builtin/packages/py_choreographer/package.py
@@ -1,0 +1,25 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyChoreographer(PythonPackage):
+    """Devtools Protocol implementation for chrome."""
+
+    homepage = "https://github.com/plotly/choreographer"
+    pypi = "choreographer/choreographer-1.0.10.tar.gz"
+
+    license("MIT")
+
+    version("1.0.10", sha256="7adf84a0d6a6054386d5cce013fdcadb2426479e49c9b0cb06af7d3712ed263c")
+
+    depends_on("python@3.8:", type=("build", "run"))
+    depends_on("py-setuptools@65:", type="build")
+    depends_on("py-setuptools-git-versioning", type="build")
+
+    depends_on("py-logistro@1.0.11:", type=("build", "run"))
+    depends_on("py-simplejson@3.19.3:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_kaleido/package.py
+++ b/repos/spack_repo/builtin/packages/py_kaleido/package.py
@@ -1,7 +1,6 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 import platform
 import sys
 
@@ -14,12 +13,17 @@ arch64_32, _ = platform.architecture()
 
 
 class PyKaleido(PythonPackage):
-    """Static image export for web-based visualization libraries with zero dependencies"""
+    """Plotly graph export library."""
 
-    homepage = "https://github.com/plotly/Kaleido"
-    pypi = "kaleido/kaleido-0.2.1-py2.py3-none-manylinux1_x86_64.whl"
+    homepage = "https://github.com/plotly/kaleido"
+    pypi = "kaleido/kaleido-1.1.0.tar.gz"
+    git = "https://github.com/plotly/Kaleido.git"
 
     maintainers("Pandapip1")
+
+    license("MIT")
+
+    version("1.1.0", sha256="5747703a56d4c034efa69abea4a9c2bfe8ef516ba848e0ec485c65b3b0ab52b6")
 
     if (arch == "x86_64" or arch == "x64") and os == "linux":  # Linux on x86_64
         version(
@@ -71,5 +75,13 @@ class PyKaleido(PythonPackage):
             expand=False,
         )
 
-    depends_on("python", type=("build", "run"))
+    depends_on("python@3.8:", type=("build", "run"), when="@1:")
+    depends_on("py-setuptools@65:", type="build", when="@1:")
     depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools-git-versioning", type="build", when="@1:")
+
+    depends_on("py-choreographer@1.0.10:", type=("build", "run"), when="@1:")
+    depends_on("py-logistro@1.0.8:", type=("build", "run"), when="@1:")
+    depends_on("py-orjson@3.10.15:", type=("build", "run"), when="@1:")
+    depends_on("py-packaging", type=("build", "run"), when="@1:")
+    depends_on("py-pytest-timeout@2.4:", type=("build", "run"), when="@1:")

--- a/repos/spack_repo/builtin/packages/py_logistro/package.py
+++ b/repos/spack_repo/builtin/packages/py_logistro/package.py
@@ -1,0 +1,22 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyLogistro(PythonPackage):
+    """Simple wrapper over logging for a couple basic features."""
+
+    homepage = "https://github.com/geopozo/logistro"
+    pypi = "logistro/logistro-1.1.0.tar.gz"
+
+    license("MIT")
+
+    version("1.1.0", sha256="ad51f0efa2bc705bea7c266e8a759cf539457cf7108202a5eec77bdf6300d774")
+
+    depends_on("python@3.8:", type=("build", "run"))
+    depends_on("py-setuptools@65:", type="build")
+    depends_on("py-setuptools-git-versioning", type="build")

--- a/repos/spack_repo/builtin/packages/py_pytest_timeout/package.py
+++ b/repos/spack_repo/builtin/packages/py_pytest_timeout/package.py
@@ -13,13 +13,23 @@ class PyPytestTimeout(PythonPackage):
     assuming the test session isn't being debugged."""
 
     homepage = "https://github.com/pytest-dev/pytest-timeout/"
-    pypi = "pytest-timeout/pytest-timeout-1.4.2.tar.gz"
+    pypi = "pytest-timeout/pytest_timeout-2.4.0.tar.gz"
 
     license("MIT")
 
+    version("2.4.0", sha256="7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a")
     version("2.2.0", sha256="3b0b95dabf3cb50bac9ef5ca912fa0cfc286526af17afc806824df20c2f72c90")
     version("1.4.2", sha256="20b3113cf6e4e80ce2d403b6fb56e9e1b871b510259206d40ff8d609f48bda76")
 
+    depends_on("python@3.7:", type="build")
     depends_on("py-setuptools", type="build")
+    depends_on("py-pytest@7:", when="@2.3:", type=("build", "run"))
     depends_on("py-pytest@5:", when="@2:", type=("build", "run"))
     depends_on("py-pytest@3.6.0:", type=("build", "run"))
+
+    def url_for_version(self, version):
+        if version >= Version("2.4"):
+            name = "pytest_timeout"
+        else:
+            name = "pytest-timeout"
+        return f"https://files.pythonhosted.org/packages/source/p/pytest-timeout/{name}-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_simplejson/package.py
+++ b/repos/spack_repo/builtin/packages/py_simplejson/package.py
@@ -14,8 +14,9 @@ class PySimplejson(PythonPackage):
     homepage = "https://github.com/simplejson/simplejson"
     pypi = "simplejson/simplejson-3.10.0.tar.gz"
 
-    license("AFL-2.1")
+    license("MIT")
 
+    version("3.20.1", sha256="e64139b4ec4f1f24c142ff7dcafe55a22b811a74d86d66560c8815687143037d")
     version("3.19.1", sha256="6277f60848a7d8319d27d2be767a7546bc965535b28070e310b3a9af90604a4c")
     version("3.18.0", sha256="58a429d2c2fa80834115b923ff689622de8f214cf0dc4afa9f59e824b444ab31")
     version("3.17.2", sha256="75ecc79f26d99222a084fbdd1ce5aad3ac3a8bd535cd9059528452da38b68841")


### PR DESCRIPTION
https://github.com/plotly/Kaleido/tree/v1.1.0/src/py

`py-kaleido` depends on the new packages `py-choreographer` (needs a newer version of `py-simplejson`) and `py-logistro` as well as a newer version of `py-pytest-timeout`, so they were added as well.

https://github.com/plotly/choreographer/tree/v1.0.10
https://github.com/simplejson/simplejson/tree/v3.20.1
https://github.com/geopozo/logistro/tree/v1.1.0
https://github.com/pytest-dev/pytest-timeout/tree/2.4.0

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
