### PR TITLE
nlohmann-json: add pearzt as package maintainer

### DIFF
--- a/repos/spack_repo/builtin/packages/nlohmann_json/package.py
+++ b/repos/spack_repo/builtin/packages/nlohmann_json/package.py
@@ -12,7 +12,7 @@ class NlohmannJson(CMakePackage):
 
     homepage = "https://nlohmann.github.io/json/"
     url = "https://github.com/nlohmann/json/archive/v3.1.2.tar.gz"
-    maintainers("ax3l")
+    maintainers("ax3l", "pearzt")
 
     license("MIT")
 


### PR DESCRIPTION
As discussed in https://github.com/spack/spack-packages/pull/988, this PR adds myself as a second maintainer to the `nlohmann-json` package to support @ax3l.
CC @alecbcs 