### PR TITLE
py-biosppy: add new package + new dep packages

### DIFF
--- a/repos/spack_repo/builtin/packages/py_bidict/package.py
+++ b/repos/spack_repo/builtin/packages/py_bidict/package.py
@@ -1,0 +1,21 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyBidict(PythonPackage):
+    """The bidirectional mapping library for Python."""
+
+    homepage = "https://github.com/jab/bidict"
+    pypi = "bidict/bidict-0.23.1.tar.gz"
+
+    license("MPL-2.0", checked_by="github_user1")
+
+    version("0.23.1", sha256="03069d763bc387bbd20e7d49914e75fc4132a41937fa3405417e1a5a2d006d71")
+
+    depends_on("python@3.8:", type=("build", "run"))
+    depends_on("py-setuptools@40.9:", type="build")

--- a/repos/spack_repo/builtin/packages/py_bidict/package.py
+++ b/repos/spack_repo/builtin/packages/py_bidict/package.py
@@ -13,7 +13,7 @@ class PyBidict(PythonPackage):
     homepage = "https://github.com/jab/bidict"
     pypi = "bidict/bidict-0.23.1.tar.gz"
 
-    license("MPL-2.0", checked_by="github_user1")
+    license("MPL-2.0")
 
     version("0.23.1", sha256="03069d763bc387bbd20e7d49914e75fc4132a41937fa3405417e1a5a2d006d71")
 

--- a/repos/spack_repo/builtin/packages/py_biosppy/package.py
+++ b/repos/spack_repo/builtin/packages/py_biosppy/package.py
@@ -1,0 +1,37 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyBiosppy(PythonPackage):
+    """A toolbox for biosignal processing written in Python."""
+
+    homepage = "https://github.com/scientisst/BioSPPy"
+    pypi = "biosppy/biosppy-2.2.3.tar.gz"
+
+    license("BSD-3-Clause")
+
+    version("2.2.3", sha256="2c4b84c98c71e3e84b43bf09a855414c31f534a8aed84e59fb05bbc3c36d9aa9")
+
+    depends_on("py-setuptools", type="build")
+
+    # version contraint from requirement.txt
+    depends_on("py-bidict@0.13.1:", type=("build", "run"))
+    depends_on("py-h5py@2.7.1:", type=("build", "run"))
+    depends_on("py-matplotlib@2.1.2:", type=("build", "run"))
+    depends_on("py-numpy@1.22:", type=("build", "run"))
+    depends_on("py-scikit-learn@0.19.1:", type=("build", "run"))
+    depends_on("py-scipy@1.2:", type=("build", "run"))
+    depends_on("py-shortuuid@0.5:", type=("build", "run"))
+    depends_on("py-six@1.11:", type=("build", "run"))
+    depends_on("py-joblib@0.11:", type=("build", "run"))
+    depends_on("py-opencv-python", type=("build", "run"))
+    depends_on("py-pywavelets@1.4.1:", type=("build", "run"))
+    depends_on("py-mock", type=("build", "run"))
+
+    # from errors when importing
+    depends_on("py-peakutils", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_opencv_python/package.py
+++ b/repos/spack_repo/builtin/packages/py_opencv_python/package.py
@@ -1,0 +1,31 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyOpencvPython(PythonPackage):
+    """Wrapper package for OpenCV python bindings."""
+
+    homepage = "https://github.com/opencv/opencv-python"
+    pypi = "opencv-python/opencv-python-4.12.0.88.tar.gz"
+
+    license("Apache-2.0")
+
+    version("4.12.0.88", sha256="8b738389cede219405f6f3880b851efa3415ccd674752219377353f017d2994d")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    depends_on("py-packaging", type="build")
+    depends_on("py-pip", type="build")
+    depends_on("py-scikit-build@0.14:", type="build")
+    # restrictions on setuptools not needed, builds fine with newer versions
+    depends_on("py-setuptools", type="build")
+
+    # build dependency version restriction from pyproject.toml not needed
+    depends_on("py-numpy@2:", type=("build", "run"), when="^python@3.9:")
+    depends_on("py-numpy@:2", type=("build", "run"), when="^python@:3.8")

--- a/repos/spack_repo/builtin/packages/py_peakutils/package.py
+++ b/repos/spack_repo/builtin/packages/py_peakutils/package.py
@@ -1,0 +1,23 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyPeakutils(PythonPackage):
+    """Peak detection utilities for 1D data."""
+
+    homepage = "https://bitbucket.org/lucashnegri/peakutils"
+    pypi = "peakutils/peakutils-1.3.5.tar.gz"
+
+    license("MIT")
+
+    version("1.3.5", sha256="4ff2e7f3330b93024fe8da1ee04e00389e26bcb2ef79bd2f9cf86ccd4962e114")
+
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-scipy", type=("build", "run"))


### PR DESCRIPTION
https://github.com/scientisst/BioSPPy/tree/v2.2.3

needs new packages as dependencies:
https://github.com/jab/bidict/tree/v0.23.1
https://github.com/opencv/opencv-python/tree/88
https://pypi.org/project/PeakUtils/#files (no tags on bitbucket)

for me it only concretizes and builds fine with a newer `py-pywavelets` version (see #1488)

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
