### PR TITLE
py-patool: add v4.0.1 + new dep package

### DIFF
--- a/repos/spack_repo/builtin/packages/py_patool/package.py
+++ b/repos/spack_repo/builtin/packages/py_patool/package.py
@@ -12,10 +12,17 @@ class PyPatool(PythonPackage):
 
     homepage = "https://wummel.github.io/patool/"
     pypi = "patool/patool-1.12.tar.gz"
+    git = "https://github.com/wummel/patool.git"
 
     license("GPL-3.0-or-later")
 
+    version("4.0.1", sha256="41f7ee21be337a5baf07b2cb4796e9d94397ab741d2379c622f98fc001099802")
     version("1.12", sha256="e3180cf8bfe13bedbcf6f5628452fca0c2c84a3b5ae8c2d3f55720ea04cb1097")
 
+    depends_on("python@3.11:", type=("build", "run"), when="@4:")
     depends_on("python@3.5:", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
+
+    depends_on("py-setuptools-reproducible", type="build", when="@4.0.1:")
+
+    # Historical dependencies
+    depends_on("py-setuptools", type="build", when="@:4.0.0")

--- a/repos/spack_repo/builtin/packages/py_setuptools_reproducible/package.py
+++ b/repos/spack_repo/builtin/packages/py_setuptools_reproducible/package.py
@@ -1,0 +1,21 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PySetuptoolsReproducible(PythonPackage):
+    """Extension of setuptools to support reproducible dists."""
+
+    homepage = "https://github.com/wimglenn/setuptools-reproducible"
+    pypi = "setuptools_reproducible/setuptools_reproducible-0.1.tar.gz"
+
+    license("MIT")
+
+    version("0.1", sha256="1ae3c0dcca3f125e0fdfb7ce749c872f63d9fe6a0fd8b36954f639ee677f2f73")
+
+    depends_on("python@3.8:", type=("build", "run"))
+    depends_on("py-setuptools", type=("build", "run"))


### PR DESCRIPTION
https://github.com/wummel/patool/tree/4.0.1

`py-patool` needs the new `py-setuptool-reproducible`, so this was added as well
https://github.com/wimglenn/setuptools-reproducible/tree/v0.1

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
