### PR TITLE
py-patsy: add v1.0.1

### DIFF
--- a/repos/spack_repo/builtin/packages/py_patsy/package.py
+++ b/repos/spack_repo/builtin/packages/py_patsy/package.py
@@ -19,6 +19,7 @@ class PyPatsy(PythonPackage):
 
     license("PSF-2.0")
 
+    version("1.0.1", sha256="e786a9391eec818c054e359b737bbce692f051aee4c661f4141cc88fb459c0c4")
     version("0.5.4", sha256="7dabc527597308de0e8f188faa20af7e06a89bdaa306756dfc7783693ea16af4")
     version("0.5.3", sha256="bdc18001875e319bc91c812c1eb6a10be4bb13cb81eb763f466179dca3b67277")
     version("0.5.2", sha256="5053de7804676aba62783dbb0f23a2b3d74e35e5bfa238b88b7cbf148a38b69d")


### PR DESCRIPTION
https://github.com/pydata/patsy/tree/v1.0.1

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
