### PR TITLE
Update py-tables package for 3.10+ compatibility

### DIFF
--- a/repos/spack_repo/builtin/packages/py_tables/package.py
+++ b/repos/spack_repo/builtin/packages/py_tables/package.py
@@ -17,7 +17,8 @@ class PyTables(PythonPackage):
 
     license("BSD-3-Clause")
 
-    version("master", branch="master")
+    version("master", branch="master", submodules=True)
+    version("3.10.2", sha256="2544812a7186fadba831d6dd34eb49ccd788d6a83f4e4c2b431b835b6796c910")
     version("3.9.0", sha256="27c9ca14c359d875caf945a6a527c12690e017650402dd17d8eb8b6caf6687d5")
     version("3.8.0", sha256="34f3fa2366ce20b18f1df573a77c1d27306ce1f2a41d9f9eff621b5192ea8788")
     version("3.7.0", sha256="e92a887ad6f2a983e564a69902de4a7645c30069fc01abd353ec5da255c5e1fe")
@@ -50,8 +51,10 @@ class PyTables(PythonPackage):
     depends_on("py-numpy@1.19:", when="@3.8:", type=("build", "run"))
     depends_on("py-numpy@1.9.3:", type=("build", "run"))
     # https://github.com/PyTables/PyTables/issues/1083
-    depends_on("py-numpy@:1", type=("build", "run"))
+    depends_on("py-numpy@:1", type=("build", "run"), when="@:3.9")
+    depends_on("py-numpy@1.25:", type=("build", "run"), when="@3.10:")
     depends_on("py-numexpr@2.6.2:", type=("build", "run"))
+    depends_on("py-numexpr@2.10.2:", type=("build", "run"), when="@3.10:")
     depends_on("py-packaging", when="@3.7:", type=("build", "run"))
     depends_on("py-py-cpuinfo", when="@3.8:", type=("build", "run"))
     depends_on("py-blosc2@2.2.8:", when="@3.9:", type=("build", "run"))


### PR DESCRIPTION
**Update py-tables package for 3.10+ compatibility**

This PR updates the py-tables Spack package to align with upstream changes in the 3.10+ series.

**Changes**

1. Adds support for `py-tables@3.10.2`.
2. Add `submodules=True` for the master branch so that the vendored Blosc (HDF5-Blosc) sources are pulled using git submodules. [PR](https://github.com/PyTables/PyTables/issues/1197)
3. For `py-tables@:3.9`, `require py-numpy@:1`: keeps compatibility with older upstream constraints.  
4. For `py-tables@3.10:`, `require py-numpy@1.25:` to support NumPy 2.0+ and match upstream’s minimum. Release notes indicate PyTables 3.10 series is finally compatible with NumPy 2, etc. [pytables.readthedocs.io](https://pytables.readthedocs.io/en/latest/release-notes/RELEASE_NOTES_v3.10.x.html?utm_source=chatgpt.com)
5. Add `py-numexpr@2.10.2:` for `py-tables@3.10:` and newer.  Upstream documentation (installation page) also reflects that newer versions require more recent `NumExpr` to support features and performance. 
[pytables.org](https://www.pytables.org/usersguide/installation.html?utm_source=chatgpt.com)

**Motivation**

Without these changes:

1. Building from master fails (or misses critical components) because Blosc sources are now in a submodule which isn’t fetched by default.
2. Spack may resolve incompatible versions of NumPy / NumExpr when installing newer PyTables, leading to build breakage or runtime errors.
3. Users relying on newer features (NumPy 2, enhanced query performance) may not be supported without the raised minimums.