### PR TITLE
dealii: use cmake option to set c++ standard

### DIFF
--- a/repos/spack_repo/builtin/packages/dealii/package.py
+++ b/repos/spack_repo/builtin/packages/dealii/package.py
@@ -499,7 +499,7 @@ class Dealii(CMakePackage, CudaPackage):
         # Enforce the specified C++ standard
         if spec.variants["cxxstd"].value != "default":
             cxxstd = spec.variants["cxxstd"].value
-            cxx_flags.extend(["-std=c++{0}".format(cxxstd)])
+            options.append(self.define("CMAKE_CXX_STANDARD", "{0}".format(cxxstd)))
 
         # Performance
         # Set recommended flags for maximum (matrix-free) performance, see

--- a/repos/spack_repo/builtin/packages/dealii/package.py
+++ b/repos/spack_repo/builtin/packages/dealii/package.py
@@ -498,8 +498,7 @@ class Dealii(CMakePackage, CudaPackage):
 
         # Enforce the specified C++ standard
         if spec.variants["cxxstd"].value != "default":
-            cxxstd = spec.variants["cxxstd"].value
-            options.append(self.define("CMAKE_CXX_STANDARD", "{0}".format(cxxstd)))
+            options.append(self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"))
 
         # Performance
         # Set recommended flags for maximum (matrix-free) performance, see


### PR DESCRIPTION
@jppelteret @luca-heltai 

Tested locally to fix #1512 . 
The new behavior: deal.ii itself is built with -std=c++17 but the flag is not exported to the `deal.IITargets.cmake` file. Only the `cxx_std_17` compile feature is exported which can be overridden in consuming projects by setting a higher c++ standard.


