### PR TITLE
Add missing `depends_on("cxx", type="build")` directive for adms

### DIFF
--- a/repos/spack_repo/builtin/packages/adms/package.py
+++ b/repos/spack_repo/builtin/packages/adms/package.py
@@ -25,6 +25,7 @@ class Adms(AutotoolsPackage):
     version("2.3.7", sha256="3a78e1283ecdc3f356410474b3ff44c4dcc82cb89772087fd3bbde8a1038ce08")
 
     depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")
 
     depends_on("bison@2.5:", type="build")
     depends_on("flex", type="build")

--- a/repos/spack_repo/builtin/packages/adms/package.py
+++ b/repos/spack_repo/builtin/packages/adms/package.py
@@ -24,7 +24,7 @@ class Adms(AutotoolsPackage):
     version("master", branch="master")
     version("2.3.7", sha256="3a78e1283ecdc3f356410474b3ff44c4dcc82cb89772087fd3bbde8a1038ce08")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
     depends_on("cxx", type="build")
 
     depends_on("bison@2.5:", type="build")


### PR DESCRIPTION
The adms package builds C++ code but does not declare this in `package.py` which makes the build fail.
On my machine, adding the directive (as suggested [here)](https://github.com/spack/spack/discussions/51159) makes the build complete without any problems (using gcc14).

@cessenat 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
