### PR TITLE
[package: py-setuptools-scm@7.1.0:] fixed build issue on dependency py-packaging <22.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_setuptools_scm/package.py
+++ b/repos/spack_repo/builtin/packages/py_setuptools_scm/package.py
@@ -74,6 +74,7 @@ class PySetuptoolsScm(PythonPackage):
         depends_on("py-typing-extensions", when="@7:8.0.4")
 
         depends_on("py-packaging@20.0:", when="@6.3:")
+        depends_on("py-packaging@22.0:", when="@7.1:")
 
         depends_on("py-importlib-metadata", when="@7: ^python@:3.7")
 

--- a/repos/spack_repo/builtin/packages/py_setuptools_scm/package.py
+++ b/repos/spack_repo/builtin/packages/py_setuptools_scm/package.py
@@ -64,6 +64,7 @@ class PySetuptoolsScm(PythonPackage):
         depends_on("py-typing-extensions", when="@7")
 
         depends_on("py-packaging@20:", when="@6.3.0:8.0.1")
+        depends_on("py-packaging@24:", when="@7.1:")
 
         depends_on("py-wheel", when="@3.4.0:6.4.2")
 
@@ -74,7 +75,7 @@ class PySetuptoolsScm(PythonPackage):
         depends_on("py-typing-extensions", when="@7:8.0.4")
 
         depends_on("py-packaging@20.0:", when="@6.3:")
-        depends_on("py-packaging@22.0:", when="@7.1:")
+        depends_on("py-packaging@24:", when="@7.1:")
 
         depends_on("py-importlib-metadata", when="@7: ^python@:3.7")
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

@RobertMaaskant py-setuptools-scm fails with an 'unexpected keyword argument strip_trailing_zero' error when py-packaging <22 is used with py-setuptools-scm@7.1.0+. This is intended behaviour according to this issue https://github.com/pypa/setuptools/issues/4483#issuecomment-2236528158

I've managed to fix it in the runtime dependency for now. Since I haven't built py-setuptools-scm from scratch yet, you might want to fix the dependency issue there as well.
