### PR TITLE
aspell: add patch to support gcc@15: and clang

### DIFF
--- a/repos/spack_repo/builtin/packages/aspell/package.py
+++ b/repos/spack_repo/builtin/packages/aspell/package.py
@@ -30,6 +30,13 @@ class Aspell(AutotoolsPackage, GNUMirrorPackage):
     patch("fix_cpp.patch")
     patch("issue-519.patch", when="@:0.60.6.1")
 
+    # allow aspell to build with newer compilers that enforce template instantiation
+    # e.g. gcc@15: and clang
+    patch(
+        "https://github.com/GNUAspell/aspell/commit/ee6cbb12ff36a1e6618d7388a78dd4e0a2b44041.patch?full_index=1",
+        sha256="96e6b23947744e5d1374640a38cf20ec541b64c00a063cbed6d1fcc3e3fc19ee",
+    )
+
     # workaround due to https://github.com/GNUAspell/aspell/issues/591
     @run_after("configure", when="@0.60.8:")
     def make_missing_files(self):

--- a/repos/spack_repo/builtin/packages/aspell/package.py
+++ b/repos/spack_repo/builtin/packages/aspell/package.py
@@ -18,6 +18,8 @@ class Aspell(AutotoolsPackage, GNUMirrorPackage):
 
     extendable = True  # support activating dictionaries
 
+    maintainers("alecbcs")
+
     license("LGPL-2.1-or-later")
 
     version("0.60.8.1", sha256="d6da12b34d42d457fa604e435ad484a74b2effcd120ff40acd6bb3fb2887d21b")


### PR DESCRIPTION
Aspell hasn't had a release since 2023 and compilers have started enforcing stricter templating standards. 
Patch is also found in Homebrew.

https://github.com/Homebrew/homebrew-core/blob/c3308ba52e699e076bd24f7eb2fe4ef94ef6445f/Formula/a/aspell.rb#L559
