### PR TITLE
py-poetry-dynamic-versioning: add v1.9.1

### DIFF
--- a/repos/spack_repo/builtin/packages/py_dunamai/package.py
+++ b/repos/spack_repo/builtin/packages/py_dunamai/package.py
@@ -20,6 +20,7 @@ class PyDunamai(PythonPackage):
     version("1.18.0", sha256="5200598561ea5ba956a6174c36e402e92206c6a6aa4a93a6c5cb8003ee1e0997")
     version("1.17.0", sha256="459381b585a1e78e4070f0d38a6afb4d67de2ee95064bf6b0438ec620dde0820")
     version("1.13.1", sha256="49597bdf653bdacdeb51ec6e0f1d4d2327309376fc83e6f1d42af6e29600515f")
+    version("1.12.0", sha256="fac4f09e2b8a105bd01f8c50450fea5aa489a6c439c949950a65f0dd388b0d20")
 
     depends_on("python@3.5:3", type=("build", "run"))
     depends_on("py-poetry-core@1:", type="build")

--- a/repos/spack_repo/builtin/packages/py_dunamai/package.py
+++ b/repos/spack_repo/builtin/packages/py_dunamai/package.py
@@ -16,6 +16,7 @@ class PyDunamai(PythonPackage):
     license("MIT")
 
     version("1.25.0", sha256="a7f8360ea286d3dbaf0b6a1473f9253280ac93d619836ad4514facb70c0719d1")
+    version("1.21.2", sha256="05827fb5f032f5596bfc944b23f613c147e676de118681f3bb1559533d8a65c4")
     version("1.18.0", sha256="5200598561ea5ba956a6174c36e402e92206c6a6aa4a93a6c5cb8003ee1e0997")
     version("1.17.0", sha256="459381b585a1e78e4070f0d38a6afb4d67de2ee95064bf6b0438ec620dde0820")
     version("1.13.1", sha256="49597bdf653bdacdeb51ec6e0f1d4d2327309376fc83e6f1d42af6e29600515f")

--- a/repos/spack_repo/builtin/packages/py_poetry_dynamic_versioning/package.py
+++ b/repos/spack_repo/builtin/packages/py_poetry_dynamic_versioning/package.py
@@ -15,13 +15,16 @@ class PyPoetryDynamicVersioning(PythonPackage):
 
     license("MIT")
 
+    version("1.9.1", sha256="d6e7b9df817aa2ca4946cd695c6c89e1379d2e6c640f008a9b6170d081a9da48")
     version("1.4.0", sha256="725178bd50a22f2dd4035de7f965151e14ecf8f7f19996b9e536f4c5559669a7")
     version("0.19.0", sha256="a11a7eba6e7be167c55a1dddec78f52b61a1832275c95519ad119c7a89a7f821")
 
     depends_on("python@3.7:3", type=("build", "run"))
     depends_on("py-poetry-core@1:", type="build")
 
-    depends_on("py-dunamai@1.12:1", type=("build", "run"))
+    depends_on("py-dunamai@1.25", type=("build", "run"), when="@1.9:")
+    depends_on("py-dunamai@1.21", type=("build", "run"), when="@1.3:1.7")
+    depends_on("py-dunamai@1.12", type=("build", "run"), when="@:0.19")
     depends_on("py-tomlkit@0.4:", type=("build", "run"))
     depends_on("py-jinja2@2.11.1:3", type=("build", "run"))
 


### PR DESCRIPTION
https://github.com/mtkennerly/poetry-dynamic-versioning/tree/v1.9.1

Also added additional `py-dunamai` versions that are needed to build older `py-poetry-dynamic-version` versions
https://github.com/mtkennerly/dunamai/tree/v1.21.2
https://github.com/mtkennerly/dunamai/tree/v1.12.0
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
