### PR TITLE
llvm-amdgpu provides fortran via amdflang

### DIFF
--- a/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
+++ b/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
@@ -52,6 +52,7 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
     version("5.7.0", sha256="4abdf00b297a77c5886cedb37e63acda2ba11cb9f4c0a64e133b05800aadfcf0")
 
     provides("c", "cxx")
+    provides("fortran")
 
     variant(
         "rocm-device-libs",


### PR DESCRIPTION
Without this, `llvm-amdgpu` cannot be used as a fortran compiler, e.g. `spack spec foo %fortran=llvm-amdgpu`

`amdflang` is available for all versions that are described in the package.