### PR TITLE
PythonPackage: empty libs/headers by default

### DIFF
--- a/repos/spack_repo/builtin/build_systems/python.py
+++ b/repos/spack_repo/builtin/build_systems/python.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import functools
-import operator
 import os
 import re
 import shutil
@@ -15,8 +13,6 @@ from spack.package import (
     ClassProperty,
     HeaderList,
     LibraryList,
-    NoHeadersError,
-    NoLibrariesError,
     PackageBase,
     Prefix,
     Spec,
@@ -27,8 +23,6 @@ from spack.package import (
     extends,
     filter_file,
     find,
-    find_all_headers,
-    find_all_libraries,
     has_shebang,
     join_path,
     path_contains_subdirectory,

--- a/repos/spack_repo/builtin/build_systems/python.py
+++ b/repos/spack_repo/builtin/build_systems/python.py
@@ -258,46 +258,11 @@ class PythonPackage(PythonExtension):
 
     @property
     def headers(self) -> HeaderList:
-        """Discover header files in platlib."""
-
-        # Remove py- prefix in package name
-        name = self.spec.name[3:]
-
-        # Headers should only be in include or platlib, but no harm in checking purelib too
-        include = self.prefix.join(self.spec["python"].package.include).join(name)
-        python = self.python_spec
-        platlib = self.prefix.join(python.package.platlib).join(name)
-        purelib = self.prefix.join(python.package.purelib).join(name)
-
-        headers_list = map(find_all_headers, [include, platlib, purelib])
-        headers = functools.reduce(operator.add, headers_list)
-
-        if headers:
-            return headers
-
-        msg = "Unable to locate {} headers in {}, {}, or {}"
-        raise NoHeadersError(msg.format(self.spec.name, include, platlib, purelib))
+        return HeaderList([])
 
     @property
     def libs(self) -> LibraryList:
-        """Discover libraries in platlib."""
-
-        # Remove py- prefix in package name
-        name = self.spec.name[3:]
-
-        # Libraries should only be in platlib, but no harm in checking purelib too
-        python = self.python_spec
-        platlib = self.prefix.join(python.package.platlib).join(name)
-        purelib = self.prefix.join(python.package.purelib).join(name)
-
-        libs_list = map(functools.partial(find_all_libraries, recursive=True), [platlib, purelib])
-        libs = functools.reduce(operator.add, libs_list)
-
-        if libs:
-            return libs
-
-        msg = "Unable to recursively locate {} libraries in {} or {}"
-        raise NoLibrariesError(msg.format(self.spec.name, platlib, purelib))
+        return LibraryList([])
 
 
 @register_builder("python_pip")

--- a/repos/spack_repo/builtin/build_systems/python.py
+++ b/repos/spack_repo/builtin/build_systems/python.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import functools
+import operator
 import os
 import re
 import shutil
@@ -13,6 +15,8 @@ from spack.package import (
     ClassProperty,
     HeaderList,
     LibraryList,
+    NoHeadersError,
+    NoLibrariesError,
     PackageBase,
     Prefix,
     Spec,
@@ -23,6 +27,8 @@ from spack.package import (
     extends,
     filter_file,
     find,
+    find_all_headers,
+    find_all_libraries,
     has_shebang,
     join_path,
     path_contains_subdirectory,

--- a/repos/spack_repo/builtin/packages/py_pythran/package.py
+++ b/repos/spack_repo/builtin/packages/py_pythran/package.py
@@ -83,13 +83,6 @@ class PyPythran(PythonPackage):
     # from distutils.errors import CompileError in run.py
     conflicts("^python@3.12:", when="@:0.15")
 
-    @property
-    def headers(self):
-        # Pythran is mainly meant to be used as a compiler, so return no headers to
-        # avoid issue https://github.com/spack/spack/issues/33237 This can be refined
-        # later to allow using pythran also as a library.
-        return HeaderList([])
-
     def patch(self):
         # Compiler is used at run-time to determine name of OpenMP library to search for
         cfg_file = join_path("pythran", "pythran-{0}.cfg".format(sys.platform))

--- a/repos/spack_repo/builtin/packages/python_venv/package.py
+++ b/repos/spack_repo/builtin/packages/python_venv/package.py
@@ -24,6 +24,9 @@ class PythonVenv(Package):
 
     extends("python")
 
+    if True:
+        pass # trigger rebuild
+
     def install(self, spec, prefix):
         # Create a virtual environment
         python("-m", "venv", "--without-pip", prefix)

--- a/repos/spack_repo/builtin/packages/python_venv/package.py
+++ b/repos/spack_repo/builtin/packages/python_venv/package.py
@@ -25,7 +25,7 @@ class PythonVenv(Package):
     extends("python")
 
     if True:
-        pass # trigger rebuild
+        pass  # trigger rebuild
 
     def install(self, spec, prefix):
         # Create a virtual environment

--- a/repos/spack_repo/builtin/packages/python_venv/package.py
+++ b/repos/spack_repo/builtin/packages/python_venv/package.py
@@ -24,9 +24,6 @@ class PythonVenv(Package):
 
     extends("python")
 
-    if True:
-        pass # trigger rebuild
-
     def install(self, spec, prefix):
         # Create a virtual environment
         python("-m", "venv", "--without-pip", prefix)

--- a/repos/spack_repo/builtin/packages/python_venv/package.py
+++ b/repos/spack_repo/builtin/packages/python_venv/package.py
@@ -25,7 +25,7 @@ class PythonVenv(Package):
     extends("python")
 
     if True:
-        pass  # trigger rebuild
+        pass # trigger rebuild
 
     def install(self, spec, prefix):
         # Create a virtual environment


### PR DESCRIPTION
The current `PythonPackage.libs` and `PythonPackage.headers` default implementations are generally redundant, as evidenced by this pipeline which built a large number of Python packages including `numpy`, `tensorflow` and `torch` and their dependents: https://gitlab.spack.io/spack/spack-packages/-/pipelines/1235620.

From my understanding:

* There is no use of `spec["py-*"].libs` and `spec["py-*"].headers` in builtin
* You typically cannot link to the libraries in the usual way (`-L... -lfoo`) because they are Python modules with names of the form `_foo.cpython-<version>-<platform>.so`. They're meant to be opened by the Python interpreter.
* For packages like `numpy`, the typical use is to ask the module itself for its headers, using `numpy.get_include()`, when defining an extension. The headers is all you need, no linking to numpy libs is necessary.
* For `numpy` there are *some* static libraries (`numpy/random/lib/libnpyrandom.a`, `numpy/core/lib/libnpymath.a`), but those don't require our rpaths, and people are moving away from them, apparently.

So, I would be in favor of defaulting to an empty library and header list, because:

1. Spack's build system always calls `.libs` and `.headers`, which can be slow when packages are marked external
2. The heuristic can be return false positives (vendored/private headers) or too many results, leading to issues like https://github.com/spack/spack/issues/33237.
3. It's not much work to add it back on per-package basis if needed, and I'm happy to do that if needed