### PR TITLE
flux-python: depends on flux-core, flux-security, json-glib

### DIFF
--- a/repos/spack_repo/builtin/packages/flux_python/package.py
+++ b/repos/spack_repo/builtin/packages/flux_python/package.py
@@ -26,3 +26,7 @@ class FluxPython(PythonPackage):
     depends_on("py-setuptools", type="build")
     depends_on("py-pyyaml", type=("build", "run"))
     depends_on("py-cffi", type=("build", "run"))
+
+    depends_on("flux-core", type=("build", "link", "run"))
+    depends_on("flux-security")
+    depends_on("json-glib")


### PR DESCRIPTION
`flux-python` build errors without these dependencies.