### PR TITLE
mapl: Add v2.61.0, conflict ESMF v9 for older versions

### DIFF
--- a/repos/spack_repo/builtin/packages/mapl/package.py
+++ b/repos/spack_repo/builtin/packages/mapl/package.py
@@ -39,6 +39,7 @@ class Mapl(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("2.61.0", sha256="bb768fd60214d5b6fe6120e08a5ebd869f576392a3252a4715fd7c32d0dea97a")
     version("2.60.0", sha256="470f4da9cc516fdf8206dbc84ab13f53792f3af5e54cd5315ff70d44e5700788")
     version("2.59.0", sha256="a1137bf62e885256d295c66929cd77658a559f88dbed4f433544f432c5c7a059")
     version("2.58.1", sha256="176c7baccd0182e353184808b1048baa6100d8700ca532e0d02bea6ae5771aba")

--- a/repos/spack_repo/builtin/packages/mapl/package.py
+++ b/repos/spack_repo/builtin/packages/mapl/package.py
@@ -330,6 +330,9 @@ class Mapl(CMakePackage):
     depends_on("esmf~debug", when="~debug")
     depends_on("esmf+debug", when="+debug")
 
+    # MAPL2 only supports ESMF 9 from 2.61 onwards
+    conflicts("esmf@9:", when="@:2.60")
+
     # udunits dependency from MAPL 2.48 onwards
     depends_on("udunits", when="@2.48:")
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR adds a `conflicts` to `mapl` for `esmf@9`. An issue was found in testing ESMF v9.0.0b03 (needed for MAPL 3 development) where a specific use of the (deprecated) `ESMF_AttributeGet` call triggered a failure (https://github.com/esmf-org/esmf/issues/493)

We also add a MAPL 2.61 which has the fixes needed to work with ESMF v9

NOTE: If needed, we could of course backport these fixes to older tags. When that happens, we can relax this.