### PR TITLE
py-geemap: add v0.36.3

### DIFF
--- a/repos/spack_repo/builtin/packages/py_geemap/package.py
+++ b/repos/spack_repo/builtin/packages/py_geemap/package.py
@@ -15,6 +15,7 @@ class PyGeemap(PythonPackage):
 
     license("MIT")
 
+    version("0.36.3", sha256="5307cb29eeae6ce1a3b4fee3a8a09ae091d5e5afc05c2b4d4d3007d7e24ec257")
     version("0.36.1", sha256="378bbaaf87a74f70f021ae727d8310871fe35a7fc4b14321dbc698a56730426c")
     version("0.36.0", sha256="cb5da3bc6414d4b75dc97a333e46cadc2492de992741abcb09d5b875e6f65823")
     version("0.35.1", sha256="98f3f17fb1d07a6fe43b06f03fb680e10517adfd96002184015a3d4fe92435d6")
@@ -38,7 +39,6 @@ class PyGeemap(PythonPackage):
         depends_on("py-ipyevents")
         depends_on("py-ipyfilechooser@0.6:")
         depends_on("py-ipyleaflet@0.19.2:")
-        depends_on("py-ipytree")
         depends_on("py-matplotlib")
         depends_on("py-numpy")
         depends_on("py-pandas")
@@ -50,3 +50,4 @@ class PyGeemap(PythonPackage):
 
         # Historical dependencies
         depends_on("py-colour", when="@:0.36.0")
+        depends_on("py-ipytree", when="@:0.36.2")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
https://github.com/gee-community/geemap/releases/tag/v0.36.3

One step closer to fixing concretization. py-ipytree had issues with newer Python versions.