### PR TITLE
qt-tools: adds depends for c, cxx

### DIFF
--- a/repos/spack_repo/builtin/packages/qt_tools/package.py
+++ b/repos/spack_repo/builtin/packages/qt_tools/package.py
@@ -43,6 +43,9 @@ class QtTools(QtPackage):
     # use of relative path in https://github.com/qt/qttools/blob/6.8.2/.gitmodules
     conflicts("+assistant", when="@6.8.2", msg="Incorrect git submodule prevents +assistant")
 
+    depends_on("c")
+    depends_on("cxx")
+
     depends_on("llvm +clang")
 
     depends_on("qt-base +network")


### PR DESCRIPTION
This PR adds depends_on statements for c and cxx to the qt-tools package.

Without these, the installation attempts to use the system gcc/g++ compiler.

Tagging @wdconinc as the listed maintainer.