### PR TITLE
libtree: add cxx compiler

### DIFF
--- a/repos/spack_repo/builtin/packages/libtree/package.py
+++ b/repos/spack_repo/builtin/packages/libtree/package.py
@@ -53,7 +53,8 @@ class Libtree(MakefilePackage, CMakePackage):
 
         return "https://github.com/haampie/libtree/archive/refs/tags/v{0}.tar.gz".format(version)
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     # Version 2.x and earlier (CMake)
     with when("build_system=cmake"):

--- a/repos/spack_repo/builtin/packages/libtree/package.py
+++ b/repos/spack_repo/builtin/packages/libtree/package.py
@@ -54,7 +54,7 @@ class Libtree(MakefilePackage, CMakePackage):
         return "https://github.com/haampie/libtree/archive/refs/tags/v{0}.tar.gz".format(version)
 
     depends_on("c", type="build")
-    depends_on("cxx", type="build")
+    depends_on("cxx", type="build", when="@:2")
 
     # Version 2.x and earlier (CMake)
     with when("build_system=cmake"):


### PR DESCRIPTION
the cmake build looks for cxx and fails without this dep