### PR TITLE
fix psyclone dependencies and config paths

### DIFF
--- a/repos/spack_repo/builtin/packages/py_psyclone/package.py
+++ b/repos/spack_repo/builtin/packages/py_psyclone/package.py
@@ -48,7 +48,7 @@ class PyPsyclone(PythonPackage):
     depends_on("py-graphviz", type=("build", "run"))
     depends_on("py-configparser", type=("build", "run"))
     depends_on("py-jinja2", type="build")
-    depends_on("py-sympy", type=("build", "run"), when="@2.2.0:")
+    depends_on("py-sympy@1.6.1:", type=("build", "run"), when="@2.2.0:")
     depends_on("py-termcolor", type=("build", "run"))
 
     # Historical dependencies
@@ -88,3 +88,7 @@ class PyPsyclone(PythonPackage):
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         # Allow testing with installed executables
         env.prepend_path("PATH", self.prefix.bin)
+
+    def setup_run_environment(self, env):
+        # Set config file path
+        env.set('PSYCLONE_CONFIG', join_path(self.prefix.share, "psyclone", "psyclone.cfg"))

--- a/repos/spack_repo/builtin/packages/py_psyclone/package.py
+++ b/repos/spack_repo/builtin/packages/py_psyclone/package.py
@@ -91,4 +91,4 @@ class PyPsyclone(PythonPackage):
 
     def setup_run_environment(self, env):
         # Set config file path
-        env.set('PSYCLONE_CONFIG', join_path(self.prefix.share, "psyclone", "psyclone.cfg"))
+        env.set("PSYCLONE_CONFIG", join_path(self.prefix.share, "psyclone", "psyclone.cfg"))


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

* Force sympy version >= 1.6.1 since any older version uses deprecated python2 syntax and throws `AttributeError: module 'inspect' has no attribute 'getargspec'.`

* set PSYCLONE_CONFIG path to prevent runtime error `psyclone.cfg not found`

Maintainers:
@arporter @sergisiso 
