### PR TITLE
xios: project moved to gitlab.in2p3.fr

### DIFF
--- a/repos/spack_repo/builtin/packages/xios/package.py
+++ b/repos/spack_repo/builtin/packages/xios/package.py
@@ -13,12 +13,9 @@ from spack.package import *
 class Xios(Package):
     """XML-IO-SERVER library for IO management of climate models."""
 
-    homepage = "https://forge.ipsl.jussieu.fr/ioserver/wiki"
-    version(
-        "2.6",
-        revision="2714",
-        svn="https://forge.ipsl.jussieu.fr/ioserver/svn/XIOS2/branches/xios-2.6",
-    )
+    homepage = "https://ipsl.pages.in2p3.fr/projets/xios-projects/xios"
+    git = "https://gitlab.in2p3.fr/ipsl/projets/xios-projects/xios.git"
+    version("2.6", branch="xios-2.6.x")
 
     variant(
         "mode",
@@ -35,7 +32,7 @@ class Xios(Package):
     patch("llvm_bug_17782.patch", when="@1.1: %apple-clang")
     patch("llvm_bug_17782.patch", when="@1.1: %clang")
 
-    patch("earcut_missing_include_2.6.patch", when="@2.6:")
+    patch("earcut_missing_include_2.6.patch", when="@2.6")
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")


### PR DESCRIPTION
Hi @tldahlgren / @alecbcs, please review:

Updates by @bernhardkaindl:

- The old hosts https://forge.ipsl.jussieu.fr and https://forge.ipsl.fr are offline.
- The project moved https://gitlab.in2p3.fr with https://ipsl.pages.in2p3.fr/projets/xios-projects/xios as documentation site and home page.
- Updated `patch("earcut_missing_include_2.6.patch", when="@2.6")` to only apply it for 2.6 as it does not apply to the new 3.x releases.
- 3.x release are not added because of build errors.