### PR TITLE
Fix voms pkg-config path for gsoap and zlib dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/voms/package.py
+++ b/repos/spack_repo/builtin/packages/voms/package.py
@@ -51,8 +51,13 @@ class Voms(AutotoolsPackage):
             join_path(self.spec["zlib-api"].prefix.lib, "pkgconfig"),
         ]
         pkg_env = {"PKG_CONFIG_PATH": ":".join(pkgconfig_paths)}
-        env.set("GSOAP_SSL_PP_CFLAGS", pkgconfig("--cflags", "gsoapssl++", "zlib", output=str, env=pkg_env),)
-        env.set("GSOAP_SSL_PP_LIBS", pkgconfig("--libs", "gsoapssl++", "zlib", output=str, env=pkg_env),)
+        env.set(
+            "GSOAP_SSL_PP_CFLAGS",
+            pkgconfig("--cflags", "gsoapssl++", "zlib", output=str, env=pkg_env),
+        )
+        env.set(
+            "GSOAP_SSL_PP_LIBS", pkgconfig("--libs", "gsoapssl++", "zlib", output=str, env=pkg_env)
+        )
 
     def autoreconf(self, spec, prefix):
         autogen = Executable("./autogen.sh")

--- a/repos/spack_repo/builtin/packages/voms/package.py
+++ b/repos/spack_repo/builtin/packages/voms/package.py
@@ -45,16 +45,14 @@ class Voms(AutotoolsPackage):
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         # https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=voms
         pkgconfig = Executable(join_path(self.spec["pkgconfig"].prefix.bin, "pkg-config"))
-        
         # Set up PKG_CONFIG_PATH to find gsoap and zlib pkg-config files
         pkgconfig_paths = [
             join_path(self.spec["gsoap"].prefix.lib, "pkgconfig"),
             join_path(self.spec["zlib-api"].prefix.lib, "pkgconfig"),
         ]
         pkg_env = {"PKG_CONFIG_PATH": ":".join(pkgconfig_paths)}
-        
-        env.set("GSOAP_SSL_PP_CFLAGS", pkgconfig("--cflags", "gsoapssl++", "zlib", output=str))
-        env.set("GSOAP_SSL_PP_LIBS", pkgconfig("--libs", "gsoapssl++", "zlib", output=str))
+        env.set("GSOAP_SSL_PP_CFLAGS", pkgconfig("--cflags", "gsoapssl++", "zlib", output=str, env=pkg_env),)
+        env.set("GSOAP_SSL_PP_LIBS", pkgconfig("--libs", "gsoapssl++", "zlib", output=str, env=pkg_env),)
 
     def autoreconf(self, spec, prefix):
         autogen = Executable("./autogen.sh")

--- a/repos/spack_repo/builtin/packages/voms/package.py
+++ b/repos/spack_repo/builtin/packages/voms/package.py
@@ -45,8 +45,16 @@ class Voms(AutotoolsPackage):
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         # https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=voms
         pkgconfig = Executable(join_path(self.spec["pkgconfig"].prefix.bin, "pkg-config"))
-        env.set("GSOAP_SSL_PP_CFLAGS", pkgconfig("--cflags", "gsoapssl++", "zlib", output=str))
-        env.set("GSOAP_SSL_PP_LIBS", pkgconfig("--libs", "gsoapssl++", "zlib", output=str))
+        
+        # Set up PKG_CONFIG_PATH to find gsoap and zlib pkg-config files
+        pkgconfig_paths = [
+            join_path(self.spec["gsoap"].prefix.lib, "pkgconfig"),
+            join_path(self.spec["zlib-api"].prefix.lib, "pkgconfig"),
+        ]
+        pkg_env = {"PKG_CONFIG_PATH": ":".join(pkgconfig_paths)}
+        
+        env.set("GSOAP_SSL_PP_CFLAGS", pkgconfig("--cflags", "gsoapssl++", "zlib", output=str, env=pkg_env))
+        env.set("GSOAP_SSL_PP_LIBS", pkgconfig("--libs", "gsoapssl++", "zlib", output=str, env=pkg_env))
 
     def autoreconf(self, spec, prefix):
         autogen = Executable("./autogen.sh")

--- a/repos/spack_repo/builtin/packages/voms/package.py
+++ b/repos/spack_repo/builtin/packages/voms/package.py
@@ -45,16 +45,22 @@ class Voms(AutotoolsPackage):
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         # https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=voms
         pkgconfig = Executable(join_path(self.spec["pkgconfig"].prefix.bin, "pkg-config"))
-        
+
         # Set up PKG_CONFIG_PATH to find gsoap and zlib pkg-config files
         pkgconfig_paths = [
             join_path(self.spec["gsoap"].prefix.lib, "pkgconfig"),
             join_path(self.spec["zlib-api"].prefix.lib, "pkgconfig"),
         ]
         pkg_env = {"PKG_CONFIG_PATH": ":".join(pkgconfig_paths)}
-        
-        env.set("GSOAP_SSL_PP_CFLAGS", pkgconfig("--cflags", "gsoapssl++", "zlib", output=str, env=pkg_env))
-        env.set("GSOAP_SSL_PP_LIBS", pkgconfig("--libs", "gsoapssl++", "zlib", output=str, env=pkg_env))
+
+        env.set(
+            "GSOAP_SSL_PP_CFLAGS",
+            pkgconfig("--cflags", "gsoapssl++", "zlib", output=str, env=pkg_env),
+        )
+        env.set(
+            "GSOAP_SSL_PP_LIBS",
+            pkgconfig("--libs", "gsoapssl++", "zlib", output=str, env=pkg_env),
+        )
 
     def autoreconf(self, spec, prefix):
         autogen = Executable("./autogen.sh")

--- a/repos/spack_repo/builtin/packages/voms/package.py
+++ b/repos/spack_repo/builtin/packages/voms/package.py
@@ -45,22 +45,16 @@ class Voms(AutotoolsPackage):
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         # https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=voms
         pkgconfig = Executable(join_path(self.spec["pkgconfig"].prefix.bin, "pkg-config"))
-
+        
         # Set up PKG_CONFIG_PATH to find gsoap and zlib pkg-config files
         pkgconfig_paths = [
             join_path(self.spec["gsoap"].prefix.lib, "pkgconfig"),
             join_path(self.spec["zlib-api"].prefix.lib, "pkgconfig"),
         ]
         pkg_env = {"PKG_CONFIG_PATH": ":".join(pkgconfig_paths)}
-
-        env.set(
-            "GSOAP_SSL_PP_CFLAGS",
-            pkgconfig("--cflags", "gsoapssl++", "zlib", output=str, env=pkg_env),
-        )
-        env.set(
-            "GSOAP_SSL_PP_LIBS",
-            pkgconfig("--libs", "gsoapssl++", "zlib", output=str, env=pkg_env),
-        )
+        
+        env.set("GSOAP_SSL_PP_CFLAGS", pkgconfig("--cflags", "gsoapssl++", "zlib", output=str))
+        env.set("GSOAP_SSL_PP_LIBS", pkgconfig("--libs", "gsoapssl++", "zlib", output=str))
 
     def autoreconf(self, spec, prefix):
         autogen = Executable("./autogen.sh")


### PR DESCRIPTION
Fixes #1564

## Problem
The voms package fails to build with pkg-config errors:
- `Package 'gsoapssl++' not found`
- `Package 'zlib' not found`

## Root Cause
The `setup_build_environment` method calls pkg-config without setting the correct `PKG_CONFIG_PATH` to include the pkgconfig directories of gsoap and zlib-api dependencies.

## Solution
- Set `PKG_CONFIG_PATH` environment variable in the pkg-config calls to include:
  - `{gsoap_prefix}/lib/pkgconfig`
  - `{zlib-api_prefix}/lib/pkgconfig`

## Testing
- Verified that both `gsoapssl++.pc` and `zlib.pc` files exist in their respective directories
- Successfully built voms@2.1.2 with this fix on linux-rhel8-icelake