### PR TITLE
cddlib: add gmp variant

### DIFF
--- a/repos/spack_repo/builtin/packages/cddlib/package.py
+++ b/repos/spack_repo/builtin/packages/cddlib/package.py
@@ -23,8 +23,10 @@ class Cddlib(AutotoolsPackage):
     version("0.94m", sha256="70dffdb3369b8704dc75428a1b3c42ab9047b81ce039f12f427e2eb2b1b0dee2")
     version("0.94h", sha256="7382782c3834214b022c8b2898ed775a7bf915f2cb2acb73fa045d6fd9a3de33")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
+    variant("gmp", default=False, description="Build with GMP support")
+    depends_on("gmp", when="+gmp")
     depends_on("gmp", when="@0.94h")
 
     def url_for_version(self, version):


### PR DESCRIPTION
GMP support is expected by some dependencies such as gfan.