### PR TITLE
fix broken conditional variant default for icu4c causing solver hang

### DIFF
--- a/repos/spack_repo/builtin/packages/icu4c/package.py
+++ b/repos/spack_repo/builtin/packages/icu4c/package.py
@@ -40,7 +40,7 @@ class Icu4c(AutotoolsPackage, MSBuildPackage):
         with when(f"platform={plat}"):
             variant(
                 "cxxstd",
-                default="11",
+                default="17",
                 values=(conditional("11", "14", when="@:74"), "17"),
                 multi=False,
                 description="Use the specified C++ standard when building",


### PR DESCRIPTION
# Problem
See https://github.com/spack/spack/issues/51245. `icu4c` defines a default `cxxstd` variant which isn't available for the default version, which leads to a solver hang in confusing ways. See:

```shell
; spack spec icu4c
# infinite hang, no ability to ^C
; spack spec 'icu4c cxxstd=17'
# works
```

# Solution
For right now, it would be good to fix the immediate solver hang, but I have prescribed some additional follow-up work in https://github.com/spack/spack/issues/51245#issuecomment-3314643303.

# Result
```shell
; spack spec icu4c
# produces the expected output without a hang
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
