### PR TITLE
py-charset-normalizer: remove optional dependency on mypy

### DIFF
--- a/repos/spack_repo/builtin/packages/py_charset_normalizer/package.py
+++ b/repos/spack_repo/builtin/packages/py_charset_normalizer/package.py
@@ -26,7 +26,8 @@ class PyCharsetNormalizer(PythonPackage):
     with default_args(type="build"):
         depends_on("py-setuptools")
         depends_on("py-setuptools-scm", when="@3.4.2:")
-        depends_on("py-mypy@1.4.1:1.15.0", when="@3.4.2:")
+        # Optional dependency when building with --use-mypyc
+        # depends_on("py-mypy@1.4.1:1.15.0", when="@3.4.2:")
 
     with default_args(type=("build", "run")):
         depends_on("python@3.7:3.13", when="@3.4:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
To the best of my understanding, mypy is not actually used in the build by default. The upper bound was causing issues with concretizing my environment.