### PR TITLE
lrslib: add v7.3

### DIFF
--- a/repos/spack_repo/builtin/packages/lrslib/multiple-definitions.patch
+++ b/repos/spack_repo/builtin/packages/lrslib/multiple-definitions.patch
@@ -1,0 +1,23 @@
+diff -Naur spack-src.old/lrsnashlib.c spack-src/lrsnashlib.c
+--- a/lrsnashlib.c	2024-07-29 09:36:20.927068643 +0200
++++ b/lrsnashlib.c	2024-07-29 09:38:53.617172534 +0200
+@@ -19,6 +19,7 @@
+ #include "lrslib.h"
+ #include "lrsnashlib.h"
+ 
++long FirstTime;
+ 
+ //========================================================================
+ // Standard solver. Modified version of main() from lrsNash
+diff -Naur spack-src.old/lrsnashlib.h spack-src/lrsnashlib.h
+--- a/lrsnashlib.h	2024-07-29 09:36:20.927068643 +0200
++++ b/lrsnashlib.h	2024-07-29 09:36:45.758760323 +0200
+@@ -65,7 +65,7 @@
+ void updateFwidth(game *g, int col, int pos, char *str);
+ 
+ 
+-long FirstTime;          /* set this to true for every new game to be solved */
++extern long FirstTime;          /* set this to true for every new game to be solved */
+ static long Debug_flag;
+ static long Verbose_flag;
+ 

--- a/repos/spack_repo/builtin/packages/lrslib/package.py
+++ b/repos/spack_repo/builtin/packages/lrslib/package.py
@@ -3,13 +3,13 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack_repo.builtin.build_systems.generic import Package
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
 
 from spack.package import *
 
 
-class Lrslib(Package):
-    """lrslib Ver 6.2 is a self-contained ANSI C implementation of the
+class Lrslib(MakefilePackage):
+    """lrslib is a self-contained ANSI C implementation of the
     reverse search algorithm for vertex enumeration/convex hull
     problems and comes with a choice of three arithmetic packages"""
 
@@ -18,14 +18,14 @@ class Lrslib(Package):
 
     license("GPL-2.0-only")
 
+    version("7.3", sha256="c49a4ebd856183473d1d5a62785fcdfe1057d5d671d4b96f3a1250eb1afe4e83")
     version("6.2", sha256="adf92f9c7e70c001340b9c28f414208d49c581df46b550f56ab9a360348e4f09")
     version("6.1", sha256="6d5b30ee67e1fdcd6bf03e14717616f18912d59b3707f6d53f9c594c1674ec45")
     version("6.0", sha256="1a569786ecd89ef4f2ddee5ebc32e321f0339505be40f4ffbd2daa95fed1c505")
     version("5.1", sha256="500893df61631944bac14a76c6e13fc08e6e729727443fa5480b2510de0db635")
     version("4.3", sha256="04fc1916ea122b3f2446968d2739717aa2c6c94b21fba1f2c627fd17fcf7a963")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
 
     # Note: lrslib can also be built with Boost, and probably without gmp
 
@@ -34,22 +34,27 @@ class Lrslib(Package):
     depends_on("libtool", type="build")
     depends_on("gmake", type="build")
 
-    patch("Makefile.spack.patch")
+    # The Makefile isn't portable; use our own instead
+    patch("Makefile.spack.patch", when="@:6.2")
     # Ref: https://github.com/mkoeppe/lrslib/commit/2e8c5bd6c06430151faea5910f44aa032c4178a9
-    patch("fix-return-value.patch")
+    patch("fix-return-value.patch", when="@:6.2")
+    # Ref: https://gitlab.epfl.ch/SCITAS/software-stack/scitas-spack-packages/-/commit/ffdeb9d
+    patch("multiple-definitions.patch", when="@:6.2")
 
     def url_for_version(self, version):
         url = "http://cgm.cs.mcgill.ca/~avis/C/lrslib/archive/lrslib-0{0}.tar.gz"
         return url.format(version.joined)
 
-    def install(self, spec, prefix):
-        # The Makefile isn't portable; use our own instead
-        makeargs = [
-            "-f",
-            "Makefile.spack",
-            "PREFIX=%s" % prefix,
-            # "BOOST_PREFIX=%s" % spec["boost"].prefix,
-            "GMP_PREFIX=%s" % spec["gmp"].prefix,
-        ]
-        make(*makeargs)
-        make("install", *makeargs)
+    @property
+    def build_targets(self):
+        if self.spec.satisfies("@:6.2"):
+            return ["-f", "Makefile.spack", f"GMP_PREFIX={self.spec['gmp'].prefix}"]
+        else:
+            return []
+
+    @property
+    def install_targets(self):
+        if self.spec.satisfies("@:6.2"):
+            return ["install", "-f", "Makefile.spack", f"PREFIX={self.prefix}"]
+        else:
+            return ["install", f"prefix={self.prefix}"]


### PR DESCRIPTION
Also:
* Update to MakefilePackage
* Stop depending on c++ compiler
* Use upstream Makefile after v6.2
* Add patch fixing "multiple definition" error in v6.2
* Remove "generated" comments

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
