### PR TITLE
py_cramjam: add dependency on c to fix `linker `cc` not found`

### DIFF
--- a/repos/spack_repo/builtin/packages/py_cramjam/package.py
+++ b/repos/spack_repo/builtin/packages/py_cramjam/package.py
@@ -17,4 +17,6 @@ class PyCramjam(PythonPackage):
 
     version("2.11.0", sha256="5c82500ed91605c2d9781380b378397012e25127e89d64f460fea6aeac4389b4")
 
+    depends_on("c", type="build")
+
     depends_on("py-maturin@0.14:", type="build")


### PR DESCRIPTION
Originally reported in https://github.com/spack/spack/issues/50740 for other rust packages, this is how I have fixed other packages so far https://github.com/spack/spack-packages/pull/106.

The error (Alma 9, GCC 14):
```
==> Error: ProcessError: Command exited with status 1:
    '/cvmfs/sw-nightlies.hsf.org/key4hep/releases/2025-09-21/x86_64-almalinux9-gcc14.2.0-opt/python-venv/1.0-rnboks/bin/python3' '-m' 'pip' '-vvv' '--no-input' '--no-cache-dir' '--disable-pip-version-check' 'install' '--no-deps' '--ignore-installed' '--no-build-isolation' '--no-warn-script-location' '--no-index' '--prefix=/cvmfs/sw-nightlies.hsf.org/key4hep/releases/2025-09-21/x86_64-almalinux9-gcc14.2.0-opt/py-cramjam/2.11.0-2a2v7h' '.'

1 error found in build log:
     74         Compiling adler2 v2.0.0
     75         Compiling cfg-if v1.0.0
     76         Compiling libcramjam v0.8.0
     77         Compiling crc32fast v1.4.2
     78      error: linker `cc` not found
     79        |
  >> 80    = note: No such file or directory (os error 2)
     81
     82      error: could not compile `zstd-safe` (build script) due t
           o 1 previous error
     83      warning: build failed, waiting for other jobs to finish..
           .
     84      error: could not compile `libcramjam` (build script) due
           to 1 previous error
     85      error: could not compile `snap` (build script) due to 1 p
           revious error
     86      error: could not compile `proc-macro2` (build script) due
            to 1 previous error

See build log for details:
  /tmp/root/spack-stage/spack-stage-py-cramjam-2.11.0-2a2v7hv5quhpl6e2s4q3pmvnzytu7s3u/spack-build-out.txt
```