### PR TITLE
ntl: depend on C compiler in "shared" variant

### DIFF
--- a/repos/spack_repo/builtin/packages/ntl/package.py
+++ b/repos/spack_repo/builtin/packages/ntl/package.py
@@ -29,7 +29,10 @@ class Ntl(MakefilePackage):
 
     variant("shared", default=False, description="Build shared library.")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
+
+    # need C compiler for compiling libtool when building shared library
+    depends_on("c", type="build", when="+shared")
 
     depends_on("gmp")
 


### PR DESCRIPTION
When SHARED is "on", ntl compiles its own copy of libtool. Previously, the build failed with:

       18    checking whether the C compiler works... no
    >> 19    configure: error: in `/tmp/root/spack-stage/spack-stage-ntl-11.5.1-
             qh6xzxnnoqdg76km2hgyfi57wbmuf4ne/spack-src/src/libtool-build':
    >> 20    configure: error: C compiler cannot create executables
       21    See `config.log' for more details
    >> 22    Error: libtool build failed

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
