### PR TITLE
ruff: add gmake as a build dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/py_ruff/package.py
+++ b/repos/spack_repo/builtin/packages/py_ruff/package.py
@@ -31,6 +31,7 @@ class PyRuff(PythonPackage):
     version("0.1.6", sha256="1b09f29b16c6ead5ea6b097ef2764b42372aebe363722f1605ecbcd2b9207184")
 
     depends_on("c", type="build")
+    depends_on("gmake", type="build")
 
     with default_args(type="build"):
         depends_on("py-maturin@1")


### PR DESCRIPTION
This fixes an issue with `failed to execute command: No such file or directory (os error 2)` when it's trying to run make. The same issue was fixed adding `gmake` for a different package in https://github.com/spack/spack-packages/pull/1593.

The error:

```
==> Error: ProcessError: Command exited with status 1:
    '/cvmfs/sw-nightlies.hsf.org/key4hep/releases/2025-09-21/x86_64-almalinux9-gcc14.2.0-opt/python-venv/1.0-rnboks/bin/python3' '-m' 'pip' '-vvv' '--no-input' '--no-cache-dir' '--disable-pip-version-check' 'install' '--no-deps' '--ignore-installed' '--no-build-isolation' '--no-warn-script-location' '--no-index' '--prefix=/cvmfs/sw-nightlies.hsf.org/key4hep/releases/2025-09-21/x86_64-almalinux9-gcc14.2.0-opt/py-ruff/0.12.0-cbwgya' '.'
==> Installing py-ruff-0.12.0-cbwgyaixip3w3qbgumrydfbdftgnfe5m [491/661]
1 error found in build log:
     909        ===============================================================
            ================
     910        running: cd "/tmp/root/spack-stage/spack-stage-py-ruff-0.12.0-c
            bwgyaixip3w3qbgumrydfbdftgnfe5m/spack-src/target/release/build/tikv
            -jemalloc-sys-ac46d6cf4c101491/out/build" && "make" "-j" "16"
     911    
     912        --- stderr
     913    
     914        thread 'main' panicked at /root/.cargo/registry/src/index.crate
            s.io-1949cf8c6b5b557f/tikv-jemalloc-sys-0.6.0+5.3.0-1-ge13ca993e8cc
            b9ba9847cc330696e02839f328f7/build.rs:384:19:
  >> 915    failed to execute command: No such file or directory (os error 2)
     916        note: run with `RUST_BACKTRACE=1` environment variable to displ
            ay a backtrace
     917      warning: build failed, waiting for other jobs to finish...
     918      💥 maturin failed
     919        Caused by: Failed to build a native library through cargo
     920        Caused by: Cargo build finished with "exit status: 101": `env -
            u CARGO "cargo" "rustc" "--message-format" "json-render-diagnostics
            " "--manifest-path" "/tmp/root/spack-stage/spack-stage-py-ruff-0.12
            .0-cbwgyaixip3w3qbgumrydfbdftgnfe5m/spack-src/crates/ruff/Cargo.tom
            l" "--release" "--bin" "ruff" "--" "-C" "strip=symbols"`
     921      Error: command ['maturin', 'pep517', 'build-wheel', '-i', '/cvmfs
            /sw-nightlies.hsf.org/key4hep/releases/2025-09-21/x86_64-almalinux9
            -gcc14.2.0-opt/python-venv/1.0-rnboks/bin/python3', '--compatibilit
            y', 'off'] returned non-zero exit status 1
See build log for details:
  /tmp/root/spack-stage/spack-stage-py-ruff-0.12.0-cbwgyaixip3w3qbgumrydfbdftgnfe5m/spack-build-out.txt
```