### PR TITLE
normaliz: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/normaliz/package.py
+++ b/repos/spack_repo/builtin/packages/normaliz/package.py
@@ -1,0 +1,44 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+
+from spack.package import *
+
+
+class Normaliz(AutotoolsPackage):
+    """Normaliz is an open-source tool for computations in discrete convex
+    geometry, including affine monoids, rational and algebraic cones, and
+    polyhedra. It supports tasks such as convex hulls, lattice point
+    enumeration, Hilbert bases, Ehrhart series, and Gröbner bases of lattice
+    and toric ideals. Normaliz provides both a command-line interface and a C++
+    library (libnormaliz) for integrating its algorithms into other
+    software."""
+
+    homepage = "https://www.normaliz.uni-osnabrueck.de/"
+    url = "https://github.com/Normaliz/Normaliz/releases/download/v3.10.5/normaliz-3.10.5.tar.gz"
+
+    maintainers("d-torrance")
+
+    license("GPL-3.0-or-later", checked_by="d-torrance")
+
+    version("3.10.5", sha256="58492cfbfebb2ee5702969a03c3c73a2cebcbca2262823416ca36e7b77356a44")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("diffutils", type="build")
+
+    depends_on("gmp")
+
+    variant(
+        "nauty",
+        default=False,
+        description="Enable nauty support for computing automorphism groups",
+    )
+    depends_on("nauty", when="+nauty")
+
+    variant("flint", default=False, description="Enable flint support for algebraic polyhedra")
+    depends_on("flint", when="+flint")
+
+    # TODO: cocoalib & e-antic variants


### PR DESCRIPTION
[Normaliz](https://www.normaliz.uni-osnabrueck.de) is an open-source tool for computations in discrete convex geometry.  It's used by Macaulay2, Singular, and Polymake.