### PR TITLE
py-anywidget: fix missing dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/py_anywidget/package.py
+++ b/repos/spack_repo/builtin/packages/py_anywidget/package.py
@@ -18,6 +18,8 @@ class PyAnywidget(PythonPackage):
     version("0.9.18", sha256="262cf459b517a7d044d6fbc84b953e9c83f026790b2dd3ce90f21a7f8eded00f")
 
     depends_on("py-hatchling", type="build")
+    # from [tool.hatch.build.hooks.jupyter-builder]
+    depends_on("py-hatch-jupyter-builder@0.5:", type="build")
 
     with default_args(type=("build", "run")):
         depends_on("py-ipywidgets@7.6:")


### PR DESCRIPTION
According to [pyproject.toml#L70](https://github.com/manzt/anywidget/blob/anywidget%400.9.18/pyproject.toml#L70) a build dependency on `py-hatch-jupyter-builder` is needed.

Without it I get the following error:
```
==> Error: ProcessError: Command exited with status 1:
    '/spack/opt/spack/linux-skylake/python-venv-1.0-uokkosk7sm7otpss7scors4bpgjmjgep/bin/python3' '-m' 'pip' '-vvv' '--no-input' '--no-cache-dir' '--disable-pip-version-check' 'install' '--no-deps' '--ignore-installed' '--no-build-isolation' '--no-warn-script-location' '--no-index' '--prefix=/spack/opt/spack/linux-skylake/py-anywidget-0.9.18-e4qn7i5ra33wzdscnbsy2qmv4y3ff3to' '.'

1 error found in build log:
     38      ╰─> See above for output.
     39    
     40      note: This error originates from a subprocess, and is likely not a problem with pip.
     41      full command: /spack/opt/spack/linux-skylake/python-venv-1.0-uokkosk7sm7otpss7scors4bpgjmjgep/bin/python3 /spack/opt/spack/linux-skylake/py-pip-25.1.1-4ubux5rnrk7itinpwgkwth4wu5nnhvyb/lib/python3.13
           /site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py prepare_metadata_for_build_wheel /tmp/tmphg7zbafc
     42      cwd: /tmp/root/spack-stage/spack-stage-py-anywidget-0.9.18-e4qn7i5ra33wzdscnbsy2qmv4y3ff3to/spack-src
     43      Preparing metadata (pyproject.toml): finished with status 'error'
  >> 44    error: metadata-generation-failed
     45    
     46    × Encountered error while generating package metadata.
     47    ╰─> See above for output.
     48    
     49    note: This is an issue with the package mentioned above, not pip.
     50    hint: See above for details.
```


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
