### PR TITLE
libiconv: patch compile error in loop_wchar.h

### DIFF
--- a/repos/spack_repo/builtin/packages/libiconv/loop_wchar_9eb508.patch
+++ b/repos/spack_repo/builtin/packages/libiconv/loop_wchar_9eb508.patch
@@ -1,0 +1,11 @@
+diff --git a/lib/loop_wchar.h b/lib/loop_wchar.h
+--- a/lib/loop_wchar.h
++++ b/lib/loop_wchar.h
+@@ -36,7 +36,6 @@
+ # include <wchar.h>
+ # define BUF_SIZE 64  /* assume MB_LEN_MAX <= 64 */
+   /* Some systems, like BeOS, have multibyte encodings but lack mbstate_t.  */
+-  extern size_t mbrtowc ();
+ # ifdef mbstate_t
+ #  define mbrtowc(pwc, s, n, ps) (mbrtowc)(pwc, s, n, 0)
+ #  define mbsinit(ps) 1

--- a/repos/spack_repo/builtin/packages/libiconv/package.py
+++ b/repos/spack_repo/builtin/packages/libiconv/package.py
@@ -36,6 +36,15 @@ class Libiconv(AutotoolsPackage, GNUMirrorPackage):
     # We cannot set up a warning for gets(), since gets() is not part
     # of C11 any more and thus might not exist.
     patch("gets.patch", when="@1.14")
+
+    # Error for declaration of mbrtowc without a prototype.
+    # https://gitweb.git.savannah.gnu.org/gitweb/?p=libiconv.git;a=commit;h=e46dee2f581c11
+    patch(
+        "loop_wchar_9eb508.patch",
+        when="@:1.17",
+        sha256="e0145a14e9fed1d9f07003a4772db916faa8cbb7c5273880a38d7c2e64d4103c",
+    )
+
     provides("iconv")
 
     conflicts("@1.14", when="%gcc@5:")


### PR DESCRIPTION
clang >=15 and gcc >=14 generate an error for a declaration of mbrtowc without a prototype. The original patch was only targeted at clang, but I found that it also applies to newer versions of gcc.

https://gitweb.git.savannah.gnu.org/gitweb/?p=libiconv.git;a=commit;h=e46dee2f581c11