### PR TITLE
laynii: add v2.8.0

### DIFF
--- a/repos/spack_repo/builtin/packages/laynii/limits.patch
+++ b/repos/spack_repo/builtin/packages/laynii/limits.patch
@@ -1,0 +1,12 @@
+diff --git a/dep/laynii_lib.h b/dep/laynii_lib.h
+index 4d470af..23eb3e2 100644
+--- a/dep/laynii_lib.h
++++ b/dep/laynii_lib.h
+@@ -6,6 +6,7 @@
+ #include <iostream>
+ #include <string>
+ #include <tuple>
++#include <limits>
+ #include "./nifti2_io.h"
+ 
+ using namespace std;

--- a/repos/spack_repo/builtin/packages/laynii/package.py
+++ b/repos/spack_repo/builtin/packages/laynii/package.py
@@ -17,11 +17,15 @@ class Laynii(MakefilePackage):
 
     license("BSD-3-Clause")
 
+    version("2.8.0", sha256="b0747dd86744ee94970a4bc64448f1216dfc98714f064d46773aa6c34b81b305")
     version("2.7.0", sha256="f0f45c6e80afaca1d89a4721dda70f152c175434e19358974a221ef9c713826b")
 
     depends_on("cxx", type="build")
 
     depends_on("zlib")
+
+    # Add missing limits header
+    patch("limits.patch", when="@2.8")
 
     def edit(self, spec, prefix):
         pass


### PR DESCRIPTION
https://github.com/layerfMRI/LAYNII/tree/v2.8.0

Without the patch I get errors like this:
```
==> Error: ProcessError: Command exited with status 2:
    '/spack/opt/spack/linux-skylake/gmake-4.4.1-mlae7jfiz77bbdnxgnnc2tg6aloddbup/bin/make' '-j16'

80 errors found in build log:
     15     c++ -std=c++11 -DHAVE_ZLIB -o LN2_BORDERIZE src/LN2_BORDERIZE.cpp dep/nifti2_io.cpp dep
            /znzlib.cpp dep/laynii_lib.cpp -I./dep  -lm -lz
     16     c++ -std=c++11 -DHAVE_ZLIB -o LN2_GEODISTANCE src/LN2_GEODISTANCE.cpp dep/nifti2_io.cpp
             dep/znzlib.cpp dep/laynii_lib.cpp -I./dep  -lm -lz
     17     c++ -std=c++11 -DHAVE_ZLIB -o LN2_IFPOINTS src/LN2_IFPOINTS.cpp dep/nifti2_io.cpp dep/z
            nzlib.cpp dep/laynii_lib.cpp -I./dep  -lm -lz
     18     c++ -std=c++11 -DHAVE_ZLIB -o LN2_DEVEIN src/LN2_DEVEIN.cpp dep/nifti2_io.cpp dep/znzli
            b.cpp dep/laynii_lib.cpp -I./dep  -lm -lz
     19     c++ -std=c++11 -DHAVE_ZLIB -o LN2_RIMIFY src/LN2_RIMIFY.cpp dep/nifti2_io.cpp dep/znzli
            b.cpp dep/laynii_lib.cpp -I./dep  -lm -lz
     20     dep/laynii_lib.cpp: In function 'void ln_normalize_to_zero_one(float*, int)':
  >> 21     dep/laynii_lib.cpp:1062:27: error: 'numeric_limits' is not a member of 'std'
     22      1062 |     float temp_max = std::numeric_limits<float>::min();
     23           |                           ^~~~~~~~~~~~~~
  >> 24     dep/laynii_lib.cpp:1062:42: error: expected primary-expression before 'float'
     25      1062 |     float temp_max = std::numeric_limits<float>::min();
     26           |                                          ^~~~~
  >> 27     dep/laynii_lib.cpp:1063:27: error: 'numeric_limits' is not a member of 'std'
     28      1063 |     float temp_min = std::numeric_limits<float>::max();
     29           |                           ^~~~~~~~~~~~~~
  >> 30     dep/laynii_lib.cpp:1063:42: error: expected primary-expression before 'float'
     31      1063 |     float temp_min = std::numeric_limits<float>::max();
     32           |                                          ^~~~~
  >> 33     make: *** [Makefile:183: LN2_RIMIFY] Error 1
     34     make: *** Waiting for unfinished jobs....
```

There is also version 2.9.0 but I did not get it to compile for now.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
