### PR TITLE
cohomcalg: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/cohomcalg/fix-literal-suffix.patch
+++ b/repos/spack_repo/builtin/packages/cohomcalg/fix-literal-suffix.patch
@@ -1,0 +1,29 @@
+From 47fac28e47b59d50aa3e219c6cd57c50fb422f20 Mon Sep 17 00:00:00 2001
+From: Doug Torrance <dtorrance@piedmont.edu>
+Date: Wed, 24 Sep 2025 03:19:46 +0000
+Subject: [PATCH] Fix C++11 literal-suffix warning by adding spaces around
+ format macro
+
+Add spaces between string literals and P_VALUE_FMT in value_print calls
+so that the macro expansion concatenates properly. This avoids the
+invalid suffix warning under C++11 and ensures portable compilation.
+---
+ source/polylib_mod/matrix.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/source/polylib_mod/matrix.c b/source/polylib_mod/matrix.c
+index 1d84800..6afc1f6 100644
+--- a/source/polylib_mod/matrix.c
++++ b/source/polylib_mod/matrix.c
+@@ -150,7 +150,7 @@ void Matrix_Print(FILE *Dst, const char *Format, Matrix *Mat)
+     p=*(Mat->p+i);
+     for (j=0;j<NbColumns;j++) {
+       if (!Format) {
+-	value_print(Dst," "P_VALUE_FMT" ",*p++);
++	value_print(Dst," " P_VALUE_FMT " ",*p++);
+       }
+       else { 
+ 	value_print(Dst,Format,*p++);
+-- 
+2.51.0
+

--- a/repos/spack_repo/builtin/packages/cohomcalg/package.py
+++ b/repos/spack_repo/builtin/packages/cohomcalg/package.py
@@ -1,0 +1,32 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
+
+from spack.package import *
+
+
+class Cohomcalg(MakefilePackage):
+    """cohomCalg is a C++ software package for computing the
+    dimensions of line bundle-valued sheaf cohomology groups on toric
+    varieties. It implements efficient algorithms from algebraic
+    geometry to support applications in both mathematics and
+    theoretical physics."""
+
+    homepage = "https://github.com/BenjaminJurke/cohomCalg"
+    git = "https://github.com/BenjaminJurke/cohomCalg"
+
+    maintainers("d-torrance")
+
+    license("GPL-3.0-or-later", checked_by="d-torrance")
+
+    version("0.32", tag="v0.32", commit="c663c8e37cceab3cc0b2bcc57d35cb895930ab1f")
+
+    depends_on("cxx", type="build")
+
+    patch("fix-literal-suffix.patch")
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install("bin/cohomcalg", prefix.bin)


### PR DESCRIPTION
[cohomCalg](https://github.com/BenjaminJurke/cohomCalg) is a software package for computation of sheaf cohomologies for line bundles on toric varieties.  It is used by Macaulay2.