### PR TITLE
glib: add recent versions and fix introspection support

### DIFF
--- a/repos/spack_repo/builtin/packages/glib/package.py
+++ b/repos/spack_repo/builtin/packages/glib/package.py
@@ -29,13 +29,12 @@ class Glib(MesonPackage):
     license("LGPL-2.1-or-later")
 
     # Even minor versions are stable, odd minor versions are development, only add even numbers
+    version("2.86.1", sha256="119d1708ca022556d6d2989ee90ad1b82bd9c0d1667e066944a6d0020e2d5e57")
+    version("2.84.4", sha256="8a9ea10943c36fc117e253f80c91e477b673525ae45762942858aef57631bb90")
     version("2.82.5", sha256="05c2031f9bdf6b5aba7a06ca84f0b4aced28b19bf1b50c6ab25cc675277cbc3f")
     version("2.82.2", sha256="ab45f5a323048b1659ee0fbda5cecd94b099ab3e4b9abf26ae06aeb3e781fd63")
-    version(
-        "2.78.3",
-        sha256="609801dd373796e515972bf95fc0b2daa44545481ee2f465c4f204d224b2bc21",
-        preferred=True,
-    )
+    version("2.80.5", sha256="9f23a9de803c695bbfde7e37d6626b18b9a83869689dd79019bf3ae66c3e6771")
+    version("2.78.3", sha256="609801dd373796e515972bf95fc0b2daa44545481ee2f465c4f204d224b2bc21")
     version("2.78.0", sha256="44eaab8b720877ce303c5540b657b126f12dc94972d9880b52959f43fb537b30")
     version("2.76.6", sha256="1136ae6987dcbb64e0be3197a80190520f7acab81e2bfb937dc85c11c8aa9f04")
     version("2.76.4", sha256="5a5a191c96836e166a7771f7ea6ca2b0069c603c7da3cba1cd38d1694a395dda")
@@ -78,6 +77,12 @@ class Glib(MesonPackage):
         values=any_combination_of("dtrace", "systemtap"),
         description="Enable tracing support",
     )
+    variant(
+        "introspection",
+        default=True,
+        description="Build with introspection support",
+        when="@2.79:",
+    )
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
@@ -89,7 +94,8 @@ class Glib(MesonPackage):
         depends_on("meson@0.52.0:", when="@2.71:")
         depends_on("meson@0.49.2:", when="@2.61.2:")
         depends_on("meson@0.48.0:")
-        depends_on("pkgconfig", type="build")
+        depends_on("pkgconfig")
+        depends_on("gobject-introspection@1.80:", when="+introspection")
 
     depends_on("libffi")
     depends_on("zlib-api")
@@ -124,8 +130,17 @@ class Glib(MesonPackage):
         gio_tests.filter("'file' : {},", "")
         gio_tests.filter("'gdbus-peer'", "'file'")
         gio_tests.filter("'gdbus-address-get-session' : {},", "")
-        filter_file("'mkenums.py'( : {})*,*", "", "gobject/tests/meson.build")
+        filter_file("'mkenums.py' : {},", "", "gobject/tests/meson.build")
         filter_file("'fileutils' : {},", "", "glib/tests/meson.build")
+
+    def setup_run_environment(self, env: EnvironmentModifications) -> None:
+        env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))
+
+    def setup_dependent_run_environment(
+        self, env: EnvironmentModifications, dependent_spec: Spec
+    ) -> None:
+        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
+        env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))
 
     @property
     def libs(self):
@@ -202,8 +217,18 @@ class MesonBuilder(meson.MesonBuilder):
                 join_path(self.spec["glib"].libs.directories[0], "pkgconfig", "glib-2.0.pc"),
             )
 
+    def setup_dependent_build_environment(
+        self, env: EnvironmentModifications, dependent_spec: Spec
+    ) -> None:
+        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
+        env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))
+
     def meson_args(self):
         args = []
+        if self.spec.satisfies("+introspection"):
+            args.append("-Dintrospection=enabled")
+        else:
+            args.append("-Dintrospection=disabled")
         if self.spec.satisfies("@2.63.5:"):
             if self.spec.satisfies("+libmount"):
                 args.append("-Dlibmount=enabled")

--- a/repos/spack_repo/builtin/packages/glib_bootstrap/package.py
+++ b/repos/spack_repo/builtin/packages/glib_bootstrap/package.py
@@ -1,0 +1,70 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems import meson
+from spack_repo.builtin.build_systems.meson import MesonPackage
+
+from spack.package import *
+
+
+class GlibBootstrap(MesonPackage):
+    """GLib provides the core application building blocks for libraries and applications written
+    in C.
+
+    The GLib package contains a low-level libraries useful for providing data structure handling
+    for C, portability wrappers and interfaces for such runtime functionality as an event loop,
+    threads, dynamic loading and an object system.
+    """
+
+    homepage = "https://developer.gnome.org/glib/"
+    url = "https://download.gnome.org/sources/glib/2.86/glib-2.86.1.tar.xz"
+    list_url = "https://download.gnome.org/sources/glib"
+    list_depth = 1
+
+    maintainers("michaelkuhn")
+
+    license("LGPL-2.1-or-later")
+
+    # Even minor versions are stable, odd minor versions are development, only add even numbers
+    version("2.86.1", sha256="119d1708ca022556d6d2989ee90ad1b82bd9c0d1667e066944a6d0020e2d5e57")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    with default_args(type="build"):
+        depends_on("meson@1.4:", when="@2.83:")
+        depends_on("pkgconfig", type="build")
+
+    depends_on("libffi")
+    depends_on("zlib-api")
+    depends_on("gettext")
+    depends_on("perl", type=("build", "run"))
+    extends("python", type=("build", "run"))
+    depends_on("pcre2@10.34:")
+    depends_on("iconv")
+
+    def url_for_version(self, version):
+        return f"https://download.gnome.org/sources/glib/{version.up_to(2)}/glib-{version}.tar.xz"
+
+    @property
+    def libs(self):
+        return find_libraries(["libglib*"], root=self.prefix, recursive=True)
+
+
+class MesonBuilder(meson.MesonBuilder):
+    def meson_args(self):
+        args = [
+            "-Dselinux=disabled",
+            "-Dlibmount=disabled",
+            "-Dman-pages=disabled",
+            "-Ddtrace=disabled",
+            "-Dsystemtap=disabled",
+            "-Dsysprof=disabled",
+            "-Dtests=false",
+            "-Dnls=disabled",
+            "-Dlibelf=disabled",
+            "-Dintrospection=disabled",
+        ]
+
+        return args

--- a/repos/spack_repo/builtin/packages/gobject_introspection/package.py
+++ b/repos/spack_repo/builtin/packages/gobject_introspection/package.py
@@ -1,7 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-from spack_repo.builtin.build_systems import autotools
+from spack_repo.builtin.build_systems import autotools, meson
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack_repo.builtin.build_systems.meson import MesonPackage
 
@@ -21,6 +21,10 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
 
     license("LGPL-2.0-or-later AND GPL-2.0-or-later AND MIT")
 
+    version("1.86.0", sha256="920d1a3fcedeadc32acff95c2e203b319039dd4b4a08dd1a2dfd283d19c0b9ae")
+    version("1.84.0", sha256="945b57da7ec262e5c266b89e091d14be800cc424277d82a02872b7d794a84779")
+    version("1.82.0", sha256="0f5a4c1908424bf26bc41e9361168c363685080fbdb87a196c891c8401ca2f09")
+    version("1.80.1", sha256="a1df7c424e15bda1ab639c00e9051b9adf5cea1a9e512f8a603b53cd199bc6d8")
     version("1.78.1", sha256="bd7babd99af7258e76819e45ba4a6bc399608fe762d83fde3cac033c50841bb4")
     version("1.76.1", sha256="196178bf64345501dcdc4d8469b36aa6fe80489354efe71cb7cb8ab82a3738bf")
     version("1.72.1", sha256="012e313186e3186cf0fde6decb57d970adf90e6b1fac5612fe69cbb5ba99543a")
@@ -45,7 +49,9 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
     # Does not build with sed from Darwin
     depends_on("sed", when="platform=darwin", type="build")
 
-    depends_on("cairo+gobject")
+    depends_on("cairo+gobject", when="@:1.78")
+    depends_on("glib-bootstrap@2.82:", when="@1.82:")
+    depends_on("glib-bootstrap@2.80:", when="@1.80")
     depends_on("glib@2.78:", when="@1.78")
     depends_on("glib@2.76:", when="@1.76")
     depends_on("glib@2.58:", when="@1.60:1.72")
@@ -124,21 +130,8 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
         url = "https://download.gnome.org/sources/gobject-introspection/{0}/gobject-introspection-{1}.tar.xz"
         return url.format(version.up_to(2), version)
 
-    def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        # Only needed for sbang.patch above
-        if self.spec.satisfies("@:1.60"):
-            env.set("SPACK_SBANG", sbang_install_path())
-        env.set("GI_SCANNER_DISABLE_CACHE", "1")
-
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))
-
-    def setup_dependent_build_environment(
-        self, env: EnvironmentModifications, dependent_spec: Spec
-    ) -> None:
-        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
-        env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))
-        env.set("GI_SCANNER_DISABLE_CACHE", "1")
 
     def setup_dependent_run_environment(
         self, env: EnvironmentModifications, dependent_spec: Spec
@@ -151,8 +144,38 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
         return not self.spec.satisfies("%fj")
 
 
-class AutotoolsBuilderPackage(autotools.AutotoolsBuilder):
+class BuildEnvironment:
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        # Only needed for sbang.patch above
+        if self.spec.satisfies("@:1.60"):
+            env.set("SPACK_SBANG", sbang_install_path())
+        env.set("GI_SCANNER_DISABLE_CACHE", "1")
+
+    def setup_dependent_build_environment(
+        self, env: EnvironmentModifications, dependent_spec: Spec
+    ) -> None:
+        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
+        env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))
+        env.set("GI_SCANNER_DISABLE_CACHE", "1")
+
+        if self.spec.satisfies("^glib-bootstrap"):
+            env.append_path("PKG_CONFIG_PATH", self.spec["glib-bootstrap"].prefix.lib.pkgconfig)
+
+
+class AutotoolsBuilder(BuildEnvironment, autotools.AutotoolsBuilder):
     @run_before("build")
     def filter_file_to_avoid_overly_long_shebangs(self):
-        # we need to filter this file to avoid an overly long hashbang line
-        filter_file("#!/usr/bin/env @PYTHON@", "#!@PYTHON@", "tools/g-ir-tool-template.in")
+        filter_file(
+            "#!/usr/bin/env @PYTHON@", "#!@PYTHON@", "tools/g-ir-tool-template.in", string=True
+        )
+
+
+class MesonBuilder(BuildEnvironment, meson.MesonBuilder):
+    @run_before("build")
+    def filter_file_to_avoid_overly_long_shebangs(self):
+        filter_file(
+            "#!@PYTHON_CMD@",
+            f"{sbang_shebang_line()}\n#!@PYTHON_CMD@",
+            "tools/g-ir-tool-template.in",
+            string=True,
+        )


### PR DESCRIPTION
This requires adding a glib-bootstrap package with introspection disabled, which can be used to bootstrap gobject-introspection. glib itself requires gobject-introspection in recent versions. 