### PR TITLE
libunwind: fix build and add v1.8.2

### DIFF
--- a/repos/spack_repo/builtin/packages/libunwind/package.py
+++ b/repos/spack_repo/builtin/packages/libunwind/package.py
@@ -12,8 +12,9 @@ class Libunwind(AutotoolsPackage):
     the call-chain of a program."""
 
     homepage = "https://www.nongnu.org/libunwind/"
-    url = "https://github.com/libunwind/libunwind/releases/download/v0.0.0/libunwind-0.0.0.tar.gz"
+    url = "https://github.com/libunwind/libunwind/releases/download/v1.8.2/libunwind-1.8.2.tar.gz"
     git = "https://github.com/libunwind/libunwind"
+
     maintainers("mwkrentel")
 
     tags = ["e4s"]
@@ -22,6 +23,7 @@ class Libunwind(AutotoolsPackage):
 
     version("master", branch="master")
     version("1.8-stable", branch="v1.8-stable")
+    version("1.8.2", sha256="7f262f1a1224f437ede0f96a6932b582c8f5421ff207c04e3d9504dfa04c8b82")
     version("1.8.1", sha256="ddf0e32dd5fafe5283198d37e4bf9decf7ba1770b6e7e006c33e6df79e6a6157")
     version("1.7-stable", branch="v1.7-stable")
     version("1.7.2", sha256="a18a6a24307443a8ace7a8acc2ce79fbbe6826cd0edf98d6326d0225d6a5d6e6")
@@ -80,12 +82,13 @@ class Libunwind(AutotoolsPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
+    depends_on("libtool", type="build")
+
     # The libunwind releases contain the autotools generated files,
     # but the git repo snapshots do not.
     reconf_versions = "@master,1.6-stable,1.7-stable,1.8-stable"
     depends_on("autoconf", type="build", when=reconf_versions)
     depends_on("automake", type="build", when=reconf_versions)
-    depends_on("libtool", type="build", when=reconf_versions)
     depends_on("m4", type="build", when=reconf_versions)
 
     depends_on("xz", type="link", when="+xz")
@@ -101,6 +104,13 @@ class Libunwind(AutotoolsPackage):
     conflicts("target=aarch64:", when="@1.8:")
 
     provides("unwind")
+
+    # Fix bad prototype for malloc() in test
+    patch(
+        "https://src.fedoraproject.org/rpms/libunwind/raw/49b1c9d51f8194546ba559f3f20e10889c8a073a/f/457612f470f8c0e718cdf7f14ef1ecb583f3b3a6.patch",
+        sha256="4562c231f1051bd327cf27b6940445e5c0d83e5d8427a6ca36c9f0853b3e4a6d",
+        when="@1.8:",
+    )
 
     def url_for_version(self, version):
         if version == Version("1.5.0"):


### PR DESCRIPTION
Added a patch to solve
```
==> Error: ProcessError: Command exited with status 2:
    '/spack/opt/spack/linux-skylake/gmake-4.4.1-2mokir4qvk25s327xhzajy5frrkytic6/bin/make' '-j16' 'V=1'

3 errors found in build log:
     879    mv -f $depbase.Tpo $depbase.Po
     880    depbase=`echo Gtest-resume-sig.o | sed 's|[^/]*$|.deps/&|;s|\.o$||'`;\
     881    /spack/opt/spack/linux-skylake/compiler-wrapper-1.0-7ovawteudbzdbaxhap54v3kxdsq2dngj/li
            bexec/spack/gcc/gcc -DHAVE_CONFIG_H -I. -I../include  -I../include -I../include/tdep-x8
            6_64 -I../src -D_GNU_SOURCE -DNDEBUG -fno-optimize-sibling-calls -g -O2 -fexceptions -W
            all -Wsign-compare -D__EXTENSIONS__ -MT Gtest-resume-sig.o -MD -MP -MF $depbase.Tpo -c 
            -o Gtest-resume-sig.o Gtest-resume-sig.c &&\
     882    mv -f $depbase.Tpo $depbase.Po
     883    In file included from Ltest-nomalloc.c:4:
     884    Gtest-nomalloc.c: In function 'malloc':
  >> 885    Gtest-nomalloc.c:49:12: error: too many arguments to function 'func'; expected 0, have 
            1
     886       49 |     return func(s);
     887          |            ^~~~ ~
  >> 888    make[1]: *** [Makefile:1740: Ltest-nomalloc.o] Error 1
     889    make[1]: *** Waiting for unfinished jobs....
     890    make[1]: Leaving directory '/tmp/root/spack-stage/spack-stage-libunwind-1.8.2-uqzdhohdw
            a7ktxem24isbri7lpzap2ui/spack-src/tests'
  >> 891    make: *** [Makefile:620: all-recursive] Error 1
```
 
and without adding a `libtool` build dependency I get errors like
```
>> 935     /spack/opt/spack/linux-skylake/binutils-2.45-2y4uwvl5bqxogicvdtfm7b4hz6fyeg3h/bin/ld: 
		 ../src/.libs/libunwind-x86_64.so: undefined reference to `dwarf_reg_state_pool'
>> 936     /spack/opt/spack/linux-skylake/binutils-2.45-2y4uwvl5bqxogicvdtfm7b4hz6fyeg3h/bin/ld: 
		 ../src/.libs/libunwind-x86_64.so: undefined reference to `dwarf_cie_info_pool'
>> 937     /spack/opt/spack/linux-skylake/binutils-2.45-2y4uwvl5bqxogicvdtfm7b4hz6fyeg3h/bin/ld: 
		 ../src/.libs/libunwind-x86_64.so: undefined reference to `_Ux86_64_dwarf_init'  
```

While at it I also added version 1.8.2


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
