### PR TITLE
pmix: fix build

### DIFF
--- a/repos/spack_repo/builtin/packages/pmix/package.py
+++ b/repos/spack_repo/builtin/packages/pmix/package.py
@@ -189,6 +189,8 @@ class Pmix(AutotoolsPackage):
     depends_on("py-docutils", type="build", when="+docs")
     depends_on("py-sphinx-rtd-theme", type="build", when="+docs")
 
+    depends_on("libtool@2.4.2:", type="build")
+
     depends_on("libevent@2.0.20:")
     depends_on("hwloc@1.11:", when="@3:")
     depends_on("hwloc@1", when="@:2")


### PR DESCRIPTION
 Without the `libtool` dependency I get the following error:
 ```
  >> 2654    /spack/opt/spack/linux-skylake/binutils-2.45-2y4uwvl5bqxogicvdtfm7b4hz6fyeg3h/bin/ld: 
             ../../../src/.libs/libpmix.so: undefined reference to `pmix_util_keyval_yylex'
  >> 2655    /spack/opt/spack/linux-skylake/binutils-2.45-2y4uwvl5bqxogicvdtfm7b4hz6fyeg3h/bin/ld: 
             ../../../src/.libs/libpmix.so: undefined reference to `pmix_util_keyval_yynewlines'
  >> 2656    /spack/opt/spack/linux-skylake/binutils-2.45-2y4uwvl5bqxogicvdtfm7b4hz6fyeg3h/bin/ld: 
             ../../../src/.libs/libpmix.so: undefined reference to `pmix_util_keyval_yyin'
  >> 2657    /spack/opt/spack/linux-skylake/binutils-2.45-2y4uwvl5bqxogicvdtfm7b4hz6fyeg3h/bin/ld: 
             ../../../src/.libs/libpmix.so: undefined reference to `pmix_util_keyval_yylex_destroy'
  >> 2658    /spack/opt/spack/linux-skylake/binutils-2.45-2y4uwvl5bqxogicvdtfm7b4hz6fyeg3h/bin/ld: 
             ../../../src/.libs/libpmix.so: undefined reference to `pmix_util_keyval_yytext'
  >> 2659    /spack/opt/spack/linux-skylake/binutils-2.45-2y4uwvl5bqxogicvdtfm7b4hz6fyeg3h/bin/ld: 
             ../../../src/.libs/libpmix.so: undefined reference to `pmix_util_keyval_init_buffer'
  >> 2660    /spack/opt/spack/linux-skylake/binutils-2.45-2y4uwvl5bqxogicvdtfm7b4hz6fyeg3h/bin/ld: 
             ../../../src/.libs/libpmix.so: undefined reference to `pmix_util_keyval_parse_done'
  >> 2661    /spack/opt/spack/linux-skylake/binutils-2.45-2y4uwvl5bqxogicvdtfm7b4hz6fyeg3h/bin/ld: 
             ../../../src/.libs/libpmix.so: undefined reference to `pmix_util_keyval_yylineno'
  >> 2662    collect2: error: ld returned 1 exit status
  >> 2663    make[2]: *** [Makefile:681: pevent] Error 1
```

The minimal version from libtool comes from [here](https://github.com/openpmix/openpmix/blob/v6.0/VERSION#L36)


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
