### PR TITLE
m4: add conflict and patches for C++17 nodiscard attribute

### DIFF
--- a/repos/spack_repo/builtin/packages/m4/nodiscard.patch
+++ b/repos/spack_repo/builtin/packages/m4/nodiscard.patch
@@ -1,0 +1,100 @@
+diff --git a/lib/gl_list.h b/lib/gl_list.h
+index 7fc22bb..3bc68b8 100644
+--- a/lib/gl_list.h
++++ b/lib/gl_list.h
+@@ -630,7 +630,7 @@ gl_list_node_value (gl_list_t list, gl_list_node_t node)
+          ->node_value (list, node);
+ }
+ 
+-GL_LIST_INLINE _GL_ATTRIBUTE_NODISCARD int
++_GL_ATTRIBUTE_NODISCARD GL_LIST_INLINE int
+ gl_list_node_nx_set_value (gl_list_t list, gl_list_node_t node,
+                            const void *elt)
+ {
+@@ -685,20 +685,20 @@ gl_list_get_last (gl_list_t list)
+   return gl_list_get_at (list, gl_list_size (list) - 1);
+ }
+ 
+-GL_LIST_INLINE _GL_ATTRIBUTE_NODISCARD gl_list_node_t
++_GL_ATTRIBUTE_NODISCARD GL_LIST_INLINE gl_list_node_t
+ gl_list_nx_set_at (gl_list_t list, size_t position, const void *elt)
+ {
+   return ((const struct gl_list_impl_base *) list)->vtable
+          ->nx_set_at (list, position, elt);
+ }
+ 
+-GL_LIST_INLINE _GL_ATTRIBUTE_NODISCARD gl_list_node_t
++_GL_ATTRIBUTE_NODISCARD GL_LIST_INLINE gl_list_node_t
+ gl_list_nx_set_first (gl_list_t list, const void *elt)
+ {
+   return gl_list_nx_set_at (list, 0, elt);
+ }
+ 
+-GL_LIST_INLINE _GL_ATTRIBUTE_NODISCARD gl_list_node_t
++_GL_ATTRIBUTE_NODISCARD GL_LIST_INLINE gl_list_node_t
+ gl_list_nx_set_last (gl_list_t list, const void *elt)
+ {
+   return gl_list_nx_set_at (list, gl_list_size (list) - 1, elt);
+@@ -752,35 +752,35 @@ gl_list_indexof_from_to (gl_list_t list, size_t start_index, size_t end_index,
+          ->indexof_from_to (list, start_index, end_index, elt);
+ }
+ 
+-GL_LIST_INLINE _GL_ATTRIBUTE_NODISCARD gl_list_node_t
++_GL_ATTRIBUTE_NODISCARD GL_LIST_INLINE gl_list_node_t
+ gl_list_nx_add_first (gl_list_t list, const void *elt)
+ {
+   return ((const struct gl_list_impl_base *) list)->vtable
+          ->nx_add_first (list, elt);
+ }
+ 
+-GL_LIST_INLINE _GL_ATTRIBUTE_NODISCARD gl_list_node_t
++_GL_ATTRIBUTE_NODISCARD GL_LIST_INLINE gl_list_node_t
+ gl_list_nx_add_last (gl_list_t list, const void *elt)
+ {
+   return ((const struct gl_list_impl_base *) list)->vtable
+          ->nx_add_last (list, elt);
+ }
+ 
+-GL_LIST_INLINE _GL_ATTRIBUTE_NODISCARD gl_list_node_t
++_GL_ATTRIBUTE_NODISCARD GL_LIST_INLINE gl_list_node_t
+ gl_list_nx_add_before (gl_list_t list, gl_list_node_t node, const void *elt)
+ {
+   return ((const struct gl_list_impl_base *) list)->vtable
+          ->nx_add_before (list, node, elt);
+ }
+ 
+-GL_LIST_INLINE _GL_ATTRIBUTE_NODISCARD gl_list_node_t
++_GL_ATTRIBUTE_NODISCARD GL_LIST_INLINE gl_list_node_t
+ gl_list_nx_add_after (gl_list_t list, gl_list_node_t node, const void *elt)
+ {
+   return ((const struct gl_list_impl_base *) list)->vtable
+          ->nx_add_after (list, node, elt);
+ }
+ 
+-GL_LIST_INLINE _GL_ATTRIBUTE_NODISCARD gl_list_node_t
++_GL_ATTRIBUTE_NODISCARD GL_LIST_INLINE gl_list_node_t
+ gl_list_nx_add_at (gl_list_t list, size_t position, const void *elt)
+ {
+   return ((const struct gl_list_impl_base *) list)->vtable
+@@ -891,7 +891,7 @@ gl_sortedlist_indexof_from_to (gl_list_t list, gl_listelement_compar_fn compar,
+                                        elt);
+ }
+ 
+-GL_LIST_INLINE _GL_ATTRIBUTE_NODISCARD gl_list_node_t
++_GL_ATTRIBUTE_NODISCARD GL_LIST_INLINE gl_list_node_t
+ gl_sortedlist_nx_add (gl_list_t list, gl_listelement_compar_fn compar, const void *elt)
+ {
+   return ((const struct gl_list_impl_base *) list)->vtable
+diff --git a/lib/gl_oset.h b/lib/gl_oset.h
+index 5e15919..740a1b4 100644
+--- a/lib/gl_oset.h
++++ b/lib/gl_oset.h
+@@ -272,7 +272,7 @@ gl_oset_search_atleast (gl_oset_t set,
+          ->search_atleast (set, threshold_fn, threshold, eltp);
+ }
+ 
+-GL_OSET_INLINE _GL_ATTRIBUTE_NODISCARD int
++_GL_ATTRIBUTE_NODISCARD GL_OSET_INLINE int
+ gl_oset_nx_add (gl_oset_t set, const void *elt)
+ {
+   return ((const struct gl_oset_impl_base *) set)->vtable->nx_add (set, elt);

--- a/repos/spack_repo/builtin/packages/m4/package.py
+++ b/repos/spack_repo/builtin/packages/m4/package.py
@@ -58,6 +58,18 @@ class M4(AutotoolsPackage, GNUMirrorPackage):
     depends_on("diffutils", type="build")
     depends_on("libsigsegv", when="+sigsegv")
 
+    # Older versions require too many patches for newer compilers
+    with when("@:1.4.18"):
+        conflicts("%gcc@14:", msg="This version is incompatible with gcc@14:")
+        conflicts("%clang@16:", msg="This version is incompatible with clang@16")
+
+    # Fix c++17 '[[nodiscard]]' attribute ordering (fixed in 1.4.20)
+    patch(
+        "nodiscard.patch",
+        when="@1.4.19",
+        sha256="5c4071ae35e6ecf7f683ad714558a0030f21cc2b0673dde2ca6ca753cd0dbb2e",
+    )
+
     build_directory = "spack-build"
 
     tags = ["build-tools"]


### PR DESCRIPTION
Older versions require all of the patches listed below, so it's easier to just not support newer compilers for those versions.

https://gitweb.git.savannah.gnu.org/gitweb/?p=gnulib.git;a=commit;h=786bb6fb17d698eb175942606db8fb129e231474 https://gitweb.git.savannah.gnu.org/gitweb/?p=gnulib.git;a=commit;h=786bb6fb17d698eb175942606db8fb129e231474 https://gitweb.git.savannah.gnu.org/gitweb/?p=gnulib.git;a=commit;h=8ca04dc0ceb71ff5b863c7f656898ab339aeb406 https://gitweb.git.savannah.gnu.org/gitweb/?p=gnulib.git;a=commit;h=dd0ad385c4b7e30052f25c5c09b6db9a81f7e293 https://gitweb.git.savannah.gnu.org/gitweb/?p=gnulib.git;a=commit;h=24a82188f918eb0724254203cff510e84d5a8760 https://gitweb.git.savannah.gnu.org/gitweb/?p=gnulib.git;a=commit;h=b865c4eb02f882291f8d2c18754e86ee8cd98d4a
