### PR TITLE
Relaxation of cuDNN version 9+ for PyTorch 2.8+

### DIFF
--- a/repos/spack_repo/builtin/packages/py_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_torch/package.py
@@ -278,8 +278,9 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
         depends_on("cuda@10.2:11.4", when="@1.10+cuda")
         depends_on("cuda@9.2:11.4", when="@1.6:1.9+cuda")
     # https://github.com/pytorch/pytorch#prerequisites
+    depends_on("cudnn@8.5:9", when="@2.8:+cudnn")
     # https://github.com/pytorch/pytorch/issues/119400
-    depends_on("cudnn@8.5:9.0", when="@2.3:+cudnn")
+    depends_on("cudnn@8.5:9.0", when="@2.3:2.7+cudnn")
     depends_on("cudnn@7:8", when="@1.6:2.2+cudnn")
     depends_on("nccl", when="+nccl+cuda")
     depends_on("magma+cuda", when="+magma+cuda")


### PR DESCRIPTION
Related to https://github.com/pytorch/pytorch/issues/119400

I relaxed cuDNN's upper bound for pytorch version `2.8:`. I couldn't find any cuDNN range specific to each pytorch version and just for stability I keep the same `cudnn@8.5:9.0` upper bounded to `2.7`.

Installation of version `2.8` was successful with `cudnn@9.8` with the current addition and the following test cuDNN convolution operation was successful:

```python
import torch

print("CUDA available:", torch.cuda.is_available())
print("CUDA device count:", torch.cuda.device_count())
if torch.cuda.is_available():
    print("CUDA device name:", torch.cuda.get_device_name(0))

print("cuDNN available:", torch.backends.cudnn.is_available())
print("cuDNN version:", torch.backends.cudnn.version())

device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
x = torch.randn(8, 3, 64, 64, device=device) 
conv = torch.nn.Conv2d(3, 16, kernel_size=3, stride=1, padding=1).to(device)

with torch.backends.cudnn.flags(enabled=True):
    y = conv(x)
    print("Conv2d output shape:", y.shape)
```

```bash
CUDA available: True
CUDA device count: 1
CUDA device name: Quadro T2000
cuDNN available: True
cuDNN version: 90800
Conv2d output shape: torch.Size([8, 16, 64, 64])
```