### PR TITLE
Added conflicts for `cuda_arch` values in range 50-60 and `py-torch@2.8: ^cuda@12.8:`

### DIFF
--- a/repos/spack_repo/builtin/packages/py_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_torch/package.py
@@ -149,7 +149,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
             conflicts(
                 f"cuda_arch={val}",
                 msg="PyTorch 2.8.0+ does not support sm_50–sm_60 architectures "
-                "with CUDA 12.8 or newer. Use CUDA 12.6 instead."
+                "with CUDA 12.8 or newer. Use CUDA 12.6 instead.",
             )
 
     # Required dependencies

--- a/repos/spack_repo/builtin/packages/py_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_torch/package.py
@@ -143,6 +143,18 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
         "https://developer.nvidia.com/cuda-gpus",
     )
 
+    # https://github.com/pytorch/pytorch/releases/tag/v2.8.0#backwards-incompatible-changes
+    with when("@2.8: +cuda ^cuda@12.8:"):
+        for val in CudaPackage.cuda_arch_values:
+            if val.isdigit() and 50 <= int(val) <= 60:
+                conflicts(
+                    f"cuda_arch={val}",
+                    msg="PyTorch 2.8.0+ does not support "
+                    "sm_50–sm_60 architectures "
+                    "with CUDA 12.8 or newer. "
+                    "Use CUDA 12.6 instead.",
+                )
+
     # Required dependencies
     depends_on("c", type="build")
     depends_on("cxx", type="build")

--- a/repos/spack_repo/builtin/packages/py_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_torch/package.py
@@ -145,15 +145,12 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
 
     # https://github.com/pytorch/pytorch/releases/tag/v2.8.0#backwards-incompatible-changes
     with when("@2.8: +cuda ^cuda@12.8:"):
-        for val in CudaPackage.cuda_arch_values:
-            if val.isdigit() and 50 <= int(val) <= 60:
-                conflicts(
-                    f"cuda_arch={val}",
-                    msg="PyTorch 2.8.0+ does not support "
-                    "sm_50–sm_60 architectures "
-                    "with CUDA 12.8 or newer. "
-                    "Use CUDA 12.6 instead.",
-                )
+        for val in [50, 52, 53, 60]:
+            conflicts(
+                f"cuda_arch={val}",
+                msg="PyTorch 2.8.0+ does not support sm_50–sm_60 architectures "
+                "with CUDA 12.8 or newer. Use CUDA 12.6 instead."
+            )
 
     # Required dependencies
     depends_on("c", type="build")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
See this: https://github.com/pytorch/pytorch/releases/tag/v2.8.0#backwards-incompatible-changes