### PR TITLE
vecgeom: new pre-release 2.0.0-rc.7

### DIFF
--- a/repos/spack_repo/builtin/packages/vecgeom/package.py
+++ b/repos/spack_repo/builtin/packages/vecgeom/package.py
@@ -32,9 +32,15 @@ class Vecgeom(CMakePackage, CudaPackage):
 
     version("master", branch="master", get_full_repo=True)
     version(
+        "2.0.0-rc.7",
+        url="https://gitlab.cern.ch/-/project/981/uploads/f1017874e9d138165f221d4b854a39a4/VecGeom-v2.0.0-rc.7.tar.gz>
+        sha256="f95eacd7154f7b41950161988465b5c086f80dade91dec8328085949c6f443a0>
+    )
+    version(
         "1.2.11",
         url="https://gitlab.cern.ch/-/project/981/uploads/f2a483a4a073fac560714280e0e223ec/VecGeom-v1.2.11.tar.gz",
         sha256="0e251b0c6d79401e49cd2137a32b499ce3857045683d1fc8b6cd3b527247a3ef",
+        preferred=True,
     )
     version(
         "1.2.10",

--- a/repos/spack_repo/builtin/packages/vecgeom/package.py
+++ b/repos/spack_repo/builtin/packages/vecgeom/package.py
@@ -33,8 +33,8 @@ class Vecgeom(CMakePackage, CudaPackage):
     version("master", branch="master", get_full_repo=True)
     version(
         "2.0.0-rc.7",
-        url="https://gitlab.cern.ch/-/project/981/uploads/f1017874e9d138165f221d4b854a39a4/VecGeom-v2.0.0-rc.7.tar.gz>
-        sha256="f95eacd7154f7b41950161988465b5c086f80dade91dec8328085949c6f443a0>
+        url="https://gitlab.cern.ch/-/project/981/uploads/f1017874e9d138165f221d4b854a39a4/VecGeom-v2.0.0-rc.7.tar.gz",
+        sha256="f95eacd7154f7b41950161988465b5c086f80dade91dec8328085949c6f443a0",
     )
     version(
         "1.2.11",


### PR DESCRIPTION
This adds a new development version for VecGeom. The only cmake change is that it doesn't pull in Doxygen from the system environment. (It wouldn't use it before, but doesn't even look for it now.)