### PR TITLE
libfabric: add 2.3.0 and gdrcopy variant

### DIFF
--- a/repos/spack_repo/builtin/packages/libfabric/package.py
+++ b/repos/spack_repo/builtin/packages/libfabric/package.py
@@ -18,7 +18,7 @@ class Libfabric(AutotoolsPackage, CudaPackage):
     homepage = "https://libfabric.org/"
     url = "https://github.com/ofiwg/libfabric/releases/download/v1.8.0/libfabric-1.8.0.tar.bz2"
     git = "https://github.com/ofiwg/libfabric.git"
-    maintainers("rajachan")
+    maintainers("rajachan", "msimberg")
 
     executables = ["^fi_info$"]
 

--- a/repos/spack_repo/builtin/packages/libfabric/package.py
+++ b/repos/spack_repo/builtin/packages/libfabric/package.py
@@ -25,6 +25,7 @@ class Libfabric(AutotoolsPackage, CudaPackage):
     license("GPL-2.0-or-later")
 
     version("main", branch="main")
+    version("2.3.0", sha256="1d18fce868f8fef68b42fccd1f5df2555369739e8cb7c148532a0529a308eb09")
     version("2.2.0", sha256="ff6d05240b4a9753bb3d1eaf962f5a06205038df5142374a6ef40f931bb55ecc")
     version("2.1.0", sha256="97df312779e2d937246d2f46385b700e0958ed796d6fed7aae77e2d18923e19f")
     version("2.0.0", sha256="1a8e40f1f331d6ee2e9ace518c0088a78c8a838968f8601c2b77fd012a7bf0f5")

--- a/repos/spack_repo/builtin/packages/libfabric/package.py
+++ b/repos/spack_repo/builtin/packages/libfabric/package.py
@@ -110,7 +110,7 @@ class Libfabric(AutotoolsPackage, CudaPackage):
     variant("debug", default=False, description="Enable debugging")
     variant("uring", default=False, when="@1.17.0:", description="Enable uring support")
     variant("level_zero", default=False, description="Enable Level Zero support")
-    variant("gdrcopy", default=False, when="+cuda", description="Enable gdrcopy support")
+    variant("gdrcopy", default=False, when="@1.12: +cuda", description="Enable gdrcopy support")
 
     # For version 1.9.0:
     # headers: fix forward-declaration of enum fi_collective_op with C++

--- a/repos/spack_repo/builtin/packages/libfabric/package.py
+++ b/repos/spack_repo/builtin/packages/libfabric/package.py
@@ -110,6 +110,7 @@ class Libfabric(AutotoolsPackage, CudaPackage):
     variant("debug", default=False, description="Enable debugging")
     variant("uring", default=False, when="@1.17.0:", description="Enable uring support")
     variant("level_zero", default=False, description="Enable Level Zero support")
+    variant("gdrcopy", default=False, when="+cuda", description="Enable gdrcopy support")
 
     # For version 1.9.0:
     # headers: fix forward-declaration of enum fi_collective_op with C++
@@ -139,6 +140,7 @@ class Libfabric(AutotoolsPackage, CudaPackage):
     depends_on("cassini-headers", when="fabrics=cxi")
     depends_on("cxi-driver", when="fabrics=cxi")
     depends_on("xpmem", when="fabrics=xpmem")
+    depends_on("gdrcopy", when="+gdrcopy")
 
     depends_on("m4", when="@main", type="build")
     depends_on("autoconf", when="@main", type="build")
@@ -229,6 +231,9 @@ class Libfabric(AutotoolsPackage, CudaPackage):
 
         if self.spec.satisfies("fabrics=xpmem"):
             args.append(f"--enable-xpmem={self.spec['xpmem'].prefix}")
+
+        if self.spec.satisfies("+gdrcopy"):
+            args.append(f"--with-gdrcopy={self.spec['gdrcopy'].prefix}")
 
         return args
 


### PR DESCRIPTION
As far as I can tell, gdrcopy support was added in 1.12: https://github.com/ofiwg/libfabric/commit/1bceb40ad32895fa5a3c32b6a86acb852fec32fa.

Also adding myself as maintainer.