### PR TITLE
build_systems/python: fix check for whether a file is executable

### DIFF
--- a/repos/spack_repo/builtin/build_systems/python.py
+++ b/repos/spack_repo/builtin/build_systems/python.py
@@ -163,7 +163,7 @@ class PythonExtension(PackageBase):
                 continue
 
             # If it's executable and has a shebang, copy and patch it.
-            if (s.st_mode & 0b111) and has_shebang(src):
+            if (s.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)) and has_shebang(src):
                 copied_files[(s.st_dev, s.st_ino)] = dst
                 shutil.copy2(src, dst)
                 filter_file(


### PR DESCRIPTION
PythonExtension overrides the default `add_files_to_view` method to ensure that shebang lines in python `bin/` files are rewritten to point to the python in the view.

The logic in this override has a bit-mask for determining whether the file is executable. The bit-mask is not correctly identifying files that are executable. This PR changes the hardcoded bitmask and replaces it with one constructed from constraints from python's `stat` module.