### PR TITLE
build_systems/oneapi: Fix for openmp lib detection

### DIFF
--- a/repos/spack_repo/builtin/build_systems/oneapi.py
+++ b/repos/spack_repo/builtin/build_systems/oneapi.py
@@ -226,10 +226,9 @@ class IntelOneApiLibraryPackage(IntelOneApiPackage):
             )
 
         # query the compiler for the library path
-        with self.compiler.compiler_environment():
-            omp_lib_path = Executable(self.compiler.cc)(
-                "--print-file-name", f"{libname}.{shared_library_suffix(self.spec)}", output=str
-            ).strip()
+        omp_lib_path = Executable(self.compiler.cc)(
+            "--print-file-name", f"{libname}.{shared_library_suffix(self.spec)}", output=str
+        ).strip()
 
         # Newer versions of clang do not give the full path to libomp. If that's
         # the case, look in a path relative to the compiler where libomp is


### PR DESCRIPTION
Removing the context manager that caused the failure.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
