### PR TITLE
fsl: remove upper bound vtk@:8 to fix concretization error

### DIFF
--- a/repos/spack_repo/builtin/packages/fsl/package.py
+++ b/repos/spack_repo/builtin/packages/fsl/package.py
@@ -36,7 +36,7 @@ class Fsl(Package, CudaPackage):
     depends_on("glu")
     depends_on("iconv")
     depends_on("openblas", when="@6:")
-    depends_on("vtk@:8")
+    depends_on("vtk")
 
     conflicts("cuda_arch=none", when="+cuda", msg="must select a CUDA architecture")
     conflicts("platform=darwin", msg="currently only packaged for linux")


### PR DESCRIPTION
Fixes #1545

### Summary

Fixes concretization error in `fsl` due to restrictive dependency on `vtk@:8`.

### Problem

The `fsl` package declared:

```python
depends_on("vtk@:8")
```
### Solution
Replaced the restrictive constraint with:

```python
depends_on("vtk")
