### PR TITLE
SST-Core: Do not set compilers manually

### DIFF
--- a/repos/spack_repo/builtin/packages/sst_core/package.py
+++ b/repos/spack_repo/builtin/packages/sst_core/package.py
@@ -126,10 +126,6 @@ class SstCore(AutotoolsPackage):
 
         if self.spec.satisfies("+pdes_mpi"):
             args.append("--enable-mpi")
-            env["CC"] = self.spec["mpi"].mpicc
-            env["CXX"] = self.spec["mpi"].mpicxx
-            env["F77"] = self.spec["mpi"].mpif77
-            env["FC"] = self.spec["mpi"].mpifc
         else:
             args.append("--disable-mpi")
 


### PR DESCRIPTION
I do not believe there is a need to set the compilers in this manner. Autotools should detect the correct compilers. 

Setting `CXX=mpicxx` causes sst-elements to also choose `mpicxx` instead of `gcc`, which causes issues with a library in Ariel, as it ends up searching for the wrong `libmpi.so`. If we do need to keep setting compilers this way, we should be using `MPICC` and `MPICXX` instead of `CC` and `CXX`. 