### PR TITLE
emacs: add +sqlite variant

### DIFF
--- a/repos/spack_repo/builtin/packages/emacs/package.py
+++ b/repos/spack_repo/builtin/packages/emacs/package.py
@@ -63,6 +63,7 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
     )
     variant("json", default=False, when="@27:", description="Build with json support")
     variant("native", default=False, when="@28:", description="Enable native compilation of elisp")
+    variant("sqlite", default=False, when="@29.1:", description="Build with sqlite3 support")
     variant("tls", default=True, description="Build with gnutls support")
     variant("treesitter", default=False, when="@29:", description="Build with tree-sitter support")
 
@@ -90,6 +91,7 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
     depends_on("tree-sitter", when="+treesitter")
     depends_on("gcc@11: +strip languages=jit", when="+native")
     depends_on("jansson@2.7:", when="+json")
+    depends_on("sqlite@3", when="+sqlite")
 
     # GUI dependencies
     with when("gui=x11"):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

The most accurate description of emacs behavior I found is [this reddit thread](https://www.reddit.com/r/emacs/comments/123klvf/emacs29_build_from_git_with_sqlite3/).
- by default (no options given), emacs detects if sqlite3 is available
  - if present, emacs is built with sqlite3 support
  - if not present, emacs is built without sqlite3 support
- there is an option to bypass the detection and build without sqlite3 support, even if sqlite3 is present
- there is no option to force sqlite3 support