### PR TITLE
plog: add missing C build dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/plog/package.py
+++ b/repos/spack_repo/builtin/packages/plog/package.py
@@ -21,3 +21,4 @@ class Plog(CMakePackage):
     version("1.1.9", sha256="058315b9ec9611b659337d4333519ab4783fad3f2f23b1cc7bb84d977ea38055")
 
     depends_on("cxx", type="build")
+    depends_on("c", type="build")


### PR DESCRIPTION
Fixes build with Spack 1.0.1

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
