### PR TITLE
py-astropy: Fix compilation error when using gcc@15

### DIFF
--- a/repos/spack_repo/builtin/packages/py_astropy/package.py
+++ b/repos/spack_repo/builtin/packages/py_astropy/package.py
@@ -191,6 +191,6 @@ class PyAstropy(PythonPackage):
     def flag_handler(self, name, flags):
         (flags, _, _) = super().flag_handler(name, flags)
         if name == "cflags":
-            if self.spec.satisfies("@:7") and self.spec.satisfies("%gcc@15:"):
+            if self.spec.satisfies("@:6.1.0") and self.spec.satisfies("%gcc@14:"):
                 flags.append("-Wno-incompatible-pointer-types")
         return (flags, None, None)

--- a/repos/spack_repo/builtin/packages/py_astropy/package.py
+++ b/repos/spack_repo/builtin/packages/py_astropy/package.py
@@ -187,3 +187,10 @@ class PyAstropy(PythonPackage):
             modules.append("astropy.visualization.wcsaxes")
 
         return modules
+
+    def flag_handler(self, name, flags):
+        (flags, _, _) = super().flag_handler(name, flags)
+        if name == "cflags":
+            if self.spec.satisfies("@:7") and self.spec.satisfies("%gcc@15:"):
+                flags.append("-Wno-incompatible-pointer-types")
+        return (flags, None, None)


### PR DESCRIPTION
Turn off incompatible pointer types error

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
