### PR TITLE
fix : rstudio concretize problem

### DIFF
--- a/repos/spack_repo/builtin/packages/qt/package.py
+++ b/repos/spack_repo/builtin/packages/qt/package.py
@@ -655,7 +655,7 @@ class Qt(Package):
             use_spack_dep("freetype")
             if spec.satisfies("platform=linux") or spec.satisfies("platform=freebsd"):
                 config_args.append("-fontconfig")
-                
+
             # Avoid sporadic vkconvenience bug by explicitly disabling vulkan
             # config_args.append("-no-vulkan")
             if spec.satisfies("@5.10:"):

--- a/repos/spack_repo/builtin/packages/qt/package.py
+++ b/repos/spack_repo/builtin/packages/qt/package.py
@@ -655,8 +655,11 @@ class Qt(Package):
             use_spack_dep("freetype")
             if spec.satisfies("platform=linux") or spec.satisfies("platform=freebsd"):
                 config_args.append("-fontconfig")
+                
             # Avoid sporadic vkconvenience bug by explicitly disabling vulkan
-            config_args.append("-no-vulkan")
+            # config_args.append("-no-vulkan")
+            if spec.satisfies("@5.10:"):
+                config_args.append("-no-vulkan")
         else:
             config_args.append("-no-freetype")
             config_args.append("-no-gui")

--- a/repos/spack_repo/builtin/packages/rstudio/package.py
+++ b/repos/spack_repo/builtin/packages/rstudio/package.py
@@ -27,7 +27,9 @@ class Rstudio(CMakePackage):
     depends_on("pkgconfig", type="build")
     depends_on("ant", type="build")
     depends_on("boost+pic@1.69:")
-    depends_on("qt+webkit@5.12:")
+    
+    # depends_on("qt+webkit@5.12:")
+    depends_on("qt+webkit@:5.6.999")
     depends_on("patchelf@0.9:")
     depends_on("yaml-cpp@:0.6.3")  # find_package fails with newest version
     depends_on("node-js")

--- a/repos/spack_repo/builtin/packages/rstudio/package.py
+++ b/repos/spack_repo/builtin/packages/rstudio/package.py
@@ -27,7 +27,7 @@ class Rstudio(CMakePackage):
     depends_on("pkgconfig", type="build")
     depends_on("ant", type="build")
     depends_on("boost+pic@1.69:")
-    
+
     # depends_on("qt+webkit@5.12:")
     depends_on("qt+webkit@:5.6.999")
     depends_on("patchelf@0.9:")

--- a/repos/spack_repo/builtin/packages/soci/package.py
+++ b/repos/spack_repo/builtin/packages/soci/package.py
@@ -42,7 +42,7 @@ class Soci(CMakePackage):
     variant("sqlite", default=False, description="Build with SQLite support")
     variant("postgresql", default=False, description="Build with PostgreSQL support")
 
-    depends_on("c", type="build") # add for "SPACK_CC_*"
+    depends_on("c", type="build")  # add for "SPACK_CC_*"
     depends_on("cxx", type="build")  # generated
 
     depends_on("boost", when="+boost")

--- a/repos/spack_repo/builtin/packages/soci/package.py
+++ b/repos/spack_repo/builtin/packages/soci/package.py
@@ -42,6 +42,7 @@ class Soci(CMakePackage):
     variant("sqlite", default=False, description="Build with SQLite support")
     variant("postgresql", default=False, description="Build with PostgreSQL support")
 
+    depends_on("c", type="build") # add for "SPACK_CC_*"
     depends_on("cxx", type="build")  # generated
 
     depends_on("boost", when="+boost")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Fix concretize problem of [#1274](https://github.com/spack/spack-packages/issues/1274#issue-3379267702) : D

## Problem
spack cannot concretize `rstudio@1.4.1717 ^qt@5.12:+webkit`
```
==> Error: failed to concretize rstudio@2025.05.01 for the following reasons:
1. Cannot satisfy 'rstudio@2025.05.01'
required because rstudio@2025.05.01 requested explicitly
2. Cannot satisfy 'rstudio@2025.05.01'
3. Cannot satisfy 'qt@5.12:'
required because rstudio depends on qt@5.12:+webkit
required because rstudio@2025.05.01 requested explicitly
4. Cannot satisfy 'qt@5.12:'
```

## Cause
This is actually caused by the package.py of qt ( line 309 ~ 313 )
```
    conflicts(
        "+webkit",
        when="@5.7:5.15",
        msg="qtwebengine@5.7:5.15 are based on Google Chromium versions which depend on Py2",
    )
```
qt doesn't support `+webkit` when the version between 5.7 and 5.15 ( and in this case you want to use qt@5.12, which triggers this conflict )

## Solution
modify package.py for `rstudio`
```
    # depends_on("qt+webkit@5.12:")
    depends_on("qt+webkit@:5.6.999")
```
and use older qt version like `5.6.3` as dependency with + webkit

for example : 
```
spack install -v --add rstudio@1.4.1717 %gcc@14.1.0 ^qt@5.6.3:+webkit
```

## Other Problem met in the installation process
1. C compiler not found for `scoi` => solved and `scoi` successfully installed
<details>
  <summary>solution</summary>

-  add `depends_on("c",type=build)` in package.py in `scoi`
- ( if you are in spack environment ) check the gcc compiler of spack.yaml contains **do have "c" in languages**
```
    gcc:
      externals:
      - spec: gcc@14.1.0 languages:='**c**,c++,fortran'
```
if the gcc compiler does not have c here, then it would get a `C compiler not found` and `"SPACK_CC_*"` error
</details>

2. `qt` package `-no-vulkan: invalid command-line switch` error => solved and successfully start build and install, but haven't installed it successfully
<details>
  <summary>solution</summary>

-  `-no-vulkan` is a flag is a configuration that `qt` add for version 5.10.0+, since here we are using version `5.6.3`, it would cause error

- So, modify the package.py of `qt` with `if` condition
```
            # Avoid sporadic vkconvenience bug by explicitly disabling vulkan
            # config_args.append("-no-vulkan")
            if spec.satisfies("@5.10:"):
                config_args.append("-no-vulkan")
```
to ensure the version of `qt` to use the `-no-vulkan` configuration

</details>

However, there is still actually some problem during installation of qt and rstudio, I think you could probably open another issue for solving it ? 
Although kinda difficult, I would still try my best to fix it out !
Hope this PR could help you and welcome to discuss any thoughts with me ! 😄