### PR TITLE
Kokkos Kernels: remove deprecated logic

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
@@ -208,9 +208,6 @@ class KokkosKernels(CMakePackage, CudaPackage):
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
         ]
 
-        if spec.satisfies("+diy"):
-            options.append(self.define("Spack_WORKAROUND", True))
-
         options.append(self.define("Kokkos_ROOT", spec["kokkos"].prefix))
         if spec.satisfies("^kokkos+rocm"):
             options.append(self.define("CMAKE_CXX_COMPILER", spec["hip"].hipcc))


### PR DESCRIPTION
The package does not define a `diy` variant. Trying `spack spec kokkos-kernels +diy` results in `==> Error: No such variant {'diy'} for spec: 'kokkos-kernels+diy'`