### PR TITLE
opendatadetector: find libs and use it for LD_LIBRARY_PATH

### DIFF
--- a/repos/spack_repo/builtin/packages/opendatadetector/package.py
+++ b/repos/spack_repo/builtin/packages/opendatadetector/package.py
@@ -36,7 +36,12 @@ class Opendatadetector(CMakePackage):
         args = [self.define("CMAKE_CXX_STANDARD", self.spec["root"].variants["cxxstd"].value)]
         return args
 
+    @property
+    def libs(self):
+        return find_libraries(
+            "libOpenDataDetector*", root=self.prefix, shared=True, recursive=True
+        )
+
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         env.set("OPENDATADETECTOR_DATA", join_path(self.prefix.share, "OpenDataDetector"))
-        for lib_path in [self.prefix.lib, self.prefix.lib64]:
-            env.prepend_path("LD_LIBRARY_PATH", lib_path)
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["opendatadetector"].libs.directories[0])


### PR DESCRIPTION
instead of adding both lib and lib64. Tested successfully on Alma 9.