### PR TITLE
syscalc: Use CMake mirror

### DIFF
--- a/repos/spack_repo/builtin/packages/syscalc/package.py
+++ b/repos/spack_repo/builtin/packages/syscalc/package.py
@@ -20,6 +20,7 @@ class Syscalc(CMakePackage):
 
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
+    depends_on("pkgconfig", type="build")
 
     tags = ["hep"]
 

--- a/repos/spack_repo/builtin/packages/syscalc/package.py
+++ b/repos/spack_repo/builtin/packages/syscalc/package.py
@@ -2,23 +2,21 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack_repo.builtin.build_systems.makefile import MakefilePackage
+from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
 
 
-class Syscalc(MakefilePackage):
+class Syscalc(CMakePackage):
     """A tool to derive theoretical systematic uncertainties"""
 
     homepage = "https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/SysCalc"
     url = "https://bazaar.launchpad.net/~mgtools/mg5amcnlo/SysCalc/tarball/17"
 
-    version(
-        "1.1.7",
-        sha256="ac73df0f9f195eb62601fafc2eede3db17a562750f7971616870d6df4abd1b6c",
-        url="https://bazaar.launchpad.net/~mgtools/mg5amcnlo/SysCalc/tarball/17",
-        extension=".tgz",
-    )
+    # This is a mirror + added CMakeLists.txt file
+    git = "https://github.com/paulgessinger/SysCalc.git"
+
+    version("1.1.7", commit="d62edf92b04a6cf89cde6837b0a999bc79601e8f")
 
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
@@ -26,6 +24,7 @@ class Syscalc(MakefilePackage):
     tags = ["hep"]
 
     depends_on("lhapdf@6:")
+    depends_on("tinyxml2")
 
     def url_for_version(self, version):
         url = self.url.rsplit("/", 1)[0]
@@ -33,13 +32,3 @@ class Syscalc(MakefilePackage):
 
         url = url.format(version)
         return url
-
-    def build(self, spec, prefix):
-        with working_dir("mg5amcnlo/SysCalc"):
-            make("all")
-
-    def install(self, spec, prefix):
-        mkdirp(prefix.bin)
-        with working_dir("mg5amcnlo/SysCalc"):
-            install("sys_calc", prefix.bin)
-            install_tree("include", prefix.include)


### PR DESCRIPTION
I don't know if a change like this controversial, but here we go:

- I've discovered that the syscalc package points at a source url that does not exist anymore (https://bazaar.launchpad.net/~mgtools/mg5amcnlo/SysCalc/tarball/17). https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/SysCalc still exists, but does not contain any relevant information. The only reason spack can still download the sources is through the mirror. **I did not manage to figure out if this was moved anywhere else**.
- The syscalc package is **tiny** and uses a custom brittle Makefile build, that uses a C++ and fortran compiler, and doesn't portably link to the fortran runtime library (it fails to build on macOS). 
- I've created a sort of "fork" of the package here (https://github.com/paulgessinger/SysCalc) where I removed the Makefiles and replace it with a straight forward CMake build
- This PR updates the package in spack to point at that repository instead and switches the package type to a CMake one
- I'm also removing the vendored version of tinyxml2 from syscalc and instead let it use a version installed from spack.

Concerning versions: since I've only had access to the source code through the mirror, I only have the 1.1.7 version of the code. However, the spack package was not referencing any other versions anyway. I don't know if or where this package is developed, so I don't know if there are updated versions.

As it stands, the package configuration as is is essentially broken, hence my suggetion. 