### PR TITLE
mochi-margo: new versions, variants, and build systems

### DIFF
--- a/repos/spack_repo/builtin/packages/mochi_margo/package.py
+++ b/repos/spack_repo/builtin/packages/mochi_margo/package.py
@@ -18,6 +18,12 @@ class MochiMargo(cmake.CMakePackage, autotools.AutotoolsPackage):
 
     maintainers("carns", "mdorier", "fbudin69500")
 
+    build_system(
+        conditional("cmake", when="@0.22.0:"),
+        conditional("autotools", when="@:0.21.0"),
+        default="cmake",
+    )
+
     version("main", branch="main")
     version("0.21.0", sha256="d0a527cd0dcbeb9a8f04d090140cdedb66d9a90c6794a046d48d6bc2d11fc278")
     version("0.20.0", sha256="ed19f65c3c0dda42b285904f64508d1997f4b0fcef81cddb011aa9c42381eb2a")

--- a/repos/spack_repo/builtin/packages/mochi_margo/package.py
+++ b/repos/spack_repo/builtin/packages/mochi_margo/package.py
@@ -71,8 +71,11 @@ class MochiMargo(cmake.CMakePackage, autotools.AutotoolsPackage):
     version("0.4.3", sha256="61a634d6983bee2ffa06e1e2da4c541cb8f56ddd9dd9f8e04e8044fb38657475")
     version("0.4.2", sha256="91085e28f50e373b9616e1ae5c3c8d40a19a7d3776259592d8f361766890bcaa")
 
-    variant('hwloc', default=True, when="@0.21:",
-            description="Use hwloc to help select network cards when possible")
+    variant('hwloc',
+            default=True,
+            when="@0.21:",
+            description="Use hwloc to help select network cards when possible"
+    )
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
@@ -94,7 +97,7 @@ class MochiMargo(cmake.CMakePackage, autotools.AutotoolsPackage):
     # "breadcrumb" support not available in mercury-1.0
     depends_on("mercury@1.0.0:", type=("build", "link", "run"), when="@:0.5.1")
     depends_on("mercury@2.0.0:", type=("build", "link", "run"), when="@0.5.2:")
-    depends_on('hwloc', when='+hwloc')
+    depends_on("hwloc", when="+hwloc")
 
     # Fix pthread detection
     # https://github.com/mochi-hpc/mochi-margo/pull/177

--- a/repos/spack_repo/builtin/packages/mochi_margo/package.py
+++ b/repos/spack_repo/builtin/packages/mochi_margo/package.py
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack_repo.builtin.build_systems import autotools, cmake
 from spack import *
 from spack.package import *
+from spack_repo.builtin.build_systems import autotools, cmake
 
 
 class MochiMargo(cmake.CMakePackage, autotools.AutotoolsPackage):

--- a/repos/spack_repo/builtin/packages/mochi_margo/package.py
+++ b/repos/spack_repo/builtin/packages/mochi_margo/package.py
@@ -75,7 +75,7 @@ class MochiMargo(cmake.CMakePackage, autotools.AutotoolsPackage):
         "hwloc",
         default=True,
         when="@0.21:",
-        description="Use hwloc to help select network cards when possible"
+        description="Use hwloc to help select network cards when possible",
     )
 
     depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/mochi_margo/package.py
+++ b/repos/spack_repo/builtin/packages/mochi_margo/package.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack_repo.builtin.build_systems import autotools, cmake
+
 from spack import *
 from spack.package import *
-from spack_repo.builtin.build_systems import autotools, cmake
 
 
 class MochiMargo(cmake.CMakePackage, autotools.AutotoolsPackage):

--- a/repos/spack_repo/builtin/packages/mochi_margo/package.py
+++ b/repos/spack_repo/builtin/packages/mochi_margo/package.py
@@ -2,12 +2,12 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
-
+from spack_repo.builtin.build_systems import cmake, autotools
+from spack import *
 from spack.package import *
 
 
-class MochiMargo(AutotoolsPackage):
+class MochiMargo(cmake.CMakePackage, autotools.AutotoolsPackage):
     """A library that provides Argobots bindings to the Mercury RPC
     implementation."""
 
@@ -18,6 +18,8 @@ class MochiMargo(AutotoolsPackage):
     maintainers("carns", "mdorier", "fbudin69500")
 
     version("main", branch="main")
+    version("0.21.0", sha256="d0a527cd0dcbeb9a8f04d090140cdedb66d9a90c6794a046d48d6bc2d11fc278")
+    version("0.20.0", sha256="ed19f65c3c0dda42b285904f64508d1997f4b0fcef81cddb011aa9c42381eb2a")
     version("0.19.2", sha256="cfd20117744631779f0e99a0bc0668a1ca4d6d3c89fce5e9926961f830491689")
     version("0.19.1", sha256="77422156be5d1e24b16f6d65109ada29a2276c9d6fdd9a5392c23f1fbe370b98")
     version("0.19.0", sha256="269e3b52228fb59a8ab502b8fac4761fc15440817455bb006f311093bd4c02f3")
@@ -69,19 +71,30 @@ class MochiMargo(AutotoolsPackage):
     version("0.4.3", sha256="61a634d6983bee2ffa06e1e2da4c541cb8f56ddd9dd9f8e04e8044fb38657475")
     version("0.4.2", sha256="91085e28f50e373b9616e1ae5c3c8d40a19a7d3776259592d8f361766890bcaa")
 
+    variant('hwloc', default=True, when="@0.21:",
+            description="Use hwloc to help select network cards when possible")
+
     depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    with when("build_system=autotools"):
+        depends_on("autoconf@2.65:", type=("build"))
+        depends_on("m4", type=("build"))
+        depends_on("automake", type=("build"))
+        depends_on("libtool", type=("build"))
+
+    with when("build_system=cmake"):
+        depends_on("cmake@3.12:", type=("build"))
 
     depends_on("json-c", when="@0.9:")
-    depends_on("autoconf@2.65:", type=("build"))
-    depends_on("m4", type=("build"))
-    depends_on("automake", type=("build"))
-    depends_on("libtool", type=("build"))
     depends_on("pkgconfig", type=("build"))
     depends_on("argobots@1.0:")
     depends_on("argobots@1.1:", when="@0.11:")
+    depends_on("argobots@1.2:", when="@0.21.0:")
     # "breadcrumb" support not available in mercury-1.0
     depends_on("mercury@1.0.0:", type=("build", "link", "run"), when="@:0.5.1")
     depends_on("mercury@2.0.0:", type=("build", "link", "run"), when="@0.5.2:")
+    depends_on('hwloc', when='+hwloc')
 
     # Fix pthread detection
     # https://github.com/mochi-hpc/mochi-margo/pull/177

--- a/repos/spack_repo/builtin/packages/mochi_margo/package.py
+++ b/repos/spack_repo/builtin/packages/mochi_margo/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack_repo.builtin.build_systems import cmake, autotools
+from spack_repo.builtin.build_systems import autotools, cmake
 from spack import *
 from spack.package import *
 

--- a/repos/spack_repo/builtin/packages/mochi_margo/package.py
+++ b/repos/spack_repo/builtin/packages/mochi_margo/package.py
@@ -71,10 +71,11 @@ class MochiMargo(cmake.CMakePackage, autotools.AutotoolsPackage):
     version("0.4.3", sha256="61a634d6983bee2ffa06e1e2da4c541cb8f56ddd9dd9f8e04e8044fb38657475")
     version("0.4.2", sha256="91085e28f50e373b9616e1ae5c3c8d40a19a7d3776259592d8f361766890bcaa")
 
-    variant('hwloc',
-            default=True,
-            when="@0.21:",
-            description="Use hwloc to help select network cards when possible"
+    variant(
+        "hwloc",
+        default=True,
+        when="@0.21:",
+        description="Use hwloc to help select network cards when possible"
     )
 
     depends_on("c", type="build")


### PR DESCRIPTION
This PR does the following:
- Converts the mochi-margo package into a dual Autotools/CMake package, as mochi-margo@main and versions > 0.21.0 now use cmake;
- Add the `+hwlock` variant;
- Add versions 0.20.0 and 0.21.0