### PR TITLE
r-ncdf4 depends on c

### DIFF
--- a/repos/spack_repo/builtin/packages/r_ncdf4/package.py
+++ b/repos/spack_repo/builtin/packages/r_ncdf4/package.py
@@ -37,4 +37,6 @@ class RNcdf4(RPackage):
     version("1.16", sha256="edd5731a805bbece3a8f6132c87c356deafc272351e1dd07256ca00574949253")
     version("1.15", sha256="d58298f4317c6c80a041a70216126492fd09ba8ecde9da09d5145ae26f324d4d")
 
+    depends_on("c", type="build")
+
     depends_on("netcdf-c@4.1:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Update required to r-ncdf4 to account for compilers-a-nodes. Same as spack/spack#50174 