### PR TITLE
superlu-dist and strumpack: restrict to ROCm 6

### DIFF
--- a/repos/spack_repo/builtin/packages/strumpack/package.py
+++ b/repos/spack_repo/builtin/packages/strumpack/package.py
@@ -94,6 +94,7 @@ class Strumpack(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("zfp@0.5.5", when="@:7.0.1 +zfp")
     depends_on("zfp", when="@7.0.2: +zfp")
     depends_on("hipblas", when="+rocm")
+    depends_on("hipblas@:6", when="@:8.0.0 +rocm")
     depends_on("hipsparse", type="link", when="@7.0.1: +rocm")
     depends_on("rocsolver", when="+rocm")
     depends_on("rocthrust", when="+rocm")

--- a/repos/spack_repo/builtin/packages/superlu_dist/package.py
+++ b/repos/spack_repo/builtin/packages/superlu_dist/package.py
@@ -76,6 +76,7 @@ class SuperluDist(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("parmetis ~int64", when="~int64")
     depends_on("cmake@3.18.1:", type="build", when="@7.1.0:")
     depends_on("hipblas", when="+rocm")
+    depends_on("hipblas@:6", when="@:9.1.0 +rocm")
     depends_on("rocsolver", when="+rocm")
 
     conflicts("+rocm", when="+cuda")


### PR DESCRIPTION
The [ROCM 7.0.0 PR](https://github.com/spack/spack-packages/pull/1655) is encountering a ci failure when building superlu-dist:
https://gitlab.spack.io/spack/spack-packages/-/jobs/18232451
```
In file included from /tmp/root/spack-stage/spack-stage-superlu-dist-9.1.0-mknc6ls5uq5qqnlpajlabihbwciv5ghv/spack-src/SRC/hip/zsuperlu_gpu.hip.cpp:1:
/tmp/root/spack-stage/spack-stage-superlu-dist-9.1.0-mknc6ls5uq5qqnlpajlabihbwciv5ghv/spack-src/SRC/cuda/zsuperlu_gpu.cu:661:15: error: use of undeclared identifier 'hipblasDoubleComplex'
  661 |                     cu_A = (gpuDoubleComplex*) &A_gpu->scubufs[streamId].Remain_L_buff[(knsupc - ldu) * Rnbrow + st_row];
      |                             ^
/tmp/root/spack-stage/spack-stage-superlu-dist-9.1.0-mknc6ls5uq5qqnlpajlabihbwciv5ghv/spack-src/SRC/include/gpu_wrapper.h:179:27: note: expanded from macro 'gpuDoubleComplex'
  179 | #define  gpuDoubleComplex hipblasDoubleComplex 
```

hipblasDoubleComplex has been removed in ROCm 7.0. Source: https://github.com/ROCm/hipBLAS/blob/rocm-7.0.0/docs/reference/deprecation.rst#removed-in-hipblas-30

**EDIT:**
adding strumpack as well:
https://gitlab.spack.io/spack/spack-packages/-/jobs/18232459
`/tmp/root/spack-stage/spack-stage-strumpack-8.0.0-kvvpv3lzcaje6ta3ggycx7l756pawmgj/spack-src/src/dense/HIPWrapper.cpp:364:35: error: unknown type name 'hipblasComplex'; did you mean 'hipFloatComplex'?
  364 |                  reinterpret_cast<hipblasComplex*>(&alpha),`

