### PR TITLE
duckdb: convert to cmake package

### DIFF
--- a/repos/spack_repo/builtin/packages/duckdb/package.py
+++ b/repos/spack_repo/builtin/packages/duckdb/package.py
@@ -3,12 +3,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack_repo.builtin.build_systems.makefile import MakefilePackage
+from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
 
 
-class Duckdb(MakefilePackage):
+class Duckdb(CMakePackage):
     """DuckDB is an in-process SQL OLAP Database Management System."""
 
     homepage = "https://duckdb.org"
@@ -29,135 +29,62 @@ class Duckdb(MakefilePackage):
     version("1.1.1", sha256="a764cef80287ccfd8555884d8facbe962154e7c747043c0842cd07873b4d6752")
     version("1.1.0", sha256="d9be2c6d3a5ebe2b3d33044fb2cb535bb0bd972a27ae38c4de5e1b4caa4bf68d")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-
-    depends_on("python@3.7:")
-    with default_args(type="build"):
-        depends_on("cmake")
-        depends_on("gmake")
-        depends_on("ninja", when="+ninjabuild")
-        depends_on("py-pip", when="+python")
-        depends_on("py-setuptools-scm", when="+python")
-        depends_on("pkgconfig", when="+static_openssl")
-        depends_on("zlib-api", when="+static_openssl")
-    depends_on("openssl", when="+httpfs")
-    depends_on("icu4c", when="~icu")
-
     # Build Options
-    variant("cli", default=True, description="Compile with command line client")
     variant("icu", default=False, description="Compile with bundled ICU library")
-    variant("ninjabuild", default=True, description="Use GEN=ninja to build")
-    variant("static_openssl", default=False, description="Build with static openSSL")
     variant("extension_autoload", default=False, description="Enable extension auto-loading")
     variant("extension_autoinstall", default=False, description="Enable extension auto-installing")
     variant("extension_repo", default=True, description="Copy extensions to prefix")
 
     # Extensions
     variant("autocomplete", default=True, description="Include autocomplete for CLI in build")
-    variant("excel", default=True, description="Include Excel formatting extension in build")
-    variant("httpfs", default=True, description="Include HTTPFS (& S3) support in build")
-    variant("inet", default=True, description="Include INET (ip address) support in build")
     variant("json", default=True, description="Include JSON support in build")
     variant("parquet", default=True, description="Include parquent support in build")
     variant("tpce", default=False, description="Include TPCE in build")
     variant("tpch", default=False, description="Include TPCH in build")
 
-    # FTS was moved to an out-of-tree extension after v1.1.3
+    # FTS and HTTPFS were moved to an out-of-tree extension in v1.2.0
     variant(
         "fts",
         default=True,
         description="Include FTS (full text search) support in build",
         when="@:1.1",
     )
+    variant(
+        "httpfs", default=True, description="Include HTTPFS (& S3) support in build", when="@:1.1"
+    )
 
     # APIs
     variant("python", default=True, description="Build with Python driver")
-    extends("python", when="+python")
 
-    @property
-    def duckdb_extension_prefix(self):
-        return self.prefix.lib.duckdb
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("python@3.7:")
+    depends_on("openssl", when="+httpfs")
+    depends_on("icu4c", when="~icu")
+
+    with when("+python"):
+        extends("python")
+        depends_on("py-pip", type="build")
+        depends_on("py-setuptools-scm", type="build")
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        cmake_args = []  # Future use
-        if self.spec.satisfies("+ninjabuild"):
-            env.set("GEN", "ninja")
         if self.spec.satisfies("+python"):
             env.set("SETUPTOOLS_SCM_PRETEND_VERSION", f"{self.spec.version}")
-        if self.spec.satisfies("+static_openssl"):
-            env.set("STATIC_OPENSSL", "1")
-        variant_flags = [
-            "autocomplete",
-            "cli",
-            "excel",
-            "fts",
-            "httpfs",
-            "icu",
-            "inet",
-            "json",
-            "openssl",  # Deprecate after 0.9.2 retired
-            "parquet",
-            "python",
-            "tpce",
-            "tpch",
+            env.set("PIP_PREFIX", self.prefix)
+
+    def cmake_args(self):
+        extensions = ("autocomplete", "icu", "json", "parquet", "tpch", "fts", "httpfs")
+        args = [
+            self.define(
+                "BUILD_EXTENSIONS", [ext for ext in extensions if self.spec.satisfies(f"+{ext}")]
+            ),
+            self.define("OVERRIDE_GIT_DESCRIBE", f"v{self.spec.version}"),
+            self.define("LOCAL_EXTENSION_REPO", self.prefix.lib.duckdb.extensions),
+            self.define("ENABLE_EXTENSION_AUTOLOADING", "1"),  # string, not boolean
+            self.define("ENABLE_EXTENSION_AUTOINSTALL", "1"),  # string, not boolean
         ]
-        for flag in variant_flags:
-            make_flag = "BUILD_" + flag.upper()
-            if "+" + flag in self.spec:
-                env.set(make_flag, "1")
-            elif "~" + flag in self.spec:
-                env.set(make_flag, "0")
-        env.set("OVERRIDE_GIT_DESCRIBE", f"v{self.spec.version}")
-        if self.spec.satisfies("+extension_repo"):
-            env.set("LOCAL_EXTENSION_REPO", self.prefix.lib.duckdb.extensions)
-        if self.spec.satisfies("+extension_autoload"):
-            env.set("ENABLE_EXTENSION_AUTOLOADING", "1")
-        if self.spec.satisfies("+extension_autoinstall"):
-            env.set("ENABLE_EXTENSION_AUTOINSTALL", "1")
-
-        if cmake_args:
-            env.set("EXTRA_CMAKE_VARIABLES", " ".join(cmake_args))
-
-    def url_for_version(self, version):
-        return "https://github.com/duckdb/duckdb/archive/refs/tags/v{0}.tar.gz".format(version)
-
-    def patch(self):
-        # DuckDB pulls its version from a git tag, which it can't find in the tarball
-        # and thus defaults to something arbitrary and breaks extensions.
-        # We use the Spack version to inject it in the right place during the build
-        # Patching is not needed for versions from 0.10.2 onward as we can
-        # set OVERRIDE_GIT_DESCRIBE to force the version when not building from a repo.
-
-        version = self.spec.version
-        # Override the fallback values that are set when GIT_COMMIT_HASH doesn't work
-        for i, n in enumerate(["MAJOR", "MINOR", "PATCH"]):
-            filter_file(
-                r"set\(DUCKDB_{0}_VERSION \d+\)".format(n),
-                "set(DUCKDB_{0}_VERSION {1})".format(n, version[i]),
-                "CMakeLists.txt",
-            )
-        # Need to manually set DUCKDB_NORMALIZED_VERSION for helper scripts
-        filter_file(
-            r'(message\(STATUS "git hash \$\{GIT_COMMIT_HASH\},'
-            r" version \$\{DUCKDB_VERSION\},"
-            r' extension folder \$\{DUCKDB_NORMALIZED_VERSION\}"\))',
-            'set(DUCKDB_VERSION "v${DUCKDB_MAJOR_VERSION}'
-            '.${DUCKDB_MINOR_VERSION}.${DUCKDB_PATCH_VERSION}")'
-            '\nset(DUCKDB_NORMALIZED_VERSION "${DUCKDB_VERSION}")'
-            "\n\\1",
-            "CMakeLists.txt",
-        )
-
-        if self.spec.satisfies("+extension_repo"):
-            mkdirp(self.prefix.lib.duckdb.extensions)
-
-    def install(self, spec, prefix):
-        mkdir(prefix.bin)
-        mkdirp(prefix.lib)
-        mkdir(prefix.include)
-        build_dir = join_path("build", "release")
-        install(join_path(build_dir, "duckdb"), prefix.bin)
-        install(join_path(build_dir, "src", "libduckdb.so"), prefix.lib)
-        install(join_path(build_dir, "src", "libduckdb_static.a"), prefix.lib)
-        install_tree(join_path("src", "include"), prefix.include)
+        if self.spec.satisfies("+python"):
+            args.append(self.define("BUILD_PYTHON", "1"))
+        if self.spec.satisfies("+tpce"):
+            args.append(self.define("BUILD_TPCE", "1"))
+        return args


### PR DESCRIPTION
The `Makefile` is just a wrapper to invoke `cmake`.

With `CMakePackage` we benefit from Spack's recommended/default CMake arguments.

* Define `httpfs` conditionally, since it's also out-of-tree since v1.2.0
* Ensure that Python extension is installed in duckdb's prefix (previously it installed in `python-venv`'s prefix).
* Remove `cli`, `excel`, `inet` variants as these extensions no longer exist or are out-of-tree in all of the versions supported by Spack
* Remove redundant `ninjabuild` variant, that's part of `CMakePackage`.
* Remove `static_openssl` variant, which only applies with `httpfs`, and is imo a non-feature because of CVEs in openssl.
* Remove redundant patch

