### PR TITLE
Update packages py_wxpython and wxwidgets to support Python > 3.11

### DIFF
--- a/repos/spack_repo/builtin/packages/py_wxpython/package.py
+++ b/repos/spack_repo/builtin/packages/py_wxpython/package.py
@@ -13,6 +13,7 @@ class PyWxpython(PythonPackage):
     homepage = "https://www.wxpython.org/"
     pypi = "wxPython/wxPython-4.0.6.tar.gz"
 
+    version("4.2.3", sha256="20d6e0c927e27ced85643719bd63e9f7fd501df6e9a8aab1489b039897fd7c01")
     version("4.2.2", sha256="5dbcb0650f67fdc2c5965795a255ffaa3d7b09fb149aa8da2d0d9aa44e38e2ba")
     version("4.1.1", sha256="00e5e3180ac7f2852f342ad341d57c44e7e4326de0b550b9a5c4a8361b6c3528")
     version("4.0.6", sha256="35cc8ae9dd5246e2c9861bb796026bbcb9fb083e4d49650f776622171ecdab37")
@@ -20,8 +21,12 @@ class PyWxpython(PythonPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
+    # Versions before 4.2.3 require distutils which is removed in python 3.12
+    depends_on("python@:3.11", when="@:4.2.2")
+
     depends_on("wxwidgets +gui")
     depends_on("wxwidgets@3.2.6 +gui", when="@4.2.2")
+    depends_on("wxwidgets@3.2.7 +gui", when="@4.2.3")
 
     # Needed by the buildtools/config.py script
     depends_on("pkgconfig", type="build")

--- a/repos/spack_repo/builtin/packages/py_wxpython/package.py
+++ b/repos/spack_repo/builtin/packages/py_wxpython/package.py
@@ -34,6 +34,7 @@ class PyWxpython(PythonPackage):
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools@:75", type="build", when="@:4.1")  # deprecated license-file
     depends_on("py-pathlib2", type="build")
+    depends_on("py-requests", type="build")
 
     # Needed at runtime
     depends_on("py-numpy", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/wxwidgets/package.py
+++ b/repos/spack_repo/builtin/packages/wxwidgets/package.py
@@ -24,6 +24,7 @@ class Wxwidgets(AutotoolsPackage):
     git = "https://github.com/wxWidgets/wxWidgets.git"
 
     version("develop", branch="master")
+    version("3.2.7", sha256="69a1722f874d91cd1c9e742b72df49e0fab02890782cf794791c3104cee868c6")
     version("3.2.6", sha256="939e5b77ddc5b6092d1d7d29491fe67010a2433cf9b9c0d841ee4d04acb9dce7")
     version("3.2.5", sha256="0ad86a3ad3e2e519b6a705248fc9226e3a09bbf069c6c692a02acf7c2d1c6b51")
     version("3.2.4", sha256="0640e1ab716db5af2ecb7389dbef6138d7679261fbff730d23845ba838ca133e")


### PR DESCRIPTION
Previous versions of `py_wxpython` (<= 4.2.2) relied on `distutils` which was removed in Python 3.12. I have added 4.2.3 which removes the need for distutils and added version constraints.
