### PR TITLE
magma, ginkgo, hypre: restrict to ROCm 6

### DIFF
--- a/repos/spack_repo/builtin/packages/ginkgo/package.py
+++ b/repos/spack_repo/builtin/packages/ginkgo/package.py
@@ -81,6 +81,8 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
     # ROCPRIM is not a direct dependency, but until we have reviewed our CMake
     # setup for rocthrust, this needs to also be added here.
     depends_on("rocprim", when="+rocm")
+    # error due to change in warpSize constant definition in ROCm 7.0
+    depends_on("hip@:6", when="@:1.9.0 +rocm")
     depends_on("hwloc@2.1:", when="+hwloc")
     # TODO: replace with the next PAPI version when available (>7.0.1.0)
     depends_on("papi@master+sde", when="+sde")

--- a/repos/spack_repo/builtin/packages/hypre/package.py
+++ b/repos/spack_repo/builtin/packages/hypre/package.py
@@ -131,6 +131,8 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
     depends_on("rocsolver", when="@2.29.0: +rocm")
     depends_on("rocblas", when="@2.29.0: +rocm")
     depends_on("hipblas", when="+rocm +superlu-dist")
+    # naming conflict with the __syncwarp function
+    depends_on("hip@:6", when="@:2.33.0 +rocm")
     depends_on("umpire", when="+umpire")
     depends_on("umpire+rocm", when="+umpire+rocm")
     depends_on("umpire+cuda", when="+umpire+cuda")

--- a/repos/spack_repo/builtin/packages/magma/package.py
+++ b/repos/spack_repo/builtin/packages/magma/package.py
@@ -53,6 +53,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("lapack")
     depends_on("cuda@8:", when="@2.5.1: +cuda")  # See PR #14471
     depends_on("hipblas", when="+rocm")
+    depends_on("hipblas@:6", when="@:2.9.0 +rocm")
     depends_on("hipsparse", when="+rocm")
     depends_on("rocm-core", when="@2.8.0: +rocm")
     depends_on("python", when="@master", type="build")


### PR DESCRIPTION
The [ROCm 7.0.0 PR](https://github.com/spack/spack-packages/pull/1655) is encountering ci failures when building ginkgo and hypre:

**ginkgo:**
https://gitlab.spack.io/spack/spack-packages/-/jobs/18232450/
`/tmp/root/spack-stage/spack-stage-ginkgo-1.9.0-g57f2xii6e4mqdsfypjkojlm5txyok7e/spack-src/hip/base/config.hip.hpp:35:29: error: constexpr variable 'warp_size' must be initialized by a constant expression
   35 |     static constexpr uint32 warp_size = warpSize;`
There's been a change in the warpSize definition in ROCm 7.0 that is causing this error. Source:
https://github.com/ROCm/clr/blob/rocm-7.0.0/CHANGELOG.md?plain=1#L132

**hypre:**
`./_hypre_utilities.hpp:1336:6: error: static declaration of '__syncwarp' follows non-static declaration
 1336 | void __syncwarp()
      |      ^
/dockerx/spack/opt/spack/linux-zen2/hip-7.0.0-yuptvj4skm2s2prrmtyo7pht5auay4cl/include/hip/amd_detail/amd_warp_sync_functions.h:167:24: note: previous definition is here
  167 | __device__ inline void __syncwarp() {
      |                        ^
`
This error is due to a naming conflict in ROCm 7. https://github.com/ROCm/clr/blob/rocm-7.0.0/CHANGELOG.md?plain=1#L23

