### PR TITLE
gcc@14.2 macos build fix

### DIFF
--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -459,10 +459,11 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
             )
 
         # aarch64-darwin support from Iain Sandoe's branch
+        # the 14.2.0 branch has patches applicable to the x86_64 builds too, e.g., https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116809
         patch(
             "https://github.com/iains/gcc-14-branch/compare/04696df09633baf97cdbbdd6e9929b9d472161d3..a495b2dded281beeafec91074e4e82a5a3df8104.patch?full_index=1",
             sha256="838cf070bec5468340018bf003f714f6340c562b878f3244303d2b7ba9949ccd",
-            when="@14.2.0 target=aarch64:",
+            when="@14.2.0",
         )
         patch(
             "https://github.com/iains/gcc-14-branch/compare/cd0059a1976303638cea95f216de129334fc04d1..gcc-14.1-darwin-r1.patch?full_index=1",

--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -526,6 +526,9 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
 
         conflicts("+bootstrap", when="@11.3.0,13.1: target=aarch64:")
 
+        # 14.2.0 cannot bootstrap on x86_64
+        conflicts("+bootstrap", when="@14.2.0")
+
         # Use -headerpad_max_install_names in the build,
         # otherwise updated load commands won't fit in the Mach-O header.
         # This is needed because `gcc` avoids the superenv shim.

--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -1112,6 +1112,14 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
                 set_install_permissions(libgomp_spec_file)
                 tty.info(f"Wrote new libgomp spec file to {libgomp_spec_file}")
 
+    # The configure --sysroot doesn't propagate down into the sub-builds, e.g., libiberty.
+    # Starting with SDK 26 and clang 17, limits.h amongst other sys includes aren't included
+    # via other means, resulting in a failed build. Keep this for other builds for safety.
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        if sys.platform == "darwin":
+            macos_sdk_path = Executable("xcrun")("--show-sdk-path", output=str).strip()
+            env.set("CFLAGS", f"--sysroot {macos_sdk_path}")
+
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         if self.cc and self.spec.satisfies("languages=c"):
             env.set("CC", self.cc)

--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -1120,7 +1120,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     # Starting with SDK 26 and clang 17, limits.h amongst other sys includes aren't included
     # via other means, resulting in a failed build. Keep this for other builds for safety.
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        if sys.platform == "darwin":
+        if self.spec.satisfies("platform=darwin"):
             macos_sdk_path = Executable("xcrun")("--show-sdk-path", output=str).strip()
             env.set("CFLAGS", f"--sysroot {macos_sdk_path}")
 


### PR DESCRIPTION
Ensures `--sysroot` is propagated to sub-configures, fixes #1686

Although this is a new failure with clang 17+SDK26, imo it is worth keeping this env modification for previous clang/sdk versions.

/cc @haampie 
/cc @adamjstewart 
