### PR TITLE
fftw: Fix NEON usage on armv8+

### DIFF
--- a/repos/spack_repo/builtin/packages/fftw/package.py
+++ b/repos/spack_repo/builtin/packages/fftw/package.py
@@ -80,13 +80,13 @@ class FftwBase(AutotoolsPackage):
         # to check NEON.
         if self.spec.satisfies("target=m1:"):
             filter_file(
-                r" aarch64)",
-                r" aarch64 | arm)",
+                r" aarch64\)",
+                r" aarch64 | arm\)",
                 "configure",
             )
             filter_file(
-                r" aarch64)",
-                r" aarch64 | arm)",
+                r" aarch64\)",
+                r" aarch64 | arm\)",
                 "configure.ac",
             )
 

--- a/repos/spack_repo/builtin/packages/fftw/package.py
+++ b/repos/spack_repo/builtin/packages/fftw/package.py
@@ -79,16 +79,8 @@ class FftwBase(AutotoolsPackage):
         # On Apple Arm machines, configure uses arm rather than aarch64
         # to check NEON.
         if self.spec.satisfies("target=m1:"):
-            filter_file(
-                r" aarch64\)",
-                r" aarch64 | arm)",
-                "configure",
-            )
-            filter_file(
-                r" aarch64\)",
-                r" aarch64 | arm)",
-                "configure.ac",
-            )
+            filter_file(r" aarch64\)", r" aarch64 | arm)", "configure")
+            filter_file(r" aarch64\)", r" aarch64 | arm)", "configure.ac")
 
     def autoreconf(self, spec, prefix):
         if spec.satisfies("+pfft_patches"):

--- a/repos/spack_repo/builtin/packages/fftw/package.py
+++ b/repos/spack_repo/builtin/packages/fftw/package.py
@@ -80,12 +80,12 @@ class FftwBase(AutotoolsPackage):
         # to check NEON.
         if self.spec.satisfies("target=m1:"):
             filter_file(
-                r"\saarch64)",
+                r" aarch64)",
                 r" aarch64 | arm)",
                 "configure",
             )
             filter_file(
-                r"\saarch64)",
+                r" aarch64)",
                 r" aarch64 | arm)",
                 "configure.ac",
             )

--- a/repos/spack_repo/builtin/packages/fftw/package.py
+++ b/repos/spack_repo/builtin/packages/fftw/package.py
@@ -123,9 +123,13 @@ class FftwBase(AutotoolsPackage):
 
         # Specific SIMD support.
         # all precisions
-        simd_features = ["sse2", "avx", "avx2", "avx512", "avx-128-fma", "kcvi", "vsx"]
+        simd_features = ["sse2", "avx", "avx2", "avx512", "avx-128-fma", "kcvi", "vsx", "asimd"]
         # float only
         float_simd_features = ["altivec", "sse", "neon"]
+
+        # aarchv8 introduced asimd to replace neon feature
+        if "asimd" in spec.target:
+            float_simd_features.remove("neon")
 
         # Workaround NVIDIA/PGI compiler bug when avx512 is enabled
         if spec.satisfies("%nvhpc"):
@@ -145,7 +149,11 @@ class FftwBase(AutotoolsPackage):
         simd_options = []
         for feature in simd_features:
             msg = "--enable-{0}" if feature in spec.target else "--disable-{0}"
-            simd_options.append(msg.format(feature))
+            feature_opt = feature
+            # CPU feature is asimd but neon used in option.
+            if feature == "asimd":
+                feature_opt = "neon"
+            simd_options.append(msg.format(feature_opt))
 
         # If no features are found, enable the generic ones
         if not any(f in spec.target for f in simd_features + float_simd_features):

--- a/repos/spack_repo/builtin/packages/fftw/package.py
+++ b/repos/spack_repo/builtin/packages/fftw/package.py
@@ -76,6 +76,20 @@ class FftwBase(AutotoolsPackage):
         if os.path.isfile("fftw/config.h"):
             os.rename("fftw/config.h", "fftw/config.h.SPACK_RENAMED")
 
+        # On Apple Arm machines, configure uses arm rather than aarch64
+        # to check NEON.
+        if self.spec.satisfies("target=m1:"):
+            filter_file(
+                r"\saarch64)",
+                r" aarch64 | arm)",
+                "configure",
+            )
+            filter_file(
+                r"\saarch64)",
+                r" aarch64 | arm)",
+                "configure.ac",
+            )
+
     def autoreconf(self, spec, prefix):
         if spec.satisfies("+pfft_patches"):
             autoreconf = which("autoreconf")
@@ -120,6 +134,9 @@ class FftwBase(AutotoolsPackage):
                 options.insert(0, "CFLAGS=" + self.compiler.openmp_flag)
         if spec.satisfies("+mpi"):
             options.append("--enable-mpi")
+
+        if spec.satisfies("target=aarch64:"):
+            options.append("--enable-armv8-cntvct-el0")
 
         # Specific SIMD support.
         # all precisions

--- a/repos/spack_repo/builtin/packages/fftw/package.py
+++ b/repos/spack_repo/builtin/packages/fftw/package.py
@@ -81,12 +81,12 @@ class FftwBase(AutotoolsPackage):
         if self.spec.satisfies("target=m1:"):
             filter_file(
                 r" aarch64\)",
-                r" aarch64 | arm\)",
+                r" aarch64 | arm)",
                 "configure",
             )
             filter_file(
                 r" aarch64\)",
-                r" aarch64 | arm\)",
+                r" aarch64 | arm)",
                 "configure.ac",
             )
 

--- a/repos/spack_repo/builtin/packages/fftw/package.py
+++ b/repos/spack_repo/builtin/packages/fftw/package.py
@@ -76,12 +76,6 @@ class FftwBase(AutotoolsPackage):
         if os.path.isfile("fftw/config.h"):
             os.rename("fftw/config.h", "fftw/config.h.SPACK_RENAMED")
 
-        # On Apple Arm machines, configure uses arm rather than aarch64
-        # to check NEON.
-        if self.spec.satisfies("target=m1:"):
-            filter_file(r" aarch64\)", r" aarch64 | arm)", "configure")
-            filter_file(r" aarch64\)", r" aarch64 | arm)", "configure.ac")
-
     def autoreconf(self, spec, prefix):
         if spec.satisfies("+pfft_patches"):
             autoreconf = which("autoreconf")
@@ -111,6 +105,13 @@ class FftwBase(AutotoolsPackage):
         # Base options
         options = ["--prefix={0}".format(prefix), "--enable-threads"]
         options.extend(self.enable_or_disable("shared"))
+
+        # On Apple Arm machines, force to use aarch64 rather than arm
+        # to check for NEON due to logic in configure.
+        if self.spec.satisfies("target=m1:"):
+            uname = Executable("uname")
+            uname_r = uname("-r", output=str)
+            options.append("--build=aarch64-apple-darwin{0}".format(uname_r))
 
         if not self.compiler.f77 or not self.compiler.fc:
             options.append("--disable-fortran")

--- a/repos/spack_repo/builtin/packages/fftw/package.py
+++ b/repos/spack_repo/builtin/packages/fftw/package.py
@@ -127,7 +127,7 @@ class FftwBase(AutotoolsPackage):
         # float only
         float_simd_features = ["altivec", "sse", "neon"]
 
-        # aarchv8 introduced asimd to replace neon feature
+        # armv8 introduced asimd to replace neon feature
         if "asimd" in spec.target:
             float_simd_features.remove("neon")
 


### PR DESCRIPTION
It looks like NEON was not being enabled on armv8+ due to "neon" CPU feature moving to "asimd".  If "asimd" is available we can enable NEON for float and double precision.

Tested as part of a wider test of the SVE patch in https://github.com/FFTW/fftw3/pull/315 where there is still a wait on 3.3.11 version of FFTW which should include this.  Without NEON enabled the performance improvement with the SVE patch was not as expected which led to discovering this issue.

Improved timer with `--enable-armv8-cntvct-el0` could also be used on armv8.

Example output from tests in fftw

Current version
```
$ ./bench -v2 -r 20 -s ocf2048
planner time: 0.001217 s
(dft-ct-dit/32
  (dftw-direct-32/62 "t1_32")
  (dft-direct-64-x32 "n1_64"))
flops: 47616 add, 11904 mul, 9344 fma
estimated cost: 78208.000000, pcost = 78208.000000
Problem: ocf2048, setup: 1.25 ms, time: 7.56 us, ``mflops'': 14897.431
Took 20 measurements for at least 10.00 ms each.
Time: min 7.56 us, max 7.62 us, avg 7.57 us, median 7.57 us
```

With fix (using Nvidia Grace CPU Superchip - neoverse-v2)
```
$ ./bench -v2 -r 20 -s ocf2048
planner time: 0.002544 s
(dft-ct-dit/32
  (dftw-direct-32/124 "t2fv_32_neon")
  (dft-direct-64-x32 "n2fv_64_neon"))
flops: 25792 add, 7936 mul, 2688 fma
estimated cost: 39104.000000, pcost = 39104.000000
Problem: ocf2048, setup: 2.57 ms, time: 5.66 us, ``mflops'': 19890.216
Took 20 measurements for at least 10.00 ms each.
Time: min 5.66 us, max 5.67 us, avg 5.67 us, median 5.67 us
```
