### PR TITLE
pkgconfig: virtual has no version

### DIFF
--- a/repos/spack_repo/builtin/packages/elfutils/package.py
+++ b/repos/spack_repo/builtin/packages/elfutils/package.py
@@ -82,7 +82,7 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
     depends_on("gettext", when="+nls")
     depends_on("iconv")
     depends_on("m4", type="build")
-    depends_on("pkgconfig@0.9.0:", type=("build", "link"))
+    depends_on("pkgconfig", type=("build", "link"))
 
     # debuginfod has extra dependencies
     with when("+debuginfod"), default_args(type="link"):

--- a/repos/spack_repo/builtin/packages/fontconfig/package.py
+++ b/repos/spack_repo/builtin/packages/fontconfig/package.py
@@ -32,7 +32,7 @@ class Fontconfig(AutotoolsPackage):
     depends_on("freetype")
     depends_on("gperf", type="build", when="@2.11.1:")
     depends_on("libxml2@2.6:")
-    depends_on("pkgconfig@0.9:", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("font-util")
     depends_on("uuid", when="@2.13.1:")
     depends_on("python@3:", type="build", when="@2.13.93:")

--- a/repos/spack_repo/builtin/packages/gdal/package.py
+++ b/repos/spack_repo/builtin/packages/gdal/package.py
@@ -257,7 +257,7 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
 
     # Required dependencies
     # Versions come from gdal_check_package in cmake/helpers/CheckDependentLibraries.cmake
-    depends_on("pkgconfig@0.25:", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("proj@6.3.1:", when="@3.9:")
     depends_on("proj@6:")
     depends_on("zlib-api")

--- a/repos/spack_repo/builtin/packages/gtk_doc/package.py
+++ b/repos/spack_repo/builtin/packages/gtk_doc/package.py
@@ -35,7 +35,7 @@ class GtkDoc(AutotoolsPackage):
     depends_on("itstool", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
-    depends_on("pkgconfig@0.19:", type=("build", "run"))
+    depends_on("pkgconfig", type=("build", "run"))
 
     depends_on("python@3.2:", type=("build", "run"))
     depends_on("py-pygments", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/imagemagick/package.py
+++ b/repos/spack_repo/builtin/packages/imagemagick/package.py
@@ -55,7 +55,7 @@ class Imagemagick(AutotoolsPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    depends_on("pkgconfig@0.20:", type="build")
+    depends_on("pkgconfig", type="build")
 
     depends_on("fontconfig@2.1:")
     depends_on("freetype@2.8:")

--- a/repos/spack_repo/builtin/packages/libnsl/package.py
+++ b/repos/spack_repo/builtin/packages/libnsl/package.py
@@ -32,7 +32,7 @@ class Libnsl(AutotoolsPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
-    depends_on("pkgconfig@0.9.0:", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("gettext")
     depends_on("rpcsvc-proto")
     depends_on("libtirpc")

--- a/repos/spack_repo/builtin/packages/libwnck/package.py
+++ b/repos/spack_repo/builtin/packages/libwnck/package.py
@@ -48,7 +48,7 @@ class Libwnck(MesonPackage, AutotoolsPackage):
     )
 
     with default_args(type="build"):
-        depends_on("pkgconfig@0.9.0:")
+        depends_on("pkgconfig")
         depends_on("gettext", when="@3.31:")
         depends_on("intltool@0.40.6:", when="@:3.24")
         depends_on("cmake", when="build_system=meson")

--- a/repos/spack_repo/builtin/packages/libxfce4util/package.py
+++ b/repos/spack_repo/builtin/packages/libxfce4util/package.py
@@ -31,7 +31,7 @@ class Libxfce4util(AutotoolsPackage):
         depends_on("gettext", when="@4.18:")
 
     with default_args(type=("run", "link", "build")):
-        depends_on("pkgconfig@0.9.0:")
+        depends_on("pkgconfig")
         depends_on("glib@2")
         depends_on("gobject-introspection", when="+introspection")
         depends_on("vala", when="+vala")

--- a/repos/spack_repo/builtin/packages/libxkbcommon/package.py
+++ b/repos/spack_repo/builtin/packages/libxkbcommon/package.py
@@ -52,7 +52,7 @@ class Libxkbcommon(MesonPackage, AutotoolsPackage):
     depends_on("meson@0.49:", type="build", when="@1.0:")
     depends_on("meson@0.51:", type="build", when="@1.5:")
     depends_on("meson@0.52:", type="build", when="@1.6:")
-    depends_on("pkgconfig@0.9.0:", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("bison", type="build")
     depends_on("util-macros")
     depends_on("xkbdata-api")

--- a/repos/spack_repo/builtin/packages/libxml2/package.py
+++ b/repos/spack_repo/builtin/packages/libxml2/package.py
@@ -77,7 +77,7 @@ class Libxml2(AutotoolsPackage, CMakePackage, NMakePackage):
 
     depends_on("c", type="build")
 
-    depends_on("pkgconfig@0.9.0:", type="build", when="build_system=autotools")
+    depends_on("pkgconfig", type="build", when="build_system=autotools")
     # conditional on non Windows, but rather than specify for each platform
     # specify for non Windows builder, which has equivalent effect
     depends_on("iconv", when="build_system=autotools")

--- a/repos/spack_repo/builtin/packages/libxslt/package.py
+++ b/repos/spack_repo/builtin/packages/libxslt/package.py
@@ -42,7 +42,7 @@ class Libxslt(AutotoolsPackage):
 
     depends_on("c", type="build")
 
-    depends_on("pkgconfig@0.9.0:", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("iconv")
     depends_on("libxml2")
     depends_on("libxml2+python", when="+python")

--- a/repos/spack_repo/builtin/packages/pango/package.py
+++ b/repos/spack_repo/builtin/packages/pango/package.py
@@ -52,7 +52,7 @@ class Pango(MesonPackage):
     depends_on("meson@0.55.3:", type="build", when="@1.48.1:")
     depends_on("meson@0.60:", type="build", when="@1.50.13:")
     depends_on("meson@0.63:", type="build", when="@1.54:")
-    depends_on("pkgconfig@0.9.0:", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("harfbuzz")
     depends_on("harfbuzz+coretext", when="platform=darwin")
     depends_on("cairo+ft+fc")

--- a/repos/spack_repo/builtin/packages/pdf2svg/package.py
+++ b/repos/spack_repo/builtin/packages/pdf2svg/package.py
@@ -21,7 +21,7 @@ class Pdf2svg(AutotoolsPackage):
 
     depends_on("c", type="build")  # generated
 
-    depends_on("pkgconfig@0.9.0:", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("cairo@1.2.6:")
     depends_on("cairo@1.16:", when="@0.2.4:")
     depends_on("poppler@0.5.4:+glib")

--- a/repos/spack_repo/builtin/packages/procps/package.py
+++ b/repos/spack_repo/builtin/packages/procps/package.py
@@ -37,7 +37,7 @@ class Procps(AutotoolsPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
-    depends_on("pkgconfig@0.9.0:", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("dejagnu", type="test")
     depends_on("iconv")
     depends_on("gettext", type="build")  # required by autogen.sh

--- a/repos/spack_repo/builtin/packages/proj/package.py
+++ b/repos/spack_repo/builtin/packages/proj/package.py
@@ -133,7 +133,7 @@ class Proj(CMakePackage, AutotoolsPackage):
         depends_on("cmake@2.6:", when="@:4", type="build")
 
     with when("build_system=autotools"):
-        depends_on("pkgconfig@0.9:", when="@6:", type="build")
+        depends_on("pkgconfig", when="@6:", type="build")
 
     depends_on("sqlite@3.11:", when="@6:")
     depends_on("libtiff@4:", when="@7:+tiff")

--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -157,7 +157,7 @@ class Python(Package):
 
     if sys.platform != "win32":
         depends_on("gmake", type="build")
-        depends_on("pkgconfig@0.9.0:", type="build")
+        depends_on("pkgconfig", type="build")
         depends_on("gettext +libxml2", when="+libxml2")
         depends_on("gettext ~libxml2", when="~libxml2")
 

--- a/repos/spack_repo/builtin/packages/watch/package.py
+++ b/repos/spack_repo/builtin/packages/watch/package.py
@@ -28,7 +28,7 @@ class Watch(AutotoolsPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
-    depends_on("pkgconfig@0.9.0:", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("gettext", type="build")
     depends_on("ncurses")
 


### PR DESCRIPTION
Remove version bounds on the `pkgconfig` virtual, because no versions
are defined for the "api" by `pkg-config` and `pkgconf`.

If these were meant to be `pkg-config` lowerbounds, they're redundant,
cause all we have is 0.28 and higher.