### PR TITLE
scotch: add determinism variant

### DIFF
--- a/repos/spack_repo/builtin/packages/scotch/package.py
+++ b/repos/spack_repo/builtin/packages/scotch/package.py
@@ -63,6 +63,13 @@ class Scotch(CMakePackage, MakefilePackage):
         when="@7.0.1",
         description="Link error handling library to libscotch/libptscotch",
     )
+    variant(
+        "determinism",
+        default="FULL",
+        values=("NONE", "FIXED_SEED", "FULL"),
+        multi=False,
+        description="Determinism configuration",
+    )
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
@@ -151,6 +158,9 @@ class CMakeBuilder(cmake.CMakeBuilder):
         if self.pkg.version > Version("7.0.4"):
             args.append(self.define("ENABLE_TESTS", self.pkg.run_tests))
 
+        if self.pkg.version >= Version("7.0.7"):
+            args.append(self.define_from_variant("SCOTCH_DETERMINISTIC", "determinism"))
+
         if "+int64" in self.spec:
             args.append("-DINTSIZE=64")
         elif self.is_64bit():
@@ -174,7 +184,14 @@ class MakefileBuilder(makefile.MakefileBuilder):
 
     def edit(self, pkg, spec, prefix):
         makefile_inc = []
-        cflags = ["-O3", "-DCOMMON_RANDOM_FIXED_SEED", "-DSCOTCH_DETERMINISTIC", "-DSCOTCH_RENAME"]
+        cflags = ["-O3", "-DSCOTCH_RENAME"]
+
+        if "determinism=FIXED_SEED" in self.spec:
+            cflags.append("-DCOMMON_RANDOM_FIXED_SEED")
+
+        if "determinism=FULL" in self.spec:
+            cflags.append("-DCOMMON_RANDOM_FIXED_SEED")
+            cflags.append("-DSCOTCH_DETERMINISTIC")
 
         # SCOTCH_Num typedef: size of integers in arguments
         # SCOTCH_Idx typedef: indices for addressing

--- a/repos/spack_repo/builtin/packages/scotch/package.py
+++ b/repos/spack_repo/builtin/packages/scotch/package.py
@@ -69,6 +69,15 @@ class Scotch(CMakePackage, MakefilePackage):
         values=("NONE", "FIXED_SEED", "FULL"),
         multi=False,
         description="Determinism configuration",
+        when="build_system=makefile",
+    )
+    variant(
+        "determinism",
+        default="FIXED_SEED",
+        values=("NONE", "FIXED_SEED", "FULL"),
+        multi=False,
+        description="Determinism configuration",
+        when="@7.0.7: build_system=cmake",
     )
 
     depends_on("c", type="build")
@@ -155,10 +164,10 @@ class CMakeBuilder(cmake.CMakeBuilder):
             self.define_from_variant("MPI_THREAD_MULTIPLE", "mpi_thread"),
         ]
 
-        if self.pkg.version > Version("7.0.4"):
+        if self.spec.satisfies("@7.0.5:"):
             args.append(self.define("ENABLE_TESTS", self.pkg.run_tests))
 
-        if self.pkg.version >= Version("7.0.7"):
+        if self.spec.satisfies("@7.0.7:"):
             args.append(self.define_from_variant("SCOTCH_DETERMINISTIC", "determinism"))
 
         if "+int64" in self.spec:


### PR DESCRIPTION
From Scotch CMake build guide:

```
  - SCOTCH_DETERMINISTIC:STRING (default value FIXED_SEED): set this
    flag to NONE to use faster, non-deterministic algorithms in
    Scotch, and a variable random seed; FIXED_SEED to use these
    algorithms with a fixed random seed; FULL, to use fully
    deterministic algorithms with a fixed random string, enabling
    fully deterministic behavior with any number of threads and the
    same number of MPI processes. These three levels are obtained by a
    combination of the Make compilation flags
    "-DCOMMON_RANDOM_FIXED_SEED" and "-DSCOTCH_DETERMINISTIC"; see
    sections 3.9) and 3.10) of this document.

```

Scotch CMake defaults to `FIXED_SEED`, but we often need to build with full determinism. Hence, makes sense to expose this option as a Spack variant.