### PR TITLE
py-gcovr: depends on python 3.9: when 8.3:

### DIFF
--- a/repos/spack_repo/builtin/packages/py_gcovr/package.py
+++ b/repos/spack_repo/builtin/packages/py_gcovr/package.py
@@ -22,6 +22,7 @@ class PyGcovr(PythonPackage):
     version("5.2", sha256="217195085ec94346291a87b7b1e6d9cfdeeee562b3e0f9a32b25c9530b3bce8f")
     version("4.2", sha256="5aae34dc81e51600cfecbbbce3c3a80ce3f7548bc0aa1faa4b74ecd18f6fca3f")
 
+    depends_on("python@3.9:", when="@8.3:", type=("build", "run"))
     depends_on("python@3.8:", when="@7.2:", type=("build", "run"))
     depends_on("python@3.7:", when="@5.1:", type=("build", "run"))
     depends_on("python@3.6:", when="@5.0", type=("build", "run"))


### PR DESCRIPTION
Missing dependency constraint for latest version of py-gcovr. See the py-gcovr changelog: https://gcovr.com/en/stable/changelog.html#january-2025