### PR TITLE
Add metatensor-torch v0.8.1

### DIFF
--- a/repos/spack_repo/builtin/packages/libmetatensor_torch/package.py
+++ b/repos/spack_repo/builtin/packages/libmetatensor_torch/package.py
@@ -18,6 +18,7 @@ class LibmetatensorTorch(CMakePackage):
     license("BSD-3-Clause", checked_by="HaoZeke")
 
     version("0.8.0", sha256="61d383ce958deafe0e3916088185527680c9118588722b17ec5c39cfbaa6da55")
+    version("0.8.1", sha256="9da124e8e09dc1859700723a76ff29aef7a216b84a19d38746cc45bf45bc599b")
 
     depends_on("cmake@3.16:", type="build")
     depends_on("cxx", type="build")

--- a/repos/spack_repo/builtin/packages/py_metatensor_core/package.py
+++ b/repos/spack_repo/builtin/packages/py_metatensor_core/package.py
@@ -7,7 +7,7 @@ from spack_repo.builtin.build_systems.python import PythonPackage
 from spack.package import *
 
 # Necessary to pin each version to libmetatensor
-VERSION_MAP = {"0.1.17": "98708f89a37652016ee508e307f824f3ca63307b85829de17ba6d2558f0b3b3b"}
+VERSIONS = {"0.1.17": "98708f89a37652016ee508e307f824f3ca63307b85829de17ba6d2558f0b3b3b"}
 
 
 class PyMetatensorCore(PythonPackage):
@@ -24,7 +24,7 @@ class PyMetatensorCore(PythonPackage):
     depends_on("python@3.9:", type=("run", "build"))
     depends_on("py-numpy", type=("run", "build"))
 
-    for ver, sha in VERSION_MAP.items():
+    for ver, sha in VERSIONS.items():
         version(ver, sha256=sha)
         depends_on(f"libmetatensor@{ver}", when=f"@{ver}")
 

--- a/repos/spack_repo/builtin/packages/py_metatensor_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_metatensor_torch/package.py
@@ -8,6 +8,11 @@ from spack_repo.builtin.build_systems.python import PythonPackage
 
 from spack.package import *
 
+VERSIONS = {
+    "0.8.0": "240ea8c37328f6bb61ec9f3e482131f0875c73166a0e349a8dd8b85204c58bd7",
+    "0.8.1": "11986d4c2964054baae9fe10ffc36c6a6ba70a78d97b406cb6c2e14e72a0cf72",
+}
+
 
 class PyMetatensorTorch(PythonPackage):
     """Torchscript bindings for metatensor"""
@@ -20,8 +25,9 @@ class PyMetatensorTorch(PythonPackage):
     maintainers("HaoZeke", "luthaf", "rmeli")
     license("BSD-3-Clause", checked_by="HaoZeke")
 
-    version("0.8.0", sha256="240ea8c37328f6bb61ec9f3e482131f0875c73166a0e349a8dd8b85204c58bd7")
-    version("0.8.1", sha256="11986d4c2964054baae9fe10ffc36c6a6ba70a78d97b406cb6c2e14e72a0cf72")
+    for ver, sha256 in VERSIONS.items():
+        version(ver, sha256=sha256)
+        depends_on(f"libmetatensor-torch@{ver}", when=f"@{ver}")
 
     depends_on("py-torch@2.1:", type=("build", "run"))
     depends_on("py-metatensor-core@0.1.13:0.1", type=("build", "run"))
@@ -31,6 +37,9 @@ class PyMetatensorTorch(PythonPackage):
     depends_on("py-setuptools@77:", type="build")
     depends_on("py-packaging@23:", type="build")
     depends_on("cmake@3.16:", type="build")
+
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        env.set("METATENSOR_TORCH_PYTHON_USE_EXTERNAL_LIB", "ON")
 
     @run_after("install")
     def workaround(self):

--- a/repos/spack_repo/builtin/packages/py_metatensor_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_metatensor_torch/package.py
@@ -21,6 +21,7 @@ class PyMetatensorTorch(PythonPackage):
     license("BSD-3-Clause", checked_by="HaoZeke")
 
     version("0.8.0", sha256="240ea8c37328f6bb61ec9f3e482131f0875c73166a0e349a8dd8b85204c58bd7")
+    version("0.8.1", sha256="11986d4c2964054baae9fe10ffc36c6a6ba70a78d97b406cb6c2e14e72a0cf72")
 
     depends_on("py-torch@2.1:", type=("build", "run"))
     depends_on("py-metatensor-core@0.1.13:0.1", type=("build", "run"))


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Adds the new release of metatensor-torch to spack; and make sure to build the `py-metatensor-torch` package using the library from `libmetatensor-torch`