### PR TITLE
tsne-cuda: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/tsne_cuda/fix_cmakelists.patch
+++ b/repos/spack_repo/builtin/packages/tsne_cuda/fix_cmakelists.patch
@@ -1,0 +1,86 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 128d72a..9d70cd7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -58,6 +58,7 @@ if(NOT DEFINED CMAKE_CUDA_STANDARD)
+     set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+ endif()
+ 
++if(NOT DEFINED CUDA_ARCH)
+ if(CUDAToolkit_VERSION_MAJOR EQUAL "10")
+     set(CUDA_ARCH
+         -gencode=arch=compute_30,code=sm_30
+@@ -106,7 +107,7 @@ else()
+         -gencode=arch=compute_61,code=sm_61
+         )
+ endif()
+-
++endif()
+ 
+ set(CUDA_OPTS
+     -O3
+@@ -157,6 +158,10 @@ if(NOT ${GPU_FAISS_FOUND})
+ endif()
+ include_directories(${FAISS_INCLUDE_DIR})
+ 
++#-------------------------------------------------------------------------------
++# cxxopts configuration
++find_package(cxxopts CONFIG REQUIRED)
++
+ # Project Setup
+ #-------------------------------------------------------------------------------
+ include_directories(
+@@ -164,7 +169,6 @@ include_directories(
+     src/include
+     ${CUDA_INCLUDE_DIRS}
+     third_party/
+-    third_party/cxxopts/include/
+     ${ZMQ_INCLUDE_DIR}
+ )
+ link_directories(
+@@ -212,7 +216,7 @@ add_library(tsnecuda SHARED ${SOURCES})
+ # set_property(TARGET tsnecuda PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+ target_link_libraries(tsnecuda PRIVATE
+     gflags
+-    gtest
++    GTest::gtest
+     CUDA::cudart
+     CUDA::cublas
+     # CUDA::cublasLt
+@@ -220,12 +224,14 @@ target_link_libraries(tsnecuda PRIVATE
+     CUDA::cufftw
+     CUDA::cusparse
+     OpenMP::OpenMP_CXX
++    cxxopts::cxxopts
+     pthread
+-    -Wl,--allow-multiple-definition
+     ${ZMQ_LIBRARIES}
+     ${FAISS_LIBRARIES}
+ )
+ 
++target_link_options(tsnecuda PRIVATE -Wl,--allow-multiple-definition)
++
+ # BLAS configuration
+ #-------------------------------------------------------------------------------
+ find_package(MKL)
+@@ -244,8 +250,19 @@ endif()
+ # Main executable
+ #-------------------------------------------------------------------------------
+ add_executable(tsne src/exe/main.cu)
+-target_link_libraries(tsne tsnecuda)
++target_link_libraries(tsne PRIVATE
++    cxxopts::cxxopts
++    tsnecuda
++)
+ 
++#-------------------------------------------------------------------------------
++# Install target
++#-------------------------------------------------------------------------------
++install(TARGETS tsne tsnecuda
++        RUNTIME DESTINATION bin
++        LIBRARY DESTINATION lib
++	ARCHIVE DESTINATION lib/static
++)
+ #-------------------------------------------------------------------------------
+ # Python library copy and build
+ #-------------------------------------------------------------------------------

--- a/repos/spack_repo/builtin/packages/tsne_cuda/package.py
+++ b/repos/spack_repo/builtin/packages/tsne_cuda/package.py
@@ -5,6 +5,7 @@
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.python import PythonExtension
+
 from spack.package import *
 
 
@@ -27,11 +28,10 @@ class TsneCuda(CMakePackage, CudaPackage, PythonExtension):
 
     patch("fix_cmakelists.patch")
 
-
     depends_on("c", type="build")  # you'll get linker errors otherwise
     depends_on("cxx", type="build")
 
-    depends_on("cmake@3.20:3.30") # CMake 3.31 messes a bit too much with find CUDA
+    depends_on("cmake@3.20:3.30")  # CMake 3.31 messes a bit too much with find CUDA
     depends_on("cuda@9:")
     depends_on("blas")
     depends_on("lapack")

--- a/repos/spack_repo/builtin/packages/tsne_cuda/package.py
+++ b/repos/spack_repo/builtin/packages/tsne_cuda/package.py
@@ -1,0 +1,66 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems.cuda import CudaPackage
+from spack_repo.builtin.build_systems.python import PythonExtension
+from spack.package import *
+
+
+class TsneCuda(CMakePackage, CudaPackage, PythonExtension):
+    """tsne-cuda is an optimized CUDA version of FIt-SNE algorithm with
+    associated python modules. We find that our implementation of t-SNE can be
+    up to 1200x faster than Sklearn, or up to 50x faster than Multicore-TSNE
+    when used with the right GPU. The paper describing our approach, as well as
+    the results below, is available at https://arxiv.org/abs/1807.11824."""
+
+    homepage = "https://github.com/CannyLab/tsne-cuda/"
+    url = "https://github.com/CannyLab/tsne-cuda/archive/refs/tags/3.0.1.tar.gz"
+
+    maintainers("Markus92")
+
+    license("BSD-3-Clause", checked_by="Markus92")
+
+    version("3.0.1", sha256="0f778247191f483df22dc4dbed792c9a6a9152ee7404329c4d9da3fd9a8774d6")
+    version("3.0.0", sha256="6f5a0c5c0c54a4a74837e0e84fa37396ca6912a2031bdf6e846d5c01254e3e2c")
+
+    patch("fix_cmakelists.patch")
+
+
+    depends_on("c", type="build")  # you'll get linker errors otherwise
+    depends_on("cxx", type="build")
+
+    depends_on("cmake@3.20:3.30") # CMake 3.31 messes a bit too much with find CUDA
+    depends_on("cuda@9:")
+    depends_on("blas")
+    depends_on("lapack")
+    depends_on("gflags@2.2:")
+    depends_on("googletest@1.10:", type=("build", "link", "run"))
+    depends_on("faiss@1.6.5: +cuda +shared", type=("build", "run"))
+    depends_on("cxxopts")
+
+    variant("cuda", default=True, description="Use CUDA acceleration")
+    conflicts("~cuda", msg="Cuda is mandatory")
+    conflicts(
+        "cuda_arch=none",
+        when="+cuda",
+        msg="Must specify CUDA compute capabilities of your GPU, see "
+        "https://developer.nvidia.com/cuda-gpus",
+    )
+
+    variant("python", default=False, description="Install Python bindings.")
+
+    extends("python", when="+python")
+    depends_on("python@3.6:", when="+python")
+    depends_on("py-numpy@1.14.1:", when="+python")
+
+    def cmake_args(self):
+        cuda_arch = self.spec.variants["cuda_arch"].value
+        cuda_gencode = " ".join(self.cuda_flags(cuda_arch))
+
+        args = []
+        args.append(self.define("FAISS_GPU_INCLUDE_DIR", self.spec["faiss"].libs))
+        args.append(self.define_from_variant("BUILD_PYTHON", "python"))
+        args.append(self.define("CUDA_ARCH", cuda_gencode))
+        return args


### PR DESCRIPTION
tsnecuda is a CUDA implementation of the TSNE algorithm. It's a dependency of Relion; it will build/run without this package but eventually give up when you try to use functionality depending on it.

A few patches to CMakeLists.txt are included (all in one .patch file): the first is as because it hardcodes the CUDA compute architectures a little too hard for my taste, not really fitting with Spack philosophy and breaking if you use Cuda 12/13; second is to use Spack's version of cxxopts instead of a submodule from 2018; third is to add an install target.