### PR TITLE
py-scifem: add v0.14.0 and fix build/link dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/py_scifem/package.py
+++ b/repos/spack_repo/builtin/packages/py_scifem/package.py
@@ -22,7 +22,7 @@ class PyScifem(PythonPackage):
     license("MIT", checked_by="jorgensd")
 
     version("main", branch="main")
-    version("0.12.0", sha256="d866d6d87277e8f541c336730d49fdcce9e3576252f855d051f9739b1ff0abb9")
+    version("0.13.1", sha256="8c5570c0a0184a1c44cfca1bf3427bebb0d72181251989ef62ecaeb2fd0ef957")
     version("0.7.0", sha256="016556573a05d2bebb983017c41427d906df870633d23e5bd9d68af8d4b81de2")
     version("0.6.0", sha256="548c9af8997537bc6830c898a9ffe7007dda16b5e40f3240c97e646cfd0a30b3")
     version("0.5.0", sha256="1e5978ab97889c2d6bad80e375c9db1b050bfb68c197eada17928e6908f15372")

--- a/repos/spack_repo/builtin/packages/py_scifem/package.py
+++ b/repos/spack_repo/builtin/packages/py_scifem/package.py
@@ -22,7 +22,7 @@ class PyScifem(PythonPackage):
     license("MIT", checked_by="jorgensd")
 
     version("main", branch="main")
-    version("0.11.1", sha256="369110e55fe51e32d38ff5708d79bd582ffb4034518830baebb2baeaa062784e")
+    version("0.12.0", sha256="d866d6d87277e8f541c336730d49fdcce9e3576252f855d051f9739b1ff0abb9")
     version("0.7.0", sha256="016556573a05d2bebb983017c41427d906df870633d23e5bd9d68af8d4b81de2")
     version("0.6.0", sha256="548c9af8997537bc6830c898a9ffe7007dda16b5e40f3240c97e646cfd0a30b3")
     version("0.5.0", sha256="1e5978ab97889c2d6bad80e375c9db1b050bfb68c197eada17928e6908f15372")
@@ -40,11 +40,15 @@ class PyScifem(PythonPackage):
     depends_on("py-scikit-build-core+pyproject", type="build")
     depends_on("py-setuptools@42:", type="build")
     depends_on("cmake@3.21:", type="build")
+    depends_on("fenics-dolfinx@0.9:", when="@0.4:", type=("build", "link"))
+    depends_on("fenics-dolfinx@main", when="@main", type=("build", "link"))
+    depends_on("fenics-basix@0.9:", when="@0.4:", type=("build", "link"))
+    depends_on("fenics-basix@main", when="@main", type=("build", "link"))
 
     depends_on("py-fenics-dolfinx@0.9:", when="@0.4:", type="run")
     depends_on("py-fenics-dolfinx@main", when="@main", type="run")
-    depends_on("py-numpy", type=("run"))
-    depends_on("py-packaging", type=("run"))
+    depends_on("py-numpy", type="run")
+    depends_on("py-packaging", type="run")
 
     with when("+adios2"):
         depends_on("adios2+python", type="run")

--- a/repos/spack_repo/builtin/packages/py_scifem/package.py
+++ b/repos/spack_repo/builtin/packages/py_scifem/package.py
@@ -22,7 +22,7 @@ class PyScifem(PythonPackage):
     license("MIT", checked_by="jorgensd")
 
     version("main", branch="main")
-    version("0.13.1", sha256="8c5570c0a0184a1c44cfca1bf3427bebb0d72181251989ef62ecaeb2fd0ef957")
+    version("0.14.0", sha256="a875311cdd21f1c6395be67c0220df2f03e52a3571041eb75deef0972d511cbb")
     version("0.7.0", sha256="016556573a05d2bebb983017c41427d906df870633d23e5bd9d68af8d4b81de2")
     version("0.6.0", sha256="548c9af8997537bc6830c898a9ffe7007dda16b5e40f3240c97e646cfd0a30b3")
     version("0.5.0", sha256="1e5978ab97889c2d6bad80e375c9db1b050bfb68c197eada17928e6908f15372")
@@ -40,10 +40,10 @@ class PyScifem(PythonPackage):
     depends_on("py-scikit-build-core+pyproject", type="build")
     depends_on("py-setuptools@42:", type="build")
     depends_on("cmake@3.21:", type="build")
-    depends_on("fenics-dolfinx@0.9:", when="@0.4:", type=("build", "link"))
     depends_on("fenics-dolfinx@main", when="@main", type=("build", "link"))
-    depends_on("fenics-basix@0.9:", when="@0.4:", type=("build", "link"))
+    depends_on("fenics-dolfinx@0.9:", when="@0.4:", type=("build", "link"))
     depends_on("fenics-basix@main", when="@main", type=("build", "link"))
+    depends_on("fenics-basix@0.9:", when="@0.4:", type=("build", "link"))
 
     depends_on("py-fenics-dolfinx@0.9:", when="@0.4:", type="run")
     depends_on("py-fenics-dolfinx@main", when="@main", type="run")

--- a/repos/spack_repo/builtin/packages/py_scifem/package.py
+++ b/repos/spack_repo/builtin/packages/py_scifem/package.py
@@ -43,7 +43,7 @@ class PyScifem(PythonPackage):
 
     depends_on("py-fenics-dolfinx@0.9:", when="@0.4:", type="run")
     depends_on("py-fenics-dolfinx@main", when="@main", type="run")
-    depends_on("py-numpy@1.20:", type=("run"))
+    depends_on("py-numpy", type=("run"))
     depends_on("py-packaging", type=("run"))
 
     with when("+adios2"):

--- a/repos/spack_repo/builtin/packages/py_scifem/package.py
+++ b/repos/spack_repo/builtin/packages/py_scifem/package.py
@@ -22,6 +22,7 @@ class PyScifem(PythonPackage):
     license("MIT", checked_by="jorgensd")
 
     version("main", branch="main")
+    version("0.11.0", sha256="93e99a10439f1b2619ffb8113649c817958132a1d04741359b55912da7d7cb9e")
     version("0.7.0", sha256="016556573a05d2bebb983017c41427d906df870633d23e5bd9d68af8d4b81de2")
     version("0.6.0", sha256="548c9af8997537bc6830c898a9ffe7007dda16b5e40f3240c97e646cfd0a30b3")
     version("0.5.0", sha256="1e5978ab97889c2d6bad80e375c9db1b050bfb68c197eada17928e6908f15372")

--- a/repos/spack_repo/builtin/packages/py_scifem/package.py
+++ b/repos/spack_repo/builtin/packages/py_scifem/package.py
@@ -22,7 +22,7 @@ class PyScifem(PythonPackage):
     license("MIT", checked_by="jorgensd")
 
     version("main", branch="main")
-    version("0.11.0", sha256="93e99a10439f1b2619ffb8113649c817958132a1d04741359b55912da7d7cb9e")
+    version("0.11.1", sha256="369110e55fe51e32d38ff5708d79bd582ffb4034518830baebb2baeaa062784e")
     version("0.7.0", sha256="016556573a05d2bebb983017c41427d906df870633d23e5bd9d68af8d4b81de2")
     version("0.6.0", sha256="548c9af8997537bc6830c898a9ffe7007dda16b5e40f3240c97e646cfd0a30b3")
     version("0.5.0", sha256="1e5978ab97889c2d6bad80e375c9db1b050bfb68c197eada17928e6908f15372")


### PR DESCRIPTION
Skipping intermediate releases.