### PR TITLE
MSVC: Retool vcvars environmental setup approach with ARM considerations

### DIFF
--- a/repos/spack_repo/builtin/packages/msvc/package.py
+++ b/repos/spack_repo/builtin/packages/msvc/package.py
@@ -2,7 +2,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os.path
+import platform
 import re
+import struct
 import subprocess
 
 from spack_repo.builtin.build_systems import compiler
@@ -144,8 +146,39 @@ class Msvc(Package, CompilerPackage):
         env_cmds = []
         compiler_root = os.path.join(os.path.dirname(self.cc), "../../../../../..")
         vcvars_script_path = os.path.join(compiler_root, "Auxiliary", "Build", "vcvarsall.bat")
+
         # get current platform architecture and format for vcvars argument
-        arch = spack.vendor.archspec.cpu.host().family.name
+        # vcvars target/host arch arguments are in the form of
+        # host-arc_target-arch, so in vcvars terms x86_64 is not the 64bit
+        # extension of x86, it's a 32bit host with a 64bit target, which, will
+        # run on a 64bit host, but is not accurate, and doesn't scale to arm.
+        # compose a proper vcvars arch string
+        
+        # get spec target
+        spec_target_arch = self.spec.target.family.name
+        # get host bitness
+        host_machine_type = platform.machine().lower()
+
+        # generic check for arm arch
+        check_arm = lambda x: "arm" in x or "aarch" in x
+
+        # establish host arch and bit
+        host_is_arm = check_arm(host_machine_type)
+        host_is_64bit = struct.calcsize('P')*8 == 64
+        # establish target arch and bit
+        target_is_arm = check_arm(spec_target_arch)
+        target_is_64bit = "64" in spec_target_arch
+
+        def compute_arch(is64bit, is_arm):
+            if is_arm:
+                return "arm64" if is64bit else "arm"
+            return "x64" if is64bit else "x86"
+        # convert understanding of target and host to vcvars terms
+        host_arch = compute_arch(host_is_64bit, host_is_arm)
+        target_arch = compute_arch(target_is_64bit, target_is_arm)
+        # vcvars target host string
+        arch = f"{host_arch}_{target_arch}"
+
         msvc_version = Version(re.search(Msvc.compiler_version_regex, self.cc).group(1))
         self.vcvars_call = VCVarsInvocation(vcvars_script_path, arch, msvc_version)
         env_cmds.append(self.vcvars_call)

--- a/repos/spack_repo/builtin/packages/msvc/package.py
+++ b/repos/spack_repo/builtin/packages/msvc/package.py
@@ -140,13 +140,21 @@ class Msvc(Package, CompilerPackage):
         # compiler.
         # Spack first finds the compilers via VSWHERE
         # and stores their path, but their respective VCVARS
-        # file must be invoked before useage.
+        # file must be invoked before useage. 
         env_cmds = []
         compiler_root = os.path.join(os.path.dirname(self.cc), "../../../../../..")
-        vcvars_script_path = os.path.join(compiler_root, "Auxiliary", "Build", "vcvars64.bat")
+        vcvars_script_path = os.path.join(compiler_root, "Auxiliary", "Build", "vcvarsall.bat")
         # get current platform architecture and format for vcvars argument
         arch = host_platform().default.lower()
-        arch = arch.replace("-", "_")
+        x86_64 = "x86_64"
+        host_map = {
+            "x86-64": x86_64,
+            "x86-64-v2": x86_64,
+            "x86-64-v3": x86_64,
+
+
+        }
+
         if self.spec.satisfies("target=x86_64:"):
             arch = "amd64"
 

--- a/repos/spack_repo/builtin/packages/msvc/package.py
+++ b/repos/spack_repo/builtin/packages/msvc/package.py
@@ -142,7 +142,7 @@ class Msvc(Package, CompilerPackage):
         # compiler.
         # Spack first finds the compilers via VSWHERE
         # and stores their path, but their respective VCVARS
-        # file must be invoked before useage. 
+        # file must be invoked before useage.
         env_cmds = []
         compiler_root = os.path.join(os.path.dirname(self.cc), "../../../../../..")
         vcvars_script_path = os.path.join(compiler_root, "Auxiliary", "Build", "vcvarsall.bat")
@@ -153,7 +153,7 @@ class Msvc(Package, CompilerPackage):
         # extension of x86, it's a 32bit host with a 64bit target, which, will
         # run on a 64bit host, but is not accurate, and doesn't scale to arm.
         # compose a proper vcvars arch string
-        
+
         # get spec target
         spec_target_arch = self.spec.target.family.name
         # get host bitness
@@ -164,7 +164,7 @@ class Msvc(Package, CompilerPackage):
 
         # establish host arch and bit
         host_is_arm = check_arm(host_machine_type)
-        host_is_64bit = struct.calcsize('P')*8 == 64
+        host_is_64bit = struct.calcsize("P") * 8 == 64
         # establish target arch and bit
         target_is_arm = check_arm(spec_target_arch)
         target_is_64bit = "64" in spec_target_arch
@@ -173,6 +173,7 @@ class Msvc(Package, CompilerPackage):
             if is_arm:
                 return "arm64" if is64bit else "arm"
             return "x64" if is64bit else "x86"
+
         # convert understanding of target and host to vcvars terms
         host_arch = compute_arch(host_is_64bit, host_is_arm)
         target_arch = compute_arch(target_is_64bit, target_is_arm)

--- a/repos/spack_repo/builtin/packages/msvc/package.py
+++ b/repos/spack_repo/builtin/packages/msvc/package.py
@@ -145,19 +145,7 @@ class Msvc(Package, CompilerPackage):
         compiler_root = os.path.join(os.path.dirname(self.cc), "../../../../../..")
         vcvars_script_path = os.path.join(compiler_root, "Auxiliary", "Build", "vcvarsall.bat")
         # get current platform architecture and format for vcvars argument
-        arch = host_platform().default.lower()
-        x86_64 = "x86_64"
-        host_map = {
-            "x86-64": x86_64,
-            "x86-64-v2": x86_64,
-            "x86-64-v3": x86_64,
-
-
-        }
-
-        if self.spec.satisfies("target=x86_64:"):
-            arch = "amd64"
-
+        arch = spack.vendor.archspec.cpu.host().family.name
         msvc_version = Version(re.search(Msvc.compiler_version_regex, self.cc).group(1))
         self.vcvars_call = VCVarsInvocation(vcvars_script_path, arch, msvc_version)
         env_cmds.append(self.vcvars_call)


### PR DESCRIPTION
Arm support is becoming more widespread on Windows, as such our vcvars handling needs an update.

Previously we assumed invoking `vcvars64.bat` would properly construct a 64bit environment, but it does not handle ARM, so we must instead invoke the generic `vcvarsall.bat` environmental setup script with properly constructed arguments to properly handle both ARM and amd/intel architectures. 

We now construct the arch argument we give to vcvarsall a bit more carefully as well.
Typically `x86_64` means "the 64bit extension of the x86 ISA", however with VCVARS, that string means "compile for 64bit with a 32bit host running the 32bit compiler", so we must translate the vcvars invocations in Spack to use the correct specification for 64bit host and 64bit target, with handling for arm. 
To do this, we determine the host bitness and intel/arm, and then compose the two values together with an underscore as vcvarsall expects.