### PR TITLE
simsipm: Add conflict for aarch64

### DIFF
--- a/repos/spack_repo/builtin/packages/simsipm/package.py
+++ b/repos/spack_repo/builtin/packages/simsipm/package.py
@@ -43,7 +43,12 @@ class Simsipm(CMakePackage):
     depends_on("python@3.6:", when="+python", type=("build", "run"))
     depends_on("py-pybind11", when="+python", type=("build", "link"))
 
-    conflicts("arch=aarch64", msg="package uses x86 internals and does not support aarch64")
+    conflicts("arch=aarch64", msg="SimSiPM < 2.1.0 uses x86 internals and does not support aarch64", when="@:2.0")
+    patch(
+        "https://github.com/EdoPro98/SimSiPM/commit/b08cc27151d70298b43ca7e216add9e46c056b04.patch?full_index=1",
+        sha256="354208cd110976a948e4770d7ae086cff367cef74534d07c22524f107ffbb7fd",
+        when="@2.1.0",
+    )
 
     def cmake_args(self):
         args = [

--- a/repos/spack_repo/builtin/packages/simsipm/package.py
+++ b/repos/spack_repo/builtin/packages/simsipm/package.py
@@ -43,6 +43,8 @@ class Simsipm(CMakePackage):
     depends_on("python@3.6:", when="+python", type=("build", "run"))
     depends_on("py-pybind11", when="+python", type=("build", "link"))
 
+    conflicts("arch=aarch64", msg="package uses x86 internals and does not support aarch64")
+
     def cmake_args(self):
         args = [
             self.define("CMAKE_CXX_STANDARD", self.spec.variants["cxxstd"].value),

--- a/repos/spack_repo/builtin/packages/simsipm/package.py
+++ b/repos/spack_repo/builtin/packages/simsipm/package.py
@@ -43,7 +43,11 @@ class Simsipm(CMakePackage):
     depends_on("python@3.6:", when="+python", type=("build", "run"))
     depends_on("py-pybind11", when="+python", type=("build", "link"))
 
-    conflicts("arch=aarch64", msg="SimSiPM < 2.1.0 uses x86 internals and does not support aarch64", when="@:2.0")
+    conflicts(
+        "arch=aarch64",
+        msg="SimSiPM < 2.1.0 uses x86 internals and does not support aarch64",
+        when="@:2.0",
+    )
     patch(
         "https://github.com/EdoPro98/SimSiPM/commit/b08cc27151d70298b43ca7e216add9e46c056b04.patch?full_index=1",
         sha256="354208cd110976a948e4770d7ae086cff367cef74534d07c22524f107ffbb7fd",


### PR DESCRIPTION
Package uses x86intrin.h header which makes it incompatible with aarch64

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
