### PR TITLE
emacs: remove +strip requirement for gcc dep when +native

### DIFF
--- a/repos/spack_repo/builtin/packages/emacs/package.py
+++ b/repos/spack_repo/builtin/packages/emacs/package.py
@@ -88,7 +88,7 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
     # Optional dependencies
     depends_on("gnutls", when="+tls")
     depends_on("tree-sitter", when="+treesitter")
-    depends_on("gcc@11: +strip languages=jit", when="+native")
+    depends_on("gcc@11: languages=jit", when="+native")
     depends_on("jansson@2.7:", when="+json")
 
     # GUI dependencies


### PR DESCRIPTION
Fixes #1163.

I don't remember the history for why emacs was depending on `gcc +strip`. Removing it here so that users can make use of their Spack built compilers as a dependency for Emacs.