### PR TITLE
mpibind: add support for NVIDIA's Grace Hopper architecture

### DIFF
--- a/repos/spack_repo/builtin/packages/hwloc/package.py
+++ b/repos/spack_repo/builtin/packages/hwloc/package.py
@@ -39,6 +39,7 @@ class Hwloc(AutotoolsPackage, CudaPackage, ROCmPackage):
     executables = ["^hwloc-bind$"]
 
     version("master", branch="master")
+    version("2.12.2", sha256="ff7d309fdff7ceddfe15c1e79eaff25f3126a134f29f44d4e85571f187a6bab8")
     version("2.11.1", sha256="9f320925cfd0daeaf3a3d724c93e127ecac63750c623654dca0298504aac4c2c")
     version("2.10.0", sha256="c7fd8a1404a9719c76aadc642864b9f77aed1dc1fc8882d6af861a9260ba240d")
     version("2.9.3", sha256="5985db3a30bbe51234c2cd26ebe4ae9b4c3352ab788b1a464c40c0483bf4de59")

--- a/repos/spack_repo/builtin/packages/mpibind/package.py
+++ b/repos/spack_repo/builtin/packages/mpibind/package.py
@@ -3,8 +3,11 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import sys
+
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+
 from spack.package import *
+
 
 class Mpibind(AutotoolsPackage):
     """A portable runtime library that automatically maps
@@ -25,33 +28,28 @@ class Mpibind(AutotoolsPackage):
     # AC_INIT would be missing the version argument,
     # which is derived with git.
     version("master", branch="master", get_full_repo=True)
-    version("0.23.0", commit="7d23407726004c7092a20ebdf6e9661f020b4ae7",
-            no_cache=True)
-    version("0.22.0", commit="7181024843b110074ad87009a7a671bb666f90a4",
-            no_cache=True)
-    version("0.21.0", commit="e8dca93adff52d464bffe7281f7ac0c3a63be4c0",
-            no_cache=True)
-    version("0.20.0", commit="8cd20ed9353a69336415193da90d86de789b1e3c",
-            no_cache=True)
+    version("0.23.0", commit="7d23407726004c7092a20ebdf6e9661f020b4ae7", no_cache=True)
+    version("0.22.0", commit="7181024843b110074ad87009a7a671bb666f90a4", no_cache=True)
+    version("0.21.0", commit="e8dca93adff52d464bffe7281f7ac0c3a63be4c0", no_cache=True)
+    version("0.20.0", commit="8cd20ed9353a69336415193da90d86de789b1e3c", no_cache=True)
 
-    version("0.8.0", commit="ff38b9dcd150ca1e8a8796835d8e1e1847b3ba68",
-            no_cache=True, deprecated=True)
-    version("0.7.0", commit="3c437a97cd841b9c13abfbe1062a0285e1a29d3e",
-            no_cache=True, deprecated=True)
-    version("0.5.0", commit="8698f07412232e4dd4de4802b508374dc0de48c9",
-            no_cache=True, deprecated=True)
+    version(
+        "0.8.0", commit="ff38b9dcd150ca1e8a8796835d8e1e1847b3ba68", no_cache=True, deprecated=True
+    )
+    version(
+        "0.7.0", commit="3c437a97cd841b9c13abfbe1062a0285e1a29d3e", no_cache=True, deprecated=True
+    )
+    version(
+        "0.5.0", commit="8698f07412232e4dd4de4802b508374dc0de48c9", no_cache=True, deprecated=True
+    )
 
     # mpibind does not depend on CUDA or ROCm, but uses
     # these variants to configure hwloc accordingly
-    variant("cuda", default=False,
-            description="Build with support for NVIDIA GPUs")
-    variant("rocm", default=False,
-            description="Build with support for AMD GPUs")
+    variant("cuda", default=False, description="Build with support for NVIDIA GPUs")
+    variant("rocm", default=False, description="Build with support for AMD GPUs")
 
-    variant("flux", default=False,
-            description="Build the Flux plugin")
-    variant("python", default=False,
-            description="Build the Python bindings")
+    variant("flux", default=False, description="Build the Flux plugin")
+    variant("python", default=False, description="Build the Python bindings")
 
     # See slurm dependency below
     # variant("slurm", default=False,
@@ -67,26 +65,21 @@ class Mpibind(AutotoolsPackage):
     depends_on("pkgconfig", type="build")
 
     depends_on("hwloc@2:+libxml2", type="link")
-    depends_on("hwloc@2:+pci", type="link",
-               when=(sys.platform != "darwin"))
+    depends_on("hwloc@2:+pci", type="link", when=(sys.platform != "darwin"))
 
-    depends_on("hwloc@2: +cuda +nvml", type="link",
-               when="+cuda")
-    depends_on("hwloc@2.4: +rocm +opencl", type="link",
-               when="@:0.19 +rocm")
-    depends_on("hwloc@2.4: +rocm", type="link",
-               when="@0.20: +rocm")
+    depends_on("hwloc@2: +cuda +nvml", type="link", when="+cuda")
+    depends_on("hwloc@2.4: +rocm +opencl", type="link", when="@:0.19 +rocm")
+    depends_on("hwloc@2.4: +rocm", type="link", when="@0.20: +rocm")
 
     # Need mpibind v0.23+ and hwloc v2.12+ for NV Grace Hopper
-    depends_on("hwloc@2.12: +cuda +nvml", type="link",
-               when="@0.23: +cuda target=neoverse_v2:")
-    conflicts("@:0.22 +cuda target=neoverse_v2:",
-              msg="version 0.23+ is needed for NVIDIA Grace Hopper")
+    depends_on("hwloc@2.12: +cuda +nvml", type="link", when="@0.23: +cuda target=neoverse_v2:")
+    conflicts(
+        "@:0.22 +cuda target=neoverse_v2:", msg="version 0.23+ is needed for NVIDIA Grace Hopper"
+    )
 
     # flux-core >= 0.30.0 supports FLUX_SHELL_RC_PATH,
     # which is needed to load the plugin into Flux
-    depends_on("flux-core@0.30:", type="link",
-               when="+flux")
+    depends_on("flux-core@0.30:", type="link", when="+flux")
 
     # The slurm spack package does not provide
     # slurm.pc (pkgconf). If mpibind can't find
@@ -98,10 +91,8 @@ class Mpibind(AutotoolsPackage):
     # depends_on("slurm", type="link",
     #            when="+slurm")
 
-    depends_on("python@3:", type=("build", "run"),
-               when="+python")
-    depends_on("py-cffi", type=("build", "run"),
-               when="+python")
+    depends_on("python@3:", type=("build", "run"), when="+python")
+    depends_on("py-cffi", type=("build", "run"), when="+python")
 
     def autoreconf(self, spec, prefix):
         autoreconf("--install", "--verbose", "--force")
@@ -109,8 +100,7 @@ class Mpibind(AutotoolsPackage):
     @when("+flux")
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         """Load the mpibind plugin into Flux"""
-        env.prepend_path("FLUX_SHELL_RC_PATH",
-                         join_path(self.prefix, "share", "mpibind"))
+        env.prepend_path("FLUX_SHELL_RC_PATH", join_path(self.prefix, "share", "mpibind"))
 
     # To build and run the C unit tests, make sure 'libtap'
     # is installed and recognized by pkgconfig.

--- a/repos/spack_repo/builtin/packages/mpibind/package.py
+++ b/repos/spack_repo/builtin/packages/mpibind/package.py
@@ -41,17 +41,21 @@ class Mpibind(AutotoolsPackage):
     version("0.5.0", commit="8698f07412232e4dd4de4802b508374dc0de48c9",
             no_cache=True, deprecated=True)
 
+    # mpibind does not depend on CUDA or ROCm, but uses
+    # these variants to configure hwloc accordingly
     variant("cuda", default=False,
             description="Build with support for NVIDIA GPUs")
     variant("rocm", default=False,
             description="Build with support for AMD GPUs")
+
     variant("flux", default=False,
             description="Build the Flux plugin")
+    variant("python", default=False,
+            description="Build the Python bindings")
+
     # See slurm dependency below
     # variant("slurm", default=False,
     #         description="Build the Slurm plugin")
-    variant("python", default=False,
-            description="Build the Python bindings")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/mpibind/package.py
+++ b/repos/spack_repo/builtin/packages/mpibind/package.py
@@ -3,17 +3,15 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import sys
-
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
-
 from spack.package import *
 
-
 class Mpibind(AutotoolsPackage):
-    """A memory-driven algorithm to map parallel codes
-    to heterogeneous architectures"""
+    """A portable runtime library that automatically maps
+    parallel applications to heterogeneous hardware architectures,
+    optimizing resource affinity for CPUs, GPUs, and memory"""
 
-    homepage = "https://github.com/LLNL/mpibind"
+    homepage = "https://mpibind.llnl.gov"
     git = "https://github.com/LLNL/mpibind.git"
 
     maintainers("eleon")
@@ -27,14 +25,33 @@ class Mpibind(AutotoolsPackage):
     # AC_INIT would be missing the version argument,
     # which is derived with git.
     version("master", branch="master", get_full_repo=True)
-    version("0.8.0", commit="ff38b9dcd150ca1e8a8796835d8e1e1847b3ba68", no_cache=True)
-    version("0.7.0", commit="3c437a97cd841b9c13abfbe1062a0285e1a29d3e", no_cache=True)
-    version("0.5.0", commit="8698f07412232e4dd4de4802b508374dc0de48c9", no_cache=True)
+    version("0.23.0", commit="7d23407726004c7092a20ebdf6e9661f020b4ae7",
+            no_cache=True)
+    version("0.22.0", commit="7181024843b110074ad87009a7a671bb666f90a4",
+            no_cache=True)
+    version("0.21.0", commit="e8dca93adff52d464bffe7281f7ac0c3a63be4c0",
+            no_cache=True)
+    version("0.20.0", commit="8cd20ed9353a69336415193da90d86de789b1e3c",
+            no_cache=True)
 
-    variant("cuda", default=False, description="Build w/support for NVIDIA GPUs.")
-    variant("rocm", default=False, description="Build w/support for AMD GPUs.")
-    variant("flux", default=False, description="Build the Flux plugin.")
-    variant("python", default=False, description="Build the Python bindings.")
+    version("0.8.0", commit="ff38b9dcd150ca1e8a8796835d8e1e1847b3ba68",
+            no_cache=True, deprecated=True)
+    version("0.7.0", commit="3c437a97cd841b9c13abfbe1062a0285e1a29d3e",
+            no_cache=True, deprecated=True)
+    version("0.5.0", commit="8698f07412232e4dd4de4802b508374dc0de48c9",
+            no_cache=True, deprecated=True)
+
+    variant("cuda", default=False,
+            description="Build with support for NVIDIA GPUs")
+    variant("rocm", default=False,
+            description="Build with support for AMD GPUs")
+    variant("flux", default=False,
+            description="Build the Flux plugin")
+    # See slurm dependency below
+    # variant("slurm", default=False,
+    #         description="Build the Slurm plugin")
+    variant("python", default=False,
+            description="Build the Python bindings")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
@@ -46,16 +63,41 @@ class Mpibind(AutotoolsPackage):
     depends_on("pkgconfig", type="build")
 
     depends_on("hwloc@2:+libxml2", type="link")
-    depends_on("hwloc@2:+cuda+nvml", type="link", when="+cuda")
-    depends_on("hwloc@2.4:+rocm+opencl", type="link", when="+rocm")
-    depends_on("hwloc@2:+pci", type="link", when=(sys.platform != "darwin"))
+    depends_on("hwloc@2:+pci", type="link",
+               when=(sys.platform != "darwin"))
+
+    depends_on("hwloc@2: +cuda +nvml", type="link",
+               when="+cuda")
+    depends_on("hwloc@2.4: +rocm +opencl", type="link",
+               when="@:0.19 +rocm")
+    depends_on("hwloc@2.4: +rocm", type="link",
+               when="@0.20: +rocm")
+
+    # Need mpibind v0.23+ and hwloc v2.12+ for NV Grace Hopper
+    depends_on("hwloc@2.12: +cuda +nvml", type="link",
+               when="@0.23: +cuda target=neoverse_v2")
+    conflicts("@:0.22 +cuda target=neoverse_v2",
+              msg="version 0.23+ is needed for NVIDIA Grace Hopper")
 
     # flux-core >= 0.30.0 supports FLUX_SHELL_RC_PATH,
     # which is needed to load the plugin into Flux
-    depends_on("flux-core@0.30:", when="+flux", type="link")
+    depends_on("flux-core@0.30:", type="link",
+               when="+flux")
 
-    depends_on("python@3:", when="+python", type=("build", "run"))
-    depends_on("py-cffi", when="+python", type=("build", "run"))
+    # The slurm spack package does not provide
+    # slurm.pc (pkgconf). If mpibind can't find
+    # slurm's includedir, the plugin won't be built.
+    # If slurm.pc is provided by slurm at some point,
+    # uncomment the dependency below, otherwise,
+    # make sure this works:
+    #   pkg-config --variable=includedir slurm
+    # depends_on("slurm", type="link",
+    #            when="+slurm")
+
+    depends_on("python@3:", type=("build", "run"),
+               when="+python")
+    depends_on("py-cffi", type=("build", "run"),
+               when="+python")
 
     def autoreconf(self, spec, prefix):
         autoreconf("--install", "--verbose", "--force")
@@ -63,7 +105,8 @@ class Mpibind(AutotoolsPackage):
     @when("+flux")
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         """Load the mpibind plugin into Flux"""
-        env.prepend_path("FLUX_SHELL_RC_PATH", join_path(self.prefix, "share", "mpibind"))
+        env.prepend_path("FLUX_SHELL_RC_PATH",
+                         join_path(self.prefix, "share", "mpibind"))
 
     # To build and run the C unit tests, make sure 'libtap'
     # is installed and recognized by pkgconfig.

--- a/repos/spack_repo/builtin/packages/mpibind/package.py
+++ b/repos/spack_repo/builtin/packages/mpibind/package.py
@@ -75,8 +75,8 @@ class Mpibind(AutotoolsPackage):
 
     # Need mpibind v0.23+ and hwloc v2.12+ for NV Grace Hopper
     depends_on("hwloc@2.12: +cuda +nvml", type="link",
-               when="@0.23: +cuda target=neoverse_v2")
-    conflicts("@:0.22 +cuda target=neoverse_v2",
+               when="@0.23: +cuda target=neoverse_v2:")
+    conflicts("@:0.22 +cuda target=neoverse_v2:",
               msg="version 0.23+ is needed for NVIDIA Grace Hopper")
 
     # flux-core >= 0.30.0 supports FLUX_SHELL_RC_PATH,


### PR DESCRIPTION
mpibind v0.23+ and hwloc v2.12+ are necessary to support NVIDIA's Grace Hopper. 
