### PR TITLE
gsl: fix external cblas

### DIFF
--- a/repos/spack_repo/builtin/packages/gsl/package.py
+++ b/repos/spack_repo/builtin/packages/gsl/package.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import re
+import os
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack_repo.builtin.build_systems.gnu import GNUMirrorPackage
@@ -65,9 +66,15 @@ class Gsl(AutotoolsPackage, GNUMirrorPackage):
     def configure_args(self):
         configure_args = []
         if self.spec.satisfies("+external-cblas"):
+
+            inc = self.spec["blas"].headers.include_flags
+            # openblas can install the headers into include/openblas which trips up the autoconf
+            if self.spec["blas"].name == "openblas":
+                inc = os.path.join(inc, "openblas")
+
             configure_args.append("--with-cblas-external")
-            configure_args.append("CBLAS_CFLAGS=%s" % self.spec["blas"].headers.include_flags)
-            configure_args.append("CBLAS_LIBS=%s" % self.spec["blas"].libs.ld_flags)
+            configure_args.append(f"CBLAS_CFLAGS={inc}")
+            configure_args.append(f"CBLAS_LIBS={self.spec["blas"].libs.ld_flags}")
 
         configure_args.extend(self.enable_or_disable("shared"))
         configure_args.extend(self.with_or_without("pic"))

--- a/repos/spack_repo/builtin/packages/gsl/package.py
+++ b/repos/spack_repo/builtin/packages/gsl/package.py
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import re
 import os
+import re
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack_repo.builtin.build_systems.gnu import GNUMirrorPackage

--- a/repos/spack_repo/builtin/packages/gsl/package.py
+++ b/repos/spack_repo/builtin/packages/gsl/package.py
@@ -73,8 +73,8 @@ class Gsl(AutotoolsPackage, GNUMirrorPackage):
                 inc = os.path.join(inc, "openblas")
 
             configure_args.append("--with-cblas-external")
-            configure_args.append(f"CBLAS_CFLAGS={inc}")
-            configure_args.append(f"CBLAS_LIBS={self.spec["blas"].libs.ld_flags}")
+            configure_args.append("CBLAS_CFLAGS=%s" % inc)
+            configure_args.append("CBLAS_LIBS=%s" % self.spec["blas"].libs.ld_flags)
 
         configure_args.extend(self.enable_or_disable("shared"))
         configure_args.extend(self.with_or_without("pic"))

--- a/repos/spack_repo/builtin/packages/openblas/package.py
+++ b/repos/spack_repo/builtin/packages/openblas/package.py
@@ -315,7 +315,7 @@ class Openblas(CMakePackage, MakefilePackage):
         # headers either included in one of these two headers, or included in
         # one of the source files implementing functions declared in these
         # headers.
-        return find_headers(["cblas", "lapacke"], self.prefix.include)
+        return find_headers(["cblas", "lapacke"], self.prefix.include, recursive=True)
 
     @property
     def libs(self):


### PR DESCRIPTION
The cblas find doesn't seem to reliably work when an openblas virtual is used because openblas puts `cblas.h` into `prefix/include/openblas` which the patch doesn't handle. 

```
     156    checking for cblas.h... no
  >> 157    configure: error:
     158    	   	*** Header file cblas.h not found.
     159    	   	*** If you installed cblas header in a non standard place,
     160    	   	*** specify its install prefix using the following option
     161    	   	***  --with-cblas-external-cflags="-I<include_dir>"
```

This PR checks the virtual being used and appends the correct openblas suffix


@cessenat @mathomp4