### PR TITLE
meson: deprecate superseded point releases

### DIFF
--- a/repos/spack_repo/builtin/packages/meson/package.py
+++ b/repos/spack_repo/builtin/packages/meson/package.py
@@ -22,10 +22,7 @@ class Meson(PythonPackage):
     license("Apache-2.0")
 
     version("1.8.5", sha256="1cd0b5b013b4208ab450f5aca93b592b707f3fb2afe96b101dc710e6e5a8245c")
-    version("1.8.4", sha256="57dfa56ead471eec31d624d76c819e743a4dd0f6e8b4cd503e63d97604d11c2c")
-    version("1.8.2", sha256="6b878fb0f6f0318cbd54e13539f89a1a8305791668e8e93ffd59d82722888dac")
     version("1.7.2", sha256="3640ef596523393100df31ba790bc5fe732215e9711a66b673a21c4eb39bc8f1")
-    version("1.7.0", sha256="a6ca46e2a11a0278bb6492ecd4e0520ff441b164ebfdef1e012b11beb848d26e")
     version("1.6.1", sha256="4889795777b536ea1a351982f3ef7c7b06a786ccb47036daba63cc5757c59edb")
     version("1.5.2", sha256="fb41882bef26ffc02647d9978cba502a4accdf2e94c0a6dc9cc498dd7463381e")
     version("1.4.2", sha256="11d1336fe35e1ade57510a846a31d7dc2e3b6ac1e2491c2831bce5a2a192ba0d")
@@ -33,6 +30,11 @@ class Meson(PythonPackage):
     version("1.2.2", sha256="1caa0ef6082e311bdca9836e7907f548b8c3f041a42ed41f0ff916b83ac7dddd")
     version("1.1.1", sha256="1c3b9e1a3a36b51adb5de498d582fd5cbf6763fadbcf151de9f2a762e02bd2e6")
     version("1.0.2", sha256="1f1239c3091668643f7d2086663d6afd8cc87fbab84fe7462bc18b9ba6d65de8")
+
+    with default_args(deprecated=True):
+        version("1.8.4", sha256="57dfa56ead471eec31d624d76c819e743a4dd0f6e8b4cd503e63d97604d11c2c")
+        version("1.8.2", sha256="6b878fb0f6f0318cbd54e13539f89a1a8305791668e8e93ffd59d82722888dac")
+        version("1.7.0", sha256="a6ca46e2a11a0278bb6492ecd4e0520ff441b164ebfdef1e012b11beb848d26e")
 
     depends_on("py-setuptools@42:", type=("build", "run"))
     depends_on("ninja@1.8.2:", type="run")


### PR DESCRIPTION
Per usual, assume that a feature release line with multiple bugfix releases does not need every bugfix release.

As a special example, meson 1.8.* was a story in "we released a daring refactor and then had repeated regressions fixed over the course of several bugfix releases". You *really* do not want to be using 1.8.2 at this point.

1.8.4 is "probably safe", as that was the specific version to include a particularly large series of bugfixes, but... why chance it if users can be encouraged to prefer 1.8.5 instead?

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
