### PR TITLE
r: add missing dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/r/package.py
+++ b/repos/spack_repo/builtin/packages/r/package.py
@@ -44,6 +44,7 @@ class R(AutotoolsPackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
+    depends_on("findutils", type="build")
 
     depends_on("blas")
     requires("^openblas symbol_suffix=none", when="^openblas")


### PR DESCRIPTION
Without the dependency I get the following error
```
make[4]: Entering directory '/tmp/root/spack-stage/spack-stage-r-4.5.1-jyawigifezy4pmovmqlqoqxci7i2id75/spack-src/spack-build/src/library/translations'
make[4]: Leaving directory '/tmp/root/spack-stage/spack-stage-r-4.5.1-jyawigifezy4pmovmqlqoqxci7i2id75/spack-src/spack-build/src/library/translations'
make[3]: *** [Makefile:23: all] Error 127
```

Caused by this line (line 23) in src/library/translations/Makefile
```
        @find "$(top_builddir)/library/$(pkg)" -name .svn -type d -prune \
            -exec rm -Rf \{\} \; 2>/dev/null
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
