### PR TITLE
acts dependencies: new versions as of 2025/09/29

### DIFF
--- a/repos/spack_repo/builtin/packages/acts_algebra_plugins/package.py
+++ b/repos/spack_repo/builtin/packages/acts_algebra_plugins/package.py
@@ -18,6 +18,8 @@ class ActsAlgebraPlugins(CMakePackage):
 
     license("MPL-2.0", checked_by="stephenswat")
 
+    version("0.30.0", sha256="fd3aa003d2091e8d4bd1ef1d9df78bed281a662d803f5ae747a3e16d263dc978")
+    version("0.29.0", sha256="ea3f6ed44a6770b64eb202471f79b3567ef62fda74af824a0f557e5364f2171a")
     version("0.28.0", sha256="d798ba2129bf922f54627233ef947b8bb2345db9199e3868cc48bc1da86d5f15")
     version("0.27.0", sha256="c2081b399b7f4e004bebd5bf8250ed9596b113002fe445bca7fdac24d2c5932c")
     version("0.26.2", sha256="0170f22e1a75493b86464f27991117bc2c5a9d52554c75786e321d4c591990e7")

--- a/repos/spack_repo/builtin/packages/detray/package.py
+++ b/repos/spack_repo/builtin/packages/detray/package.py
@@ -21,6 +21,9 @@ class Detray(CMakePackage):
 
     license("MPL-2.0", checked_by="stephenswat")
 
+    version("0.103.0", sha256="7b3d3c94cf42be7450e9fe008b567a2f425e6f1986b61d8a3a66814383599043")
+    version("0.102.0", sha256="534848b5d5d25c33dffd35a48cda04b24aea03c7c13d0c1240ad73ef06765368")
+    version("0.101.0", sha256="f13db54da9b888258ab73a963d5a4bc08b655cc4aef47935e486b7cbe43e0965")
     version("0.100.1", sha256="5e68986889ae083503b3506015c649a0dcf1eadbeec642bb7749ee91c9fca201")
     version("0.100.0", sha256="a34686403807db822dc71f2bc61b9d72e9837a525b22c0b86c6452bf9ec7b0e4")
     version("0.99.0", sha256="86baa957ec55e8eecb5a9dffe135b88265dd0f88f75bf0068c9068ea304c0fb5")
@@ -89,7 +92,9 @@ class Detray(CMakePackage):
     depends_on("cmake@3.21:", type="build", when="@0.95:")
     depends_on("vecmem@1.6.0:")
     depends_on("vecmem@1.8.0:", when="@0.76:")
+    depends_on("vecmem@1.18.0:", when="@0.102:")
     depends_on("covfie@0.10.0:")
+    depends_on("covfie@0.15.3:", when="@0.102:")
     depends_on("nlohmann-json@3.11.0:", when="+json")
     depends_on("dfelibs@20211029:", when="@:0.88")
     depends_on("acts-algebra-plugins@0.18.0: +vecmem")
@@ -99,6 +104,7 @@ class Detray(CMakePackage):
     # The version number of algebra plugins was not correct before v0.28.0.
     depends_on("acts-algebra-plugins@0.28.0:", when="@0.87:")
     depends_on("acts-algebra-plugins@0.28.0: +vecmem", when="@0.95:")
+    depends_on("acts-algebra-plugins@0.30.0: +vecmem", when="@0.103:")
 
     # Detray imposes requirements on the C++ standard values used by Algebra
     # Plugins.

--- a/repos/spack_repo/builtin/packages/vecmem/package.py
+++ b/repos/spack_repo/builtin/packages/vecmem/package.py
@@ -19,6 +19,8 @@ class Vecmem(CMakePackage, CudaPackage):
 
     license("MPL-2.0-no-copyleft-exception")
 
+    version("1.20.0", sha256="73c817b2a1a0961e357a2ca204ad610c8892b2697a6af2b1d794d0760a1009bf")
+    version("1.19.0", sha256="0a1c77f0cee40f0b111ceab28cc77bfae4cfee29fea0aa3f7d91d2a58ff70236")
     version("1.18.0", sha256="2b9e92d10f8883eafb45f48fd357ecaf7456badec11ccd375d3f2505e71aa9d2")
     version("1.17.0", sha256="6032279e8fc8bdb48d39c4ac19ffe561bcc53576e36f71ee2ed3ed75835f1af9")
     version("1.16.0", sha256="04da7077381e12c2b9bf869e1357105683596ed9105e3acff3c6d9214be04fbd")


### PR DESCRIPTION
This commit adds new versions of the ACTS algebra plugins package, the detray package, and the vecmem package.