### PR TITLE
py-pytest-runner: add v6.0.1

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pytest_runner/package.py
+++ b/repos/spack_repo/builtin/packages/py_pytest_runner/package.py
@@ -15,14 +15,15 @@ class PyPytestRunner(PythonPackage):
 
     license("MIT")
 
+    version("6.0.1", sha256="70d4739585a7008f37bf4933c013fdb327b8878a5a69fcbb3316c88882f0f49b")
     version("6.0.0", sha256="b4d85362ed29b4c348678de797df438f0f0509497ddb8c647096c02a6d87b685")
     version("5.3.1", sha256="0fce5b8dc68760f353979d99fdd6b3ad46330b6b1837e2077a89ebcf204aac91")
     version("5.1", sha256="25a013c8d84f0ca60bb01bd11913a3bcab420f601f0f236de4423074af656e7a")
     version("2.11.1", sha256="983a31eab45e375240e250161a556163bc8d250edaba97960909338c273a89b3")
 
     # requirements from pyproject.toml are marked with *
-    depends_on("python@3.6:", when="@5.3:", type=("build", "run"))
     depends_on("python@3.7:", when="@6.0.0:", type=("build", "run"))
+    depends_on("python@3.6:", when="@5.3:", type=("build", "run"))
     depends_on("py-setuptools@56:", when="@6.0.0:", type=("build", "run"))  # *
     depends_on("py-setuptools@42:", when="@5.3:", type=("build", "run"))  # *
     depends_on("py-setuptools@34.4:", when="@5:", type=("build", "run"))  # *


### PR DESCRIPTION
https://github.com/pytest-dev/pytest-runner/tree/v6.0.1

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
