### PR TITLE
preCICE: fix for eigen 5.0.0

### DIFF
--- a/repos/spack_repo/builtin/packages/precice/package.py
+++ b/repos/spack_repo/builtin/packages/precice/package.py
@@ -102,6 +102,7 @@ class Precice(CMakePackage):
     depends_on("eigen@3.2:")
     depends_on("eigen@3.4:", when="@3.2:")
     depends_on("eigen@:3.3.7", type="build", when="@:1.5")  # bug in prettyprint
+    depends_on("eigen@:3.4.99", when="@:3.3")
 
     depends_on("libxml2")
     depends_on("libxml2@:2.11.99", type="build", when="@:2.5.0")


### PR DESCRIPTION
This PR fixes the version ranges for the newest release of Eigen 5.0.0.
This release of Eigen is supported on develop and the upcoming release 3.3.0 of preCICE.
