### PR TITLE
kokkos: fix cmake conflict

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -82,7 +82,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("cxx", type="build")  # Kokkos requires a C++ compiler
 
     depends_on("cmake@3.16:", type="build")
-    conflicts("cmake@3.28", when="@:4.2.01 +cuda")
+    conflicts("^cmake@3.28", when="@:4.2.01 +cuda")
     conflicts("^cuda@13:", when="@:4.7.0")
 
     devices_variants = {


### PR DESCRIPTION
The PR fixes the conflict with cmake 3.28 when enabling CUDA.

Before the PR:
```
spack spec --fresh kokkos@4.2.1 +cuda cuda_arch=90 ^cmake@3.28
 -   kokkos@4.2.01~aggressive_vectorization~alloc_async~cmake_lang~compiler_warnings+complex_align+cuda~cuda_constexpr~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~hip_relocatable_device_code~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl~openmp~openmptarget~pic~rocm+serial+shared~sycl~tests~threads~tuning~wrapper build_system=cmake build_type=Release cuda_arch=90 cxxstd=17 generator=make intel_gpu_arch=none arch=linux-ubuntu20.04-icelake %c,cxx=gcc@10.5.0
 -       ^cmake@3.28.6~doc+ncurses+ownlibs~qtgui build_system=generic build_type=Release patches:=dbc3892 arch=linux-ubuntu20.04-icelake %c,cxx=gcc@10.5.0
 -           ^curl@8.11.1~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs:=shared,static tls:=openssl arch=linux-ubuntu20.04-icelake %c,cxx=gcc@10.5.0
 -               ^nghttp2@1.65.0 build_system=autotools arch=linux-ubuntu20.04-icelake %c,cxx=gcc@10.5.0
 -                   ^diffutils@3.10 build_system=autotools arch=linux-ubuntu20.04-icelake %c=gcc@10.5.0
 -               ^openssl@3.4.1~docs+shared build_system=generic certs=mozilla arch=linux-ubuntu20.04-icelake %c,cxx=gcc@10.5.0
 -                   ^ca-certificates-mozilla@2025-05-20 build_system=generic arch=linux-ubuntu20.04-icelake 
 -                   ^perl@5.40.0+cpanm+opcode+open+shared+threads build_system=generic arch=linux-ubuntu20.04-icelake %c=gcc@10.5.0
 -                       ^berkeley-db@18.1.40+cxx~docs+stl build_system=autotools patches:=26090f4,b231fcc arch=linux-ubuntu20.04-icelake %c,cxx=gcc@10.5.0
 -                       ^bzip2@1.0.8~debug~pic+shared build_system=generic arch=linux-ubuntu20.04-icelake %c=gcc@10.5.0
 -                       ^gdbm@1.23 build_system=autotools arch=linux-ubuntu20.04-icelake %c=gcc@10.5.0
 -                           ^readline@8.2 build_system=autotools patches:=1ea4349,24f587b,3d9885e,5911a5b,622ba38,6c8adf8,758e2ec,79572ee,a177edc,bbf97f1,c7b45ff,e0013d9,e065038 arch=linux-ubuntu20.04-icelake %c=gcc@10.5.0
 -               ^pkgconf@2.3.0 build_system=autotools arch=linux-ubuntu20.04-icelake %c=gcc@10.5.0
 -           ^ncurses@6.5~symlinks+termlib abi=none build_system=autotools patches:=7a351bc arch=linux-ubuntu20.04-icelake %c,cxx=gcc@10.5.0
 -           ^zlib-ng@2.2.4+compat+new_strategies+opt+pic+shared build_system=autotools arch=linux-ubuntu20.04-icelake %c,cxx=gcc@10.5.0
[+]      ^compiler-wrapper@1.0 build_system=generic arch=linux-ubuntu20.04-icelake 
 -       ^cuda@12.9.0~allow-unsupported-compilers~dev build_system=generic arch=linux-ubuntu20.04-icelake 
 -           ^libxml2@2.13.5~http+pic~python+shared build_system=autotools arch=linux-ubuntu20.04-icelake %c=gcc@10.5.0
 -               ^libiconv@1.18 build_system=autotools libs:=shared,static arch=linux-ubuntu20.04-icelake %c=gcc@10.5.0
 -               ^xz@5.6.3~pic build_system=autotools libs:=shared,static arch=linux-ubuntu20.04-icelake %c=gcc@10.5.0
[e]      ^gcc@10.5.0~binutils+bootstrap~graphite~nvptx~piclibs~profiled~strip build_system=autotools build_type=RelWithDebInfo languages:='c,c++,fortran' patches:=2c18531 arch=linux-ubuntu20.04-icelake 
 -       ^gcc-runtime@10.5.0 build_system=generic arch=linux-ubuntu20.04-icelake 
[e]      ^glibc@2.31 build_system=autotools arch=linux-ubuntu20.04-icelake 
 -       ^gmake@4.4.1~guile build_system=generic arch=linux-ubuntu20.04-icelake %c=gcc@10.5.0
```

After the PR:
```
spack spec --fresh kokkos@4.2.1 +cuda cuda_arch=90 ^cmake@3.28
==> Error: failed to concretize `kokkos@4.2.1+cuda cuda_arch=90 ^cmake@3.28` for the following reasons:
     1. Cannot satisfy 'kokkos@4.2.1'
        required because kokkos@4.2.1+cuda cuda_arch=90 ^cmake@3.28 requested explicitly 
     2. Cannot satisfy 'kokkos@4.2.1'
```