### PR TITLE
openblas: fix building on darwin with sdk 26

### DIFF
--- a/repos/spack_repo/builtin/packages/openblas/openblas-0.3.30-apple-LTO.patch
+++ b/repos/spack_repo/builtin/packages/openblas/openblas-0.3.30-apple-LTO.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.system b/Makefile.system
+index 38646c3c6..e81ccf083 100644
+--- a/Makefile.system
++++ b/Makefile.system
+@@ -436,7 +436,7 @@ ifeq (x$(XCVER), x 15)
+ CCOMMON_OPT += -Wl,-ld_classic
+ FCOMMON_OPT += -Wl,-ld_classic
+ endif
+-ifeq (x$(XCVER), x 16)
++ifeq ($(shell [ $(XCVER) -ge 16 ] && echo yes),yes)
+ ifeq ($(F_COMPILER), GFORTRAN)
+ override CEXTRALIB := $(filter-out(-lto_library, $(CEXTRALIB))) 
+ endif

--- a/repos/spack_repo/builtin/packages/openblas/package.py
+++ b/repos/spack_repo/builtin/packages/openblas/package.py
@@ -162,6 +162,9 @@ class Openblas(CMakePackage, MakefilePackage):
     # https://github.com/OpenMathLib/OpenBLAS/pull/1703
     patch("openblas-0.3.2-cmake.patch", when="@0.3.1:0.3.2")
 
+    # https://github.com/OpenMathLib/OpenBLAS/issues/5473
+    patch("openblas-0.3.30-apple-LTO.patch", when="@0.3.30 platform=darwin")
+
     # Disable experimental TLS code that lead to many threading issues
     # https://github.com/OpenMathLib/OpenBLAS/issues/1735#issuecomment-422954465
     # https://github.com/OpenMathLib/OpenBLAS/issues/1761#issuecomment-421039174


### PR DESCRIPTION
Fixes https://github.com/spack/spack-packages/issues/620

This applies the PR from https://github.com/OpenMathLib/OpenBLAS/pull/5474 as a patch to ensure that the filtering fix is applied to sdk >= 16

@mathomp4 

/cc @cpraveen @adamjstewart 