### PR TITLE
py-breathe: add v4.36.0, add self as maintainer

### DIFF
--- a/repos/spack_repo/builtin/packages/py_breathe/package.py
+++ b/repos/spack_repo/builtin/packages/py_breathe/package.py
@@ -14,6 +14,8 @@ class PyBreathe(PythonPackage):
     homepage = "https://github.com/michaeljones/breathe"
     url = "https://github.com/michaeljones/breathe/archive/v4.11.1.tar.gz"
 
+    maintainers("sethrj")
+
     license("BSD-3-Clause")
 
     version("4.36.0", sha256="94fc2277e639929e898cb95559d9d2c51cf764b787eaf6fa04f848a6550c2ff5")
@@ -31,9 +33,6 @@ class PyBreathe(PythonPackage):
     version("4.7.2", sha256="982d47909d22fcd71b48bad5aef3644294340b24f612b2887cde2e3be464d960")
     version("4.7.1", sha256="afb1ab0084b25d3670fa8f5cf2eeaee6fe61bfc77876e3816b140eacd4949875")
     version("4.7.0", sha256="5629c67f5adb41f39375d36c5f0d60d34b1230be268125e535205d77f69211e4")
-
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
 
     depends_on("py-setuptools", type="build")
 

--- a/repos/spack_repo/builtin/packages/py_breathe/package.py
+++ b/repos/spack_repo/builtin/packages/py_breathe/package.py
@@ -16,6 +16,7 @@ class PyBreathe(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("4.36.0", sha256="94fc2277e639929e898cb95559d9d2c51cf764b787eaf6fa04f848a6550c2ff5")
     version("4.35.0", sha256="55b54723752fc04b892a0f868782b1df65e69db6ca94fb32cf04be495bfd7841")
     version("4.34.0", sha256="b22e70eb4000492508d687d71f258c8f9678398e277bcee0daf34cd438a46e25")
     version("4.33.1", sha256="acda75b216b227ec09ffd74378a6c7ed8f023df4539693c6e20574d1df52e75b")

--- a/repos/spack_repo/builtin/packages/py_breathe/package.py
+++ b/repos/spack_repo/builtin/packages/py_breathe/package.py
@@ -56,4 +56,3 @@ class PyBreathe(PythonPackage):
     # but it is not called directly. It is used directly by the examples, which
     # are not hooked up to this spack recipe.
     depends_on("doxygen@1.8.4:", type="run")
-

--- a/repos/spack_repo/builtin/packages/py_breathe/package.py
+++ b/repos/spack_repo/builtin/packages/py_breathe/package.py
@@ -9,10 +9,10 @@ from spack.package import *
 
 class PyBreathe(PythonPackage):
     """This is an extension to reStructuredText and Sphinx to be able to read
-    and render the Doxygen xml output."""
+    and render Doxygen XML output."""
 
-    homepage = "https://github.com/michaeljones/breathe"
-    url = "https://github.com/michaeljones/breathe/archive/v4.11.1.tar.gz"
+    homepage = "https://github.com/breathe-doc/breathe"
+    url = "https://github.com/breathe-doc/breathe/archive/refs/tags/v4.36.0.tar.gz"
 
     maintainers("sethrj")
 
@@ -34,22 +34,26 @@ class PyBreathe(PythonPackage):
     version("4.7.1", sha256="afb1ab0084b25d3670fa8f5cf2eeaee6fe61bfc77876e3816b140eacd4949875")
     version("4.7.0", sha256="5629c67f5adb41f39375d36c5f0d60d34b1230be268125e535205d77f69211e4")
 
-    depends_on("py-setuptools", type="build")
+    with default_args(type=("build", "run")):
+        depends_on("python@3.9:", when="@4.36:")
+        depends_on("python@3.6:", when="@4.33:4.35")
+        depends_on("python@3.5:", when="@4.21:4.32")
 
-    depends_on("python@3.5:", type=("build", "run"), when="@4.21:4.32")
-    depends_on("python@3.6:", type=("build", "run"), when="@4.33:")
-    depends_on("py-docutils@0.5:", type=("build", "run"), when="@:4.20")
-    depends_on("py-docutils@0.12:", type=("build", "run"), when="@4.21:")
-    # Note: Pygments is missing from the setup.py in 4.34.0 but is listed in
-    # the requirements file and used by breathe.filetypes.
-    depends_on("py-pygments@1.6:", type=("build", "run"), when="@4.21:")
-    depends_on("py-six@1.4:", type=("build", "run"), when="@:4.20")
-    depends_on("py-six@1.9:", type=("build", "run"), when="@4.21:4.32")
-    depends_on("py-sphinx", type=("build", "run"))
-    depends_on("py-sphinx@:3", type=("build", "run"), when="@:4.20")
-    depends_on("py-sphinx@3:3.2", type=("build", "run"), when="@4.21:4.32")
-    depends_on("py-sphinx@3:4", type=("build", "run"), when="@4.33")
-    depends_on("py-sphinx@4,5.0.1:5", type=("build", "run"), when="@4.34")
-    depends_on("py-sphinx@4,5.0.1:", type=("build", "run"), when="@4.35:")
+        depends_on("py-sphinx@7.2:", when="@4.35:")
+        depends_on("py-sphinx@4,5.0.1:5", when="@4.34")
+        depends_on("py-sphinx@3:4", when="@4.33")
+        depends_on("py-sphinx@3:3.2", when="@4.21:4.32")
+        depends_on("py-sphinx@:3", when="@:4.20")
 
+        depends_on("py-six@1.9:", when="@4.21:4.32")
+        depends_on("py-six@1.4:", when="@:4.20")
+
+    with default_args(type="build"):
+        depends_on("py-flit-core@3.7:", when="@4.36:")
+        depends_on("py-setuptools", type="build", when="@:4.35")
+
+    # Doxygen is *implicitly* required to build the XML files used by breathe,
+    # but it is not called directly. It is used directly by the examples, which
+    # are not hooked up to this spack recipe.
     depends_on("doxygen@1.8.4:", type="run")
+


### PR DESCRIPTION
This was released in February as a bugfix release. 

Version 4.36 now contains a pyproject.toml file. I have overhauled the package recipe to use the latest URL, remove incorrect dependencies, and use `default_args` for cleaner presentation.