### PR TITLE
Affinity: Explicitly add C and CXX dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/affinity/package.py
+++ b/repos/spack_repo/builtin/packages/affinity/package.py
@@ -28,6 +28,9 @@ class Affinity(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("cmake@3.21:", type="build")
     depends_on("mpi", when="+mpi")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     def cmake_args(self):
         args = [self.define_from_variant("AFFINITY_MPI", "mpi")]
         args += [


### PR DESCRIPTION
I was getting failures in a container of the type:

```
2 errors found in build log:
  >> 5     CMake Error at CMakeLists.txt:2 (project):
     6       No CMAKE_C_COMPILER could be found.
     7     
     8       Tell CMake where to find the compiler by setting either the environment
     9       variable "CC" or the CMake cache entry CMAKE_C_COMPILER to the full path to
     10      the compiler, or to the compiler name if it is in the PATH.
     11    
     12    
  >> 13    CMake Error at CMakeLists.txt:2 (project):
     14      No CMAKE_CXX_COMPILER could be found.
     15    
     16      Tell CMake where to find the compiler by setting either the environment
     17      variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
     18      to the compiler, or to the compiler name if it is in the PATH.
     19  
```

and it made me realize we need to set the C/CXX dependencies explicitly for this package so Spack/the concretizer picks it up correctly in different environments. Doing so and reconcretizing/reattempting installation fixed the issue in my container, so I'm upstreaming the fix here.