### PR TITLE
PDAL: add v2.9.2

### DIFF
--- a/repos/spack_repo/builtin/packages/pdal/package.py
+++ b/repos/spack_repo/builtin/packages/pdal/package.py
@@ -19,6 +19,7 @@ class Pdal(CMakePackage):
 
     license("BSD")
 
+    version("2.9.2", sha256="a93f9e5d56814fd9c46a0f48de6c0f65b00ce09984c9f3293774a9c78e094266")
     version("2.6.2", sha256="ec4175cfe19dc6b70a0434850f837317f7202f84b63cd8dcc65ca83e04678f57")
     version("2.6.1", sha256="da6e615f01b6110414ef3e2250f112e49df129091abc91ba6866bb01dc68454e")
     version("2.6.0", sha256="12eedeac16ec3aaef42f06078f03f657701c25781207a8e09a3547519228780e")
@@ -27,7 +28,8 @@ class Pdal(CMakePackage):
     version("2.4.3", sha256="e1a910d593311e68b51f32d1f4f8fe4327b97ae7a8de209147b6111091b6f75b")
     version("2.3.0", sha256="8ae848e9b3fe5149a9277fe60e10b9858edb9a3cf1a40728f11712498e5da13a")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("cmake@3.13:", type="build")
     depends_on("gdal@3:")


### PR DESCRIPTION
Confirmed that the build requires both C and C++ compilers.