### PR TITLE
at-spi2-core: add required dependency on libxml2.

### DIFF
--- a/repos/spack_repo/builtin/packages/at_spi2_core/package.py
+++ b/repos/spack_repo/builtin/packages/at_spi2_core/package.py
@@ -40,6 +40,7 @@ class AtSpi2Core(MesonPackage):
     depends_on("gettext")
     depends_on("libx11")
     depends_on("libxi")
+    depends_on("libxml2", type="build", when="@2.47:")
     depends_on("libxtst")
     depends_on("recordproto")
     depends_on("inputproto")


### PR DESCRIPTION
+ The `meson.build` file indicates that `libxml2` is needed.  This additional dependency matches my experience when building `at-spi2-core` with spack.
+ Newer versions of `at-spi2-core` are available, but the recipe for `gtkplus` limits us to `at-spi2-core@2.46:2.48`, so I didn't add options to use a newer version.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
