### PR TITLE
cmake: add v4.1.2

### DIFF
--- a/repos/spack_repo/builtin/packages/cmake/package.py
+++ b/repos/spack_repo/builtin/packages/cmake/package.py
@@ -31,6 +31,7 @@ class Cmake(Package):
     license("BSD-3-Clause")
 
     version("master", branch="master")
+    version("4.1.2", sha256="643f04182b7ba323ab31f526f785134fb79cba3188a852206ef0473fee282a15")
     version("4.1.1", sha256="b29f6f19733aa224b7763507a108a427ed48c688e1faf22b29c44e1c30549282")
     version("4.0.4", sha256="629be82af0b76e029b675a4a37569e2ddc1769d42a768957c00ec0e98407737e")
     version(


### PR DESCRIPTION
CMake 4.1.1? 👎 
CMake 4.1.2? 👍 

Patch release for CMake 4.1 release series, see release notes and milestone for more context: 
* https://cmake.org/cmake/help/latest/release/4.1.html
* https://gitlab.kitware.com/cmake/cmake/-/milestones/182