### PR TITLE
bcftools: add v1.22 and htslib: add v1.22.1

### DIFF
--- a/repos/spack_repo/builtin/packages/bcftools/package.py
+++ b/repos/spack_repo/builtin/packages/bcftools/package.py
@@ -1,3 +1,4 @@
+
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -21,6 +22,7 @@ class Bcftools(AutotoolsPackage):
 
     license("GPL-3.0-or-later")
 
+    version("1.22", sha256="f2ab9e2f605b1203a7e9cbfb0a3eb7689322297f8c34b45dc5237fe57d98489f")
     version("1.21", sha256="528a4cc1d3555368db75a700b22a3c95da893fd1827f6d304716dfd45ea4e282")
     version("1.20", sha256="312b8329de5130dd3a37678c712951e61e5771557c7129a70a327a300fda8620")
     version("1.19", sha256="782b5f1bc690415192231e82213b3493b047f45e630dc8ef6f154d6126ab3e68")
@@ -43,7 +45,7 @@ class Bcftools(AutotoolsPackage):
     variant(
         "libgsl",
         default=False,
-        description="build options that require the GNU scientific " "library",
+        description="build options that require the GNU scientific library",
     )
 
     variant(
@@ -63,6 +65,7 @@ class Bcftools(AutotoolsPackage):
     depends_on("perl", when="@1.8:+perl-filters", type=("build", "run"))
 
     depends_on("htslib")
+    depends_on("htslib@1.22", when="@1.22")
     depends_on("htslib@1.21", when="@1.21")
     depends_on("htslib@1.20", when="@1.20")
     depends_on("htslib@1.19", when="@1.19")

--- a/repos/spack_repo/builtin/packages/bcftools/package.py
+++ b/repos/spack_repo/builtin/packages/bcftools/package.py
@@ -1,4 +1,3 @@
-
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/repos/spack_repo/builtin/packages/htslib/package.py
+++ b/repos/spack_repo/builtin/packages/htslib/package.py
@@ -18,7 +18,7 @@ class Htslib(AutotoolsPackage):
 
     license("MIT AND BSD-3-Clause-Modification")
 
-    version("1.22.1", sha256="3dfa6eeb71db719907fe3ef7c72cb2ec9965b20b58036547c858c89b58c342f7")  # FIXME
+    version("1.22.1", sha256="3dfa6eeb71db719907fe3ef7c72cb2ec9965b20b58036547c858c89b58c342f7")
     version("1.21", sha256="84b510e735f4963641f26fd88c8abdee81ff4cb62168310ae716636aac0f1823")
     version("1.20", sha256="e52d95b14da68e0cfd7d27faf56fef2f88c2eaf32a2be51c72e146e3aa928544")
     version("1.19.1", sha256="222d74d3574fb67b158c6988c980eeaaba8a0656f5e4ffb76b5fa57f035933ec")

--- a/repos/spack_repo/builtin/packages/htslib/package.py
+++ b/repos/spack_repo/builtin/packages/htslib/package.py
@@ -1,3 +1,4 @@
+
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -17,6 +18,7 @@ class Htslib(AutotoolsPackage):
 
     license("MIT AND BSD-3-Clause-Modification")
 
+    version("1.22.1", sha256="3dfa6eeb71db719907fe3ef7c72cb2ec9965b20b58036547c858c89b58c342f7")  # FIXME
     version("1.21", sha256="84b510e735f4963641f26fd88c8abdee81ff4cb62168310ae716636aac0f1823")
     version("1.20", sha256="e52d95b14da68e0cfd7d27faf56fef2f88c2eaf32a2be51c72e146e3aa928544")
     version("1.19.1", sha256="222d74d3574fb67b158c6988c980eeaaba8a0656f5e4ffb76b5fa57f035933ec")

--- a/repos/spack_repo/builtin/packages/htslib/package.py
+++ b/repos/spack_repo/builtin/packages/htslib/package.py
@@ -1,4 +1,3 @@
-
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)


### PR DESCRIPTION
Update bcftools and htslib versions.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
