### PR TITLE
r-ncdf4: add missing gmake dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/r_ncdf4/package.py
+++ b/repos/spack_repo/builtin/packages/r_ncdf4/package.py
@@ -38,5 +38,6 @@ class RNcdf4(RPackage):
     version("1.15", sha256="d58298f4317c6c80a041a70216126492fd09ba8ecde9da09d5145ae26f324d4d")
 
     depends_on("c", type="build")
+    depends_on("gmake", type="build")
 
     depends_on("netcdf-c@4.1:")


### PR DESCRIPTION
Without the dependency I get errors like:
```
     11    /spack/opt/spack/linux-skylake/r-4.5.1-scfluqiqrzyu45gclihmww2xb463wnea/rlib/R/bin/config: line 197: make: command not found
     12    /spack/opt/spack/linux-skylake/r-4.5.1-scfluqiqrzyu45gclihmww2xb463wnea/rlib/R/bin/config: line 346: make: command not found
  >> 13    Error in `<current-expression>` : error in running command
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
