### PR TITLE
Override default retry:when dict

### DIFF
--- a/.ci/gitlab/configs/ci.yaml
+++ b/.ci/gitlab/configs/ci.yaml
@@ -43,7 +43,7 @@ ci:
       # Retry for everything but "legitimate build failures" (script_failure)
       retry:
         max: 2
-        when:
+        when::
           - unknown_failure
           - api_failure
           - stuck_or_timeout_failure


### PR DESCRIPTION
The motivation behind this change is to properly honor the ["retry everything but legitimate build failures" logic](https://github.com/spack/spack-packages/blob/d2a3a6f0d5d840b68bf9386484edd682e47ddbc9/.ci/gitlab/configs/ci.yaml#L43).

This is currently not working as intended because `script_failure` is in our [default list of retry conditions](https://github.com/spack/spack/blob/f09c960b014285bc40afb67e1f7e03b1247f0b59/lib/spack/spack/ci/gitlab.py#L34).
