### PR TITLE
RepeatModeler: Fix directory used during configuration

### DIFF
--- a/repos/spack_repo/builtin/packages/repeatmodeler/package.py
+++ b/repos/spack_repo/builtin/packages/repeatmodeler/package.py
@@ -76,7 +76,7 @@ class Repeatmodeler(Package):
                 spec["ncbi-rmblastn"].prefix.bin,
                 "y",
                 spec["genometools"].prefix.bin,
-                spec["ltr-retriever"].prefix.bin,
+                spec["ltr-retriever"].prefix,
                 spec["mafft"].prefix.bin,
                 spec["ninja-phylogeny"].prefix.bin,
             ]


### PR DESCRIPTION
While attempting to install RepeatModeler, I found that it's configuration script looks for the `LTR_retriever` program within `spec["ltr-retriever"].prefix.bin`. The problem is that there is no `LTR_retriever` program within `bin/`, but rather it's within the project's root. ([LTR_retriever repo](https://github.com/oushujun/LTR_retriever)).

Obligatory mention of the maintainer: @snehring
