### PR TITLE
py-torch: Populate libs property properly

### DIFF
--- a/repos/spack_repo/builtin/packages/py_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_torch/package.py
@@ -800,6 +800,10 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
             python("run_test.py")
 
     @property
+    def libs(self):
+        return find_libraries("libtorch*", root=python_platlib, recursive=True, shared=True)
+
+    @property
     def cmake_prefix_paths(self):
         cmake_prefix_paths = [join_path(python_platlib, "torch", "share", "cmake")]
         return cmake_prefix_paths


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This populates the `libs` properties of `py-torch` properly. Without this `libs` returns an empty list, as the fact that they are installed in the python platform directory puts them outside of the default root for searching.