### PR TITLE
py_psyclone package update - add 3.2.0 version

### DIFF
--- a/repos/spack_repo/builtin/packages/py_psyclone/package.py
+++ b/repos/spack_repo/builtin/packages/py_psyclone/package.py
@@ -20,7 +20,7 @@ class PyPsyclone(PythonPackage):
     # Links
     homepage = "https://github.com/stfc/PSyclone"
     git = "https://github.com/stfc/PSyclone.git"
-    pypi = "PSyclone/psyclone-3.1.0.tar.gz"
+    pypi = "PSyclone/psyclone-3.2.0.tar.gz"
 
     # Maintainers
     maintainers("arporter", "sergisiso", "TeranIvy", "hiker")
@@ -30,6 +30,7 @@ class PyPsyclone(PythonPackage):
 
     # Releases
     version("master", branch="master")
+    version("3.2.0", sha256="9b3ba5c7c60dae365e06b0f6ca426d5667e004bd0049a96e6d9d468c03d79daa")
     version("3.1.0", sha256="7b369353942358afcb93b199ef2b11116d756cf9d671667ca95fa83fb31f0355")
     version("3.0.0", sha256="25085a6d0dad36c03ec1f06becf7e2f915ded26603d4a1a2981392f5752fdb3e")
     version("2.5.0", sha256="dd1b40d635423c6b23effd2c569908d319afa6153680692e1cbae27f7b5bf4dc")
@@ -44,7 +45,7 @@ class PyPsyclone(PythonPackage):
     # Current dependencies
     depends_on("py-setuptools", type="build")
     depends_on("py-pyparsing", type=("build", "run"))
-    depends_on("py-fparser@0.2.0:", type=("build", "run"), when="@3.0.0:")
+    depends_on("py-fparser@0.2.1:", type=("build", "run"), when="@3.2.0:")
     depends_on("py-graphviz", type=("build", "run"))
     depends_on("py-configparser", type=("build", "run"))
     depends_on("py-jinja2", type="build")
@@ -56,6 +57,7 @@ class PyPsyclone(PythonPackage):
     depends_on("py-jsonschema@3.0.2", type=("build", "run"), when="@2.1.0:2.4.0")
 
     # Test cases fail without compatible versions of py-fparser:
+    depends_on("py-fparser@0.2.0", type=("build", "run"), when="@3.1.0")
     depends_on("py-fparser@0.1.4", type=("build", "run"), when="@2.5.0")
     depends_on("py-fparser@0.1.3", type=("build", "run"), when="@2.4.0")
     depends_on("py-fparser@0.0.16", type=("build", "run"), when="@2.3.1")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Adds the 3.2.0 release and updates the version of the fparser dependency (requires #1797)