### PR TITLE
py-pytz: add v2025.2

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pytz/package.py
+++ b/repos/spack_repo/builtin/packages/py_pytz/package.py
@@ -16,6 +16,7 @@ class PyPytz(PythonPackage):
 
     license("MIT")
 
+    version("2025.2", sha256="360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3")
     version("2024.2", sha256="2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a")
     version("2023.3", sha256="1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588")
     version("2022.2.1", sha256="cea221417204f2d1a2aa03ddae3e867921971d0d76f14d87abb4414415bbdcf5")


### PR DESCRIPTION
https://github.com/stub42/pytz/tree/release_2025.2/src

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
