### PR TITLE
py-fastjsonschema: Fix issue with python@3.12:

### DIFF
--- a/repos/spack_repo/builtin/packages/py_fastjsonschema/package.py
+++ b/repos/spack_repo/builtin/packages/py_fastjsonschema/package.py
@@ -30,8 +30,8 @@ class PyFastjsonschema(PythonPackage):
     version("2.15.1", sha256="671f36d225b3493629b5e789428660109528f373cf4b8a22bac6fa2f8191c2d2")
 
     depends_on("python@3.3:3.13", when="@2.21:", type=("build", "run"))
-    depends_on("python@3.3:3.12", when="@2.20:", type=("build", "run"))
-    depends_on("python@3.3:3.11", when="@2.16.3:", type=("build", "run"))
+    depends_on("python@3.3:3.12", when="@2.20", type=("build", "run"))
+    depends_on("python@3.3:3.11", when="@2.16.3:@2.19", type=("build", "run"))
     depends_on("python@3.3:", when="@2.15:", type=("build", "run"))
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_fastjsonschema/package.py
+++ b/repos/spack_repo/builtin/packages/py_fastjsonschema/package.py
@@ -31,7 +31,7 @@ class PyFastjsonschema(PythonPackage):
 
     depends_on("python@3.3:3.13", when="@2.21:", type=("build", "run"))
     depends_on("python@3.3:3.12", when="@2.20", type=("build", "run"))
-    depends_on("python@3.3:3.11", when="@2.16.3:@2.19", type=("build", "run"))
+    depends_on("python@3.3:3.11", when="@2.16.3:2.19", type=("build", "run"))
     depends_on("python@3.3:", when="@2.15:", type=("build", "run"))
 
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
This should #1779

The original depends_on(python) lines restricting python versions were using open ended version ranges for py-fastjsonschema in the when clause, effectively making the lines for python@3.3.12: ignored.

This fixes that by adding upper limits on the version ranges in the when clauses.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
