### PR TITLE
hpctoolkit: fix build for +gtpin

### DIFF
--- a/repos/spack_repo/builtin/packages/hpctoolkit/package.py
+++ b/repos/spack_repo/builtin/packages/hpctoolkit/package.py
@@ -274,6 +274,13 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
     # hsa include path is hsa-rocr-dev-prefix-path/include
     patch("correcting-hsa-include-path.patch", when="@2024.01 ^hip@6.0:")
 
+    # Fix +gtpin build for original Meson release
+    patch(
+        "https://gitlab.com/hpctoolkit/hpctoolkit/-/merge_requests/1329.diff",
+        when="@2025.0.1 +gtpin",
+        sha256="ac486278726620ef932c48aef41d5aab6ba0359b5b1eced651724237877f445b",
+    )
+
     # Fix a bug where make would mistakenly overwrite hpcrun-fmt.h.
     # https://gitlab.com/hpctoolkit/hpctoolkit/-/merge_requests/751
     @when("@:2022")

--- a/repos/spack_repo/builtin/packages/intel_gtpin/package.py
+++ b/repos/spack_repo/builtin/packages/intel_gtpin/package.py
@@ -127,7 +127,7 @@ class IntelGtpin(Package):
 
     @property
     def headers(self):
-        return find_headers("gtpin", self.prefix.Include)
+        return find_all_headers(self.prefix.Include)
 
     @property
     def libs(self):


### PR DESCRIPTION
In `hpctoolkit@2025.0.1` we changed how we expect GTPin to be exposed to our build system, we now expect GTPin to be available through `CFLAGS`/`LDFLAGS` or, in Spack's case, compiler wrappers. The recent addition of this version to Spack exposed two issues related to this:

1. Our code expected to find the root GTPin `Include/` directory on the include path (i.e. `#include <api/gtpin_api.h>`). However, Spack's `find_headers` functionality exposes the headers directly (i.e. `#include <gtpin_api.h>`), which also matches how most (but not all!) of the examples provided with GTPin are written.\
   This PR applies upstream MR [!1329](https://gitlab.com/hpctoolkit/hpctoolkit/-/merge_requests/1329) to `@2025.0.1` to use the latter "correct" approach for this version when `+gtpin` is requested, it is already merged into upstream `@develop` and `@2025.0.stable` branches.

3. The `intel-gtpin` package exposes **no** include paths to dependent packages. This is both because the binary GTPin package uses a non-standard name for the include directory, and because the recipe's `find_headers` call only looks for the non-existent `gtpin.h`. To make matters worse, it turns out the GTPin "API" headers (`Include/api`) include headers in a separate subdirectory (`Include/ged/intel64`) without full paths, meaning both subdirectories need to be on the include path for success.\
   This PR uses the catch-all `find_all_headers` to deal with the non-standard layout used in these binary releases, the GTPin headers can now be used by downstream packages.

With the fixes in this PR, `hpctoolkit@2025.0.1 +gtpin` now builds successfully.

CC @mwkrentel 