### PR TITLE
py-referencing: add v0.36.2

### DIFF
--- a/repos/spack_repo/builtin/packages/py_referencing/package.py
+++ b/repos/spack_repo/builtin/packages/py_referencing/package.py
@@ -17,10 +17,14 @@ class PyReferencing(PythonPackage):
 
     license("MIT", checked_by="wdconinc")
 
+    version("0.36.2", sha256="df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa")
     version("0.35.1", sha256="25b42124a6c8b632a425174f24087783efb348a6f1e0008e63cd4466fedf703c")
 
+    depends_on("python@3.9:", type=("build", "run"), when="@0.36:")
+    depends_on("python@3.8:", type=("build", "run"), when="@:0.35")
     depends_on("py-hatchling", type="build")
     depends_on("py-hatch-vcs", type="build")
 
     depends_on("py-attrs@22.2.0:", type=("build", "run"))
     depends_on("py-rpds-py@0.7.0:", type=("build", "run"))
+    depends_on("py-typing-extensions@4.4:", type=("build", "run"), when="@0.36.1: ^python@:3.12")


### PR DESCRIPTION
https://github.com/python-jsonschema/referencing/tree/v0.36.2

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
