### PR TITLE
add c/cxx dependency for compiler selectivity

### DIFF
--- a/repos/spack_repo/builtin/packages/alpscore/package.py
+++ b/repos/spack_repo/builtin/packages/alpscore/package.py
@@ -27,6 +27,8 @@ class Alpscore(CMakePackage):
 
     # Build system dependencies
     depends_on("cmake@3.1:", type="build")
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     # Other dependencies
     depends_on("mpi")

--- a/repos/spack_repo/builtin/packages/green_mbpt/package.py
+++ b/repos/spack_repo/builtin/packages/green_mbpt/package.py
@@ -36,6 +36,8 @@ class GreenMbpt(CMakePackage, CudaPackage):
 
     # Build system dependency
     depends_on("cmake@3.27:", type="build")
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     # Other dependencies
     depends_on("mpi")

--- a/repos/spack_repo/builtin/packages/green_seet/package.py
+++ b/repos/spack_repo/builtin/packages/green_seet/package.py
@@ -29,6 +29,8 @@ class GreenSeet(CMakePackage):
 
     # Build system dependency
     depends_on("cmake@3.27:", type="build")
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     # Other dependencies
     depends_on("mpi")


### PR DESCRIPTION
Add support for different compilers for alpscore, green-mbpt and green-seet packages to allow install statements like `spack install alpscore %gcc@13.2.0`.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
