### PR TITLE
malt: Add 1.4.0 and mark some old deprecated

### DIFF
--- a/repos/spack_repo/builtin/packages/malt/package.py
+++ b/repos/spack_repo/builtin/packages/malt/package.py
@@ -22,34 +22,71 @@ class Malt(CMakePackage):
     license("CECILL-C")
 
     # Versions
+    version("1.4.0", sha256="fb64e99eec9b9d3cb46b5f9cbd1e47b31354356ebc0502c27af101dfcff68b9f")
+    version("1.3.1", sha256="9f3b22ace13e0a3bc773fed4044a5c19439aeb9111077582704382b3d1675194")
+    version("1.3.0", sha256="7b19db65dd1d95a84c06676c31059312ff11a6e65cbba32b160370d0e1dad33b")
     version("1.2.5", sha256="9660e42f92230e6acf5c19df5195f59a4c2d7d919eeab4410fe943507eee2c67")
-    version("1.2.4", sha256="47068fe981b4cbbfe30eeff37767d9057992f8515106d7809ce090d3390a712f")
-    version("1.2.3", sha256="edba5d9e6a11308f82b9c8b61871e47a8ae18493bf8bff7b6ff4f4a4369428de")
-    version("1.2.2", sha256="543cace664203fd9eb6b7d4945c573a3e507a43da105b5dc7ac03c78e9bb1a10")
+    version(
+        "1.2.4",
+        sha256="47068fe981b4cbbfe30eeff37767d9057992f8515106d7809ce090d3390a712f",
+        deprecated=True,
+    )
+    version(
+        "1.2.3",
+        sha256="edba5d9e6a11308f82b9c8b61871e47a8ae18493bf8bff7b6ff4f4a4369428de",
+        deprecated=True,
+    )
+    version(
+        "1.2.2",
+        sha256="543cace664203fd9eb6b7d4945c573a3e507a43da105b5dc7ac03c78e9bb1a10",
+        deprecated=True,
+    )
     version(
         "1.2.1",
         sha256="0e4c0743561f9fcc04dc83457386167a9851fc9289765f8b4f9390384ae3618a",
         url="https://github.com/memtt/malt/archive/v1.2.1.tar.gz",
     )
 
-    # Variants
+    # Variants up to 1.3.1
     variant(
         "nodejs",
         default=True,
         description="Enable the installation of the Web GUI based on NodeJS",
+        when="@:1.3.1",
     )
+
+    # Variants up to 1.2.5
     variant(
         "qt",
         default=False,
-        when="+nodejs",
+        when="+nodejs@:1.2.5",
         description="Build the viewer based on NodeJS + QT web toolkit (requires NodeJS too)",
     )
 
     # Dependencies
     depends_on("cxx", type="build")
+    depends_on("c", type="build")
 
-    depends_on("node-js@18:", type=("build", "run"), when="+nodejs")
+    # Old deps up to 1.3.1
+    depends_on("node-js@18:", type=("build", "run"), when="+nodejs@:1.3.1")
+    depends_on("qt", when="+qt@:1.3.1")
+
+    # common deps
     depends_on("libelf")
     depends_on("libunwind")
     depends_on("binutils", type="run")
-    depends_on("qt", when="+qt")
+
+    # since 1.4.0
+    depends_on("openssl", when="@:1.4.0")
+    depends_on("python@3:", when="@:1.4.0")
+
+    # configure options
+    def cmake_args(self):
+        if when("@1.4.0:"):
+            return [
+                f"-DCRYPTO_PREFIX={self.spec['openssl'].prefix}",
+                f"-DPYTHON_PREFIX={self.spec['python'].prefix}",
+                "-DLIBDIR=lib64",
+            ]
+        else:
+            return []

--- a/repos/spack_repo/builtin/packages/malt/package.py
+++ b/repos/spack_repo/builtin/packages/malt/package.py
@@ -65,12 +65,12 @@ class Malt(CMakePackage):
     depends_on("binutils", type="run")
 
     # since 1.4.0
-    depends_on("openssl", when="@:1.4.0")
-    depends_on("python@3:", when="@:1.4.0")
+    depends_on("openssl", when="@1.4.0:")
+    depends_on("python@3:", when="@1.4.0:")
 
     # configure options
     def cmake_args(self):
-        if when("@1.4.0:"):
+        if self.spec.satisfies("@1.4.0:"):
             return [
                 f"-DCRYPTO_PREFIX={self.spec['openssl'].prefix}",
                 f"-DPYTHON_PREFIX={self.spec['python'].prefix}",
@@ -78,3 +78,4 @@ class Malt(CMakePackage):
             ]
         else:
             return []
+	return []

--- a/repos/spack_repo/builtin/packages/malt/package.py
+++ b/repos/spack_repo/builtin/packages/malt/package.py
@@ -24,28 +24,16 @@ class Malt(CMakePackage):
     # Versions
     version("1.4.0", sha256="fb64e99eec9b9d3cb46b5f9cbd1e47b31354356ebc0502c27af101dfcff68b9f")
     version("1.3.1", sha256="9f3b22ace13e0a3bc773fed4044a5c19439aeb9111077582704382b3d1675194")
-    version("1.3.0", sha256="7b19db65dd1d95a84c06676c31059312ff11a6e65cbba32b160370d0e1dad33b")
     version("1.2.5", sha256="9660e42f92230e6acf5c19df5195f59a4c2d7d919eeab4410fe943507eee2c67")
-    version(
-        "1.2.4",
-        sha256="47068fe981b4cbbfe30eeff37767d9057992f8515106d7809ce090d3390a712f",
-        deprecated=True,
-    )
-    version(
-        "1.2.3",
-        sha256="edba5d9e6a11308f82b9c8b61871e47a8ae18493bf8bff7b6ff4f4a4369428de",
-        deprecated=True,
-    )
-    version(
-        "1.2.2",
-        sha256="543cace664203fd9eb6b7d4945c573a3e507a43da105b5dc7ac03c78e9bb1a10",
-        deprecated=True,
-    )
-    version(
-        "1.2.1",
-        sha256="0e4c0743561f9fcc04dc83457386167a9851fc9289765f8b4f9390384ae3618a",
-        url="https://github.com/memtt/malt/archive/v1.2.1.tar.gz",
-    )
+    with default_args(deprecated=True):
+        version("1.2.4", sha256="47068fe981b4cbbfe30eeff37767d9057992f8515106d7809ce090d3390a712f")
+        version("1.2.3", sha256="edba5d9e6a11308f82b9c8b61871e47a8ae18493bf8bff7b6ff4f4a4369428de")
+        version("1.2.2", sha256="543cace664203fd9eb6b7d4945c573a3e507a43da105b5dc7ac03c78e9bb1a10")
+        version(
+            "1.2.1",
+            sha256="0e4c0743561f9fcc04dc83457386167a9851fc9289765f8b4f9390384ae3618a",
+            url="https://github.com/memtt/malt/archive/v1.2.1.tar.gz",
+        )
 
     # Variants up to 1.3.1
     variant(


### PR DESCRIPTION
Hi,
here a patch to add support of new version 1.4.0 of malt with some changes about dependencies compared to the older versions.

I don't know what is the policy, to keep the old versions in or to remove the old one time to time ?

Best regards.