### PR TITLE
py-rnc2rng: add v2.7.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_rnc2rng/package.py
+++ b/repos/spack_repo/builtin/packages/py_rnc2rng/package.py
@@ -15,6 +15,7 @@ class PyRnc2rng(PythonPackage):
 
     license("MIT")
 
+    version("2.7.0", sha256="dd9ffbbd69d09cb07e6e7a8cf80fd28703fdc6d3b9026f8756b49cbe3314676b")
     version("2.6.6", sha256="5a01d157857b5f010a94167e7092cc49efe2531d58e013f12c4e60b8c4df78f1")
     version("2.6.5", sha256="d354afcf0bf8e3b1e8f8d37d71a8fe5b1c0cf75cbd4b71364a9d90b5108a16e5")
 


### PR DESCRIPTION
https://github.com/djc/rnc2rng/tree/2.7.0

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
