### PR TITLE
py-roman-numerals-py: add v3.1.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_roman_numerals_py/package.py
+++ b/repos/spack_repo/builtin/packages/py_roman_numerals_py/package.py
@@ -15,6 +15,8 @@ class PyRomanNumeralsPy(PythonPackage):
 
     license("0BSD OR CC0-1.0")
 
+    version("3.1.0", sha256="be4bf804f083a4ce001b5eb7e3c0862479d10f94c936f6c4e5f250aa5ff5bd2d")
     version("3.0.0", sha256="91199c4373658c03d87d9fe004f4a5120a20f6cb192be745c2377cce274ef41c")
 
+    depends_on("python@3.9:", type=("build", "run"))
     depends_on("py-flit-core@3.7:3", type="build")


### PR DESCRIPTION
https://github.com/AA-Turner/roman-numerals/tree/v3.1.0/python

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
