### PR TITLE
kokkos-kernels: Make +lapack depend on +blas

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
@@ -187,7 +187,7 @@ class KokkosKernels(CMakePackage, CudaPackage):
         depends_on(spackname, when=f"+{tpl}")
 
     # lapack TPL depends on blas TPL
-    conflicts('+lapack', when='~blas')
+    conflicts("+lapack", when="~blas")
 
     patch("pr_2296_430.patch", when="@4.3.00:4.4.00")
     patch("pr_2296_400.patch", when="@4.0.00:4.2.01")

--- a/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
@@ -186,6 +186,9 @@ class KokkosKernels(CMakePackage, CudaPackage):
         variant(tpl, default=deflt_bool, when=f"{condition}", description=descr)
         depends_on(spackname, when=f"+{tpl}")
 
+    # lapack TPL depends on blas TPL
+    conflicts('+lapack', when='~blas')
+
     patch("pr_2296_430.patch", when="@4.3.00:4.4.00")
     patch("pr_2296_400.patch", when="@4.0.00:4.2.01")
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

In KokkosKernels, we had the ``+blas`` and ``+lapack`` variants being independent of each other. But in the library code, certain macros were defined only when the BLAS TPL is enabled, and the LAPACK TPL wrappers use these same macros. Effectively this means the LAPACK TPL depends on the BLAS TPL.

For spack, this meant specs like ``kokkos-kernels +lapack`` would fail during the build step:
```
  >> 153    .../spack-stage/spack-stage-kokkos-kernels-4.7.01-gpgzhtduestvywivx5iz4zu2m75mo5cp/spack-src/lapack/tpls/KokkosLapack_Host_tpl.cpp:32:27: error: expected ')' before ',' token
     154       32 | void F77_BLAS_MANGLE(sgesv, SGESV)(int*, int*, float*, int*, int*, float*, int*, int*);
```

This PR ensures that if ``+lapack`` is enabled, then ``+blas`` is also enabled. Now the spec ``+lapack`` is equivalent to ``+blas +lapack``, so the installation works as expected.