### PR TITLE
libunwind: make m4 directory before autoreconf step

### DIFF
--- a/repos/spack_repo/builtin/packages/libunwind/package.py
+++ b/repos/spack_repo/builtin/packages/libunwind/package.py
@@ -136,6 +136,11 @@ class Libunwind(AutotoolsPackage):
 
         return (wrapper_flags, None, flags)
 
+    # The master/stable branches don't have an m4 directory.
+    @run_before("autoreconf")
+    def make_m4_dir(self):
+        mkdirp("m4")
+
     def configure_args(self):
         spec = self.spec
         args = []


### PR DESCRIPTION
Aclocal installs files into m4, but the master and stable branches for libunwind don't include an m4 directory which causes aclocal to fail. This fixes the build for the master and stable branches.

The fgsl, httperf and libgdsii packages also do this.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
