### PR TITLE
Fix for broken libpaths in ESMF mkfile

### DIFF
--- a/repos/spack_repo/builtin/packages/esmf/package.py
+++ b/repos/spack_repo/builtin/packages/esmf/package.py
@@ -323,7 +323,14 @@ class MakefileBuilder(makefile.MakefileBuilder):
             env.set("ESMF_LAPACK", "system")
 
             # Specifies the path where the LAPACK library is located.
-            env.set("ESMF_LAPACK_LIBPATH", spec["lapack"].prefix.lib)
+            env.set(
+                "ESMF_LAPACK_LIBPATH",
+                [
+                    lib_dir
+                    for lib_dir in spec["lapack"].libs.directories
+                    if spec["lapack"].prefix in lib_dir
+                ][0],
+            )
 
             # Specifies the linker directive needed to link the LAPACK library
             # to the application.

--- a/repos/spack_repo/builtin/packages/esmf/package.py
+++ b/repos/spack_repo/builtin/packages/esmf/package.py
@@ -322,7 +322,11 @@ class MakefileBuilder(makefile.MakefileBuilder):
             # ESMF code.
             env.set("ESMF_LAPACK", "system")
 
-            # Specifies the path where the LAPACK library is located.
+            # Specifies the path where the LAPACK library is located. We cannot
+            # simply rely on spec["lapack"].prefix.lib here because some
+            # providers (e.g., MKL) use a deeper directory structure for the
+            # library directory that is not easily generalized. We must also
+            # filter out any system library paths included by the package.
             env.set(
                 "ESMF_LAPACK_LIBPATH",
                 [


### PR DESCRIPTION
The ESMF package sets a number of environment variables to control compilation, which are then documented in the ESMFMKFILE. The logic used to set the `ESMF_LAPACK_LIBPATH` for system LAPACK installations doesn't generally work, as many vendor supplied libraries don't put the libraries into `prefix.lib`. For example:

```
[09:05] ~$ grep LAPACK_LIBPATH /glade/u/apps/casper/24.12/spack/opt/spack/esmf/8.9.0/openmpi/5.0.6/oneapi/2024.2.1/hepb/lib/esmf.mk
# ESMF_LAPACK_LIBPATH:    /glade/u/apps/casper/24.12/spack/opt/spack/intel-oneapi-mkl/2024.2.2/oneapi/2024.2.1/kvnq/lib
#  ESMF_LAPACK_LIBPATH=/glade/u/apps/casper/24.12/spack/opt/spack/intel-oneapi-mkl/2024.2.2/oneapi/2024.2.1/kvnq/lib

[09:05] ~$ ls /glade/u/apps/casper/24.12/spack/opt/spack/intel-oneapi-mkl/2024.2.2/oneapi/2024.2.1/kvnq/lib
ls: cannot access '/glade/u/apps/casper/24.12/spack/opt/spack/intel-oneapi-mkl/2024.2.2/oneapi/2024.2.1/kvnq/lib': No such file or directory

[09:06] ~$ ls /glade/u/apps/casper/24.12/spack/opt/spack/intel-oneapi-mkl/2024.2.2/oneapi/2024.2.1/kvnq/mkl/2024.2/lib/libmkl_core.so
/glade/u/apps/casper/24.12/spack/opt/spack/intel-oneapi-mkl/2024.2.2/oneapi/2024.2.1/kvnq/mkl/2024.2/lib/libmkl_core.so
```

This modified code should give the actual path reported by the LAPACK provider. Since at least one library - mkl - will also report system library paths for things like `-lm`, we need to ensure that only the path containing the provider's prefix is used. If there is a better way to do that than what I propose here, I'm happy to make changes.
