### PR TITLE
ci: pause cray stacks until update completed

### DIFF
--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -9,6 +9,9 @@ variables:
   # PROTECTED_MIRROR_FETCH_DOMAIN: "https://binaries.spack.io"
   PROTECTED_MIRROR_FETCH_DOMAIN: "s3://spack-binaries"
   PROTECTED_MIRROR_PUSH_DOMAIN: "s3://spack-binaries"
+  SPACK_CI_DISABLE_STACKS:
+    value: /^.*cray.*$/
+    expand: false
 
 default:
   image: { "name": "ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18", "entrypoint": [""] }


### PR DESCRIPTION
Pausing E4S Cray pipelines until system upgrades are completed and the relevant stack details are updated accordingly.