### PR TITLE
kokkos-tools: Disable Variorum and SystemTap CMake options

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos_tools/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_tools/package.py
@@ -28,6 +28,12 @@ class KokkosTools(CMakePackage):
 
     def cmake_args(self):
         args = [
+            self.define("CMAKE_DISABLE_FIND_PACKAGE_Variorum", True),
+            self.define("KokkosTools_ENABLE_APEX", False),
+            self.define("KokkosTools_ENABLE_CALIPER", False),
+            self.define("KokkosTools_ENABLE_EXAMPLES", False),
+            self.define("KokkosTools_ENABLE_SINGLE", False),
+            self.define("KokkosTools_ENABLE_TESTS", False),
             self.define_from_variant("KokkosTools_ENABLE_MPI", "mpi"),
             self.define_from_variant("KokkosTools_ENABLE_PAPI", "papi"),
         ]

--- a/repos/spack_repo/builtin/packages/kokkos_tools/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_tools/package.py
@@ -28,9 +28,10 @@ class KokkosTools(CMakePackage):
 
     def cmake_args(self):
         args = [
-            self.define("CMAKE_DISABLE_FIND_PACKAGE_Variorum", True),
             self.define("KokkosTools_ENABLE_APEX", False),
             self.define("KokkosTools_ENABLE_CALIPER", False),
+            self.define("KokkosTools_ENABLE_SYSTEMTAP", False),
+            self.define("KokkosTools_ENABLE_VARIORUM", False),
             self.define("KokkosTools_ENABLE_EXAMPLES", False),
             self.define("KokkosTools_ENABLE_SINGLE", False),
             self.define("KokkosTools_ENABLE_TESTS", False),

--- a/repos/spack_repo/builtin/packages/kokkos_tools/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_tools/package.py
@@ -27,6 +27,9 @@ class KokkosTools(CMakePackage):
     depends_on("papi", when="+papi")
 
     def cmake_args(self):
+        # The plugins are intentionally disabled the time to properly introduce new variants
+        # with associated dependencies.
+        # Feel free to contribute.
         args = [
             self.define("KokkosTools_ENABLE_APEX", False),
             self.define("KokkosTools_ENABLE_CALIPER", False),


### PR DESCRIPTION
~~The PR disables the optional `find_package(Variorum QUIET)` call~~, The PR disables the Variorum and SystemTap cmake options, this should ~~help~~ fix #377. These options can be later defined as Spack variants with associated dependencies. 

@jennfshr 