### PR TITLE
e4s-oneapi ci stack: upgrade to 2025.2 container image

### DIFF
--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -313,7 +313,7 @@ e4s-rocm-external-build:
 
 e4s-oneapi-generate:
   extends: [ ".e4s-oneapi", ".generate-x86_64"]
-  image: ghcr.io/spack/spack/ubuntu22.04-runner-amd64-oneapi-2025.1:2025.03.24
+  image: ghcr.io/spack/e4s-oneapi-base-x86_64:v2025.2-1759968993
 
 e4s-oneapi-build:
   extends: [ ".e4s-oneapi", ".build" ]

--- a/stacks/e4s-oneapi/spack.yaml
+++ b/stacks/e4s-oneapi/spack.yaml
@@ -209,12 +209,12 @@ spack:
   - py-pytest
   - py-scikit-learn
   - py-scipy
-  - py-seaborn
+  # - py-seaborn # error
   # --
   # - py-jupyterlab                 # py-maturin: rust-lld: error: undefined symbol: _intel_fast_memcpy
   # - py-notebook                   # py-maturin: rust-lld: error: undefined symbol: _intel_fast_memcpy
   - py-numba                      # llvm-14.0.6: https://github.com/spack/spack/issues/49625
-  - py-pandas                     # llvm-14.0.6: https://github.com/spack/spack/issues/49625
+  # - py-pandas                     # llvm-14.0.6: https://github.com/spack/spack/issues/49625
   # - py-plotly                     # py-maturin: rust-lld: error: undefined symbol: _intel_fast_memcpy
 
   - aml +level_zero

--- a/stacks/e4s-oneapi/spack.yaml
+++ b/stacks/e4s-oneapi/spack.yaml
@@ -238,7 +238,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: ghcr.io/spack/spack/ubuntu22.04-runner-amd64-oneapi-2025.1:2025.03.24
+        image: ghcr.io/spack/e4s-oneapi-base-x86_64:v2025.2-1759968993
 
   cdash:
     build-group: E4S OneAPI


### PR DESCRIPTION
E4S OneAPI CI stack - use upgraded runner image with 2025.2.1 OneAPI compilers.