### PR TITLE
Vtk: fix 9.4 ionit and 9.4/9.5 gl2ps link bugs

### DIFF
--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -180,7 +180,7 @@ class Vtk(CMakePackage):
     # backport that to 9.4
     patch(
         "https://gitlab.kitware.com/vtk/vtk/-/commit/ee029647e086b3ca01a372b347704f30be87d499.patch",
-        sha="50cbb7dfedafe6740772ff974be426ed870d430e90a23988b8a692f90ba120d3",
+        sha256="50cbb7dfedafe6740772ff974be426ed870d430e90a23988b8a692f90ba120d3",
         when="@9.4"
     )
     # Linking against an external gl2ps causes linker errors due to a lack of

--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -178,11 +178,7 @@ class Vtk(CMakePackage):
     patch("vtk_alias_hdf5.patch", when="@9:")
     # VTK 9.5 adds linkage to inonit when using an external IOSS
     # backport that to 9.4
-    patch(
-        "https://gitlab.kitware.com/vtk/vtk/-/commit/ee029647e086b3ca01a372b347704f30be87d499.diff",
-        sha256="50cbb7dfedafe6740772ff974be426ed870d430e90a23988b8a692f90ba120d3",
-        when="@9.4",
-    )
+    patch("vtk_9.4_external_ioss_linkage.patch", when="@9.4")
     # Linking against an external gl2ps causes linker errors due to a lack of
     # glgetdoublev on macos. Vtk provides an alias for this, us it
     # Upstream issue: https://gitlab.kitware.com/vtk/vtk/-/issues/19561

--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -177,7 +177,8 @@ class Vtk(CMakePackage):
     # the two patches are the same but for the path to the files they patch
     patch("vtk_alias_hdf5.patch", when="@9:")
     # VTK 9.5 adds linkage to inonit when using an external IOSS
-    # backport that to 9.4
+    # backport that to 9.4 
+    # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/12279
     patch("vtk_9.4_external_ioss_linkage.patch", when="@9.4")
     # Linking against an external gl2ps causes linker errors due to a lack of
     # glgetdoublev on macos. Vtk provides an alias for this, us it

--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -181,7 +181,7 @@ class Vtk(CMakePackage):
     patch(
         "https://gitlab.kitware.com/vtk/vtk/-/commit/ee029647e086b3ca01a372b347704f30be87d499.patch",
         sha256="50cbb7dfedafe6740772ff974be426ed870d430e90a23988b8a692f90ba120d3",
-        when="@9.4"
+        when="@9.4",
     )
     # Linking against an external gl2ps causes linker errors due to a lack of
     # glgetdoublev on macos. Vtk provides an alias for this, us it

--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -176,6 +176,18 @@ class Vtk(CMakePackage):
     # a patch with the same name is also applied to paraview
     # the two patches are the same but for the path to the files they patch
     patch("vtk_alias_hdf5.patch", when="@9:")
+    # VTK 9.5 adds linkage to inonit when using an external IOSS
+    # backport that to 9.4
+    patch(
+        "https://gitlab.kitware.com/vtk/vtk/-/commit/ee029647e086b3ca01a372b347704f30be87d499.patch",
+        sha="50cbb7dfedafe6740772ff974be426ed870d430e90a23988b8a692f90ba120d3",
+        when="@9.4"
+    )
+    # Linking against an external gl2ps causes linker errors due to a lack of
+    # glgetdoublev on macos. Vtk provides an alias for this, us it
+    # Upstream issue: https://gitlab.kitware.com/vtk/vtk/-/issues/19561
+    patch("vtk-alias-gldoublev.patch", when="platform=darwin @9.4:")
+
     # VTK 9.0 on Windows uses dll instead of lib for hdf5-hl target, which fails linking. Can't
     # be fixed by bumping CMake lower bound, because VTK vendors FindHDF5.cmake. Various other
     # patches to FindHDF5.cmake are missing, so add conflict instead of a series of patches.

--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -177,7 +177,7 @@ class Vtk(CMakePackage):
     # the two patches are the same but for the path to the files they patch
     patch("vtk_alias_hdf5.patch", when="@9:")
     # VTK 9.5 adds linkage to inonit when using an external IOSS
-    # backport that to 9.4 
+    # backport that to 9.4
     # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/12279
     patch("vtk_9.4_external_ioss_linkage.patch", when="@9.4")
     # Linking against an external gl2ps causes linker errors due to a lack of

--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -179,7 +179,7 @@ class Vtk(CMakePackage):
     # VTK 9.5 adds linkage to inonit when using an external IOSS
     # backport that to 9.4
     patch(
-        "https://gitlab.kitware.com/vtk/vtk/-/commit/ee029647e086b3ca01a372b347704f30be87d499.patch",
+        "https://gitlab.kitware.com/vtk/vtk/-/commit/ee029647e086b3ca01a372b347704f30be87d499.diff",
         sha256="50cbb7dfedafe6740772ff974be426ed870d430e90a23988b8a692f90ba120d3",
         when="@9.4",
     )

--- a/repos/spack_repo/builtin/packages/vtk/vtk-alias-gldoublev.patch
+++ b/repos/spack_repo/builtin/packages/vtk/vtk-alias-gldoublev.patch
@@ -1,0 +1,12 @@
+diff --git a/Rendering/GL2PSOpenGL2/vtkOpenGLGL2PSHelperImpl.cxx b/Rendering/GL2PSOpenGL2/vtkOpenGLGL2PSHelperImpl.cxx
+index eece0354e1..e99c67fd08 100644
+--- a/Rendering/GL2PSOpenGL2/vtkOpenGLGL2PSHelperImpl.cxx
++++ b/Rendering/GL2PSOpenGL2/vtkOpenGLGL2PSHelperImpl.cxx
+@@ -21,6 +21,7 @@
+ #include "vtkTextRenderer.h"
+ #include "vtkTransformFeedback.h"
+ 
++#include "vtk_glad.h"
+ #include "vtk_gl2ps.h"
+ 
+ #include <algorithm>

--- a/repos/spack_repo/builtin/packages/vtk/vtk_9.4_external_ioss_linkage.patch
+++ b/repos/spack_repo/builtin/packages/vtk/vtk_9.4_external_ioss_linkage.patch
@@ -1,0 +1,13 @@
+diff --git a/ThirdParty/ioss/CMakeLists.txt b/ThirdParty/ioss/CMakeLists.txt
+index 3a6348e2c031f82b90b34452b097f46b24456913..764ad351806e721c4602815518de357ef853f761 100644
+--- a/ThirdParty/ioss/CMakeLists.txt
++++ b/ThirdParty/ioss/CMakeLists.txt
+@@ -13,7 +13,7 @@ vtk_module_third_party(
+     STANDARD_INCLUDE_DIRS
+   EXTERNAL
+     PACKAGE SEACASIoss
+-    TARGETS Ioss
++    TARGETS Ioss Ionit
+     USE_VARIABLES SEACASIoss_INCLUDE_DIRS
+     STANDARD_INCLUDE_DIRS)
+ 


### PR DESCRIPTION
Vtk@9.4 backport Ionit fix from 9.5 to 9.4

Fixup bug linking to gl2ps on MacOS where gl2ps does not provide the symbol `glgetdoublev`, use VTK's header that provides bridge functionality 