### PR TITLE
AutotoolsPackage: add missing diffutils dependency

### DIFF
--- a/repos/spack_repo/builtin/build_systems/autotools.py
+++ b/repos/spack_repo/builtin/build_systems/autotools.py
@@ -60,6 +60,7 @@ class AutotoolsPackage(PackageBase):
         depends_on("gnuconfig", type="build", when="target=aarch64:")
         depends_on("gnuconfig", type="build", when="target=riscv64:")
         depends_on("gmake", type="build")
+        depends_on("diffutils", type="build")
         conflicts("platform=windows")
 
     def flags_to_build_system_args(self, flags):

--- a/repos/spack_repo/builtin/packages/diffutils/package.py
+++ b/repos/spack_repo/builtin/packages/diffutils/package.py
@@ -4,13 +4,13 @@
 
 import re
 
-from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.build_systems.generic import Package
 from spack_repo.builtin.build_systems.gnu import GNUMirrorPackage
 
 from spack.package import *
 
 
-class Diffutils(AutotoolsPackage, GNUMirrorPackage):
+class Diffutils(Package, GNUMirrorPackage):
     """GNU Diffutils is a package of several programs related to finding
     differences between files."""
 
@@ -55,3 +55,11 @@ class Diffutils(AutotoolsPackage, GNUMirrorPackage):
         output = Executable(exe)("--version", output=str, error=str)
         match = re.search(r"diff \(GNU diffutils\) (\S+)", output)
         return match.group(1) if match else None
+
+    def install(self, spec, prefix):
+        configure = Executable(join_path(self.stage.source_path, "configure"))
+        make = which("make")
+        with working_dir(self.build_directory, create=True):
+            configure(f"--prefix={prefix}")
+            make()
+            make("install")

--- a/repos/spack_repo/builtin/packages/libiconv/package.py
+++ b/repos/spack_repo/builtin/packages/libiconv/package.py
@@ -2,13 +2,13 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.build_systems.generic import Package
 from spack_repo.builtin.build_systems.gnu import GNUMirrorPackage
 
 from spack.package import *
 
 
-class Libiconv(AutotoolsPackage, GNUMirrorPackage):
+class Libiconv(Package, GNUMirrorPackage):
     """GNU libiconv provides an implementation of the iconv() function
     and the iconv program for character set conversion."""
 
@@ -23,7 +23,9 @@ class Libiconv(AutotoolsPackage, GNUMirrorPackage):
     version("1.15", sha256="ccf536620a45458d26ba83887a983b96827001e92a13847b45e4925cc8913178")
     version("1.14", sha256="72b24ded17d687193c3366d0ebe7cde1e6b18f0df8c55438ac95be39e8a30613")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
+
+    build_directory = "spack-build"
 
     variant(
         "libs",
@@ -43,7 +45,16 @@ class Libiconv(AutotoolsPackage, GNUMirrorPackage):
     def configure_args(self):
         args = ["--enable-extra-encodings"]
 
-        args += self.enable_or_disable("libs")
+        if self.spec.satisfies("libs=shared"):
+            args.append("--enable-shared")
+        else:
+            args.append("--disable-shared")
+
+        if self.spec.satisfies("libs=static"):
+            args.append("--enable-static")
+        else:
+            args.append("--disable-static")
+
         args.append("--with-pic")
 
         # Starting version 1.17, libiconv uses the version of gnulib that implements a
@@ -57,9 +68,17 @@ class Libiconv(AutotoolsPackage, GNUMirrorPackage):
         if self.spec.satisfies("@1.17:%nvhpc"):
             args.append("gl_cv_cc_wallow=none")
 
+        return args
+
+    def install(self, spec, prefix):
+        configure = Executable(join_path(self.stage.source_path, "configure"))
+        make = which("make")
         # A hack to patch config.guess in the libcharset sub directory
         copy("./build-aux/config.guess", "libcharset/build-aux/config.guess")
-        return args
+        with working_dir(self.build_directory, create=True):
+            configure(f"--prefix={prefix}", *self.configure_args())
+            make()
+            make("install")
 
     @property
     def libs(self):


### PR DESCRIPTION
While debugging a build failure in yaksa, I noticed that many, if not all, configure scripts require diffutils, e.g.:
```
checking if $SPACK/opt/spack/linux-skylake/compiler-wrapper-1.0-famqftdrjs5p3x2icdckr35xxszwhzhn/libexec/spack/gcc/gcc supports -fno-rtti -fno-exceptions... $SPACK_STAGE/spack-stage-yaksa-0.3-rwuygjddrlbs76e64zgg2fszdlvidl5b/spack-src/configure: line 9713: diff: command not found
```
However, in this case, the error was hidden:
```
checking whether C compiler accepts option -std=c11... no
```
This is obviously not true and caused the build failure. `config.log` contains:
```
configure:14539: checking whether C compiler accepts option -std=c11
configure:14594: $SPACK/opt/spack/linux-skylake/compiler-wrapper-1.0-famqftdrjs5p3x2icdckr35xxszwhzhn/libexec/spack/gcc/gcc -o conftest  -std=c11   conftest.c  > pac_test1.log 2>&1
configure:14594: $? = 0
configure:14629: $SPACK/opt/spack/linux-skylake/compiler-wrapper-1.0-famqftdrjs5p3x2icdckr35xxszwhzhn/libexec/spack/gcc/gcc -o conftest -std=c11  -std=c11   conftest.c  > pac_test2.log 2>&1
configure:14629: $? = 0
configure:14638: diff -b pac_test1.log pac_test2.log > pac_test.log
$SPACK_STAGE/spack-stage-yaksa-0.3-rwuygjddrlbs76e64zgg2fszdlvidl5b/spack-src/configure: line 14639: diff: command not found
configure:14641: $? = 127
configure: program exited with status 127
*** diff -b pac_test1.log pac_test2.log :
configure:14753: result: no
```
Adding diffutils as a build dependency required changing diffutils and libiconv (diffutil's only dependency) from AutotoolsPackage to Package, which is obviously a bit ugly since AutotoolsPackage provides quite a bit of convenience functionality.

This error happens in, e.g., Rocky Linux and Fedora containers since both do not contain `diff`.