### PR TITLE
ESMF: workaround for legacy linking to MPI C++ interface

### DIFF
--- a/repos/spack_repo/builtin/packages/esmf/package.py
+++ b/repos/spack_repo/builtin/packages/esmf/package.py
@@ -422,6 +422,8 @@ class MakefileBuilder(makefile.MakefileBuilder):
                 library_path = os.path.join(self.prefix.lib, "libesmf.%s" % suffix)
                 if os.path.exists(library_path):
                     os.symlink(library_path, os.path.join(self.prefix.lib, "libESMF.%s" % suffix))
+        # https://github.com/esmf-org/esmf/issues/497
+        filter_file("-lmpi_cxx", "", os.path.join(self.prefix.lib, "esmf.mk"), string=True)
 
     def check(self):
         make("check", parallel=False)


### PR DESCRIPTION
## Description

`repos/spack_repo/builtin/packages/esmf/package.py`: workaround for legacy linking to MPI C++ interface.

A fix for this will be made upstream for newer versions of ESMF (release/beta snapshot unknown). The `filter_file` function doesn't cause any harm if the search string can't be found, therefore not applying any version bounds to this patch.

## Issues

See https://github.com/esmf-org/esmf/issues/497.

## Testing

Tested on Navy DSRC Nautilus system that has the MPI C++ bindings installed.
