### PR TITLE
ambertools: update package to ambertools 2025

### DIFF
--- a/repos/spack_repo/builtin/packages/ambertools/package.py
+++ b/repos/spack_repo/builtin/packages/ambertools/package.py
@@ -1,6 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 
@@ -13,15 +14,26 @@ class Ambertools(CMakePackage):
     and its components are mostly released under the GNU General Public
     License (GPL). A few components are included that are in the public
     domain or which have other, open-source, licenses. The libsander and
-    libpbsa libraries use the LGPL license."""
+    libpbsa libraries use the LGPL license.
+
+    A manual download is required for AmberTools. Spack will search your current
+    directory for the download files. Alternatively, add the files to a mirror
+    so that Spack can find them. For instructions on how to set up a mirror, see
+    https://spack.readthedocs.io/en/latest/mirrors.html
+    """
 
     homepage = "https://ambermd.org/AmberTools.php"
-    url = "https://ambermd.org/downloads/AmberTools22jlmrcc.tar.bz2"
+    url = f"file://{os.getcwd()}/ambertools25.tar.bz2"
+    manual_download = True
 
     maintainers("d-beltran")
 
-    version("22jlmrcc", sha256="1571d4e0f7d45b2a71dce5999fa875aea8c90ee219eb218d7916bf30ea229121")
-    version("v25", sha256="ac009b2adeb25ccd2191db28905b867df49240e038dc590f423edf0d84f8a13b", url="https://ambermd.org/downloads/ambertools25.tar.bz2")
+    version(
+        "22jlmrcc",
+        sha256="1571d4e0f7d45b2a71dce5999fa875aea8c90ee219eb218d7916bf30ea229121",
+        deprecated=True,
+    )
+    version("25", sha256="ac009b2adeb25ccd2191db28905b867df49240e038dc590f423edf0d84f8a13b")
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
@@ -44,8 +56,8 @@ class Ambertools(CMakePackage):
         type=("build", "run"),
     )
     # Python dependencies
-    depends_on("python@3.8:3.10 +tkinter",when="22jlmrcc", type=("build", "run"))
-    depends_on("python@3.11:", when="v25", type=("build", "run"))
+    depends_on("python@3.8:3.10 +tkinter", when="^22jlmrcc", type=("build", "run"))
+    depends_on("python@3.11:", when="^25", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-matplotlib", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/ambertools/package.py
+++ b/repos/spack_repo/builtin/packages/ambertools/package.py
@@ -36,6 +36,7 @@ class Ambertools(CMakePackage):
     version("25", sha256="ac009b2adeb25ccd2191db28905b867df49240e038dc590f423edf0d84f8a13b")
     depends_on("c", type="build")
     depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
 
     depends_on("flex", type="build")
     depends_on("bison", type="build")

--- a/repos/spack_repo/builtin/packages/ambertools/package.py
+++ b/repos/spack_repo/builtin/packages/ambertools/package.py
@@ -21,7 +21,7 @@ class Ambertools(CMakePackage):
     maintainers("d-beltran")
 
     version("22jlmrcc", sha256="1571d4e0f7d45b2a71dce5999fa875aea8c90ee219eb218d7916bf30ea229121")
-
+    version("v25", sha256="ac009b2adeb25ccd2191db28905b867df49240e038dc590f423edf0d84f8a13b", url="https://ambermd.org/downloads/ambertools25.tar.bz2")
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
@@ -44,7 +44,8 @@ class Ambertools(CMakePackage):
         type=("build", "run"),
     )
     # Python dependencies
-    depends_on("python@3.8:3.10 +tkinter", type=("build", "run"))
+    depends_on("python@3.8:3.10 +tkinter",when="22jlmrcc", type=("build", "run"))
+    depends_on("python@3.11:", when="v25", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-matplotlib", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/ambertools/package.py
+++ b/repos/spack_repo/builtin/packages/ambertools/package.py
@@ -56,8 +56,8 @@ class Ambertools(CMakePackage):
         type=("build", "run"),
     )
     # Python dependencies
-    depends_on("python@3.8:3.10 +tkinter", when="^22jlmrcc", type=("build", "run"))
-    depends_on("python@3.11:", when="^25", type=("build", "run"))
+    depends_on("python@3.8:3.10 +tkinter", when="@22jlmrcc", type=("build", "run"))
+    depends_on("python@3.11:", when="@25:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-matplotlib", type=("build", "run"))


### PR DESCRIPTION
This PR adds version 2025 of `ambertools` to the `builtin` spack-package that was merged in #42684 and bumps the python dependency to `python@3.11:`. There are some issues with this package as noted in my original issue: #1659 including that the `ambertools` tar file requires a manual download from https://ambermd.org/GetAmber.php#ambertools and that the package does not install locally with my changes as they are here because of a problem with `netlib-xblas`, (which maybe needs to be modified as well) i.e.:

```bash
==> No binary for netlib-xblas-1.0.248-l7ztnsl2rzigfm34c3v2m4qamref5iur found: installing from source
==> Installing netlib-xblas-1.0.248-l7ztnsl2rzigfm34c3v2m4qamref5iur [46/79]
==> Fetching https://mirror.spack.io/_source-cache/archive/b5/b5fe7c71c2da1ed9bcdc5784a12c5fa9fb417577513fe8a38de5de0007f7aaa1.tar.gz
    [100%]    2.09 MB @    7.5 MB/s
==> No patches needed for netlib-xblas
==> netlib-xblas: Executing phase: 'autoreconf'
==> netlib-xblas: Executing phase: 'configure'
==> Error: ProcessError: Command exited with status 1:
    '/tmp/awitmer/spack-stage/spack-stage-netlib-xblas-1.0.248-l7ztnsl2rzigfm34c3v2m4qamref5iur/spack-src/configure' '--prefix=/users/awitmer/spack/opt/spack/linux-icelake/netlib-xblas-1.0.248-l7ztnsl2rzigfm34c3v2m4qamref5iur' '--disable-plain-blas'

2 errors found in build log:
     27    checking whether we are using the GNU Fortran compiler... no
     28    checking whether f77 accepts -g... no
     29    checking how to get verbose linking output from f77... configure: WARNING: compilation failed
     30    
     31    checking for Fortran libraries of f77...
     32    checking for dummy main to link with Fortran libraries... none
  >> 33    checking for Fortran name-mangling scheme... configure: error: in `/tmp/awitmer/spack-stage/spack-stage-netlib-xblas-1.0.248-l7ztnsl2rzigfm34c3v2m4qamref5iur/spack-src':
  >> 34    configure: error: cannot compile a simple Fortran program
     35    See `config.log' for more details.
```

Perhaps @d-beltran, who wrote the initial package can provide some insight into this? Also @rbberger can you let me know if you need me to download and include the install `.tar` file from the website here or what's the best way to go about including that in the package? Thanks!

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
