### PR TITLE
Proj: 8:9.1 use documented curl include interface

### DIFF
--- a/repos/spack_repo/builtin/packages/proj/package.py
+++ b/repos/spack_repo/builtin/packages/proj/package.py
@@ -171,6 +171,8 @@ class CMakeBuilder(AnyBuilder, cmake.CMakeBuilder):
         else:
             test_flag = "PROJ4_TESTS"
         args.append(self.define(test_flag, self.pkg.run_tests))
+        if self.spec["curl"].satisfies("build_system=cmake"):
+            args.append(self.define("CMAKE_CXX_FLAGS", "-DCURL_STATICLIB"))
         return args
 
 

--- a/repos/spack_repo/builtin/packages/proj/package.py
+++ b/repos/spack_repo/builtin/packages/proj/package.py
@@ -107,6 +107,15 @@ class Proj(CMakePackage, AutotoolsPackage):
         patch("proj.cmakelists.5.0.patch", when="@5.0")
         patch("proj.cmakelists.5.1.patch", when="@5.1:5.2")
 
+        # proj 8-9.1 relies on an undocumented side effect of CMake's
+        # FindCurl module, patch it to use the interface supported by
+        # both curl's cmake module and CMake's find curl module
+        # This is fixed in proj upstream as of 9.2
+        # there is a slight difference in requirements for 8 vs 9:9.1
+        # hence two patches
+        patch("proj_8_include_curl_dirs.patch", when="@8")
+        patch("proj_9_include_curl_dirs.patch", when="@9:9.1")
+
         depends_on("cmake@3.16:", when="@9.4:", type="build")
         depends_on("cmake@3.9:", when="@6:", type="build")
         depends_on("cmake@3.5:", when="@5", type="build")

--- a/repos/spack_repo/builtin/packages/proj/package.py
+++ b/repos/spack_repo/builtin/packages/proj/package.py
@@ -116,6 +116,11 @@ class Proj(CMakePackage, AutotoolsPackage):
         patch("proj_8_include_curl_dirs.patch", when="@8")
         patch("proj_9_include_curl_dirs.patch", when="@9:9.1")
 
+        # proj 8 uses CURL_LIBRARY instead of the correct
+        # CURL_LIBRARIES, patch to correct that useage
+        # fixed in upstream proj as of 9
+        patch("proj_8_curl_libraries.patch", when="@8")
+
         depends_on("cmake@3.16:", when="@9.4:", type="build")
         depends_on("cmake@3.9:", when="@6:", type="build")
         depends_on("cmake@3.5:", when="@5", type="build")

--- a/repos/spack_repo/builtin/packages/proj/proj_8_curl_libraries.patch
+++ b/repos/spack_repo/builtin/packages/proj/proj_8_curl_libraries.patch
@@ -1,0 +1,13 @@
+diff --git a/src/lib_proj.cmake b/src/lib_proj.cmake
+index f2de1c10..034b601d 100644
+--- a/src/lib_proj.cmake
++++ b/src/lib_proj.cmake
+@@ -413,7 +413,7 @@ if(CURL_ENABLED)
+   target_include_directories(proj PRIVATE ${CURL_INCLUDE_DIR})
+   target_link_libraries(proj
+     PRIVATE
+-      ${CURL_LIBRARY}
++      ${CURL_LIBRARIES}
+       $<$<CXX_COMPILER_ID:MSVC>:ws2_32>
+       $<$<CXX_COMPILER_ID:MSVC>:wldap32>
+       $<$<CXX_COMPILER_ID:MSVC>:advapi32>

--- a/repos/spack_repo/builtin/packages/proj/proj_8_include_curl_dirs.patch
+++ b/repos/spack_repo/builtin/packages/proj/proj_8_include_curl_dirs.patch
@@ -1,0 +1,26 @@
+diff --git a/src/lib_proj.cmake b/src/lib_proj.cmake
+index a35eeb8c..b98a435d 100644
+--- a/src/lib_proj.cmake
++++ b/src/lib_proj.cmake
+@@ -470,7 +470,7 @@ endif()
+ 
+ if(CURL_ENABLED)
+   target_compile_definitions(proj PRIVATE -DCURL_ENABLED)
+-  target_include_directories(proj PRIVATE ${CURL_INCLUDE_DIR})
++  target_include_directories(proj PRIVATE ${CURL_INCLUDE_DIRS})
+   target_link_libraries(proj
+     PRIVATE
+       ${CURL_LIBRARY}
+diff --git a/test/unit/CMakeLists.txt b/test/unit/CMakeLists.txt
+index eb41a6c8..a09bed62 100644
+--- a/test/unit/CMakeLists.txt
++++ b/test/unit/CMakeLists.txt
+@@ -144,7 +144,7 @@ add_executable(test_network
+   main.cpp
+   test_network.cpp)
+ if(CURL_ENABLED)
+-  include_directories(${CURL_INCLUDE_DIR})
++  include_directories(${CURL_INCLUDE_DIRS})
+   target_compile_definitions(test_network PRIVATE -DCURL_ENABLED)
+   target_link_libraries(test_network PRIVATE ${CURL_LIBRARY})
+ endif()

--- a/repos/spack_repo/builtin/packages/proj/proj_9_include_curl_dirs.patch
+++ b/repos/spack_repo/builtin/packages/proj/proj_9_include_curl_dirs.patch
@@ -1,0 +1,13 @@
+diff --git a/test/unit/CMakeLists.txt b/test/unit/CMakeLists.txt
+index 43eeca98..e0084f3c 100644
+--- a/test/unit/CMakeLists.txt
++++ b/test/unit/CMakeLists.txt
+@@ -160,7 +160,7 @@ add_executable(test_network
+   main.cpp
+   test_network.cpp)
+ if(CURL_ENABLED)
+-  include_directories(${CURL_INCLUDE_DIR})
++  include_directories(${CURL_INCLUDE_DIRS})
+   target_compile_definitions(test_network PRIVATE -DCURL_ENABLED)
+   target_link_libraries(test_network PRIVATE ${CURL_LIBRARY})
+ endif()


### PR DESCRIPTION
Proj `@8:9.1` references the curl include dirs via `CURL_INCLUDE_DIR`, which is not a part of the `FindCURL` interface, but is a side effect of the CMake vendored curl find module. 

Both CMake's find curl module and Curl's CMake config support `CURL_INCLUDE_DIRS` (note the plural) so use that instead.

This issue is resolved in upstream proj 9.2 and later.