### PR TITLE
mvapich: remove cuda variant

### DIFF
--- a/repos/spack_repo/builtin/packages/beatnik/package.py
+++ b/repos/spack_repo/builtin/packages/beatnik/package.py
@@ -35,8 +35,8 @@ class Beatnik(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("mpi")
     with when("+cuda"):
         depends_on("mpich +cuda", when="^[virtuals=mpi] mpich")
-        depends_on("mvapich +cuda", when="^[virtuals=mpi] mvapich")
-        depends_on("mvapich2 +cuda", when="^[virtuals=mpi] mvapich2")
+        depends_on("mvapich-plus +cuda", when="^[virtuals=mpi] mvapich")
+        depends_on("mvapich2-gdr +cuda", when="^[virtuals=mpi] mvapich2-gdr")
         depends_on("openmpi +cuda", when="^[virtuals=mpi] openmpi")
 
     with when("+rocm"):

--- a/repos/spack_repo/builtin/packages/beatnik/package.py
+++ b/repos/spack_repo/builtin/packages/beatnik/package.py
@@ -36,11 +36,12 @@ class Beatnik(CMakePackage, CudaPackage, ROCmPackage):
     with when("+cuda"):
         depends_on("mpich +cuda", when="^[virtuals=mpi] mpich")
         depends_on("mvapich-plus +cuda", when="^[virtuals=mpi] mvapich")
-        depends_on("mvapich2-gdr +cuda", when="^[virtuals=mpi] mvapich2-gdr")
         depends_on("openmpi +cuda", when="^[virtuals=mpi] openmpi")
 
     with when("+rocm"):
         depends_on("mpich +rocm", when="^[virtuals=mpi] mpich")
+        depends_on("mvapich-plus +rocm", when="^[virtuals=mpi] mvapich-plus")
+        depends_on("openmpi +rocm", when="^[virtuals=mpi] openmpi@5:")
 
     # Kokkos dependencies
     depends_on("kokkos @4:")

--- a/repos/spack_repo/builtin/packages/beatnik/package.py
+++ b/repos/spack_repo/builtin/packages/beatnik/package.py
@@ -35,7 +35,7 @@ class Beatnik(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("mpi")
     with when("+cuda"):
         depends_on("mpich +cuda", when="^[virtuals=mpi] mpich")
-        depends_on("mvapich-plus +cuda", when="^[virtuals=mpi] mvapich")
+        depends_on("mvapich-plus +cuda", when="^[virtuals=mpi] mvapich-plus")
         depends_on("openmpi +cuda", when="^[virtuals=mpi] openmpi")
 
     with when("+rocm"):

--- a/repos/spack_repo/builtin/packages/mvapich/package.py
+++ b/repos/spack_repo/builtin/packages/mvapich/package.py
@@ -197,6 +197,8 @@ class Mvapich(MpichEnvironmentModifications, AutotoolsPackage):
             "--disable-silent-rules",
             "--disable-new-dtags",
             "--enable-fortran=all",
+            "--disable-cuda",
+            "--disable-hip",
             "--enable-threads={0}".format(spec.variants["threads"].value),
             "--with-ch3-rank-bits={0}".format(spec.variants["ch3_rank_bits"].value),
             "--enable-wrapper-rpath={0}".format("no" if "~wrapperrpath" in spec else "yes"),

--- a/repos/spack_repo/builtin/packages/mvapich/package.py
+++ b/repos/spack_repo/builtin/packages/mvapich/package.py
@@ -6,13 +6,15 @@ import itertools
 import re
 import sys
 
+from spack_repo.builtin.build_systems.cuda import CudaPackage
+from spack_repo.builtin.build_systems.rocm import ROCmPackage
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack_repo.builtin.packages.mpich.package import MpichEnvironmentModifications
 
 from spack.package import *
 
 
-class Mvapich(MpichEnvironmentModifications, AutotoolsPackage):
+class Mvapich(MpichEnvironmentModifications, AutotoolsPackage, CudaPackage, ROCmPackage):
     """Mvapich is a High-Performance MPI Library for clusters with diverse
     networks (InfiniBand, Omni-Path, Ethernet/iWARP, and RoCE) and computing
     platforms (x86 (Intel and AMD), ARM and OpenPOWER)"""
@@ -38,8 +40,6 @@ class Mvapich(MpichEnvironmentModifications, AutotoolsPackage):
 
     variant("wrapperrpath", default=True, description="Enable wrapper rpath")
     variant("debug", default=False, description="Enable debug info and error messages at run-time")
-
-    variant("cuda", default=False, description="Enable CUDA extension")
 
     variant("regcache", default=True, description="Enable memory registration cache")
 
@@ -229,6 +229,11 @@ class Mvapich(MpichEnvironmentModifications, AutotoolsPackage):
             args.extend(["--enable-cuda", "--with-cuda={0}".format(spec["cuda"].prefix)])
         else:
             args.append("--disable-cuda")
+
+        if "+rocm" in self.spec:
+            args.extend(["--enable-hip", "--with-hip={0}".format(spec["hip"].prefix)])
+        else:
+            args.append("--disable-hip")
 
         if "+regcache" in self.spec:
             args.append("--enable-registration-cache")

--- a/repos/spack_repo/builtin/packages/mvapich/package.py
+++ b/repos/spack_repo/builtin/packages/mvapich/package.py
@@ -7,14 +7,12 @@ import re
 import sys
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
-from spack_repo.builtin.build_systems.cuda import CudaPackage
-from spack_repo.builtin.build_systems.rocm import ROCmPackage
 from spack_repo.builtin.packages.mpich.package import MpichEnvironmentModifications
 
 from spack.package import *
 
 
-class Mvapich(MpichEnvironmentModifications, AutotoolsPackage, CudaPackage, ROCmPackage):
+class Mvapich(MpichEnvironmentModifications, AutotoolsPackage):
     """Mvapich is a High-Performance MPI Library for clusters with diverse
     networks (InfiniBand, Omni-Path, Ethernet/iWARP, and RoCE) and computing
     platforms (x86 (Intel and AMD), ARM and OpenPOWER)"""
@@ -97,7 +95,6 @@ class Mvapich(MpichEnvironmentModifications, AutotoolsPackage, CudaPackage, ROCm
     depends_on("zlib-api")
     depends_on("libpciaccess", when=(sys.platform != "darwin"))
     depends_on("libxml2")
-    depends_on("cuda", when="+cuda")
     depends_on("libfabric", when="netmod=ofi")
     depends_on("slurm", when="process_managers=slurm")
     depends_on("ucx", when="netmod=ucx")
@@ -224,16 +221,6 @@ class Mvapich(MpichEnvironmentModifications, AutotoolsPackage, CudaPackage, ROCm
             )
         else:
             args.append("--enable-fast=all")
-
-        if "+cuda" in self.spec:
-            args.extend(["--enable-cuda", "--with-cuda={0}".format(spec["cuda"].prefix)])
-        else:
-            args.append("--disable-cuda")
-
-        if "+rocm" in self.spec:
-            args.extend(["--enable-hip", "--with-hip={0}".format(spec["hip"].prefix)])
-        else:
-            args.append("--disable-hip")
 
         if "+regcache" in self.spec:
             args.append("--enable-registration-cache")

--- a/repos/spack_repo/builtin/packages/mvapich/package.py
+++ b/repos/spack_repo/builtin/packages/mvapich/package.py
@@ -6,9 +6,9 @@ import itertools
 import re
 import sys
 
+from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
-from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack_repo.builtin.packages.mpich.package import MpichEnvironmentModifications
 
 from spack.package import *

--- a/repos/spack_repo/builtin/packages/mvapich2/package.py
+++ b/repos/spack_repo/builtin/packages/mvapich2/package.py
@@ -48,8 +48,6 @@ class Mvapich2(MpichEnvironmentModifications, AutotoolsPackage):
     variant("wrapperrpath", default=True, description="Enable wrapper rpath")
     variant("debug", default=False, description="Enable debug info and error messages at run-time")
 
-    variant("cuda", default=False, description="Enable CUDA extension")
-
     variant("regcache", default=True, description="Enable memory registration cache")
 
     # Accepted values are:
@@ -139,7 +137,6 @@ class Mvapich2(MpichEnvironmentModifications, AutotoolsPackage):
     depends_on("zlib-api")
     depends_on("libpciaccess", when=(sys.platform != "darwin"))
     depends_on("libxml2")
-    depends_on("cuda", when="+cuda")
     depends_on("psm", when="fabrics=psm")
     depends_on("opa-psm2", when="fabrics=psm2")
     depends_on("rdma-core", when="fabrics=mrail")
@@ -202,11 +199,6 @@ class Mvapich2(MpichEnvironmentModifications, AutotoolsPackage):
                 variants += "+debug"
             else:
                 variants += "~debug"
-
-            if re.search("--enable-cuda", output):
-                variants += "+cuda"
-            else:
-                variants += "~cuda"
 
             if re.search("--enable-registration-cache", output):
                 variants += "+regcache"
@@ -387,6 +379,7 @@ class Mvapich2(MpichEnvironmentModifications, AutotoolsPackage):
             "--disable-silent-rules",
             "--disable-new-dtags",
             "--enable-fortran=all",
+            "--disable-cuda",
             "--enable-threads={0}".format(spec.variants["threads"].value),
             "--with-ch3-rank-bits={0}".format(spec.variants["ch3_rank_bits"].value),
             "--enable-wrapper-rpath={0}".format("no" if "~wrapperrpath" in spec else "yes"),
@@ -407,11 +400,6 @@ class Mvapich2(MpichEnvironmentModifications, AutotoolsPackage):
             )
         else:
             args.append("--enable-fast=all")
-
-        if "+cuda" in self.spec:
-            args.extend(["--enable-cuda", "--with-cuda={0}".format(spec["cuda"].prefix)])
-        else:
-            args.append("--disable-cuda")
         if "~hwloc_graphics" in self.spec:
             args.append("--disable-opencl")
             args.append("--disable-gl")

--- a/repos/spack_repo/builtin/packages/mvapich_plus/package.py
+++ b/repos/spack_repo/builtin/packages/mvapich_plus/package.py
@@ -263,7 +263,7 @@ class MvapichPlus(AutotoolsPackage, CudaPackage, ROCmPackage):
             "--disable-opencl",
             "--disable-gl",
             "--enable-fortran=all",
-            "-disable-omb",
+            "--disable-omb",
             f"--enable-wrapper-rpath={'no' if spec.satisfies('~wrapperrpath') else 'yes'}",
         ]
 

--- a/repos/spack_repo/builtin/packages/seissol/package.py
+++ b/repos/spack_repo/builtin/packages/seissol/package.py
@@ -185,11 +185,11 @@ class Seissol(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("mpi")
 
     with when("+cuda"):
-        for var in ["openmpi", "mpich", "mvapich", "mvapich2"]:
+        for var in ["openmpi", "mpich", "mvapich-plus"]:
             depends_on(f"{var} +cuda", when=f"^[virtuals=mpi] {var}")
 
     with when("+rocm"):
-        for var in ["mpich"]:
+        for var in ["openmpi@5:", "mpich", "mvapich-plus"]:
             depends_on(f"{var} +rocm", when=f"^[virtuals=mpi] {var}")
 
     # with cuda 12 and llvm 14:15, we have the issue: "error: no template named 'texture"

--- a/repos/spack_repo/builtin/packages/sphexa/package.py
+++ b/repos/spack_repo/builtin/packages/sphexa/package.py
@@ -40,8 +40,8 @@ class Sphexa(CMakePackage, CudaPackage, ROCmPackage):
     with when("+gpu_aware_mpi"):
         depends_on("openmpi +cuda", when="+cuda ^[virtuals=mpi] openmpi")
         depends_on("mpich +cuda", when="+cuda ^[virtuals=mpi] mpich")
-        depends_on("mvapich +cuda", when="+cuda ^[virtuals=mpi] mvapich")
-        depends_on("mvapich2 +cuda", when="+cuda ^[virtuals=mpi] mvapich2")
+        depends_on("mvapich-plus +cuda", when="+cuda ^[virtuals=mpi] mvapich-plus")
+        depends_on("mvapich2-gdr +cuda", when="+cuda ^[virtuals=mpi] mvapich2-gdr")
 
         depends_on("mpich +rocm", when="+rocm ^[virtuals=mpi] mpich")
 

--- a/repos/spack_repo/builtin/packages/sphexa/package.py
+++ b/repos/spack_repo/builtin/packages/sphexa/package.py
@@ -41,7 +41,6 @@ class Sphexa(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("openmpi +cuda", when="+cuda ^[virtuals=mpi] openmpi")
         depends_on("mpich +cuda", when="+cuda ^[virtuals=mpi] mpich")
         depends_on("mvapich-plus +cuda", when="+cuda ^[virtuals=mpi] mvapich-plus")
-        depends_on("mvapich2-gdr +cuda", when="+cuda ^[virtuals=mpi] mvapich2-gdr")
 
         depends_on("mpich +rocm", when="+rocm ^[virtuals=mpi] mpich")
 

--- a/repos/spack_repo/builtin/packages/tandem/package.py
+++ b/repos/spack_repo/builtin/packages/tandem/package.py
@@ -62,7 +62,7 @@ class Tandem(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("cxx", type="build")  # generated
     depends_on("mpi")
 
-    for var in ["openmpi", "mpich", "mvapich", "mvapich2"]:
+    for var in ["openmpi", "mpich", "mvapich-plus"]:
         depends_on(f"{var} +cuda", when=f"+cuda ^[virtuals=mpi] {var}")
 
     for var in ["openmpi", "mpich"]:
@@ -70,11 +70,9 @@ class Tandem(CMakePackage, CudaPackage, ROCmPackage):
             depends_on(
                 f"{var} +cuda cuda_arch={tgt}", when=f"+cuda cuda_arch={tgt} ^[virtuals=mpi] {var}"
             )
-    # these 2 are not cuda packages
-    for var in ["mvapich", "mvapich2"]:
-        depends_on(f"{var} +cuda", when=f"+cuda ^[virtuals=mpi] {var}")
 
-    for var in ["mpich"]:
+    # these are not cuda packages
+    for var in ["openmpi", "mpich", "mvapich-plus"]:
         depends_on(f"{var} +rocm", when=f"+rocm ^[virtuals=mpi] {var}")
 
     depends_on("parmetis +int64 +shared")

--- a/repos/spack_repo/builtin/packages/tandem/package.py
+++ b/repos/spack_repo/builtin/packages/tandem/package.py
@@ -72,7 +72,7 @@ class Tandem(CMakePackage, CudaPackage, ROCmPackage):
             )
 
     # these are not cuda packages
-    for var in ["openmpi", "mpich", "mvapich-plus"]:
+    for var in ["openmpi@5:", "mpich", "mvapich-plus"]:
         depends_on(f"{var} +rocm", when=f"+rocm ^[virtuals=mpi] {var}")
 
     depends_on("parmetis +int64 +shared")


### PR DESCRIPTION
Hello @natshineman and @MatthewLieber,

Initially this PR was designed to shore up GPU support in the MVAPICH non-Plus package. However, in the conversation below, it was determined that GPU support should not be built in this package and users should instead be directed to MVAPICH-Plus. Therefore, this PR now removes the erroneous CUDA variant.

Please let me know what you think.

Thanks,
Nate