### PR TITLE
slepc, py-slepc4py, petsc, py-petsc4py  add v3.24.0

### DIFF
--- a/repos/spack_repo/builtin/packages/petsc/package.py
+++ b/repos/spack_repo/builtin/packages/petsc/package.py
@@ -24,6 +24,8 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     tags = ["e4s"]
 
     version("main", branch="main")
+    version("3.24.0", sha256="cc9063d80cae3ca87dd34586a92bac49613818a0689d9eac1bd91a799c5d0983")
+    version("3.23.7", sha256="f4fb2bad8c80319e723987868e87d8384f2ae2162e07917d4c41d6e467b1d254")
     version("3.23.6", sha256="07e0492c5c38d2fc5aa6dd981c450086f3b88f8834df11247a87d4becfb85c72")
     version("3.23.5", sha256="b0bb614dfbf36c286c8cad30912fe77359dccbf6b65a5edd1dde82af293f21fc")
     version("3.23.4", sha256="711b2ad46b14f12fe74fcbc7f9b514444646f1e7b20ed57dc7482d34dfc4ca77")

--- a/repos/spack_repo/builtin/packages/py_petsc4py/package.py
+++ b/repos/spack_repo/builtin/packages/py_petsc4py/package.py
@@ -21,6 +21,8 @@ class PyPetsc4py(PythonPackage):
     license("BSD-2-Clause")
 
     version("main", branch="main")
+    version("3.24.0", sha256="3dc92ccb27a80d5bce87e186e5644ec90a3bd91569145ae1908ee6364816911b")
+    version("3.23.7", sha256="9b2a667922683b176ca8a80ada365c69b01093f0aa5b095fd594e15a5ae2552c")
     version("3.23.6", sha256="2f122b79c84c728702e3367e0d72e4ccf16cdf25aa200148018b4e7864e431e8")
     version("3.23.5", sha256="2d4d5c98d86c4d9f2e6d811a3ba85d2be8a2af7153db446b6e411eb2a2e35a18")
     version("3.23.4", sha256="e91a7020873131eb3afdd108ab6b523e1d136e67a3283a703f9bf330ae9eaccd")
@@ -107,7 +109,7 @@ class PyPetsc4py(PythonPackage):
     depends_on("petsc+mpi", when="+mpi")
     depends_on("petsc~mpi", when="~mpi")
     depends_on("petsc@main", when="@main")
-    for ver in ["3.23", "3.22", "3.21", "3.20", "3.19", "3.18", "3.17", "3.16", "3.15"]:
+    for ver in ["3.24", "3.23", "3.22", "3.21", "3.20", "3.19", "3.18", "3.17", "3.16", "3.15"]:
         depends_on(f"petsc@{ver}", when=f"@{ver}")
     depends_on("petsc@3.14.2:3.14", when="@3.14.1:3.14")
     depends_on("petsc@3.14.0:3.14.1", when="@3.14.0")

--- a/repos/spack_repo/builtin/packages/py_slepc4py/package.py
+++ b/repos/spack_repo/builtin/packages/py_slepc4py/package.py
@@ -19,6 +19,8 @@ class PySlepc4py(PythonPackage):
     license("BSD-2-Clause")
 
     version("main", branch="main")
+    version("3.24.0", sha256="50c9b6a75f47db8131c690b1cda07a15bf532cb79a3e645a0b08d7941f6738f2")
+    version("3.23.3", sha256="aa00f90939c4b312b9efe041e4f50f8f7947f50cb8c0d8f6ca60d4d78dda92c9")
     version("3.23.2", sha256="6c98e6c728b9d440d1680047f623aead03d9870c0c4d2ea97c754bab291d1fb5")
     version("3.23.1", sha256="da3ac9854ad120699359c112be857298bd3e4b62c0cecee752f34ad2dec81cd9")
     version("3.23.0", sha256="cc00cfd02bf302363adf03404bdcf6d8d4f1b9448cb28d4305eef3e88ddd9059")
@@ -59,7 +61,7 @@ class PySlepc4py(PythonPackage):
 
     depends_on("py-petsc4py@main", when="@main", type=("build", "run"))
     depends_on("slepc@main", when="@main")
-    for ver in ["3.23", "3.22", "3.21", "3.20", "3.19", "3.18", "3.17", "3.16", "3.15"]:
+    for ver in ["3.24", "3.23", "3.22", "3.21", "3.20", "3.19", "3.18", "3.17", "3.16", "3.15"]:
         depends_on(f"py-petsc4py@{ver}", when=f"@{ver}", type=("build", "run"))
         depends_on(f"slepc@{ver}", when=f"@{ver}")
 

--- a/repos/spack_repo/builtin/packages/slepc/package.py
+++ b/repos/spack_repo/builtin/packages/slepc/package.py
@@ -25,6 +25,8 @@ class Slepc(Package, CudaPackage, ROCmPackage):
     test_requires_compiler = True
 
     version("main", branch="main")
+    version("3.24.0", sha256="6e2d14c98aa9138ac698a2a04a7c6a9f9569988f570b2cfbe4935d32364cb4e9")
+    version("3.23.3", sha256="6b0c4f706bdfca46f00b30026b4d92a4eb68faa03e40cbcbfeadb89999653621")
     version("3.23.2", sha256="3060a95692151ef0f9ba4ca11da18d5dcd86697b59f6aeee723de92d7bd465a1")
     version("3.23.1", sha256="c2fde066521bbccfbc80aa15182bca69ffaf00a7de648459fd04b81589896238")
     version("3.23.0", sha256="78252f7b2f540c5fdadadee0fd21f3e6eff810f82cb45482f327b524c8db63d0")
@@ -72,7 +74,19 @@ class Slepc(Package, CudaPackage, ROCmPackage):
 
     # Cannot mix release and development versions of SLEPc and PETSc:
     depends_on("petsc@main", when="@main")
-    for ver in ["3.23", "3.22", "3.21", "3.20", "3.19", "3.18", "3.17", "3.16", "3.15", "3.14"]:
+    for ver in [
+        "3.24",
+        "3.23",
+        "3.22",
+        "3.21",
+        "3.20",
+        "3.19",
+        "3.18",
+        "3.17",
+        "3.16",
+        "3.15",
+        "3.14",
+    ]:
         depends_on(f"petsc@{ver}", when=f"@{ver}")
     depends_on("petsc+cuda", when="+cuda")
     depends_on("arpack-ng~mpi", when="+arpack^petsc~mpi~int64")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
