### PR TITLE
py-smartypants: add v2.0.2

### DIFF
--- a/repos/spack_repo/builtin/packages/py_smartypants/package.py
+++ b/repos/spack_repo/builtin/packages/py_smartypants/package.py
@@ -11,12 +11,16 @@ class PySmartypants(PythonPackage):
     """smartypants is a Python fork of SmartyPants."""
 
     homepage = "https://github.com/leohemsted/smartypants.py"
-
-    # PyPI only has the wheel
-    url = "https://github.com/leohemsted/smartypants.py/archive/refs/tags/v2.0.1.tar.gz"
+    pypi = "smartypants/smartypants-2.0.2.tar.gz"
 
     license("BSD-3-Clause")
 
-    version("2.0.1", sha256="b98191911ff3b4144ef8ad53e776a2d0ad24bd508a905c6ce523597c40022773")
+    version("2.0.2", sha256="39d64ce1d7cc6964b698297bdf391bc12c3251b7f608e6e55d857cd7c5f800c6")
+    version(
+        "2.0.1",
+        sha256="b98191911ff3b4144ef8ad53e776a2d0ad24bd508a905c6ce523597c40022773",
+        # PyPI only has the wheel
+        url="https://github.com/leohemsted/smartypants.py/archive/refs/tags/v2.0.1.tar.gz",
+    )
 
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
https://github.com/justinmayer/smartypants.py/tree/v2.0.2
(first new release since 2017)

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
