### PR TITLE
py-sphinxcontrib-serializinghtml: add v2.0.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_sphinxcontrib_serializinghtml/package.py
+++ b/repos/spack_repo/builtin/packages/py_sphinxcontrib_serializinghtml/package.py
@@ -20,6 +20,7 @@ class PySphinxcontribSerializinghtml(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("2.0.0", sha256="e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d")
     version("1.1.9", sha256="0c64ff898339e1fac29abd2bf5f11078f3ec413cfe9c046d3120d7ca65530b54")
     version("1.1.5", sha256="aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952")
     version("1.1.3", sha256="c0efb33f8052c04fd7a26c0a07f1678e8512e0faec19f4aa8f2473a8b81d5227")
@@ -28,7 +29,8 @@ class PySphinxcontribSerializinghtml(PythonPackage):
     depends_on("py-flit-core@3.7:", when="@1.1.6:", type="build")
 
     # Circular dependency
-    # depends_on("py-sphinx@5:", when="@1.1.6:", type=("build", "run"))
+    # depends_on("py-sphinx@5:", when="@1.1.6:1.1.9", type=("build", "run"))
+    # also a dependency for variant "standalone"
 
     # Historical dependencies
     depends_on("py-setuptools", when="@:1.1.5", type="build")


### PR DESCRIPTION
https://github.com/sphinx-doc/sphinxcontrib-serializinghtml/tree/2.0.0

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
