### PR TITLE
pbzip2: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/pbzip2/package.py
+++ b/repos/spack_repo/builtin/packages/pbzip2/package.py
@@ -2,21 +2,22 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
+
 from spack.package import *
 
 
 class Pbzip2(MakefilePackage):
-    """ PBZIP2 is a parallel implementation of the bzip2 block-sorting file
+    """PBZIP2 is a parallel implementation of the bzip2 block-sorting file
     compressor that uses pthreads and achieves near-linear speedup on SMP
     machines. The output of this version is fully compatible with bzip2 v1.0.2
     or newer (ie: anything compressed with pbzip2 can be decompressed with
     bzip2). PBZIP2 should work on any system that has a pthreads compatible C++
     compiler (such as gcc)."""
 
-    homepage = "http://compression.great-site.net/pbzip2/" 
+    homepage = "http://compression.great-site.net/pbzip2/"
     url = "https://launchpad.net/pbzip2/1.1/1.1.13/+download/pbzip2-1.1.13.tar.gz"
 
-    maintainers("Markus92") 
+    maintainers("Markus92")
 
     license("bzip2-1.0.6", checked_by="Markus92")
 

--- a/repos/spack_repo/builtin/packages/pbzip2/package.py
+++ b/repos/spack_repo/builtin/packages/pbzip2/package.py
@@ -1,0 +1,30 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
+from spack.package import *
+
+
+class Pbzip2(MakefilePackage):
+    """ PBZIP2 is a parallel implementation of the bzip2 block-sorting file
+    compressor that uses pthreads and achieves near-linear speedup on SMP
+    machines. The output of this version is fully compatible with bzip2 v1.0.2
+    or newer (ie: anything compressed with pbzip2 can be decompressed with
+    bzip2). PBZIP2 should work on any system that has a pthreads compatible C++
+    compiler (such as gcc)."""
+
+    homepage = "http://compression.great-site.net/pbzip2/" 
+    url = "https://launchpad.net/pbzip2/1.1/1.1.13/+download/pbzip2-1.1.13.tar.gz"
+
+    maintainers("Markus92") 
+
+    license("bzip2-1.0.6", checked_by="Markus92")
+
+    version("1.1.13", sha256="8fd13eaaa266f7ee91f85c1ea97c86d9c9cc985969db9059cdebcb1e1b7bdbe6")
+
+    depends_on("cxx", type="build")
+    depends_on("bzip2 +shared", type=("build", "run"))
+
+    def edit(self, spec, prefix):
+        makefile = FileFilter("Makefile")
+        makefile.filter("PREFIX = .*", f"PREFIX = {prefix}")


### PR DESCRIPTION
pbzip2 is a parallel implementation of bzip2. It splits the file up in chunks, then uses bzip2 to compress it. It achieves significant speed-ups.

It's not very maintained anymore by upstream, but still fully functional and included in Ubuntu, Debian, RHEL, Arch and a lot of other Linux distributions, so it's still relevant I'd say.

It's a dependency for Relion.