### PR TITLE
Charliecloud: Fix URL and update bdw-gc dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/charliecloud/package.py
+++ b/repos/spack_repo/builtin/packages/charliecloud/package.py
@@ -34,6 +34,7 @@ class Charliecloud(AutotoolsPackage):
     variant("cdi", default=True, description="Build with CDI support", when="@0.40:")
 
     depends_on("c", type="build")  # generated
+    depends_on("bdw-gc@8:", type=("build", "link"))
 
     # Autoconf.
     depends_on("m4", type="build")

--- a/repos/spack_repo/builtin/packages/charliecloud/package.py
+++ b/repos/spack_repo/builtin/packages/charliecloud/package.py
@@ -34,7 +34,8 @@ class Charliecloud(AutotoolsPackage):
     variant("cdi", default=True, description="Build with CDI support", when="@0.40:")
 
     depends_on("c", type="build")  # generated
-    depends_on("bdw-gc@8:", type=("build", "link"))
+    depends_on("bdw-gc", type=("build", "link"))
+    depends_on("bdw-gc@8:", type=("build", "link"), when="@0.40:")
 
     # Autoconf.
     depends_on("m4", type="build")

--- a/repos/spack_repo/builtin/packages/charliecloud/package.py
+++ b/repos/spack_repo/builtin/packages/charliecloud/package.py
@@ -12,7 +12,7 @@ class Charliecloud(AutotoolsPackage):
 
     maintainers("j-ogas", "reidpr", "loshak")
     homepage = "https://charliecloud.io/"
-    url = "https://gitlab.com/charliecloud/main/-/archive/v0.42/main-v0.42.tar.gz"
+    url = "https://gitlab.com/charliecloud/charliecloud/-/archive/v0.42/main-v0.42.tar.gz"
     git = "https://gitlab.com/charliecloud/charliecloud.git"
 
     tags = ["e4s"]

--- a/repos/spack_repo/builtin/packages/charliecloud/package.py
+++ b/repos/spack_repo/builtin/packages/charliecloud/package.py
@@ -11,15 +11,17 @@ class Charliecloud(AutotoolsPackage):
     """Lightweight user-defined software stacks for HPC."""
 
     maintainers("j-ogas", "reidpr", "loshak")
-    homepage = "https://hpc.github.io/charliecloud"
-    url = "https://github.com/hpc/charliecloud/releases/download/v0.18/charliecloud-0.18.tar.gz"
-    git = "https://github.com/hpc/charliecloud.git"
+    homepage = "https://charliecloud.io/"
+    url = "https://gitlab.com/charliecloud/main/-/archive/v0.42/main-v0.42.tar.gz"
+    git = "https://gitlab.com/charliecloud/charliecloud.git"
 
     tags = ["e4s"]
 
     license("Apache-2.0")
 
-    version("master", branch="master")
+    version("main", branch="main")
+    version("0.42", sha256="be98c025f58336a7b6e6d79804ef89dd489c5dcc5ad8faccb551ea0065dcd13a")
+    version("0.41", sha256="065cc50f8b7893f8a0e28d9d06e2e3640d0d8139d10ad59fe941aea1e33dfdc6")
     version("0.40", sha256="dcad81136d1fed905be6e573a7bf191ea655ae7827f7980bbe6559942f2affdd")
     version("0.39", sha256="38503b507119a970ac288df7181aefe6cd1a125b9d509f5cb162dacea7143fd1")
     version("0.38", sha256="1a3766d57ff4db9c65fd5c561bbaac52476c9a19fa10c1554190912a03429b7a")


### PR DESCRIPTION
Hello @j-ogas @reidpr and @loshak,

I have updated the `charliecloud` package to build the latest versions I could find over on your new Gitlab project/repo. I would like to request feedback on the following:

## URL update and intended tarballs for distribution

Please take a look at the tar URL I used. I played around with the Gitlab API somewhat and couldn't find a decent way to get the correct versions and checksums programmatically so I left it up to Spack and used the URLs it auto-resolved when I pointed it at the Gitlab URL. However, these tarballs *may not* be the ones you intended folks to download, in which case we should talk to the Spack maintainers about `lib/spack/spack/llnl/url.py` as I believe that's where the "auto-resolution" is coming from.

## Charliecloud version using newer symbols from `bdw-gc`

I ran into errors of the type: 
```
spack-src/bin/mem.c:316: undefined reference to `GC_get_full_gc_total_time'
```
when building "naively" on RHEL 8. Some digging found that the missing symbols were added in bdw-gc (the Boehm Garbage Collector) version 8. RHEL 8 only has version 7.6.2. I'm not sure when you started adding references to these symbols (maybe version 0.41?) so I just made `bdw-gc@8:` a blanket build dependency. However, there was more fun to be had as autotools appeared to happily ignore the existence of the Spack-installed newer version of `bdw-gc` and the link line didn't include it explicitly, so I made it a `link` dependency in Spack as well. Now it builds for me.

Anyway please take a look and tell me what you think.

Thanks,
Nate