### PR TITLE
croc: add new package

### DIFF
--- a/repos/spack_repo/builtin/packages/croc/package.py
+++ b/repos/spack_repo/builtin/packages/croc/package.py
@@ -1,0 +1,22 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.go import GoPackage
+
+from spack.package import *
+
+
+class Croc(GoPackage):
+    """croc is a tool that allows any two computers to simply and securely transfer files and folders."""
+
+    homepage = "https://schollz.com/software/croc6"
+    url = "https://github.com/schollz/croc/archive/refs/tags/v10.2.5.tar.gz"
+
+    maintainers("zzzoom")
+
+    license("MIT", checked_by="zzzoom")
+
+    version("10.2.5", sha256="993e0bb72e79c5168d78db5c14d84f69beeab819ab4d06f4d98fcddd23487207")
+
+    depends_on("go@1.24.0:", type="build", when="@10.2.5:")

--- a/repos/spack_repo/builtin/packages/croc/package.py
+++ b/repos/spack_repo/builtin/packages/croc/package.py
@@ -8,7 +8,9 @@ from spack.package import *
 
 
 class Croc(GoPackage):
-    """croc is a tool that allows any two computers to simply and securely transfer files and folders."""
+    """croc is a tool that allows any two computers to simply and securely transfer files and
+    folders.
+    """
 
     homepage = "https://schollz.com/software/croc6"
     url = "https://github.com/schollz/croc/archive/refs/tags/v10.2.5.tar.gz"


### PR DESCRIPTION
Adding the `croc` file transfer tool to spack.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
