### PR TITLE
Added the packages PyTUQ and QUiNN (uqinn on PyPI)

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pytuq/package.py
+++ b/repos/spack_repo/builtin/packages/py_pytuq/package.py
@@ -1,0 +1,46 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyPytuq(PythonPackage):
+    """The Python Toolkit for Uncertainty Quantification (PyTUQ) is a
+    Python-only collection of libraries and tools designed for quantifying
+    uncertainty in computational models. PyTUQ offers a range of UQ
+    functionalities, including Bayesian inference and linear regression
+    methods, polynomial chaos expansions, and global sensitivity analysis
+    methods. PyTUQ features advanced techniques for dimensionality
+    reduction, such as SVD and Karhunen-Loeve expansions, along with
+    various MCMC methods for calibration and inference. The toolkit also
+    includes robust classes for multivariate random variables and
+    integration techniques, making it a versatile resource for researchers
+    and practitioners seeking to quantify uncertainty in their numerical
+    predictions."""
+
+    homepage = "https://sandialabs.github.io/pytuq/"
+    pypi = "pytuq/pytuq-1.0.0.tar.gz"
+
+    maintainers("bjdebus", "ksargsyan", "gregvw")
+
+    license("BSD-3-Clause", checked_by="gregvw")
+
+    version("1.0.0", sha256="1fc9fabf7bf183d38e104564e99d1950f7e2103baac5a13960c356173b9997ff")
+
+    depends_on("python@3.8:", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+    depends_on("py-wheel", type="build")
+
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-scipy", type=("build", "run"))
+    depends_on("py-matplotlib", type=("build", "run"))
+
+    variant("nn", default=False, description="Enable neural network support")
+    variant("optim", default=False, description="Enable optimization support")
+
+    depends_on("py-torch", type=("build", "run"), when="+nn")
+    depends_on("py-uqinn", type=("build", "run"), when="+nn")
+    depends_on("py-pyswarms", type=("build", "run"), when="+optim")

--- a/repos/spack_repo/builtin/packages/py_pytuq/package.py
+++ b/repos/spack_repo/builtin/packages/py_pytuq/package.py
@@ -39,8 +39,6 @@ class PyPytuq(PythonPackage):
     depends_on("py-matplotlib", type=("build", "run"))
 
     variant("nn", default=False, description="Enable neural network support")
-    variant("optim", default=False, description="Enable optimization support")
 
     depends_on("py-torch", type=("build", "run"), when="+nn")
     depends_on("py-uqinn", type=("build", "run"), when="+nn")
-    depends_on("py-pyswarms", type=("build", "run"), when="+optim")

--- a/repos/spack_repo/builtin/packages/py_uqinn/package.py
+++ b/repos/spack_repo/builtin/packages/py_uqinn/package.py
@@ -1,0 +1,31 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyUqinn(PythonPackage):
+    """Quantification of Uncertainties in Neural Networks (QUiNN) is a
+    python library centered around various probabilistic wrappers over
+    PyTorch modules in order to provide uncertainty estimation in Neural
+    Network (NN) predictions."""
+
+    homepage = "https://github.com/sandialabs/quinn"
+    pypi = "uqinn/uqinn-1.0.0.tar.gz"
+
+    maintainers("ksargsyan", "odiazib", "gregvw")
+
+    license("BSD-3-Clause", checked_by="gregvw")
+
+    version("1.0.0", sha256="07c6a5a81bc14af2679e9510f438ef1bbb85eba00c4fdd993fcb1f018f511cac")
+
+    depends_on("python@3.8:", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-scipy", type=("build", "run"))
+    depends_on("py-matplotlib", type=("build", "run"))
+    depends_on("py-torch", type=("build", "run"))


### PR DESCRIPTION
  ## Summary

  Add two new packages for xSDK community policy M1 compliance:
  - `py-pytuq`: Python Toolkit for Uncertainty Quantification
  - `py-uqinn`: Quantification of Uncertainties in Neural Networks (QUiNN)

  Both packages are developed at Sandia National Laboratories and are published on PyPI. PyTUQ is a Python-only toolkit for uncertainty
  quantification with features including Bayesian inference, polynomial chaos expansions, and sensitivity analysis. QUiNN provides uncertainty
  estimation wrappers for PyTorch neural networks.

  ## Details

  - PyTUQ includes optional variants for neural network support (`+nn`) and optimization (`+optim`)
  - Both packages depend on standard scientific Python libraries (numpy, scipy, matplotlib)
  - PyTUQ's `+nn` variant depends on py-uqinn
  - Packages are BSD-3-Clause licensed

  ## Testing

  - [x] Package builds successfully
  - [x] Dependencies resolve correctly
  - [x] Variants work as expected

