### PR TITLE
codipack: add C compiler dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/codipack/package.py
+++ b/repos/spack_repo/builtin/packages/codipack/package.py
@@ -25,7 +25,8 @@ class Codipack(CMakePackage, Package):
     version("1.9.3", sha256="27dd92d0b5132de37b431989c0c3d5bd829821a6a2e31e0529137e427421f06e")
     version("openmp", branch="experimentalOpenMPSupport")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("cmake@3.12:", type="build", when="@2.1.0:")
 


### PR DESCRIPTION
Codipack needs an explicit dependency on a C compiler for now. It doesn't specify `LANGUAGES` in its `CMakeLists.txt` and therefore defaults to `C CXX`. See also SciCompKL/CoDiPack#47.