### PR TITLE
kokkos: add missing amdgpu_target override

### DIFF
--- a/repos/spack_repo/builtin/packages/hip/package.py
+++ b/repos/spack_repo/builtin/packages/hip/package.py
@@ -434,9 +434,12 @@ class Hip(CMakePackage):
         self.set_variables(env)
 
         if "amdgpu_target" in dependent_spec.variants:
-            arch = dependent_spec.variants["amdgpu_target"]
+            arch = dependent_spec.variants["amdgpu_target"].value
+            # some packages may define their own amdgpu_target variant that is not multi
+            if isinstance(arch, str):
+                arch = [arch]
             if "none" not in arch and "auto" not in arch:
-                env.set("HCC_AMDGPU_TARGET", ",".join(arch.value))
+                env.set("HCC_AMDGPU_TARGET", ",".join(arch))
 
     def setup_dependent_run_environment(
         self, env: EnvironmentModifications, dependent_spec: Spec

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -189,6 +189,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         when="+cuda",
     )
 
+    # Since Kokkos supports only one amdgpu_target at a time, the multi-value property is disabled.
     variant(
         "amdgpu_target",
         description="AMD GPU architecture",

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -388,13 +388,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
 
         spack_microarches = []
         if spec.satisfies("+cuda"):
-            if isinstance(spec.variants["cuda_arch"].value, str):
-                cuda_arch = spec.variants["cuda_arch"].value
-            else:
-                if len(spec.variants["cuda_arch"].value) > 1:
-                    msg = "Kokkos supports only one cuda_arch at a time."
-                    raise InstallError(msg)
-                cuda_arch = spec.variants["cuda_arch"].value[0]
+            cuda_arch = spec.variants["cuda_arch"].value
             if cuda_arch != "none":
                 kokkos_arch_name = self.spack_cuda_arch_map[cuda_arch]
                 spack_microarches.append(kokkos_arch_name)
@@ -404,17 +398,17 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
             spack_microarches.append(kokkos_microarch_name)
 
         if spec.satisfies("+rocm"):
-            for amdgpu_target in spec.variants["amdgpu_target"].value:
-                if amdgpu_target != "none":
-                    if amdgpu_target in self.amdgpu_arch_map:
-                        if spec.satisfies("+apu") and amdgpu_target in self.amdgpu_apu_arch_map:
-                            spack_microarches.append(self.amdgpu_apu_arch_map[amdgpu_target])
-                        else:
-                            spack_microarches.append(self.amdgpu_arch_map[amdgpu_target])
+            amdgpu_target = spec.variants["amdgpu_target"].value
+            if amdgpu_target != "none":
+                if amdgpu_target in self.amdgpu_arch_map:
+                    if spec.satisfies("+apu") and amdgpu_target in self.amdgpu_apu_arch_map:
+                        spack_microarches.append(self.amdgpu_apu_arch_map[amdgpu_target])
                     else:
-                        # Note that conflict declarations should prevent
-                        # choosing an unsupported AMD GPU target
-                        raise SpackError("Unsupported target: {0}".format(amdgpu_target))
+                        spack_microarches.append(self.amdgpu_arch_map[amdgpu_target])
+                else:
+                    # Note that conflict declarations should prevent
+                    # choosing an unsupported AMD GPU target
+                    raise SpackError("Unsupported target: {0}".format(amdgpu_target))
 
         if self.spec.variants["intel_gpu_arch"].value != "none":
             spack_microarches.append(self.spec.variants["intel_gpu_arch"].value)

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -189,6 +189,16 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         when="+cuda",
     )
 
+    variant(
+        "amdgpu_target",
+        description="AMD GPU architecture",
+        values=("none",) + ROCmPackage.amdgpu_targets,
+        default="none",
+        multi=False,
+        sticky=True,
+        when="+rocm",
+    )
+
     amdgpu_arch_map = {
         "gfx900": "vega900",
         "gfx906": "vega906",


### PR DESCRIPTION
Without this change, the concretizer has the freedom to choose a combination of `amdgpu_target` values. We actually have the same override for `cuda_arch`. But recently this oversight started to become an issue for some concretizations.