### PR TITLE
python: 3.14.0, 3.13.8, 3.12.12, 3.11.14, 3.10.19, 3.9.24

### DIFF
--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -487,7 +487,7 @@ class Python(Package):
         # install headers
         include_dir = proj_root / "Include"
         copy_tree(str(include_dir), prefix.include)
-        if self.spec.satisfies("@3.13:"):
+        if self.spec.satisfies("@3.13"):  # reverted in 3.14
             pyconfig = pcbuild_root / platform.machine().lower() / "pyconfig.h"
         else:
             pyconfig = proj_root / "PC" / "pyconfig.h"

--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -46,7 +46,7 @@ class Python(Package):
     list_depth = 1
     tags = ["windows", "build-tools"]
 
-    maintainers("adamjstewart", "skosukhin", "scheibelp")
+    maintainers("adamjstewart", "scheibelp")
 
     phases = ["configure", "build", "install"]
 

--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -160,6 +160,7 @@ class Python(Package):
     variant("zlib", default=True, description="Build zlib module")
     variant("bz2", default=True, description="Build bz2 module")
     variant("lzma", default=True, description="Build lzma module")
+    variant("zstd", default=True, description="Build zstd module", when="@3.14:")
     variant("pyexpat", default=True, description="Build pyexpat module")
     variant("ctypes", default=True, description="Build ctypes module")
     variant("tkinter", default=False, description="Build tkinter module")
@@ -193,6 +194,7 @@ class Python(Package):
         depends_on("zlib-api", when="+zlib")
         depends_on("bzip2", when="+bz2")
         depends_on("xz libs=shared", when="+lzma")
+        depends_on("zstd libs=shared", when="+zstd")
         depends_on("expat", when="+pyexpat")
         depends_on("libffi", when="+ctypes")
         # https://docs.python.org/3/whatsnew/3.11.html#build-changes
@@ -325,6 +327,13 @@ class Python(Package):
                 variants += "+tix"
             except ProcessError:
                 variants += "~tix"
+
+        if Version(version_str) >= Version("3.14"):
+            try:
+                python("-c", "import compression.zstd", error=os.devnull)
+                variants += "+zstd"
+            except ProcessError:
+                variants += "~zstd"
 
         # Some modules are platform-dependent
         if sys.platform != "win32" and Version(version_str) < Version("3.13"):

--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -56,14 +56,18 @@ class Python(Package):
 
     license("0BSD")
 
-    version("3.13.7", sha256="6c9d80839cfa20024f34d9a6dd31ae2a9cd97ff5e980e969209746037a5153b2")
-    version("3.12.11", sha256="7b8d59af8216044d2313de8120bfc2cc00a9bd2e542f15795e1d616c51faf3d6")
-    version("3.11.13", sha256="0f1a22f4dfd34595a29cf69ee7ea73b9eff8b1cc89d7ab29b3ab0ec04179dad8")
-    version("3.10.18", sha256="1b19ab802518eb36a851f5ddef571862c7a31ece533109a99df6d5af0a1ceb99")
-    version("3.9.23", sha256="9a69aad184dc1d06f6819930741da3a328d34875a41f8ba33875774dbfc51b51")
+    version("3.14.0", sha256="88d2da4eed42fa9a5f42ff58a8bc8988881bd6c547e297e46682c2687638a851")
+    version("3.13.8", sha256="06108fe96f4089b7d9e0096cb4ca9c81ddcd5135f779a7de94cf59abcaa4b53f")
+    version("3.12.12", sha256="487c908ddf4097a1b9ba859f25fe46d22ccaabfb335880faac305ac62bffb79b")
+    version("3.11.14", sha256="563d2a1b2a5ba5d5409b5ecd05a0e1bf9b028cf3e6a6f0c87a5dc8dc3f2d9182")
+    version("3.10.19", sha256="a078fb2d7a216071ebbe2e34b5f5355dd6b6e9b0cd1bacc4a41c63990c5a0eec")
+    version("3.9.24", sha256="9a32cfc683aecaadbd9ed891ac2af9451ff37f48a00a2d8e1f4ecd9c2a1ffdcb")
 
     # Deprecated because newer bug fix patch releases exist
     with default_args(deprecated=True):
+        version(
+            "3.13.7", sha256="6c9d80839cfa20024f34d9a6dd31ae2a9cd97ff5e980e969209746037a5153b2"
+        )
         version(
             "3.13.5", sha256="e6190f52699b534ee203d9f417bdbca05a92f23e35c19c691a50ed2942835385"
         )
@@ -83,6 +87,9 @@ class Python(Package):
             "3.13.0", sha256="12445c7b3db3126c41190bfdc1c8239c39c719404e844babbd015a1bc3fafcd4"
         )
         version(
+            "3.12.11", sha256="7b8d59af8216044d2313de8120bfc2cc00a9bd2e542f15795e1d616c51faf3d6"
+        )
+        version(
             "3.12.9", sha256="45313e4c5f0e8acdec9580161d565cf5fea578e3eabf25df7cc6355bf4afa1ee"
         )
         version(
@@ -92,10 +99,19 @@ class Python(Package):
             "3.12.7", sha256="73ac8fe780227bf371add8373c3079f42a0dc62deff8d612cd15a618082ab623"
         )
         version(
+            "3.11.13", sha256="0f1a22f4dfd34595a29cf69ee7ea73b9eff8b1cc89d7ab29b3ab0ec04179dad8"
+        )
+        version(
             "3.11.11", sha256="883bddee3c92fcb91cf9c09c5343196953cbb9ced826213545849693970868ed"
         )
         version(
+            "3.10.18", sha256="1b19ab802518eb36a851f5ddef571862c7a31ece533109a99df6d5af0a1ceb99"
+        )
+        version(
             "3.10.16", sha256="f2e22ed965a93cfeb642378ed6e6cdbc127682664b24123679f3d013fafe9cd0"
+        )
+        version(
+            "3.9.23", sha256="9a69aad184dc1d06f6819930741da3a328d34875a41f8ba33875774dbfc51b51"
         )
         version(
             "3.9.21", sha256="667c3ba2ca98d39ead1162f6548c3475768582e2ff89e0821d25eb956ac09944"


### PR DESCRIPTION
I would suggest to make `3.14.0` the preferred version and add forward compat bounds if we see issues with particular packages.