### PR TITLE
gha: add python 3.14 to canonicalization test

### DIFF
--- a/.github/workflows/prechecks.yml
+++ b/.github/workflows/prechecks.yml
@@ -78,7 +78,7 @@ jobs:
     name: package.py canonicalization
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/spack/all-pythons:2025-07-25
+      image: ghcr.io/spack/all-pythons:2025-10-10
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
@@ -89,6 +89,6 @@ jobs:
       - name: Test package.py canonicalization
         run: .github/workflows/bin/canonicalize.py
           --spack $PWD/spack-core
-          --python python3.6 python3.7 python3.8 python3.9 python3.10 python3.11 python3.12 python3.13
+          --python python3.6 python3.7 python3.8 python3.9 python3.10 python3.11 python3.12 python3.13 python3.14
           --input-dir repos/spack_repo/builtin/packages/
           --output-dir canonicalized


### PR DESCRIPTION
Test package hash consistency across all Python versions:

```
# for x in 6 7 8 9 10 11 12 13 14; do python3.$x --version; done
Python 3.6.15
Python 3.7.17
Python 3.8.20
Python 3.9.24
Python 3.10.19
Python 3.11.14
Python 3.12.12
Python 3.13.8
Python 3.14.0
```

This time all were built with `+optimizations`, which seems to improve the runtime of the github actions a bit: 1m45s -> 1m23s even though yet another python was added to the list.