### PR TITLE
py-cartopy: add missing dependency on c language

### DIFF
--- a/repos/spack_repo/builtin/packages/py_cartopy/package.py
+++ b/repos/spack_repo/builtin/packages/py_cartopy/package.py
@@ -43,6 +43,7 @@ class PyCartopy(PythonPackage):
     )
     variant("plotting", default=False, description="Add plotting functionality")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")
 
     # Based on wheel availability on PyPI


### PR DESCRIPTION
## Description

See title. I am still not clear why these errors (SPACK_CC_..._ARGS not set) don't show up on every system. But in this case, it shows up up on the DOD HPCMP Narwhal system (Cray) with gcc@12.2.0, and adding the c dependency fixes the build error.
