### PR TITLE
arrow: don't build mimalloc with intel 2025

### DIFF
--- a/repos/spack_repo/builtin/packages/arrow/package.py
+++ b/repos/spack_repo/builtin/packages/arrow/package.py
@@ -6,6 +6,7 @@ from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 
 from spack.package import *
+import os
 
 
 class Arrow(CMakePackage, CudaPackage):
@@ -160,6 +161,10 @@ class Arrow(CMakePackage, CudaPackage):
             # ARROW_USE_SSE was removed in 0.12
             # see https://issues.apache.org/jira/browse/ARROW-3844
             args.append(self.define("ARROW_USE_SSE", "ON"))
+
+        # https://github.com/apache/arrow/issues/47790
+        if self.spec.satisfies("%oneapi@2025:"):
+            args.append(self.define("ARROW_MIMALLOC","OFF"))
 
         args.append(self.define_from_variant("ARROW_COMPUTE", "compute"))
         args.append(self.define_from_variant("ARROW_CUDA", "cuda"))

--- a/repos/spack_repo/builtin/packages/arrow/package.py
+++ b/repos/spack_repo/builtin/packages/arrow/package.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 
 from spack.package import *
-import os
 
 
 class Arrow(CMakePackage, CudaPackage):
@@ -164,7 +165,7 @@ class Arrow(CMakePackage, CudaPackage):
 
         # https://github.com/apache/arrow/issues/47790
         if self.spec.satisfies("%oneapi@2025:"):
-            args.append(self.define("ARROW_MIMALLOC","OFF"))
+            args.append(self.define("ARROW_MIMALLOC", "OFF"))
 
         args.append(self.define_from_variant("ARROW_COMPUTE", "compute"))
         args.append(self.define_from_variant("ARROW_CUDA", "cuda"))

--- a/repos/spack_repo/builtin/packages/arrow/package.py
+++ b/repos/spack_repo/builtin/packages/arrow/package.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 


### PR DESCRIPTION
Works around https://github.com/apache/arrow/issues/47790 which prevents building with the new clang/llvm intel-oneapi compilers