### PR TITLE
astropy: correct numpy dependency version

### DIFF
--- a/repos/spack_repo/builtin/packages/py_astropy/package.py
+++ b/repos/spack_repo/builtin/packages/py_astropy/package.py
@@ -20,6 +20,7 @@ class PyAstropy(PythonPackage):
 
     license("BSD-3-Clause", checked_by="lgarrison")
 
+    version("7.1.1", sha256="6d128f0005e2c34f70113484468bf9d0e4ca1ee15a279cfd08bdd979d38db0f8")
     version("7.1.0", sha256="c8f254322295b1b8cf24303d6f155bf7efdb6c1282882b966ce3040eff8c53c5")
     version("7.0.1", sha256="392feeb443b2437cd4c2e0641a65e0f15ba791e148e9b1e5ed7de7dfcb38e460")
     version("6.1.0", sha256="6c3b915f10b1576190730ddce45f6245f9927dda3de6e3f692db45779708950f")
@@ -55,6 +56,7 @@ class PyAstropy(PythonPackage):
     # in newer pip versions --install-option does not exist
     depends_on("py-pip@:23.0", when="@:4.0", type="build")
 
+    depends_on("py-astropy-iers-data@0.2025.9.29.0.35.48:", when="@7.1.1:", type=("build", "run"))
     depends_on("py-astropy-iers-data@0.2025.1.31.12.41.4:", when="@7.0.1:", type=("build", "run"))
     depends_on("py-astropy-iers-data@0.2025.4.28.0.37.27:", when="@7.1.0:", type=("build", "run"))
     depends_on("py-astropy-iers-data", when="@6:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_astropy/package.py
+++ b/repos/spack_repo/builtin/packages/py_astropy/package.py
@@ -44,7 +44,6 @@ class PyAstropy(PythonPackage):
     depends_on("py-cython@0.29.30", when="@5.1:6.0", type="build")
     depends_on("py-cython@3.0", when="@6.1.0:6", type="build")
     depends_on("py-cython@3", when="@7.0.1:", type="build")
-    depends_on("py-numpy@2", when="@7.0.1:", type="build")
     depends_on("py-setuptools-scm@6.2:", when="@5.1:", type="build")
     depends_on("py-extension-helpers", when="@5.1:", type="build")
     depends_on("py-extension-helpers@1", when="@7.0.1:", type="build")
@@ -55,7 +54,7 @@ class PyAstropy(PythonPackage):
 
     depends_on("py-astropy-iers-data@0.2025.1.31.12.41.4:", when="@7.0.1:", type=("build", "run"))
     depends_on("py-astropy-iers-data", when="@6:", type=("build", "run"))
-    depends_on("py-numpy@1.23.2:", when="@7.0.1:", type="run")
+    depends_on("py-numpy@1.23.2:", when="@7.0.1:", type=("build", "run"))
     depends_on("py-numpy@1.23:", when="@6.1:", type=("build", "run"))
     depends_on("py-numpy@1.18:", when="@5.1:", type=("build", "run"))
     depends_on("py-numpy@1.16:", when="@4.0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_astropy/package.py
+++ b/repos/spack_repo/builtin/packages/py_astropy/package.py
@@ -145,7 +145,7 @@ class PyAstropy(PythonPackage):
         depends_on("py-pytest", when="@:6", type=("build", "run"))
         depends_on("py-fsspec+http@2023.4:", when="@6.1:", type=("build", "run"))
         depends_on("py-s3fs@2023.4:", when="@6.1:", type=("build", "run"))
-        #depends_on("py-uncompresspy@0.4:", type=("build", "run"))
+        # depends_on("py-uncompresspy@0.4:", type=("build", "run"))
         depends_on("py-typing-extensions@3.10.0.1:", when="@5.0.2:6", type=("build", "run"))
 
         # Historical optional dependencies

--- a/repos/spack_repo/builtin/packages/py_astropy/package.py
+++ b/repos/spack_repo/builtin/packages/py_astropy/package.py
@@ -20,6 +20,7 @@ class PyAstropy(PythonPackage):
 
     license("BSD-3-Clause", checked_by="lgarrison")
 
+    version("7.1.0", sha256="c8f254322295b1b8cf24303d6f155bf7efdb6c1282882b966ce3040eff8c53c5")
     version("7.0.1", sha256="392feeb443b2437cd4c2e0641a65e0f15ba791e148e9b1e5ed7de7dfcb38e460")
     version("6.1.0", sha256="6c3b915f10b1576190730ddce45f6245f9927dda3de6e3f692db45779708950f")
     version("5.1", sha256="1db1b2c7eddfc773ca66fa33bd07b25d5b9c3b5eee2b934e0ca277fa5b1b7b7e")
@@ -40,6 +41,8 @@ class PyAstropy(PythonPackage):
     depends_on("python@3.10:", when="@6.1.0:", type=("build", "run"))
     depends_on("python@3.8:", when="@5.1:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@77.0.0:", when="@7.1.0:", type="build")
+    depends_on("py-setuptools-scm@8:", when="@7.1.0:", type="build")
     depends_on("py-cython@0.29.13:", type="build")
     depends_on("py-cython@0.29.30", when="@5.1:6.0", type="build")
     depends_on("py-cython@3.0", when="@6.1.0:6", type="build")
@@ -53,6 +56,7 @@ class PyAstropy(PythonPackage):
     depends_on("py-pip@:23.0", when="@:4.0", type="build")
 
     depends_on("py-astropy-iers-data@0.2025.1.31.12.41.4:", when="@7.0.1:", type=("build", "run"))
+    depends_on("py-astropy-iers-data@0.2025.4.28.0.37.27:", when="@7.1.0:", type=("build", "run"))
     depends_on("py-astropy-iers-data", when="@6:", type=("build", "run"))
     depends_on("py-numpy@1.23.2:", when="@7.0.1:", type=("build", "run"))
     depends_on("py-numpy@1.23:", when="@6.1:", type=("build", "run"))
@@ -73,8 +77,10 @@ class PyAstropy(PythonPackage):
     depends_on("py-pyerfa@2.0.1.1:", when="@6.1.0:", type=("build", "run"))
 
     depends_on("py-coverage@6.4.4:", when="@7.0.1:", type="test")
+    depends_on("py-pytest@8:", when="@7.1.0:", type="test")
     depends_on("py-pytest@7.3:", when="@7.0.1:", type="test")
     depends_on("py-pytest@7:", type="test")
+    depends_on("py-pytest-doctestplus@1.4.0:", when="@7.1.0:", type="test")
     depends_on("py-pytest-doctestplus@0.12:", type="test")
     depends_on("py-pytest-astropy-header@0.2.1:", type="test")
     depends_on("py-pytest-astropy@0.10:", type="test")
@@ -110,8 +116,11 @@ class PyAstropy(PythonPackage):
         depends_on("py-pandas-stubs@2.0:", when="@7.0.1:", type=("build", "run"))
         depends_on("py-pandas@2:", when="@7.0.1:", type=("build", "run"))
         depends_on("py-pandas", type=("build", "run"))
+        depends_on("py-sortedcontainers@1.5.7:", when="@7.1.0:", type=("build", "run"))
         depends_on("py-sortedcontainers", type=("build", "run"))
+        depends_on("py-pytz@2016.10:", when="@7.1.0:", type=("build", "run"))
         depends_on("py-pytz", type=("build", "run"))
+        depends_on("py-jplephem@2.6:", when="@7.1.0:", type=("build", "run"))
         depends_on("py-jplephem", type=("build", "run"))
         depends_on("py-mpmath@1.2.1:", when="@7.0.1:", type=("build", "run"))
         depends_on("py-mpmath", type=("build", "run"))
@@ -122,7 +131,9 @@ class PyAstropy(PythonPackage):
         depends_on("py-asdf@2.3:", type=("build", "run"))
         depends_on("py-bottleneck@1.3.3:", when="@7.0.1:", type=("build", "run"))
         depends_on("py-bottleneck", type=("build", "run"))
+        depends_on("py-ipywidgets@7.7.3:", when="@7.1.0:", type=("build", "run"))
         depends_on("py-ipywidgets", when="@7.0.1:", type=("build", "run"))
+        depends_on("py-ipykernel@6.16.0:", when="@7.1.0:", type=("build", "run"))
         depends_on("py-ipykernel", when="@7.0.1:", type=("build", "run"))
         # depends_on("py-ipydatagrid", when="@7.0.1:", type=("build", "run"))
         depends_on("py-ipython@8:", when="@7.0.1:", type=("build", "run"))
@@ -132,6 +143,7 @@ class PyAstropy(PythonPackage):
         depends_on("py-pytest", when="@:6", type=("build", "run"))
         depends_on("py-fsspec+http@2023.4:", when="@6.1:", type=("build", "run"))
         depends_on("py-s3fs@2023.4:", when="@6.1:", type=("build", "run"))
+        #depends_on("py-uncompresspy@0.4:", type=("build", "run"))
         depends_on("py-typing-extensions@3.10.0.1:", when="@5.0.2:6", type=("build", "run"))
 
         # Historical optional dependencies

--- a/repos/spack_repo/builtin/packages/py_astropy_iers_data/package.py
+++ b/repos/spack_repo/builtin/packages/py_astropy_iers_data/package.py
@@ -16,6 +16,11 @@ class PyAstropyIersData(PythonPackage):
     homepage = "https://github.com/astropy/astropy-iers-data"
     pypi = "astropy-iers-data/astropy_iers_data-0.2024.4.29.0.28.48.tar.gz"
 
+
+    version(
+        "0.2025.9.29.0.35.48",
+        sha256="0a7841c9a0ff41e2abafcde984cb6b271cdfd9cb5b13e01d5ddd0ed2e8fc4065",
+    )
     version(
         "0.2025.4.28.0.37.27",
         sha256="840efbe7085a20ab1fe3a93bf5eeba28fcb4a0fc4196cbcc1b06d51a182accb0",
@@ -34,6 +39,8 @@ class PyAstropyIersData(PythonPackage):
     )
 
     depends_on("python@3.8:")
-    depends_on("py-setuptools", type="build")
-    depends_on("py-setuptools-scm", type="build")
-    depends_on("py-wheel", type="build")
+    depends_on("py-hatchling", when="@0.2025.6.9.14.9.37:", type="build")
+    depends_on("py-hatch-vcs", when="@0.2025.6.9.14.9.37:", type="build")
+    depends_on("py-setuptools", when="@:0.2025.6.0.39.3", type="build")
+    depends_on("py-setuptools-scm", when="@:0.2025.6.0.39.3", type="build")
+    depends_on("py-wheel", when="@:0.2025.6.0.39.3", type="build")

--- a/repos/spack_repo/builtin/packages/py_astropy_iers_data/package.py
+++ b/repos/spack_repo/builtin/packages/py_astropy_iers_data/package.py
@@ -16,7 +16,6 @@ class PyAstropyIersData(PythonPackage):
     homepage = "https://github.com/astropy/astropy-iers-data"
     pypi = "astropy-iers-data/astropy_iers_data-0.2024.4.29.0.28.48.tar.gz"
 
-
     version(
         "0.2025.9.29.0.35.48",
         sha256="0a7841c9a0ff41e2abafcde984cb6b271cdfd9cb5b13e01d5ddd0ed2e8fc4065",

--- a/repos/spack_repo/builtin/packages/py_astropy_iers_data/package.py
+++ b/repos/spack_repo/builtin/packages/py_astropy_iers_data/package.py
@@ -17,6 +17,10 @@ class PyAstropyIersData(PythonPackage):
     pypi = "astropy-iers-data/astropy_iers_data-0.2024.4.29.0.28.48.tar.gz"
 
     version(
+        "0.2025.4.28.0.37.27",
+        sha256="840efbe7085a20ab1fe3a93bf5eeba28fcb4a0fc4196cbcc1b06d51a182accb0",
+    )
+    version(
         "0.2025.3.10.0.29.26",
         sha256="dd4865861f00dec8a442ef8135f034675a7b05f17846562e2ea71678f5dbaa97",
     )

--- a/repos/spack_repo/builtin/packages/py_pytest_doctestplus/package.py
+++ b/repos/spack_repo/builtin/packages/py_pytest_doctestplus/package.py
@@ -16,8 +16,18 @@ class PyPytestDoctestplus(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.4.0", sha256="df83832b1d11288572df2ee4c7cccdb421d812b8038a658bb514c9c62bdbd626")
+    version("1.3.0", sha256="709ad23ea98da9a835ace0a4365c85371c376e000f2860f30de6df3a6f00728a")
     version("0.13.0", sha256="f884e2231fe5378cc8e5d1a272d19b01ebd352df0591a5add55ff50adac2d2d0")
     version("0.9.0", sha256="6fe747418461d7b202824a3486ba8f4fa17a9bd0b1eddc743ba1d6d87f03391a")
+
+    def url_for_version(self, version):
+        url = "https://files.pythonhosted.org/packages/source/p/{0}/{0}-{1}.tar.gz"
+        if version >= Version("1.3.0"):
+            name = "pytest_doctestplus"
+        else:
+            name = "pytest-doctestplus"
+        return url.format(name, version)
 
     depends_on("py-setuptools@30.3.0:", type=("build", "run"))
     depends_on("py-setuptools-scm", type="build")

--- a/repos/spack_repo/builtin/packages/py_pytest_doctestplus/package.py
+++ b/repos/spack_repo/builtin/packages/py_pytest_doctestplus/package.py
@@ -23,10 +23,10 @@ class PyPytestDoctestplus(PythonPackage):
 
     depends_on("py-setuptools-scm", type="build")
     depends_on("py-setuptools@30.3.0:", type=("build", "run"))
-    depends_on("python@3.9:", when="@1.4.0:", type("build", "run"))
-    depends_on("python@3.8:", when="@1.1.0:", type("build", "run"))
-    depends_on("python@3.7:", when="@0.10.0:", type("build", "run"))
-    depends_on("python@3.6:", when="@0.9.0:", type("build", "run"))
+    depends_on("python@3.9:", when="@1.4.0:", type=("build", "run"))
+    depends_on("python@3.8:", when="@1.1.0:", type=("build", "run"))
+    depends_on("python@3.7:", when="@0.10.0:", type=("build", "run"))
+    depends_on("python@3.6:", when="@0.9.0:", type=("build", "run"))
 
     depends_on("py-pytest@4.6:", type=("build", "run"))
     depends_on("py-packaging@17:", when="@0.10:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_pytest_doctestplus/package.py
+++ b/repos/spack_repo/builtin/packages/py_pytest_doctestplus/package.py
@@ -21,6 +21,16 @@ class PyPytestDoctestplus(PythonPackage):
     version("0.13.0", sha256="f884e2231fe5378cc8e5d1a272d19b01ebd352df0591a5add55ff50adac2d2d0")
     version("0.9.0", sha256="6fe747418461d7b202824a3486ba8f4fa17a9bd0b1eddc743ba1d6d87f03391a")
 
+    depends_on("py-setuptools-scm", type="build")
+    depends_on("py-setuptools@30.3.0:", type=("build", "run"))
+    depends_on("python@3.9:", when="@1.4.0:", type("build", "run"))
+    depends_on("python@3.8:", when="@1.1.0:", type("build", "run"))
+    depends_on("python@3.7:", when="@0.10.0:", type("build", "run"))
+    depends_on("python@3.6:", when="@0.9.0:", type("build", "run"))
+
+    depends_on("py-pytest@4.6:", type=("build", "run"))
+    depends_on("py-packaging@17:", when="@0.10:", type=("build", "run"))
+
     def url_for_version(self, version):
         url = "https://files.pythonhosted.org/packages/source/p/{0}/{0}-{1}.tar.gz"
         if version >= Version("1.3.0"):
@@ -28,9 +38,3 @@ class PyPytestDoctestplus(PythonPackage):
         else:
             name = "pytest-doctestplus"
         return url.format(name, version)
-
-    depends_on("py-setuptools@30.3.0:", type=("build", "run"))
-    depends_on("py-setuptools-scm", type="build")
-
-    depends_on("py-pytest@4.6:", type=("build", "run"))
-    depends_on("py-packaging@17:", when="@0.10:", type=("build", "run"))


### PR DESCRIPTION
newer astropy actually builds fine with numpy@1 and pytests run just fine.
tested to be working with numpy@1.26.4
related to:
- https://github.com/spack/spack-packages/issues/1947
- https://github.com/astropy/astropy/issues/18544
- https://github.com/spack/spack-packages/pull/729