### PR TITLE
Update github workflow: vermin 1.7.0

### DIFF
--- a/.github/workflows/requirements/style/requirements.txt
+++ b/.github/workflows/requirements/style/requirements.txt
@@ -4,5 +4,5 @@ flake8==7.2.0
 isort==6.0.1
 mypy==1.15.0
 types-six==1.17.0.20250515
-vermin==1.6.0
+vermin==1.7.0
 pylint==3.3.7


### PR DESCRIPTION
After having released version [1.7.0](https://github.com/netromdk/vermin/releases/tag/v1.7.0) of Vermin, it would make sense to also use it for the Spack workflows.

Relates to https://github.com/spack/spack-packages/pull/1940.
