### PR TITLE
lcio: Add version 2.23 and update cxxstd variant

### DIFF
--- a/repos/spack_repo/builtin/packages/lcio/package.py
+++ b/repos/spack_repo/builtin/packages/lcio/package.py
@@ -22,6 +22,7 @@ class Lcio(CMakePackage):
     license("BSD-3-Clause")
 
     version("master", branch="master")
+    version("2.23", sha256="8e56b96e0957173acc22fd4360d2002f4ebc8b5acb704ad7359b855f6d453896")
     version("2.22.6", sha256="69271f021198d15390a0134110ab5c1cbeea9a183cef3f94f0d1ee91fa4748bb")
     version("2.22.5", sha256="a756521a2419f8d25d4a4f1bab0008e16c9947020d015f2f6ce457ab0a0429bf")
     version("2.22.4", sha256="5d60eeb4df8611059f4bc839ac098f5d7e3608a662591e9cbae48aed07995514")
@@ -61,6 +62,7 @@ class Lcio(CMakePackage):
             "20",
             # c++17 became minimum with 2.18
             conditional("17", "20", when="@2.18:"),
+            conditional("17,", "20", "23", when="@2.23:"),
         ),
         multi=False,
         description="Use the specified C++ standard when building.",


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Release notes: https://github.com/iLCSoft/LCIO/releases/tag/v02-23