### PR TITLE
yasm: patch for C23 compliance

### DIFF
--- a/repos/spack_repo/builtin/packages/yasm/libyasm_bitvect_c23_bool.patch
+++ b/repos/spack_repo/builtin/packages/yasm/libyasm_bitvect_c23_bool.patch
@@ -1,0 +1,36 @@
+From 64ef740eb262f329e55eebadf2ce276b146d44e9 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin.jansa@gmail.com>
+Date: Tue, 22 Apr 2025 19:06:24 +0200
+Subject: [PATCH] bitvect: fix build with gcc-15
+
+* fixes:
+libyasm/bitvect.h:86:32: error: cannot use keyword 'false' as enumeration constant
+   86 |         typedef enum boolean { false = FALSE, true = TRUE } boolean;
+      |                                ^~~~~
+../git/libyasm/bitvect.h:86:32: note: 'false' is a keyword with '-std=c23' onwards
+
+as suggested in:
+https://github.com/yasm/yasm/issues/283#issuecomment-2661108816
+
+Signed-off-by: Martin Jansa <martin.jansa@gmail.com>
+---
+ libyasm/bitvect.h | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/libyasm/bitvect.h b/libyasm/bitvect.h
+index 3aee3a531..a13470ada 100644
+--- a/libyasm/bitvect.h
++++ b/libyasm/bitvect.h
+@@ -83,7 +83,11 @@ typedef  Z_longword         *Z_longwordptr;
+     #ifdef MACOS_TRADITIONAL
+         #define boolean Boolean
+     #else
+-        typedef enum boolean { false = FALSE, true = TRUE } boolean;
++        #if __STDC_VERSION__ < 202311L
++             typedef enum boolean { false = FALSE, true = TRUE } boolean;
++        #else
++             typedef bool boolean;
++        #endif
+     #endif
+ #endif
+ 

--- a/repos/spack_repo/builtin/packages/yasm/package.py
+++ b/repos/spack_repo/builtin/packages/yasm/package.py
@@ -1,4 +1,4 @@
-classyright Spack Project Developers. See COPYRIGHT file for details.
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
@@ -23,6 +23,7 @@ class Yasm(AutotoolsPackage):
     version("1.3.0", sha256="3dce6601b495f5b3d45b59f7d2492a340ee7e84b5beca17e48f862502bd5603f")
 
     # Ensure C23 compliance in boolean enum
+    # https://github.com/yasm/yasm/pull/287
     patch("libyasm_bitvect_c23_bool.patch")
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/yasm/package.py
+++ b/repos/spack_repo/builtin/packages/yasm/package.py
@@ -1,4 +1,4 @@
-# Copyright Spack Project Developers. See COPYRIGHT file for details.
+classyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
@@ -21,6 +21,9 @@ class Yasm(AutotoolsPackage):
 
     version("develop", branch="master")
     version("1.3.0", sha256="3dce6601b495f5b3d45b59f7d2492a340ee7e84b5beca17e48f862502bd5603f")
+
+    # Ensure C23 compliance in boolean enum
+    patch("libyasm_bitvect_c23_bool.patch")
 
     depends_on("c", type="build")  # generated
 


### PR DESCRIPTION
This PR added a patch to ensure C23 compliance in boolean enum. See https://github.com/yasm/yasm/pull/287.

```
==> Installing yasm-1.3.0-nbnk3rgvw2othq7hvs7ati4oxjbyva47 [8/8]
==> Using cached archive: /opt/spack/cache/_source-cache/archive/3d/3dce6601b495f5b3d45b59f7d2492a340ee7e84b5beca17e48f862502bd5603f.tar.gz
==> Applied patch /home/wdconinc/git/spack-packages/repos/spack_repo/builtin/packages/yasm/libyasm_bitvect_c23_bool.patch
==> yasm: Executing phase: 'autoreconf'
==> yasm: Executing phase: 'configure'
==> yasm: Executing phase: 'build'
==> yasm: Executing phase: 'install'
==> yasm: Successfully installed yasm-1.3.0-nbnk3rgvw2othq7hvs7ati4oxjbyva47
  Stage: 0.04s.  Autoreconf: 0.00s.  Configure: 2.27s.  Build: 4.34s.  Install: 0.20s.  Post-install: 0.12s.  Total: 7.03s
```