### PR TITLE
unuran: add v1.11.0

### DIFF
--- a/repos/spack_repo/builtin/packages/unuran/package.py
+++ b/repos/spack_repo/builtin/packages/unuran/package.py
@@ -12,9 +12,11 @@ class Unuran(AutotoolsPackage):
 
     homepage = "https://statmath.wu.ac.at/unuran"
     url = "https://statmath.wu.ac.at/unuran/unuran-1.8.1.tar.gz"
+    git = "https://github.com/unuran/unuran.git"
 
     license("GPL-2.0-or-later")
 
+    version("1.11.0", sha256="098793854c590b4c2c7e98bc48a45408875f48c5ad47650b5fabbd3e94dd8049")
     version("1.8.1", sha256="c270ae96857857dbac6450043df865e0517f52856ddbe5202fd35583b13c5193")
 
     variant("shared", default=True, description="Enable the build of shared libraries")


### PR DESCRIPTION
This PR adds `unuran`, v1.11.0, https://github.com/unuran/unuran/compare/unuran-1.8.1...unuran-1.11.0. No major changes (but fixes a bug in https://github.com/unuran/unuran/commit/8cb1dc4f1330492c3976d099270ff271bfe38f35).

```
==> No binary for unuran-1.11.0-blberzycfn7y5t57tpov6ccltznsar3f found: installing from source
==> Installing unuran-1.11.0-blberzycfn7y5t57tpov6ccltznsar3f [9/9]
==> Fetching https://statmath.wu.ac.at/unuran/unuran-1.11.0.tar.gz
    [100%]    3.82 MB @    1.3 MB/s
==> No patches needed for unuran
==> unuran: Executing phase: 'autoreconf'
==> unuran: Executing phase: 'configure'
==> unuran: Executing phase: 'build'
==> unuran: Executing phase: 'install'
==> Warning: unuran@1.11.0~gsl+rngstreams+shared build_system=autotools platform=linux os=ubuntu25.10 target=skylake/blberzy uses more than one compiler, and might not fit the LMod hierarchy. Using gcc@15.1.0~binutils+bootstrap~graphite~mold~nvptx~piclibs~profiled~strip build_system=autotools build_type=RelWithDebInfo languages:='c,c++,fortran' platform=linux os=ubuntu25.10 target=skylake/wffsqfd as the LMod compiler.
==> unuran: Successfully installed unuran-1.11.0-blberzycfn7y5t57tpov6ccltznsar3f
  Stage: 4.18s.  Autoreconf: 0.00s.  Configure: 6.26s.  Build: 30.24s.  Install: 0.71s.  Post-install: 0.14s.  Total: 41.60s
[+] /opt/software/linux-skylake/unuran-1.11.0-blberzycfn7y5t57tpov6ccltznsar3f
```