### PR TITLE
superlu-dist: add patch for compilation with CUDA

### DIFF
--- a/repos/spack_repo/builtin/packages/superlu_dist/package.py
+++ b/repos/spack_repo/builtin/packages/superlu_dist/package.py
@@ -88,6 +88,11 @@ class SuperluDist(CMakePackage, CudaPackage, ROCmPackage):
     patch("xl-611.patch", when="@:6.1.1 %xl_r")
     patch("superlu-cray-ftn-case.patch", when="@7.1.1 %cce")
     patch("CMAKE_INSTALL_LIBDIR.patch", when="@7.0.0:7.2.0")
+    patch(
+        "https://github.com/xiaoyeli/superlu_dist/commit/5a1946f347e6d813a250af874dee0942f4fdfc44.patch?full_index=1",
+        sha256="6472c192f6d24d4d762193385c5a46a536282cae786c13354a5e80f5ebfac64c",
+        when="@9.0:9.1",
+    )
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
This backports a bugfix available on superlu-dist master, but not yet in a release, which fixes compilation with `+cuda` (possibly also `+rocm`, but I have not tried that): https://github.com/xiaoyeli/superlu_dist/commit/5a1946f347e6d813a250af874dee0942f4fdfc44. The patch applies to 9.0 and 9.1, though with 9.0 there is another build failure that I have not tried to fix, since 9.1 builds now.