### PR TITLE
Repeatmodeler 2.0.7

### DIFF
--- a/repos/spack_repo/builtin/packages/ltr_retriever/package.py
+++ b/repos/spack_repo/builtin/packages/ltr_retriever/package.py
@@ -19,6 +19,7 @@ class LtrRetriever(Package):
     license("GPL-3.0-only")
 
     version("2.9.4", sha256="a9f4668113d2d75ab97cd85b456f11b00afd4876848a8ef099622ec0d9e505e7")
+    version("2.9.0", sha256="e2d94f6179c33990a77fa9fdcefb842c8481b4c30833c9c12cbbe54cb3fdda73")
     version("2.8.7", sha256="29ca6f699c57b5e964aa0ee6c7d3e1e4cd5362dadd789e5f0e8c82fe0bb29369")
 
     depends_on("perl", type="run")

--- a/repos/spack_repo/builtin/packages/repeatafterme/package.py
+++ b/repos/spack_repo/builtin/packages/repeatafterme/package.py
@@ -1,0 +1,29 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
+
+from spack.package import *
+
+
+class Repeatafterme(MakefilePackage):
+    """A package for the extension of repetitive DNA sequences"""
+
+    homepage = "https://github.com/Dfam-consortium/RepeatAfterMe"
+    url = "https://github.com/Dfam-consortium/RepeatAfterMe/archive/refs/tags/RepeatAfterMe_V0.0.7.tar.gz"
+
+    maintainers("snehring")
+
+    license("CC0-1.0", checked_by="snehring")
+
+    version("0.7", sha256="8a4c96be6c0fcedf24ee28796fea3bffef022c7479d8f49fbd2f83e56d697f26")
+
+    depends_on("c", type="build")
+
+    parallel = False
+
+    def edit(self, spec, prefix):
+        filter_file(r"^INSTDIR = .*$", f"INSTDIR = {spec.prefix}", "Makefile")
+        filter_file(r"^\s+@mkdir \$\(INSTDIR\)$", "", "Makefile")
+        filter_file(r"^\s+@mkdir \$\(INSTDIR\)/bin$", "\t@mkdir -p $(INSTDIR)/bin", "Makefile")

--- a/repos/spack_repo/builtin/packages/repeatmodeler/package.py
+++ b/repos/spack_repo/builtin/packages/repeatmodeler/package.py
@@ -18,11 +18,13 @@ class Repeatmodeler(Package):
 
     license("OSL-2.1")
 
+    version("2.0.7", sha256="2873697a885e7115bf5e940cf880f47de17efb7a200ec2d3a1627d5a689f7a8f")
     version("2.0.4", sha256="94aad46cc70911d48de3001836fc3165adb95b2b282b5c53ab0d1da98c27a6b6")
     version(
         "1.0.11",
         sha256="7ff0d588b40f9ad5ce78876f3ab8d2332a20f5128f6357413f741bb7fa172193",
         url="https://www.repeatmasker.org/RepeatModeler/RepeatModeler-open-1.0.11.tar.gz",
+        deprecated=True,
     )
 
     depends_on("perl", type=("build", "run"))
@@ -45,7 +47,8 @@ class Repeatmodeler(Package):
     depends_on("mafft", type="run", when="@2.0.4:")
     depends_on("ninja-phylogeny", type="run", when="@2.0.4:")
     depends_on("blat", type="run", when="@2.0.4:")
-    depends_on("ltr-retriever", type="run", when="@2.0.4:")
+    depends_on("ltr-retriever@=2.9.0", type="run", when="@2.0.4:")
+    depends_on("repeatafterme", type="run", when="@2.0.7:")
 
     def patch(self):
         file_list = [
@@ -98,6 +101,7 @@ class Repeatmodeler(Package):
 
     def install(self, spec, prefix):
         # interactive configuration script
+        # once 1.0.11 is removed we can clean this up a bit
         if spec.satisfies("@1.0.11"):
             config_answers = [
                 "",
@@ -129,6 +133,8 @@ class Repeatmodeler(Package):
                 spec["mafft"].prefix.bin,
                 spec["ninja-phylogeny"].prefix.bin,
             ]
+        if spec.satisfies("@2.0.7:"):
+            config_answers.insert(2, spec["repeatafterme"].prefix.bin)
 
         config_filename = "spack-config.in"
 


### PR DESCRIPTION
Version update. I'm also deprecating the 1.0.11 version with the intent to remove it in the near future to allow a bit of recipe rework. The ltr_retreiver version requirement for repeatmodeler became 2.9.0 after the 2.0.4 release, but I assume it's equally relevant for it.