### PR TITLE
py-matplotlib: matplotlib < 3.5.0 is incompatible with Python >= 3.12

### DIFF
--- a/repos/spack_repo/builtin/packages/py_matplotlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_matplotlib/package.py
@@ -149,6 +149,8 @@ class PyMatplotlib(PythonPackage):
     depends_on("python@3.10:", when="@3.10:", type=("build", "link", "run"))
     depends_on("python@3.9:", when="@3.8:", type=("build", "link", "run"))
     depends_on("python@3.8:", when="@3.6:", type=("build", "link", "run"))
+    # Python 3.12 removed SafeConfigParser, which was used up to matplotlib 3.5.0.
+    depends_on("python@:3.11", when="@:3.4", type=("build", "link", "run"))
     depends_on("python", type=("build", "link", "run"))
     depends_on("py-contourpy@1.0.1:", when="@3.6:", type=("build", "run"))
     depends_on("py-cycler@0.10:", type=("build", "run"))


### PR DESCRIPTION
The setup routine of the older matplotlib version uses `SafeConfigParser`, which was removed from Python 3.12.