### PR TITLE
py-python-dateutil: fix pip version number to not be "0.0.0" with 2.9.0.post0 version

### DIFF
--- a/repos/spack_repo/builtin/packages/py_python_dateutil/package.py
+++ b/repos/spack_repo/builtin/packages/py_python_dateutil/package.py
@@ -29,7 +29,11 @@ class PyPythonDateutil(PythonPackage):
 
     with default_args(type="build"):
         depends_on("py-setuptools@24.3:")
-        depends_on("py-setuptools-scm@:7", when="@2.9.0.post0:")
+        # Upstream restricts this dep version regardless of Python version, but it 
+        # is only actually needed for Python 2 and it breaks the version number when 
+        # installed by spack (pip / python thinks the version is "0.0.0") 
+        depends_on("py-setuptools-scm@:7", when="@2.9.0.post0: ^python@:2")
+        depends_on("py-setuptools-scm@8:", when="@2.9.0.post0: ^python@3:")
         depends_on("py-wheel", when="@2.8.0:")
 
     with default_args(type=("build", "run")):


### PR DESCRIPTION
Installing latest version (2.9.0.post0) causes pip to think the version is "0.0.0". Not restricting the version of "py-setuptools-scm" for Python3 (which is unnecessary) fixes it:

https://github.com/dateutil/dateutil/pull/1346#issuecomment-1978841433
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
