### PR TITLE
scotch: add versions 7.0.8-7.0.10 (+fortran variant)

### DIFF
--- a/repos/spack_repo/builtin/packages/scotch/package.py
+++ b/repos/spack_repo/builtin/packages/scotch/package.py
@@ -19,8 +19,10 @@ class Scotch(CMakePackage, MakefilePackage):
     url = "https://gitlab.inria.fr/scotch/scotch/-/archive/v7.0.1/scotch-v7.0.1.tar.gz"
     list_url = "https://gforge.inria.fr/frs/?group_id=248"
 
-    maintainers("AlexanderRichert-NOAA", "climbfuji")
+    maintainers("pghysels")
 
+    version("7.0.10", sha256="8327725a08cdd4fc7575e291251883b4f93f75b07a54bc58f89f50dcbba7b244")
+    version("7.0.9", sha256="6d50c3f66e3e0e2058bce45ed9eee171fd8d6c01123c802a98544948a1c3d5d1")
     version("7.0.8", sha256="21f48ac85c7991a5eb5fae9232dd68584556ccc500f85e2ebd6b5b275617e11a")
     version("7.0.7", sha256="02084471d2ca525f8a59b4bb8c607eb5cca452d6a38cf5c89f5f92f7edc1a5b5")
     version("7.0.6", sha256="b44acd0d2f53de4b578fa3a88944cccc45c4d2961cd8cefa9b9a1d5431de8e2b")
@@ -63,26 +65,12 @@ class Scotch(CMakePackage, MakefilePackage):
         when="@7.0.1",
         description="Link error handling library to libscotch/libptscotch",
     )
-    variant(
-        "determinism",
-        default="FULL",
-        values=("NONE", "FIXED_SEED", "FULL"),
-        multi=False,
-        description="Determinism configuration",
-        when="build_system=makefile",
-    )
-    variant(
-        "determinism",
-        default="FIXED_SEED",
-        values=("NONE", "FIXED_SEED", "FULL"),
-        multi=False,
-        description="Determinism configuration",
-        when="@7.0.7: build_system=cmake",
-    )
+    variant("fortran", default=True, when="@7.0.9:", description="Enable Fortran interface")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
-    depends_on("fortran", type="build")
+    depends_on("fortran", type="build", when="@:7.0.8")
+    depends_on("fortran", type="build", when="+fortran")
 
     # Does not build with flex 2.6.[23]
     depends_on("flex@:2.6.1,2.6.4:", type="build")
@@ -153,6 +141,7 @@ class Scotch(CMakePackage, MakefilePackage):
 
 
 class CMakeBuilder(cmake.CMakeBuilder):
+
     def cmake_args(self):
         args = [
             self.define_from_variant("BUILD_LIBSCOTCHMETIS", "metis"),
@@ -164,11 +153,8 @@ class CMakeBuilder(cmake.CMakeBuilder):
             self.define_from_variant("MPI_THREAD_MULTIPLE", "mpi_thread"),
         ]
 
-        if self.spec.satisfies("@7.0.5:"):
+        if self.pkg.version > Version("7.0.4"):
             args.append(self.define("ENABLE_TESTS", self.pkg.run_tests))
-
-        if self.spec.satisfies("@7.0.7:"):
-            args.append(self.define_from_variant("SCOTCH_DETERMINISTIC", "determinism"))
 
         if "+int64" in self.spec:
             args.append("-DINTSIZE=64")
@@ -193,14 +179,7 @@ class MakefileBuilder(makefile.MakefileBuilder):
 
     def edit(self, pkg, spec, prefix):
         makefile_inc = []
-        cflags = ["-O3", "-DSCOTCH_RENAME"]
-
-        if "determinism=FIXED_SEED" in self.spec:
-            cflags.append("-DCOMMON_RANDOM_FIXED_SEED")
-
-        if "determinism=FULL" in self.spec:
-            cflags.append("-DCOMMON_RANDOM_FIXED_SEED")
-            cflags.append("-DSCOTCH_DETERMINISTIC")
+        cflags = ["-O3", "-DCOMMON_RANDOM_FIXED_SEED", "-DSCOTCH_DETERMINISTIC", "-DSCOTCH_RENAME"]
 
         # SCOTCH_Num typedef: size of integers in arguments
         # SCOTCH_Idx typedef: indices for addressing


### PR DESCRIPTION
This PR adds Scotch versions 7.0.8-7.0.10, including a new "fortran" variant as of version 7.0.9.