### PR TITLE
CP2K: Add openPMD-api as an optional dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/cp2k/package.py
+++ b/repos/spack_repo/builtin/packages/cp2k/package.py
@@ -118,7 +118,12 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         " are enabled",
     )
     variant("pytorch", default=False, description="Enable libtorch support")
-    variant("openpmd-api", default=False, description="Enable openPMD support", when="@2026.1: build_system=cmake")
+    variant(
+        "openpmd-api",
+        default=False,
+        description="Enable openPMD support",
+        when="@2026.1: build_system=cmake",
+    )
     variant("quip", default=False, description="Enable quip support")
     variant("dftd4", when="@2024.2:", default=False, description="Enable DFT-D4 support")
     variant("mpi_f08", default=False, description="Use MPI F08 module", when="+mpi")

--- a/repos/spack_repo/builtin/packages/cp2k/package.py
+++ b/repos/spack_repo/builtin/packages/cp2k/package.py
@@ -118,7 +118,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         " are enabled",
     )
     variant("pytorch", default=False, description="Enable libtorch support")
-    variant("openpmd-api", default=False, description="Enable openPMD support", when=@2026.1: build_system=cmake)
+    variant("openpmd-api", default=False, description="Enable openPMD support", when="@2026.1: build_system=cmake")
     variant("quip", default=False, description="Enable quip support")
     variant("dftd4", when="@2024.2:", default=False, description="Enable DFT-D4 support")
     variant("mpi_f08", default=False, description="Use MPI F08 module", when="+mpi")

--- a/repos/spack_repo/builtin/packages/cp2k/package.py
+++ b/repos/spack_repo/builtin/packages/cp2k/package.py
@@ -118,6 +118,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         " are enabled",
     )
     variant("pytorch", default=False, description="Enable libtorch support")
+    variant("openpmd-api", default=False, description="Enable openPMD support")
     variant("quip", default=False, description="Enable quip support")
     variant("dftd4", when="@2024.2:", default=False, description="Enable DFT-D4 support")
     variant("mpi_f08", default=False, description="Use MPI F08 module", when="+mpi")
@@ -382,6 +383,9 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         depends_on("libvori@201219:", when="@8.1")
         depends_on("libvori@210412:", when="@8.2:")
         depends_on("libvori@220621:", when="@2023.1:")
+
+    with when("+openpmd-api"):
+        depends_on("openpmd-api@0.16.1:")
 
     # the bundled libcusmm uses numpy in the parameter prediction (v7+)
     # which is written using Python 3
@@ -1136,6 +1140,7 @@ class CMakeBuilder(cmake.CMakeBuilder):
             self.define_from_variant("CP2K_USE_COSMA", "cosma"),
             self.define_from_variant("CP2K_USE_LIBXC", "libxc"),
             self.define_from_variant("CP2K_USE_LIBTORCH", "pytorch"),
+            self.define_from_variant("CP2K_USE_OPENPMD", "openpmd-api"),
             self.define_from_variant("CP2K_USE_METIS", "pexsi"),
             self.define_from_variant("CP2K_USE_SUPERLU", "pexsi"),
             self.define_from_variant("CP2K_USE_PLUMED", "plumed"),

--- a/repos/spack_repo/builtin/packages/cp2k/package.py
+++ b/repos/spack_repo/builtin/packages/cp2k/package.py
@@ -118,7 +118,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         " are enabled",
     )
     variant("pytorch", default=False, description="Enable libtorch support")
-    variant("openpmd-api", default=False, description="Enable openPMD support")
+    variant("openpmd-api", default=False, description="Enable openPMD support", when=@2026.1: build_system=cmake)
     variant("quip", default=False, description="Enable quip support")
     variant("dftd4", when="@2024.2:", default=False, description="Enable DFT-D4 support")
     variant("mpi_f08", default=False, description="Use MPI F08 module", when="+mpi")


### PR DESCRIPTION
Related: https://github.com/cp2k/cp2k/pull/4058

TODO:

- [x] Expose this dependency only for current dev and upcoming release versions of CP2K

Now that spack and spack-packages are separated, is there any documentation on how to test packages from a local clone of spack-packages?

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
