### PR TITLE
py-pyyaml: add CFLAGS and LDFLAGS for libyaml

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pyyaml/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyyaml/package.py
@@ -79,7 +79,6 @@ class PyPyyaml(PythonPackage):
 
     def setup_build_environment(self, env):
         if "+libyaml" in self.spec:
-            # Add the libyaml path to RPATH so it's embedded in the binary
             env.append_flags("LDFLAGS", f"-L{self.spec['libyaml'].prefix.lib}")
             env.append_flags("LDFLAGS", f"-Wl,-rpath,{self.spec['libyaml'].prefix.lib}")
             env.append_flags("CFLAGS", f"-I{self.spec['libyaml'].prefix.include}")

--- a/repos/spack_repo/builtin/packages/py_pyyaml/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyyaml/package.py
@@ -76,3 +76,10 @@ class PyPyyaml(PythonPackage):
             args.append("--without-libyaml")
 
         return args
+
+    def setup_build_environment(self, env):
+        if "+libyaml" in self.spec:
+            # Add the libyaml path to RPATH so it's embedded in the binary
+            env.append_flags("LDFLAGS", f"-L{self.spec['libyaml'].prefix.lib}")
+            env.append_flags("LDFLAGS", f"-Wl,-rpath,{self.spec['libyaml'].prefix.lib}")
+            env.append_flags("CFLAGS", f"-I{self.spec['libyaml'].prefix.include}")


### PR DESCRIPTION
`py-pyyaml+libyaml` is not building the libyaml binding even though `--with-libyaml` is set.

I get the following error when trying to use `CSafeLoader`:
```
>>> from yaml import CSafeLoader
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    from yaml import CSafeLoader
ImportError: cannot import name 'CSafeLoader' from 'yaml' (/dockerx/spack/opt/spack/linux-zen2/py-pyyaml-6.0.2-xwmm5tjaoqgdvzuq4qyp5vxtdxfykm5t/lib/python3.14/site-packages/yaml/__init__.py). Did you mean: 'SafeLoader'?
```

I also see this error in the py-pyyaml build log:
```
  /usr/bin/gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -fPIC -I/dockerx/spack/opt/spack/linux-zen2/python-venv-1.0-7dz7wwxw4jfxxz6tlqypefuy3j4oqxmu/include -I/dockerx/spack/opt/spack/linux-zen2/python-3.14.0-ffppvhyhnsznjwwmfithskpt6c2k5x3b/include/python3.14 -c yaml/_yaml.c -o build/temp.linux-x86_64-cpython-314/yaml/_yaml.o
  In file included from yaml/_yaml.c:1121:
  yaml/_yaml.h:2:10: fatal error: yaml.h: No such file or directory
      2 | #include <yaml.h>
        |          ^~~~~~~~
  compilation terminated.
  Error compiling module, falling back to pure Python
```
It seems that the include and lib directories for `libyaml` are not visible, so I've explicitly added the paths to `CFLAGS` and `LDFLAGS`
