### PR TITLE
py-pyyaml: add 6.0.3

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pyyaml/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyyaml/package.py
@@ -23,6 +23,7 @@ class PyPyyaml(PythonPackage):
     # (see url_for_version below). Since "spack checksum" does not use url_for_version,
     # for versions older than 6.0.2, you'll need to use "spack checksum py-pyyaml x.y.z"
     # as we changed the pypi url above to lowercase.
+    version("6.0.3", sha256="d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f")
     version("6.0.2", sha256="d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e")
     version("6.0.1", sha256="bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43")
     version("6.0", sha256="68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2")
@@ -76,3 +77,9 @@ class PyPyyaml(PythonPackage):
             args.append("--without-libyaml")
 
         return args
+
+    def setup_build_environment(self, env):
+        if "+libyaml" in self.spec:
+            env.append_flags("LDFLAGS", f"-L{self.spec['libyaml'].prefix.lib}")
+            env.append_flags("LDFLAGS", f"-Wl,-rpath,{self.spec['libyaml'].prefix.lib}")
+            env.append_flags("CFLAGS", f"-I{self.spec['libyaml'].prefix.include}")

--- a/repos/spack_repo/builtin/packages/py_pyyaml/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyyaml/package.py
@@ -51,6 +51,11 @@ class PyPyyaml(PythonPackage):
     # 6.0.2+ do now support Cython 3 per release notes
     conflicts("^py-cython@3:", when="@:6.0.1")
 
+    # Per pyyaml release notes, support for Python 3.13 was added in 6.0.2
+    # and support for Python 3.14 was added in 6.0.3.
+    conflicts("^python@3.13:", when="@:6.0.1")
+    conflicts("^python@3.14:", when="@:6.0.2")
+
     # With pyyaml 6.0.2, the tarfile changed from PyYAML-6.0.1.tar.gz to pyyaml-6.0.2.tar.gz
     def url_for_version(self, version):
         if version >= Version("6.0.2"):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR adds py-pyyaml 6.0.3

Also, per the [pyyaml release notes](https://github.com/yaml/pyyaml/releases), Python 3.13 first supported in 6.0.2 and Python 3.14 in 6.0.3. So we add conflicts to reflect this.

I also pull over the valid fixes from #1999 by @afzpatel in case this gets merged in first.

Closes #1999

