### PR TITLE
emacs: fix build on MacOS 15.7 with Xcode 26 tools

### DIFF
--- a/repos/spack_repo/builtin/packages/emacs/disable-posix-spawn-macos.patch
+++ b/repos/spack_repo/builtin/packages/emacs/disable-posix-spawn-macos.patch
@@ -1,0 +1,12 @@
+diff --git a/src/callproc.c b/src/callproc.c
+--- a/src/callproc.c
++++ b/src/callproc.c
+@@ -44,7 +44,7 @@ Copyright (C) 1985-1988, 1993-1995, 1999-2025 Free Software Foundation,
+      Haiku */                                              \
+   && !defined HAIKU
+ # include <spawn.h>
+-# define USABLE_POSIX_SPAWN 1
++# define USABLE_POSIX_SPAWN 0
+ #else
+ # define USABLE_POSIX_SPAWN 0
+ #endif

--- a/repos/spack_repo/builtin/packages/emacs/package.py
+++ b/repos/spack_repo/builtin/packages/emacs/package.py
@@ -109,6 +109,13 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
     conflicts("gui=x11", when="platform=darwin", msg="Use gui=cocoa for macOS GUI support")
     conflicts("@:26.3", when="platform=darwin os=catalina")
 
+    # Xcode 26 adds support for `posix_spawn_file_actions_addchdir`, but older
+    # macOS kernels (for example, macOS 15) do not implement it. The newer CLI
+    # tools can therefore appear to support the feature even though the kernel
+    # lacks the required support, causing Emacs to segfault during compilation.
+    patch("disable-posix-spawn-macos.patch", when="@28:30.2 platform=darwin os=sequoia")
+    patch("disable-posix-spawn-macos.patch", when="@28:30.2 platform=darwin os=sonoma")
+
     def configure_args(self):
         args = []
 


### PR DESCRIPTION
MacOS 15.7 introduced the Xcode 26 CLI Tools, which incorrectly state that they support `posix_spawn_file_actions_addchdir` [when used on MacOS v15.7 instead of v26.](https://yhetil.org/emacs-devel/F03CCC08-FA37-402A-BC1A-EAD7D7987176@secure.kjonigsen.net/T/#t)

This was [fixed in upstream Emacs](https://cgit.git.savannah.gnu.org/cgit/emacs.git/commit/?id=dc5ae70cb44354de17d0994aee4b36ecc05456ff), but the patch relies on work that is not in Emacs v30.2. Thus we're using a different patch written by the Emacs developers to selectively backport the fix to `emacs@28:30.2` when the host system is MacOS.

