### PR TITLE
LinuxPerf: fix python-config not found for external Python

### DIFF
--- a/repos/spack_repo/builtin/packages/linux_perf/package.py
+++ b/repos/spack_repo/builtin/packages/linux_perf/package.py
@@ -153,9 +153,13 @@ class LinuxPerf(Package):
             checks.add("libpython")
             args.append("PYTHON={}".format(spec["python"].command))
             if which(spec["python"].prefix.bin.join("python-config")):
-                args.append("PYTHON_CONFIG={}".format(spec["python"].prefix.bin.join("python-config")))
+                args.append(
+                    "PYTHON_CONFIG={}".format(spec["python"].prefix.bin.join("python-config"))
+                )
             elif which(spec["python"].prefix.bin.join("python3-config")):
-                args.append("PYTHON_CONFIG={}".format(spec["python"].prefix.bin.join("python3-config")))
+                args.append(
+                    "PYTHON_CONFIG={}".format(spec["python"].prefix.bin.join("python3-config"))
+                )
         else:
             args.append("NO_LIBPYTHON=1")
 

--- a/repos/spack_repo/builtin/packages/linux_perf/package.py
+++ b/repos/spack_repo/builtin/packages/linux_perf/package.py
@@ -151,12 +151,11 @@ class LinuxPerf(Package):
 
         if spec.satisfies("+python"):
             checks.add("libpython")
-            args.extend(
-                [
-                    "PYTHON={}".format(spec["python"].command),
-                    "PYTHON_CONFIG={}".format(spec["python"].prefix.bin.join("python-config")),
-                ]
-            )
+            args.append("PYTHON={}".format(spec["python"].command))
+            if which(spec["python"].prefix.bin.join("python-config")):
+                args.append("PYTHON_CONFIG={}".format(spec["python"].prefix.bin.join("python-config")))
+            elif which(spec["python"].prefix.bin.join("python3-config")):
+                args.append("PYTHON_CONFIG={}".format(spec["python"].prefix.bin.join("python3-config")))
         else:
             args.append("NO_LIBPYTHON=1")
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Original setting `python-config` is not available for Python package which is found externally (no symlink python-config -> python3-config). Therefore, I add `which` to check `python3-config` which is commonly used for external python package and avoid `python-config` command not found issue.