### PR TITLE
openmpi: add missing header for +rocm build

### DIFF
--- a/repos/spack_repo/builtin/packages/openmpi/add_string.patch
+++ b/repos/spack_repo/builtin/packages/openmpi/add_string.patch
@@ -1,0 +1,12 @@
+diff --git a/opal/mca/accelerator/rocm/accelerator_rocm_module.c b/opal/mca/accelerator/rocm/accelerator_rocm_module.c
+index 8f1bb2c..5ef7f09 100644
+--- a/opal/mca/accelerator/rocm/accelerator_rocm_module.c
++++ b/opal/mca/accelerator/rocm/accelerator_rocm_module.c
+@@ -13,6 +13,7 @@
+ #include "opal/mca/accelerator/base/base.h"
+ #include "opal/constants.h"
+ #include "opal/util/output.h"
++#include <string.h>
+ 
+ /* Accelerator API's */
+ static int mca_accelerator_rocm_check_addr(const void *addr, int *dev_id, uint64_t *flags);

--- a/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -501,6 +501,11 @@ class Openmpi(AutotoolsPackage, CudaPackage, ROCmPackage):
         sha256="38529b557df029d6a987fa7e337db40b0ac1c1bb921776b95aacaa40e945cd21",
         when="@4.1.8,5.0.7",
     )
+
+    # Add missing header for memcpy
+    # https://github.com/open-mpi/ompi/commit/aa5577441ff1ab7f97f8b63e442b37457c7bd997
+    patch("add_string.patch", when="@5.0.1:5.0.8 +rocm")
+
     FABRICS = (
         "psm",
         "psm2",


### PR DESCRIPTION
The following error is seen when building `+rocm` with `rocmcc`:
```
  >> 5300    accelerator_rocm_module.c:283:9: error: call to undeclared library
              function 'memcpy' with type 'void *(void *, const void *, unsigne
             d long)'; ISO C99 and later do not support implicit function decla
             rations [-Wimplicit-function-declaration]
     5301      283 |         memcpy(dest, src, size);
     5302          |         ^
```
adding this patch to resolve the issue: https://github.com/open-mpi/ompi/commit/15d97a054a286c7bf8e4296f6fed2ca6cd43f063