### PR TITLE
dorado: Fix hdf5/libaec inclusion

### DIFF
--- a/repos/spack_repo/builtin/packages/dorado/hdf5-libaec.patch
+++ b/repos/spack_repo/builtin/packages/dorado/hdf5-libaec.patch
@@ -1,0 +1,10 @@
+diff --git a/cmake/HDF5.cmake b/cmake/HDF5.cmake
+index 256a17c0..e99ef8ec 100644
+--- a/cmake/HDF5.cmake
++++ b/cmake/HDF5.cmake
+@@ -55,4 +55,5 @@ else()
+ endif()
+ 
+ find_package(ZLIB QUIET)
++find_package(libaec COMPONENTS sz-shared)
+ find_package(HDF5 COMPONENTS C QUIET)

--- a/repos/spack_repo/builtin/packages/dorado/package.py
+++ b/repos/spack_repo/builtin/packages/dorado/package.py
@@ -40,6 +40,7 @@ class Dorado(CMakePackage, CudaPackage):
     conflicts("%gcc@13:", msg="Dorado will not build with gcc@13 and newer.")
 
     patch("cmake-htslib.patch")
+    patch("hdf5-libaec.patch")
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         env.prepend_path("LD_LIBRARY_PATH", self.spec["libdeflate"].prefix.lib64)


### PR DESCRIPTION
Prior to this patch, attempting to install dorado resulted in errors with how HDF5 used libaec

<details>
<summary>Full original error log</summary>

```console
CMake Error at /home/ejaco020/spack_dev/spack/opt/spack/linux-x86_64_v2/hdf5-1.14.6-ymluro2dqc2zhohq3n47zy4keaqjc2nz/cmake/hdf5-targets.cmake:59 (set_target_properties):                                                                                                    
  The link interface of target "hdf5-static" contains:                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                           
    libaec::sz-shared                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                           
  but the target was not found.  Possible reasons include:                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                           
    * There is a typo in the target name.                                                                                                                                                                                                                                                  
    * A find_package call is missing for an IMPORTED target.                                                                                                                                                                                                                               
    * An ALIAS target is missing.                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                           
Call Stack (most recent call first):                                                                                                                                                                                                                                                       
  /home/ejaco020/spack_dev/spack/opt/spack/linux-x86_64_v2/hdf5-1.14.6-ymluro2dqc2zhohq3n47zy4keaqjc2nz/cmake/hdf5-config.cmake:175 (include)                                                                                                                                
  /home/pkgadmin/opt/linux/centos/8.x/x86_64/pkgs/miniconda3/py39_4.12.0/lib/python3.9/site-packages/cmake/data/share/cmake-3.26/Modules/FindHDF5.cmake:486 (find_package)                                                                                                   
  cmake/HDF5.cmake:58 (find_package)                                                                                                                                                                                                                                                       
  CMakeLists.txt:82 (include)
```
</details>

Obligatory mention of maintainer @snehring 

There also seems to be ~15 versions of Dorado newer than Spack's 0.5.3 version that I plan to add, though I'll work on that in a separate branch/PR.