### PR TITLE
ci: allow maintainers to ping private members via GitHub App

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -23,6 +23,12 @@ jobs:
         with:
           ref: develop # DO NOT CHANGE
 
+      - uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42
+        id: generate-spackbot-token
+        with:
+          app-id: ${{ secrets.SPACKBOT_TRIAGE_APP_ID }}
+          private-key: ${{ secrets.SPACKBOT_TRIAGE_PRIVATE_KEY }}
+
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
       - uses: ./.github/actions/checkout-spack
 
@@ -35,7 +41,7 @@ jobs:
         env:
           GH_PR_NUMBER: ${{ github.event.number }}
           GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.generate-spackbot-token.outputs.token }}
           LABELS_CONFIG: .github/labels.yml
 
       - name: Tag Maintainers on PR
@@ -45,4 +51,4 @@ jobs:
         env:
           GH_PR_NUMBER: ${{ github.event.number }}
           GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.generate-spackbot-token.outputs.token }}


### PR DESCRIPTION
This PR addresses issues with the current maintainer pinging system by moving to a GitHub App token that has increased read-only permissions into the Spack Organization. (Reported by @tldahlgren.)

The previous system could not ping package maintainers that did not make their Spack membership public due to privacy limits with the GitHub API. Here we modify the GitHub token used to be a short-term dynamic token created via a GitHub app private key. The GitHub App (`spackbot-triage`) does not have any additional write permissions compared to the default GitHub Token, it only contains one additional read-only token allowing it to read the private membership to the Spack organization for GitHub users.

This workflow was created by following the official GitHub Documentation here.
https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow