### PR TITLE
parallelio: require serial netcdf when without pnetcdf

### DIFF
--- a/repos/spack_repo/builtin/packages/parallelio/package.py
+++ b/repos/spack_repo/builtin/packages/parallelio/package.py
@@ -64,6 +64,7 @@ class Parallelio(CMakePackage):
     depends_on("netcdf-c ~mpi", type="link", when="~mpi")
     depends_on("netcdf-fortran", type="link", when="+fortran")
     depends_on("parallel-netcdf", type="link", when="+pnetcdf")
+    depends_on("netcdf-c ~parallel-netcdf", type="link", when="~pnetcdf")
 
     resource(
         name="genf90",


### PR DESCRIPTION
This resolves an undefined symbol error that could be caused by `parallelio ~pnetcdf ^netcdf-c+parallel-netcdf`.

@harshula FYI
