### PR TITLE
prod_util: add version 2.1.2

### DIFF
--- a/repos/spack_repo/builtin/packages/prod_util/package.py
+++ b/repos/spack_repo/builtin/packages/prod_util/package.py
@@ -20,6 +20,7 @@ class ProdUtil(CMakePackage):
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett")
 
     version("develop", branch="develop")
+    version("2.1.2", sha256="af2e0163152b3afbc5a51ce5260265c3fb38e195900f4f90bff52cecb2bbf773")
     version("2.1.1", sha256="2f7507fa378a44f42b971f60de8152387c311bfa9c5c05a274c87b43a143aacd")
     version("2.1.0", sha256="fa7df4a82dae269ffb347b9007376fb0d9979c17c4974814ea82204b12d70ea5")
 


### PR DESCRIPTION
This PR adds v2.1.2 of prod_util. No new variants, dep changes, etc.