### PR TITLE
py-wcwidth: add v0.2.14

### DIFF
--- a/repos/spack_repo/builtin/packages/py_wcwidth/package.py
+++ b/repos/spack_repo/builtin/packages/py_wcwidth/package.py
@@ -15,6 +15,7 @@ class PyWcwidth(PythonPackage):
 
     license("MIT")
 
+    version("0.2.14", sha256="4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605")
     version("0.2.7", sha256="1b6d30a98ddd5ce9bbdb33658191fd2423fc9da203fe3ef1855407dcb7ee4e26")
     version("0.2.5", sha256="c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83")
     version("0.1.7", sha256="3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e")


### PR DESCRIPTION
https://github.com/jquast/wcwidth/tree/0.2.14

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
