### PR TITLE
py_pycubexr: add v2.0.1, v2.1.0, relax numpy version, add pearzt as maintainer

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pycubexr/package.py
+++ b/repos/spack_repo/builtin/packages/py_pycubexr/package.py
@@ -15,7 +15,10 @@ class PyPycubexr(PythonPackage):
 
     license("BSD-3-Clause")
 
+    maintainers("pearzt")
+
+    version("2.0.1", sha256="699643c076b603fb1140564da6c4589b73ec9efd3b9112cd3d957f5bee646915")
     version("2.0.0", sha256="03504fbbc9cbd514943e8aeb57919ad49731fe264bdbab86711bf10851276924")
 
     depends_on("py-setuptools", type="build")
-    depends_on("py-numpy@1.18:1", type=("build", "run"))
+    depends_on("py-numpy@1.18:2", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_pycubexr/package.py
+++ b/repos/spack_repo/builtin/packages/py_pycubexr/package.py
@@ -17,6 +17,7 @@ class PyPycubexr(PythonPackage):
 
     maintainers("pearzt")
 
+    version("2.1.0", sha256="c09ea0d3a13465f38ce1302eb980f8e0cd1293f9d1dc5d21eb5bd47c19f8fe0d")
     version("2.0.1", sha256="699643c076b603fb1140564da6c4589b73ec9efd3b9112cd3d957f5bee646915")
     version("2.0.0", sha256="03504fbbc9cbd514943e8aeb57919ad49731fe264bdbab86711bf10851276924")
 


### PR DESCRIPTION
- Relaxes NumPy version requirement to work with NumPy 2.x (analogous to https://github.com/extra-p/pycubexr/pull/7)
- Adds v2.0.1, v2.1.0
- Adds myself as package maintainer

CC pycubexr project maintainer @ageiss2