### PR TITLE
pbzip2: add compiler flag for clang compatbility

### DIFF
--- a/repos/spack_repo/builtin/packages/pbzip2/package.py
+++ b/repos/spack_repo/builtin/packages/pbzip2/package.py
@@ -32,5 +32,6 @@ class Pbzip2(MakefilePackage):
 
     def flag_handler(self, name: str, flags: List[str]):
         if name == "cxxflags":
-            flags.append("-Wno-reserved-user-defined-literal")
+            if self.spec.satisfies("%clang") or self.spec.satisfies("%apple-clang"):
+                flags.append("-Wno-reserved-user-defined-literal")
         return (flags, None, None)

--- a/repos/spack_repo/builtin/packages/pbzip2/package.py
+++ b/repos/spack_repo/builtin/packages/pbzip2/package.py
@@ -32,6 +32,6 @@ class Pbzip2(MakefilePackage):
 
     def flag_handler(self, name: str, flags: List[str]):
         if name == "cxxflags":
-            if self.spec.satisfies("%clang") or self.spec.satisfies("%apple-clang"):
+            if self.spec.satisfies("%cxx=clang") or self.spec.satisfies("%cxx=apple-clang"):
                 flags.append("-Wno-reserved-user-defined-literal")
         return (flags, None, None)

--- a/repos/spack_repo/builtin/packages/pbzip2/package.py
+++ b/repos/spack_repo/builtin/packages/pbzip2/package.py
@@ -29,3 +29,8 @@ class Pbzip2(MakefilePackage):
     def edit(self, spec, prefix):
         makefile = FileFilter("Makefile")
         makefile.filter("PREFIX = .*", f"PREFIX = {prefix}")
+
+    def flag_handler(self, name: str, flags: List[str]):
+        if name == "cxxflags":
+            flags.append("-Wno-reserved-user-defined-literal")
+        return (flags, None, None)


### PR DESCRIPTION
Hi all, noticed that the pbzip2 package doesn't compile on my mac. Turns out clang is a bit stricter about old syntax, so it needs an extra compiler flag.

Works fine with now with clang@17 at macOS 15, gcc@14 at macOS 15 and RHEL 9, and gcc@11 at RHEL 9.

Maintainer of this package is myself. 