### PR TITLE
py-jupyterlab: add v4.4.10

### DIFF
--- a/repos/spack_repo/builtin/packages/py_jupyterlab/package.py
+++ b/repos/spack_repo/builtin/packages/py_jupyterlab/package.py
@@ -18,6 +18,7 @@ class PyJupyterlab(PythonPackage):
 
     license("BSD-3-Clause", checked_by="lgarrison")
 
+    version("4.4.10", sha256="521c017508af4e1d6d9d8a9d90f47a11c61197ad63b2178342489de42540a615")
     version("4.4.7", sha256="8c8e225492f4513ebde9bbbc00a05b651ab9a1f5b0013015d96fabf671c37188")
     version("4.3.5", sha256="c779bf72ced007d7d29d5bcef128e7fdda96ea69299e19b04a43635a7d641f9d")
     version("4.0.1", sha256="4dc3901f7bbfd4704c994b7a893a49955256abf57dba9831f4825e3f3165b8bb")


### PR DESCRIPTION
https://github.com/jupyterlab/jupyterlab/tree/v4.4.10

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
