### PR TITLE
pkg-config: disable strict integer conversion check for amdclang

### DIFF
--- a/repos/spack_repo/builtin/packages/pkg_config/package.py
+++ b/repos/spack_repo/builtin/packages/pkg_config/package.py
@@ -64,7 +64,7 @@ class PkgConfig(AutotoolsPackage):
             # the cycle by using the internal glib.
             config_args.append("--with-internal-glib")
 
-        for strict_compiler in ("%oneapi", "%cce", "%apple-clang@15:", "%clang@15:"):
+        for strict_compiler in ("%oneapi", "%cce", "%apple-clang@15:", "%clang@15:", "%llvm-amdgpu@7:"):
             if spec.satisfies(strict_compiler):
                 config_args.append("CFLAGS=-Wno-error=int-conversion")
                 break

--- a/repos/spack_repo/builtin/packages/pkg_config/package.py
+++ b/repos/spack_repo/builtin/packages/pkg_config/package.py
@@ -64,7 +64,13 @@ class PkgConfig(AutotoolsPackage):
             # the cycle by using the internal glib.
             config_args.append("--with-internal-glib")
 
-        for strict_compiler in ("%oneapi", "%cce", "%apple-clang@15:", "%clang@15:", "%llvm-amdgpu@7:"):
+        for strict_compiler in (
+            "%oneapi",
+            "%cce",
+            "%apple-clang@15:",
+            "%clang@15:",
+            "%llvm-amdgpu@7:",
+        ):
             if spec.satisfies(strict_compiler):
                 config_args.append("CFLAGS=-Wno-error=int-conversion")
                 break


### PR DESCRIPTION
Add missing `-Wno-error=int-conversion` flag for pkg-config when compiled with amdclang 7, because without it compiler will fail to compile internal glib with the following error:
```
>> 670    gatomic.c:392:10: error: incompatible integer to pointer conversion passing 'gssize' (aka 'long') to parameter of type 'gpointer' (aka 'void *') 
            [-Wint-conversion]
     671      392 |   return g_atomic_pointer_add ((volatile gpointer *) atomic, val);
     672          |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     673    ./gatomic.h:170:46: note: expanded from macro 'g_atomic_pointer_add'
     674      170 |     (gssize) __sync_fetch_and_add ((atomic), (val));                         \
     675          |                                              ^~~~~
  >> 676    gatomic.c:416:10: error: incompatible integer to pointer conversion passing 'gsize' (aka 'unsigned long') to parameter of type 'gpointer' (aka 'v
            oid *') [-Wint-conversion]
     677      416 |   return g_atomic_pointer_and ((volatile gpointer *) atomic, val);
     678          |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     679    ./gatomic.h:177:45: note: expanded from macro 'g_atomic_pointer_and'
     680      177 |     (gsize) __sync_fetch_and_and ((atomic), (val));                          \
     681          |                                             ^~~~~
  >> 682    gatomic.c:440:10: error: incompatible integer to pointer conversion passing 'gsize' (aka 'unsigned long') to parameter of type 'gpointer' (aka 'v
            oid *') [-Wint-conversion]
     683      440 |   return g_atomic_pointer_or ((volatile gpointer *) atomic, val);
     684          |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     685    ./gatomic.h:184:44: note: expanded from macro 'g_atomic_pointer_or'
     686      184 |     (gsize) __sync_fetch_and_or ((atomic), (val));                           \
     687          |                                            ^~~~~

  >> 688    gatomic.c:464:10: error: incompatible integer to pointer conversion passing 'gsize' (aka 'unsigned long') to parameter of type 'gpointer' (aka 'v
            oid *') [-Wint-conversion]
     689      464 |   return g_atomic_pointer_xor ((volatile gpointer *) atomic, val);
     690          |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     691    ./gatomic.h:191:45: note: expanded from macro 'g_atomic_pointer_xor'
     692      191 |     (gsize) __sync_fetch_and_xor ((atomic), (val));                          \
     693          |                                             ^~~~~
     694    4 errors generated.
```
See https://gitlab.freedesktop.org/pkg-config/pkg-config/-/issues/81 and https://github.com/Homebrew/homebrew-core/pull/165878/commits/2e498f1400961fd6ac68e7d31ef0261f13fdd0a8