### PR TITLE
iozone: Inject cflags to allow compile with newer GCC versions

### DIFF
--- a/repos/spack_repo/builtin/packages/iozone/package.py
+++ b/repos/spack_repo/builtin/packages/iozone/package.py
@@ -44,3 +44,17 @@ class Iozone(MakefilePackage):
 
         with working_dir(self.build_directory):
             install_tree(".", prefix.bin)
+
+    def flag_handler(self, name, flags):
+        # Suppress some standard checks to allow compiling with
+        # newer gcc.
+        if name == "cflags":
+            if self.spec.satisfies("%gcc@10:"):
+                flags.append("-fcommon")
+            if self.spec.satisfies("%gcc@14:"):
+                flags.append("-Wno-error=implicit-int")
+                flags.append("-Wno-error=implicit-function-declaration")
+            if self.spec.satisfies("%gcc@15:"):
+                # Work around compilation errors with the default gnu23.
+                flags.append("-std=gnu17")
+        return (flags, None, None)


### PR DESCRIPTION
Before the change, only GCC < 10 compiles. Newer ones fail due to failing some (since set to default) checks.

Tested the change with gcc@8.5, gcc@14.3 and gcc@15.2.

Before:

```
$ spack install iozone@3_506 %gcc@15.2.0

...snip...
libbif.c: In function 'close_xls':
libbif.c:189:1: warning: old-style function definition [-Wold-style-definition]
  189 | close_xls(fd)
      | ^~~~~~~~~
libbif.c:191:1: error: number of arguments doesn't match prototype
  191 | {
      | ^
libbif.c:170:1: error: prototype declaration
  170 | close_xls();
      | ^~~~~~~~~
libbif.c:193:9: error: too many arguments to function 'do_eof'; expected 0, have 1
  193 |         do_eof(fd);
      |         ^~~~~~ ~~
...snip...
```

After:

```
$ spack install iozone@3_506 %gcc@15.2.0
[+] /lustre/linsword_google_com/spack/opt/spack/linux-x86_64/gcc-15.2.0-kihne2eyjaxedyvo6hkm4uwdn55ixatw (external gcc-15.2.0-ljvmd5amdwhmn7qs6v7zx3zuahqccytk)
[+] /usr (external glibc-2.28-iyhte7x7am7ap6asyuvzpe5hklifmvq5)
[+] /lustre/linsword_google_com/spack/opt/spack/linux-zen2/compiler-wrapper-1.0-mgebylcovhefg74gwhe46ozqfohenfij
[+] /lustre/linsword_google_com/spack/opt/spack/linux-zen2/gcc-runtime-15.2.0-hzzbrezy3d2reou2ktgi2gbna7ylbi54
[+] /lustre/linsword_google_com/spack/opt/spack/linux-zen2/gmake-4.4.1-7uyxdtkya27qfmmc372zxqux52oaefgv
==> No binary for iozone-3_506-lnnjpxfhz7f5d6vukrsfxgcnz2uoo77f found: installing from source
==> Installing iozone-3_506-lnnjpxfhz7f5d6vukrsfxgcnz2uoo77f [6/6]
==> Using cached archive: /lustre/linsword_google_com/spack/var/spack/cache/_source-cache/archive/11/114ce5c071873b9a2c7ba6e73d05d5ef7e66564392acbfcdc0b3261db10fcbe7.tar
==> No patches needed for iozone
==> iozone: Executing phase: 'edit'
==> iozone: Executing phase: 'build'
==> iozone: Executing phase: 'install'
==> iozone: Successfully installed iozone-3_506-lnnjpxfhz7f5d6vukrsfxgcnz2uoo77f
  Stage: 0.07s.  Edit: 0.01s.  Build: 6.67s.  Install: 0.26s.  Post-install: 0.21s.  Total: 7.33s
[+] /lustre/linsword_google_com/spack/opt/spack/linux-zen2/iozone-3_506-lnnjpxfhz7f5d6vukrsfxgcnz2uoo77f
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
