### PR TITLE
py-numba: add rocm-openmp-extras dependency when compiler is amdclang

### DIFF
--- a/repos/spack_repo/builtin/packages/py_numba/package.py
+++ b/repos/spack_repo/builtin/packages/py_numba/package.py
@@ -36,6 +36,8 @@ class PyNumba(PythonPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
+    depends_on("rocm-openmp-extras", when="%llvm-amdgpu", type="build")
+
     # Be careful that the bounds given in setup.py are exclusive on the upper bound
     # i.e., [min, max)
     depends_on("python@3.10:3.13", when="@0.61:", type=("build", "run"))


### PR DESCRIPTION
This pr fixes the same issue as in https://github.com/spack/spack-packages/pull/2070. py-numba includes `omp.h` and amdclang fails to find it without  `rocm-openmp-extras`.
