### PR TITLE
hpctoolkit: add rocm-openmp-extras dependency when compiler is amdclang

### DIFF
--- a/repos/spack_repo/builtin/packages/hpctoolkit/package.py
+++ b/repos/spack_repo/builtin/packages/hpctoolkit/package.py
@@ -134,6 +134,8 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
+    depends_on("rocm-openmp-extras", when="%llvm-amdgpu", type="build")
+
     with when("@2024.01: build_system=autotools"):
         depends_on("autoconf", type="build")
         depends_on("automake", type="build")


### PR DESCRIPTION
This is the same as in https://github.com/spack/spack-packages/pull/2070 and https://github.com/spack/spack-packages/pull/2083: compilation fails without `rocm-openmp-extras`.