### PR TITLE
fenics-basix: add version 0.10.0

### DIFF
--- a/repos/spack_repo/builtin/packages/fenics_basix/package.py
+++ b/repos/spack_repo/builtin/packages/fenics_basix/package.py
@@ -18,6 +18,7 @@ class FenicsBasix(CMakePackage):
     license("MIT")
 
     version("main", branch="main", no_cache=True)
+    version("0.10.0", sha256="b93221dac7d3fea8c10e77617f6201036de35d0c5437440b718de69a28c3773f")
     version("0.9.0", sha256="60e96b2393084729b261cb10370f0e44d12735ab3dbd1f15890dec23b9e85329")
     version("0.8.0", sha256="b299af82daf8fa3e4845e17f202491fe71b313bf6ab64c767a5287190b3dd7fe")
     with default_args(deprecated=True):


### PR DESCRIPTION
Adds `fenics-basix` version `0.10.0`.