### PR TITLE
scitokens-cpp: add master branch version with jwt-cpp@0.7 support

### DIFF
--- a/repos/spack_repo/builtin/packages/scitokens_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/scitokens_cpp/package.py
@@ -13,11 +13,13 @@ class ScitokensCpp(CMakePackage):
 
     homepage = "https://github.com/scitokens/scitokens-cpp"
     url = "https://github.com/scitokens/scitokens-cpp/archive/refs/tags/v0.7.0.tar.gz"
+    git = "https://github.com/scitokens/scitokens-cpp.git"
 
     maintainers("gartung", "greenc-FNAL", "marcmengel", "vitodb")
 
     license("Apache-2.0")
 
+    version("master", branch="master")
     version("1.1.3", sha256="eeaeb06da74cae92bd03d6be4c407e4855db023f409c59540b3143069407be1f")
     version("1.1.2", sha256="07d33cb51a3ccd8460f2acebb15b35393aeccfc70e3554a73c9e5cffed6edb39")
     version("1.1.1", sha256="a9091b888fc778282caf2a6808c86f685d2411557673152d58fe53932a6c7212")
@@ -45,7 +47,8 @@ class ScitokensCpp(CMakePackage):
     depends_on("openssl")
     depends_on("sqlite")
     depends_on("curl")
-    depends_on("jwt-cpp", type="build")
+    depends_on("jwt-cpp", type="build")sc
+    depends_on("jwt-cpp@0.7:", type="build", when="@master")
     depends_on("pkgconfig", type="build")
     depends_on("uuid", type="build")
 

--- a/repos/spack_repo/builtin/packages/scitokens_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/scitokens_cpp/package.py
@@ -47,7 +47,7 @@ class ScitokensCpp(CMakePackage):
     depends_on("openssl")
     depends_on("sqlite")
     depends_on("curl")
-    depends_on("jwt-cpp", type="build")sc
+    depends_on("jwt-cpp", type="build")
     depends_on("jwt-cpp@0.7:", type="build", when="@master")
     depends_on("pkgconfig", type="build")
     depends_on("uuid", type="build")


### PR DESCRIPTION
This PR adds `scitokens-cpp`, version `master`, to allow for `jwt-cpp@0.7:` support (since `jwt-cpp@0.6` does not compile on gcc15 without further work). I was unable to compile `scitokens-cpp@master` with the older `jwt-cpp`, but the upgraded dependency is not yet documented.

```
==> No binary for jwt-cpp-0.7.1-3dkpzbjuod2dgknek3o2y3mskerfnyjv found: installing from source
==> Installing jwt-cpp-0.7.1-3dkpzbjuod2dgknek3o2y3mskerfnyjv [22/23]
==> Fetching https://mirror.spack.io/_source-cache/archive/e5/e52f247d5e62fac5da6191170998271a70ce27f747f2ce8fde9b09f96a5375a4.tar.gz
    [100%]  159.95 KB @    2.1 MB/s
==> No patches needed for jwt-cpp
==> jwt-cpp: Executing phase: 'cmake'
==> jwt-cpp: Executing phase: 'build'
==> jwt-cpp: Executing phase: 'install'
==> jwt-cpp: Successfully installed jwt-cpp-0.7.1-3dkpzbjuod2dgknek3o2y3mskerfnyjv
  Stage: 0.52s.  Cmake: 0.99s.  Build: 0.05s.  Install: 0.10s.  Post-install: 0.75s.  Total: 2.63s
[+] /opt/software/linux-skylake/jwt-cpp-0.7.1-3dkpzbjuod2dgknek3o2y3mskerfnyjv
==> No binary for scitokens-cpp-master-vue62m3nffmurdogekagckbb2s5zxm4t found: installing from source
==> Installing scitokens-cpp-master-vue62m3nffmurdogekagckbb2s5zxm4t [23/23]
==> Using cached archive: /opt/spack/cache/_source-cache/git//scitokens/scitokens-cpp.git/e21b2a3f11ed4ae058874faede2f3874e2eb42ce.tar.gz
==> Warning: Using download cache instead of version control
  The required sources are normally checked out from a version control system, but have been archived in download cache: file:///opt/spack/cache/_source-cache/git//scitokens/scitokens-cpp.git/e21b2a3f11ed4ae058874faede2f3874e2eb42ce.tar.gz. Spack lacks a tree hash to verify the integrity of this archive. Make sure your download cache is in a secure location.
==> No patches needed for scitokens-cpp
==> scitokens-cpp: Executing phase: 'cmake'
==> scitokens-cpp: Executing phase: 'build'
==> scitokens-cpp: Executing phase: 'install'
==> scitokens-cpp: Successfully installed scitokens-cpp-master-vue62m3nffmurdogekagckbb2s5zxm4t
  Stage: 0.07s.  Cmake: 1.73s.  Build: 50.43s.  Install: 0.26s.  Post-install: 0.41s.  Total: 53.09s
[+] /opt/software/linux-skylake/scitokens-cpp-master-vue62m3nffmurdogekagckbb2s5zxm4t
```