### PR TITLE
libgeotiff: add v1.7.4

### DIFF
--- a/repos/spack_repo/builtin/packages/libgeotiff/package.py
+++ b/repos/spack_repo/builtin/packages/libgeotiff/package.py
@@ -20,6 +20,7 @@ class Libgeotiff(AutotoolsPackage):
 
     license("Public-Domain")
 
+    version("1.7.4", sha256="c598d04fdf2ba25c4352844dafa81dde3f7fd968daa7ad131228cd91e9d3dc47")
     version("1.7.1", sha256="05ab1347aaa471fc97347d8d4269ff0c00f30fa666d956baba37948ec87e55d6")
     version("1.7.0", sha256="fc304d8839ca5947cfbeb63adb9d1aa47acef38fc6d6689e622926e672a99a7e")
     version("1.6.0", sha256="9311017e5284cffb86f2c7b7a9df1fb5ebcdc61c30468fb2e6bca36e4272ebca")


### PR DESCRIPTION
https://github.com/OSGeo/libgeotiff/releases/tag/1.7.4

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
