### PR TITLE
py-pydantic-core: add v2.41.4

### DIFF
--- a/repos/spack_repo/builtin/packages/py_maturin/package.py
+++ b/repos/spack_repo/builtin/packages/py_maturin/package.py
@@ -19,6 +19,7 @@ class PyMaturin(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.9.6", sha256="2c2ae37144811d365509889ed7220b0598487f1278c2441829c3abf56cc6324a")
     version("1.9.1", sha256="97b52fb19d20c1fdc70e4efdc05d79853a4c9c0051030c93a793cd5181dc4ccd")
     version("1.8.3", sha256="304762f86fd53a8031b1bf006d12572a2aa0a5235485031113195cc0152e1e12")
     version("1.8.2", sha256="e31abc70f6f93285d6e63d2f4459c079c94c259dd757370482d2d4ceb9ec1fa0")
@@ -30,6 +31,7 @@ class PyMaturin(PythonPackage):
     version("0.13.7", sha256="c0a77aa0c57f945649ca711c806203a1b6888ad49c2b8b85196ffdcf0421db77")
 
     with default_args(type="build"):
+        depends_on("py-setuptools@77:", when="@1.9.6:")
         depends_on("py-setuptools")
         depends_on("py-setuptools-rust@1.11:", when="@1.8.6:")
         depends_on("py-setuptools-rust@1.4:")

--- a/repos/spack_repo/builtin/packages/py_pydantic_core/package.py
+++ b/repos/spack_repo/builtin/packages/py_pydantic_core/package.py
@@ -16,12 +16,26 @@ class PyPydanticCore(PythonPackage):
 
     license("MIT", checked_by="qwertos")
 
+    version("2.41.4", sha256="70e47929a9d4a1905a67e4b687d5946026390568a8e952b92824118063cee4d5")
     version("2.27.1", sha256="62a763352879b84aa31058fc931884055fd75089cccbd9d58bb6afd01141b235")
     version("2.18.4", sha256="ec3beeada09ff865c344ff3bc2f427f5e6c26401cc6113d77e372c3fdac73864")
 
-    # Based on PyPI wheel availability
-    depends_on("python@:3.13", type=("build", "run"))
-    depends_on("python@:3.12", when="@:2.19", type=("build", "run"))
-    depends_on("rust@1.76:", type="build")
-    depends_on("py-maturin@1", type="build")
-    depends_on("py-typing-extensions@4.6,4.7.1:", type="build")
+    with default_args(type="build"):
+        # Cargo.toml
+        depends_on("rust@1.75:", when="@2.27:")
+        depends_on("rust@1.76:", when="@2.18")
+
+        # pyproject.toml
+        depends_on("py-maturin@1.9.4:1", when="@2.41:")
+        depends_on("py-maturin@1")
+
+    with default_args(type=("build", "run")):
+        # Based on PyPI wheel availability
+        depends_on("python@:3.14")
+        depends_on("python@:3.13", when="@:2.27")
+        depends_on("python@:3.12", when="@:2.19")
+
+        depends_on("py-typing-extensions@4.14.1:", when="@2.41:")
+        depends_on("py-typing-extensions@4.6:")
+
+    conflicts("py-typing-extensions@4.7.0")


### PR DESCRIPTION
closes #1528 (adds py-maturin v1.9.6)
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Add Python 3.14 support, fix missing run-time dep on typing-extensions