### PR TITLE
gaudi: conflict with boost@1.89: when @:40.0

### DIFF
--- a/repos/spack_repo/builtin/packages/gaudi/package.py
+++ b/repos/spack_repo/builtin/packages/gaudi/package.py
@@ -144,7 +144,7 @@ class Gaudi(CMakePackage, CudaPackage):
     )
     depends_on(f"boost@1.70: +{boost_libs}", when="@35:")
     depends_on(f"boost@1.70: +{boost_libs}+fiber", when="@39:")
-    # Until gaudi@40.0, there is a build dependency on boost::system, which was removed in boost@1.89.
+    # Until gaudi@40.0, there is a build dependency on boost::system, removed in boost@1.89.
     # Ref: https://gitlab.cern.ch/gaudi/Gaudi/-/merge_requests/1809
     conflicts("^boost@1.89:", when="@:40.0", msg="Boost@1.89: requires Gaudi@40.1:")
 

--- a/repos/spack_repo/builtin/packages/gaudi/package.py
+++ b/repos/spack_repo/builtin/packages/gaudi/package.py
@@ -144,6 +144,9 @@ class Gaudi(CMakePackage, CudaPackage):
     )
     depends_on(f"boost@1.70: +{boost_libs}", when="@35:")
     depends_on(f"boost@1.70: +{boost_libs}+fiber", when="@39:")
+    # Until gaudi@40.0, there is a build dependency on boost::system, which was removed in boost@1.89.
+    # Ref: https://gitlab.cern.ch/gaudi/Gaudi/-/merge_requests/1809
+    conflicts("^boost@1.89:", when="@:40.0", msg="Boost@1.89: requires Gaudi@40.1:")
 
     depends_on("clhep")
     depends_on("cmake", type="build")


### PR DESCRIPTION
This PR adds as conflict to `gaudi` for `boost@1.89:` when `gaudi@:40.0`. Without this conflict, the build of gaudi 40.0 and boost 1.89 fails with:
```

1 error found in build log:
     25      For compatibility, find_package is ignoring the variable, but code in a
     26      .cmake module might still use it.
     27    Call Stack (most recent call first):
     28      CMakeLists.txt:118 (include)
     29    This warning is for project developers.  Use -Wno-dev to suppress it.
     30    
  >> 31    CMake Error at /opt/software/linux-skylake/boost-1.89.0-niaka6a2rf2yyola32uc6mg6gpfa4lca/lib/cmake/Boost-1.89.0/BoostConfig.cmake:141 (find_package):
     32      Could not find a package configuration file provided by "boost_system"
     33      (requested version 1.89.0) with any of the following names:
     34    
     35        boost_systemConfig.cmake
     36        boost_system-config.cmake
     37    

See build log for details:
  /opt/spack/stage/wdconinc/spack-stage-gaudi-40.0-wkr6xb4zm7tip3gwj33u7e5hgerw2dqx/spack-build-out.txt

```

See https://gitlab.cern.ch/gaudi/Gaudi/-/merge_requests/1809.