### PR TITLE
Fix pkgconfig dependency for several packages

### DIFF
--- a/repos/spack_repo/builtin/packages/geopm_service/package.py
+++ b/repos/spack_repo/builtin/packages/geopm_service/package.py
@@ -81,7 +81,7 @@ class GeopmService(AutotoolsPackage):
     depends_on("cuda", when="+nvml")
     depends_on("grpc+shared", when="+grpc")
     depends_on("protobuf", when="+grpc")
-    depends_on("pkgconf", when="+grpc")
+    depends_on("pkgconfig", when="+grpc")
 
     configure_directory = "libgeopmd"
 

--- a/repos/spack_repo/builtin/packages/octopus/package.py
+++ b/repos/spack_repo/builtin/packages/octopus/package.py
@@ -117,7 +117,7 @@ class Octopus(cmake.CMakePackage, autotools.AutotoolsPackage, CudaPackage):
     with when("build_system=cmake"):
         depends_on("cmake@3.25:", type="build", when="@17:")
         depends_on("cmake@3.20:", type="build", when="@:16")
-        depends_on("pkgconf", type="build")
+        depends_on("pkgconfig", type="build")
         cmake.generator("ninja")
 
     depends_on("perl", type="build")

--- a/repos/spack_repo/builtin/packages/rocm_smi_lib/package.py
+++ b/repos/spack_repo/builtin/packages/rocm_smi_lib/package.py
@@ -93,7 +93,7 @@ class RocmSmiLib(CMakePackage):
     ]:
         depends_on("llvm-amdgpu", when=f"@{ver}+asan")
 
-    depends_on("pkg-config", when="@6.4:")
+    depends_on("pkgconfig", when="@6.4:")
     depends_on("libdrm", when="@6.4:")
 
     patch(

--- a/repos/spack_repo/builtin/packages/theia_ide/package.py
+++ b/repos/spack_repo/builtin/packages/theia_ide/package.py
@@ -35,7 +35,7 @@ class TheiaIde(Package):
         depends_on("libxcb")
         depends_on("libxdmcp")
         depends_on("libxkbfile")
-        depends_on("pkg-config")
+        depends_on("pkgconfig")
         depends_on("xproto")
 
         depends_on("npm@10.8.2:")


### PR DESCRIPTION
pkgconfig is the virtual dependency that should be used in most cases.