### PR TITLE
r-rbibutils: add missing c dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/r_rbibutils/package.py
+++ b/repos/spack_repo/builtin/packages/r_rbibutils/package.py
@@ -26,4 +26,6 @@ class RRbibutils(RPackage):
     version("2.2.7", sha256="7c9e6719556b8caa9fb58743b717e89f45e8e7018371bf16f07dc3c1f96a55c5")
     version("2.0", sha256="03d13abee321decb88bc4e7c9f27276d62a4a880fa72bb6b86be91885010cfed")
 
+    depends_on("c", type="build")
+
     depends_on("r@2.10:", type=("build", "run"))


### PR DESCRIPTION
without it I get
```
  >> 36     using C compiler: '[spack cc]: Error: Spack compiler must be run from Spack! Input 'SPA
            CK_COMPILER_WRAPPER_PATH' is missing.'
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
