### PR TITLE
r-nloptr: add missing c and cxx dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/r_nloptr/package.py
+++ b/repos/spack_repo/builtin/packages/r_nloptr/package.py
@@ -34,6 +34,9 @@ class RNloptr(RPackage):
     version("1.2.1", sha256="1f86e33ecde6c3b0d2098c47591a9cd0fa41fb973ebf5145859677492730df97")
     version("1.0.4", sha256="84225b993cb1ef7854edda9629858662cc8592b0d1344baadea4177486ece1eb")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r-testthat", when="@2.0.0:2.1.0")
     depends_on("nlopt@2.4.0:")
     depends_on("nlopt@2.7.0:", when="@2.0.0:")


### PR DESCRIPTION
Error message:
```
     324    checking whether the C++ compiler works... no
  >> 325    configure: error: in `/tmp/root/spack-stage/spack-stage-r-nloptr-2.1.1-msrwadeb33f4ils5
            gajxylkj734o6in6/spack-src':
  >> 326    configure: error: C++ compiler cannot create executables
```
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
