### PR TITLE
trilinos: Add variants cusparse and muelu_test

### DIFF
--- a/repos/spack_repo/builtin/packages/trilinos/package.py
+++ b/repos/spack_repo/builtin/packages/trilinos/package.py
@@ -93,11 +93,13 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         description="Enable relaxed constexpr functions for CUDA build",
     )
     variant("cuda_rdc", default=False, description="Turn on RDC for CUDA build")
+    variant("cusparse", default=False, description="Enable cuSPARSE support")
     variant("rocm_rdc", default=False, description="Turn on RDC for ROCm build")
     variant(
         "cxxstd", default="14", description="C++ standard", values=["11", "14", "17"], multi=False
     )
     variant("debug", default=False, description="Enable runtime safety and debug checks")
+    variant("muelu_test", default=False, description="Enable build of MueLu test")
     variant(
         "explicit_template_instantiation",
         default=True,
@@ -137,6 +139,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     variant("mumps", default=False, description="Compile with support for MUMPS solvers")
     variant("suite-sparse", default=False, description="Compile with SuiteSparse solvers")
     variant("superlu-dist", default=False, description="Compile with SuperluDist solvers")
+    variant("superlu", default=False, description="Compile with SuperLU solvers")
     variant("strumpack", default=False, description="Compile with STRUMPACK solvers")
     variant("x11", default=False, description="Compile with X11 when +exodus")
 
@@ -347,6 +350,11 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("+mesquite", when="@:12.10,master")
     # Strumpack is only available as of mid-2021
     conflicts("+strumpack", when="@:13.0")
+    # Can only use one type of SuperLU
+    conflicts("+superlu-dist", when="+superlu")
+    # Amesos and Ifpack only support up to SuperLU 4.x.y interfaces
+    conflicts("+amesos", when="+superlu@5:")
+    conflicts("+ifpack", when="+superlu@5:")
     # For Trilinos v11 we need to force SuperLUDist=OFF, since only the
     # deprecated SuperLUDist v3.3 together with an Amesos patch is working.
     conflicts("+superlu-dist", when="@11.4.1:11.14.3")
@@ -376,6 +384,8 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         msg="trilinos~wrapper+cuda can only be built with the Clang compiler",
     )
     conflicts("+cuda_rdc", when="~cuda")
+    conflicts("+cusparse", when="~cuda", msg="cuSPARSE requires CUDA")
+    conflicts("+muelu_test", when="~muelu", msg="MueLu is required in order to build its tests.")
     conflicts("+rocm_rdc", when="~rocm")
     conflicts("+wrapper", when="~cuda")
     conflicts("+wrapper", when="%clang")
@@ -423,12 +433,12 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("kokkos-kernels~shared", when="+cuda_rdc")
         depends_on("kokkos-kernels~shared", when="+rocm_rdc")
         depends_on("kokkos~complex_align")
-        depends_on("kokkos@=4.7.01", when="@master:")
+        depends_on("kokkos@=4.6.01", when="@master:")
         depends_on("kokkos@=4.5.01", when="@16.1")
         depends_on("kokkos@=4.3.01", when="@16.0")
         depends_on("kokkos@=4.2.01", when="@15.1:15")
         depends_on("kokkos@=4.1.00", when="@14.4:15.0")
-        depends_on("kokkos-kernels@=4.7.01", when="@master:")
+        depends_on("kokkos-kernels@=4.6.01", when="@master:")
         depends_on("kokkos-kernels@=4.5.01", when="@16.1")
         depends_on("kokkos-kernels@=4.3.01", when="@16.0")
         depends_on("kokkos-kernels@=4.2.01", when="@15.1:15")
@@ -475,6 +485,9 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("strumpack+shared", when="+strumpack")
     depends_on("suite-sparse@:7.3.1", when="+suite-sparse")
     depends_on("superlu-dist", when="+superlu-dist")
+    depends_on("superlu@3:5.2", when="@12.18.1: +superlu")
+    depends_on("superlu@3:5.1.1", when="@12.14.1 +superlu")
+    depends_on("superlu@3:4", when="@:12.12.1 +superlu")
     depends_on("swig", when="@:14 +python")
     depends_on("zlib-api", when="+zoltan")
 
@@ -707,6 +720,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         options.extend(
             [
                 define("Trilinos_VERBOSE_CONFIGURE", False),
+                define_from_variant("MueLu_ENABLE_TESTS", "muelu_test"),
                 define_from_variant("BUILD_SHARED_LIBS", "shared"),
                 define_trilinos_enable("ALL_OPTIONAL_PACKAGES", False),
                 define_trilinos_enable("ALL_PACKAGES", False),
@@ -905,11 +919,13 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
             ("ADIOS2", "adios2", "adios2"),
             ("Boost", "boost", "boost"),
             ("CUDA", "cuda", "cuda"),
+            ("CUSPARSE", "cusparse", "cuda"),
             ("HDF5", "hdf5", "hdf5"),
             ("HYPRE", "hypre", "hypre"),
             ("MUMPS", "mumps", "mumps"),
             ("AMD", "suite-sparse", "suite-sparse"),
             ("UMFPACK", "suite-sparse", "suite-sparse"),
+            ("SuperLU", "superlu", "superlu"),
             ("SuperLUDist", "superlu-dist", "superlu-dist"),
             ("X11", "x11", "libx11"),
         ]


### PR DESCRIPTION
Creates the variant cusparse to enable the cuSPARSE TPL.
Also creates the variant muelu_test in order to activate MueLu_ENABLE_TESTS and build the MueLu_Driver.exe binary.