### PR TITLE
intel-tbb: add version 2022.2.0 and 2022.1.0, plus logic for respecting `ipo` variant

### DIFF
--- a/repos/spack_repo/builtin/packages/intel_tbb/package.py
+++ b/repos/spack_repo/builtin/packages/intel_tbb/package.py
@@ -214,7 +214,7 @@ class CMakeBuilder(cmake.CMakeBuilder, SetupEnvironment):
             self.define("TBB_TEST", False),
         ]
 
-        if spec in "@2021.6.0:":
+        if spec.satisfies("@2021.6.0:"):
             options.append(self.define_from_variant("TBB_ENABLE_IPO", "ipo"))
 
         if spec.variants["cxxstd"].value != "default":

--- a/repos/spack_repo/builtin/packages/intel_tbb/package.py
+++ b/repos/spack_repo/builtin/packages/intel_tbb/package.py
@@ -213,8 +213,13 @@ class CMakeBuilder(cmake.CMakeBuilder, SetupEnvironment):
             self.define("TBB_STRICT", False),
             self.define("TBB_TEST", False),
         ]
+
+        if spec in "@2021.6.0:":
+            options.append(self.define_from_variant("TBB_ENABLE_IPO", "ipo"))
+
         if spec.variants["cxxstd"].value != "default":
             options.append(self.define("CMAKE_CXX_STANDARD", spec.variants["cxxstd"].value))
+
         return options
 
     @run_after("install")

--- a/repos/spack_repo/builtin/packages/intel_tbb/package.py
+++ b/repos/spack_repo/builtin/packages/intel_tbb/package.py
@@ -33,6 +33,8 @@ class IntelTbb(CMakePackage, MakefilePackage):
     license("Apache-2.0")
 
     version("master", branch="master")
+    version("2022.2.0", sha256="f0f78001c8c8edb4bddc3d4c5ee7428d56ae313254158ad1eec49eced57f6a5b")
+    version("2022.1.0", sha256="ed067603ece0dc832d2881ba5c516625ac2522c665d95f767ef6304e34f961b5")
     version("2022.0.0", sha256="e8e89c9c345415b17b30a2db3095ba9d47647611662073f7fbf54ad48b7f3c2a")
     version("2021.13.0", sha256="3ad5dd08954b39d113dc5b3f8a8dc6dc1fd5250032b7c491eb07aed5c94133e1")
     version("2021.12.0", sha256="c7bb7aa69c254d91b8f0041a71c5bcc3936acb64408a1719aec0b2b7639dd84f")


### PR DESCRIPTION
Beside bumping version, I did a quick research about `TBB_ENABLE_IPO` and it seems to appear in `2021.06.0`

https://github.com/uxlfoundation/oneTBB/blob/v2021.6.0/CMakeLists.txt#L108

This was useful to workaround a compilation error I was getting during build, related to an "lto-wrapper fatal error".