### PR TITLE
darshan: add v3.5.0

### DIFF
--- a/repos/spack_repo/builtin/packages/darshan_runtime/package.py
+++ b/repos/spack_repo/builtin/packages/darshan_runtime/package.py
@@ -120,7 +120,7 @@ class DarshanRuntime(AutotoolsPackage):
     variant("group_readable_logs", default=False, description="Write group-readable logs")
 
     def url_for_version(self, version):
-        if version < Version("3.5.0"):
+        if self.spec.satisfies("@:3.4"):
             return f"https://web.cels.anl.gov/projects/darshan/releases/darshan-{version}.tar.gz"
         else:
             return f"https://github.com/darshan-hpc/darshan/archive/refs/tags/{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/darshan_runtime/package.py
+++ b/repos/spack_repo/builtin/packages/darshan_runtime/package.py
@@ -17,7 +17,7 @@ class DarshanRuntime(AutotoolsPackage):
     systems where you intend to instrument MPI applications."""
 
     homepage = "https://www.mcs.anl.gov/research/projects/darshan/"
-    url = "https://web.cels.anl.gov/projects/darshan/releases/darshan-3.4.0.tar.gz"
+    url = "https://github.com/darshan-hpc/darshan/archive/refs/tags/3.5.0.tar.gz"
     git = "https://github.com/darshan-hpc/darshan.git"
 
     maintainers("carns", "wkliao")
@@ -26,6 +26,7 @@ class DarshanRuntime(AutotoolsPackage):
     test_requires_compiler = True
 
     version("main", branch="main", submodules=True)
+    version("3.5.0", sha256="76eac5a3ff556476ef8df53aa61851756bf6dcab59f5b92bb307abfdcbcd7f36")
     version("3.4.7", sha256="115a6d840b3bdb30751c271c0dec098b25bed2f8c77175125c133564d76afe5b")
     version("3.4.6", sha256="092b35e7af859af903dce0c51bcb5d3901dd0d9ad79d1b2f3282692407f032ee")
     version("3.4.5", sha256="1c017ac635fab5ee0e87a6b52c5c7273962813569495cb1dd3b7cfa6e19f6ed0")
@@ -104,8 +105,25 @@ class DarshanRuntime(AutotoolsPackage):
         default="none",
         description="Path to centralized, formatted Darshan log directory",
     )
-    variant("mmap_logs", default=False, description="Use mmap to store Darshan log data")
+
+    variant(
+        "mmap_logs",
+        default=False,
+        description="Use mmap to store Darshan log data",
+        when="@:3.4.7",
+    )
+
+    variant(
+        "mmap_logs", default=True, description="Use mmap to store Darshan log data", when="@3.5.0:"
+    )
+
     variant("group_readable_logs", default=False, description="Write group-readable logs")
+
+    def url_for_version(self, version):
+        if version < Version("3.5.0"):
+            return f"https://web.cels.anl.gov/projects/darshan/releases/darshan-{version}.tar.gz"
+        else:
+            return f"https://github.com/darshan-hpc/darshan/archive/refs/tags/{version}.tar.gz"
 
     @property
     def configure_directory(self):

--- a/repos/spack_repo/builtin/packages/darshan_util/package.py
+++ b/repos/spack_repo/builtin/packages/darshan_util/package.py
@@ -14,14 +14,15 @@ class DarshanUtil(AutotoolsPackage):
     log files produced by Darshan (runtime)."""
 
     homepage = "https://www.mcs.anl.gov/research/projects/darshan/"
-    url = "https://web.cels.anl.gov/projects/darshan/releases/darshan-3.4.0.tar.gz"
+    url = "https://github.com/darshan-hpc/darshan/archive/refs/tags/3.5.0.tar.gz"
     git = "https://github.com/darshan-hpc/darshan.git"
 
     maintainers("carns", "wkliao")
 
     tags = ["e4s"]
 
-    version("main", branch="main", submodules=True)
+    version("main", branch="main", submodules="True")
+    version("3.5.0", sha256="76eac5a3ff556476ef8df53aa61851756bf6dcab59f5b92bb307abfdcbcd7f36")
     version("3.4.7", sha256="115a6d840b3bdb30751c271c0dec098b25bed2f8c77175125c133564d76afe5b")
     version("3.4.6", sha256="092b35e7af859af903dce0c51bcb5d3901dd0d9ad79d1b2f3282692407f032ee")
     version("3.4.5", sha256="1c017ac635fab5ee0e87a6b52c5c7273962813569495cb1dd3b7cfa6e19f6ed0")
@@ -76,6 +77,12 @@ class DarshanUtil(AutotoolsPackage):
     depends_on("m4", type="build", when="@3.4.0:")
 
     patch("retvoid.patch", when="@3.2.0:3.2.1")
+
+    def url_for_version(self, version):
+        if version < Version("3.5.0"):
+            return f"https://web.cels.anl.gov/projects/darshan/releases/darshan-{version}.tar.gz"
+        else:
+            return f"https://github.com/darshan-hpc/darshan/archive/refs/tags/{version}.tar.gz"
 
     @property
     def configure_directory(self):

--- a/repos/spack_repo/builtin/packages/darshan_util/package.py
+++ b/repos/spack_repo/builtin/packages/darshan_util/package.py
@@ -79,7 +79,7 @@ class DarshanUtil(AutotoolsPackage):
     patch("retvoid.patch", when="@3.2.0:3.2.1")
 
     def url_for_version(self, version):
-        if version < Version("3.5.0"):
+        if self.spec.satisfies("@:3.4"):
             return f"https://web.cels.anl.gov/projects/darshan/releases/darshan-{version}.tar.gz"
         else:
             return f"https://github.com/darshan-hpc/darshan/archive/refs/tags/{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_darshan/package.py
+++ b/repos/spack_repo/builtin/packages/py_darshan/package.py
@@ -54,10 +54,8 @@ class PyDarshan(PythonPackage):
     # py-darshan depends on specific darshan-util versions corresponding
     # to the first 3 parts of the py-darshan version string
     # (i.e., py-darshan@3.4.3.0 requires darshan-util@3.4.3, etc.)
-    for v in ["3.4.0", "3.4.1", "3.4.2", "3.4.3", "3.4.4", "3.4.5", "3.4.6", "3.4.7"]:
-        depends_on(f"darshan-util@{v}", when=f"@{v}", type=("build", "run"))
-
-    depends_on("darshan-util@3.5.0", when="@3.5.0", type=("build", "run"))
+for v in ["3.4.0", "3.4.1", "3.4.2", "3.4.3", "3.4.4", "3.4.5", "3.4.6", "3.4.7", "3.5.0"]:
+depends_on(f"darshan-util@{v}", when=f"@{v}", type=("build", "run"))
 
     @run_after("install")
     @on_package_attributes(run_tests=True)

--- a/repos/spack_repo/builtin/packages/py_darshan/package.py
+++ b/repos/spack_repo/builtin/packages/py_darshan/package.py
@@ -54,8 +54,8 @@ class PyDarshan(PythonPackage):
     # py-darshan depends on specific darshan-util versions corresponding
     # to the first 3 parts of the py-darshan version string
     # (i.e., py-darshan@3.4.3.0 requires darshan-util@3.4.3, etc.)
-for v in ["3.4.0", "3.4.1", "3.4.2", "3.4.3", "3.4.4", "3.4.5", "3.4.6", "3.4.7", "3.5.0"]:
-depends_on(f"darshan-util@{v}", when=f"@{v}", type=("build", "run"))
+    for v in ["3.4.0", "3.4.1", "3.4.2", "3.4.3", "3.4.4", "3.4.5", "3.4.6", "3.4.7", "3.5.0"]:
+        depends_on(f"darshan-util@{v}", when=f"@{v}", type=("build", "run"))
 
     @run_after("install")
     @on_package_attributes(run_tests=True)

--- a/repos/spack_repo/builtin/packages/py_darshan/package.py
+++ b/repos/spack_repo/builtin/packages/py_darshan/package.py
@@ -11,14 +11,15 @@ class PyDarshan(PythonPackage):
     """Python utilities to interact with Darshan log records of HPC applications."""
 
     homepage = "https://www.mcs.anl.gov/research/projects/darshan"
-    pypi = "darshan/darshan-3.4.0.1.tar.gz"
+    pypi = "darshan/darshan-3.5.0.tar.gz"
 
-    maintainers("jeanbez", "carns")
+    maintainers("jeanbez", "carns", "wkliao")
 
     tags = ["e4s"]
 
     # NOTE: don't forget to update the version array further down that sets the appropriate
     #       darshan-util dependency
+    version("3.5.0", sha256="4b2214bd715d261a7d37e54a5aedd6b38b9990aaee61bb55d741cb795b728020")
     version("3.4.7.0", sha256="e4e37c2707c5526a865bf4813b248ae4c327664538772e95c946f3b0079dc347")
     version("3.4.6.0", sha256="a105ec5c9bcd4a20469470ca51db8016336ede34a1c33f4488d1ba263a73c378")
     version("3.4.5.0", sha256="1419e246b2383d3e71da14942d6579a86fb298bf6dbbc3f507accefa614c6e50")
@@ -55,6 +56,8 @@ class PyDarshan(PythonPackage):
     # (i.e., py-darshan@3.4.3.0 requires darshan-util@3.4.3, etc.)
     for v in ["3.4.0", "3.4.1", "3.4.2", "3.4.3", "3.4.4", "3.4.5", "3.4.6", "3.4.7"]:
         depends_on(f"darshan-util@{v}", when=f"@{v}", type=("build", "run"))
+
+    depends_on("darshan-util@3.5.0", when="@3.5.0", type=("build", "run"))
 
     @run_after("install")
     @on_package_attributes(run_tests=True)


### PR DESCRIPTION
Darshan version 3.5.0 was released on October 20, 2025.
Release tar ball and release note are available on
https://github.com/darshan-hpc/darshan/releases

cc: @carns 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
