### PR TITLE
rocprofiler-systems: use external intel-tbb when building with rocmcc

### DIFF
--- a/repos/spack_repo/builtin/packages/rocprofiler_systems/package.py
+++ b/repos/spack_repo/builtin/packages/rocprofiler_systems/package.py
@@ -152,6 +152,8 @@ class RocprofilerSystems(CMakePackage):
         when="+internal-dyninst",
     )
     depends_on("libiberty+pic", when="+internal-dyninst")
+    depends_on("intel-tbb@2019", when="%c,cxx=rocmcc")
+    depends_on("elfutils")
     depends_on("m4")
     depends_on("texinfo")
     depends_on("libunwind", type=("build", "run"))
@@ -197,6 +199,8 @@ class RocprofilerSystems(CMakePackage):
         working_dir="external/dyninst",
     )
 
+    patch("timemory-rocmcc.patch", when="@6.4.0: %c,cxx=rocmcc")
+
     def cmake_args(self):
         spec = self.spec
 
@@ -218,6 +222,7 @@ class RocprofilerSystems(CMakePackage):
             self.define_from_variant("ROCPROFSYS_USE_MPI_HEADERS", "mpi_headers"),
             self.define_from_variant("ROCPROFSYS_STRIP_LIBRARIES", "strip"),
             self.define_from_variant("ROCPROFSYS_INSTALL_PERFETTO_TOOLS", "perfetto_tools"),
+            self.define("ElfUtils_ROOT_DIR", spec["elfutils"].prefix),
             # timemory arguments
             self.define("TIMEMORY_BUILD_CALIPER", False),
             self.define_from_variant("TIMEMORY_USE_TAU", "tau"),
@@ -244,8 +249,16 @@ class RocprofilerSystems(CMakePackage):
             args.append(
                 self.define("libunwind_INCLUDE_DIR", self.spec["libunwind"].prefix.include)
             )
-        if spec.satisfies("@7.0:"):
-            args.append(self.define("ROCPROFSYS_BUILD_TBB", "ON"))
+        if spec.satisfies("%c,cxx=rocmcc"):
+            if spec.satisfies("@7.0"):
+                args.append(self.define("ROCPROFSYS_BUILD_TBB", "OFF"))
+            if spec.satisfies("+internal-dyninst"):
+                args.append(self.define("DYNINST_BUILD_TBB", "OFF"))
+        else:
+            if spec.satisfies("@7.0"):
+                args.append(self.define("ROCPROFSYS_BUILD_TBB", "ON"))
+            if spec.satisfies("+internal-dyninst"):
+                args.append(self.define("DYNINST_BUILD_TBB", "ON"))
         return args
 
     def flag_handler(self, name, flags):

--- a/repos/spack_repo/builtin/packages/rocprofiler_systems/package.py
+++ b/repos/spack_repo/builtin/packages/rocprofiler_systems/package.py
@@ -136,6 +136,10 @@ class RocprofilerSystems(CMakePackage):
         ),
     )
     variant("internal-dyninst", default=False, description="build internal dyninst")
+    variant("internal-tbb", default=False, description="build internal tbb")
+
+    conflicts("%rocmcc", when="+internal-tbb")
+    conflicts("%clang", when="+internal-tbb")
 
     extends("python", when="+python")
 
@@ -152,7 +156,7 @@ class RocprofilerSystems(CMakePackage):
         when="+internal-dyninst",
     )
     depends_on("libiberty+pic", when="+internal-dyninst")
-    depends_on("intel-tbb@2019:2020.3", when="%c,cxx=rocmcc")
+    depends_on("intel-tbb@2019:2020.3", when="~internal-tbb")
     depends_on("elfutils")
     depends_on("m4")
     depends_on("texinfo")
@@ -212,7 +216,6 @@ class RocprofilerSystems(CMakePackage):
             self.define("ROCPROFSYS_BUILD_STATIC_LIBGCC", False),
             self.define("ROCPROFSYS_BUILD_STATIC_LIBSTDCXX", False),
             self.define_from_variant("ROCPROFSYS_BUILD_DYNINST", "internal-dyninst"),
-            self.define_from_variant("DYNINST_BUILD_TBB", "internal-dyninst"),
             self.define_from_variant("ROCPROFSYS_BUILD_LTO", "ipo"),
             self.define_from_variant("ROCPROFSYS_USE_MPI", "mpi"),
             self.define_from_variant("ROCPROFSYS_USE_OMPT", "ompt"),
@@ -249,16 +252,11 @@ class RocprofilerSystems(CMakePackage):
             args.append(
                 self.define("libunwind_INCLUDE_DIR", self.spec["libunwind"].prefix.include)
             )
-        if spec.satisfies("%c,cxx=rocmcc"):
-            if spec.satisfies("@7.0"):
-                args.append(self.define("ROCPROFSYS_BUILD_TBB", "OFF"))
-            if spec.satisfies("+internal-dyninst"):
-                args.append(self.define("DYNINST_BUILD_TBB", "OFF"))
-        else:
-            if spec.satisfies("@7.0"):
-                args.append(self.define("ROCPROFSYS_BUILD_TBB", "ON"))
-            if spec.satisfies("+internal-dyninst"):
-                args.append(self.define("DYNINST_BUILD_TBB", "ON"))
+
+        if spec.satisfies("@7.0:"):
+            args.append(self.define_from_variant("ROCPROFSYS_BUILD_TBB", "internal-tbb"))
+        if spec.satisfies("+internal-dyninst"):
+            args.append(self.define_from_variant("DYNINST_BUILD_TBB", "internal-tbb"))
         return args
 
     def flag_handler(self, name, flags):

--- a/repos/spack_repo/builtin/packages/rocprofiler_systems/package.py
+++ b/repos/spack_repo/builtin/packages/rocprofiler_systems/package.py
@@ -152,7 +152,7 @@ class RocprofilerSystems(CMakePackage):
         when="+internal-dyninst",
     )
     depends_on("libiberty+pic", when="+internal-dyninst")
-    depends_on("intel-tbb@2019", when="%c,cxx=rocmcc")
+    depends_on("intel-tbb@2019:2020.3", when="%c,cxx=rocmcc")
     depends_on("elfutils")
     depends_on("m4")
     depends_on("texinfo")
@@ -199,7 +199,7 @@ class RocprofilerSystems(CMakePackage):
         working_dir="external/dyninst",
     )
 
-    patch("timemory-rocmcc.patch", when="@6.4.0: %c,cxx=rocmcc")
+    patch("timemory-rocmcc.patch", when="%c,cxx=rocmcc")
 
     def cmake_args(self):
         spec = self.spec

--- a/repos/spack_repo/builtin/packages/rocprofiler_systems/timemory-rocmcc.patch
+++ b/repos/spack_repo/builtin/packages/rocprofiler_systems/timemory-rocmcc.patch
@@ -1,0 +1,23 @@
+Submodule external/timemory contains modified content
+diff --git a/external/timemory/source/timemory/tpls/cereal/cereal/types/tuple.hpp b/external/timemory/source/timemory/tpls/cereal/cereal/types/tuple.hpp
+index 3f02ba23..ec125506 100644
+--- a/external/timemory/source/timemory/tpls/cereal/cereal/types/tuple.hpp
++++ b/external/timemory/source/timemory/tpls/cereal/cereal/types/tuple.hpp
+@@ -101,7 +101,7 @@ struct serialize
+     template <class Archive, class... Types>
+     inline static void apply(Archive& ar, std::tuple<Types...>& tuple)
+     {
+-        serialize<Height - 1>::template apply(ar, tuple);
++        serialize<Height - 1>::template apply<>(ar, tuple);
+         ar(TIMEMORY_CEREAL_NVP_(tuple_element_name<Height - 1>::c_str(),
+                                 std::get<Height - 1>(tuple)));
+     }
+@@ -123,7 +123,7 @@ template <class Archive, class... Types>
+ inline void
+ TIMEMORY_CEREAL_SERIALIZE_FUNCTION_NAME(Archive& ar, std::tuple<Types...>& tuple)
+ {
+-    tuple_detail::serialize<std::tuple_size<std::tuple<Types...>>::value>::template apply(
++    tuple_detail::serialize<std::tuple_size<std::tuple<Types...>>::value>::template apply<>(
+         ar, tuple);
+ }
+ }  // namespace cereal


### PR DESCRIPTION
This pr adds an `intel-tbb` dependency when building with `rocmcc`. `rocprofiler-systems` is configured to fetch `intel-tbb` from an invalid link when the clang compiler is used:
https://github.com/ROCm/rocm-systems/blob/develop/projects/rocprofiler-systems/cmake/DyninstTBB.cmake#L46


This pr also adds a patch to fix this error when building with `rocmcc`:
```
/tmp/root/spack-stage/spack-stage-rocprofiler-systems-7.0.0-k3eg6bzp2s36kxszurdlpighkwacqllq/spack-src/external/timemory/source/timemory/tpls/cereal/cereal/types/tuple.hpp:104:41: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
  104 |         serialize<Height - 1>::template apply(ar, tuple);
      |                                         ^
/tmp/root/spack-stage/spack-stage-rocprofiler-systems-7.0.0-k3eg6bzp2s36kxszurdlpighkwacqllq/spack-src/external/timemory/source/timemory/tpls/cereal/cereal/types/tuple.hpp:126:85: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
  126 |     tuple_detail::serialize<std::tuple_size<std::tuple<Types...>>::value>::template apply(
      |                                                                                     ^
/tmp/root/spack-stage/spack-stage-rocprofiler-systems-7.0.0-k3eg6bzp2s36kxszurdlpighkwacqllq/spack-build-k3eg6bz/external/tbb/src/rocprofiler-systems-tbb-build/src/../src/tbb/arena.cpp:258:14: warning: variable 'drained' set but not used [-Wunused-but-set-variable]
  258 |     intptr_t drained = 0;
      |        
```
