### PR TITLE
graphite2: fix build for gcc@15

### DIFF
--- a/repos/spack_repo/builtin/packages/graphite2/package.py
+++ b/repos/spack_repo/builtin/packages/graphite2/package.py
@@ -31,6 +31,12 @@ class Graphite2(CMakePackage):
 
     patch("regparm.patch")
 
+    patch(
+        "https://src.fedoraproject.org/rpms/graphite2/raw/deba28323b0a3b7a3dcfd06df1efc2195b102ed7/f/graphite2-1.3.14-gcc15.patch",
+        sha256="4cff0ae949153596d26d5f8bfaa4ce80bcff23a157b34ff797c6d00b4268a4b1",
+        when="%gcc@15:",
+    )
+
     @run_after("install")
     def darwin_fix(self):
         # The shared library is not installed correctly on Darwin; fix this


### PR DESCRIPTION
Error message without the patch

```
  >> 438    /tmp/root/spack-stage/spack-stage-graphite2-1.3.14-a5oqc75qfuplhmgghrsjk2gfm77pvp3i/spa
            ck-src/tests/featuremap/featuremaptest.cpp:49:15: error: 'uint8_t' was not declared in 
            this scope
     439       49 |   std::vector<uint8_t> _ttf;
     440          |               ^~~~~~~
     441    /tmp/root/spack-stage/spack-stage-graphite2-1.3.14-a5oqc75qfuplhmgghrsjk2gfm77pvp3i/spa
            ck-src/tests/featuremap/featuremaptest.cpp:35:1: note: 'uint8_t' is defined in header '
            <cstdint>'; this is probably fixable by adding '#include <cstdint>'
     442       34 | #include "inc/Face.h"
     443      +++ |+#include <cstdint>
     444       35 | #include "inc/FeatureMap.h"
  >> 445    /tmp/root/spack-stage/spack-stage-graphite2-1.3.14-a5oqc75qfuplhmgghrsjk2gfm77pvp3i/spa
            ck-src/tests/featuremap/featuremaptest.cpp:49:22: error: template argument 1 is invalid
     446       49 |   std::vector<uint8_t> _ttf;
     447          |                      ^
  >> 448    /tmp/root/spack-stage/spack-stage-graphite2-1.3.14-a5oqc75qfuplhmgghrsjk2gfm77pvp3i/spa
            ck-src/tests/featuremap/featuremaptest.cpp:49:22: error: template argument 2 is invalid
```
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
