### PR TITLE
e4s ci stack: add arkouda, py-arkouda

### DIFF
--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -84,6 +84,7 @@ spack:
   - amrex
   - arborx
   - argobots
+  - arkouda
   - axom
   - bolt
   - boost
@@ -171,6 +172,7 @@ spack:
   - pruners-ninja
   - pumi
   - py-amrex
+  - py-arkouda
   - py-h5py
   - py-jupyterhub
   - py-libensemble


### PR DESCRIPTION
E4S: Adding the following packages to our CI stack:
* `arkouda`
* `py-arkouda`

* https://github.com/E4S-Project/e4s/issues/158

@bradcray
