### PR TITLE
medipack: needs C dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/medipack/package.py
+++ b/repos/spack_repo/builtin/packages/medipack/package.py
@@ -20,7 +20,8 @@ class Medipack(CMakePackage):
     version("1.2.2", sha256="8937fa1025c6fb12f516cacf38a7f776221e7e818b30f17ce334c63f78513aa7")
     version("1.2.1", sha256="c746196b98cfe24a212584cdb88bd12ebb14f4a54728070d605e0c6d0e75db8a")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")  # needed until CMakeLists.txt is fixed
+    depends_on("cxx", type="build")
 
     depends_on("cmake@3.12:", type="build", when="@1.2.2:")
     depends_on("mpi", type=("build", "link", "run"))


### PR DESCRIPTION
MeDiPack needs a `c` language dependency because its `CMakeLists.txt` does not specify the language and therefore defaults to `C CXX`. This could be relaxed for releases after SciCompKL/MeDiPack#4 is merged.