### PR TITLE
pkg-config: add -Wno-error=int-conversion for older versions of rocmcc

### DIFF
--- a/repos/spack_repo/builtin/packages/pkg_config/package.py
+++ b/repos/spack_repo/builtin/packages/pkg_config/package.py
@@ -69,7 +69,7 @@ class PkgConfig(AutotoolsPackage):
             "%cce",
             "%apple-clang@15:",
             "%clang@15:",
-            "%llvm-amdgpu@7:",
+            "%llvm-amdgpu",
         ):
             if spec.satisfies(strict_compiler):
                 config_args.append("CFLAGS=-Wno-error=int-conversion")


### PR DESCRIPTION
The changes from https://github.com/spack/spack-packages/pull/2069 should be used for all versions of `llvm-amdgpu`