### PR TITLE
Update scnlib package.py

### DIFF
--- a/repos/spack_repo/builtin/packages/scnlib/package.py
+++ b/repos/spack_repo/builtin/packages/scnlib/package.py
@@ -11,12 +11,13 @@ class Scnlib(CMakePackage):
     """scanf for modern C++"""
 
     homepage = "https://scnlib.dev"
-    url = "https://github.com/eliaskosunen/scnlib/archive/refs/tags/v3.0.1.tar.gz"
+    url = "https://github.com/eliaskosunen/scnlib/archive/refs/tags/v4.0.1.tar.gz"
 
     maintainers("pranav-sivaraman")
 
     license("Apache-2.0", checked_by="pranav-sivaraman")
 
+    version("4.0.1", sha256="ece17b26840894cc57a7127138fe4540929adcb297524dec02c490c233ff46a7")
     version("3.0.1", sha256="bc8a668873601d00cce6841c2d0f2c93f836f63f0fbc77997834dea12e951eb1")
 
     variant("shared", default=True, description="Build shared libs")
@@ -37,7 +38,7 @@ class Scnlib(CMakePackage):
     depends_on("cxx", type="build")
     depends_on("cmake@3.16:", type="build")
 
-    depends_on("fast-float@5:")
+    depends_on("fast-float@5:6")
 
     depends_on("boost +regex cxxstd=17", when="regex-backend=Boost")
     depends_on("boost +icu", when="+icu")


### PR DESCRIPTION
PR #2122 updated `fast-float` and I found that `scnlib` is not compatible with versions of `fast-float` newer than 6. I'll open an issue (and maybe a PR) to report this upstream, but in the meantime, I updated the package.py to account for this incompatibility. I also added version 4.

Here's the error:
```
5 errors found in build log:
     180    cd /tmp/runner/spack-stage/spack-stage-scnlib-3.0.1-j4wgylr2ljzv53x
            s2qmu5am55zm7omrt/spack-build-j4wgylr/benchmark/binarysize && /opt/
            spack/linux-x86_64_v3/compiler-wrapper-1.0-kr35wwg7rvdhdh26tpinvbyg
            zmd6fwrz/libexec/spack/gcc/g++   -O3 -DNDEBUG -Wno-unused -Wno-unus
            ed-but-set-variable -Wno-redundant-decls -Wno-missing-declarations
            -MD -MT benchmark/binarysize/CMakeFiles/scn_benchmark_binarysize_sc
            anf.dir/out/scanf/binarysize_test_tmp_15.cpp.o -MF CMakeFiles/scn_b
            enchmark_binarysize_scanf.dir/out/scanf/binarysize_test_tmp_15.cpp.
            o.d -o CMakeFiles/scn_benchmark_binarysize_scanf.dir/out/scanf/bina
            rysize_test_tmp_15.cpp.o -c /tmp/runner/spack-stage/spack-stage-scn
            lib-3.0.1-j4wgylr2ljzv53xs2qmu5am55zm7omrt/spack-build-j4wgylr/benc
            hmark/binarysize/out/scanf/binarysize_test_tmp_15.cpp
     181    [ 71%] Building CXX object benchmark/binarysize/CMakeFiles/scn_benc
            hmark_binarysize_scanf.dir/out/scanf/binarysize_test_tmp_16.cpp.o
     182    cd /tmp/runner/spack-stage/spack-stage-scnlib-3.0.1-j4wgylr2ljzv53x
            s2qmu5am55zm7omrt/spack-build-j4wgylr/benchmark/binarysize && /opt/
            spack/linux-x86_64_v3/compiler-wrapper-1.0-kr35wwg7rvdhdh26tpinvbyg
            zmd6fwrz/libexec/spack/gcc/g++   -O3 -DNDEBUG -Wno-unused -Wno-unus
            ed-but-set-variable -Wno-redundant-decls -Wno-missing-declarations
            -MD -MT benchmark/binarysize/CMakeFiles/scn_benchmark_binarysize_sc
            anf.dir/out/scanf/binarysize_test_tmp_16.cpp.o -MF CMakeFiles/scn_b
            enchmark_binarysize_scanf.dir/out/scanf/binarysize_test_tmp_16.cpp.
            o.d -o CMakeFiles/scn_benchmark_binarysize_scanf.dir/out/scanf/bina
            rysize_test_tmp_16.cpp.o -c /tmp/runner/spack-stage/spack-stage-scn
            lib-3.0.1-j4wgylr2ljzv53xs2qmu5am55zm7omrt/spack-build-j4wgylr/benc
            hmark/binarysize/out/scanf/binarysize_test_tmp_16.cpp
     183    [ 72%] Building CXX object benchmark/binarysize/CMakeFiles/scn_benc
            hmark_binarysize_iostream.dir/out/iostream/binarysize_test_tmp_16.c
            pp.o
     184    cd /tmp/runner/spack-stage/spack-stage-scnlib-3.0.1-j4wgylr2ljzv53x
            s2qmu5am55zm7omrt/spack-build-j4wgylr/benchmark/binarysize && /opt/
            spack/linux-x86_64_v3/compiler-wrapper-1.0-kr35wwg7rvdhdh26tpinvbyg
            zmd6fwrz/libexec/spack/gcc/g++   -O3 -DNDEBUG -Wno-unused -Wno-unus
            ed-but-set-variable -Wno-redundant-decls -Wno-missing-declarations
            -MD -MT benchmark/binarysize/CMakeFiles/scn_benchmark_binarysize_io
            stream.dir/out/iostream/binarysize_test_tmp_16.cpp.o -MF CMakeFiles
            /scn_benchmark_binarysize_iostream.dir/out/iostream/binarysize_test
            _tmp_16.cpp.o.d -o CMakeFiles/scn_benchmark_binarysize_iostream.dir
            /out/iostream/binarysize_test_tmp_16.cpp.o -c /tmp/runner/spack-sta
            ge/spack-stage-scnlib-3.0.1-j4wgylr2ljzv53xs2qmu5am55zm7omrt/spack-
            build-j4wgylr/benchmark/binarysize/out/iostream/binarysize_test_tmp
            _16.cpp
     185    /tmp/runner/spack-stage/spack-stage-scnlib-3.0.1-j4wgylr2ljzv53xs2q
            mu5am55zm7omrt/spack-src/src/scn/impl.cpp: In member function 'fast
            _float::chars_format scn::v3::impl::{anonymous}::fast_float_impl_ba
            se::get_flags() const':
  >> 186    /tmp/runner/spack-stage/spack-stage-scnlib-3.0.1-j4wgylr2ljzv53xs2q
            mu5am55zm7omrt/spack-src/src/scn/impl.cpp:1063:41: error: 'fixed' i
            s not a member of 'fast_float'
     187     1063 |             format_flags |= fast_float::fixed;
     188          |                                         ^~~~~
     189    /tmp/runner/spack-stage/spack-stage-scnlib-3.0.1-j4wgylr2ljzv53xs2q
            mu5am55zm7omrt/spack-src/src/scn/impl.cpp:1063:41: note: suggested
            alternatives:
     190    In file included from /usr/include/c++/14/streambuf:43,
     191                     from /usr/include/c++/14/bits/streambuf_iterator.h
            :35,
     192                     from /usr/include/c++/14/iterator:66,

     ...

     205                     from /tmp/runner/spack-stage/spack-stage-scnlib-3.
            0.1-j4wgylr2ljzv53xs2qmu5am55zm7omrt/spack-src/src/scn/impl.cpp:47:
     206    /opt/spack/linux-x86_64_v3/fast-float-8.1.0-o3w24stbxqx5jhiljl6pdgr
            oujiyaktj/include/fast_float/float_common.h:45:3: note:   'fast_flo
            at::chars_format::fixed'
     207       45 |   fixed = 1 << 2,
     208          |   ^~~~~
     209    [ 73%] Linking CXX executable scn_benchmark_binarysize_scanf
     210    cd /tmp/runner/spack-stage/spack-stage-scnlib-3.0.1-j4wgylr2ljzv53x
            s2qmu5am55zm7omrt/spack-build-j4wgylr/benchmark/binarysize && /usr/
            local/bin/cmake -E cmake_link_script CMakeFiles/scn_benchmark_binar
            ysize_scanf.dir/link.txt --verbose=1
  >> 211    /tmp/runner/spack-stage/spack-stage-scnlib-3.0.1-j4wgylr2ljzv53xs2q
            mu5am55zm7omrt/spack-src/src/scn/impl.cpp:1066:41: error: 'scientif
            ic' is not a member of 'fast_float'
     212     1066 |             format_flags |= fast_float::scientific;
     213          |                                         ^~~~~~~~~~
     214    /tmp/runner/spack-stage/spack-stage-scnlib-3.0.1-j4wgylr2ljzv53xs2q
            mu5am55zm7omrt/spack-src/src/scn/impl.cpp:1066:41: note: suggested
            alternatives:
     215    /usr/include/c++/14/bits/ios_base.h:1112:3: note:   'std::scientifi
            c'
     216     1112 |   scientific(ios_base& __base)
     217          |   ^~~~~~~~~~

     ...

     226    [ 73%] Built target scn_benchmark_binarysize_scanf
     227    [ 75%] Linking CXX executable scn_benchmark_binarysize_iostream
     228    cd /tmp/runner/spack-stage/spack-stage-scnlib-3.0.1-j4wgylr2ljzv53x
            s2qmu5am55zm7omrt/spack-build-j4wgylr/benchmark/binarysize && /usr/
            local/bin/cmake -E cmake_link_script CMakeFiles/scn_benchmark_binar
            ysize_iostream.dir/link.txt --verbose=1
     229    /opt/spack/linux-x86_64_v3/compiler-wrapper-1.0-kr35wwg7rvdhdh26tpi
            nvbygzmd6fwrz/libexec/spack/gcc/g++ -O3 -DNDEBUG -Wl,--dependency-f
            ile=CMakeFiles/scn_benchmark_binarysize_iostream.dir/link.d CMakeFi
            les/scn_benchmark_binarysize_iostream.dir/out/iostream/binarysize_t
            est_main.cpp.o CMakeFiles/scn_benchmark_binarysize_iostream.dir/out
            /iostream/binarysize_test_tmp_0.cpp.o CMakeFiles/scn_benchmark_bina
            rysize_iostream.dir/out/iostream/binarysize_test_tmp_1.cpp.o CMakeF
            iles/scn_benchmark_binarysize_iostream.dir/out/iostream/binarysize_
            test_tmp_2.cpp.o CMakeFiles/scn_benchmark_binarysize_iostream.dir/o
            ut/iostream/binarysize_test_tmp_3.cpp.o CMakeFiles/scn_benchmark_bi
            narysize_iostream.dir/out/iostream/binarysize_test_tmp_4.cpp.o CMak
            eFiles/scn_benchmark_binarysize_iostream.dir/out/iostream/binarysiz
            e_test_tmp_5.cpp.o CMakeFiles/scn_benchmark_binarysize_iostream.dir
            /out/iostream/binarysize_test_tmp_6.cpp.o CMakeFiles/scn_benchmark_
            binarysize_iostream.dir/out/iostream/binarysize_test_tmp_7.cpp.o CM
            akeFiles/scn_benchmark_binarysize_iostream.dir/out/iostream/binarys
            ize_test_tmp_8.cpp.o CMakeFiles/scn_benchmark_binarysize_iostream.d
            ir/out/iostream/binarysize_test_tmp_9.cpp.o CMakeFiles/scn_benchmar
            k_binarysize_iostream.dir/out/iostream/binarysize_test_tmp_10.cpp.o
             CMakeFiles/scn_benchmark_binarysize_iostream.dir/out/iostream/bina
            rysize_test_tmp_11.cpp.o CMakeFiles/scn_benchmark_binarysize_iostre
            am.dir/out/iostream/binarysize_test_tmp_12.cpp.o CMakeFiles/scn_ben
            chmark_binarysize_iostream.dir/out/iostream/binarysize_test_tmp_13.
            cpp.o CMakeFiles/scn_benchmark_binarysize_iostream.dir/out/iostream
            /binarysize_test_tmp_14.cpp.o CMakeFiles/scn_benchmark_binarysize_i
            ostream.dir/out/iostream/binarysize_test_tmp_15.cpp.o CMakeFiles/sc
            n_benchmark_binarysize_iostream.dir/out/iostream/binarysize_test_tm
            p_16.cpp.o -o scn_benchmark_binarysize_iostream
     230    make[2]: Leaving directory '/tmp/runner/spack-stage/spack-stage-scn
            lib-3.0.1-j4wgylr2ljzv53xs2qmu5am55zm7omrt/spack-build-j4wgylr'
     231    [ 75%] Built target scn_benchmark_binarysize_iostream
  >> 232    make[2]: *** [CMakeFiles/scn.dir/build.make:82: CMakeFiles/scn.dir/
            src/scn/impl.cpp.o] Error 1
     233    make[2]: Leaving directory '/tmp/runner/spack-stage/spack-stage-scn
            lib-3.0.1-j4wgylr2ljzv53xs2qmu5am55zm7omrt/spack-build-j4wgylr'
  >> 234    make[1]: *** [CMakeFiles/Makefile2:300: CMakeFiles/scn.dir/all] Err
            or 2
     235    make[1]: Leaving directory '/tmp/runner/spack-stage/spack-stage-scn
            lib-3.0.1-j4wgylr2ljzv53xs2qmu5am55zm7omrt/spack-build-j4wgylr'
  >> 236    make: *** [Makefile:149: all] Error 2

See build log for details:
  /tmp/runner/spack-stage/spack-stage-scnlib-3.0.1-j4wgylr2ljzv53xs2qmu5am55zm7omrt/spack-bui
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
