### PR TITLE
podman: fix Spack failing on older versions of MacOS

### DIFF
--- a/repos/spack_repo/builtin/packages/podman/package.py
+++ b/repos/spack_repo/builtin/packages/podman/package.py
@@ -62,7 +62,8 @@ class Podman(Package):
     )
 
     # see https://github.com/containers/podman/issues/22121
-    conflicts("platform=darwin os:=monterey", msg="podman for macOS requires Ventura or later")
+    if _is_macos and macos_version() < Version("13"):
+        conflicts("platform=darwin", msg="podman for macOS requires Ventura or later")
 
     # See <https://github.com/containers/podman/issues/16996> for the
     # respective issue and the suggested patch

--- a/repos/spack_repo/builtin/packages/podman/package.py
+++ b/repos/spack_repo/builtin/packages/podman/package.py
@@ -62,8 +62,7 @@ class Podman(Package):
     )
 
     # see https://github.com/containers/podman/issues/22121
-    if _is_macos and macos_version() < Version("13"):
-        raise InstallError("podman for macOS requires Ventura or later")
+    conflicts("platform=darwin os:=monterey", msg="podman for macOS requires Ventura or later")
 
     # See <https://github.com/containers/podman/issues/16996> for the
     # respective issue and the suggested patch


### PR DESCRIPTION
I'd originally approved a modification to the Podman package without remembering that we execute all packages during initial load and so this one package was breaking Spack on old versions of MacOS. This is breaking the bootstrap cache builder.