### PR TITLE
py-twine: ensure urllib3@2: compatibility

### DIFF
--- a/repos/spack_repo/builtin/packages/py_twine/package.py
+++ b/repos/spack_repo/builtin/packages/py_twine/package.py
@@ -31,9 +31,19 @@ class PyTwine(PythonPackage):
         depends_on("py-pkginfo@1.4.2:", when="@:3.6")
         depends_on("py-readme-renderer@35:", when="@4.0.1:")
         depends_on("py-readme-renderer@21.0:")
-        depends_on("py-requests@2.20:")
-        depends_on("py-requests-toolbelt@0.8,0.9.1:")
-        depends_on("py-urllib3@1.26:", when="@3.8:")
+        
+        # requests@2.30 brings in compatibility with urllib3@2, which has minor breaking.
+        # even though the requests/urlib pairing is compatible, twine wasn't compatible
+        # with urllib3@2: changes
+        # https://github.com/pypa/twine/issues/1148#issuecomment-2629533797
+        # https://github.com/psf/requests/blob/main/HISTORY.md#2300-2023-05-03
+        depends_on("py-requests@2.20:2.29.0", when="@:4")
+        depends_on("py-requests@2.20:", when="@6:")
+        depends_on("py-requests-toolbelt@0.8,0.9.1", when="^py-urllib3@1")   
+        depends_on("py-requests-toolbelt@1:", when="^py-urllib3@2:") 
+        depends_on("py-urllib3@1.26:1", when="@3.8:4")
+        depends_on("py-urllib3@1.26:", when="@6:")
+
         depends_on("py-importlib-metadata@3.6:", when="@6:^python@:3.9")
         depends_on("py-importlib-metadata@3.6:", when="@3.4:4")
         depends_on("py-keyring@15.1:", when="@3:")

--- a/repos/spack_repo/builtin/packages/py_twine/package.py
+++ b/repos/spack_repo/builtin/packages/py_twine/package.py
@@ -31,7 +31,7 @@ class PyTwine(PythonPackage):
         depends_on("py-pkginfo@1.4.2:", when="@:3.6")
         depends_on("py-readme-renderer@35:", when="@4.0.1:")
         depends_on("py-readme-renderer@21.0:")
-        
+
         # requests@2.30 brings in compatibility with urllib3@2, which has minor breaking.
         # even though the requests/urlib pairing is compatible, twine wasn't compatible
         # with urllib3@2: changes
@@ -39,8 +39,8 @@ class PyTwine(PythonPackage):
         # https://github.com/psf/requests/blob/main/HISTORY.md#2300-2023-05-03
         depends_on("py-requests@2.20:2.29.0", when="@:4")
         depends_on("py-requests@2.20:", when="@6:")
-        depends_on("py-requests-toolbelt@0.8,0.9.1", when="^py-urllib3@1")   
-        depends_on("py-requests-toolbelt@1:", when="^py-urllib3@2:") 
+        depends_on("py-requests-toolbelt@0.8,0.9.1", when="^py-urllib3@1")
+        depends_on("py-requests-toolbelt@1:", when="^py-urllib3@2:")
         depends_on("py-urllib3@1.26:1", when="@3.8:4")
         depends_on("py-urllib3@1.26:", when="@6:")
 


### PR DESCRIPTION
There is a complex interaction between `urllib3@2`, `requests`, `requests-toolbelt`, and `py-twine`  that produces a combination that doesn't run. Specifically, `urllib3@2:` is used alongside a `requests-toolbelt` that isn't updated for `urllib3@2:`. Because `requests-toolbelt` doesn't depend on urllib3 directly, consumers need to ensure this all lines up. 

This PR ensures the ranges are correct