### PR TITLE
papi: Add topdown variant

### DIFF
--- a/repos/spack_repo/builtin/packages/papi/package.py
+++ b/repos/spack_repo/builtin/packages/papi/package.py
@@ -62,6 +62,7 @@ class Papi(AutotoolsPackage, ROCmPackage):
         when="@6.0.0:",
         description="Enable use of rdpmc for reading counters, when possible",
     )
+    variant("topdown", default=False, when="@7.2:", description="Enable topdown support")
 
     variant("shared", default=True, description="Build shared libraries")
     # PAPI requires building static libraries, so there is no "static" variant
@@ -167,6 +168,7 @@ class Papi(AutotoolsPackage, ROCmPackage):
                 "rocm",
                 "rocm_smi",
                 "rocp_sdk",
+                "topdown",
             ],
         )
         if components:


### PR DESCRIPTION
Adds topdown variant for papi v7.2

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
