### PR TITLE
py-safetensors: add v0.6.2

### DIFF
--- a/repos/spack_repo/builtin/packages/py_safetensors/package.py
+++ b/repos/spack_repo/builtin/packages/py_safetensors/package.py
@@ -15,14 +15,20 @@ class PySafetensors(PythonPackage):
 
     maintainers("thomas-bouvier")
 
+    version("0.6.2", sha256="43ff2aa0e6fa2dc3ea5524ac7ad93a9839256b8703761e76e2d0b2a3fa4f15d9")
     version("0.4.5", sha256="d73de19682deabb02524b3d5d1f8b3aaba94c72f1bbfc7911b9b9d5d391c0310")
     version("0.4.3", sha256="2f85fc50c4e07a21e95c24e07460fe6f7e2859d0ce88092838352b798ce711c2")
     version("0.3.1", sha256="571da56ff8d0bec8ae54923b621cda98d36dcef10feb36fd492c4d0c2cd0e869")
 
+    depends_on("c", type="build")
+
+    depends_on("python@3.9:", when="@0.6:", type=("build", "run"))
+    # Build errors with python@3.14
+    depends_on("python@3.7:3.13", when="@:0.4.5", type=("build", "run"))
     # Based on PyPI wheel availability
-    depends_on("python@:3.12", when="@:0.4.3", type=("build", "run"))
+    depends_on("python@3.7:3.12", when="@:0.4.3", type=("build", "run"))
     depends_on("py-maturin@1", type="build", when="@0.4.3:")
+
+    # Historical dependencies
     depends_on("py-setuptools", when="@0.3.1", type="build")
     depends_on("py-setuptools-rust", when="@0.3.1", type="build")
-
-    depends_on("c", type="build")


### PR DESCRIPTION
https://github.com/huggingface/safetensors/tree/v0.6.2/bindings/python

This adds `python@3.14` support which is needed for the CI pipeline to succeed in #2080

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
