### PR TITLE
r-rcppeigen: add v0.3.4.0.2 and missing cxx dep

### DIFF
--- a/repos/spack_repo/builtin/packages/r_rcppeigen/package.py
+++ b/repos/spack_repo/builtin/packages/r_rcppeigen/package.py
@@ -28,6 +28,7 @@ class RRcppeigen(RPackage):
 
     license("MPL-2.0")
 
+    version("0.3.4.0.2", sha256="ecad7ba2129fd48b7ebb825558d38492ed1f3a8934959e27fcd6688175e542bb")
     version("0.3.4.0.1", sha256="25ed48f148b50aaadd92752d73e3eefe00ab4ecd4ae5662ae91a9ff3f72a4e26")
     version("0.3.3.9.3", sha256="5873a47fd6587d916f86119ab140c6736abf80ac45d06ff1c9d198708e7d1c76")
     version("0.3.3.9.2", sha256="2547e794d5a6fb8d9fbadf19e64afa0bcf413cc69ecf3f428995fa5a0fced493")
@@ -38,7 +39,10 @@ class RRcppeigen(RPackage):
     version("0.3.2.9.0", sha256="25affba9065e3c12d67b1934d1ce97a928a4011a7738f7b90f0e9830409ec93b")
     version("0.3.2.8.1", sha256="ceccb8785531c5c23f9232b594e5372c214a114a08ec759115e946badd08d681")
 
+    depends_on("cxx", type="build")
+
     depends_on("r-rcpp@0.11.0:", type=("build", "run"))
     depends_on("r@3.6.0:", type=("build", "run"), when="@0.3.3.9.3:")
 
+    # Historical dependencies
     depends_on("r-matrix@1.1-0:", type=("build", "run"), when="@:0.3.3.9.3")


### PR DESCRIPTION
https://cloud.r-project.org/web/packages/RcppEigen/index.html

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
