### PR TITLE
r-quickjsr: add v1.8.1 and missing c and cxx dep

### DIFF
--- a/repos/spack_repo/builtin/packages/r_quickjsr/package.py
+++ b/repos/spack_repo/builtin/packages/r_quickjsr/package.py
@@ -17,4 +17,8 @@ class RQuickjsr(RPackage):
 
     license("MIT", checked_by="wdconinc")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    version("1.8.1", sha256="dd4cf107016d659991cdbd313908209e3998ea8b093f3632d8b3a84dea435e0f")
     version("1.3.1", sha256="10559d6e84a838ec97acdbc6028a59e2121811d4a20e83c95cdb8fb4ce208fd1")


### PR DESCRIPTION
https://cran.r-project.org/web/packages/QuickJSR/index.html

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
