### PR TITLE
scnlib: Fix dependency version requirements.

### DIFF
--- a/repos/spack_repo/builtin/packages/scnlib/package.py
+++ b/repos/spack_repo/builtin/packages/scnlib/package.py
@@ -38,6 +38,7 @@ class Scnlib(CMakePackage):
     depends_on("cmake@3.16:", type="build")
 
     depends_on("fast-float@5:")
+    depends_on("fast-float@:6", when="@:3")
 
     depends_on("boost +regex cxxstd=17", when="regex-backend=Boost")
     depends_on("boost +icu", when="+icu")


### PR DESCRIPTION
+ `fast-float` API has an incompatible change introduced with `@7`:
+ When linking to `fast-float@7:`, the following build error is reported:

```
  >> 196    .../spack-stage/spack-stage-scnlib-3.0.1-<hash>/spack-src/src/scn/impl.cpp:1063:41: 
            error: 'fixed' is not a member of 'fast_float'
     197    1063 |             format_flags |= fast_float::fixed;
     198         |                                         ^~~~~
```
+ linking to `fast-float@6` prevents this build failure.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
