### PR TITLE
[kokkos] Cleaning up cmake options to prepare Kokkos 5.0

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -125,6 +125,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     }
 
     conflicts("~debug_dualview_modify_check", when="@4.7:")  # always enable from 4.7.00
+    conflicts("+cuda ~cuda_lambda", when="@4.1:")  # Kokkos version 5. will fail if CUDA_LAMBDA is not set.
 
     spack_micro_arch_map = {
         "thunderx2": "THUNDERX2",


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Some variants should have been "deprecated" for quite a while, and now is a good time to clean up before the next major release of Kokkos.