### PR TITLE
ncbi-toolkit: Added versions 27 and 28

### DIFF
--- a/repos/spack_repo/builtin/packages/ncbi_toolkit/package.py
+++ b/repos/spack_repo/builtin/packages/ncbi_toolkit/package.py
@@ -73,6 +73,9 @@ class NcbiToolkit(AutotoolsPackage):
 
     # boost 1.87 removes dummy_cond(). ncbi-toolset 29.5.0 fixes this.
     conflicts("boost@1.87:", when="@:29_4")
+
+    # libxml2's xmlGetLastError starts returning const in libxml2@2.12:
+    # ncbi-toolkit fixes this in :29
     conflicts("libxml2@2.12:", when="@:28")
 
     def configure_args(self):

--- a/repos/spack_repo/builtin/packages/ncbi_toolkit/package.py
+++ b/repos/spack_repo/builtin/packages/ncbi_toolkit/package.py
@@ -18,6 +18,16 @@ class NcbiToolkit(AutotoolsPackage):
     # Per https://ncbi.github.io/cxx-toolkit/pages/ch_getcode_svn#ch_getcode_svn.external
     # New versions are released on github
     version(
+        "28_0_12",
+        sha256="db8a21ca242480badce126a6cad6ed5a2a8bcf40427fe6ea0dfd1ce6e8755a33",
+        url="https://github.com/ncbi/ncbi-cxx-toolkit-public/archive/refs/tags/release-28.0.12.tar.gz",
+    )
+    version(
+        "27_0_0",
+        sha256="c8fb3f99c6fce4f170b381f3a7789c76a2ff1c23c094c9852e2e3de1fdc57277",
+        url="https://github.com/ncbi/ncbi-cxx-toolkit-public/archive/refs/tags/release-27.0.0.tar.gz",
+    )
+    version(
         "26_0_1",
         sha256="aba79da5c8d0407ffc92b7831f4f8f8a8096a15e47a016ada81b6568f9d280cc",
         url="https://github.com/ncbi/ncbi-cxx-toolkit-public/archive/refs/tags/release-26.0.1.tar.gz",
@@ -60,6 +70,10 @@ class NcbiToolkit(AutotoolsPackage):
     depends_on("samtools")
     depends_on("bamtools")
     depends_on("berkeley-db")
+
+    # boost 1.87 removes dummy_cond(). ncbi-toolset 29.5.0 fixes this.
+    conflicts("boost@1.87:", when="@:29_4")
+    conflicts("libxml2@2.12:", when="@:28")
 
     def configure_args(self):
         args = ["--without-sybase", "--without-fastcgi"]


### PR DESCRIPTION
Added versions 27 and 28 of the NCBI C++ Toolkit.

There are problems using newer versions of boost that no longer have some functions, so a conflict was added for that. It also refuses to compile using newer versions of libxml2, so a conflict was added for that.