### PR TITLE
fix intel_oneapi_compilers_classic@:2021.10

### DIFF
--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers_classic/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers_classic/package.py
@@ -150,8 +150,27 @@ class IntelOneapiCompilersClassic(Package, CompilerPackage):
     def install(self, spec, prefix):
         # We do a full copy (not symlinks) to avoid a run dependency on intel-oneapi-compilers
         # which would prevent mixing versions in a DAG
-        install_tree(self.oneapi_compiler_prefix.linux.bin.intel64, prefix.bin)
+        install_tree(self.oneapi_compiler_prefix.linux.bin.intel64, prefix.bin.intel64)
+        binaries = [
+            "codecov",
+            "fortcom",
+            "fpp",
+            "icc",
+            "icpc",
+            "ifort",
+            "mcpcom",
+            "profdcg",
+            "profmerge",
+            "profmergesampling",
+            "proforder",
+            "tselect",
+            "xiar",
+            "xild",
+        ]
+        for binary in binaries:
+            os.symlink(prefix.bin.intel64.join(binary), prefix.bin.join(binary))
         install_tree(self.oneapi_compiler_prefix.linux.lib, prefix.lib)
+        install_tree(self.oneapi_compiler_prefix.linux.compiler.lib.intel64_lin, prefix.linux.compiler.lib.intel64_lin)
         install_tree(self.oneapi_compiler_prefix.linux.include, prefix.include)
         install_tree(self.oneapi_compiler_prefix.linux.compiler, prefix.compiler)
         install_tree(self.oneapi_compiler_prefix.documentation.en.man, prefix.man)

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers_classic/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers_classic/package.py
@@ -170,7 +170,10 @@ class IntelOneapiCompilersClassic(Package, CompilerPackage):
         for binary in binaries:
             os.symlink(prefix.bin.intel64.join(binary), prefix.bin.join(binary))
         install_tree(self.oneapi_compiler_prefix.linux.lib, prefix.lib)
-        install_tree(self.oneapi_compiler_prefix.linux.compiler.lib.intel64_lin, prefix.linux.compiler.lib.intel64_lin)
+        install_tree(
+            self.oneapi_compiler_prefix.linux.compiler.lib.intel64_lin,
+            prefix.linux.compiler.lib.intel64_lin,
+        )
         install_tree(self.oneapi_compiler_prefix.linux.include, prefix.include)
         install_tree(self.oneapi_compiler_prefix.linux.compiler, prefix.compiler)
         install_tree(self.oneapi_compiler_prefix.documentation.en.man, prefix.man)


### PR DESCRIPTION
With previous commit (a3806d96d2) (PR #1123), installing intel-oneapi-compilers-classic@2021.10.0 gives this erreur:

````sh
./bad/bin/icc
icc: remark #10441: The Intel(R) C++ Compiler Classic (ICC) is deprecated and will be removed from product release in the second half of 2023. The Intel(R) oneAPI DPC++/C++ Compiler (ICX) is the recommended compiler moving forward. Please transition to use this compiler. Use '-diag-disable=10441' to disable this message. ld: cannot find -limf
ld: cannot find -lsvml
ld: cannot find -lirng
````

This patch partially reverts Commit a3806d96d2 to get the expected behavior:
````sh
./good/bin/icc
icc: remark #10441: The Intel(R) C++ Compiler Classic (ICC) is deprecated and will be removed from product release in the second half of 2023. The Intel(R) oneAPI DPC++/C++ Compiler (ICX) is the recommended compiler moving forward. Please transition to use this compiler. Use '-diag-disable=10441' to disable this message. ld: /usr/lib/gcc/x85_64-redhat-linux/11/../../../../lib64/crt1.o: in function `_start': (.text+0x1b): undefined reference to `main'
````

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
