### PR TITLE
Fix hypre@2 with GPU when using autotools

### DIFF
--- a/repos/spack_repo/builtin/packages/hypre/package.py
+++ b/repos/spack_repo/builtin/packages/hypre/package.py
@@ -427,7 +427,7 @@ class AutotoolsBuilder(AutotoolsBuilder):
             configure_args.append("--with-extra-CFLAGS=-Wno-error=incompatible-pointer-types")
 
         if spec.satisfies("+cuda") or spec.satisfies("+rocm") or spec.satisfies("+sycl"):
-            configure_args.append(f"--with-cxxstandard={self.spec.cxxstd}")
+            configure_args.append(f"--with-cxxstandard={self.spec.variants['cxxstd'].value}")
             if spec.satisfies("+pic"):
                 configure_args.append("--with-extra-CXXFLAGS=-fPIC")
 


### PR DESCRIPTION
#1855 turned cxxstandard into a variant, so the syntax for accessing the value should have changed.

This was not caught because hypre@3 uses cmake and not autotools.
