### PR TITLE
quandary: add v4.3

### DIFF
--- a/repos/spack_repo/builtin/packages/quandary/package.py
+++ b/repos/spack_repo/builtin/packages/quandary/package.py
@@ -24,6 +24,7 @@ class Quandary(CachedCMakePackage, CudaPackage, ROCmPackage):
     license("MIT", checked_by="tdrwenski")
 
     version("main", branch="main", preferred=True)
+    version("4.3", tag="v4.3", commit="d5087e7ac82665ceb028b492c88b3fe8acd5cd13")
     version("4.2", tag="v4.2", commit="557675fd76daf9fd0be7ebd6321bf2afcb6a6b9c")
     version("learning", branch="learning")
 


### PR DESCRIPTION
Add new tag for new Quandary release [version](https://github.com/LLNL/quandary/releases/tag/v4.3)