### PR TITLE
Add missing build dependencies to package.py

### DIFF
--- a/repos/spack_repo/builtin/packages/wcslib/package.py
+++ b/repos/spack_repo/builtin/packages/wcslib/package.py
@@ -23,8 +23,10 @@ class Wcslib(AutotoolsPackage):
     variant("cfitsio", default=False, description="Include CFITSIO support")
     variant("x", default=False, description="Use the X Window System")
 
+    depends_on("c", type="build")
     depends_on("gmake", type="build")
     depends_on("flex@2.5.9:", type="build")
+    depends_on("fortran", type="build")
     depends_on("cfitsio", when="+cfitsio")
     depends_on("libx11", when="+x")
 


### PR DESCRIPTION
The package wcslib fails on build because of missing dependency on c and fortran compiler