### PR TITLE
medipack: install all files

### DIFF
--- a/repos/spack_repo/builtin/packages/medipack/package.py
+++ b/repos/spack_repo/builtin/packages/medipack/package.py
@@ -33,7 +33,6 @@ class Medipack(CMakePackage):
     )
 
     def install(self, spec, prefix):
-        mkdirp(self.prefix.include)
-        install_tree(join_path(self.stage.source_path, "include"), self.prefix.include)
+        super().install(spec, prefix)
         mkdirp(self.prefix.src)
         install_tree(join_path(self.stage.source_path, "src"), self.prefix.src)


### PR DESCRIPTION
This now calls the `install` method of `CMakePacakge` as well to install the cmake files in share and the compiled library in lib.

`include` is already installed automatically. It's still installing `src` additionally.
