### PR TITLE
MVAPICH: Update Checksums

### DIFF
--- a/repos/spack_repo/builtin/packages/mvapich/package.py
+++ b/repos/spack_repo/builtin/packages/mvapich/package.py
@@ -29,7 +29,7 @@ class Mvapich(MpichEnvironmentModifications, AutotoolsPackage):
 
     # Prefer the latest stable release
     version("4.1", sha256="25a53d3725b669e2c648158fb7c9fc5b1388953f3a2f949748586c447d0e43ee")
-    version("4.0", sha256="ee076c4e672d18d6bf8dd2250e4a91fa96aac1db2c788e4572b5513d86936efb")
+    version("4.0", sha256="c532f7bdd5cca71f78c12e0885c492f6e276e283711806c84d0b0f80bb3e3b74")
     with default_args(deprecated=True):
         version("3.0", sha256="ee076c4e672d18d6bf8dd2250e4a91fa96aac1db2c788e4572b5513d86936efb")
 

--- a/repos/spack_repo/builtin/packages/mvapich/package.py
+++ b/repos/spack_repo/builtin/packages/mvapich/package.py
@@ -28,8 +28,8 @@ class Mvapich(MpichEnvironmentModifications, AutotoolsPackage):
     license("Unlicense")
 
     # Prefer the latest stable release
-    version("4.1", sha256="a36c459befd5b0d1b66e4a217250d89d9f77b903fcc4a050efddb1c475b8dcab")
-    version("4.0", sha256="c532f7bdd5cca71f78c12e0885c492f6e276e283711806c84d0b0f80bb3e3b74")
+    version("4.1", sha256="25a53d3725b669e2c648158fb7c9fc5b1388953f3a2f949748586c447d0e43ee")
+    version("4.0", sha256="ee076c4e672d18d6bf8dd2250e4a91fa96aac1db2c788e4572b5513d86936efb")
     with default_args(deprecated=True):
         version("3.0", sha256="ee076c4e672d18d6bf8dd2250e4a91fa96aac1db2c788e4572b5513d86936efb")
 


### PR DESCRIPTION
@MatthewLieber @natshineman The checksums on the `mvapich` package appear outdated across several systems. This PR would update the checksums.