### PR TITLE
rccl-tests: fix build and update build system to cmake

### DIFF
--- a/repos/spack_repo/builtin/packages/rccl_tests/package.py
+++ b/repos/spack_repo/builtin/packages/rccl_tests/package.py
@@ -26,7 +26,7 @@ class RcclTests(CMakePackage):
     variant("mpi", default=True, description="with MPI support")
 
     depends_on("cxx", type="build")
-    requires("%cxx=llvm-amdgpu")
+    requires("%cxx=llvm-amdgpu", msg="rccl-tests builds only with llvm-amdgpu")
 
     depends_on("hip")
     depends_on("rccl")

--- a/repos/spack_repo/builtin/packages/rccl_tests/package.py
+++ b/repos/spack_repo/builtin/packages/rccl_tests/package.py
@@ -2,12 +2,12 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack_repo.builtin.build_systems.makefile import MakefilePackage
+from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
 
 
-class RcclTests(MakefilePackage):
+class RcclTests(CMakePackage):
     """These tests check both the performance and the correctness of RCCL
     operations. They can be compiled against RCCL."""
 
@@ -25,21 +25,17 @@ class RcclTests(MakefilePackage):
 
     variant("mpi", default=True, description="with MPI support")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
+    requires("%cxx=llvm-amdgpu")
 
     depends_on("hip")
     depends_on("rccl")
     depends_on("mpi", when="+mpi")
 
-    def build_targets(self):
-        targets = []
-        targets.append("HIP_HOME={0}".format(self.spec["hip"].prefix))
-        targets.append("RCCL_HOME={0}".format(self.spec["rccl"].prefix))
-        if "+mpi" in self.spec:
-            targets.append("MPI_HOME={0}".format(self.spec["mpi"].prefix))
-            targets.append("MPI=1")
-        return targets
-
-    def install(self, spec, prefix):
-        mkdirp(prefix.bin)
-        install_tree("./build", prefix.bin)
+    def cmake_args(self):
+        return [
+            self.define("EXPLICIT_ROCM_VERSION", self.spec["hip"].version),
+            self.define("ROCM_PATH", self.spec["hip"].prefix),
+            self.define("RCCL_ROOT", self.spec["rccl"].prefix),
+            self.define_from_variant("USE_MPI", "mpi"),
+        ]


### PR DESCRIPTION
Since there are no versions, and the two branches that are supported both contain a CMakeLists.txt on the latest commits (added in 2022: https://github.com/ROCm/rccl-tests/commits/develop/CMakeLists.txt) I'm changing the build system unconditionally to CMake.

The Makefile build was also broken in strange ways, so I figured it's easiest to move to something a bit saner.

I've added a `requires("%cxx=llvm-amdgpu")` as the package requires this (https://github.com/ROCm/rccl-tests/blob/6405c76e6826663bbb67bd40aeee8c70aa5d3094/CMakeLists.txt#L88-L105). The old Makefile assumed this was the case (https://github.com/ROCm/rccl-tests/blob/6405c76e6826663bbb67bd40aeee8c70aa5d3094/src/Makefile#L17; there are .cu files that require building with a device compiler).

I'm setting `EXPLICIT_ROCM_VERSION` since it's typically not found in a spack-installed HIP stack. The `.info/version` file/directory (https://github.com/ROCm/rccl-tests/blob/6405c76e6826663bbb67bd40aeee8c70aa5d3094/CMakeLists.txt#L156) is not under what should be considered `ROCM_PATH` (i.e. the hip package prefix). It's under the rocm-core prefix (`.../rocm-core-6.3.3-eogndzhvabdqdbjyzch3otskainwqs7q/.info/version`).

Final note: This should in principle be a `ROCmPackage` because there are GPU kernels that can/should be compiled for a given `amdgpu_target`. However, I've had trouble getting the package to concretize inheriting from `ROCmPackage` and `+rocm`. Since the target has not been set so far, I'm leaving fixing that as a future exercise.