### PR TITLE
py-rasterio: GDAL 3.11 not yet supported

### DIFF
--- a/repos/spack_repo/builtin/packages/py_rasterio/package.py
+++ b/repos/spack_repo/builtin/packages/py_rasterio/package.py
@@ -81,5 +81,7 @@ class PyRasterio(PythonPackage):
     depends_on("gdal@2.4:3.3", when="@1.2.7:1.2")
     depends_on("gdal@2.3:3.2", when="@1.2.0:1.2.6")
 
+    # https://github.com/rasterio/rasterio/issues/3371
+    conflicts("^gdal@3.11:", when="@:1.4.3")
     # https://github.com/rasterio/rasterio/pull/3212
     conflicts("^gdal@3.10:", when="@:1.4.1")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
