### PR TITLE
py-kornia-rs: Python 3.14 only supported in main

### DIFF
--- a/repos/spack_repo/builtin/packages/py_kornia_rs/package.py
+++ b/repos/spack_repo/builtin/packages/py_kornia_rs/package.py
@@ -12,6 +12,7 @@ class PyKorniaRs(PythonPackage):
 
     homepage = "http://www.kornia.org/"
     url = "https://github.com/kornia/kornia-rs/archive/refs/tags/v0.1.1.tar.gz"
+    git = "https://github.com/kornia/kornia-rs.git"
 
     license("Apache-2.0")
     maintainers(
@@ -24,9 +25,18 @@ class PyKorniaRs(PythonPackage):
         "adamjstewart",
     )
 
+    version("main", branch="main")
     version("0.1.9", sha256="a9b8a6afa00d80c9b1b1e3e5ff650762dac9605829a4f768ff5aedf47649efc2")
     version("0.1.1", sha256="b9ac327fae6e982e6d7df9faeadd1d4f6453e65521819ae9ae5b90e9da0ed1a5")
     version("0.1.0", sha256="0fca64f901dddff49b72e51fc92a25f0a7606e9a1a72ef283606245ea6b4f90d")
+
+    # PyO3 has tight coupling with CPython version
+    # Assume Python versions aren't supported until wheels are available on PyPI
+    with default_args(type=("build", "run")):
+        depends_on("python@:3.14")
+        depends_on("python@:3.13", when="@:0.1.9")
+        depends_on("python@:3.12", when="@:0.1.7")
+        depends_on("python@:3.11", when="@:0.1.0")
 
     depends_on("py-maturin@1", when="@0.1.6:", type="build")
     depends_on("py-maturin@1.3.2:", when="@:0.1.5", type="build")


### PR DESCRIPTION
Python 3.14 is not yet supported by any stable releases. A couple PRs were merged in parallel and now our CI is broken. This should fix things.