### PR TITLE
Glib: build fix

### DIFF
--- a/repos/spack_repo/builtin/packages/gir_scanner/package.py
+++ b/repos/spack_repo/builtin/packages/gir_scanner/package.py
@@ -1,0 +1,92 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack_repo.builtin.build_systems import meson
+from spack_repo.builtin.build_systems.meson import MesonPackage
+
+from spack.package import *
+
+
+class GirScanner(MesonPackage):
+    """The gi-r-scanner is from the GObject Introspection and required for building full glib.
+    """
+
+    homepage = "https://wiki.gnome.org/Projects/GObjectIntrospection"
+    url = "https://download.gnome.org/sources/gobject-introspection/1.72/gobject-introspection-1.72.0.tar.xz"
+
+    maintainers("michaelkuhn")
+
+    license("LGPL-2.0-or-later AND GPL-2.0-or-later AND MIT")
+
+    version("1.86.0", sha256="920d1a3fcedeadc32acff95c2e203b319039dd4b4a08dd1a2dfd283d19c0b9ae")
+
+    depends_on("c", type="build")  # generated
+
+    depends_on("pkgconfig", type="build")
+    depends_on("bison", type="build")
+    depends_on("flex", type="build")
+
+    # Does not build with sed from Darwin
+    depends_on("sed", when="platform=darwin", type="build")
+
+    #depends_on("cairo+gobject")
+    depends_on("glib-bootstrap@2.86:", when="@1.86", type="link")
+
+    depends_on("libffi")
+    depends_on("python", type=("build", "run"))
+
+    with when("^python@3.12:"):
+        depends_on("py-setuptools@48:", type=("build", "run"))
+        patch("setuptools.patch", when="@1.78:")
+
+    # g-ir-scanner uses distutils
+    # - https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/361
+    # - https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/395
+    # for new enough versions we import setuptools first
+    # patch("setuptools.patch", when="@1.78: ^python@3.12:")
+
+    def url_for_version(self, version):
+        url = "https://download.gnome.org/sources/gobject-introspection/{0}/gobject-introspection-{1}.tar.xz"
+        return url.format(version.up_to(2), version)
+
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        env.set("GI_SCANNER_DISABLE_CACHE", "1")
+
+    def setup_run_environment(self, env: EnvironmentModifications) -> None:
+        env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))
+
+    def setup_dependent_build_environment(
+        self, env: EnvironmentModifications, dependent_spec: Spec
+    ) -> None:
+        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
+        env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))
+        env.set("GI_SCANNER_DISABLE_CACHE", "1")
+
+    def setup_dependent_run_environment(
+        self, env: EnvironmentModifications, dependent_spec: Spec
+    ) -> None:
+        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
+        env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))
+
+    @property
+    def parallel(self):
+        return not self.spec.satisfies("%fj")
+
+class MesonBuilder(meson.MesonBuilder):
+    def meson_args(self):
+        args = []
+        args.append("-Dcairo=disabled")
+        args.append("-Ddoctool=disabled")
+        #args.append("-Dbuild_introspection_data=false")
+        
+        return args
+
+    @run_after("install")
+    def clean_install(self):
+        rm = which("rm")
+        binaries = ["g-ir-compiler", "g-ir-generate",
+                    "g-ir-annotation-tool", "g-ir-inspect"]
+        rm("-r", self.prefix.include, join_path(self.prefix.share, "man"))
+        rm("-r", join_path(self.prefix.share, "aclocal"))
+        for b in binaries:
+            rm(join_path(self.prefix.bin, b))

--- a/repos/spack_repo/builtin/packages/gir_scanner/package.py
+++ b/repos/spack_repo/builtin/packages/gir_scanner/package.py
@@ -8,8 +8,7 @@ from spack.package import *
 
 
 class GirScanner(MesonPackage):
-    """The gi-r-scanner is from the GObject Introspection and required for building full glib.
-    """
+    """The gi-r-scanner is from the GObject Introspection and required for building full glib."""
 
     homepage = "https://wiki.gnome.org/Projects/GObjectIntrospection"
     url = "https://download.gnome.org/sources/gobject-introspection/1.72/gobject-introspection-1.72.0.tar.xz"
@@ -29,7 +28,7 @@ class GirScanner(MesonPackage):
     # Does not build with sed from Darwin
     depends_on("sed", when="platform=darwin", type="build")
 
-    #depends_on("cairo+gobject")
+    # depends_on("cairo+gobject")
     depends_on("glib-bootstrap@2.86:", when="@1.86", type="link")
 
     depends_on("libffi")
@@ -72,20 +71,20 @@ class GirScanner(MesonPackage):
     def parallel(self):
         return not self.spec.satisfies("%fj")
 
+
 class MesonBuilder(meson.MesonBuilder):
     def meson_args(self):
         args = []
         args.append("-Dcairo=disabled")
         args.append("-Ddoctool=disabled")
-        #args.append("-Dbuild_introspection_data=false")
-        
+        # args.append("-Dbuild_introspection_data=false")
+
         return args
 
     @run_after("install")
     def clean_install(self):
         rm = which("rm")
-        binaries = ["g-ir-compiler", "g-ir-generate",
-                    "g-ir-annotation-tool", "g-ir-inspect"]
+        binaries = ["g-ir-compiler", "g-ir-generate", "g-ir-annotation-tool", "g-ir-inspect"]
         rm("-r", self.prefix.include, join_path(self.prefix.share, "man"))
         rm("-r", join_path(self.prefix.share, "aclocal"))
         for b in binaries:

--- a/repos/spack_repo/builtin/packages/gir_scanner/setuptools.patch
+++ b/repos/spack_repo/builtin/packages/gir_scanner/setuptools.patch
@@ -1,0 +1,60 @@
+diff --git a/giscanner/ccompiler.py b/giscanner/ccompiler.py
+index 2f03fd85..8e7424b7 100644
+--- a/giscanner/ccompiler.py
++++ b/giscanner/ccompiler.py
+@@ -24,6 +24,7 @@ import subprocess
+ import tempfile
+ 
+ import sys
++import setuptools
+ import distutils
+ 
+ from distutils.unixccompiler import UnixCCompiler
+diff --git a/giscanner/msvccompiler.py b/giscanner/msvccompiler.py
+index e333a80f..5168930a 100644
+--- a/giscanner/msvccompiler.py
++++ b/giscanner/msvccompiler.py
+@@ -21,6 +21,7 @@
+ import os
+ from typing import Type
+ 
++import setuptools
+ from distutils.errors import DistutilsExecError, CompileError
+ from distutils.ccompiler import CCompiler, gen_preprocess_options, new_compiler
+ from distutils.dep_util import newer
+diff --git a/giscanner/scannermain.py b/giscanner/scannermain.py
+index 987df819..08cb432f 100644
+--- a/giscanner/scannermain.py
++++ b/giscanner/scannermain.py
+@@ -552,6 +552,7 @@ def scanner_main(args):
+     (options, args) = parser.parse_args(args)
+ 
+     if options.verbose:
++        import setuptools
+         import distutils
+         distutils.log.set_threshold(distutils.log.DEBUG)
+     if options.passthrough_gir:
+diff --git a/giscanner/utils.py b/giscanner/utils.py
+index 9840143c..6fbcbce4 100644
+--- a/giscanner/utils.py
++++ b/giscanner/utils.py
+@@ -382,6 +382,7 @@ def get_msvcr_overwrite():
+             return ['vcruntime140']
+ 
+ 
++import setuptools
+ import distutils.cygwinccompiler
+ orig_get_msvcr = distutils.cygwinccompiler.get_msvcr  # type: ignore
+ distutils.cygwinccompiler.get_msvcr = get_msvcr_overwrite  # type: ignore
+diff --git a/tests/scanner/test_ccompiler.py b/tests/scanner/test_ccompiler.py
+index 6c0674a1..248df21c 100644
+--- a/tests/scanner/test_ccompiler.py
++++ b/tests/scanner/test_ccompiler.py
+@@ -15,6 +15,7 @@
+ # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ # Boston, MA 02111-1307, USA.
+ 
++import setuptools
+ import distutils
+ import os
+ import shlex

--- a/repos/spack_repo/builtin/packages/glib/package.py
+++ b/repos/spack_repo/builtin/packages/glib/package.py
@@ -29,6 +29,7 @@ class Glib(MesonPackage):
     license("LGPL-2.1-or-later")
 
     # Even minor versions are stable, odd minor versions are development, only add even numbers
+    version("2.86.1", sha256="119d1708ca022556d6d2989ee90ad1b82bd9c0d1667e066944a6d0020e2d5e57")
     version("2.82.5", sha256="05c2031f9bdf6b5aba7a06ca84f0b4aced28b19bf1b50c6ab25cc675277cbc3f")
     version("2.82.2", sha256="ab45f5a323048b1659ee0fbda5cecd94b099ab3e4b9abf26ae06aeb3e781fd63")
     version(
@@ -94,6 +95,7 @@ class Glib(MesonPackage):
     depends_on("libffi")
     depends_on("zlib-api")
     depends_on("gettext")
+    depends_on("gir-scanner", when="@2.79:", type="build")
     depends_on("perl", type=("build", "run"))
     extends("python", type=("build", "run"))
     # Uses distutils in gio/gdbus-2.0/codegen/utils.py
@@ -124,7 +126,7 @@ class Glib(MesonPackage):
         gio_tests.filter("'file' : {},", "")
         gio_tests.filter("'gdbus-peer'", "'file'")
         gio_tests.filter("'gdbus-address-get-session' : {},", "")
-        filter_file("'mkenums.py'( : {})*,*", "", "gobject/tests/meson.build")
+        #filter_file("'mkenums.py'( : {})*,*", "", "gobject/tests/meson.build")
         filter_file("'fileutils' : {},", "", "glib/tests/meson.build")
 
     @property

--- a/repos/spack_repo/builtin/packages/glib/package.py
+++ b/repos/spack_repo/builtin/packages/glib/package.py
@@ -126,7 +126,7 @@ class Glib(MesonPackage):
         gio_tests.filter("'file' : {},", "")
         gio_tests.filter("'gdbus-peer'", "'file'")
         gio_tests.filter("'gdbus-address-get-session' : {},", "")
-        #filter_file("'mkenums.py'( : {})*,*", "", "gobject/tests/meson.build")
+        # filter_file("'mkenums.py'( : {})*,*", "", "gobject/tests/meson.build")
         filter_file("'fileutils' : {},", "", "glib/tests/meson.build")
 
     @property

--- a/repos/spack_repo/builtin/packages/glib_bootstrap/package.py
+++ b/repos/spack_repo/builtin/packages/glib_bootstrap/package.py
@@ -1,0 +1,101 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack_repo.builtin.build_systems import meson
+from spack_repo.builtin.build_systems.meson import MesonPackage
+
+from spack.package import *
+
+
+class GlibBootstrap(MesonPackage):
+    """GLib with no dependency on gobject-introspection used to bootstrap a gobject-introspection.
+    """
+
+    homepage = "https://developer.gnome.org/glib/"
+    url = "https://download.gnome.org/sources/glib/2.82/glib-2.82.5.tar.xz"
+    list_url = "https://download.gnome.org/sources/glib"
+    list_depth = 1
+
+    maintainers("michaelkuhn")
+
+    license("LGPL-2.1-or-later")
+
+    # Even minor versions are stable, odd minor versions are development, only add even numbers
+    version("2.86.1", sha256="119d1708ca022556d6d2989ee90ad1b82bd9c0d1667e066944a6d0020e2d5e57")
+    version("2.82.5", sha256="05c2031f9bdf6b5aba7a06ca84f0b4aced28b19bf1b50c6ab25cc675277cbc3f")
+    version("2.82.2", sha256="ab45f5a323048b1659ee0fbda5cecd94b099ab3e4b9abf26ae06aeb3e781fd63")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    with default_args(type="build"):
+        depends_on("meson@1.4:", when="@2.83:")
+        depends_on("meson@1.2:", when="@2.79:")
+        depends_on("pkgconfig", type="build")
+
+    depends_on("libffi")
+    depends_on("zlib-api")
+    depends_on("gettext")
+    depends_on("perl", type=("build", "run"))
+    extends("python", type=("build", "run"))
+    depends_on("pcre2@10.34:", when="@2.74:")
+    depends_on("iconv")
+    depends_on("elf")  # bin/gresource
+
+    def url_for_version(self, version):
+        return f"https://download.gnome.org/sources/glib/{version.up_to(2)}/glib-{version}.tar.xz"
+
+    def patch(self):
+        """A few glib tests have external dependencies / try to access the X server"""
+        # Surgically disable tests which we cannot make pass in a spack build
+        gio_tests = FileFilter("gio/tests/meson.build")
+        gio_tests.filter("if not glib_have_cocoa", "if false")
+        gio_tests.filter("'contenttype' : {},", "")
+        gio_tests.filter("'file' : {},", "")
+        gio_tests.filter("'gdbus-peer'", "'file'")
+        gio_tests.filter("'gdbus-address-get-session' : {},", "")
+        filter_file("'fileutils' : {},", "", "glib/tests/meson.build")
+
+    @property
+    def libs(self):
+        return find_libraries(["libglib*"], root=self.prefix, recursive=True)
+
+
+class MesonBuilder(meson.MesonBuilder):
+
+    @run_after("install")
+    def gettext_libdir(self):
+        # Packages that link to glib were also picking up -lintl from glib's
+        # glib-2.0.pc file. However, packages such as py-pygobject were
+        # bypassing spack's compiler wrapper for linking and thus not finding
+        # the gettext library directory. The patch below explicitly adds the
+        # appropriate -L path.
+        spec = self.spec
+        if (
+            spec.satisfies("@2")
+            and "intl" in spec["gettext"].libs.names
+            and not is_system_path(spec["gettext"].prefix)
+        ):
+            filter_file(
+                "Libs:",
+                "Libs: -L{0} -Wl,-rpath={0} ".format(spec["gettext"].libs.directories[0]),
+                join_path(self.spec["glib-bootstrap"].libs.directories[0], "pkgconfig", "glib-2.0.pc"),
+            )
+
+    def meson_args(self):
+        args = []
+        args.append("-Dlibmount=disabled")
+        args.append("-Ddtrace=false")
+        args.append("-Dsystemtap=false")
+        args.append("-Dselinux=disabled")
+        args.append("-Dgtk_doc=false")
+        args.append("-Dlibelf=enabled")
+        args.append("-Dintrospection=disabled")
+        args.append("-Dglib_debug=disabled")
+        args.append("-Dman=false")
+        args.append("-Dman-pages=false")
+
+        return args

--- a/repos/spack_repo/builtin/packages/glib_bootstrap/package.py
+++ b/repos/spack_repo/builtin/packages/glib_bootstrap/package.py
@@ -11,8 +11,7 @@ from spack.package import *
 
 
 class GlibBootstrap(MesonPackage):
-    """GLib with no dependency on gobject-introspection used to bootstrap a gobject-introspection.
-    """
+    """GLib with no dependency on gobject-introspection used to bootstrap a gobject-introspection."""
 
     homepage = "https://developer.gnome.org/glib/"
     url = "https://download.gnome.org/sources/glib/2.82/glib-2.82.5.tar.xz"
@@ -82,7 +81,9 @@ class MesonBuilder(meson.MesonBuilder):
             filter_file(
                 "Libs:",
                 "Libs: -L{0} -Wl,-rpath={0} ".format(spec["gettext"].libs.directories[0]),
-                join_path(self.spec["glib-bootstrap"].libs.directories[0], "pkgconfig", "glib-2.0.pc"),
+                join_path(
+                    self.spec["glib-bootstrap"].libs.directories[0], "pkgconfig", "glib-2.0.pc"
+                ),
             )
 
     def meson_args(self):

--- a/repos/spack_repo/builtin/packages/gobject_introspection/package.py
+++ b/repos/spack_repo/builtin/packages/gobject_introspection/package.py
@@ -21,6 +21,7 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
 
     license("LGPL-2.0-or-later AND GPL-2.0-or-later AND MIT")
 
+    version("1.86.0", sha256="920d1a3fcedeadc32acff95c2e203b319039dd4b4a08dd1a2dfd283d19c0b9ae")
     version("1.78.1", sha256="bd7babd99af7258e76819e45ba4a6bc399608fe762d83fde3cac033c50841bb4")
     version("1.76.1", sha256="196178bf64345501dcdc4d8469b36aa6fe80489354efe71cb7cb8ab82a3738bf")
     version("1.72.1", sha256="012e313186e3186cf0fde6decb57d970adf90e6b1fac5612fe69cbb5ba99543a")
@@ -46,6 +47,7 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
     depends_on("sed", when="platform=darwin", type="build")
 
     depends_on("cairo+gobject")
+    depends_on("glib@2.86:", when="@1.86", type="link")
     depends_on("glib@2.78:", when="@1.78")
     depends_on("glib@2.76:", when="@1.76")
     depends_on("glib@2.58:", when="@1.60:1.72")


### PR DESCRIPTION
Added new package `glib-bootstrap` and `gir-scanner` to solve circular dependency between `glib@2.79:` and `gobject-introspection`.

The new packages are added according to suggestions in #381 and fixes the issue. To keep the environment clean, a static `g-ir-scanner` was boostrapped first, then used to build `glib` as a pure `build` dependent.

@spackbot fix style
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
