### PR TITLE
Visit: Make blueprint features required together

### DIFF
--- a/repos/spack_repo/builtin/packages/visit/package.py
+++ b/repos/spack_repo/builtin/packages/visit/package.py
@@ -187,6 +187,10 @@ class Visit(CMakePackage):
     depends_on("mfem+shared+exceptions+fms+conduit", when="+mfem")
     depends_on("libfms@0.2:", when="+mfem")
 
+    # The checks in the build system are not consistent
+    requires("+mfem", when="+conduit")
+    requires("+conduit", when="+mfem")
+
     with when("+adios2"):
         depends_on("adios2")
         # adios 2.8 removed adios2_taustubs (https://github.com/visit-dav/visit/issues/19209)


### PR DESCRIPTION
Visit enables blueprints if both MFEM and Conduit are enabled, but then only checks for conduit in source when including blueprint headers.

Instead of patching to apply the checks consistently in the headers just force the variants both on until this is fixed upstream.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
