### PR TITLE
Vtk: make patches that require ipv4 fetches local

### DIFF
--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -94,18 +94,12 @@ class Vtk(CMakePackage):
 
     # Fix missing standard includes that lead to build errors on newer compilers
     # Patch for <limits>
-    patch(
-        "https://gitlab.kitware.com/vtk/vtk/-/commit/e066c3f4fbbfe7470c6207db0fc3f3952db633c.diff",
-        when="@9:9.0",
-        sha256="0546696bd02f3a99fccb9b7c49533377bf8179df16d901cefe5abf251173716d",
-    )
+    # https://gitlab.kitware.com/vtk/vtk/-/commit/e066c3f4fbbfe7470c6207db0fc3f3952db633c
+    patch("vtk_9_include_missing_limits.patch", when="@9:9.0")
     # Patch for <cstdint>
     # See https://gitlab.kitware.com/vtk/vtk/-/issues/18782
-    patch(
-        "https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9996.diff",
-        sha256="dab51ffd0d62b00c089c1245e6b105f740106b53893305c87193d4ba03a948e0",
-        when="@9.1:9.2",
-    )
+
+    patch("vtk_9_1_2_improve_cstdint_includes.patch", when="@9.1:9.2")
 
     # Patch for paraview 5.10: +hdf5 ^hdf5@1.13.2:
     # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9690
@@ -262,31 +256,15 @@ class Vtk(CMakePackage):
     # Freetype@2.10.3 no longer exports FT_CALLBACK_DEF, this
     # patch replaces FT_CALLBACK_DEF with simple extern "C"
     # See https://gitlab.kitware.com/vtk/vtk/-/issues/18033
-    patch(
-        "https://gitlab.kitware.com/vtk/vtk/uploads/c6fa799a1a028b8f8a728a40d26d3fec/vtk-freetype-2.10.3-replace-FT_CALLBACK_DEF.patch",
-        sha256="eefda851f844e8a1dfb4ebd8a9ff92d2b78efc57f205774052c5f4c049cc886a",
-        when="@:9.0.1 ^freetype@2.10.3:",
-    )
+    patch("vtk_freetype_2.10.3_replace_FT_CALLBACK_DEF.patch", when="@:9.0.1 ^freetype@2.10.3:")
 
-    patch(
-        "https://gitlab.kitware.com/vtk/vtk/-/commit/5a1c96e12e9b4a660d326be3bed115a2ceadb573.diff",
-        sha256="c446a90459b108082db5b28d9aeda99d030e636325e01929beba062cafb16b76",
-        when="@9.1",
-    )
+    patch("vtk_module_skip_argless_target_calls.patch", when="@9.1")
 
     # SEACAS >= 2024-06-27 needs c++17 which is already required in VTK master.
-    patch(
-        "https://gitlab.kitware.com/vtk/vtk/-/commit/00afe3ae0def6c2d0a6f7cb497c8d55874127820.diff",
-        sha256="1e5fb55b14ba6455a1891d27aa4a0506f47e3155014af06f97633ae1ef6e9cc2",
-        when="@9.4",
-    )
+    patch("vtk_minimum_version_cpp_17.patch", when="@9.4")
 
     # Needed to build VTK with external SEACAS.
-    patch(
-        "https://gitlab.kitware.com/vtk/vtk/-/commit/e98526813691e527fff7d5df6a1641ae36c0cf4f.diff",
-        sha256="174930dde06828ead84c68b1a192202766f6297a60f0c54eef6cab2605a466ef",
-        when="@9.4",
-    )
+    patch("vtk_ioss_transform_2d_elem_block_to_3d.patch", when="@9.4")
 
     # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=280893
     #  incorrect member accesses fixed in 9.4

--- a/repos/spack_repo/builtin/packages/vtk/vtk_9_1_2_improve_cstdint_includes.patch
+++ b/repos/spack_repo/builtin/packages/vtk/vtk_9_1_2_improve_cstdint_includes.patch
@@ -1,0 +1,42 @@
+diff --git a/IO/Image/vtkSEPReader.h b/IO/Image/vtkSEPReader.h
+index 83d127a41e457e95240bdb335c26a54d36cd1c3a..b9110780f261e35f61dad0d93f6e206a9b9b43ba 100644
+--- a/IO/Image/vtkSEPReader.h
++++ b/IO/Image/vtkSEPReader.h
+@@ -25,8 +25,9 @@
+ #include "vtkImageAlgorithm.h"
+ #include "vtkNew.h" // for ivars
+ 
+-#include <array>  // for std::array
+-#include <string> // for std::string
++#include <array>   // for std::array
++#include <cstdint> // for std::uint8_t and std::uint32_t
++#include <string>  // for std::string
+ 
+ namespace details
+ {
+diff --git a/IO/PIO/PIOData.h b/IO/PIO/PIOData.h
+index 98137f44c1ca30aec961e264ed4165b57176314f..03e59f7c832ed2d9f2c71c1dd0ebc675bf71d282 100644
+--- a/IO/PIO/PIOData.h
++++ b/IO/PIO/PIOData.h
+@@ -1,6 +1,7 @@
+ #if !defined(_PIODATA_H)
+ #define _PIODATA_H
+ 
++#include <cstdint>
+ #include <fstream>
+ #include <iostream>
+ #include <list>
+diff --git a/Rendering/Matplotlib/vtkMatplotlibMathTextUtilities.h b/Rendering/Matplotlib/vtkMatplotlibMathTextUtilities.h
+index ca5445ddf4bb4dac25d60ea87687fd1a264eab80..d0ba449a3c0d917cde563a095a6df6a8cb59f987 100644
+--- a/Rendering/Matplotlib/vtkMatplotlibMathTextUtilities.h
++++ b/Rendering/Matplotlib/vtkMatplotlibMathTextUtilities.h
+@@ -49,7 +49,8 @@
+ #include "vtkMathTextUtilities.h"
+ #include "vtkRenderingMatplotlibModule.h" // For export macro
+ 
+-#include <vector> // for std::vector
++#include <cstdint> // for std::uint64_t
++#include <vector>  // for std::vector
+ 
+ struct _object;
+ typedef struct _object PyObject;

--- a/repos/spack_repo/builtin/packages/vtk/vtk_9_include_missing_limits.patch
+++ b/repos/spack_repo/builtin/packages/vtk/vtk_9_include_missing_limits.patch
@@ -1,0 +1,48 @@
+diff --git a/Common/Core/vtkGenericDataArrayLookupHelper.h b/Common/Core/vtkGenericDataArrayLookupHelper.h
+index ab9d57248f8eb0689dd2d389f69cf74873168c65..202aaa27f4ae9a1b3a6eecfec101b81b59f8fdcf 100644
+--- a/Common/Core/vtkGenericDataArrayLookupHelper.h
++++ b/Common/Core/vtkGenericDataArrayLookupHelper.h
+@@ -25,6 +25,7 @@
+ #include "vtkIdList.h"
+ #include <algorithm>
+ #include <cmath>
++#include <limits>
+ #include <unordered_map>
+ #include <vector>
+ 
+diff --git a/Common/DataModel/vtkPiecewiseFunction.cxx b/Common/DataModel/vtkPiecewiseFunction.cxx
+index 22eca0bc22e17189b37d48e483a0062d90ac035d..11086f1dc421b720d19c72326850c4f04d54cf57 100644
+--- a/Common/DataModel/vtkPiecewiseFunction.cxx
++++ b/Common/DataModel/vtkPiecewiseFunction.cxx
+@@ -22,6 +22,7 @@
+ #include <cassert>
+ #include <cmath>
+ #include <iterator>
++#include <limits>
+ #include <set>
+ #include <vector>
+ 
+diff --git a/Filters/HyperTree/vtkHyperTreeGridThreshold.cxx b/Filters/HyperTree/vtkHyperTreeGridThreshold.cxx
+index a16bb27fc66850f8fd832bbb8f01c36c8a58bbd2..1052192c61635eb7a215ec66648a5fd88dd9fc6a 100644
+--- a/Filters/HyperTree/vtkHyperTreeGridThreshold.cxx
++++ b/Filters/HyperTree/vtkHyperTreeGridThreshold.cxx
+@@ -27,6 +27,7 @@
+ #include "vtkHyperTreeGridNonOrientedCursor.h"
+ 
+ #include <cmath>
++#include <limits>
+ 
+ vtkStandardNewMacro(vtkHyperTreeGridThreshold);
+ 
+diff --git a/Rendering/Core/vtkColorTransferFunction.cxx b/Rendering/Core/vtkColorTransferFunction.cxx
+index 55c046b4df76129611d0f6c65cdafdedb8b5b11c..1be02919ab9043472f819d8a3ff3ef68ade78e18 100644
+--- a/Rendering/Core/vtkColorTransferFunction.cxx
++++ b/Rendering/Core/vtkColorTransferFunction.cxx
+@@ -21,6 +21,7 @@
+ #include <algorithm>
+ #include <cmath>
+ #include <iterator>
++#include <limits>
+ #include <set>
+ #include <vector>
+ 

--- a/repos/spack_repo/builtin/packages/vtk/vtk_freetype_2.10.3_replace_FT_CALLBACK_DEF.patch
+++ b/repos/spack_repo/builtin/packages/vtk/vtk_freetype_2.10.3_replace_FT_CALLBACK_DEF.patch
@@ -1,0 +1,33 @@
+--- VTK-8.2.0/Rendering/FreeType/vtkFreeTypeTools.cxx.orig	2019-01-30 18:15:13.000000000 +0100
++++ VTK-8.2.0/Rendering/FreeType/vtkFreeTypeTools.cxx	2020-10-17 00:21:55.153442255 +0200
+@@ -387,7 +387,7 @@ FTC_CMapCache* vtkFreeTypeTools::GetCMap
+ }
+ 
+ //----------------------------------------------------------------------------
+-FT_CALLBACK_DEF(FT_Error)
++extern "C" FT_Error
+ vtkFreeTypeToolsFaceRequester(FTC_FaceID face_id,
+                               FT_Library lib,
+                               FT_Pointer request_data,
+--- VTK-8.2.0/Rendering/FreeTypeFontConfig/vtkFontConfigFreeTypeTools.cxx.orig	2019-01-30 18:15:13.000000000 +0100
++++ VTK-8.2.0/Rendering/FreeTypeFontConfig/vtkFontConfigFreeTypeTools.cxx	2020-10-17 00:38:23.457937944 +0200
+@@ -26,10 +26,8 @@
+ 
+ vtkStandardNewMacro(vtkFontConfigFreeTypeTools)
+ 
+-namespace
+-{
+ // The FreeType face requester callback:
+-FT_CALLBACK_DEF(FT_Error)
++extern "C" FT_Error
+ vtkFontConfigFreeTypeToolsFaceRequester(FTC_FaceID face_id,
+                                         FT_Library lib,
+                                         FT_Pointer request_data,
+@@ -75,7 +73,6 @@ vtkFontConfigFreeTypeToolsFaceRequester(
+ 
+   return static_cast<FT_Error>(0);
+ }
+-} // end anon namespace
+ 
+ void vtkFontConfigFreeTypeTools::PrintSelf(ostream &os, vtkIndent indent)
+ {

--- a/repos/spack_repo/builtin/packages/vtk/vtk_ioss_transform_2d_elem_block_to_3d.patch
+++ b/repos/spack_repo/builtin/packages/vtk/vtk_ioss_transform_2d_elem_block_to_3d.patch
@@ -1,0 +1,18 @@
+diff --git a/IO/IOSS/vtkIOSSUtilities.cxx b/IO/IOSS/vtkIOSSUtilities.cxx
+index 71d9cfbe55c828b907b6f214fbff1aae7ff55480..f662a06ca6918c9eed7867ffbe3e1705b05593a1 100644
+--- a/IO/IOSS/vtkIOSSUtilities.cxx
++++ b/IO/IOSS/vtkIOSSUtilities.cxx
+@@ -302,10 +302,9 @@ vtkSmartPointer<vtkDataArray> GetData(const Ioss::GroupingEntity* entity,
+   }
+ 
+   // Check for Transient 2D data that should be 3D for WarpByVector/Glyphs
+-  if (entity->type() == vtkioss_Ioss::NODEBLOCK &&
+-    field.get_role() == vtkioss_Ioss::Field::RoleType::TRANSIENT && // Nodal / Elem Variables
+-    entity->get_property("component_degree").get_int() == 2 &&      // dimension 2 mesh nodeblock
+-    field.raw_storage()->component_count() == 2)                    // 2D Vector
++  bool isField2DTransientVector = field.get_role() == Ioss::Field::RoleType::TRANSIENT &&
++    field.raw_storage()->component_count() == 2;
++  if (isField2DTransientVector)
+   {
+     array = ChangeComponents(array, 3);
+   }

--- a/repos/spack_repo/builtin/packages/vtk/vtk_minimum_version_cpp_17.patch
+++ b/repos/spack_repo/builtin/packages/vtk/vtk_minimum_version_cpp_17.patch
@@ -1,0 +1,63 @@
+diff --git a/CMake/vtkCompilerChecks.cmake b/CMake/vtkCompilerChecks.cmake
+index c4452d6dfbd2f8c236ee68970b4c193430f8c5d0..2bef073a823a07b6403097a7f0948fb8dbd10f70 100644
+--- a/CMake/vtkCompilerChecks.cmake
++++ b/CMake/vtkCompilerChecks.cmake
+@@ -1,39 +1,39 @@
+-# Minimum compiler version check: GCC >= 4.8
++# Minimum compiler version check: GCC >= 8.0
+ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
+-    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8)
+-  message(FATAL_ERROR "GCC 4.8 or later is required.")
++    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
++  message(FATAL_ERROR "GCC 8.0 or later is required.")
+ endif ()
+ 
+-# Minimum compiler version check: LLVM Clang >= 3.3
++# Minimum compiler version check: LLVM Clang >= 5.0
+ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND
+-    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.3)
+-  message(FATAL_ERROR "LLVM Clang 3.3 or later is required.")
++    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
++  message(FATAL_ERROR "LLVM Clang 5.0 or later is required.")
+ endif ()
+ 
+-# Minimum compiler version check: Apple Clang >= 7.0 (Xcode 7.2.1)
++# Minimum compiler version check: Apple Clang >= 10.0 (Xcode 10.2.1)
+ if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND
+-    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
+-  message(FATAL_ERROR "Apple Clang 7.0 or later is required.")
++    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.0)
++  message(FATAL_ERROR "Apple Clang 10.0 or later is required.")
+ endif ()
+ 
+-# Minimum compiler version check: Microsoft C/C++ >= 19.0 (aka VS 2015)
++# Minimum compiler version check: Microsoft C/C++ >= 19.10 (aka VS 2017)
+ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND
+-    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.0)
+-  message(FATAL_ERROR "Microsoft Visual Studio 2015 or later is required.")
++    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.10)
++  message(FATAL_ERROR "Microsoft Visual Studio 2017 or later is required.")
+ endif ()
+ 
+-# Minimum compiler version check: Intel C++ (ICC) >= 14
++# Minimum compiler version check: Intel C++ (ICC) >= 19
+ if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel" AND
+-    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14.0)
+-  message(FATAL_ERROR "Intel C++ (ICC) 14.0 or later is required.")
++    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.0)
++  message(FATAL_ERROR "Intel C++ (ICC) 19.0 or later is required.")
+ endif ()
+ 
+-# Make sure we have C++11 enabled.
+-if(NOT VTK_IGNORE_CMAKE_CXX11_CHECKS)
++# Make sure we have C++17 enabled.
++if(NOT VTK_IGNORE_CMAKE_CXX17_CHECKS)
+   # Needed to make sure libraries and executables not built by the
+-  # vtkModuleMacros still have the C++11 compiler flags enabled
++  # vtkModuleMacros still have the C++17 compiler flags enabled
+   # Wrap this in an escape hatch for unknown compilers
+-  set(CMAKE_CXX_STANDARD 11)
++  set(CMAKE_CXX_STANDARD 17)
+   set(CMAKE_CXX_STANDARD_REQUIRED True)
+   set(CMAKE_CXX_EXTENSIONS False)
+ endif()

--- a/repos/spack_repo/builtin/packages/vtk/vtk_module_skip_argless_target_calls.patch
+++ b/repos/spack_repo/builtin/packages/vtk/vtk_module_skip_argless_target_calls.patch
@@ -1,0 +1,82 @@
+diff --git a/CMake/vtkModule.cmake b/CMake/vtkModule.cmake
+index 9f12fcf1964af3ff5c1c729f70e4abe80e73d8f0..bf21f6b3c14f8a4993083d92c3ac345ba5d19a65 100644
+--- a/CMake/vtkModule.cmake
++++ b/CMake/vtkModule.cmake
+@@ -1485,6 +1485,12 @@ function (vtk_module_include module)
+     set(_vtk_include_system_arg SYSTEM)
+   endif ()
+ 
++  if (NOT _vtk_include_INTERFACE_args AND
++      NOT _vtk_include_PUBLIC_args AND
++      NOT _vtk_include_PRIVATE_args)
++    return ()
++  endif ()
++
+   target_include_directories("${_vtk_include_target}"
+     ${_vtk_include_system_arg}
+     ${_vtk_include_INTERFACE_args}
+@@ -1520,6 +1526,12 @@ function (vtk_module_definitions module)
+   _vtk_module_real_target(_vtk_definitions_target "${module}")
+   _vtk_module_target_function(_vtk_definitions)
+ 
++  if (NOT _vtk_definitions_INTERFACE_args AND
++      NOT _vtk_definitions_PUBLIC_args AND
++      NOT _vtk_definitions_PRIVATE_args)
++    return ()
++  endif ()
++
+   target_compile_definitions("${_vtk_definitions_target}"
+     ${_vtk_definitions_INTERFACE_args}
+     ${_vtk_definitions_PUBLIC_args}
+@@ -1554,6 +1566,12 @@ function (vtk_module_compile_options module)
+   _vtk_module_real_target(_vtk_compile_options_target "${module}")
+   _vtk_module_target_function(_vtk_compile_options)
+ 
++  if (NOT _vtk_compile_options_INTERFACE_args AND
++      NOT _vtk_compile_options_PUBLIC_args AND
++      NOT _vtk_compile_options_PRIVATE_args)
++    return ()
++  endif ()
++
+   target_compile_options("${_vtk_compile_options_target}"
+     ${_vtk_compile_options_INTERFACE_args}
+     ${_vtk_compile_options_PUBLIC_args}
+@@ -1588,6 +1606,12 @@ function (vtk_module_compile_features module)
+   _vtk_module_real_target(_vtk_compile_features_target "${module}")
+   _vtk_module_target_function(_vtk_compile_features)
+ 
++  if (NOT _vtk_compile_features_INTERFACE_args AND
++      NOT _vtk_compile_features_PUBLIC_args AND
++      NOT _vtk_compile_features_PRIVATE_args)
++    return ()
++  endif ()
++
+   target_compile_features("${_vtk_compile_features_target}"
+     ${_vtk_compile_features_INTERFACE_args}
+     ${_vtk_compile_features_PUBLIC_args}
+@@ -1710,6 +1734,12 @@ function (vtk_module_link module)
+     endif ()
+   endif ()
+ 
++  if (NOT _vtk_link_INTERFACE_args AND
++      NOT _vtk_link_PUBLIC_args AND
++      NOT _vtk_link_PRIVATE_args)
++    return ()
++  endif ()
++
+   target_link_libraries("${_vtk_link_target}"
+     ${_vtk_link_INTERFACE_args}
+     ${_vtk_link_PUBLIC_args}
+@@ -1744,6 +1774,12 @@ function (vtk_module_link_options module)
+   _vtk_module_real_target(_vtk_link_options_target "${module}")
+   _vtk_module_target_function(_vtk_link_options)
+ 
++  if (NOT _vtk_link_options_INTERFACE_args AND
++      NOT _vtk_link_options_PUBLIC_args AND
++      NOT _vtk_link_options_PRIVATE_args)
++    return ()
++  endif ()
++
+   target_link_options("${_vtk_link_options_target}"
+     ${_vtk_link_options_INTERFACE_args}
+     ${_vtk_link_options_PUBLIC_args}


### PR DESCRIPTION
Some SC networks are now ipv6 only, and these patches reference links that are ipv4 only, make the patches local so fetch source does not introduce errors.

cc @kwryankrattiger 