### PR TITLE
r-stanheaders: add missing c dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/r_stanheaders/package.py
+++ b/repos/spack_repo/builtin/packages/r_stanheaders/package.py
@@ -36,6 +36,8 @@ class RStanheaders(RPackage):
     version("2.17.1", sha256="4300a1910a2eb40d7a6ecabea3c1e26f0aa9421eeb3000689272a0f62cb80d97")
     version("2.10.0-2", sha256="ce4e335172bc65da874699302f6ba5466cdbcf69458c11954c0f131fc78b59b7")
 
+    depends_on("c", type=("build"))
+
     depends_on("r+X", type=("build", "run"))
     depends_on("r@3.4.0:", type=("build", "run"), when="@2.18.0:")
     depends_on("r-rcppparallel@5.0.1:", type=("build", "run"), when="@2.21.0:")


### PR DESCRIPTION
depends on #2157 and  #2159

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
