### PR TITLE
compiler dependency: octave_struct depends on cxx + new version 1.0.18

### DIFF
--- a/repos/spack_repo/builtin/packages/octave_struct/package.py
+++ b/repos/spack_repo/builtin/packages/octave_struct/package.py
@@ -16,6 +16,8 @@ class OctaveStruct(OctavePackage, SourceforgePackage):
 
     license("GPL-3.0-only")
 
+    version("1.0.18", sha256="fccea7dd84c1104ed3babb47a28f05e0012a89c284f39ab094090450915294ce")
     version("1.0.17", sha256="0137bbb5df650f29104f6243502f3a2302aaaa5e42ea9f02d8a3943aaf668433")
     version("1.0.14", sha256="ad4e17687bc24650f032757271b20b70fe32c35513d4dd9ab1e549919df36b47")
+    depends_on("cxx", type="build")
     extends("octave@2.9.7:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
New version compiles with recent compiler (gcc 13.3.0 from Ubuntu 24) and octave 9.4.0 at least.