### PR TITLE
compiler dependency: octave_optim depends on cxx + new version 1.6.2

### DIFF
--- a/repos/spack_repo/builtin/packages/octave_optim/package.py
+++ b/repos/spack_repo/builtin/packages/octave_optim/package.py
@@ -14,10 +14,12 @@ class OctaveOptim(OctavePackage, SourceforgePackage):
     homepage = "https://octave.sourceforge.io/optim/"
     sourceforge_mirror_path = "octave/optim-1.5.2.tar.gz"
 
+    version("1.6.2", sha256="554a8e18bb7195ae861f5059c14f1a557844265c1addb5bfbf3ab9885524787e")
     version("1.6.1", sha256="7150cdfac7e9da31ec7ac1cfe8619d9c0e9c8b3f787f54bf89e0fb1c275be584")
     version("1.5.2", sha256="7b36033c5581559dc3e7616f97d402bc44dde0dfd74c0e3afdf47d452a76dddf")
 
     depends_on("octave-struct@1.0.12:")
     depends_on("octave-statistics@1.4.0:")
+    depends_on("cxx", type="build")
     extends("octave@3.6.0:", when="@:1.5.2")
     extends("octave@4.0.0:", when="@1.6.1:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
New version compiles with recent compiler (gcc 13.3.0 from Ubuntu 24) and octave 9.4.0.
It fails (as the the previous versions) with octave 10.2, but this is a known bug:
https://savannah.gnu.org/bugs/index.php?67189