### PR TITLE
qt-*: update ecosystem and py-pyqt6: fix build

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pyqt6/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyqt6/package.py
@@ -16,6 +16,7 @@ class PyPyqt6(SIPPackage):
 
     license("GPL-3.0-or-later")
 
+    version("6.10.0", sha256="710ecfd720d9a03b2c684881ae37f528e11d17e8f1bf96431d00a6a73f308e36")
     version("6.9.1", sha256="50642be03fb40f1c2111a09a1f5a0f79813e039c15e78267e6faaf8a96c1c3a6")
     version("6.7.0", sha256="3d31b2c59dc378ee26e16586d9469842483588142fc377280aad22aaf2fa6235")
     version("6.6.1", sha256="9f158aa29d205142c56f0f35d07784b8df0be28378d20a97bcda8bd64ffd0379")
@@ -27,9 +28,11 @@ class PyPyqt6(SIPPackage):
     # pyproject.toml
     depends_on("python@3.9:", type=("build", "run"), when="@6.8:")
     depends_on("python@3.8:", type=("build", "run"), when="@6.7:")
+    depends_on("py-sip@6.13.1:6", type="build", when="@6.10:")
     depends_on("py-sip@6.12:6", type="build", when="@6.9.1:")
     depends_on("py-sip@6.8:6", type="build", when="@6.7:")
     depends_on("py-sip@6.5:6", type="build", when="@:6.6")
+    depends_on("py-pyqt-builder@1.19:1", type="build", when="@6.10:")
     depends_on("py-pyqt-builder@1.17:1", type="build", when="@6.8:")
     depends_on("py-pyqt-builder@1.15:1", type="build")
 
@@ -39,7 +42,7 @@ class PyPyqt6(SIPPackage):
     depends_on("py-pyqt6-sip@13.4:13", type=("build", "run"), when="@:6.5.2")
 
     # README
-    depends_on("qt-base@6")
+    depends_on("qt-base@6+gui+accessibility")
 
     def url_for_version(self, version):
         if version >= Version("6.8.1"):

--- a/repos/spack_repo/builtin/packages/py_pyqt_builder/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyqt_builder/package.py
@@ -15,6 +15,7 @@ class PyPyqtBuilder(PythonPackage):
 
     license("GPL-2.0-or-later")
 
+    version("1.19.0", sha256="79540e001c476bc050180db00fffcb1e9fa74544d95c148e48ad6117e49d6ea2")
     version("1.18.2", sha256="56dfea461484a87a8f0c8b0229190defc436d7ec5de71102e20b35e5639180bc")
     version("1.15.1", sha256="a2bd3cfbf952e959141dfe55b44b451aa945ca8916d1b773850bb2f9c0fa2985")
     version("1.12.2", sha256="f62bb688d70e0afd88c413a8d994bda824e6cebd12b612902d1945c5a67edcd7")

--- a/repos/spack_repo/builtin/packages/py_sip/package.py
+++ b/repos/spack_repo/builtin/packages/py_sip/package.py
@@ -17,6 +17,7 @@ class PySip(PythonPackage):
 
     license("GPL-2.0-or-later")
 
+    version("6.14.0", sha256="20c086aba387707b34cf47fd96d1a978d01e2b95807e86f8aaa960081f163b28")
     version("6.12.0", sha256="083ced94f85315493231119a63970b2ba42b1d38b38e730a70e02a99191a89c6")
     version("6.8.5", sha256="5dddd5966e9875d89ecde9d3e6ac63225f9972e4d25c09e20fa22f1819409c70")
     version("6.7.9", sha256="35d51fc10f599d3696abb50f29d068ad04763df7b77808c76b74597660f99b17")

--- a/repos/spack_repo/builtin/packages/qt_base/package.py
+++ b/repos/spack_repo/builtin/packages/qt_base/package.py
@@ -148,6 +148,7 @@ class QtBase(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.10.0", sha256="6bc0cab63e70ef9634825de47790409079e00da77bad18d036b7ab83c5618346")
     version("6.9.1", sha256="487e49508b8b4bb74908882cde04d3473f2c783651c72c75ee4a2a4691788263")
     version("6.9.0", sha256="defc1b7e6a98f0093254126b1cd80681f1d2a170df127d60c6297358ced43090")
     version("6.8.3", sha256="cea5c8f2c20d9cbd684f8a402721e63b87a2886e906f6ec7e0f7e1ff69c83206")

--- a/repos/spack_repo/builtin/packages/qt_declarative/package.py
+++ b/repos/spack_repo/builtin/packages/qt_declarative/package.py
@@ -16,6 +16,7 @@ class QtDeclarative(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.10.0", sha256="d5dcb10bd3152cfc616afababaa2cd7ea21119bdd03239700d37690c0db8211e")
     version("6.9.1", sha256="00f09b210c7c4268646645baf39fa436563f1cfc232f12ce0b2d37f9bb83da94")
     version("6.9.0", sha256="b6ef116dba80badf1cf36efc111e164edc4dd7e47c568d5d35165c6e8bca2c5d")
     version("6.8.3", sha256="e5e0d67236bf0a436f0dda6363c7a31085c9a8147f92f817c3fa817186a5a151")

--- a/repos/spack_repo/builtin/packages/qt_quick3d/package.py
+++ b/repos/spack_repo/builtin/packages/qt_quick3d/package.py
@@ -16,6 +16,7 @@ class QtQuick3d(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.10.0", sha256="4a87e5c8f9f187a672af15da8bd1e412fe745d57d71a1df32e4114f340b72ffe")
     version("6.9.1", sha256="127ea0306c5ca1a67d90b13c8d60a21b8e52ade007853bac7bcbf55af61ae0db")
     version("6.9.0", sha256="49c743ca41528787fb26057e603854c115a85efb3edb56977e49bf81ba3fada0")
     version("6.8.3", sha256="7a6d2087a5112b1d1bfe7455ae023418a2d5f6ef6d3d8de8ccdcef979a7cdd17")

--- a/repos/spack_repo/builtin/packages/qt_quicktimeline/package.py
+++ b/repos/spack_repo/builtin/packages/qt_quicktimeline/package.py
@@ -16,6 +16,7 @@ class QtQuicktimeline(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.10.0", sha256="6af28c87896cf93f1033965323a80a9e5dd7ed004ecfa30826fe8056216f4102")
     version("6.9.1", sha256="b9e06d733003097fa72ec4987c44ef6967ff9e630770e8cb6763a65d20d97532")
     version("6.9.0", sha256="5945693d20ca9ab753ff2cb0324c2535b47db86072c6652b26d90f34f768c5e4")
     version("6.8.3", sha256="e2129c5a4301ba8c8805837f399178d24f9eeea1757fd14cb5053e6b8ea3f260")

--- a/repos/spack_repo/builtin/packages/qt_shadertools/package.py
+++ b/repos/spack_repo/builtin/packages/qt_shadertools/package.py
@@ -18,6 +18,7 @@ class QtShadertools(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.10.0", sha256="da7721256607e0074b0d959c61b6e1b422b5b7d0ad2a30b0e409aa9d8afc3d1f")
     version("6.9.1", sha256="c2aafc1f28a59e69f19494211763948cc8f69f71d22fdbdbefd418e40c267b86")
     version("6.9.0", sha256="27bdda7abee92d6573e2b3ecc9113eb2f625a3ae952693d6cfc45c4062987ec9")
     version("6.8.3", sha256="b6c6cf0006476a219f8f3494ae0f356c8ca98cdd6be43dd9b105d7bea17d0ea0")

--- a/repos/spack_repo/builtin/packages/qt_svg/package.py
+++ b/repos/spack_repo/builtin/packages/qt_svg/package.py
@@ -18,6 +18,7 @@ class QtSvg(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.10.0", sha256="bda1574665edc73d08fc5ed0575a65f28e6fa5be2fcdeaae613bebd114a6a982")
     version("6.9.1", sha256="4b6b98dde835263a344c5bd696c3aae36f20239daaf42a3b38057dc85c739085")
     version("6.9.0", sha256="2f58d8c021b3d221204c1f623f84a6ba5f69d5fcdf9bd26b8c2da2934cf90444")
     version("6.8.3", sha256="fb53da582e98d23cbf6e8bedb71efb60720e61a982d31a741742c543e2f3838d")

--- a/repos/spack_repo/builtin/packages/qt_tools/package.py
+++ b/repos/spack_repo/builtin/packages/qt_tools/package.py
@@ -20,6 +20,7 @@ class QtTools(QtPackage):
     license("BSD-3-Clause")
 
     # src/assistant/qlitehtml is a submodule that is not in the git archive
+    version("6.10.0", commit="f33c4bb1dee569eec4ffe1333584cb4b75af6c59", submodules=True)
     version("6.9.1", commit="9e8f157b49c78c05abf8fa87da21e04cdf09780c", submodules=True)
     version("6.9.0", commit="087e300bf286aaee92682d828ee0bd622e00d52a", submodules=True)
     version("6.8.3", commit="2649ea1aa5cc1c23bd920ae94dd50071315ea30f", submodules=True)


### PR DESCRIPTION
Without `qt-base+accessibility` building `py-pyqt6` fails with the following error:
```
4 errors found in build log:
     1476          |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
     1477    In file included from /tmp/root/spack-stage/spack-stage-py-pyqt6-6.10.0-z2kctdjbd6smkgointjgbkkij5up4d2a/spack-src/sip/QtWidgets/qapplication.sip:28:
     1478    /spack/opt/spack/linux-skylake/qt-base-6.10.0-75keg3lwnsi5rgvxuibsf2xdfabsma3k/include/QtWidgets/qapplication.h:84:17: note: declared here
     1479       84 |     static void setActiveWindow(QWidget* act);
     1480          |                 ^~~~~~~~~~~~~~~
     1481    /tmp/root/spack-stage/spack-stage-py-pyqt6-6.10.0-z2kctdjbd6smkgointjgbkkij5up4d2a/spack-src/build/QtWidgets/sipQtWidgetsQWidget.cpp: In function 'PyObject* meth_QWidget_accessibleIdentifier(PyObjec
             t*, PyObject*)':
  >> 1482    /tmp/root/spack-stage/spack-stage-py-pyqt6-6.10.0-z2kctdjbd6smkgointjgbkkij5up4d2a/spack-src/build/QtWidgets/sipQtWidgetsQWidget.cpp:8683:44: error: 'const class QWidget' has no member named 'access
             ibleIdentifier'
     1483     8683 |             sipRes = new ::QString(sipCpp->accessibleIdentifier());
     1484          |                                            ^~~~~~~~~~~~~~~~~~~~
     1485    /tmp/root/spack-stage/spack-stage-py-pyqt6-6.10.0-z2kctdjbd6smkgointjgbkkij5up4d2a/spack-src/build/QtWidgets/sipQtWidgetsQWidget.cpp: In function 'PyObject* meth_QWidget_setAccessibleIdentifier(PyOb
             ject*, PyObject*)':
  >> 1486    /tmp/root/spack-stage/spack-stage-py-pyqt6-6.10.0-z2kctdjbd6smkgointjgbkkij5up4d2a/spack-src/build/QtWidgets/sipQtWidgetsQWidget.cpp:8709:21: error: 'class QWidget' has no member named 'setAccessibl
             eIdentifier'
     1487     8709 |             sipCpp->setAccessibleIdentifier(*a0);
     1488          |                     ^~~~~~~~~~~~~~~~~~~~~~~
  >> 1489    make[1]: *** [Makefile:82291: sipQtWidgetsQWidget.o] Error 1
     1490    make[1]: *** Waiting for unfinished jobs....
     1491    make[1]: Leaving directory '/tmp/root/spack-stage/spack-stage-py-pyqt6-6.10.0-z2kctdjbd6smkgointjgbkkij5up4d2a/spack-src/build/QtWidgets'
  >> 1492    make: *** [Makefile:139: sub-QtWidgets-make_first-ordered] Error 2
```
It seems that is because of changes in the concretizer (in August the build on the same system worked fine). Forcing the variants to be enabled fixes the issues. 

While at it (and trying to find out the problem), I also updated the related packages to the newest versions.
`py-pyqt6`: https://pypi.org/project/PyQt6/#files
`py-pyqt-builder`: https://github.com/Python-PyQt/PyQt-builder/tree/1.19.0
`py-sip`: https://github.com/Python-SIP/sip/tree/6.14.0
`qt-base`: https://github.com/qt/qtbase/tree/v6.10.0

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
