### PR TITLE
compiler dependency: octave_instrctl new version 0.9.5

### DIFF
--- a/repos/spack_repo/builtin/packages/octave_instrctl/package.py
+++ b/repos/spack_repo/builtin/packages/octave_instrctl/package.py
@@ -15,6 +15,7 @@ class OctaveInstrctl(OctavePackage, SourceforgePackage):
     homepage = "https://octave.sourceforge.io/instrument-control/"
     sourceforge_mirror_path = "octave/instrument-control-0.3.1.tar.gz"
 
+    version("0.9.5", sha256="426d5a17e75b870ac351287c56224709921cd03899d63235d7b4e74a49eacd7d")
     version("0.3.1", sha256="d9c3b2e258cc8245ebfdd282e6314af12987daf453f4356555f56ca5ec55873c")
 
     depends_on("cxx", type="build")  # generated


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This version is >= 0.5.0 demanded by octave_arduino >= 0.12.2