### PR TITLE
compiler dependency: octave_splines depends on cxx + new version 1.3.5

### DIFF
--- a/repos/spack_repo/builtin/packages/octave_splines/package.py
+++ b/repos/spack_repo/builtin/packages/octave_splines/package.py
@@ -16,6 +16,9 @@ class OctaveSplines(OctavePackage, SourceforgePackage):
 
     license("GPL-3.0-or-later")
 
+    version("1.3.5", sha256="af886877797c3a9c8a36ce7d94613c1059f79fab4883429e7b32a3b01e03d7a6")
     version("1.3.3", sha256="0a4bf9544b1fedb4aed4222eff1333928b0e3c903f140822eb857585e0d5919b")
     version("1.3.1", sha256="f9665d780c37aa6a6e17d1f424c49bdeedb89d1192319a4e39c08784122d18f9")
+
+    depends_on("cxx", type="build")  # generated
     extends("octave@3.6.0:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This new version compiles with recent compiler (gcc 13.3.0 from Ubuntu 24) and octave 9.4.0 at least.