### PR TITLE
compiler dependency: octave_symbolic depends on cxx + new version 3.2.2

### DIFF
--- a/repos/spack_repo/builtin/packages/octave_symbolic/package.py
+++ b/repos/spack_repo/builtin/packages/octave_symbolic/package.py
@@ -20,6 +20,8 @@ class OctaveSymbolic(OctavePackage, SourceforgePackage):
 
     license("GPL-3.0-only")
 
+    version("3.2.2", sha256="8eb492408ec5aafe4e196ec5bdbd2298e0ac068d2b754948f34b9082b9126b37")
     version("2.9.0", sha256="089ec44a0a49417a8b78797e87f338da6a6e227509f3080724996483d39b23cb")
 
+    depends_on("cxx", type="build")
     extends("octave@4.2.0:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
New version compiles with recent compiler (gcc 13.3.0 from Ubuntu 24) and octave 9.4.0 at least.