### PR TITLE
add `gfx942` to `rocm-openmp-extras`

### DIFF
--- a/repos/spack_repo/builtin/packages/rocm_openmp_extras/package.py
+++ b/repos/spack_repo/builtin/packages/rocm_openmp_extras/package.py
@@ -377,7 +377,7 @@ class RocmOpenmpExtras(Package):
         gfx_list = "gfx700 gfx701 gfx801 gfx803 gfx900 gfx902 gfx906 gfx908"
 
         if self.spec.version >= Version("4.3.1"):
-            gfx_list = gfx_list + " gfx90a gfx1030 gfx1031"
+            gfx_list = gfx_list + " gfx90a gfx1030 gfx1031 gfx942"
         env.set("GFXLIST", gfx_list)
         if self.spec.satisfies("%cxx=gcc"):
             env.prepend_path("LD_LIBRARY_PATH", self.spec["gcc-runtime"].prefix.lib)


### PR DESCRIPTION
The target for MI300 was missing in `rocm-openmp-extras`. 
Question for the maintainers @srekolam @renjithravindrankannath is there a reason why the `gfx_list` is hardcoded and not read from `amdgpu_target`?

I've tested compilation for `6.3.3`, not sure what the minimum supported version is for `gfx942`.