### PR TITLE
vtk: version bump to 9.5.2, cleanup deps and externals logic

### DIFF
--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -78,7 +78,6 @@ class Vtk(CMakePackage):
         ).with_default("cgns,exodusii,ioss,netcdf"),
         description="Enable IO modules",
     )
-    requires("io=adios2", when="io=fides")
 
     variant(
         "raytracing",
@@ -87,6 +86,43 @@ class Vtk(CMakePackage):
     )
     variant("advanced_debug", default=False, description="Enable the VTK_DEBUG_LEAKS flag")
 
+    # === 3rd party dependencies
+    depends_on("expat")
+
+    depends_on("hdf5~mpi", when="~mpi")
+    depends_on("hdf5+mpi", when="+mpi")
+    depends_on("hdf5@1.10:", when="@9.1:")
+    depends_on("hdf5@1.8:", when="@8:9.0")
+
+    depends_on("freetype")
+    # https://gitlab.kitware.com/vtk/vtk/-/issues/18033
+    depends_on("freetype @:2.10.2", when="@:9.0.1")
+
+    depends_on("py-mpi4py", when="+python+mpi", type="run")
+
+    depends_on("jpeg")
+    depends_on("jsoncpp")
+    depends_on("libxml2")
+    depends_on("lz4")
+    depends_on("libpng")
+    depends_on("libtiff")
+    depends_on("nlohmann-json", when="@9.2:")
+    depends_on("zlib-api")
+    depends_on("eigen@:3", when="@8.2.0:")
+    depends_on("double-conversion", when="@8.2.0:9.5")
+    depends_on("sqlite", when="@8.2.0:")
+    depends_on("pugixml", when="@9:")
+    depends_on("libtheora")
+    depends_on("utf8cpp", when="@9:")
+
+    # "8.2.1a" uses an internal proj so this special cases 8.2.1a
+    depends_on("proj@4:7", when="@:8.2.0, 9:9.1")  # TODO verify this
+    depends_on("proj@8:", when="@9.2:")  # TODO upper bound?
+
+    # TODO conditional NOT ANDROID AND NOT APPLE_IOS AND NOT VTK_OPENGL_USE_GLES
+    depends_on("gl2ps", when="@8.1:")
+    depends_on("gl2ps@1.4.1:", when="@9:")
+
     with when("@9.5:"):
         depends_on("cli11")
         depends_on("fast-float")
@@ -94,42 +130,93 @@ class Vtk(CMakePackage):
         depends_on("fmt")
         depends_on("fmt@11", when="@:9.5.2")
         depends_on("libharu")
-        depends_on("libproj")
         depends_on("lzma")
         depends_on("pegtl")
         depends_on("pegtl@3", when="@:9.5.2")
         depends_on("scnlib")
         depends_on("verdict")
 
-        # depends_on("cgns") # conditional?
-        # depends_on("double-conversion", when="@:9.5")
-        # depends_on("eigen")
-        # depends_on("expat")
-        # depends_on("freetype")
-        # depends_on("gl2ps")
-        # depends_on("hdf5")
-        # depends_on("jpeg")
-        # depends_on("jsoncpp")
-        # depends_on("libogg")
-        # depends_on("libpng")
-        # depends_on("libtheora")
-        # depends_on("libtiff")
-        # depends_on("libxml2")
-        # depends_on("lz4")
-        # depends_on("netcdf-c")  # conditional?
-        # depends_on("nlohmann-json")
-        # depends_on("pugixml")
-        # depends_on("py-mpi4py")  # conditional?
-        # depends_on("seacas")  # conditional?
-        # depends_on("sqlite")
-        # depends_on("utf8cpp")
-        # depends_on("zlib-api")
-
-        # EXCLUDED
+        # currently excluded
         # depends_on("viskores")
         # depends_on("token")
         # depends_on("exprtk")
 
+    # === 2nd-level DEPENDENCIES, for 3rd party libraries built internally
+    with when("@:8 io=xdmf"):
+        depends_on("mpi", when="+mpi")
+
+        depends_on("boost")
+        depends_on("boost+mpi", when="+mpi")
+
+        # TODO: replace this with an explicit list of components of Boost,
+        # for instance depends_on('boost +filesystem')
+        # See https://github.com/spack/spack/pull/22303 for reference
+        depends_on(Boost.with_default_variants, when="io=xdmf")
+
+    depends_on("mpi", when="+mpi")  # for builing viskores internally
+
+    # just for theora WIP check when theora stopped being built internally
+    depends_on("libogg", when="@:8")
+
+    # === CONDITIONAL DEPENDENCIES
+    depends_on("adios2+mpi", when="io=adios2 +mpi")
+    depends_on("adios2~mpi", when="io=adios2 ~mpi")
+    requires("io=adios2", when="@:8 io=fides")
+
+    depends_on("ffmpeg", when="io=ffmpeg")
+
+    with when("io=cgns"):
+        with when("@9:"):
+            depends_on("cgns@4.1.1:")
+            depends_on("cgns+mpi", when="+mpi")
+            depends_on("cgns~mpi", when="~mpi")
+
+    # VTK introduced Seacas IOSS dependency on 9.1
+    with when("@9.1: io=ioss"):
+        depends_on("seacas+mpi", when="+mpi")
+        depends_on("seacas~mpi", when="~mpi")
+
+        depends_on("seacas@2021-05-12:2022-10-14", when="@9.1")
+        # vtk@9.2: need Ioss::Utils::get_debug_stream() which only 2022-10-14 provides,
+        # and to be safe against other issues, make them build with this version only:
+        depends_on("seacas@2022-10-14", when="@9.2:9.3")
+        depends_on("seacas@2024-06-27", when="@9.4:")
+        # TODO probably we can bump version
+
+    with when("@9: io=netcdf"):
+        depends_on("netcdf-c ~mpi", when="~mpi")
+        depends_on("netcdf-c +mpi", when="+mpi")
+        depends_on("netcdf-c@:4.9.2")
+    depends_on("netcdf-cxx4", when="io=netcdf @:8.1.2")
+
+    depends_on("ospray@2.1:2", when="raytracing=ospray")
+    depends_on("openimagedenoise", when="raytracing=ospray")
+    depends_on("ospray +mpi", when="raytracing=ospray +mpi")
+
+    # VTK will need Qt5OpenGL, and qt needs '-opengl' for that
+    depends_on("qt+opengl", when="+qt")
+
+    # === TODO TO BE CHECKED
+
+    # The use of the OpenGL2 backend requires at least OpenGL Core Profile
+    # version 3.2 or higher.
+    depends_on("gl@3.2:", when="+opengl2")
+    depends_on("gl@1.2:", when="~opengl2")
+
+    depends_on("xz")
+    depends_on("libxt", when="^[virtuals=gl] glx platform=linux")  # just for x11? web?
+    depends_on("glew")  # viskores
+
+    # === PYTHON
+    # Based on PyPI wheel availability
+    with when("+python"), default_args(type=("build", "link", "run")):
+        extends("python@:3.13")
+        extends("python@:3.12", when="@:9.3")
+        extends("python@:3.11", when="@:9.2")
+        extends("python@:3.10", when="@:9.2.2")
+        extends("python@:3.9", when="@:9.1")
+
+    # === PATCHES
     patch("gcc.patch", when="@6.1.0")
 
     # Fix missing standard includes that lead to build errors on newer compilers
@@ -161,17 +248,6 @@ class Vtk(CMakePackage):
     # has a bogus version check for GCC/Intel version to early exit. This drops the early exit.
     patch("vtk-bogus-compiler-check.patch", when="@7.1:8")
 
-    # Based on PyPI wheel availability
-    with when("+python"), default_args(type=("build", "link", "run")):
-        extends("python@:3.13")
-        extends("python@:3.12", when="@:9.3")
-        extends("python@:3.11", when="@:9.2")
-        extends("python@:3.10", when="@:9.2.2")
-        extends("python@:3.9", when="@:9.1")
-
-    # We need mpi4py if buidling python wrappers and using MPI
-    depends_on("py-mpi4py", when="+python+mpi", type="run")
-
     # python3.7 compatibility patch backported from upstream
     # https://gitlab.kitware.com/vtk/vtk/commit/706f1b397df09a27ab8981ab9464547028d0c322
     patch("python3.7-const-char.patch", when="@7.0.0:8.1.1 ^python@3.7:")
@@ -195,12 +271,6 @@ class Vtk(CMakePackage):
     # Fix link error in exodusII
     patch("vtk-8.2-exodusII-gcc11.patch", when="@8.2.1a")
 
-    # The use of the OpenGL2 backend requires at least OpenGL Core Profile
-    # version 3.2 or higher.
-    depends_on("gl@3.2:", when="+opengl2")
-    depends_on("gl@1.2:", when="~opengl2")
-
-    depends_on("xz")
     patch("vtk_find_liblzma.patch", when="@8.2")
     patch("vtk_movie_link_ogg.patch", when="@8.2")
     patch("vtk_use_sqlite_name_vtk_expects.patch", when="@8.2")
@@ -220,75 +290,6 @@ class Vtk(CMakePackage):
     # be fixed by bumping CMake lower bound, because VTK vendors FindHDF5.cmake. Various other
     # patches to FindHDF5.cmake are missing, so add conflict instead of a series of patches.
     conflicts("@9.0 platform=windows")
-    depends_on("libxt", when="^[virtuals=gl] glx platform=linux")
-
-    # VTK will need Qt5OpenGL, and qt needs '-opengl' for that
-    depends_on("qt+opengl", when="+qt")
-
-    depends_on("boost", when="io=xdmf")
-    depends_on("boost+mpi", when="io=xdmf +mpi")
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants, when="io=xdmf")
-    depends_on("ffmpeg", when="io=ffmpeg")
-    depends_on("mpi", when="+mpi")
-
-    depends_on("adios2+mpi", when="io=adios2 +mpi")
-    depends_on("adios2~mpi", when="io=adios2 ~mpi")
-    depends_on("expat")
-    # See <https://gitlab.kitware.com/vtk/vtk/-/issues/18033> for why vtk doesn't
-    # work yet with freetype 2.10.3 (including possible patches)
-    depends_on("freetype @:2.10.2", when="@:9.0.1")
-    depends_on("freetype")
-    depends_on("glew")
-    depends_on("hdf5~mpi", when="~mpi")
-    depends_on("hdf5+mpi", when="+mpi")
-    depends_on("hdf5@1.8:", when="@8:9.0")
-    depends_on("hdf5@1.10:", when="@9.1:")  # TODO upper bound?
-    depends_on("jpeg")
-    depends_on("jsoncpp")
-    depends_on("libxml2")
-    depends_on("lz4")
-    depends_on("netcdf-c@:4.9.2", when="io=exodusii")
-    depends_on("netcdf-c@:4.9.2~mpi", when="io=netcdf ~mpi")
-    depends_on("netcdf-c@:4.9.2+mpi", when="io=netcdf +mpi")
-    depends_on("netcdf-cxx4", when="io=netcdf @:8.1.2")
-    depends_on("libpng")
-    depends_on("libtiff")
-    depends_on("zlib-api")
-    depends_on("eigen@:3", when="@8.2.0:")
-    depends_on("double-conversion", when="@8.2.0:9.5")
-    depends_on("sqlite", when="@8.2.0:")
-    depends_on("pugixml", when="@9:")
-    depends_on("libogg")
-    depends_on("libtheora")
-    depends_on("utf8cpp", when="@9:")  # TODO upper bound?
-    depends_on("gl2ps", when="@8.1:")  # TODO upper bound?
-    depends_on("gl2ps@1.4.1:", when="@9:")  # TODO upper bound?
-    # "8.2.1a" uses an internal proj so this special cases 8.2.1a
-    depends_on("proj@4:7", when="@:8.2.0, 9:9.1")  # TODO verify this
-    depends_on("proj@8:", when="@9.2:")  # TODO upper bound?
-    depends_on("cgns@4.1.1:+mpi", when="@9.1: io=cgns +mpi")  # TODO upper bound?
-    depends_on("cgns@4.1.1:~mpi", when="@9.1: io=cgns ~mpi")  # TODO upper bound?
-    depends_on("ospray@2.1:2", when="raytracing=ospray")
-    depends_on("openimagedenoise", when="raytracing=ospray")
-    depends_on("ospray +mpi", when="raytracing=ospray +mpi")
-
-    # VTK introduced Seacas IOSS dependency on 9.1
-    with when("@9.1: io=ioss"):  # TODO upper bound?
-        depends_on("seacas+mpi", when="+mpi")
-        depends_on("seacas~mpi", when="~mpi")
-        depends_on("seacas@2021-05-12:2022-10-14", when="@9.1")
-        # vtk@9.2: need Ioss::Utils::get_debug_stream() which only 2022-10-14 provides,
-        # and to be safe against other issues, make them build with this version only:
-        depends_on("seacas@2022-10-14", when="@9.2:9.3")
-        depends_on("seacas@2024-06-27", when="@9.4:")
-        # TODO probably we can bump version
-
-    depends_on("nlohmann-json", when="@9.2:")
-
     # For finding Fujitsu-MPI wrapper commands
     patch("find_fujitsu_mpi.patch", when="@:8.2.0%fj")
     # Freetype@2.10.3 no longer exports FT_CALLBACK_DEF, this

--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -87,6 +87,20 @@ class Vtk(CMakePackage):
     )
     variant("advanced_debug", default=False, description="Enable the VTK_DEBUG_LEAKS flag")
 
+    with when("@9.5:"):
+        depends_on("cli11")
+        depends_on("fast-float")
+        depends_on("fast-float@7", when="@:9.5.2")
+        depends_on("fmt")
+        depends_on("fmt@11", when="@:9.5.2")
+        depends_on("libharu")
+        depends_on("libproj")
+        depends_on("lzma")
+        depends_on("pegtl")
+        depends_on("pegtl@3", when="@:9.5.2")
+        depends_on("scnlib")
+        depends_on("verdict")
+
     patch("gcc.patch", when="@6.1.0")
 
     # Fix missing standard includes that lead to build errors on newer compilers
@@ -216,9 +230,9 @@ class Vtk(CMakePackage):
     depends_on("libtiff")
     depends_on("zlib-api")
     depends_on("eigen@:3", when="@8.2.0:")
-    depends_on("double-conversion", when="@8.2.0:")
+    depends_on("double-conversion", when="@8.2.0:9.5")
     depends_on("sqlite", when="@8.2.0:")
-    depends_on("pugixml", when="@8.3.0:")
+    depends_on("pugixml", when="@9:")
     depends_on("libogg")
     depends_on("libtheora")
     depends_on("utf8cpp", when="@9:")

--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -141,6 +141,9 @@ class Vtk(CMakePackage):
         # depends_on("token")
         # depends_on("exprtk")
 
+    # TODO IOLAS, InfoVis/Boost, InfoVis/BoostGraph and FilterReebGraph
+    depends_on(Boost.with_default_variants)
+
     # === 2nd-level DEPENDENCIES, for 3rd party libraries built internally
     with when("@:8 io=xdmf"):
         depends_on("mpi", when="+mpi")
@@ -332,6 +335,7 @@ class Vtk(CMakePackage):
     # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=280893
     patch("vtk_clang19_size_t.patch", when="@9.2:9.4.2")
 
+    # TODO this patch method is a workaround for applying multiple patches
     def patch(self):
         if self.spec.satisfies("@9.2: io=ioss"):
             # provide definition for Ioss::Init::Initializer::Initializer(),

--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -158,7 +158,7 @@ class Vtk(CMakePackage):
 
     depends_on("mpi", when="+mpi")  # for builing viskores internally
 
-    # just for theora WIP check when theora stopped being built internally
+    # TODO just for theora, check when theora stopped being built internally
     depends_on("libogg", when="@:8")
 
     # === CONDITIONAL DEPENDENCIES

--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -162,8 +162,9 @@ class Vtk(CMakePackage):
     depends_on("libogg", when="@:8")
 
     # === CONDITIONAL DEPENDENCIES
-    depends_on("adios2+mpi", when="io=adios2 +mpi")
-    depends_on("adios2~mpi", when="io=adios2 ~mpi")
+    with when("io=adios2"):
+        depends_on("adios2+mpi", when="+mpi")
+        depends_on("adios2~mpi", when="~mpi")
     requires("io=adios2", when="@:8 io=fides")
 
     depends_on("ffmpeg", when="io=ffmpeg")

--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -25,11 +25,8 @@ class Vtk(CMakePackage):
 
     license("BSD-3-Clause")
 
-    version(
-        "9.5.1",
-        sha256="14443661c7b095d05b4e376fb3f40613f173e34fc9d4658234e9ec1d624a618f",
-        preferred=True,
-    )
+    version("9.5.2", sha256="cee64b98d270ff7302daf1ef13458dff5d5ac1ecb45d47723835f7f7d562c989")
+    version("9.5.1", sha256="14443661c7b095d05b4e376fb3f40613f173e34fc9d4658234e9ec1d624a618f")
     version("9.5.0", sha256="04ae86246b9557c6b61afbc534a6df099244fbc8f3937f82e6bc0570953af87d")
     version("9.4.1", sha256="c253b0c8d002aaf98871c6d0cb76afc4936c301b72358a08d5f3f72ef8bc4529")
     version("9.3.1", sha256="8354ec084ea0d2dc3d23dbe4243823c4bfc270382d0ce8d658939fd50061cab8")

--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -131,7 +131,7 @@ class Vtk(CMakePackage):
         depends_on("libharu")
         depends_on("lzma")
         depends_on("pegtl")
-        depends_on("pegtl@3", when="@:9.5.2")
+        depends_on("pegtl@2", when="@:9.5.2")
         depends_on("scnlib")
         depends_on("verdict")
 

--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -101,6 +101,35 @@ class Vtk(CMakePackage):
         depends_on("scnlib")
         depends_on("verdict")
 
+        # depends_on("cgns") # conditional?
+        # depends_on("double-conversion", when="@:9.5")
+        # depends_on("eigen")
+        # depends_on("expat")
+        # depends_on("freetype")
+        # depends_on("gl2ps")
+        # depends_on("hdf5")
+        # depends_on("jpeg")
+        # depends_on("jsoncpp")
+        # depends_on("libogg")
+        # depends_on("libpng")
+        # depends_on("libtheora")
+        # depends_on("libtiff")
+        # depends_on("libxml2")
+        # depends_on("lz4")
+        # depends_on("netcdf-c")  # conditional?
+        # depends_on("nlohmann-json")
+        # depends_on("pugixml")
+        # depends_on("py-mpi4py")  # conditional?
+        # depends_on("seacas")  # conditional?
+        # depends_on("sqlite")
+        # depends_on("utf8cpp")
+        # depends_on("zlib-api")
+
+        # EXCLUDED
+        # depends_on("viskores")
+        # depends_on("token")
+        # depends_on("exprtk")
+
     patch("gcc.patch", when="@6.1.0")
 
     # Fix missing standard includes that lead to build errors on newer compilers
@@ -179,14 +208,14 @@ class Vtk(CMakePackage):
     # allow proj to be detected via a CMake produced export config file
     # failing that, falls back on standard library detection
     # required for VTK to build against modern proj/more robustly
-    patch("vtk_findproj_config.patch", when="@9:")
+    patch("vtk_findproj_config.patch", when="@9:")  # TODO upper bound?
     # adds a fake target alias'ing the hdf5 target to prevent
     # checks for that target from falling on VTK's empty stub target
     # Required to consume netcdf and hdf5 both built
     # with CMake from VTK
     # a patch with the same name is also applied to paraview
     # the two patches are the same but for the path to the files they patch
-    patch("vtk_alias_hdf5.patch", when="@9:")
+    patch("vtk_alias_hdf5.patch", when="@9:")  # TODO upper bound?
     # VTK 9.0 on Windows uses dll instead of lib for hdf5-hl target, which fails linking. Can't
     # be fixed by bumping CMake lower bound, because VTK vendors FindHDF5.cmake. Various other
     # patches to FindHDF5.cmake are missing, so add conflict instead of a series of patches.
@@ -217,7 +246,7 @@ class Vtk(CMakePackage):
     depends_on("hdf5~mpi", when="~mpi")
     depends_on("hdf5+mpi", when="+mpi")
     depends_on("hdf5@1.8:", when="@8:9.0")
-    depends_on("hdf5@1.10:", when="@9.1:")
+    depends_on("hdf5@1.10:", when="@9.1:")  # TODO upper bound?
     depends_on("jpeg")
     depends_on("jsoncpp")
     depends_on("libxml2")
@@ -235,20 +264,20 @@ class Vtk(CMakePackage):
     depends_on("pugixml", when="@9:")
     depends_on("libogg")
     depends_on("libtheora")
-    depends_on("utf8cpp", when="@9:")
-    depends_on("gl2ps", when="@8.1:")
-    depends_on("gl2ps@1.4.1:", when="@9:")
+    depends_on("utf8cpp", when="@9:")  # TODO upper bound?
+    depends_on("gl2ps", when="@8.1:")  # TODO upper bound?
+    depends_on("gl2ps@1.4.1:", when="@9:")  # TODO upper bound?
     # "8.2.1a" uses an internal proj so this special cases 8.2.1a
-    depends_on("proj@4:7", when="@:8.2.0, 9:9.1")
-    depends_on("proj@8:", when="@9.2:")
-    depends_on("cgns@4.1.1:+mpi", when="@9.1: io=cgns +mpi")
-    depends_on("cgns@4.1.1:~mpi", when="@9.1: io=cgns ~mpi")
+    depends_on("proj@4:7", when="@:8.2.0, 9:9.1")  # TODO verify this
+    depends_on("proj@8:", when="@9.2:")  # TODO upper bound?
+    depends_on("cgns@4.1.1:+mpi", when="@9.1: io=cgns +mpi")  # TODO upper bound?
+    depends_on("cgns@4.1.1:~mpi", when="@9.1: io=cgns ~mpi")  # TODO upper bound?
     depends_on("ospray@2.1:2", when="raytracing=ospray")
     depends_on("openimagedenoise", when="raytracing=ospray")
     depends_on("ospray +mpi", when="raytracing=ospray +mpi")
 
     # VTK introduced Seacas IOSS dependency on 9.1
-    with when("@9.1: io=ioss"):
+    with when("@9.1: io=ioss"):  # TODO upper bound?
         depends_on("seacas+mpi", when="+mpi")
         depends_on("seacas~mpi", when="~mpi")
         depends_on("seacas@2021-05-12:2022-10-14", when="@9.1")
@@ -256,6 +285,7 @@ class Vtk(CMakePackage):
         # and to be safe against other issues, make them build with this version only:
         depends_on("seacas@2022-10-14", when="@9.2:9.3")
         depends_on("seacas@2024-06-27", when="@9.4:")
+        # TODO probably we can bump version
 
     depends_on("nlohmann-json", when="@9.2:")
 

--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -155,7 +155,7 @@ class Vtk(CMakePackage):
         # See https://github.com/spack/spack/pull/22303 for reference
         depends_on(Boost.with_default_variants, when="io=xdmf")
 
-    depends_on("mpi", when="+mpi")  # for builing viskores internally
+    depends_on("mpi", when="+mpi")  # for building viskores internally
 
     # TODO just for theora, check when theora stopped being built internally
     depends_on("libogg", when="@:8")

--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -372,11 +372,6 @@ class Vtk(CMakePackage):
             cmake_args.append("-DVTK_ENABLE_OSPRAY:BOOL=ON")
             cmake_args.append("-DVTKOSPRAY_ENABLE_DENOISER:BOOL=ON")
 
-        # Version 8.2.1a using internal libproj/pugixml for compatability
-        if spec.satisfies("@8.2.1a"):
-            cmake_args.append("-DVTK_USE_SYSTEM_LIBPROJ:BOOL=OFF")
-            cmake_args.append("-DVTK_USE_SYSTEM_PUGIXML:BOOL=OFF")
-
         # Disable wrappers for other languages.
         cmake_args.append("-DVTK_WRAP_JAVA=OFF")
         if spec.satisfies("@:8.1"):
@@ -384,54 +379,68 @@ class Vtk(CMakePackage):
 
         # In general, we disable use of VTK "ThirdParty" libs, preferring
         # spack-built versions whenever possible but there are exceptions.
-        if spec.satisfies("@:8"):
-            cmake_args.extend(
-                ["-DVTK_USE_SYSTEM_LIBRARIES:BOOL=ON", "-DVTK_USE_SYSTEM_LIBHARU=OFF"]
-            )
-            if spec.satisfies("@:8.0"):
-                cmake_args.append("-DVTK_USE_SYSTEM_GL2PS=OFF")
-        else:
-            cmake_args.extend(
-                [
-                    "-DVTK_USE_EXTERNAL:BOOL=ON",
-                    "-DVTK_MODULE_USE_EXTERNAL_VTK_fast_float:BOOL=OFF",
-                    "-DVTK_MODULE_USE_EXTERNAL_VTK_libharu:BOOL=OFF",
-                    "-DVTK_MODULE_USE_EXTERNAL_VTK_pegtl:BOOL=OFF",
-                    "-DVTK_MODULE_USE_EXTERNAL_VTK_token:BOOL=OFF",
+        if spec.satisfies("@9:"):
+            cmake_args.append(self.define("VTK_USE_EXTERNAL", True))
+
+            if spec.satisfies("@9.5:"):
+                cmake_args += [
+                    self.define("VTK_MODULE_USE_EXTERNAL_VTK_vtkviskores", False),
+                    self.define("VTK_MODULE_USE_EXTERNAL_VTK_token", False),
+                    self.define("VTK_MODULE_USE_EXTERNAL_VTK_exprtk", False),
+                ]
+            else:
+                cmake_args += [
+                    self.define("VTK_MODULE_USE_EXTERNAL_VTK_fast_float", False),
+                    self.define("VTK_MODULE_USE_EXTERNAL_VTK_libharu", False),
+                    self.define("VTK_MODULE_USE_EXTERNAL_VTK_pegtl", False),
+                    self.define("VTK_MODULE_USE_EXTERNAL_VTK_token", False),
                     f"-DHDF5_ROOT={spec['hdf5'].prefix}",
                 ]
-            )
-            if spec.satisfies("@9.1:"):
-                cmake_args.extend(
-                    [
-                        "-DVTK_MODULE_USE_EXTERNAL_VTK_exprtk:BOOL=OFF",
-                        # uses an unreleased version of fmt
-                        "-DVTK_MODULE_USE_EXTERNAL_VTK_fmt:BOOL=OFF",
-                    ]
-                )
-            if spec.satisfies("@9.2:"):
-                cmake_args.append("-DVTK_MODULE_USE_EXTERNAL_VTK_verdict:BOOL=OFF")
-            if spec.satisfies("@9.5:"):
-                cmake_args.append("-DVTK_MODULE_USE_EXTERNAL_VTK_vtkviskores:BOOL=OFF")
 
-        # Some variable names have changed
-        if spec.satisfies("@8.2.0"):
-            cmake_args.append("-DVTK_USE_SYSTEM_PUGIXML:BOOL=OFF")
-        elif spec.satisfies("@:8.1"):
-            cmake_args.extend(
-                [
-                    "-DVTK_USE_SYSTEM_LIBPROJ4:BOOL=OFF",
+                # dependencies introduced as external but not yet used (cumulative)
+
+                if spec.satisfies("@9.2:"):
+                    cmake_args.append(self.define("VTK_MODULE_USE_EXTERNAL_VTK_verdict", False))
+
+                if spec.satisfies("@9.1:"):
+                    cmake_args += [
+                        self.define("VTK_MODULE_USE_EXTERNAL_VTK_exprtk", False),
+                        # uses an unreleased version of fmt
+                        self.define("VTK_MODULE_USE_EXTERNAL_VTK_fmt", False),
+                    ]
+        elif spec.satisfies("@:8"):
+            cmake_args += [
+                self.define("VTK_USE_SYSTEM_LIBRARIES", True),
+                self.define("VTK_USE_SYSTEM_LIBHARU", False),
+                # MPI related
+                self.define("VTK_USE_SYSTEM_DIY2", False),
+                self.define("VTK_USE_SYSTEM_MPI4PY", True),
+                # The xdmf project does not export any CMake file...
+                self.define("VTK_USE_SYSTEM_XDMF3", False),
+                self.define("VTK_USE_SYSTEM_XDMF2", False),
+            ]
+
+            if spec.satisfies("@8.2.0:"):
+                cmake_args += [
+                    # libproj handling changed in VTK 8.2
+                    self.define("VTK_USE_SYSTEM_LIBPROJ", False),
+                    # pugixml has been introduced, but not yet used as external
+                    self.define("VTK_USE_SYSTEM_PUGIXML", False),
+                ]
+            elif spec.satisfies("@:8.1"):
+                cmake_args += [
+                    self.define("VTK_USE_SYSTEM_LIBPROJ4", False),
                     f"-DNETCDF_CXX_ROOT={spec['netcdf-cxx'].prefix}",
                 ]
-            )
 
-        if "+mpi" in spec:
-            if spec.satisfies("@:8.2.0"):
-                cmake_args.extend(["-DVTK_Group_MPI:BOOL=ON", "-DVTK_USE_SYSTEM_DIY2:BOOL=OFF"])
-            else:
-                cmake_args.extend(["-DVTK_USE_MPI=ON"])
+            # gl2ps will be used as external only starting from 8.1
+            if spec.satisfies("@:8.0"):
+                cmake_args.append(self.define("VTK_USE_SYSTEM_GL2PS", False))
+
+        if spec.satisfies("@9:"):
+            cmake_args.append(self.define_from_variant("VTK_USE_MPI", "mpi"))
         else:
-            cmake_args.append("-DVTK_USE_MPI=OFF")
+            cmake_args.append(self.define_from_variant("VTK_Group_MPI", "mpi"))
 
         if spec.satisfies("io=ffmpeg"):
             if spec.satisfies("@:8"):
@@ -442,8 +451,6 @@ class Vtk(CMakePackage):
         # Enable/Disable wrappers for Python.
         if "+python" in spec:
             cmake_args.append("-DVTK_WRAP_PYTHON=ON")
-            if "+mpi" in spec and spec.satisfies("@:8"):
-                cmake_args.append("-DVTK_USE_SYSTEM_MPI4PY:BOOL=ON")
             if spec.satisfies("@9.0.0: ^python@3:"):
                 cmake_args.append("-DVTK_PYTHON_VERSION=3")
         else:
@@ -515,9 +522,6 @@ class Vtk(CMakePackage):
                         # and they stick to system boost if there's a system boost
                         # installed with CMake
                         "-DBoost_NO_BOOST_CMAKE:BOOL=ON",
-                        # The xdmf project does not export any CMake file...
-                        "-DVTK_USE_SYSTEM_XDMF3:BOOL=OFF",
-                        "-DVTK_USE_SYSTEM_XDMF2:BOOL=OFF",
                     ]
                 )
             else:

--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -115,9 +115,9 @@ class Vtk(CMakePackage):
     depends_on("libtheora")
     depends_on("utf8cpp", when="@9:")
 
-    # "8.2.1a" uses an internal proj so this special cases 8.2.1a
-    depends_on("proj@4:7", when="@:8.2.0, 9:9.1")  # TODO verify this
-    depends_on("proj@8:", when="@9.2:")  # TODO upper bound?
+    # 8.2.1a uses an internal proj so this special case
+    depends_on("proj@4:7", when="@:8.2.0, 9:9.1")
+    depends_on("proj@8:", when="@9.2:")
 
     # TODO conditional NOT ANDROID AND NOT APPLE_IOS AND NOT VTK_OPENGL_USE_GLES
     depends_on("gl2ps", when="@8.1:")
@@ -471,8 +471,9 @@ class Vtk(CMakePackage):
 
             if spec.satisfies("@8.2.0:"):
                 cmake_args += [
-                    # libproj handling changed in VTK 8.2
-                    self.define("VTK_USE_SYSTEM_LIBPROJ", False),
+                    # libproj handling changed in VTK 8.2,
+                    # and 8.2.1a is the only one that should use internal version
+                    self.define("VTK_USE_SYSTEM_LIBPROJ", not spec.satisfies("@=8.2.1a")),
                     # pugixml has been introduced, but not yet used as external
                     self.define("VTK_USE_SYSTEM_PUGIXML", False),
                 ]

--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -115,8 +115,7 @@ class Vtk(CMakePackage):
     depends_on("libtheora")
     depends_on("utf8cpp", when="@9:")
 
-    # 8.2.1a uses an internal proj so this special case
-    depends_on("proj@4:7", when="@:8.2.0, 9:9.1")
+    depends_on("proj@4:7", when="@:8.2.0, 9:9.1")  # exclude 8.2.1a which uses internal one
     depends_on("proj@8:", when="@9.2:")
 
     # TODO conditional NOT ANDROID AND NOT APPLE_IOS AND NOT VTK_OPENGL_USE_GLES

--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -121,6 +121,7 @@ class Vtk(CMakePackage):
     # TODO conditional NOT ANDROID AND NOT APPLE_IOS AND NOT VTK_OPENGL_USE_GLES
     depends_on("gl2ps", when="@8.1:")
     depends_on("gl2ps@1.4.1:", when="@9:")
+    depends_on("xz")
 
     with when("@9.5:"):
         depends_on("cli11")
@@ -129,7 +130,6 @@ class Vtk(CMakePackage):
         depends_on("fmt")
         depends_on("fmt@11", when="@:9.5.2")
         depends_on("libharu")
-        depends_on("lzma")
         depends_on("pegtl")
         depends_on("pegtl@2", when="@:9.5.2")
         depends_on("scnlib")
@@ -206,7 +206,6 @@ class Vtk(CMakePackage):
     depends_on("gl@3.2:", when="+opengl2")
     depends_on("gl@1.2:", when="~opengl2")
 
-    depends_on("xz")
     depends_on("libxt", when="^[virtuals=gl] glx platform=linux")  # just for x11? web?
     depends_on("glew")  # viskores
 

--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -98,7 +98,7 @@ class Vtk(CMakePackage):
     # https://gitlab.kitware.com/vtk/vtk/-/issues/18033
     depends_on("freetype @:2.10.2", when="@:9.0.1")
 
-    depends_on("py-mpi4py", when="+python+mpi", type="run")
+    depends_on("py-mpi4py", when="+python+mpi", type=("build", "run"))
 
     depends_on("jpeg")
     depends_on("jsoncpp")

--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -183,8 +183,8 @@ class Vtk(CMakePackage):
         # vtk@9.2: need Ioss::Utils::get_debug_stream() which only 2022-10-14 provides,
         # and to be safe against other issues, make them build with this version only:
         depends_on("seacas@2022-10-14", when="@9.2:9.3")
-        depends_on("seacas@2024-06-27", when="@9.4:")
-        # TODO probably we can bump version
+        depends_on("seacas@2024-06-27", when="@9.4")
+        depends_on("seacas@2025-02-27", when="@9.5")
 
     with when("@9: io=netcdf"):
         depends_on("netcdf-c ~mpi", when="~mpi")


### PR DESCRIPTION
Note: I'm trying to make `paraview` and related dependencies more "spack-friendly", as in "use as much as possible external libraries". I had some problems with `viskores` (which I'm going to follow up) so I started from `vtk`.

I hope this PR, and following ones, might get accepted after some collective work with the package maintainers that knows way better the details.

The main categories of changes in this PR:
- group together the logic for selection of external packages, and update it to allow as much as possible the use of externals starting from version 9.5 onwards
- group `depends_on` directives in
  - "3rd party": mainly what VTK provides in `ThirdParty` that could be built internally, but we prefer using as externals
  - "2nd-level": Dependencies needed in case some ThirdParty is used as "internal". Mainly targeting the past, but also a couple of libraries that are not yet used as external
  - "conditionals": Dependencies depending on the spec
- it also bumps the version to 9.5.2

I'm starting it as draft so we can start discussing if the effort is worth or not.

Thanks in advance to the maintainers that will review and help improving the package.