### PR TITLE
acts: add upper limit on podio

### DIFF
--- a/repos/spack_repo/builtin/packages/acts/package.py
+++ b/repos/spack_repo/builtin/packages/acts/package.py
@@ -417,6 +417,7 @@ class Acts(CMakePackage, CudaPackage):
     depends_on("podio @0.6:", when="@25: +edm4hep")
     depends_on("podio @0.16:", when="@30.3: +edm4hep")
     depends_on("podio @:0", when="@:35 +edm4hep")
+    depends_on("podio @:1.4", when="@:44 +edm4hep +examples")
     depends_on("podio @0.16:", when="+podio")
     depends_on("podio @:0", when="@:35 +podio")
     depends_on("pythia8", when="+pythia8")


### PR DESCRIPTION
This pull request adds a version constraint so that when building `acts` versions up to `44` with both `+edm4hep` and `+examples`, the package now depends on `podio` version `1.4` or earlier.

Ref: https://github.com/acts-project/acts/issues/4764