### PR TITLE
tutorial stack: use when_possible and bootstrap gcc12 (new container)

### DIFF
--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -580,7 +580,7 @@ tools-sdk-build:
 
 tutorial-generate:
   extends: [ ".tutorial", ".generate-x86_64"]
-  image: ghcr.io/spack/tutorial-ubuntu-22.04:v2023-10-30
+  image: ghcr.io/spack/tutorial-ubuntu-22.04:pr-70  # fixme when merged
 
 tutorial-build:
   extends: [ ".tutorial", ".build" ]

--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -580,7 +580,7 @@ tools-sdk-build:
 
 tutorial-generate:
   extends: [ ".tutorial", ".generate-x86_64"]
-  image: ghcr.io/spack/tutorial-ubuntu-22.04:pr-70  # fixme when merged
+  image: ghcr.io/spack/tutorial-ubuntu-22.04:f626551836c51800fe45b3e40674daab730fba97fb45393296aef05b185c3ebc
 
 tutorial-build:
   extends: [ ".tutorial", ".build" ]

--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -580,7 +580,7 @@ tools-sdk-build:
 
 tutorial-generate:
   extends: [ ".tutorial", ".generate-x86_64"]
-  image: ghcr.io/spack/tutorial-ubuntu-22.04:f626551836c51800fe45b3e40674daab730fba97fb45393296aef05b185c3ebc
+  image: ghcr.io/spack/tutorial-ubuntu-22.04:main
 
 tutorial-build:
   extends: [ ".tutorial", ".build" ]

--- a/.ci/gitlab/configs/linux/ci.yaml
+++ b/.ci/gitlab/configs/linux/ci.yaml
@@ -4,7 +4,7 @@ ci:
       before_script-:
       # Test package relocation on linux using a modified prefix
       # This is not well supported on MacOS (https://github.com/spack/spack/issues/37162)
-      - - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture.platform}-{architecture.target}/{name}-{version}-{hash}'"
+      - - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}/${SPACK_JOB_SPEC_DAG_HASH}:'morepadding/{architecture.platform}-{architecture.target}/{name}-{version}-{hash}'"
   - match_behavior: first
     submapping:
     - match:

--- a/.ci/gitlab/configs/win64/ci.yaml
+++ b/.ci/gitlab/configs/win64/ci.yaml
@@ -19,7 +19,7 @@ ci:
 
       script::
       - spack.ps1 env activate --without-view ${SPACK_CONCRETE_ENV_DIR}
-      - spack.ps1 config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{hash}'"
+      - spack.ps1 config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}/${SPACK_JOB_SPEC_DAG_HASH}:'morepadding/{hash}'"
       - mkdir ${SPACK_ARTIFACTS_ROOT}/user_data
       - spack.ps1 --backtrace ci rebuild | Tee-Object -FilePath "${env:SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt" 2>&1 | Tee-Object -FilePath "${env:SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt"
       image: "ghcr.io/johnwparent/windows-server21h2:sha-1c12b61"

--- a/stacks/tutorial/spack.yaml
+++ b/stacks/tutorial/spack.yaml
@@ -64,7 +64,7 @@ spack:
     pipeline-gen:
     - build-job:
         image:
-          name: ghcr.io/spack/tutorial-ubuntu-22.04:f626551836c51800fe45b3e40674daab730fba97fb45393296aef05b185c3ebc
+          name: ghcr.io/spack/tutorial-ubuntu-22.04:main
           entrypoint: ['']
   cdash:
     build-group: Spack Tutorial

--- a/stacks/tutorial/spack.yaml
+++ b/stacks/tutorial/spack.yaml
@@ -5,7 +5,14 @@ spack:
   - ../../.ci/gitlab/
   packages:
     all:
-      require: target=x86_64_v3
+      require:
+      - target=x86_64_v3
+      - spec: '%gcc-runtime@12'
+        when: '%gcc@12'
+      - spec: '%gcc-runtime@11'
+        when: '%gcc@11'
+      - spec: '%gcc-runtime@10'
+        when: '%gcc@10'
     tbb:
       require: intel-tbb
   definitions:
@@ -52,6 +59,7 @@ spack:
   concretizer:
     # Hacky way to allow bootstrapping the compiler
     unify: when_possible
+    compiler_mixing: false
   ci:
     pipeline-gen:
     - build-job:

--- a/stacks/tutorial/spack.yaml
+++ b/stacks/tutorial/spack.yaml
@@ -64,7 +64,7 @@ spack:
     pipeline-gen:
     - build-job:
         image:
-          name: ghcr.io/spack/tutorial-ubuntu-22.04:pr-70  # FIXME when merged
+          name: ghcr.io/spack/tutorial-ubuntu-22.04:f626551836c51800fe45b3e40674daab730fba97fb45393296aef05b185c3ebc
           entrypoint: ['']
   cdash:
     build-group: Spack Tutorial

--- a/stacks/tutorial/spack.yaml
+++ b/stacks/tutorial/spack.yaml
@@ -49,12 +49,14 @@ spack:
   - $gcc_old_packages
   - $clang_packages
   - $gcc_spack_built_packages
-
+  concretizer:
+    # Hacky way to allow bootstrapping the compiler
+    unify: when_possible
   ci:
     pipeline-gen:
     - build-job:
         image:
-          name: ghcr.io/spack/tutorial-ubuntu-22.04:v2023-10-30
+          name: ghcr.io/spack/tutorial-ubuntu-22.04:pr-70  # FIXME when merged
           entrypoint: ['']
   cdash:
     build-group: Spack Tutorial

--- a/stacks/tutorial/spack.yaml
+++ b/stacks/tutorial/spack.yaml
@@ -18,15 +18,15 @@ spack:
   definitions:
   - gcc_system_packages:
     - matrix:
-      - - zlib-ng
+      - - zlib-ng@2.2.4
         - zlib-ng@2.0.7
         - zlib-ng@2.0.7 cflags=-O3
-        - tcl
+        - tcl ^zlib-ng@2.2.4
         - tcl ^zlib-ng@2.0.7 cflags=-O3
-        - hdf5
+        - hdf5+mpi^openmpi
         - hdf5~mpi
         - hdf5+hl+mpi ^mpich
-        - trilinos
+        - trilinos ^openmpi
         - trilinos +hdf5 ^hdf5+hl+mpi ^mpich
         - gcc@12.3
         - mpileaks
@@ -37,10 +37,10 @@ spack:
         - vim
       - ['%gcc@11']
   - gcc_old_packages:
-    - zlib-ng%gcc@10
+    - zlib-ng@2.2.4%gcc@10
   - clang_packages:
     - matrix:
-      - [zlib-ng, tcl ^zlib-ng@2.0.7]
+      - [zlib-ng@2.2.4, tcl ^zlib-ng@2.0.7]
       - ['%clang@14']
   - gcc_spack_built_packages:
     - matrix:


### PR DESCRIPTION
Use new container that doesn't have gcc-12 installed

Use `when_possible` to bootstrap the compiler from the container in a multi-round solve as @haampie pointed out is possible.