### PR TITLE
flecsi: depend on Graphviz < 13

### DIFF
--- a/repos/spack_repo/builtin/packages/flecsi/package.py
+++ b/repos/spack_repo/builtin/packages/flecsi/package.py
@@ -63,7 +63,7 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
     for level in ("low", "medium", "high"):
         depends_on("caliper@:2.5,2.8:", when=f"caliper_detail={level}")
 
-    depends_on("graphviz", when="+graphviz")
+    depends_on("graphviz@:12", when="+graphviz")
     depends_on("hdf5+hl+mpi", when="+hdf5")
     depends_on("metis@5.1.0:", when="@:2.3.1")
     depends_on("parmetis@4.0.3:", when="@:2.3.1")


### PR DESCRIPTION
Graphviz 13 had a breaking API change that is not yet supported by any version of FleCSI.