### PR TITLE
r: add v4.5.2 and SVN trunk

### DIFF
--- a/repos/spack_repo/builtin/packages/r/package.py
+++ b/repos/spack_repo/builtin/packages/r/package.py
@@ -26,6 +26,8 @@ class R(AutotoolsPackage):
 
     license("GPL-2.0-or-later")
 
+    version("trunk", svn="https://svn.r-project.org/R/trunk")
+    version("4.5.2", sha256="0d71ff7106ec69cd7c67e1e95ed1a3cee355880931f2eb78c530014a9e379f20")
     version("4.5.1", sha256="b42a7921400386645b10105b91c68728787db5c4c83c9f6c30acdce632e1bb70")
     version("4.5.0", sha256="3b33ea113e0d1ddc9793874d5949cec2c7386f66e4abfb1cef9aec22846c3ce1")
     version("4.4.3", sha256="0d93d224442dea253c2b086f088db6d0d3cfd9b592cd5496e8cb2143e90fc9e8")


### PR DESCRIPTION
* Checked the release notes and 4.5.2 is strictly a bugfix release with some upstream fixes for the macOS build; the zstd dependency mentioned was applied previously in @4.5: as listed in https://stat.ethz.ch/pipermail/r-announce/2025/000716.html

* Developing against SVN trunk is part of the R Bioconductor package development and submission process as explained in https://contributions.bioconductor.org/use-devel.html

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
