### PR TITLE
py-rapidfuzz: added versions 3.14.3 and 3.14.5

### DIFF
--- a/repos/spack_repo/builtin/packages/py_rapidfuzz/package.py
+++ b/repos/spack_repo/builtin/packages/py_rapidfuzz/package.py
@@ -15,6 +15,7 @@ class PyRapidfuzz(PythonPackage):
 
     license("MIT")
 
+    version("3.14.3", sha256="2491937177868bc4b1e469087601d53f925e8d270ccc21e07404b4b5814b7b5f")
     version("3.14.1", sha256="b02850e7f7152bd1edff27e9d584505b84968cacedee7a734ec4050c655a803c")
     version("3.3.1", sha256="6783b3852f15ed7567688e2e358757a7b4f38683a915ba5edc6c64f1a3f0b450")
     version("2.2.0", sha256="acb8839aac452ec61a419fdc8799e8a6e6cd21bed53d04678cdda6fba1247e2f")

--- a/repos/spack_repo/builtin/packages/py_rapidfuzz/package.py
+++ b/repos/spack_repo/builtin/packages/py_rapidfuzz/package.py
@@ -15,6 +15,7 @@ class PyRapidfuzz(PythonPackage):
 
     license("MIT")
 
+    version("3.14.3", sha256="2491937177868bc4b1e469087601d53f925e8d270ccc21e07404b4b5814b7b5f")
     version("3.3.1", sha256="6783b3852f15ed7567688e2e358757a7b4f38683a915ba5edc6c64f1a3f0b450")
     version("2.2.0", sha256="acb8839aac452ec61a419fdc8799e8a6e6cd21bed53d04678cdda6fba1247e2f")
     version("1.8.2", sha256="d6efbb2b6b18b3a67d7bdfbcd9bb72732f55736852bbef823bdf210f9e0c6c90")
@@ -22,13 +23,16 @@ class PyRapidfuzz(PythonPackage):
     depends_on("cxx", type="build")  # generated
 
     depends_on("python", type=("build", "link", "run"))
-    depends_on("py-setuptools@42:", when="@2:", type="build")
-    depends_on("py-setuptools", type="build")
-    depends_on("py-scikit-build@0.17", when="@3:", type="build")
-    depends_on("py-scikit-build@0.13:", when="@2.2:", type="build")
+    depends_on("python@3.10:", when="@3.14.3:", type=("build", "link", "run"))
+    depends_on("py-setuptools@42:", when="@2:3.3.1", type="build")
+    depends_on("py-setuptools", when="@:3.3.1", type="build")
+    depends_on("py-scikit-build-core@0.11:", when="@3.14.3:", type="build")
+    depends_on("py-scikit-build@0.17", when="@3:3.3.1", type="build")
+    depends_on("py-scikit-build@0.13:", when="@2.2:3.3.1", type="build")
     depends_on("py-rapidfuzz-capi@1.0.5", when="@2", type="build")
     depends_on("py-jarowinkler@1.2.0:1", when="@2", type=("build", "run"))
 
     # CMakeLists.txt
-    depends_on("cmake@3.12:", type="build")
+    depends_on("cmake@3.12:", when="@:3.3.1", type="build")
+    depends_on("cmake@3.15:3.30", when="@3.14.3:", type="build")
     depends_on("ninja", type="build")

--- a/repos/spack_repo/builtin/packages/py_rapidfuzz/package.py
+++ b/repos/spack_repo/builtin/packages/py_rapidfuzz/package.py
@@ -27,6 +27,7 @@ class PyRapidfuzz(PythonPackage):
     depends_on("python@3.10:", type=("build", "link", "run"), when="@3.14:")
     depends_on("py-scikit-build-core@0.11:", type="build", when="@3.14.1:")
     depends_on("py-cython@3.0.12:3.1", type="build", when="@3.14.1:")
+    depends_on("py-cython@3.1.6:3.1", type="build", when="@3.14.2:")
 
     # historical
     with when("@:3.3.1"):

--- a/repos/spack_repo/builtin/packages/py_rapidfuzz/package.py
+++ b/repos/spack_repo/builtin/packages/py_rapidfuzz/package.py
@@ -15,6 +15,7 @@ class PyRapidfuzz(PythonPackage):
 
     license("MIT")
 
+    version("3.14.5", sha256="ba10ac57884ce82112f7ed910b67e7fb6072d8ef2c06e30dc63c0f604a112e0e")
     version("3.14.3", sha256="2491937177868bc4b1e469087601d53f925e8d270ccc21e07404b4b5814b7b5f")
     version("3.14.1", sha256="b02850e7f7152bd1edff27e9d584505b84968cacedee7a734ec4050c655a803c")
     version("3.3.1", sha256="6783b3852f15ed7567688e2e358757a7b4f38683a915ba5edc6c64f1a3f0b450")
@@ -26,8 +27,10 @@ class PyRapidfuzz(PythonPackage):
     depends_on("python", type=("build", "link", "run"))
     depends_on("python@3.10:", type=("build", "link", "run"), when="@3.14:")
     depends_on("py-scikit-build-core@0.11:", type="build", when="@3.14.1:")
-    depends_on("py-cython@3.0.12:3.1", type="build", when="@3.14.1:")
-    depends_on("py-cython@3.1.6:3.1", type="build", when="@3.14.2:")
+
+    depends_on("py-cython@3.0.12:3.1", type="build", when="@3.14.1:3.14.3")
+    depends_on("py-cython@3.1.6:3.1", type="build", when="@3.14.2:3.14.3")
+    depends_on("py-cython@3.1.6:3.2", type="build", when="@3.14.4:")
 
     # historical
     with when("@:3.3.1"):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
