### PR TITLE
libcxi: add new versions, remove version build requirement

### DIFF
--- a/repos/spack_repo/builtin/packages/libcxi/package.py
+++ b/repos/spack_repo/builtin/packages/libcxi/package.py
@@ -16,8 +16,10 @@ class Libcxi(AutotoolsPackage):
 
     license("LGPL-2.1-or-later or BSD-3-Clause")
 
-    # no releases, tags: see https://github.com/HewlettPackard/shs-libcxi/issues/2
     version("main", branch="main")
+    version("13.0.0", tag="release/shs-13.0.0")
+    version("12.0.1", tag="release/shs-12.0.1")
+    version("12.0.0", tag="release/shs-12.0.0")
 
     variant("level_zero", default=False, description="Enable level zero support")
     variant("cuda", default=False, description="Build with CUDA support")

--- a/repos/spack_repo/builtin/packages/libcxi/package.py
+++ b/repos/spack_repo/builtin/packages/libcxi/package.py
@@ -27,7 +27,7 @@ class Libcxi(AutotoolsPackage):
 
     depends_on("c", type="build")
 
-    with default_args(type="build", when="@main"):
+    with default_args(type="build"):
         depends_on("autoconf")
         depends_on("automake")
         depends_on("libtool")
@@ -59,7 +59,6 @@ class Libcxi(AutotoolsPackage):
             string=True,
         )
 
-    @when("@main")
     def autoreconf(self, spec, prefix):
         sh = which("sh")
         sh("autogen.sh")


### PR DESCRIPTION
This adds several new versions from git tags and removed the `@main` version requirement from building.
