### PR TITLE
e4s: comment out gptune

### DIFF
--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -117,7 +117,7 @@ spack:
   - glvis
   - gmp
   - gotcha
-  - gptune ~mpispawn
+  # - gptune ~mpispawn
   - gromacs +cp2k ^cp2k +dlaf build_system=cmake
   - h5bench
   - hdf5-vol-async


### PR DESCRIPTION
The package is outdated, and causes PRs to fail with issues like in https://github.com/spack/spack-packages/pull/2098

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
