### PR TITLE
verdict: add shared and pic variants to the package

### DIFF
--- a/repos/spack_repo/builtin/packages/verdict/package.py
+++ b/repos/spack_repo/builtin/packages/verdict/package.py
@@ -23,6 +23,9 @@ class Verdict(CMakePackage):
     version("1.4.2", sha256="225c8c5318f4b02e7215cefa61b5dc3f99e05147ad3fefe6ee5a3ee5b828964b")
     version("1.4.1", sha256="26fa583265cb2ced2e9b30ed26260f6c9f89c3296221d96ccd5e7bfeec219de7")
 
+    variant("pic", default=False, description="Build position independent code")
+    variant("shared", default=False, description="Build shared libraries")
+
     variant("doc", default=False, description="install documentation with library")
     variant(
         "mangle",
@@ -37,6 +40,8 @@ class Verdict(CMakePackage):
 
     def cmake_args(self):
         args = [
+            self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant("VERDICT_BUILD_DOCS", "doc"),
             self.define_from_variant("VERDICT_MANGLE", "mangle"),
             self.define_from_variant("VERDICT_ENABLE_TESTING", "test"),


### PR DESCRIPTION
I was building VTK with externals, and `verdict` is one of them.

At some point the build stopped with the following message

```
/usr/bin/ld: /user-environment/linux-zen2/verdict-1.4.4-5kpp5mib5lw45takv2jtex2mzjuuhmnc/lib64/libverdict.a(V_HexMetric.cpp.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: failed to set dynamic section sizes: bad value
```

because apparently VTK was creating a shared library and including `verdict`...but `verdict` in spack by default is built as static library, which by default are not built (by CMake) with positional independent code (`-fPIC`).

I opted for adding `pic` and `shared` variants copying what has been already done in other packages.