### PR TITLE
warp: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/warp/cmakelists.patch
+++ b/repos/spack_repo/builtin/packages/warp/cmakelists.patch
@@ -1,0 +1,43 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+new file mode 100644
+index 0000000..5974207
+--- /dev/null
++++ b/CMakeLists.txt
+@@ -0,0 +1,8 @@
++cmake_minimum_required(VERSION 3.14)
++project(Warp)
++
++add_subdirectory(NativeAcceleration)
++add_subdirectory(LibTorchSharp)
++
++install(TARGETS NativeAcceleration DESTINATION lib)
++install(TARGETS LibTorchSharp DESTINATION lib)
+diff --git a/LibTorchSharp/CMakeLists.txt b/LibTorchSharp/CMakeLists.txt
+index e709380..e06b0c8 100644
+--- a/LibTorchSharp/CMakeLists.txt
++++ b/LibTorchSharp/CMakeLists.txt
+@@ -1,4 +1,5 @@
+ cmake_minimum_required (VERSION 3.0)
++PROJECT(LibTorchSharp LANGUAGES CUDA CXX)
+ 
+ set(CMAKE_CXX_STANDARD 11)
+ set(CMAKE_INSTALL_PREFIX $ENV{__CMakeBinDir})
+diff --git a/NativeAcceleration/CMakeLists.txt b/NativeAcceleration/CMakeLists.txt
+index 12c67a4..a9fb41c 100644
+--- a/NativeAcceleration/CMakeLists.txt
++++ b/NativeAcceleration/CMakeLists.txt
+@@ -22,7 +22,7 @@ INCLUDE_DIRECTORIES("${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}")
+ 
+ FILE(GLOB_RECURSE SOURCES src/*.cu src/*.cpp gtom/src/*.cu gtom/src/*.cpp liblion/*.cpp liblion/*.cc)
+ 
+-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -w -fPIC -mavx2 -mf16c")
++SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -w -fPIC")
+ SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")
+ 
+ add_compile_definitions("FLOAT_PRECISION")
+@@ -40,3 +40,5 @@ ADD_LIBRARY(NativeAcceleration SHARED ${SOURCES})
+ set_target_properties(NativeAcceleration PROPERTIES CUDA_ARCHITECTURES "52;61;75;86")
+ 
+ TARGET_LINK_LIBRARIES(NativeAcceleration ${FFTW_LIBRARIES} libtiff.so libcudart.so libcufft.so libcublas.so libcurand.so ${CMAKE_THREAD_LIBS_INIT})
++
++# INSTALL(TARGETS NativeAcceleration LIBRARY DESTINATION lib)

--- a/repos/spack_repo/builtin/packages/warp/package.py
+++ b/repos/spack_repo/builtin/packages/warp/package.py
@@ -135,7 +135,7 @@ class Warp(CMakePackage, CudaPackage):
                 "/p:PublishSingleFile=true",
                 "/p:DebugType=None",
                 "-o",
-                f"{self.spec.prefix}/bin",
+                self.spec.prefix.bin,
                 tool,
             )
 

--- a/repos/spack_repo/builtin/packages/warp/package.py
+++ b/repos/spack_repo/builtin/packages/warp/package.py
@@ -1,0 +1,187 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+# from spack_repo.builtin.build_systems.package import Package
+import shlex
+import shutil
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems.cuda import CudaPackage
+
+from spack.package import *
+
+
+class Warp(CMakePackage, CudaPackage):
+    """Warp is a set of tools for cryo-EM and cryo-ET data processing
+    including, among other tools: Warp, M, WarpTools, MTools, MCore, and
+    Noise2Map."""
+
+    homepage = "https://warpem.github.io/"
+    url = "https://github.com/warpem/warp/archive/refs/tags/v2.0.0dev36.tar.gz"
+
+    maintainers("Markus92")
+
+    license("GPL-3", checked_by="Markus92")
+
+    version(
+        "2.0.0dev36", sha256="a50b019bbe2143d3709c4782db3e689455b94eb7162b5f8dd955996e9710a291"
+    )
+
+    # The source is riddled with calls to avx intrinsics, so make sure target supports it
+    conflicts("target=:k10")  # last AMD processor not to support avx
+    conflicts("target=:westmere")  # last Intel processor not to support avx
+    conflicts("target=:x86_64_v2")  # last generic architecture not to support avx
+
+    variant("cuda", default=True, description="Build with CUDA")
+    conflicts("~cuda", msg="Cuda is required.")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    # Upstream builds with gcc@9.5.0; The d_ValueFill function (in NativeAcceleration)
+    # is templated but not explicitly instantiated. This leads to unknown symbols in gcc 10+
+    # Cause is the removal of '-frepo' in gcc 10+
+    # conflicts("%gcc@10:", msg="gcc 10+ no longer supports -frepo")
+    # conflicts("%llvm", msg="gcc < 10 is required")
+
+    depends_on("cmake@3.18:", type="build")
+    depends_on("gmake", type="build")
+    depends_on("patchelf", type=("build", "link"))
+    depends_on("dotnet-core-sdk", type=("build"))
+
+    depends_on("cuda@11.8:11", type=("build", "link"))
+    depends_on("fftw@3 ~mpi precision=float", type=("build", "link"))
+    depends_on("libtiff +shared")
+    # depends_on("intel-oneapi-mkl@2024: +shared")
+    depends_on("python@3.11")
+    depends_on("cudnn@8.7.0")
+    depends_on("py-torch@2.0.1 +cuda")
+
+    # Link dependencies for libSkiaSharp.so
+    depends_on("fontconfig@2:", type="link")
+    depends_on("freetype@2.10: +shared", type="link")
+    depends_on("libxml2@2.9.13: +shared", type="link")
+    depends_on("bzip2 +shared", type="link")
+    depends_on("libpng libs=shared", type="link")
+    depends_on("zlib +shared", type="link")
+    depends_on("harfbuzz@2.7.4: default_library=shared", type="link")
+    depends_on("brotli", type="link")
+    depends_on("xz libs=shared", type="link")
+    depends_on("glib@2: default_library=shared", type="link")
+    depends_on("graphite2@1.3.14:", type="link")
+    depends_on("pcre +shared", type="link")
+
+    # Patch adds install target and creates a project-wide CMakeLists.txt
+    patch("cmakelists.patch")
+    patch(
+        "https://github.com/warpem/warp/commit/f41372135e97e2d5cab1e4b66bc9b44cfcda23f6.patch?full_index=1",
+        sha256="0309fd44d125f3f212381e99ab10e5a28d8630347a88d73341b983dfba972f9a",
+    )
+
+    @run_before("cmake")
+    def set_cuda_archs(self) -> None:
+        cuda_targets = ";".join(self.spec.variants["cuda_arch"].value)
+        filter_file(
+            r'^set_target_properties\(NativeAcceleration PROPERTIES CUDA_ARCHITECTURES "\d+(?:;\d+)*"\)$',
+            f'set_target_properties(NativeAcceleration PROPERTIES CUDA_ARCHITECTURES "{cuda_targets}")',
+            "NativeAcceleration/CMakeLists.txt",
+        )
+
+    def cmake_args(self):
+        spec = self.spec
+        args = []
+        args.append(
+            "-DTorch_DIR={0}/lib/python{1}/site-packages/torch/share/cmake/Torch".format(
+                spec["py-torch"].prefix, spec["python"].version.up_to(2)
+            )
+        )
+        return args
+
+    @property
+    def cuda_arch(self):
+        cuda_arch = ";".join(self.spec.variants["cuda_arch"].value)
+        if cuda_arch == "none":
+            raise InstallError("Must select at least one value for cuda_arch")
+        return cuda_arch
+
+    # Build the .NET source code
+    @run_before("build")
+    def build_dotnet(self) -> None:
+        dotnet = Executable("dotnet")
+        for tool in [
+            "Noise2Map/Noise2Map.csproj",
+            "Noise2Mic/Noise2Mic.csproj",
+            "Noise2Tomo/Noise2Tomo.csproj",
+            "Noise2Half/Noise2Half.csproj",
+            "EstimateWeights/EstimateWeights.csproj",
+            "Frankenmap/Frankenmap.csproj",
+            "MrcConverter/MrcConverter.csproj",
+            "WarpWorker/WarpWorker.csproj",
+            "WarpTools/WarpTools.csproj",
+            "MTools/MTools.csproj",
+            "MCore/MCore.csproj",
+        ]:
+            dotnet(
+                "publish",
+                "-nowarn:CS0219,CS0162,CS0168,CS0649,CS0067,CS0414,CS0661,CS0659,CS0169,CS0618,CS1998,MSB3270,SYSLIB0011",
+                "--configuration",
+                "Release",
+                "--framework",
+                "net8.0",
+                "--self-contained",
+                "true",
+                "/p:PublishSingleFile=true",
+                "/p:DebugType=None",
+                "-o",
+                f"{self.spec.prefix}/bin",
+                tool,
+            )
+
+    @run_after("install")
+    def ensure_rpaths(self):
+        # Patch the .NET rpath
+        patchelf = Executable("patchelf")
+        with working_dir(self.spec.prefix.bin):
+            for tool in [
+                "EstimateWeights",
+                "Frankenmap",
+                "MCore",
+                "MrcConverter",
+                "MTools",
+                "Noise2Half",
+                "Noise2Map",
+                "Noise2Mic",
+                "Noise2Tomo",
+                "WarpTools",
+                "WarpWorker",
+            ]:
+                patchelf("--add-rpath", self.spec.prefix.lib, tool)
+
+        # .NET stores one of the libs in the output bin
+        shutil.move(join_path(self.spec.prefix.bin, "libSkiaSharp.so"), self.spec.prefix.lib)
+
+        skia_libs = [
+            "fontconfig",
+            "freetype",
+            "libxml2",
+            "bzip2",
+            "libpng",
+            "zlib",
+            "harfbuzz",
+            "xz",
+            "glib",
+            "graphite2",
+            "pcre",
+        ]
+        for dependency in skia_libs:
+            for libdir in self.spec[dependency].libs.directories:
+                patchelf(
+                    "--add-rpath",
+                    shlex.quote(libdir),
+                    join_path(self.spec.prefix.lib, "libSkiaSharp.so"),
+                )
+        # Brotli complains it cannot find library dir
+        patchelf(
+            "--add-rpath",
+            shlex.quote(self.spec["brotli"].prefix.lib64),
+            join_path(self.spec.prefix.lib, "libSkiaSharp.so"),
+        )

--- a/repos/spack_repo/builtin/packages/warp/package.py
+++ b/repos/spack_repo/builtin/packages/warp/package.py
@@ -81,8 +81,10 @@ class Warp(CMakePackage, CudaPackage):
     def set_cuda_archs(self) -> None:
         cuda_targets = ";".join(self.spec.variants["cuda_arch"].value)
         filter_file(
-            r'^set_target_properties\(NativeAcceleration PROPERTIES CUDA_ARCHITECTURES "\d+(?:;\d+)*"\)$',
-            f'set_target_properties(NativeAcceleration PROPERTIES CUDA_ARCHITECTURES "{cuda_targets}")',
+            r"^set_target_properties\(NativeAcceleration PROPERTIES CUDA_ARCHITECTURES"
+            + r'\d+(?:;\d+)*"\)$',
+            "set_target_properties(NativeAcceleration"
+            + f'PROPERTIES CUDA_ARCHITECTURES "{cuda_targets}")',
             "NativeAcceleration/CMakeLists.txt",
         )
 
@@ -122,7 +124,8 @@ class Warp(CMakePackage, CudaPackage):
         ]:
             dotnet(
                 "publish",
-                "-nowarn:CS0219,CS0162,CS0168,CS0649,CS0067,CS0414,CS0661,CS0659,CS0169,CS0618,CS1998,MSB3270,SYSLIB0011",
+                "-nowarn:CS0219,CS0162,CS0168,CS0649,CS0067,CS0414,"
+                + "CS0661,CS0659,CS0169,CS0618,CS1998,MSB3270,SYSLIB0011",
                 "--configuration",
                 "Release",
                 "--framework",

--- a/repos/spack_repo/builtin/packages/warp/package.py
+++ b/repos/spack_repo/builtin/packages/warp/package.py
@@ -31,17 +31,13 @@ class Warp(CMakePackage, CudaPackage):
     conflicts("target=:k10")  # last AMD processor not to support avx
     conflicts("target=:westmere")  # last Intel processor not to support avx
     conflicts("target=:x86_64_v2")  # last generic architecture not to support avx
+    requires("target=x86_64:")  # Block non-x86_64 targets
 
     variant("cuda", default=True, description="Build with CUDA")
     conflicts("~cuda", msg="Cuda is required.")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
-    # Upstream builds with gcc@9.5.0; The d_ValueFill function (in NativeAcceleration)
-    # is templated but not explicitly instantiated. This leads to unknown symbols in gcc 10+
-    # Cause is the removal of '-frepo' in gcc 10+
-    # conflicts("%gcc@10:", msg="gcc 10+ no longer supports -frepo")
-    # conflicts("%llvm", msg="gcc < 10 is required")
 
     depends_on("cmake@3.18:", type="build")
     depends_on("gmake", type="build")
@@ -51,7 +47,6 @@ class Warp(CMakePackage, CudaPackage):
     depends_on("cuda@11.8:11", type=("build", "link"))
     depends_on("fftw@3 ~mpi precision=float", type=("build", "link"))
     depends_on("libtiff +shared")
-    # depends_on("intel-oneapi-mkl@2024: +shared")
     depends_on("python@3.11")
     depends_on("cudnn@8.7.0")
     depends_on("py-torch@2.0.1 +cuda")
@@ -91,11 +86,7 @@ class Warp(CMakePackage, CudaPackage):
     def cmake_args(self):
         spec = self.spec
         args = []
-        args.append(
-            "-DTorch_DIR={0}/lib/python{1}/site-packages/torch/share/cmake/Torch".format(
-                spec["py-torch"].prefix, spec["python"].version.up_to(2)
-            )
-        )
+        args.append(f"-DTorch_DIR=f{join_path(self["py-torch"].cmake_prefix_paths[0], "Torch")}")
         return args
 
     @property

--- a/repos/spack_repo/builtin/packages/warp/package.py
+++ b/repos/spack_repo/builtin/packages/warp/package.py
@@ -84,9 +84,8 @@ class Warp(CMakePackage, CudaPackage):
         )
 
     def cmake_args(self):
-        spec = self.spec
         args = []
-        args.append(f"-DTorch_DIR=f{join_path(self['py-torch'].cmake_prefix_paths[0], 'Torch')}")
+        args.append(f"-DTorch_DIR=f{join_path(self['py-torch'].cmake_prefix_paths[0], 'Torch)}")
         return args
 
     @property

--- a/repos/spack_repo/builtin/packages/warp/package.py
+++ b/repos/spack_repo/builtin/packages/warp/package.py
@@ -85,7 +85,7 @@ class Warp(CMakePackage, CudaPackage):
 
     def cmake_args(self):
         args = []
-        args.append(f"-DTorch_DIR=f{join_path(self['py-torch'].cmake_prefix_paths[0], 'Torch)}")
+        args.append(f"-DTorch_DIR=f{join_path(self['py-torch'].cmake_prefix_paths[0], 'Torch')}")
         return args
 
     @property

--- a/repos/spack_repo/builtin/packages/warp/package.py
+++ b/repos/spack_repo/builtin/packages/warp/package.py
@@ -86,7 +86,7 @@ class Warp(CMakePackage, CudaPackage):
     def cmake_args(self):
         spec = self.spec
         args = []
-        args.append(f"-DTorch_DIR=f{join_path(self["py-torch"].cmake_prefix_paths[0], "Torch")}")
+        args.append(f"-DTorch_DIR=f{join_path(self['py-torch'].cmake_prefix_paths[0], 'Torch')}")
         return args
 
     @property


### PR DESCRIPTION
New package for [Warp](https://github.com/warpem/warp), another set of Cryo-EM tools.

It uses .NET; It builds a library `libSkiaSharp.so` and it is unclear how/where it gets it's dependencies (and which ones it actually are). I patch the `rpath` of it to use Spack stuff and that seemed to do the trick, but it could be a bit fragile on systems not RHEL 9.