### PR TITLE
fmt version for umpire

### DIFF
--- a/repos/spack_repo/builtin/packages/umpire/package.py
+++ b/repos/spack_repo/builtin/packages/umpire/package.py
@@ -265,9 +265,9 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("sqlite", when="+sqlite_experimental")
     depends_on("mpi", when="+mpi")
 
-    depends_on("fmt@9.1:11.0", when="@2024.02.0:")
+    depends_on("fmt@9.1:", when="@2024.02.0:")
     # For some reason, we need c++ 17 explicitly only with intel
-    depends_on("fmt@9.1:11.0 cxxstd=17", when="@2024.02.0: %intel@19.1")
+    depends_on("fmt@9.1: cxxstd=17", when="@2024.02.0: %intel@19.1")
 
     with when("@5.0.0:"):
         with when("+cuda"):


### PR DESCRIPTION
I verified that umpire builds with fmt 12

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
