### PR TITLE
(py-)onnx: add v1.18.0, v1.19.1

### DIFF
--- a/repos/spack_repo/builtin/packages/onnx/OpSchemaRegisterOnce.patch
+++ b/repos/spack_repo/builtin/packages/onnx/OpSchemaRegisterOnce.patch
@@ -1,0 +1,30 @@
+diff --git a/onnx/defs/schema.h b/onnx/defs/schema.h
+index 6a870de4c7cd4d6a144d4e6fea9c7f937c7292cf..a4ceac17692d109c0cacaece93b7ca0e9d25bbec 100644
+--- a/onnx/defs/schema.h
++++ b/onnx/defs/schema.h
+@@ -994,8 +994,10 @@ class OpSchemaRegistry final : public ISchemaRegistry {
+ 
+   class OpSchemaRegisterOnce final {
+    public:
+-    // Export to cpp custom register macro
+-    explicit OpSchemaRegisterOnce(
++    // Export to cpp custom register macro.
++    // DO NOT decorate the constructor as "explicit" because that breaks the macro ONNX_OPERATOR_SCHEMA_UNIQ.
++    // NOLINTNEXTLINE(google-explicit-constructor)
++    OpSchemaRegisterOnce( // NOSONAR
+         OpSchema op_schema,
+         int opset_version_to_load = 0,
+         bool fail_duplicate_schema = true) {
+@@ -1341,9 +1343,9 @@ size_t ReplaceAll(std::string& s, const char* from, const char* to);
+ // Legacy macros to register schema at static initialization
+ #define ONNX_OPERATOR_SCHEMA(name) ONNX_OPERATOR_SCHEMA_UNIQ_HELPER(__COUNTER__, name)
+ #define ONNX_OPERATOR_SCHEMA_UNIQ_HELPER(Counter, name) ONNX_OPERATOR_SCHEMA_UNIQ(Counter, name)
+-#define ONNX_OPERATOR_SCHEMA_UNIQ(Counter, name)                                                                      \
+-  static ONNX_NAMESPACE::OpSchemaRegistry::OpSchemaRegisterOnce(op_schema_register_once##name##Counter) ONNX_UNUSED = \
+-      OpSchema(#name, __FILE__, __LINE__)
++#define ONNX_OPERATOR_SCHEMA_UNIQ(Counter, name)                                                                     \
++  static ONNX_NAMESPACE::OpSchemaRegistry::OpSchemaRegisterOnce op_schema_register_once##name##Counter ONNX_UNUSED = \
++      ONNX_NAMESPACE::OpSchema(#name, __FILE__, __LINE__)
+ 
+ ONNX_API inline std::string GenerateOptionalArgumentsDoc() {
+   return "This operator has **optional** inputs/outputs. "

--- a/repos/spack_repo/builtin/packages/onnx/package.py
+++ b/repos/spack_repo/builtin/packages/onnx/package.py
@@ -20,7 +20,11 @@ class Onnx(CMakePackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("master", branch="master")
+    version("main", branch="main")
+    version("master", branch="master", deprecated=True)
+    version("1.19.1", sha256="ce9d2569a61d64e8a3d05b92194f60ffb7c868dbb754a71f5b4d992273a9413d")
+    version("1.19.0", sha256="2c2ac5a078b0350a0723fac606be8cd9e9e8cbd4c99bab1bffe2623b188fd236")
+    version("1.18.0", sha256="b466af96fd8d9f485d1bb14f9bbdd2dfb8421bc5544583f014088fb941a1d21e")
     version("1.17.0", sha256="8d5e983c36037003615e5a02d36b18fc286541bf52de1a78f6cf9f32005a820e")
     version("1.16.2", sha256="84fc1c3d6133417f8a13af6643ed50983c91dacde5ffba16cc8bb39b22c2acbb")
     version("1.16.1", sha256="0e6aa2c0a59bb2d90858ad0040ea1807117cc2f05b97702170f18e6cd6b66fb3")
@@ -54,14 +58,18 @@ class Onnx(CMakePackage):
     version("1.6.0_2020-02-16", commit="9fdae4c68960a2d44cd1cc871c74a6a9d469fa1f")  # py-torch@1.5
     version("1.6.0_2019-11-06", commit="fea8568cac61a482ed208748fdc0e1a8e47f62f5")  # py-torch@1.4
 
-    depends_on("c", type="build")  # FIXME: note https://github.com/onnx/onnx/pull/6826
+    depends_on("c", type="build", when="@:1.18")
     depends_on("cxx", type="build")
 
     generator("ninja")
     depends_on("cmake@3.1:", type="build")
     depends_on("cmake@3.14:", type="build", when="@1.17:")
+    depends_on("cmake@3.26:", type="build", when="@1.20:")
     depends_on("python", type="build")
     depends_on("protobuf")
+
+    # Allow conversion from OpSchema to OpSchemaRegisterOnce (needed for onnxruntime)
+    patch("OpSchemaRegisterOnce.patch", when="@1.18.0:1.19")
 
     def patch(self):
         if self.spec.satisfies("@1.13:1.14 ^protobuf@3.22:"):

--- a/repos/spack_repo/builtin/packages/onnx/package.py
+++ b/repos/spack_repo/builtin/packages/onnx/package.py
@@ -88,6 +88,7 @@ class Onnx(CMakePackage):
             # Try to get ONNX to use the same version of python as the spec is using
             self.define("PY_VERSION", self.spec["python"].version.up_to(2)),
             self.define("ONNX_BUILD_TESTS", self.run_tests),
+            self.define("ONNX_USE_PROTOBUF_SHARED_LIBS", self.spec["protobuf"].variants["shared"].value),
         ]
         if self.spec.satisfies("@1.15: ^protobuf@3.22:"):
             # CMAKE_CXX_STANDARD can be set on command line as of 1.15

--- a/repos/spack_repo/builtin/packages/onnx/package.py
+++ b/repos/spack_repo/builtin/packages/onnx/package.py
@@ -69,6 +69,7 @@ class Onnx(CMakePackage):
     depends_on("protobuf")
 
     # Allow conversion from OpSchema to OpSchemaRegisterOnce (needed for onnxruntime)
+    # Ref: https://github.com/onnx/onnx/pull/7390
     patch("OpSchemaRegisterOnce.patch", when="@1.18.0:1.19")
 
     def patch(self):

--- a/repos/spack_repo/builtin/packages/onnx/package.py
+++ b/repos/spack_repo/builtin/packages/onnx/package.py
@@ -20,6 +20,8 @@ class Onnx(CMakePackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    maintainers("wdconinc")
+
     version("main", branch="main")
     version("master", branch="master", deprecated=True)
     version("1.19.1", sha256="ce9d2569a61d64e8a3d05b92194f60ffb7c868dbb754a71f5b4d992273a9413d")

--- a/repos/spack_repo/builtin/packages/onnx/package.py
+++ b/repos/spack_repo/builtin/packages/onnx/package.py
@@ -88,7 +88,9 @@ class Onnx(CMakePackage):
             # Try to get ONNX to use the same version of python as the spec is using
             self.define("PY_VERSION", self.spec["python"].version.up_to(2)),
             self.define("ONNX_BUILD_TESTS", self.run_tests),
-            self.define("ONNX_USE_PROTOBUF_SHARED_LIBS", self.spec["protobuf"].variants["shared"].value),
+            self.define(
+                "ONNX_USE_PROTOBUF_SHARED_LIBS", self.spec["protobuf"].variants["shared"].value
+            ),
         ]
         if self.spec.satisfies("@1.15: ^protobuf@3.22:"):
             # CMAKE_CXX_STANDARD can be set on command line as of 1.15

--- a/repos/spack_repo/builtin/packages/py_onnx/OpSchemaRegisterOnce.patch
+++ b/repos/spack_repo/builtin/packages/py_onnx/OpSchemaRegisterOnce.patch
@@ -1,0 +1,30 @@
+diff --git a/onnx/defs/schema.h b/onnx/defs/schema.h
+index 6a870de4c7cd4d6a144d4e6fea9c7f937c7292cf..a4ceac17692d109c0cacaece93b7ca0e9d25bbec 100644
+--- a/onnx/defs/schema.h
++++ b/onnx/defs/schema.h
+@@ -994,8 +994,10 @@ class OpSchemaRegistry final : public ISchemaRegistry {
+ 
+   class OpSchemaRegisterOnce final {
+    public:
+-    // Export to cpp custom register macro
+-    explicit OpSchemaRegisterOnce(
++    // Export to cpp custom register macro.
++    // DO NOT decorate the constructor as "explicit" because that breaks the macro ONNX_OPERATOR_SCHEMA_UNIQ.
++    // NOLINTNEXTLINE(google-explicit-constructor)
++    OpSchemaRegisterOnce( // NOSONAR
+         OpSchema op_schema,
+         int opset_version_to_load = 0,
+         bool fail_duplicate_schema = true) {
+@@ -1341,9 +1343,9 @@ size_t ReplaceAll(std::string& s, const char* from, const char* to);
+ // Legacy macros to register schema at static initialization
+ #define ONNX_OPERATOR_SCHEMA(name) ONNX_OPERATOR_SCHEMA_UNIQ_HELPER(__COUNTER__, name)
+ #define ONNX_OPERATOR_SCHEMA_UNIQ_HELPER(Counter, name) ONNX_OPERATOR_SCHEMA_UNIQ(Counter, name)
+-#define ONNX_OPERATOR_SCHEMA_UNIQ(Counter, name)                                                                      \
+-  static ONNX_NAMESPACE::OpSchemaRegistry::OpSchemaRegisterOnce(op_schema_register_once##name##Counter) ONNX_UNUSED = \
+-      OpSchema(#name, __FILE__, __LINE__)
++#define ONNX_OPERATOR_SCHEMA_UNIQ(Counter, name)                                                                     \
++  static ONNX_NAMESPACE::OpSchemaRegistry::OpSchemaRegisterOnce op_schema_register_once##name##Counter ONNX_UNUSED = \
++      ONNX_NAMESPACE::OpSchema(#name, __FILE__, __LINE__)
+ 
+ ONNX_API inline std::string GenerateOptionalArgumentsDoc() {
+   return "This operator has **optional** inputs/outputs. "

--- a/repos/spack_repo/builtin/packages/py_onnx/package.py
+++ b/repos/spack_repo/builtin/packages/py_onnx/package.py
@@ -19,6 +19,7 @@ class PyOnnx(PythonPackage):
 
     homepage = "https://github.com/onnx/onnx"
     pypi = "Onnx/onnx-1.6.0.tar.gz"
+    git = "https://github.com/onnx/onnx.git"
 
     license("Apache-2.0", checked_by="wdconinc")
 

--- a/repos/spack_repo/builtin/packages/py_onnx/package.py
+++ b/repos/spack_repo/builtin/packages/py_onnx/package.py
@@ -101,6 +101,7 @@ class PyOnnx(PythonPackage):
     )
 
     # Allow conversion from OpSchema to OpSchemaRegisterOnce (needed for onnxruntime)
+    # Ref: https://github.com/onnx/onnx/pull/7390
     patch("OpSchemaRegisterOnce.patch", when="@1.18.0:1.19")
 
     # By default, ONNX always uses .setuptools-cmake-build/ under the source path,

--- a/repos/spack_repo/builtin/packages/py_onnx/package.py
+++ b/repos/spack_repo/builtin/packages/py_onnx/package.py
@@ -22,6 +22,10 @@ class PyOnnx(PythonPackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    version("main", branch="main")
+    version("1.19.1", sha256="737524d6eb3907d3499ea459c6f01c5a96278bb3a0f2ff8ae04786fb5d7f1ed5")
+    version("1.19.0", sha256="aa3f70b60f54a29015e41639298ace06adf1dd6b023b9b30f1bca91bb0db9473")
+    version("1.18.0", sha256="3d8dbf9e996629131ba3aa1afd1d8239b660d1f830c6688dd7e03157cccd6b9c")
     version("1.17.0", sha256="48ca1a91ff73c1d5e3ea2eef20ae5d0e709bb8a2355ed798ffc2169753013fd3")
     version("1.16.2", sha256="b33a282b038813c4b69e73ea65c2909768e8dd6cc10619b70632335daf094646")
     version("1.16.1", sha256="8299193f0f2a3849bfc069641aa8e4f93696602da8d165632af8ee48ec7556b6")
@@ -38,18 +42,22 @@ class PyOnnx(PythonPackage):
     version("1.6.0", sha256="3b88c3fe521151651a0403c4d131cb2e0311bd28b753ef692020a432a81ce345")
     version("1.5.0", sha256="1a584a4ef62a6db178c257fffb06a9d8e61b41c0a80bfd8bcd8a253d72c4b0b4")
 
-    depends_on("c", type="build")
+    depends_on("c", type="build", when="@:1.18")
     depends_on("cxx", type="build")
 
     # CMakeLists.txt
     depends_on("cmake@3.1:", type="build")
     depends_on("cmake@3.14:", type="build", when="@1.17:")
-    depends_on("py-pybind11@2.2:", type=("build", "link"))
+    depends_on("cmake@3.26:", type="build", when="@1.20:")
+    depends_on("py-pybind11@2.2:", type=("build", "link"), when="@:1.19")
+    depends_on("py-nanobind@2.8:", type=("build", "link"), when="@1.20:")
 
     # requirements.txt
+    depends_on("py-setuptools@77:", type="build", when="@1.20:")
     depends_on("py-setuptools@64:", type="build")
     depends_on("py-setuptools", type="build")
     depends_on("protobuf")
+    depends_on("py-protobuf@4.25.1:", type=("build", "run"), when="@1.18:")
     depends_on("py-protobuf@3.20.2:", type=("build", "run"), when="@1.15:")
     depends_on("py-protobuf@3.20.2:3", type=("build", "run"), when="@1.13")
     depends_on("py-protobuf@3.12.2:3.20.1", type=("build", "run"), when="@1.12")
@@ -62,10 +70,14 @@ class PyOnnx(PythonPackage):
     # https://github.com/onnx/onnx/pull/3112
     depends_on("py-protobuf@:3.17", type=("build", "run"), when="@:1.8")
     depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-numpy@1.23.2:", type=("build", "run"), when="@1.20:")
+    depends_on("py-numpy@1.22:", type=("build", "run"), when="@1.18:")
     depends_on("py-numpy@1.16.6:", type=("build", "run"), when="@1.8.1:1.13")
     depends_on("py-numpy@1.20:", type=("build", "run"), when="@1.16.0:")
     depends_on("py-numpy@1.21:", type=("build", "run"), when="@1.16.2:")
     depends_on("py-numpy@:1", type=("build", "run"), when="@:1.16")
+    depends_on("py-typing-extensions@4.7.1:", type=("build", "run"), when="@1.18:")
+    depends_on("py-ml-dtypes", type=("build", "run"), when="@1.19:")
 
     # Historical dependencies
     depends_on("py-six", type=("build", "run"), when="@:1.8.1")
@@ -87,6 +99,9 @@ class PyOnnx(PythonPackage):
         sha256="be12f589bc4113982e4162efcdbd95835a6c161a9a7e10cd1dde026cadedf8aa",
         when="@1.15.0 ^abseil-cpp cxxstd=20",
     )
+
+    # Allow conversion from OpSchema to OpSchemaRegisterOnce (needed for onnxruntime)
+    patch("OpSchemaRegisterOnce.patch", when="@1.18.0:1.19")
 
     # By default, ONNX always uses .setuptools-cmake-build/ under the source path,
     # so we allow overriding with a build environment variable

--- a/repos/spack_repo/builtin/packages/py_onnx/package.py
+++ b/repos/spack_repo/builtin/packages/py_onnx/package.py
@@ -23,6 +23,8 @@ class PyOnnx(PythonPackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    maintainers("wdconinc")
+
     version("main", branch="main")
     version("1.19.1", sha256="737524d6eb3907d3499ea459c6f01c5a96278bb3a0f2ff8ae04786fb5d7f1ed5")
     version("1.19.0", sha256="aa3f70b60f54a29015e41639298ace06adf1dd6b023b9b30f1bca91bb0db9473")

--- a/repos/spack_repo/builtin/packages/py_onnx/package.py
+++ b/repos/spack_repo/builtin/packages/py_onnx/package.py
@@ -77,7 +77,7 @@ class PyOnnx(PythonPackage):
     depends_on("py-numpy@1.21:", type=("build", "run"), when="@1.16.2:")
     depends_on("py-numpy@:1", type=("build", "run"), when="@:1.16")
     depends_on("py-typing-extensions@4.7.1:", type=("build", "run"), when="@1.18:")
-    depends_on("py-ml-dtypes", type=("build", "run"), when="@1.19:")
+    depends_on("py-ml-dtypes@0.5:", type=("build", "run"), when="@1.19:")
 
     # Historical dependencies
     depends_on("py-six", type=("build", "run"), when="@:1.8.1")


### PR DESCRIPTION
This PR adds newer versions of `onnx` and `py-onnx`, in particular v1.18.0, v1.19.0, v1.19.1. Added all point versions since some ML dependencies are very specific. The patch is specific to onnxruntime.