### PR TITLE
py-onnxruntime: add v1.21.1, v1.22.2

### DIFF
--- a/repos/spack_repo/builtin/packages/py_onnxruntime/package.py
+++ b/repos/spack_repo/builtin/packages/py_onnxruntime/package.py
@@ -26,6 +26,8 @@ class PyOnnxruntime(CMakePackage, PythonExtension, ROCmPackage, CudaPackage):
 
     license("MIT")
 
+    version("1.22.2", tag="v1.22.2", commit="5630b081cd25e4eccc7516a652ff956e51676794")
+    version("1.21.1", tag="v1.21.1", commit="8f7cce3a49fdbdac96e0868b75b7d0159db7ac7f")
     version("1.21.0", tag="v1.21.0", commit="e0b66cad282043d4377cea5269083f17771b6dfc")
     version("1.20.2", tag="v1.20.2", commit="8608bf02f21774be0388d2aa3a9f886d009d0b4c")
     version("1.19.2", tag="v1.19.2", commit="ffceed9d44f2f3efb9dd69fa75fea51163c91d91")
@@ -38,12 +40,13 @@ class PyOnnxruntime(CMakePackage, PythonExtension, ROCmPackage, CudaPackage):
     version("1.10.0", tag="v1.10.0", commit="0d9030e79888d1d5828730b254fedc53c7b640c1")
     version("1.7.2", tag="v1.7.2", commit="5bc92dff16b0ddd5063b717fb8522ca2ad023cb0")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("binutils@2.36:", type="build")
 
     # cmake/CMakeLists.txt
+    depends_on("cmake@3.28:", when="@1.21:", type="build")
     depends_on("cmake@3.26:", when="@1.17:", type="build")
     depends_on("cmake@3.1:", type="build")
 


### PR DESCRIPTION
This PR adds `py-onnxruntime`, v1.21.1, v1.22.2. No major changes, just a newer CMake required.

Not adding v1.23 yet since requires newer abseil-cpp and onnx.