### PR TITLE
netcdf-c: fix +mpi cmake builds

### DIFF
--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -379,6 +379,9 @@ class CMakeBuilder(AnyBuilder, cmake.CMakeBuilder):
             self.define(nc + "ENABLE_LARGE_FILE_SUPPORT", True),
             self.define_from_variant("NETCDF_ENABLE_LOGGING", "logging"),
         ]
+        # Note: NC_EXTRA_DEPS is not subject to the v4.9.3 name change.
+        if "+mpi" in self.pkg.spec:
+            base_cmake_args.append(self.define("NC_EXTRA_DEPS", "mpi"))
         if "+parallel-netcdf" in self.pkg.spec:
             base_cmake_args.append(self.define(nc + "ENABLE_PNETCDF", True))
         if self.pkg.spec.satisfies("@4.3.1:"):

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -380,7 +380,7 @@ class CMakeBuilder(AnyBuilder, cmake.CMakeBuilder):
             self.define_from_variant("NETCDF_ENABLE_LOGGING", "logging"),
         ]
         # Note: NC_EXTRA_DEPS is not subject to the v4.9.3 name change.
-        if "+mpi" in self.pkg.spec:
+        if "+mpi" in self.pkg.spec and "platform=windows" not in self.pkg.spec:
             base_cmake_args.append(self.define("NC_EXTRA_DEPS", "mpi"))
         if "+parallel-netcdf" in self.pkg.spec:
             base_cmake_args.append(self.define(nc + "ENABLE_PNETCDF", True))


### PR DESCRIPTION
This change adds a parameter to the cmake builder to fix a bug where MPI builds were failing to build the fortran compatibility layer even when it was present. See https://github.com/Unidata/netcdf-c/issues/3199 for background on the issue.

While a durable fix is proposed in the issue linked above, all current version are affected by this bug and all netcdf-fortran binaries based on the current spack `build_system=cmake` binary will have difficult to trace segfaults if they are built without this patch adding an argument for `NC_EXTRA_DEPS`.

