### PR TITLE
r ecosystem: add missing language deps

### DIFF
--- a/repos/spack_repo/builtin/packages/r_acepack/package.py
+++ b/repos/spack_repo/builtin/packages/r_acepack/package.py
@@ -32,3 +32,6 @@ class RAcepack(RPackage):
 
     version("1.4.2", sha256="5bffcd12b783f372bb6c50e35317744ac31597c91b6433442a7b0dce2f66ac91")
     version("1.4.1", sha256="82750507926f02a696f6cc03693e8d4a5ee7e92500c8c15a16a9c12addcd28b9")
+
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/r_adephylo/package.py
+++ b/repos/spack_repo/builtin/packages/r_adephylo/package.py
@@ -21,6 +21,8 @@ class RAdephylo(RPackage):
     version("1.1-13", sha256="2aa132fee9d0a14ac09b0a96af40ac332cb4e13c892908803c335aa7319ca76d")
     version("1.1-11", sha256="154bf2645eac4493b85877933b9445442524ca4891aefe4e80c294c398cff61a")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r-ade4@1.7-10:", type=("build", "run"))
     depends_on("r-phylobase", type=("build", "run"))
     depends_on("r-ape", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_adespatial/package.py
+++ b/repos/spack_repo/builtin/packages/r_adespatial/package.py
@@ -28,6 +28,8 @@ class RAdespatial(RPackage):
     version("0.3-14", sha256="a2ef7549c1ed7a23651716c633b25eaff468af8ccbf2e9fcd164e485984cbfbf")
     version("0.3-8", sha256="e3fd3209ce3f0a862a0794187e8c884f1697c87c96e569a2f51f252e00022906")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r-ade4@1.7-13:", type=("build", "run"))
     depends_on("r-adegraphics", type=("build", "run"))
     depends_on("r-adephylo", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_amelia/package.py
+++ b/repos/spack_repo/builtin/packages/r_amelia/package.py
@@ -33,6 +33,9 @@ class RAmelia(RPackage):
     version("1.8.0", sha256="3ec1d5a68dac601b354227916aa8ec72fa1216b603dd887aae2b24cb69b5995e")
     version("1.7.6", sha256="63c08d374aaf78af46c34dc78da719b3085e58d9fabdc76c6460d5193a621bea")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.0.2:", type=("build", "run"))
     depends_on("r-rcpp@0.11:", type=("build", "run"))
     depends_on("r-foreign", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_bayesm/package.py
+++ b/repos/spack_repo/builtin/packages/r_bayesm/package.py
@@ -42,6 +42,8 @@ class RBayesm(RPackage):
     version("3.1-1", sha256="4854517dec30ab7c994de862aae1998c2d0c5e71265fd9eb7ed36891d4676078")
     version("3.1-0.1", sha256="5879823b7fb6e6df0c0fe98faabc1044a4149bb65989062df4ade64e19d26411")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.2.0:", type=("build", "run"))
     depends_on("r-rcpp@0.12.0:", type=("build", "run"))
     depends_on("r-rcpparmadillo", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_bglr/package.py
+++ b/repos/spack_repo/builtin/packages/r_bglr/package.py
@@ -19,6 +19,8 @@ class RBglr(RPackage):
     version("1.0.9", sha256="440a96f9f502e0d6ecc8c00720d1ccdbab5ee8223e1def6c930edaa9a9de9099")
     version("1.0.8", sha256="5e969590d80b2f272c02a43b487ab1ffa13af386e0342993e6ac484fc82c9b95")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.5.0:", type=("build", "run"))
     depends_on("r-truncnorm", type=("build", "run"))
     depends_on("r-mass", type=("build", "run"), when="@1.0.9:")

--- a/repos/spack_repo/builtin/packages/r_bh/package.py
+++ b/repos/spack_repo/builtin/packages/r_bh/package.py
@@ -36,3 +36,5 @@ class RBh(RPackage):
     version("1.69.0-1", sha256="a0fd4364b7e368f09c56dec030823f52c16da0787580af7e4615eddeb99baca2")
     version("1.65.0-1", sha256="82baa78afe8f1edc3c7e84e1c9924321047e14c1e990df9b848407baf3f7cb58")
     version("1.60.0-2", sha256="e441aede925d760dc0142be77079ebd7a46f2392772b875cde6ca567dd49c48c")
+
+    depends_on("cxx", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/r_bigalgebra/package.py
+++ b/repos/spack_repo/builtin/packages/r_bigalgebra/package.py
@@ -29,6 +29,10 @@ class RBigalgebra(RPackage):
     version("1.0.0", sha256="f186b603bd660be0cc5b7a52c943e23e92fef264f0bc96a8858e38df6cfc4085")
     version("0.8.4.2", sha256="29962468cbfa6416f8628563d5ed8c9f76089190311ff1c618f099ee8d9eea75")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r-bigmemory@4.0.0:", type=("build", "run"))
     depends_on("r-bh", type=("build", "run"))
     depends_on("r-rcpp", type=("build", "run"), when="@1.0.0:")

--- a/repos/spack_repo/builtin/packages/r_biglm/package.py
+++ b/repos/spack_repo/builtin/packages/r_biglm/package.py
@@ -17,4 +17,7 @@ class RBiglm(RPackage):
 
     version("0.9-3", sha256="805d483dc58c041f1616267abeb39cecaaf7271a34e90668a5439383bf9a0d58")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r-dbi", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_bigmemory/package.py
+++ b/repos/spack_repo/builtin/packages/r_bigmemory/package.py
@@ -23,6 +23,8 @@ class RBigmemory(RPackage):
     version("4.6.1", sha256="b56e157c87ed6c4fc69d4cb9c697ae9a2001726e776e41aa7c48b35327b65141")
     version("4.5.36", sha256="18c67fbe6344b2f8223456c4f19ceebcf6c1166255eab81311001fd67a45ef0e")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.2.0:", type=("build", "run"))
     depends_on("r-bigmemory-sri", type=("build", "run"))
     depends_on("r-rcpp", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_bindrcpp/package.py
+++ b/repos/spack_repo/builtin/packages/r_bindrcpp/package.py
@@ -21,6 +21,8 @@ class RBindrcpp(RPackage):
     version("0.2.2", sha256="48130709eba9d133679a0e959e49a7b14acbce4f47c1e15c4ab46bd9e48ae467")
     version("0.2", sha256="d0efa1313cb8148880f7902a4267de1dcedae916f28d9a0ef5911f44bf103450")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r-rcpp@0.12.16:", type=("build", "run"))
     depends_on("r-bindr@0.1.1:", type=("build", "run"))
     depends_on("r-plogr", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_blavaan/package.py
+++ b/repos/spack_repo/builtin/packages/r_blavaan/package.py
@@ -26,6 +26,8 @@ class RBlavaan(RPackage):
     version("0.3-18", sha256="373960a22fc741c765e2ad2e0d99c1d4b2162f5f2a230ef314778ef8f433e865")
     version("0.3-15", sha256="f73ead024bc3b65bdb0c5e5cd5458845158914eb579c07be2fd697a3573ebe6f")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.5.0:", type=("build", "run"))
     depends_on("r-lavaan@0.6-5:", type=("build", "run"))
     depends_on("r-lavaan@0.6-7:", type=("build", "run"), when="@0.3-18:")

--- a/repos/spack_repo/builtin/packages/r_blockmodeling/package.py
+++ b/repos/spack_repo/builtin/packages/r_blockmodeling/package.py
@@ -25,6 +25,9 @@ class RBlockmodeling(RPackage):
     version("0.3.4", sha256="a269c83669dd5294cff0adddab36bc023db6a276a06b74b1fa94b7e407486987")
     version("0.3.1", sha256="39e8360400cec6baa920d5589d4e779568bdf2954f7331be0e3cadf22a217d31")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@2.10:", type=("build", "run"))
     depends_on("r-matrix", type=("build", "run"))
 

--- a/repos/spack_repo/builtin/packages/r_brio/package.py
+++ b/repos/spack_repo/builtin/packages/r_brio/package.py
@@ -22,4 +22,6 @@ class RBrio(RPackage):
     version("1.1.3", sha256="eaa89041856189bee545bf1c42c7920a0bb0f1f70bb477487c467ee3e8fedcc6")
     version("1.1.0", sha256="6bb3a3b47bea13f1a1e3dcdc8b9f688502643e4b40a481a34aa04a261aabea38")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.6:", when="@1.1.4:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_bwstest/package.py
+++ b/repos/spack_repo/builtin/packages/r_bwstest/package.py
@@ -21,5 +21,7 @@ class RBwstest(RPackage):
     version("0.2.3", sha256="4bc4cc27fcf0aa60c6497048b74528923aae852c98480900204835a8ebd714b2")
     version("0.2.2", sha256="faff1dd698f1673a6befacb94d14281077d4c19be035a0a3bf85d77c1dfd5509")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r-memoise", type=("build", "run"))
     depends_on("r-rcpp@0.12.3:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_cairo/package.py
+++ b/repos/spack_repo/builtin/packages/r_cairo/package.py
@@ -34,6 +34,8 @@ class RCairo(RPackage):
     version("1.5-10", sha256="7837f0c384cd49bb3342cb39a916d7a80b02fffbf123913a58014e597f69b5d5")
     version("1.5-9", sha256="2a867b6cae96671d6bc3acf9334d6615dc01f6ecf1953a27cde8a43c724a38f4")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r+X", type=("build", "run"))
     depends_on("r@2.4.0:", type=("build", "run"))
     # "The Cairo package requires cairo library 1.2.0 or higher with PNG support enabled"

--- a/repos/spack_repo/builtin/packages/r_chron/package.py
+++ b/repos/spack_repo/builtin/packages/r_chron/package.py
@@ -25,4 +25,6 @@ class RChron(RPackage):
     version("2.3-52", sha256="c47fcf4abb635babe6337604c876d4853d8a24639a98b71523746c56ce75b4a0")
     version("2.3-47", sha256="9a8c771021165de517e54c3369c622aaac1bf3e220a2fbf595aba285e60445f6")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.12.0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_clarabel/package.py
+++ b/repos/spack_repo/builtin/packages/r_clarabel/package.py
@@ -26,4 +26,6 @@ class RClarabel(RPackage):
 
     version("0.9.0", sha256="50963022f8e5dc9d956193acf7b87194548dc4b3555bd844aa1f9f4d34f2c6bc")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("rust", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_class/package.py
+++ b/repos/spack_repo/builtin/packages/r_class/package.py
@@ -25,5 +25,7 @@ class RClass(RPackage):
     version("7.3-15", sha256="f6bf33d610c726d58622b6cea78a808c7d6a317d02409d27c17741dfd1c730f4")
     version("7.3-14", sha256="18b876dbc18bebe6a00890eab7d04ef72b903ba0049d5ce50731406a82426b9c")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r-mass", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_classint/package.py
+++ b/repos/spack_repo/builtin/packages/r_classint/package.py
@@ -24,6 +24,9 @@ class RClassint(RPackage):
     version("0.3-1", sha256="e2e6f857b544dfecb482b99346aa3ecfdc27b4d401c3537ee8fbaf91caca92b9")
     version("0.1-24", sha256="f3dc9084450ea3da07e1ea5eeb097fd2fedc7e29e5d7794b418bcb438c4fcfa2")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@2.2:", type=("build", "run"))
     depends_on("r-e1071", type=("build", "run"))
     depends_on("r-class", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_clock/package.py
+++ b/repos/spack_repo/builtin/packages/r_clock/package.py
@@ -24,6 +24,8 @@ class RClock(RPackage):
     version("0.7.1", sha256="432d2fc39d3f20e348f09a9b6136a02a588db585bab428d184da71bf6aa1f0d8")
     version("0.6.1", sha256="f80c385fd8229538968ffb71d7de53ddc82bfcec6641f8e76f299546c43c1702")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.4:", type=("build", "run"))
     depends_on("r@3.6.0:", type=("build", "run"), when="@0.7.1:")
     depends_on("r-cli@3.6.1:", type=("build", "run"), when="@0.7.0:")

--- a/repos/spack_repo/builtin/packages/r_clue/package.py
+++ b/repos/spack_repo/builtin/packages/r_clue/package.py
@@ -22,5 +22,7 @@ class RClue(RPackage):
     version("0.3-58", sha256="2ab6662eaa1103a7b633477e8ebd266b262ed54fac6f9326b160067a2ded9ce7")
     version("0.3-57", sha256="6e369d07b464a9624209a06b5078bf988f01f7963076e946649d76aea0622d17")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.2.0:", type=("build", "run"))
     depends_on("r-cluster", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_cluster/package.py
+++ b/repos/spack_repo/builtin/packages/r_cluster/package.py
@@ -27,6 +27,9 @@ class RCluster(RPackage):
     version("2.0.5", sha256="4b309133bc2ad7b8fe4fa538dd69635bc8a4cd724a3c95f01084098876c57bae")
     version("2.0.4", sha256="d4d925c4fc1fc4f2e2e3c9208e518507aad6c28bb143b4358a05a8a8944ac6e4")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@3.0.1:", type=("build", "run"))
     depends_on("r@3.2.0:", type=("build", "run"), when="@2.0.7:")
     depends_on("r@3.3.0:", type=("build", "run"), when="@2.0.8:")

--- a/repos/spack_repo/builtin/packages/r_coin/package.py
+++ b/repos/spack_repo/builtin/packages/r_coin/package.py
@@ -25,6 +25,8 @@ class RCoin(RPackage):
     version("1.2-2", sha256="d518065d3e1eb00121cb4e0200e1e4ae6b68eca6e249afc38bbffa35d24105bb")
     version("1.1-3", sha256="8b88ecc25903c83539dfc73cdc31a160e2aa4a7bea1773b22c79133d2f006035")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.14.0:", type=("build", "run"))
     depends_on("r@3.4.0:", type=("build", "run"), when="@1.3-0:")
     depends_on("r@3.6.0:", type=("build", "run"), when="@1.4-2:")

--- a/repos/spack_repo/builtin/packages/r_commonmark/package.py
+++ b/repos/spack_repo/builtin/packages/r_commonmark/package.py
@@ -26,3 +26,5 @@ class RCommonmark(RPackage):
     version("1.8.1", sha256="96adcb093de3d2e48811af402da70e7222a313b97f1e979e0cbe84dd59bd5cbe")
     version("1.8.0", sha256="7d07e72937b1cf158e69f183722bf79dbb91b8967a9dd29f4fa145500c2be668")
     version("1.7", sha256="d14a767a3ea9778d6165f44f980dd257423ca6043926e3cd8f664f7171f89108")
+
+    depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/r_compositions/package.py
+++ b/repos/spack_repo/builtin/packages/r_compositions/package.py
@@ -24,6 +24,8 @@ class RCompositions(RPackage):
     version("2.0-1", sha256="84a291308faf858e5a9d9570135c2da5e57b0887f407903485fa85d09da61a0f")
     version("1.40-2", sha256="110d71ae000561987cb73fc76cd953bd69d37562cb401ed3c36dca137d01b78a")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.2.0:", type=("build", "run"))
     depends_on("r@3.6:", type=("build", "run"), when="@2.0-4:")
 

--- a/repos/spack_repo/builtin/packages/r_construct/package.py
+++ b/repos/spack_repo/builtin/packages/r_construct/package.py
@@ -24,6 +24,8 @@ class RConstruct(RPackage):
     version("1.0.4", sha256="4e585b718a361061bc1432cea46fc65f802fb0ef58e4516d33e1af99bbfe90ce")
     version("1.0.3", sha256="b449c133a944ad05a28f84f312ed4ccbc1574c4659aa09c678618d2ae9008310")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r+X", type=("build", "run"))
     depends_on("r@3.4.0:", type=("build", "run"))
     depends_on("r-rcpp@0.12.0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_copula/package.py
+++ b/repos/spack_repo/builtin/packages/r_copula/package.py
@@ -33,6 +33,9 @@ class RCopula(RPackage):
     version("1.0-1", sha256="d09b2ccffc7379e48b00952aa6b282baf502feebaf55cc44e93f881d7b909742")
     version("0.999-20", sha256="7d3d47bce2dacb05b94a772f84dbf3d83c99ac2ac11e5f1b4b03d50d9d5c0fb0")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@3.2.0:", type=("build", "run"))
     depends_on("r@3.5.0:", type=("build", "run"), when="@1.0-1:")
     depends_on("r-matrix", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_covr/package.py
+++ b/repos/spack_repo/builtin/packages/r_covr/package.py
@@ -32,6 +32,9 @@ class RCovr(RPackage):
     version("3.2.0", sha256="b26135306b1d6b14dd4deb481359dd919a7ca1e802ca5479fed394dcf35f0ef9")
     version("3.0.1", sha256="66b799fd03cb83a9ab382d9cf4ff40603d1e3f3a89905a3174546b0c63e8d184")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.1.0:", type=("build", "run"))
     depends_on("r-digest", type=("build", "run"), when="@3.2.0:")
     depends_on("r-jsonlite", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_cpp11/package.py
+++ b/repos/spack_repo/builtin/packages/r_cpp11/package.py
@@ -25,4 +25,6 @@ class RCpp11(RPackage):
     version("0.4.0", sha256="1768fd07dc30dfbbf8f3fb1a1183947cb7e1dfd909165c4d612a63c163a41e87")
     version("0.2.5", sha256="6fef9306c0c3043252c987e77c99ef679b2ea46dffafae318dbeb38ad21a2e20")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.5.0:", when="@0.4.6:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_cubature/package.py
+++ b/repos/spack_repo/builtin/packages/r_cubature/package.py
@@ -31,6 +31,10 @@ class RCubature(RPackage):
     version("2.0.2", sha256="641165c665ff490c523bccc05c42bb6851e42676b6b366b55fc442a51a8fbe8c")
     version("1.1-2", sha256="0a05469bdc85d6bd8165a42a3fc5c35a06700d279e4e8b3cf4669df19edffeed")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r-rcpp", type=("build", "run"), when="@2.0.3:")
     depends_on("gmake", type="build")
 

--- a/repos/spack_repo/builtin/packages/r_cubist/package.py
+++ b/repos/spack_repo/builtin/packages/r_cubist/package.py
@@ -23,5 +23,7 @@ class RCubist(RPackage):
     version("0.2.1", sha256="b310c3f166f15fa3e16f8d110d39931b0bb1b0aa8d0c9ac2af5a9a45081588a3")
     version("0.0.19", sha256="101379979acb12a58bcf32a912fef32d497b00263ebea918f2b85a2c32934aae")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r-lattice", type=("build", "run"))
     depends_on("r-reshape2", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_cvxr/package.py
+++ b/repos/spack_repo/builtin/packages/r_cvxr/package.py
@@ -26,6 +26,8 @@ class RCvxr(RPackage):
     version("1.0-14", sha256="4d027cc2b933720ded4edcc098fde1259992673825abdb109fd84fee4af57cdb")
     version("1.0-11", sha256="e92a9638f35f4909e2a29c3b7106081e3dae7ff88b14bb6466b87fbdc80b972a")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.4.0:", type=("build", "run"))
     depends_on("r-r6", type=("build", "run"))
     depends_on("r-matrix", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_deldir/package.py
+++ b/repos/spack_repo/builtin/packages/r_deldir/package.py
@@ -27,5 +27,8 @@ class RDeldir(RPackage):
     version("0.1-21", sha256="b9dabcc1813c7a0f8edaf720a94bdd611a83baf3d3e52e861d352369e815690c")
     version("0.1-14", sha256="89d365a980ef8589971e5d311c6bd59fe32c48dbac8000a880b9655032c99289")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@0.99:", type=("build", "run"))
     depends_on("r@3.5.0:", type=("build", "run"), when="@0.2-3:")

--- a/repos/spack_repo/builtin/packages/r_desolve/package.py
+++ b/repos/spack_repo/builtin/packages/r_desolve/package.py
@@ -35,6 +35,9 @@ class RDesolve(RPackage):
     version("1.21", sha256="45c372d458fe4c7c11943d4c409517849b1be6782dc05bd9a74b066e67250c63")
     version("1.20", sha256="56e945835b0c66d36ebc4ec8b55197b616e387d990788a2e52e924ce551ddda2")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@2.15.0:", type=("build", "run"))
     depends_on("r@3.3.0:", type=("build", "run"), when="@1.28:")
     depends_on("r@4.0.0:", type=("build", "run"), when="@1.32:")

--- a/repos/spack_repo/builtin/packages/r_diptest/package.py
+++ b/repos/spack_repo/builtin/packages/r_diptest/package.py
@@ -21,3 +21,5 @@ class RDiptest(RPackage):
     version("0.77-1", sha256="224eae00f483ce0fb131719065667227417cc98ad2beda55bfd5efe2bb612813")
     version("0.76-0", sha256="508a5ebb161519cd0fcd156dc047b51becb216d545d62c6522496463f94ec280")
     version("0.75-7", sha256="462900100ca598ef21dbe566bf1ab2ce7c49cdeab6b7a600a50489b05f61b61b")
+
+    depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/r_dismo/package.py
+++ b/repos/spack_repo/builtin/packages/r_dismo/package.py
@@ -24,6 +24,8 @@ class RDismo(RPackage):
     version("1.3-3", sha256="fd65331ac18a4287ba0856b90508ddd0e2738c653eecc5f3eb2b14e1d06949ca")
     version("1.1-4", sha256="f2110f716cd9e4cca5fd2b22130c6954658aaf61361d2fe688ba22bbfdfa97c8")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.2.0:", type=("build", "run"))
     depends_on("r@4.0.0:", type=("build", "run"), when="@1.3-5:")
     depends_on("r@3.6.3:", type=("build", "run"), when="@1.3-9:")

--- a/repos/spack_repo/builtin/packages/r_diversitree/package.py
+++ b/repos/spack_repo/builtin/packages/r_diversitree/package.py
@@ -28,6 +28,9 @@ class RDiversitree(RPackage):
     version("0.9-11", sha256="4caa6a468f93de9f1c8c30e4457f34bb8346e1acdaf74f684005bfa86a950ecb")
     version("0.9-10", sha256="e7df5910c8508a5c2c2d6d3deea53dd3f947bb762196901094c32a7033cb043e")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@2.10:", type=("build", "run"))
     depends_on("r-ape", type=("build", "run"))
     depends_on("r-desolve@1.7:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_dotcall64/package.py
+++ b/repos/spack_repo/builtin/packages/r_dotcall64/package.py
@@ -24,4 +24,7 @@ class RDotcall64(RPackage):
     version("1.0-1", sha256="f10b28fcffb9453b1d8888a72c8fd2112038b5ac33e02a481492c7bd249aa5c6")
     version("1.0-0", sha256="69318dc6b8aecc54d4f789c8105e672198363b395f1a764ebaeb54c0473d17ad")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@3.1:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_dqrng/package.py
+++ b/repos/spack_repo/builtin/packages/r_dqrng/package.py
@@ -31,6 +31,8 @@ class RDqrng(RPackage):
     version("0.3.0", sha256="4beeabfe245ce7196b07369f2a7d277cb08869ad8b45a22c6354c4cc70a39abb")
     version("0.2.1", sha256="e149c105b1db31e7f46b1aebf31d911a109e380923f3696fc56a53197fc1e866")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.1.0:", type=("build", "run"))
     depends_on("r@3.5.0:", type=("build", "run"), when="@0.3.1:")
     depends_on("r-rcpp@0.12.16:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_e1071/package.py
+++ b/repos/spack_repo/builtin/packages/r_e1071/package.py
@@ -29,5 +29,8 @@ class RE1071(RPackage):
     version("1.7-1", sha256="5c5f04a51c1cd2c7dbdf69987adef9bc07116804c63992cd36d804a1daf89dfe")
     version("1.6-7", sha256="7048fbc0ac17d7e3420fe68081d0e0a2176b1154ee3191d53558ea9724c7c980")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r-class", type=("build", "run"))
     depends_on("r-proxy", type=("build", "run"), when="@1.7-9:")

--- a/repos/spack_repo/builtin/packages/r_earth/package.py
+++ b/repos/spack_repo/builtin/packages/r_earth/package.py
@@ -24,6 +24,9 @@ class REarth(RPackage):
     version("5.3.0", sha256="05ace806271a74b3ddf8718a93237fe2a8550a8659ebd87f8079c0bda5e02437")
     version("5.1.2", sha256="326f98e8c29365ca3cd5584cf2bd6529358f5ef81664cbd494162f92b6c3488d")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@3.4.0:", type=("build", "run"))
     depends_on("r-formula@1.2-3:", type=("build", "run"))
     depends_on("r-plotmo@3.5.4:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_ecosolver/package.py
+++ b/repos/spack_repo/builtin/packages/r_ecosolver/package.py
@@ -21,4 +21,6 @@ class REcosolver(RPackage):
     version("0.5.5", sha256="2594ed1602b2fe159cc9aff3475e9cba7c1927b496c3daeabc1c0d227943ecc7")
     version("0.5.4", sha256="5d7489e8176c1df3f3f1290732243429280efca4f837916e6b6faa6dc8a8e324")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("gmake", type="build")

--- a/repos/spack_repo/builtin/packages/r_ecp/package.py
+++ b/repos/spack_repo/builtin/packages/r_ecp/package.py
@@ -27,5 +27,8 @@ class REcp(RPackage):
     version("3.1.3", sha256="a80ab10bafe30cc96287b9220e44c4b4eda40f5dd0546e4d2a2e1baab514c058")
     version("3.1.1", sha256="d2ab194e22e6ab0168222fbccfcf2e25c6cd51a73edc959086b0c6e0a7410268")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r-rcpp", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_ergm/package.py
+++ b/repos/spack_repo/builtin/packages/r_ergm/package.py
@@ -32,6 +32,8 @@ class RErgm(RPackage):
     version("3.10.1", sha256="a2ac249ff07ba55b3359242f20389a892543b4fff5956d74143d2d41fa6d4beb")
     version("3.7.1", sha256="91dd011953b93ecb2b84bb3ababe7bddae25d9d86e69337156effd1da84b54c3")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.5:", type=("build", "run"), when="@4.1.2:")
     depends_on("r@4.0:", type=("build", "run"), when="@4.2.1:")
     depends_on("r@4.1:", type=("build", "run"), when="@4.4.0:")

--- a/repos/spack_repo/builtin/packages/r_evd/package.py
+++ b/repos/spack_repo/builtin/packages/r_evd/package.py
@@ -24,3 +24,5 @@ class REvd(RPackage):
     version("2.3-6.1", sha256="662c592d3f5c5693dbf1c673d1137c4a60a347e330b71be1f3933f201d2c8971")
     version("2.3-6", sha256="8edb8bc4f06d246c4343fd923bb5d5df99724d6db8821bfd996220343a834cb6")
     version("2.3-3", sha256="2fc5ef2e0c3a2a9392425ddd45914445497433d90fb80b8c363877baee4559b4")
+
+    depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/r_exactextractr/package.py
+++ b/repos/spack_repo/builtin/packages/r_exactextractr/package.py
@@ -26,6 +26,8 @@ class RExactextractr(RPackage):
     version("0.3.0", sha256="c7fb38b38b9dc8b3ca5b8f1f84f4ba3256efd331f2b4636b496d42689ffc3fb0")
     version("0.2.1", sha256="d0b998c77c3fd9265a600a0e08e9bf32a2490a06c19df0d0c0dea4b5c9ab5773")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.4.0:", type=("build", "run"))
     depends_on("r-rcpp@0.12.12:", type=("build", "run"))
     depends_on("r-raster", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_exomedepth/package.py
+++ b/repos/spack_repo/builtin/packages/r_exomedepth/package.py
@@ -19,6 +19,9 @@ class RExomedepth(RPackage):
     version("1.1.16", sha256="7ba6b51e7ea435a2799b25d99bb9f48e2b1e99e15e47f88e514e98120b4cebe4")
     version("1.1.15", sha256="112bcb536f5766d9d0b55e064feedd6727ccab14cb1edfdba1f0d7b890e55ad2")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.4.0:", type=("build", "run"))
     depends_on("r-biostrings", type=("build", "run"))
     depends_on("r-iranges", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_expm/package.py
+++ b/repos/spack_repo/builtin/packages/r_expm/package.py
@@ -24,4 +24,7 @@ class RExpm(RPackage):
     version("0.999-3", sha256="511bac5860cc5b3888bca626cdf23241b6118eabcc82d100935386039e516412")
     version("0.999-2", sha256="38f1e5bfa90f794486789695d0d9e49158c7eb9445dc171dd83dec3d8fa130d6")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r-matrix", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_factominer/package.py
+++ b/repos/spack_repo/builtin/packages/r_factominer/package.py
@@ -33,6 +33,8 @@ class RFactominer(RPackage):
     version("1.36", sha256="2198c3facaa41a23df6f9373d4ccb636b98a8810896e379e5deb686ab31b36de")
     version("1.35", sha256="afe176fe561d1d16c5965ecb2b80ec90a56d0fbcd75c43ec8025a401a5b715a9")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r@3.5.0:", type=("build", "run"), when="@2.4:")
     depends_on("r@4.0:", type=("build", "run"), when="@2.6:")

--- a/repos/spack_repo/builtin/packages/r_fastdigest/package.py
+++ b/repos/spack_repo/builtin/packages/r_fastdigest/package.py
@@ -26,3 +26,5 @@ class RFastdigest(RPackage):
 
     version("0.6-4", sha256="b2b6a550d90446bed911c9ad7642efd2a869257ecc5b9eb57e66b2cd4ef109a0")
     version("0.6-3", sha256="62a04aa39f751cf9bb7ff43cadb3c1a8d2270d7f3e8550a2d6ca9e1d8ca09a09")
+
+    depends_on("cxx", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/r_fastica/package.py
+++ b/repos/spack_repo/builtin/packages/r_fastica/package.py
@@ -19,5 +19,7 @@ class RFastica(RPackage):
     version("1.2-3", sha256="e9ef82644cb64bb49ae3b7b6e0885f4fb2dc08ae030f8c76fe8dd8507b658950")
     version("1.2-2", sha256="32223593374102bf54c8fdca7b57231e4f4d0dd0be02d9f3500ad41b1996f1fe")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r@4.0.0:", type=("build", "run"), when="@1.2-3:")

--- a/repos/spack_repo/builtin/packages/r_fastmatch/package.py
+++ b/repos/spack_repo/builtin/packages/r_fastmatch/package.py
@@ -23,4 +23,6 @@ class RFastmatch(RPackage):
     version("1.1-3", sha256="1defa0b08bc3f48e4c3e4ba8df4f1b9e8299932fd8c747c67d32de44f90b9861")
     version("1.1-0", sha256="20b51aa4838dbe829e11e951444a9c77257dcaf85130807508f6d7e76797007d")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.3.0:", type=("build", "run"), when="@1.1-3:")

--- a/repos/spack_repo/builtin/packages/r_fastmatrix/package.py
+++ b/repos/spack_repo/builtin/packages/r_fastmatrix/package.py
@@ -38,4 +38,7 @@ class RFastmatrix(RPackage):
     version("0.3-8196", sha256="72fae07c627b995a091ccc3e14b2b2167474e3b1f14d723e87252538cf978fb6")
     version("0.3", sha256="d92e789454a129db5f6f5b23e0d2245f3d55ff34b167427af265b9a6331e7c21")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@3.5.0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_ff/package.py
+++ b/repos/spack_repo/builtin/packages/r_ff/package.py
@@ -65,6 +65,9 @@ class RFf(RPackage):
     version("2.2-14", sha256="1c6307847275b1b8ad9e2ffdce3f4df3c9d955dc2e8a45e3fd7bfd2b0926e2f0")
     version("2.2-13", sha256="8bfb08afe0651ef3c23aaad49208146d5f929af5af12a25262fe7743fa346ddb")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@2.10.1:", type=("build", "run"))
     depends_on("r-bit@1.1-13:", type=("build", "run"))
     depends_on("r-bit@4.0.0:", type=("build", "run"), when="@4.0.4:")

--- a/repos/spack_repo/builtin/packages/r_fields/package.py
+++ b/repos/spack_repo/builtin/packages/r_fields/package.py
@@ -45,6 +45,9 @@ class RFields(RPackage):
     version("11.6", sha256="8600d1d992c40668cc2ab01b3c17d0e1bd44a001ec7ba9f468bc0e9ef87c59db")
     version("9.9", sha256="262f03c630773b580c7162ab2a031c894ca489fd83989fd8a2f67573306e78e1")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@3.0:", type=("build", "run"))
     depends_on("r@3.5.0:", type=("build", "run"), when="@14.1:")
     depends_on("r-spam", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_filehash/package.py
+++ b/repos/spack_repo/builtin/packages/r_filehash/package.py
@@ -31,5 +31,7 @@ class RFilehash(RPackage):
     version("2.4-1", sha256="d0e087d338d89372c251c18fc93b53fb24b1750ea154833216ff16aff3b1eaf4")
     version("2.3", sha256="63b098df9a2cf4aac862cd7bf86ae516e00852a8ad0f3090f9721b6b173e6edb")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r-digest", type=("build", "run"), when="@2.4-5:")

--- a/repos/spack_repo/builtin/packages/r_flexclust/package.py
+++ b/repos/spack_repo/builtin/packages/r_flexclust/package.py
@@ -27,6 +27,8 @@ class RFlexclust(RPackage):
     version("1.4-0", sha256="82fe445075a795c724644864c7ee803c5dd332a89ea9e6ccf7cd1ae2d1ecfc74")
     version("1.3-5", sha256="dbf49969c93a7b314d9dc3299a0764ed9a804ba7dcbdc08a1235f244f4b85059")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.14.0:", type=("build", "run"))
     depends_on("r-lattice", type=("build", "run"))
     depends_on("r-modeltools", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_fnn/package.py
+++ b/repos/spack_repo/builtin/packages/r_fnn/package.py
@@ -27,5 +27,8 @@ class RFnn(RPackage):
     version("0.6-3", sha256="9ac1817852427a056b5c6ad6ac5212bc43abd29ce15f98441a6261b25cf5f810")
     version("0.6-2", sha256="f1fc410c341175bdb11a75b063c8c987e15b632378b56148d3566b91fca53a31")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r@4.0.0:", type=("build", "run"), when="@1.1.4:")

--- a/repos/spack_repo/builtin/packages/r_forecast/package.py
+++ b/repos/spack_repo/builtin/packages/r_forecast/package.py
@@ -28,6 +28,9 @@ class RForecast(RPackage):
     version("8.6", sha256="4279e4f700e26310bae39419ab4a9b5918a850148667a5e577a4807d53eb4d02")
     version("8.2", sha256="eb3fab64ed139d068e7d026cd3880f1b623f4153a832fb71845488fa75e8b812")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.0.2:", type=("build", "run"))
     depends_on("r@3.5.0:", type=("build", "run"), when="@8.18:")
     depends_on("r-colorspace", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_foreign/package.py
+++ b/repos/spack_repo/builtin/packages/r_foreign/package.py
@@ -28,5 +28,7 @@ class RForeign(RPackage):
     version("0.8-70.2", sha256="ae82fad68159860b8ca75b49538406ef3d2522818e649d7ccc209c18085ef179")
     version("0.8-66", sha256="d7401e5fcab9ce6e697d3520dbb8475e229c30341c0004c4fa489c82aa4447a4")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r@4.0.0:", type=("build", "run"), when="@0.8-81:")

--- a/repos/spack_repo/builtin/packages/r_fracdiff/package.py
+++ b/repos/spack_repo/builtin/packages/r_fracdiff/package.py
@@ -23,3 +23,5 @@ class RFracdiff(RPackage):
     version("1.5-2", sha256="ac5f881330287f5bc68b5cdce4fb74156a95356ffb875ee171538bc44200f437")
     version("1.5-1", sha256="b8103b32a4ca3a59dda1624c07da08ecd144c7a91a747d1f4663e99421950eb6")
     version("1.4-2", sha256="983781cedc2b4e3ba9fa020213957d5133ae9cd6710bc61d6225728e2f6e850e")
+
+    depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/r_gamlss/package.py
+++ b/repos/spack_repo/builtin/packages/r_gamlss/package.py
@@ -30,6 +30,8 @@ class RGamlss(RPackage):
     version("5.1-3", sha256="d37d121bc2acdbacc20cea04a1ed4489a575079e2a7b17b4a9823ee283857317")
     version("5.1-2", sha256="0d404e74768a8f98c6a5e9a48bd2cf4280125831a5dcd8c7f7b57922f57e016b")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.3.0:", type=("build", "run"))
     depends_on("r-gamlss-data@5.0-0:", type=("build", "run"))
     depends_on("r-gamlss-dist@4.3.1:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_gamlss_dist/package.py
+++ b/repos/spack_repo/builtin/packages/r_gamlss_dist/package.py
@@ -31,6 +31,8 @@ class RGamlssDist(RPackage):
     version("5.1-3", sha256="87fd643c82579519b67c66c1d87383fa1e203e8b09f607649ee7bce142bda404")
     version("5.1-1", sha256="44f999ff74ee516757eb39c8308c48aa850523aad2f38e622268313a13dda0b1")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.15:", type=("build", "run"))
     depends_on("r@3.5.0:", type=("build", "run"), when="@6.0-3:")
     depends_on("r-mass", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_gbm/package.py
+++ b/repos/spack_repo/builtin/packages/r_gbm/package.py
@@ -27,6 +27,9 @@ class RGbm(RPackage):
     version("2.1.5", sha256="06fbde10639dfa886554379b40a7402d1f1236a9152eca517e97738895a4466f")
     version("2.1.3", sha256="eaf24be931d762f1ccca4f90e15997719d01005f152160a3d20d858a0bbed92b")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@2.9.0:", type=("build", "run"))
     depends_on("r-lattice", type=("build", "run"))
     depends_on("r-survival", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_gensa/package.py
+++ b/repos/spack_repo/builtin/packages/r_gensa/package.py
@@ -19,4 +19,7 @@ class RGensa(RPackage):
     version("1.1.8", sha256="375e87541eb6b098584afccab361dc28ff09d03cf1d062ff970208e294eca216")
     version("1.1.7", sha256="9d99d3d0a4b7770c3c3a6de44206811272d78ab94481713a8c369f7d6ae7b80f")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@2.12.0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_geometries/package.py
+++ b/repos/spack_repo/builtin/packages/r_geometries/package.py
@@ -23,5 +23,7 @@ class RGeometries(RPackage):
     version("0.2.2", sha256="32d3063de0f8a751382788f85ebaee5f39d68e486253c159d553bb3d72d69141")
     version("0.2.0", sha256="8cf5094f3c2458fef5d755799c766afd27c66cd1c292574a6ab532d608360314")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r-rcpp", type=("build", "run"))
     depends_on("r-rcpp@1.0.10:", type=("build", "run"), when="@0.2.2:")

--- a/repos/spack_repo/builtin/packages/r_geor/package.py
+++ b/repos/spack_repo/builtin/packages/r_geor/package.py
@@ -21,6 +21,8 @@ class RGeor(RPackage):
     version("1.8-1", sha256="990647804590b925a50f72897b24bbabd331cebef0be1696a60528b2f79d6fd3")
     version("1.7-5.2.1", sha256="3895e49c005a5745738d190ccaad43bb0aa49c74465d4d0b4dd88c5850ed63b9")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r+X", type=("build", "run"))
     depends_on("r@2.10:", type=("build", "run"))
     depends_on("r-mass", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_gert/package.py
+++ b/repos/spack_repo/builtin/packages/r_gert/package.py
@@ -27,6 +27,8 @@ class RGert(RPackage):
     version("1.5.0", sha256="9fc330893b0cb43360905fd204e674813e1906449a95dc4037fe8802bd74a2ae")
     version("1.0.2", sha256="36687ab98291d50a35752fcb2e734a926a6b845345c18d36e3f48823f68304d3")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r-askpass", type=("build", "run"))
     depends_on("r-credentials@1.2.1:", type=("build", "run"))
     depends_on("r-openssl@1.4.1:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_ggforce/package.py
+++ b/repos/spack_repo/builtin/packages/r_ggforce/package.py
@@ -26,6 +26,8 @@ class RGgforce(RPackage):
     version("0.3.2", sha256="4cce8acb60ce06af44c1c76bbacd7de129eed9b51ed6a85e03a9bf55b0eff4d2")
     version("0.3.1", sha256="a05271da9b226c12ae5fe6bc6eddb9ad7bfe19e1737e2bfcd6d7a89631332211")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.3.0:", type=("build", "run"))
     depends_on("r-ggplot2@3.0.0:", type=("build", "run"))
     depends_on("r-ggplot2@3.3.6:", type=("build", "run"), when="@0.4.1:")

--- a/repos/spack_repo/builtin/packages/r_ggraph/package.py
+++ b/repos/spack_repo/builtin/packages/r_ggraph/package.py
@@ -27,6 +27,8 @@ class RGgraph(RPackage):
     version("2.0.4", sha256="9c6092d9a98b7b116f9c765ba44de7a34ceff2f584e776ef7a2082ad1d717dc8")
     version("2.0.0", sha256="4307efe85bfc6a0496797f6b86d6b174ba196538c51b1a6b6af55de0d4e04762")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@2.10:", type=("build", "run"))
     depends_on("r-ggplot2@3.0.0:", type=("build", "run"))
     depends_on("r-ggplot2@3.5.0:", type=("build", "run"), when="@2.2.0:")

--- a/repos/spack_repo/builtin/packages/r_ggrepel/package.py
+++ b/repos/spack_repo/builtin/packages/r_ggrepel/package.py
@@ -27,6 +27,8 @@ class RGgrepel(RPackage):
     version("0.8.0", sha256="6386606e716d326354a29fcb6cd09f9b3d3b5e7c5ba0d5f7ff35416b1a4177d4")
     version("0.6.5", sha256="360ae9d199755f9e260fefbd3baba3448fad3f024f20bcd9942a862b8c41a752")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r-ggplot2@2.2.0:", type=("build", "run"))
     depends_on("r-rcpp", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_git2r/package.py
+++ b/repos/spack_repo/builtin/packages/r_git2r/package.py
@@ -30,6 +30,8 @@ class RGit2r(RPackage):
     version("0.18.0", sha256="91b32e49afb859c0c4f6f77988343645e9499e5046ef08d945d4d8149b6eff2d")
     version("0.15.0", sha256="682ab9e7f71b2ed13a9ef95840df3c6b429eeea070edeb4d21d725cf0b72ede6")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.1:", type=("build", "run"))
     depends_on("r@3.4:", type=("build", "run"), when="@0.31.0:")
     depends_on("r@4.0:", type=("build", "run"), when="@0.33.0:")

--- a/repos/spack_repo/builtin/packages/r_glmnet/package.py
+++ b/repos/spack_repo/builtin/packages/r_glmnet/package.py
@@ -30,6 +30,10 @@ class RGlmnet(RPackage):
     version("2.0-13", sha256="f3288dcaddb2f7014d42b755bede6563f73c17bc87f8292c2ef7776cb9b9b8fd")
     version("2.0-5", sha256="2ca95352c8fbd93aa7800f3d972ee6c1a5fcfeabc6be8c10deee0cb457fd77b1")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@3.6.0:", type=("build", "run"), when="@4.1:")
 
     depends_on("r-matrix@1.0-6:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_gmp/package.py
+++ b/repos/spack_repo/builtin/packages/r_gmp/package.py
@@ -29,6 +29,8 @@ class RGmp(RPackage):
     version("0.5-13.4", sha256="f05605b40fc39fc589e3a4d2f526a591a649faa45eef7f95c096e1bff8775196")
     version("0.5-13.1", sha256="2f805374a26742cd43f6b2054130d8670eda1940070aabb9971e9e48226d0976")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r@3.5.0:", type=("build", "run"), when="@0.6-2:")
     depends_on("gmp@4.2.3:")

--- a/repos/spack_repo/builtin/packages/r_graphlayouts/package.py
+++ b/repos/spack_repo/builtin/packages/r_graphlayouts/package.py
@@ -28,6 +28,8 @@ class RGraphlayouts(RPackage):
     version("0.7.1", sha256="380f8ccb0b08735694e83f661fd56a0d592a78448ae91b89c290ba8582d66717")
     version("0.5.0", sha256="83f61ce07580c5a64c7044c12b20d98ccf138c7e78ff12855cdfc206e1fab10d")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.2.0:", type=("build", "run"))
     depends_on("r-igraph", type=("build", "run"))
     depends_on("r-rcpp", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_grbase/package.py
+++ b/repos/spack_repo/builtin/packages/r_grbase/package.py
@@ -34,6 +34,9 @@ class RGrbase(RPackage):
     version("1.8-6.7", sha256="aaafc7e1b521de60e1a57c0175ac64d4283850c3273bd14774cf24dabc743388")
     version("1.8-3.4", sha256="d35f94c2fb7cbd4ce3991570424dfe6723a849658da32e13df29f53b6ea2cc2c")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r+X", type=("build", "run"))
     depends_on("r@3.0.2:", type=("build", "run"))
     depends_on("r@3.6.0:", type=("build", "run"), when="@1.8-6.7:")

--- a/repos/spack_repo/builtin/packages/r_gss/package.py
+++ b/repos/spack_repo/builtin/packages/r_gss/package.py
@@ -24,5 +24,8 @@ class RGss(RPackage):
     version("2.1-10", sha256="26c47ecae6a9b7854a1b531c09f869cf8b813462bd8093e3618e1091ace61ee2")
     version("2.1-7", sha256="0405bb5e4c4d60b466335e5da07be4f9570045a24aed09e7bc0640e1a00f3adb")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@2.14.0:", type=("build", "run"))
     depends_on("r@3.0.0:", type=("build", "run"), when="@2.2-2:")

--- a/repos/spack_repo/builtin/packages/r_gwmodel/package.py
+++ b/repos/spack_repo/builtin/packages/r_gwmodel/package.py
@@ -33,6 +33,9 @@ class RGwmodel(RPackage):
     version("2.1-1", sha256="91241b4e26d423a54c7c6784ef5159759058a5dafdff18a1ea8451faf979d1f3")
     version("2.0-9", sha256="b479af2c19d4aec30f1883d00193d52e342c609c1badcb51cc0344e4404cffa7")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r-robustbase", type=("build", "run"))
     depends_on("r-sf", type=("build", "run"), when="@2.3-1:")

--- a/repos/spack_repo/builtin/packages/r_hdf5r/package.py
+++ b/repos/spack_repo/builtin/packages/r_hdf5r/package.py
@@ -28,6 +28,8 @@ class RHdf5r(RPackage):
     version("1.3.3", sha256="a0f83cbf21563e81dbd1a1bd8379623ed0c9c4df4e094c75013abfd7a5271545")
     version("1.2.0", sha256="58813e334fd3f9040038345a7186e5cb02090898883ac192477a76a5b8b4fe81")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.2.2:", type=("build", "run"))
     depends_on("r-r6", type=("build", "run"))
     depends_on("r-bit64", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_hmisc/package.py
+++ b/repos/spack_repo/builtin/packages/r_hmisc/package.py
@@ -28,6 +28,9 @@ class RHmisc(RPackage):
     version("4.2-0", sha256="9e9614673288dd00295f250fa0bf96fc9e9fed692c69bf97691081c1a01411d9")
     version("4.1-1", sha256="991db21cdf73ffbf5b0239a4876b2e76fd243ea33528afd88dc968792f281498")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@4.1.0:", type=("build", "run"), when="@5.1-2:")
     depends_on("r-formula", type=("build", "run"))
     depends_on("r-ggplot2@2.2:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_httpuv/package.py
+++ b/repos/spack_repo/builtin/packages/r_httpuv/package.py
@@ -31,6 +31,9 @@ class RHttpuv(RPackage):
     version("1.3.5", sha256="4336b993afccca2a194aca577b1975b89a35ac863423b18a11cdbb3f8470e4e9")
     version("1.3.3", sha256="bb37452ddc4d9381bee84cdf524582859af6a988e291debb71c8a2e120d02b2a")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@2.15.1:", type=("build", "run"))
     depends_on("r-rcpp@0.11.0:", type=("build", "run"))
     depends_on("r-rcpp@1.0.7:", type=("build", "run"), when="@1.6.5:")

--- a/repos/spack_repo/builtin/packages/r_igraph/package.py
+++ b/repos/spack_repo/builtin/packages/r_igraph/package.py
@@ -29,6 +29,10 @@ class RIgraph(RPackage):
     version("1.1.2", sha256="89b16b41bc77949ea208419e52a18b78b5d418c7fedc52cd47d06a51a6e746ec")
     version("1.0.1", sha256="dc64ed09b8b5f8d66ed4936cde3491974d6bc5178dd259b6eab7ef3936aa5602")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@3.0.2:", type=("build", "run"), when="@1.4.2:")
     depends_on("r@3.5.0:", type=("build", "run"), when="@1.5.0:")
 

--- a/repos/spack_repo/builtin/packages/r_imager/package.py
+++ b/repos/spack_repo/builtin/packages/r_imager/package.py
@@ -29,6 +29,8 @@ class RImager(RPackage):
     version("0.42.3", sha256="6fc308153df8251cef48f1e13978abd5d29ec85046fbe0b27c428801d05ebbf3")
     version("0.41.2", sha256="9be8bc8b3190d469fcb2883045a404d3b496a0380f887ee3caea11f0a07cd8a5")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r+X")
     depends_on("r@2.10.0:", type=("build", "run"))
     depends_on("r@4.0.0:", type=("build", "run"), when="@1.0.0:")

--- a/repos/spack_repo/builtin/packages/r_influencer/package.py
+++ b/repos/spack_repo/builtin/packages/r_influencer/package.py
@@ -25,6 +25,8 @@ class RInfluencer(RPackage):
     version("0.1.0.1", sha256="63c46f1175fced33fb1b78d4d56e37fbee09b408945b0106dac36e3344cd4766")
     version("0.1.0", sha256="4fc9324179bd8896875fc0e879a8a96b9ef2a6cf42a296c3b7b4d9098519e98a")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.2.0:", type=("build", "run"))
     depends_on("r-igraph@1.0.1:", type=("build", "run"))
     depends_on("r-matrix@1.1-4:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_interp/package.py
+++ b/repos/spack_repo/builtin/packages/r_interp/package.py
@@ -37,6 +37,10 @@ class RInterp(RPackage):
     version("1.1-4", sha256="4f7b5d388132a4d76e8635e2a7c4fa0d705df2b49e7d108faa16ce2236e34d06")
     version("1.1-3", sha256="b74e606b38cfb02985c1f9e3e45093620f76c0307b1b0b4058761e871eb5fa3f")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@3.5.0:", type=("build", "run"))
 
     depends_on("r-rcpp@0.12.9:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_intervals/package.py
+++ b/repos/spack_repo/builtin/packages/r_intervals/package.py
@@ -19,4 +19,7 @@ class RIntervals(RPackage):
     version("0.15.2", sha256="0bd23b0ce817ddd851238233d8a5420bf3a6d29e75fd361418cbc50118777c57")
     version("0.15.1", sha256="9a8b3854300f2055e1492c71932cc808b02feac8c4d3dbf6cba1c7dbd09f4ae4")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@2.9.0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_iso/package.py
+++ b/repos/spack_repo/builtin/packages/r_iso/package.py
@@ -20,4 +20,7 @@ class RIso(RPackage):
     version("0.0-18", sha256="2d7e8c4452653364ee086d95cea620c50378e30acfcff129b7261e1756a99504")
     version("0.0-17", sha256="c007d6eaf6335a15c1912b0804276ff39abce27b7a61539a91b8fda653629252")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@1.7.0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_jade/package.py
+++ b/repos/spack_repo/builtin/packages/r_jade/package.py
@@ -22,4 +22,7 @@ class RJade(RPackage):
     version("2.0-4", sha256="d4b3d65a33cae454d3ab13343bceabfb3f6b8004ac64ae7bd86dee92a1cd2055")
     version("2.0-3", sha256="56d68a993fa16fc6dec758c843960eee840814c4ca2271e97681a9d2b9e242ba")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r-clue", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_ks/package.py
+++ b/repos/spack_repo/builtin/packages/r_ks/package.py
@@ -28,6 +28,8 @@ class RKs(RPackage):
     version("1.11.4", sha256="0beffaf8694819fba8c93af07a8782674a15fe00a04ad1d94d31238d0a41b134")
     version("1.11.2", sha256="9dfd485096e1e67abc7dfcb7b76a83de110dd15bcfeffe5c899605b3a5592961")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.10:", type=("build", "run"))
     depends_on("r@2.10.0:", type=("build", "run"), when="@1.14.0:")
     depends_on("r-fnn@1.1:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_ksamples/package.py
+++ b/repos/spack_repo/builtin/packages/r_ksamples/package.py
@@ -28,4 +28,6 @@ class RKsamples(RPackage):
     version("1.2-10", sha256="2d66cc0511fb1be3190c5a285dcd93d02419468ee1ff5ae6d0838f16df2b578d")
     version("1.2-9", sha256="ba3ec4af3dfcf7cf12f0b784ef67bfea565e16985647ead904629886cc1542ff")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r-suppdists", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_later/package.py
+++ b/repos/spack_repo/builtin/packages/r_later/package.py
@@ -22,6 +22,9 @@ class RLater(RPackage):
     version("1.1.0.1", sha256="71baa7beae774a35a117e01d7b95698511c3cdc5eea36e29732ff1fe8f1436cd")
     version("0.8.0", sha256="6b2a28b43c619b2c7890840c62145cd3a34a7ed65b31207fdedde52efb00e521")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r-rcpp@0.12.9:", type=("build", "run"))
     depends_on("r-rlang", type=("build", "run"))
 

--- a/repos/spack_repo/builtin/packages/r_ldheatmap/package.py
+++ b/repos/spack_repo/builtin/packages/r_ldheatmap/package.py
@@ -25,6 +25,8 @@ class RLdheatmap(RPackage):
     version("1.0-4", sha256="07eb385f19e6a195e8e4d75be0b47c57744eabbf14045e527f0c27e1183ae5ca")
     version("0.99-7", sha256="aca54c839a424506d8be7153bf03b32026aeefe7ed38f534e8e19708e34212e4")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@2.14.0:", type=("build", "run"))
     depends_on("r@4.0:", type=("build", "run"), when="@1.0-4:")
     depends_on("r-genetics", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_leaps/package.py
+++ b/repos/spack_repo/builtin/packages/r_leaps/package.py
@@ -19,3 +19,6 @@ class RLeaps(RPackage):
     version("3.2", sha256="a0d6bebb676e5cdc0ecf3e3a07163ce0d60b6fe72a083d91f0413e11a8a96fad")
     version("3.1", sha256="3d7c3a102ce68433ecf167ece96a7ebb4207729e4defd0ac8fc00e7003f5c3b6")
     version("3.0", sha256="55a879cdad5a4c9bc3b5697dd4d364b3a094a49d8facb6692f5ce6af82adf285")
+
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/r_lfe/package.py
+++ b/repos/spack_repo/builtin/packages/r_lfe/package.py
@@ -33,6 +33,8 @@ class RLfe(RPackage):
     version("2.8-5", sha256="fd80c573d334594db933ff38f67bd4c9f899aaf648c3bd68f19477a0059723c2")
     version("2.8-4", sha256="ee5f6e312214aa73e285ae84a6bdf49ba10e830f1a68ffded2fea2e532f2cd6a")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.15.2:", type=("build", "run"))
     depends_on("r-matrix@1.1-2:", type=("build", "run"))
     depends_on("r-formula", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_lhs/package.py
+++ b/repos/spack_repo/builtin/packages/r_lhs/package.py
@@ -26,6 +26,9 @@ class RLhs(RPackage):
     version("1.0", sha256="38c53482b360bdea89ddcfadf6d45476c80b99aee8902f97c5e97975903e2745")
     version("0.16", sha256="9cd199c3b5b2be1736d585ef0fd39a00e31fc015a053333a7a319668d0809425")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.3.0:", type=("build", "run"))
     depends_on("r@3.4.0:", type=("build", "run"), when="@1.0:")
     depends_on("r-rcpp", type=("build", "run"), when="@1.0:")

--- a/repos/spack_repo/builtin/packages/r_libcoin/package.py
+++ b/repos/spack_repo/builtin/packages/r_libcoin/package.py
@@ -24,5 +24,7 @@ class RLibcoin(RPackage):
     version("1.0-6", sha256="48afc1415fc89b29e4f2c8b6f6db3cffef1531580e5c806ad7cacf4afe6a4e5a")
     version("1.0-4", sha256="91dcbaa0ab8c2109aa54c3eda29ad0acd67c870efcda208e27acce9d641c09c5")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.4.0:", type=("build", "run"))
     depends_on("r-mvtnorm", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_limsolve/package.py
+++ b/repos/spack_repo/builtin/packages/r_limsolve/package.py
@@ -22,6 +22,9 @@ class RLimsolve(RPackage):
     version("1.5.7.1", sha256="a5945217bbf512724297883f8d7c65846a11202266b2b6bb3355372935e85b92")
     version("1.5.6", sha256="b97ea9930383634c8112cdbc42f71c4e93fe0e7bfaa8f401921835cb44cb49a0")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@2.10:", type=("build", "run"))
     depends_on("r-quadprog", type=("build", "run"))
     depends_on("r-lpsolve", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_list/package.py
+++ b/repos/spack_repo/builtin/packages/r_list/package.py
@@ -18,6 +18,8 @@ class RList(RPackage):
 
     version("9.2.6", sha256="6a2b1dd9cdee87d739605fb38463cb6e04680c94b73f51fbd39b5552a62432e4")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.2.0:", type=("build", "run"))
     depends_on("r-sandwich@2.3-3:", type=("build", "run"))
     depends_on("r-vgam@0.9-8:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_lpsolve/package.py
+++ b/repos/spack_repo/builtin/packages/r_lpsolve/package.py
@@ -26,3 +26,5 @@ class RLpsolve(RPackage):
     version("5.6.13.2", sha256="75f0c0af5cbdc219ac29c792342ecd625903632ad86e581c408879958aa88539")
     version("5.6.13.1", sha256="6ad8dc430f72a4698fc4a615bb5ecb73690b3c4520e84d9094af51a528f720b8")
     version("5.6.13", sha256="d5d41c53212dead4fd8e6425a9d3c5767cdc5feb19d768a4704116d791cf498d")
+
+    depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/r_lpsolveapi/package.py
+++ b/repos/spack_repo/builtin/packages/r_lpsolveapi/package.py
@@ -29,3 +29,5 @@ class RLpsolveapi(RPackage):
     version(
         "5.5.2.0-17.7", sha256="9ebc8e45ad73eb51e0b25049598a5bc758370cf89508e2328cf4bd93d68d55bb"
     )
+
+    depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/r_lwgeom/package.py
+++ b/repos/spack_repo/builtin/packages/r_lwgeom/package.py
@@ -24,6 +24,9 @@ class RLwgeom(RPackage):
     version("0.2-8", sha256="f48a92de222da0590b37a30d5cbf2364555044a842795f6b488afecc650b8b34")
     version("0.2-5", sha256="4a1d93f96c10c2aac173d8186cf7d7bef7febcb3cf066a7f45da32251496d02f")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.3.0:", type=("build", "run"))
     depends_on("r-rcpp", type=("build", "run"))
     depends_on("r-units", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_magick/package.py
+++ b/repos/spack_repo/builtin/packages/r_magick/package.py
@@ -31,6 +31,8 @@ class RMagick(RPackage):
     version("2.6.0", sha256="66585336e3ff18793ae9e2726af67a6672622f270468670ab5fe5e013bc48ecc")
     version("2.1", sha256="ef4fb8fc1c5a9cfcc36b22485a0e17d622f61e55803b1e7423fd15f0550de7df")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r+X", type=("build", "run"))
     depends_on("r-rcpp@0.12.12:", type=("build", "run"))
     depends_on("r-magrittr", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_maldiquant/package.py
+++ b/repos/spack_repo/builtin/packages/r_maldiquant/package.py
@@ -28,5 +28,7 @@ class RMaldiquant(RPackage):
     version("1.19.2", sha256="8c6efc4ae4f1af4770b079db29743049f2fd597bcdefeaeb16f623be43ddeb87")
     version("1.16.4", sha256="9b910dbd5dd1a739a17a7ee3f83d7e1ebad2fee89fd01a5b274415d2b6d3b0de")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.2.0:", type=("build", "run"))
     depends_on("r@4.0.0:", type=("build", "run"), when="@1.21:")

--- a/repos/spack_repo/builtin/packages/r_maps/package.py
+++ b/repos/spack_repo/builtin/packages/r_maps/package.py
@@ -24,5 +24,7 @@ class RMaps(RPackage):
     version("3.2.0", sha256="437abeb4fa4ad4a36af6165d319634b89bfc6bf2b1827ca86c478d56d670e714")
     version("3.1.1", sha256="972260e5ce9519ecc09b18e5d7a28e01bed313fadbccd7b06c571af349cb4d2a")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r@3.5.0:", type=("build", "run"), when="@3.4.0:")

--- a/repos/spack_repo/builtin/packages/r_maptools/package.py
+++ b/repos/spack_repo/builtin/packages/r_maptools/package.py
@@ -20,6 +20,8 @@ class RMaptools(RPackage):
 
     version("1.1-8", sha256="5e8579e3f559161935f1dde622ece703eefa2a28a677ce553d7f27611e66e0f7")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.10:", type=("build", "run"))
     depends_on("r-sp@1.0-11:", type=("build", "run"))
     depends_on("r-foreign@0.8:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_mclust/package.py
+++ b/repos/spack_repo/builtin/packages/r_mclust/package.py
@@ -29,5 +29,8 @@ class RMclust(RPackage):
     version("5.4.4", sha256="ccc31b0ad445e121a447b04988e73232a085c506fcc7ebdf11a3e0754aae3e0d")
     version("5.3", sha256="2b1b6d8266ae16b0e96f118df81559f208a568744a7c105af9f9abf1eef6ba40")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r@3.0:", type=("build", "run"), when="@6.0.0:")

--- a/repos/spack_repo/builtin/packages/r_mcmc/package.py
+++ b/repos/spack_repo/builtin/packages/r_mcmc/package.py
@@ -25,5 +25,7 @@ class RMcmc(RPackage):
     version("0.9-8", sha256="6a06440d4b58e8a7f122747d92046ff40da4bb58a20bf642228a648a0c826ea7")
     version("0.9-7", sha256="b7c4d3d5f9364c67a4a3cd49296a61c315ad9bd49324a22deccbacb314aa8260")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.0.2:", type=("build", "run"))
     depends_on("r@3.6.0:", type=("build", "run"), when="@0.9-8:")

--- a/repos/spack_repo/builtin/packages/r_mcmcglmm/package.py
+++ b/repos/spack_repo/builtin/packages/r_mcmcglmm/package.py
@@ -25,6 +25,9 @@ class RMcmcglmm(RPackage):
     version("2.28", sha256="7d92e6d35638e5e060a590b92c3b1bfc02a11386276a8ab99bceec5d797bfc2a")
     version("2.25", sha256="3072316bf5c66f6db5447cb488395ff019f6c47122813467384474f340643133")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r-matrix", type=("build", "run"))
     depends_on("r-coda", type=("build", "run"))
     depends_on("r-ape", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_mcmcpack/package.py
+++ b/repos/spack_repo/builtin/packages/r_mcmcpack/package.py
@@ -25,6 +25,9 @@ class RMcmcpack(RPackage):
     version("1.6-0", sha256="b5b9493457d11d4dca12f7732bd1b3eb1443852977c8ee78393126f13deaf29b")
     version("1.5-0", sha256="795ffd3d62bf14d3ecb3f5307bd329cd75798cf4b270ff0e768bc71a35de0ace")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.6:", type=("build", "run"))
     depends_on("r-coda@0.11-3:", type=("build", "run"))
     depends_on("r-lattice", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_mco/package.py
+++ b/repos/spack_repo/builtin/packages/r_mco/package.py
@@ -23,5 +23,7 @@ class RMco(RPackage):
     version("1.0-15.1", sha256="3c13ebc8c1f1bfa18f3f95b3998c57fde5259876e92456b6c6d4c59bef07c193")
     version("1.0-15", sha256="a25e3effbb6dcae735fdbd6c0bfc775e9fbbcc00dc00076b69c53fe250627055")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r@3.4.0:", type=("build", "run"), when="@1.17:")

--- a/repos/spack_repo/builtin/packages/r_mda/package.py
+++ b/repos/spack_repo/builtin/packages/r_mda/package.py
@@ -23,6 +23,9 @@ class RMda(RPackage):
     version("0.4-10", sha256="7036bc622a8fea5b2de94fc19e6b64f5f0c27e5d743ae7646e116af08c9de6a5")
     version("0.4-9", sha256="b72456d2fa5b49895644489735d21cf4836d3d597f5e693e6103cce1887ffd85")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@1.9.0:", type=("build", "run"))
     depends_on("r@3.5.0:", type=("build", "run"), when="@0.5-2:")
     depends_on("r-class", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_memisc/package.py
+++ b/repos/spack_repo/builtin/packages/r_memisc/package.py
@@ -24,6 +24,8 @@ class RMemisc(RPackage):
     version("0.99.31.7", sha256="b403185850520db18ebd608df85c76df80e6c64af428cdc4e49c2fe487483637")
     version("0.99.31.6", sha256="52336b4ffc6e60c3ed10ccc7417231582b0d2e4c5c3b2184396a7d3ca9c1d96e")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.3.0:", type=("build", "run"))
     depends_on("r-lattice", type=("build", "run"))
     depends_on("r-mass", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_mendelianrandomization/package.py
+++ b/repos/spack_repo/builtin/packages/r_mendelianrandomization/package.py
@@ -21,6 +21,8 @@ class RMendelianrandomization(RPackage):
     version("0.10.0", sha256="0851e91f826424f20fd4a58348ffe161d147bdc091d24d676e14d4cd6180e13c")
     version("0.7.0", sha256="cad7cc1b6964fc7d299864378694c5fd947caa83796a1958e581299796b854c7")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.0.1:", type=("build", "run"))
     depends_on("r-knitr", type=("build", "run"))
     depends_on("r-rmarkdown", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_mice/package.py
+++ b/repos/spack_repo/builtin/packages/r_mice/package.py
@@ -34,6 +34,8 @@ class RMice(RPackage):
     version("3.5.0", sha256="4fccecdf9e8d8f9f63558597bfbbf054a873b2d0b0820ceefa7b6911066b9e45")
     version("3.0.0", sha256="98b6bb1c5f8fb099bd0024779da8c865146edb25219cc0c9542a8254152c0add")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@2.10.0:", type=("build", "run"))
     depends_on("r-broom", type=("build", "run"))
     depends_on("r-dplyr", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_mlbench/package.py
+++ b/repos/spack_repo/builtin/packages/r_mlbench/package.py
@@ -21,4 +21,6 @@ class RMlbench(RPackage):
     version("2.1-3", sha256="b1f92be633243185ab86e880a1e1ac5a4dd3c535d01ebd187a4872d0a8c6f194")
     version("2.1-1", sha256="748141d56531a39dc4d37cf0a5165a40b653a04c507e916854053ed77119e0e6")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.10:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_mlr/package.py
+++ b/repos/spack_repo/builtin/packages/r_mlr/package.py
@@ -35,6 +35,8 @@ class RMlr(RPackage):
     version("2.12.1", sha256="9cbb98b82eb493b783fe8808a18d76f32881d941364466ef8829b852fabbc82c")
     version("2.12", sha256="cfe00089ae4cd88c6d03826eda43d4fe29e467e3a7c95d103fafca8308f5c161")
 
+    depends_on("c", type="build")  # generated
+
     # There are some potential variants for this.
     # SystemRequirements: gdal (optional), geos (optional), proj (optional),
     # udunits (optional), gsl (optional), gmp (optional), glu (optional), jags

--- a/repos/spack_repo/builtin/packages/r_multicool/package.py
+++ b/repos/spack_repo/builtin/packages/r_multicool/package.py
@@ -36,4 +36,6 @@ class RMulticool(RPackage):
     version("0.1-10", sha256="5bb0cb0d9eb64420c862877247a79bb0afadacfe23262ec8c3fa26e5e34d6ff9")
     version("0.1-9", sha256="bdf92571cef1b649952d155395a92b8683099ee13114f73a9d41fc5d7d49d329")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r-rcpp@0.11.2:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_multitaper/package.py
+++ b/repos/spack_repo/builtin/packages/r_multitaper/package.py
@@ -27,4 +27,7 @@ class RMultitaper(RPackage):
     version("1.0-15", sha256="837d71f3b46fbce2bea210449cf75e609f5363ff23b7808f5f115fdc51e6a3be")
     version("1.0-14", sha256="c84c122541dc2874131446e23b212259b3b00590d701efee49e6740fd74a8d13")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@3.0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_nanotime/package.py
+++ b/repos/spack_repo/builtin/packages/r_nanotime/package.py
@@ -28,6 +28,8 @@ class RNanotime(RPackage):
     version("0.2.3", sha256="7d6df69a4223ae154f610b650e24ece38ce4aa706edfa38bec27d15473229f5d")
     version("0.2.0", sha256="9ce420707dc4f0cb4241763579b849d842904a3aa0d88de8ffef334d08fa188d")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r-bit64", type=("build", "run"))
     depends_on("r-rcppcctz@0.2.3:", type=("build", "run"))
     depends_on("r-rcppcctz@0.2.9:", type=("build", "run"), when="@0.3.2:")

--- a/repos/spack_repo/builtin/packages/r_network/package.py
+++ b/repos/spack_repo/builtin/packages/r_network/package.py
@@ -28,6 +28,8 @@ class RNetwork(RPackage):
     version("1.14-377", sha256="013c02f8d97f1f87f2c421760534df9353d2a8c2277f20b46b59fb79822d3e46")
     version("1.13.0", sha256="7a04ea89261cdf32ccb52222810699d5fca59a849053e306b5ec9dd5c1184f87")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.10:", type=("build", "run"))
     depends_on("r-tibble", type=("build", "run"), when="@1.14-377:")
     depends_on("r-magrittr", type=("build", "run"), when="@1.14-377:")

--- a/repos/spack_repo/builtin/packages/r_nimble/package.py
+++ b/repos/spack_repo/builtin/packages/r_nimble/package.py
@@ -37,6 +37,8 @@ class RNimble(RPackage):
     version("0.9.1", sha256="ad5e8a171193cb0172e68bf61c4f94432c45c131a150101ad1c5c7318c335757")
     version("0.9.0", sha256="ebc28fadf933143eea73900cacaf96ff81cb3c2d607405016062b7e93afa5611")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.1.2:", type=("build", "run"))
     depends_on("r-igraph", type=("build", "run"))
     depends_on("r-coda", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_nmf/package.py
+++ b/repos/spack_repo/builtin/packages/r_nmf/package.py
@@ -25,6 +25,9 @@ class RNmf(RPackage):
     version("0.23.0", sha256="0f0cca01b37bf46fce90d2e951df609d3d377908aa607825083fd0c47cc24753")
     version("0.21.0", sha256="3b30c81c66066fab4a63c5611a0313418b840d8b63414db31ef0e932872d02e3")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r-registry", type=("build", "run"))
     depends_on("r-rngtools@1.2.3:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_nnls/package.py
+++ b/repos/spack_repo/builtin/packages/r_nnls/package.py
@@ -20,3 +20,6 @@ class RNnls(RPackage):
 
     version("1.5", sha256="cd70feb286f86f6dead75da693a8f67c9bd3b91eb738e6e6ac659e3b8c7a3452")
     version("1.4", sha256="0e5d77abae12bc50639d34354f96a8e079408c9d7138a360743b73bd7bce6c1f")
+
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/r_ordinal/package.py
+++ b/repos/spack_repo/builtin/packages/r_ordinal/package.py
@@ -37,6 +37,8 @@ class ROrdinal(RPackage):
     )
     version("2019.4-25", sha256="2812ad7a123cae5dbe053d1fe5f2d9935afc799314077eac185c844e3c9d79df")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.13.0:", type=("build", "run"))
     depends_on("r-ucminf", type=("build", "run"))
     depends_on("r-mass", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_osqp/package.py
+++ b/repos/spack_repo/builtin/packages/r_osqp/package.py
@@ -23,6 +23,9 @@ class ROsqp(RPackage):
     version("0.6.0.8", sha256="14034045ae4ae5ec4eae4944653d41d94282fa85a0cd53614ac86f34fd02ed97")
     version("0.6.0.7", sha256="ee6584d02341e3f1d8fab3b2cb93defd6c48d561297d82a6bedb3e7541868203")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r-rcpp@0.12.14:", type=("build", "run"))
     depends_on("r-matrix", type=("build", "run"))
     depends_on("r-matrix@1.6-1:", type=("build", "run"), when="@0.6.3:")

--- a/repos/spack_repo/builtin/packages/r_pan/package.py
+++ b/repos/spack_repo/builtin/packages/r_pan/package.py
@@ -25,4 +25,7 @@ class RPan(RPackage):
     version("1.6", sha256="adc0df816ae38bc188bce0aef3aeb71d19c0fc26e063107eeee71a81a49463b6")
     version("1.4", sha256="e6a83f0799cc9714f5052f159be6e82ececd013d1626f40c828cda0ceb8b76dc")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@2.10:", when="@1.9:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_party/package.py
+++ b/repos/spack_repo/builtin/packages/r_party/package.py
@@ -41,6 +41,8 @@ class RParty(RPackage):
     version("1.3-2", sha256="9f350fa21114151c49bccc3d5f8536dbc5a608cfd88f60461c9805a4c630510b")
     version("1.1-2", sha256="c3632b4b02dc12ec949e2ee5b24004e4a4768b0bc9737432e9a85acbc2ed0e74")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.14.0:", type=("build", "run"))
     depends_on("r@3.0.0:", type=("build", "run"), when="@1.2-3:")
     depends_on("r-mvtnorm@1.0-2:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_pcapp/package.py
+++ b/repos/spack_repo/builtin/packages/r_pcapp/package.py
@@ -30,5 +30,8 @@ class RPcapp(RPackage):
     version("1.9-60", sha256="9a4b471957ac39ed7c860e3165bf8e099b5b55cf814654adb58f9d19df2718e7")
     version("1.9-50", sha256="137637314fba6e11883c63b0475d8e50aa7f363e064baa1e70245f7692565b56")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.6.2:", type=("build", "run"), when="@2.0-4:")
     depends_on("r-mvtnorm", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_pegas/package.py
+++ b/repos/spack_repo/builtin/packages/r_pegas/package.py
@@ -28,6 +28,8 @@ class RPegas(RPackage):
     version("1.1", sha256="87ba91a819496dfc3abdcc792ff853a6d49caae6335598a24c23e8851505ed59")
     version("0.14", sha256="7df90e6c4a69e8dbed2b3f68b18f1975182475bf6f86d4159256b52fd5332053")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.2.0:", type=("build", "run"))
     depends_on("r-ape@5.3-11:", type=("build", "run"))
 

--- a/repos/spack_repo/builtin/packages/r_philentropy/package.py
+++ b/repos/spack_repo/builtin/packages/r_philentropy/package.py
@@ -29,6 +29,8 @@ class RPhilentropy(RPackage):
     version("0.5.0", sha256="b39e9a825458f3377e23b2a133180566780e89019e9d22a6a5b7ca87c49c412f")
     version("0.4.0", sha256="bfd30bf5635aab6a82716299a87d44cf96c7ab7f4ee069843869bcc85c357127")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.1.2:", type=("build", "run"))
     depends_on("r-rcpp", type=("build", "run"))
     depends_on("r-kernsmooth", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_phylobase/package.py
+++ b/repos/spack_repo/builtin/packages/r_phylobase/package.py
@@ -20,6 +20,9 @@ class RPhylobase(RPackage):
     version("0.8.12", sha256="9b81ca60dc6215e74b720880cc2db3abc1f7e6d8785ea7d7df95a950f0778f20")
     version("0.8.10", sha256="5a44380ff49bab333a56f6f96157324ade8afb4af0730e013194c4badb0bf94b")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r-ade4", type=("build", "run"))
     depends_on("r-ape@3.0:", type=("build", "run"))
     depends_on("r-rcpp@0.11.0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_pkgbuild/package.py
+++ b/repos/spack_repo/builtin/packages/r_pkgbuild/package.py
@@ -26,6 +26,8 @@ class RPkgbuild(RPackage):
     version("1.0.4", sha256="2934efa5ff9ccfe1636d360aedec36713f3bb3128a493241dbb728d842ea3b5f")
     version("1.0.3", sha256="c93aceb499886e42bcd61eb7fb59e47a76c9ba5ab5349a426736d46c8ce21f4d")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.1:", type=("build", "run"))
     depends_on("r@3.4:", type=("build", "run"), when="@1.4.0:")
     depends_on("r@3.5:", type=("build", "run"), when="@1.4.3:")

--- a/repos/spack_repo/builtin/packages/r_pkgcache/package.py
+++ b/repos/spack_repo/builtin/packages/r_pkgcache/package.py
@@ -25,6 +25,8 @@ class RPkgcache(RPackage):
     version("2.0.1", sha256="1add648c6f30543cbd5e43369c4d1462248d4caaedfcb588ee7b946a75d42f4f")
     version("1.3.0", sha256="bd5f460a3bee9fc1298cf9f747bc59a6b9fbed90e92454bc6ea6bf82c15b9471")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.1:", type=("build", "run"))
     depends_on("r@3.4:", type=("build", "run"), when="@2.0.2:")
     depends_on("r-callr@2.0.4.9000:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_pkgdepends/package.py
+++ b/repos/spack_repo/builtin/packages/r_pkgdepends/package.py
@@ -29,6 +29,8 @@ class RPkgdepends(RPackage):
     version("0.3.1", sha256="8e4263a1792871ee9629b0d6a8caeb53b77012db3b5be91b432f3553cd2a80be")
     version("0.2.0", sha256="59afdbe0e59663088ba4facac5cd011a0a05b0b9c540103fb8b9f0a673bf4d94")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.4:", type=("build", "run"), when="@0.3.1:")
     depends_on("r@3.5:", type=("build", "run"), when="@0.7.0:")
     depends_on("r-callr@3.3.1:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_pkgload/package.py
+++ b/repos/spack_repo/builtin/packages/r_pkgload/package.py
@@ -29,6 +29,9 @@ class RPkgload(RPackage):
     version("1.1.0", sha256="189d460dbba2b35fa15dd59ce832df252dfa654a5acee0c9a8471b4d70477b0d")
     version("1.0.2", sha256="3186564e690fb05eabe76e1ac0bfd4312562c3ac8794b29f8850399515dcf27c")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.4.0:", type=("build", "run"), when="@1.3.0:")
 
     depends_on("r-cli", type=("build", "run"), when="@1.1.0:")

--- a/repos/spack_repo/builtin/packages/r_pki/package.py
+++ b/repos/spack_repo/builtin/packages/r_pki/package.py
@@ -19,5 +19,7 @@ class RPki(RPackage):
 
     version("0.1-14", sha256="c024e81977b978b705460df96639e3369420bd7e8f4f3242ec796255dc1b7966")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.9.0:", type=("build", "run"))
     depends_on("r-base64enc", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_pmcmrplus/package.py
+++ b/repos/spack_repo/builtin/packages/r_pmcmrplus/package.py
@@ -42,6 +42,9 @@ class RPmcmrplus(RPackage):
     version("1.9.4", sha256="1ec36674bb6d2fac3a1b0889c4672e40849c7e3565ffb34bb73b61f973bba19a")
     version("1.9.3", sha256="76baba60f57343fa5bb6f6d2ea27aab77178e02b0d2f9d5d74abde7d18994f03")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@3.5.0:", type=("build", "run"))
     depends_on("r-mvtnorm@1.0:", type=("build", "run"))
     depends_on("r-multcompview", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_polspline/package.py
+++ b/repos/spack_repo/builtin/packages/r_polspline/package.py
@@ -26,3 +26,6 @@ class RPolspline(RPackage):
     version("1.1.17", sha256="d67b269d01105d4a6ea774737e921e66e065a859d1931ae38a70f88b6fb7ee30")
     version("1.1.16", sha256="aa3b5a1560008a1a401a65a25f19a27ba6f0a6ea185b6d093acd40e4e2818934")
     version("1.1.15", sha256="8cdbaa5ee672055a4d02f965025199ce764958f84bfa159e853feba7ee24faa7")
+
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/r_polyclip/package.py
+++ b/repos/spack_repo/builtin/packages/r_polyclip/package.py
@@ -26,5 +26,8 @@ class RPolyclip(RPackage):
     version("1.10-4", sha256="84d2c9778771d3759b49d7d16fb54c8ddc5397da3b1d21074bc4aa42c02e6f56")
     version("1.10-0", sha256="74dabc0dfe5a527114f0bb8f3d22f5d1ae694e6ea9345912909bae885525d34b")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r@3.5.0:", type=("build", "run"), when="@1.10-7:")

--- a/repos/spack_repo/builtin/packages/r_popgenome/package.py
+++ b/repos/spack_repo/builtin/packages/r_popgenome/package.py
@@ -23,6 +23,9 @@ class RPopgenome(RPackage):
     version("2.7.1", sha256="a84903b151528fa026ccaba42ada22cd89babbc1824afd40269b7204e488a5fa")
     version("2.6.1", sha256="7a2922ed505fa801117a153e479d246bcf4854b91c6ab0241acc620a9d779b1c")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@2.14.2:", type=("build", "run"))
     depends_on("r-ff", type=("build", "run"))
     depends_on("zlib-api")

--- a/repos/spack_repo/builtin/packages/r_proc/package.py
+++ b/repos/spack_repo/builtin/packages/r_proc/package.py
@@ -21,6 +21,8 @@ class RProc(RPackage):
     version("1.18.0", sha256="d5ef54b384176ece6d6448014ba40570a98181b58fee742f315604addb5f7ba9")
     version("1.17.0.1", sha256="221c726ffb81b04b999905effccfd3a223cd73cae70d7d86688e2dd30e51a6bd")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@2.14:", type=("build", "run"))
     depends_on("r-plyr", type=("build", "run"))
     depends_on("r-rcpp@0.11.1:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_prodlim/package.py
+++ b/repos/spack_repo/builtin/packages/r_prodlim/package.py
@@ -33,6 +33,8 @@ class RProdlim(RPackage):
     version("1.6.1", sha256="3f2665257118a3db8682731a500b1ae4d669af344672dc2037f987bee3cca154")
     version("1.5.9", sha256="853644886c57102e7f6dd26b6e03e54bf3f9e126f54c76f8d63a3324811f7b42")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.9.0:", type=("build", "run"))
     depends_on("r-rcpp@0.11.5:", type=("build", "run"))
     depends_on("r-diagram", type=("build", "run"), when="@2023.03.31:")

--- a/repos/spack_repo/builtin/packages/r_profvis/package.py
+++ b/repos/spack_repo/builtin/packages/r_profvis/package.py
@@ -17,6 +17,8 @@ class RProfvis(RPackage):
     version("0.3.8", sha256="ec02c75bc9907a73564e691adfa8e06651ca0bd73b7915412960231cd265b4b2")
     version("0.3.7", sha256="43974863cb793f81dbea4b94096343c321f7739c9038980405c9b16b04a906b9")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.0:", type=("build", "run"))
     depends_on("r-htmlwidgets@0.3.2:", type=("build", "run"))
     depends_on("r-purrr", type=("build", "run"), when="@0.3.8:")

--- a/repos/spack_repo/builtin/packages/r_progress/package.py
+++ b/repos/spack_repo/builtin/packages/r_progress/package.py
@@ -24,6 +24,8 @@ class RProgress(RPackage):
     version("1.2.1", sha256="7401e86ff76bef4d26508b74ee8bd169a0377b2738d9ec79ebff0b7fd5c55326")
     version("1.1.2", sha256="a9f4abfd9579b80967cd681041643fe9dfcc4eb3beeba45391bb64e9209baabb")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.6:", type=("build", "run"), when="@1.2.3:")
     depends_on("r-r6", type=("build", "run"))
     depends_on("r-prettyunits", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_proj/package.py
+++ b/repos/spack_repo/builtin/packages/r_proj/package.py
@@ -23,6 +23,8 @@ class RProj(RPackage):
     version("0.4.0", sha256="dde90cfeca83864e61a7422e1573d2d55bb0377c32b9a8f550f47b8631121ce7")
     version("0.1.0", sha256="5186f221335e8092bbcd4d82bd323ee7e752c7c9cf83d3f94e4567e0b407aa6f")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.10:", type=("build", "run"))
     depends_on("r@3.0.2:", type=("build", "run"), when="@0.4.0:")
 

--- a/repos/spack_repo/builtin/packages/r_proj4/package.py
+++ b/repos/spack_repo/builtin/packages/r_proj4/package.py
@@ -25,6 +25,8 @@ class RProj4(RPackage):
     version("1.0-10", sha256="5f396f172a17cfa9821a390f11ff7d3bff3c92ccf585572116dec459c621d1d0")
     version("1.0-8.1", sha256="a3a2a8f0014fd79fa34b5957440fd38299d8e97f1a802a61a068a6c6cda10a7e")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.0.0:", type=("build", "run"))
     depends_on("proj@4.4.6:7", when="@:1.0-8")
     depends_on("proj@4.4.6:")

--- a/repos/spack_repo/builtin/packages/r_projpred/package.py
+++ b/repos/spack_repo/builtin/packages/r_projpred/package.py
@@ -28,6 +28,8 @@ class RProjpred(RPackage):
     version("2.1.2", sha256="a88a651e533c118aad0e8c2c905cfcf688d9c419ed195896036b8f6667b5cfb0")
     version("2.0.2", sha256="af0a9fb53f706090fe81b6381b27b0b6bd3f7ae1e1e44b0ada6f40972b09a55b")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.5.0:", type=("build", "run"))
     depends_on("r@3.6.0:", type=("build", "run"), when="@2.7.0:")
     depends_on("r-rcpp", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_promises/package.py
+++ b/repos/spack_repo/builtin/packages/r_promises/package.py
@@ -25,6 +25,8 @@ class RPromises(RPackage):
     version("1.1.1", sha256="3718c6eb2c3362cbe89389e613118f783f9977dbf24757f85026e661199c5800")
     version("1.0.1", sha256="c2dbc7734adf009377a41e570dfe0d82afb91335c9d0ca1ef464b9bdcca65558")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r-r6", type=("build", "run"))
     depends_on("r-fastmap@1.1.0:", type=("build", "run"), when="@1.2.1:")
     depends_on("r-later", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_pspline/package.py
+++ b/repos/spack_repo/builtin/packages/r_pspline/package.py
@@ -20,4 +20,7 @@ class RPspline(RPackage):
     version("1.0-19", sha256="ba55bf193f1df9785a0e13b7ef727d5fd2415b318cd6a26b48a2db490c4dfe40")
     version("1.0-18", sha256="f71cf293bd5462e510ac5ad16c4a96eda18891a0bfa6447dd881c65845e19ac7")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@2.0.0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_qs/package.py
+++ b/repos/spack_repo/builtin/packages/r_qs/package.py
@@ -26,6 +26,9 @@ class RQs(RPackage):
     version("0.25.2", sha256="fe428ae5dc46f88fdf454ca74c4a073f5ac288d6d039080a3c0d66c4ebbd5cbf")
     version("0.23.6", sha256="c6e958e9741ee981bf2388c91b8f181718ffb0f32283cd7ebcd2d054817280e4")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.5.0:", type=("build", "run"))
     depends_on("r@3.0.2:", type=("build", "run"), when="@0.25.2:")
     depends_on("r-bh", type=("build", "run"), when="@0.26.0:")

--- a/repos/spack_repo/builtin/packages/r_qtl/package.py
+++ b/repos/spack_repo/builtin/packages/r_qtl/package.py
@@ -26,4 +26,7 @@ class RQtl(RPackage):
     version("1.47-9", sha256="6ba4e7b40d946b3ab68d54624599284b1d352c86fb50d31b134826be758ece41")
     version("1.44-9", sha256="315063f0c3fbb95cd2169eb4109ade0339e8f3c28670b38c3167214b9bdf950e")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@2.14.0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_randomfields/package.py
+++ b/repos/spack_repo/builtin/packages/r_randomfields/package.py
@@ -24,6 +24,9 @@ class RRandomfields(RPackage):
     version("3.3.4", sha256="a340d4f3ba7950d62acdfa19b9724c82e439d7b1a9f73340124038b7c90c73d4")
     version("3.1.50", sha256="2d6a07c3a716ce20f9c685deb59e8fcc64fd52c8a50b0f04baf451b6b928e848")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.0:", type=("build", "run"))
     depends_on("r@3.5.0:", type=("build", "run"), when="@3.3.8:")
     depends_on("r-sp", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_randomfieldsutils/package.py
+++ b/repos/spack_repo/builtin/packages/r_randomfieldsutils/package.py
@@ -23,4 +23,8 @@ class RRandomfieldsutils(RPackage):
     version("0.5.3", sha256="ea823cba2e254a9f534efb4b772c0aeef2039ee9ef99744e077b969a87f8031d")
     version("0.5.1", sha256="a95aab4e2025c4247503ff513570a65aa3c8e63cb7ce2979c9317a2798dfaca2")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@3.0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_ranger/package.py
+++ b/repos/spack_repo/builtin/packages/r_ranger/package.py
@@ -34,6 +34,8 @@ class RRanger(RPackage):
     version("0.5.0", sha256="bc55811e723c9076c35aac4d82f29770ef84b40846198235d8b0ea9a4e91f144")
     version("0.4.0", sha256="d9f5761c3b07357aa586270cf7cbc97fc3db56ba731b6d0f3baf296f635f2be5")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.1:", type=("build", "run"))
     depends_on("r-rcpp@0.11.2:", type=("build", "run"))
     depends_on("r-matrix", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_rapiserialize/package.py
+++ b/repos/spack_repo/builtin/packages/r_rapiserialize/package.py
@@ -26,3 +26,6 @@ class RRapiserialize(RPackage):
     version("0.1.3", sha256="9f413759eabb2acce2b9a363687ca365e1bbedaf9851d23a2ec3683a3d46f42b")
     version("0.1.2", sha256="9cc0bbb918eeadb394339c64b15324e8123fbb0061692f40102b111417a2600a")
     version("0.1.0", sha256="324d42c655c27b4647d194bfcd7c675da95c67ea3a74ce99853502022792a23e")
+
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/r_raster/package.py
+++ b/repos/spack_repo/builtin/packages/r_raster/package.py
@@ -29,6 +29,9 @@ class RRaster(RPackage):
     version("2.9-22", sha256="8107d95f1aa85cea801c8101c6aa391becfef4b5b915d9bc7a323531fee26128")
     version("2.5-8", sha256="47992abd783450513fbce3770298cc257030bf0eb77e42aa3a4b3924b16264cc")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r@3.5.0:", type=("build", "run"), when="@3.4-5:")
     depends_on("r-sp@1.2-0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_rcppannoy/package.py
+++ b/repos/spack_repo/builtin/packages/r_rcppannoy/package.py
@@ -27,6 +27,9 @@ class RRcppannoy(RPackage):
     version("0.0.18", sha256="e4e7ddf071109b47b4fdf285db6d2155618ed73da829c30d8e64fc778e63c858")
     version("0.0.12", sha256="8f736cbbb4a32c80cb08ba4e81df633846d725f27867e983af2012966eac0eac")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.1:", type=("build", "run"))
     depends_on("r-rcpp", type=("build", "run"))
     depends_on("r-rcpp@0.11.3:", type=("build", "run"), when="@:0.0.12")

--- a/repos/spack_repo/builtin/packages/r_rcppblaze/package.py
+++ b/repos/spack_repo/builtin/packages/r_rcppblaze/package.py
@@ -41,6 +41,9 @@ class RRcppblaze(RPackage):
     version("1.0.1", sha256="2d152294dc231e4ab097a377ddeda6f2bbb608970c82563a893c77de08916227")
     version("0.2.2", sha256="67550ed8aea12a219047af61b41e5b9f991608a21ce9a8fbf7ac55da0f7c2742")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.0.2:", type=("build", "run"))
     depends_on("r@4.2.0:", type=("build", "run"), when="@1.0.0:")
     depends_on("r-rcpp@0.11.0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_rcppcnpy/package.py
+++ b/repos/spack_repo/builtin/packages/r_rcppcnpy/package.py
@@ -26,6 +26,8 @@ class RRcppcnpy(RPackage):
     version("0.2.10", sha256="77d6fbc86520a08da40d44c0b82767099f8f719ca95870d91efff1a9cab1ab9c")
     version("0.2.9", sha256="733f004ad1a8b0e5aafbf547c4349d2df3118afd57f1ff99f20e39135c6edb30")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.1.0:", type=("build", "run"))
     depends_on("r-rcpp", type=("build", "run"))
     depends_on("zlib-api")

--- a/repos/spack_repo/builtin/packages/r_rcppensmallen/package.py
+++ b/repos/spack_repo/builtin/packages/r_rcppensmallen/package.py
@@ -19,6 +19,8 @@ class RRcppensmallen(RPackage):
         "0.2.19.0.1", sha256="b4a9bde4dde309a52a47b56790389ecab14fe64066098d2a38b1b588ba3d8631"
     )
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.3.0:", type=("build", "run"))
     depends_on("r@4.0.0:", type=("build", "run"), when="@0.2.20.0.1:")
     depends_on("r-rcpp", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_rcpphnsw/package.py
+++ b/repos/spack_repo/builtin/packages/r_rcpphnsw/package.py
@@ -23,4 +23,6 @@ class RRcpphnsw(RPackage):
     version("0.3.0", sha256="a0eb4eea65e28ba31e8306a1856f7e617a192bd448b148f88abe99181cbde007")
     version("0.1.0", sha256="75a54c30953845dec685764c7b3b4cd7315197c91aef4ab3b4eb0a6293010a95")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r-rcpp@0.11.3:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_rcpproll/package.py
+++ b/repos/spack_repo/builtin/packages/r_rcpproll/package.py
@@ -20,5 +20,7 @@ class RRcpproll(RPackage):
     version("0.3.1", sha256="d2f5d978b6feb8510ec1a1a50ba0e8bf9002bb77bfad7d120f5b30b8f56036df")
     version("0.3.0", sha256="cbff2096443a8a38a6f1dabf8c90b9e14a43d2196b412b5bfe5390393f743f6b")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@2.15.1:", type=("build", "run"))
     depends_on("r-rcpp", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_reordercluster/package.py
+++ b/repos/spack_repo/builtin/packages/r_reordercluster/package.py
@@ -19,6 +19,8 @@ class RReordercluster(RPackage):
     version("2.0", sha256="38862ba2ef2a88ea70b12d50352a96f3b2ea032861256702387989bdfb20017f")
     version("1.0", sha256="a87898faa20380aac3e06a52eedcb2f0eb2b35ab74fdc3435d40ee9f1d28476b")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@2.10:", type=("build", "run"))
     depends_on("r@2.13.0:", type=("build", "run"), when="@2.0:")
     depends_on("r-gtools", type=("build", "run"), when="@2.0:")

--- a/repos/spack_repo/builtin/packages/r_reticulate/package.py
+++ b/repos/spack_repo/builtin/packages/r_reticulate/package.py
@@ -30,6 +30,8 @@ class RReticulate(RPackage):
     version("1.15", sha256="47db3e9c9424263ade15287da8e74f6ba261a936b644b197dba6772853b7b50d")
     version("1.13", sha256="adbe41d556b667c4419d563680f8608a56b0f792b8bc427b3bf4c584ff819de3")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.0:", type=("build", "run"))
     depends_on("r@3.5:", type=("build", "run"), when="@1.30.0:")
     depends_on("r-matrix", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_rfast/package.py
+++ b/repos/spack_repo/builtin/packages/r_rfast/package.py
@@ -27,6 +27,9 @@ class RRfast(RPackage):
     version("2.0.6", sha256="34694b5c67ce8fcbdc90aac2ac80a74d4b66515f383e6301aea7c020009ebe7f")
     version("2.0.4", sha256="959907e36e24620c07ec282b203b40214f4914f4928c07ee6491043c27af31d9")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.5.0:", type=("build", "run"))
     depends_on("r-rcpp@0.12.3:", type=("build", "run"))
     depends_on("r-rcppparallel", type=("build", "run"), when="@2.1.0:")

--- a/repos/spack_repo/builtin/packages/r_rgdal/package.py
+++ b/repos/spack_repo/builtin/packages/r_rgdal/package.py
@@ -26,6 +26,9 @@ class RRgdal(RPackage):
 
     version("1.6-7", sha256="555cedfdadb05db90b061d4b056f96d8b7010c00ea54bc6c1bbcc7684fadae33")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.3.0:", type=("build", "run"))
     depends_on("r@3.5.0:", type=("build", "run"), when="@1.5:")
     depends_on("r-sp@1.1-0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_rgenoud/package.py
+++ b/repos/spack_repo/builtin/packages/r_rgenoud/package.py
@@ -22,4 +22,7 @@ class RRgenoud(RPackage):
     version("5.8-2.0", sha256="106c4f6a6df5159578e929a0141b3cfbaa88141a70703ff59a1fc48a27e2d239")
     version("5.8-1.0", sha256="9deca354be6887f56bf9f4ca9a7291296050e51149ae9a3b757501704126c38a")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@2.15:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_rgeos/package.py
+++ b/repos/spack_repo/builtin/packages/r_rgeos/package.py
@@ -33,6 +33,9 @@ class RRgeos(RPackage):
 
     version("0.6-4", sha256="9d03c4de96fd3fad55ff8d1ff8113dcaaa00f15d9d0588e54c9f91751bcede11")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.3.0:", type=("build", "run"))
     depends_on("r-sp@1.1-0:", type=("build", "run"))
     depends_on("geos@3.2.0:3.8.0", when="@:0.5-1")

--- a/repos/spack_repo/builtin/packages/r_rgl/package.py
+++ b/repos/spack_repo/builtin/packages/r_rgl/package.py
@@ -33,6 +33,9 @@ class RRgl(RPackage):
     version("0.99.16", sha256="692a545ed2ff0f5e15289338736f0e3c092667574c43ac358d8004901d7a1a61")
     version("0.98.1", sha256="5f49bed9e092e672f73c8a1a5365cdffcda06db0315ac087e95ab9c9c71a6986")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r+X", type=("build", "run"))
     depends_on("r@3.2.0:", type=("build", "run"))
     depends_on("r@3.3.0:", type=("build", "run"), when="@0.108.3:")

--- a/repos/spack_repo/builtin/packages/r_rjags/package.py
+++ b/repos/spack_repo/builtin/packages/r_rjags/package.py
@@ -25,6 +25,9 @@ class RRjags(RPackage):
     version("4-8", sha256="1529827ab11493fb5f05552e239d700ae2f818995d86d3c9e4c92523f594b59f")
     version("4-6", sha256="cf24bb1e7c8445bafb49097089ad33e5bd5d8efbccf16fc7e32ad230f05f89ad")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@2.14.0:", type=("build", "run"))
     depends_on("r-coda@0.13:", type=("build", "run"))
     depends_on("jags@4.0.0:4.999.999", type=("link"))

--- a/repos/spack_repo/builtin/packages/r_rjava/package.py
+++ b/repos/spack_repo/builtin/packages/r_rjava/package.py
@@ -21,6 +21,8 @@ class RRjava(RPackage):
     version("0.9-11", sha256="c28ae131456a98f4d3498aa8f6eac9d4df48727008dacff1aa561fc883972c69")
     version("0.9-8", sha256="dada5e031414da54eb80b9024d51866c20b92d41d68da65789fe0130bc54bd8a")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.5:", type=("build", "run"))
     depends_on("r@3.6.0:", type=("build", "run"), when="@1.0-6:")
     depends_on("java@2:")

--- a/repos/spack_repo/builtin/packages/r_rjsonio/package.py
+++ b/repos/spack_repo/builtin/packages/r_rjsonio/package.py
@@ -35,3 +35,6 @@ class RRjsonio(RPackage):
     version("1.3-1.2", sha256="550e18f7c04186376d67747b8258f529d205bfc929da9194fe45ec384e092d7e")
     version("1.3-1.1", sha256="c72493b441758cd1e3e9d91296b9ea31068e71104649f46ad84c854a02c09693")
     version("1.3-0", sha256="119334b7761c6c1c3cec52fa17dbc1b72eaebb520c53e68d873dea147cf48fb7")
+
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/r_rmariadb/package.py
+++ b/repos/spack_repo/builtin/packages/r_rmariadb/package.py
@@ -22,6 +22,8 @@ class RRmariadb(RPackage):
     version("1.1.0", sha256="9ffa63a15052876a51a7996ca4e6a5b7b937f594b5cc7ca5a86f43789e22a956")
     version("1.0.8", sha256="3c8aedc519dc063ceb068535a3700bc5caf26f867078cc5a228aa8961e2d99f5")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@2.8.0:", type=("build", "run"))
     depends_on("r-bit64", type=("build", "run"))
     depends_on("r-blob", type=("build", "run"), when="@1.2.1:")

--- a/repos/spack_repo/builtin/packages/r_rmpfr/package.py
+++ b/repos/spack_repo/builtin/packages/r_rmpfr/package.py
@@ -27,6 +27,8 @@ class RRmpfr(RPackage):
     version("0.7-1", sha256="9b3021617a22b0710b0f1acc279290762317ff123fd9e8fd03f1449f4bbfe204")
     version("0.6-1", sha256="bf50991055e9336cd6a110d711ae8a91a0551b96f9eaab5fef8c05f578006e1c")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.0.1:", type=("build", "run"))
     depends_on("r@3.1.0:", type=("build", "run"), when="@0.7-0")
     depends_on("r@3.3.0:", type=("build", "run"), when="@0.7-1:")

--- a/repos/spack_repo/builtin/packages/r_rmpi/package.py
+++ b/repos/spack_repo/builtin/packages/r_rmpi/package.py
@@ -22,6 +22,8 @@ class RRmpi(RPackage):
     version("0.6-8", sha256="9b453ce3bd7284eda33493a0e47bf16db6719e3c48ac5f69deac6746f5438d96")
     version("0.6-6", sha256="d8fc09ad38264697caa86079885a7a1098921a3116d5a77a62022b9508f8a63a")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.15.1:", type=("build", "run"))
     depends_on("mpi")
 

--- a/repos/spack_repo/builtin/packages/r_rms/package.py
+++ b/repos/spack_repo/builtin/packages/r_rms/package.py
@@ -39,6 +39,9 @@ class RRms(RPackage):
     version("5.1-2", sha256="f1cfeef466ac436105756679353a3468027d97a600e3be755b819aef30ed9207")
     version("5.1-1", sha256="c489948df5c434b40bcf5288844f5b4e08d157f36939d09230c1600f88d1bfe3")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@3.5.0:", type=("build", "run"))
     depends_on("r@4.1.0:", type=("build", "run"), when="@6.8-0:")
     depends_on("r-hmisc@4.3-0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_rmysql/package.py
+++ b/repos/spack_repo/builtin/packages/r_rmysql/package.py
@@ -24,6 +24,8 @@ class RRmysql(RPackage):
     version("0.10.17", sha256="754df4fce159078c1682ef34fc96aa5ae30981dc91f4f2bada8d1018537255f5")
     version("0.10.9", sha256="41289c743dc8ee2e0dea8b8f291d65f0a7cd11e799b713d94840406ff296fd42")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.8.0:", type=("build", "run"))
     depends_on("r-dbi@0.4:", type=("build", "run"))
     depends_on("mariadb-client")

--- a/repos/spack_repo/builtin/packages/r_robust/package.py
+++ b/repos/spack_repo/builtin/packages/r_robust/package.py
@@ -26,6 +26,9 @@ class RRobust(RPackage):
     version("0.4-18.1", sha256="de31901882873ef89748bb6863caf55734431df5b3eb3c6663ed17ee2e4a4077")
     version("0.4-18", sha256="e4196f01bb3b0d768759d4411d524238b627eb8dc213d84cb30014e75480f8ac")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r-fit-models", type=("build", "run"))
     depends_on("r-lattice", type=("build", "run"))
     depends_on("r-mass", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_robustbase/package.py
+++ b/repos/spack_repo/builtin/packages/r_robustbase/package.py
@@ -29,6 +29,9 @@ class RRobustbase(RPackage):
     version("0.93-4", sha256="ea9e03d484ef52ea805803477ffc48881e4c8c86ffda4eea56109f8b23f0a6e0")
     version("0.92-7", sha256="fcbd6ccbb0291b599fe6a674a91344511e0a691b9cadba0a9d40037faa22bf8f")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@3.0.2:", type=("build", "run"))
     depends_on("r@3.1.0:", type=("build", "run"), when="@0.93-2:")
     depends_on("r@3.5.0:", type=("build", "run"), when="@0.93-9:")

--- a/repos/spack_repo/builtin/packages/r_rodbc/package.py
+++ b/repos/spack_repo/builtin/packages/r_rodbc/package.py
@@ -23,6 +23,8 @@ class RRodbc(RPackage):
     version("1.3-15", sha256="c43e5a2f0aa2f46607e664bfc0bb3caa230bbb779f4ff084e01727642da136e1")
     version("1.3-13", sha256="e8ea7eb77a07be36fc2d824c28bb426334da7484957ffbc719140373adf1667c")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r@4.0.0:", type=("build", "run"), when="@1.3-17:")
     depends_on("unixodbc")

--- a/repos/spack_repo/builtin/packages/r_roxygen2/package.py
+++ b/repos/spack_repo/builtin/packages/r_roxygen2/package.py
@@ -29,6 +29,8 @@ class RRoxygen2(RPackage):
     version("6.1.1", sha256="ed46b7e062e0dfd8de671c7a5f6d120fb2b720982e918dbeb01e6985694c0273")
     version("5.0.1", sha256="9f755ddd08358be436f08b02df398e50e7508b856131aeeed235099bb3a7eba5")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.0.2:", type=("build", "run"))
     depends_on("r@3.1:", type=("build", "run"), when="@6.1.0:")
     depends_on("r@3.2:", type=("build", "run"), when="@7.1.0:")

--- a/repos/spack_repo/builtin/packages/r_rpart/package.py
+++ b/repos/spack_repo/builtin/packages/r_rpart/package.py
@@ -26,4 +26,6 @@ class RRpart(RPackage):
     version("4.1-11", sha256="38ab80959f59bcdd2c4c72860e8dd0deab0307668cbbf24f96014d7a2496ad98")
     version("4.1-10", sha256="c5ddaed288d38118876a94c7aa5000dce0070b8d736dba12de64a9cb04dc2d85")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.15.0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_rpostgres/package.py
+++ b/repos/spack_repo/builtin/packages/r_rpostgres/package.py
@@ -21,6 +21,9 @@ class RRpostgres(RPackage):
     version("1.4.3", sha256="a5be494a54b6e989fadafdc6ee2dc5c4c15bb17bacea9ad540b175c693331be2")
     version("1.3.1", sha256="f68ab095567317ec32d3faa10e5bcac400aee5aeca8d7132260d4e90f82158ea")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.1.0:", type=("build", "run"))
     depends_on("r-bit64", type=("build", "run"))
     depends_on("r-blob@1.2.0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_rpostgresql/package.py
+++ b/repos/spack_repo/builtin/packages/r_rpostgresql/package.py
@@ -31,6 +31,8 @@ class RRpostgresql(RPackage):
     version("0.6-2", sha256="080118647208bfa2621bcaac0d324891cc513e07618fa22e3c50ec2050e1b0d5")
     version("0.4-1", sha256="6292e37fa841670a3fb1a0950ceb83d15beb4631c3c532c8ce279d1c0d10bf79")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.9.0:", type=("build", "run"))
     depends_on("r-dbi@0.3:", type=("build", "run"))
     depends_on("postgresql")

--- a/repos/spack_repo/builtin/packages/r_rrcov/package.py
+++ b/repos/spack_repo/builtin/packages/r_rrcov/package.py
@@ -33,6 +33,9 @@ class RRrcov(RPackage):
     version("1.5-5", sha256="1f7f07558e347e7d1f1adff68631764670bc672777a7d990901c4fa94cc0e629")
     version("1.4-7", sha256="cbd08ccce8b583a2f88946a3267c8fc494ee2b44ba749b9296a6e3d818f6f293")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@2.10:", type=("build", "run"))
     depends_on("r-robustbase@0.92.1:", type=("build", "run"))
     depends_on("r-mvtnorm", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_rsnns/package.py
+++ b/repos/spack_repo/builtin/packages/r_rsnns/package.py
@@ -29,5 +29,8 @@ class RRsnns(RPackage):
     version("0.4-10.1", sha256="38bb3d172390bd01219332ec834744274b87b01f94d23b29a9d818c2bca04071")
     version("0.4-7", sha256="ec941dddda55e4e29ed281bd8768a93d65e0d86d56ecab0f2013c64c8d1a4994")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@2.10.0:", type=("build", "run"))
     depends_on("r-rcpp@0.8.5:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_rstantools/package.py
+++ b/repos/spack_repo/builtin/packages/r_rstantools/package.py
@@ -26,6 +26,8 @@ class RRstantools(RPackage):
     version("2.1.1", sha256="c95b15de8ec577eeb24bb5206e7b685d882f88b5e6902efda924b7217f463d2d")
     version("1.5.1", sha256="5cab16c132c12e84bd08e18cd6ef25ba39d67a04ce61015fc4490659c7cfb485")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r+X", type=("build", "run"))
     depends_on("r-desc", type=("build", "run"), when="@2.1.1:")
     depends_on("r-rcpp@0.12.16:", type=("build", "run"), when="@2.1.1:")

--- a/repos/spack_repo/builtin/packages/r_rtsne/package.py
+++ b/repos/spack_repo/builtin/packages/r_rtsne/package.py
@@ -23,4 +23,6 @@ class RRtsne(RPackage):
     version("0.11", sha256="1e2e7368f3de870b9270f70b207ba9e8feea67f9b061cb6abb2fec785fb7247e")
     version("0.10", sha256="c54371f4a935520e7e7ab938ef8f5f7f9ad2a829123b9513ae715c07de034790")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r-rcpp@0.11.0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_runjags/package.py
+++ b/repos/spack_repo/builtin/packages/r_runjags/package.py
@@ -30,6 +30,9 @@ class RRunjags(RPackage):
     version("2.2.0-3", sha256="1b1fc0b0cfecf9ecdecc3abcba804cdc114b3c5352d5cc801602deeca90db528")
     version("2.2.0-2", sha256="e5dfeb83d36faf19ebe64429f6db64aedecf3c9a040fd5bf9c0200914bf5039a")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@2.14.0:", type=("build", "run"))
     depends_on("r-lattice@0.20-10:", type=("build", "run"))
     depends_on("r-coda@0.17-1:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_rzmq/package.py
+++ b/repos/spack_repo/builtin/packages/r_rzmq/package.py
@@ -25,5 +25,8 @@ class RRzmq(RPackage):
     version("0.9.4", sha256="03fbda756d823c11fba359b94a6213c3440e61973331668eaac35779717f73ad")
     version("0.7.7", sha256="bdbaf77a0e04c5b6d6ce79ab2747848a5044355eed2e2c4d39c4ba16f97dc83d")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.1.0:", type=("build", "run"), when="@0.9.0:")
     depends_on("libzmq@3.0.0:")

--- a/repos/spack_repo/builtin/packages/r_s2/package.py
+++ b/repos/spack_repo/builtin/packages/r_s2/package.py
@@ -27,6 +27,9 @@ class RS2(RPackage):
     version("1.0.7", sha256="2010c1c6ae29938ec9cd153a8b2c06a333ea4d647932369b2fc7d0c68d6d9e3f")
     version("1.0.4", sha256="3c274ebae33aa5473f94afb3066c6f388aced17ff3b5f6add9edcc9af22b985e")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r-rcpp", type=("build", "run"))
     depends_on("r-wk", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_satellite/package.py
+++ b/repos/spack_repo/builtin/packages/r_satellite/package.py
@@ -30,6 +30,8 @@ class RSatellite(RPackage):
     version("1.0.4", sha256="99e79577a70489930c32da46ac26453af53e21c2d3a99f51fbf1f55f2d80dc7c")
     version("1.0.2", sha256="6447476bd31216e5abe504221e465677954d07419b4174ab4f4e4f7a197969c5")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@2.10:", type=("build", "run"))
     depends_on("r-raster", type=("build", "run"))
     depends_on("r-plyr", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_scattermore/package.py
+++ b/repos/spack_repo/builtin/packages/r_scattermore/package.py
@@ -21,5 +21,8 @@ class RScattermore(RPackage):
     version("0.8", sha256="dbdd73d8261cb063464bb29d5c17733b7e87bc50a19948bc80439e19f2a9f8e5")
     version("0.7", sha256="f36280197b8476314d6ce81a51c4ae737180b180204043d2937bc25bf3a5dfa2")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r-ggplot2", type=("build", "run"))
     depends_on("r-scales", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_sctransform/package.py
+++ b/repos/spack_repo/builtin/packages/r_sctransform/package.py
@@ -27,6 +27,8 @@ class RSctransform(RPackage):
     version("0.3.2", sha256="5dbb0a045e514c19f51bbe11c2dba0b72dca1942d6eb044c36b0538b443475dc")
     version("0.2.0", sha256="d7f4c7958693823454f1426b23b0e1e9c207ad61a7a228602a1885a1318eb3e4")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.0.2:", type=("build", "run"))
     depends_on("r@3.1.0:", type=("build", "run"), when="@0.3.2:")
     depends_on("r@3.5.0:", type=("build", "run"), when="@0.3.3:")

--- a/repos/spack_repo/builtin/packages/r_sdmtools/package.py
+++ b/repos/spack_repo/builtin/packages/r_sdmtools/package.py
@@ -32,4 +32,6 @@ class RSdmtools(RPackage):
     version("1.1-12", sha256="6dc4a8a046e7fced190402f39a9bae6f863e08c320f0881367c022b2f220f14b")
     version("1.1-11", sha256="1caf8fa1914ad6921d76e7b22a8c25cfe55892b0d21aef3b2a7b8f5b79b9388b")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r-r-utils", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_seqinr/package.py
+++ b/repos/spack_repo/builtin/packages/r_seqinr/package.py
@@ -27,6 +27,8 @@ class RSeqinr(RPackage):
     version("3.4-5", sha256="162a347495fd52cbb62e8187a4692e7c50b9fa62123c5ef98f2744c98a05fb9f")
     version("3.3-6", sha256="42a3ae01331db744d67cc9c5432ce9ae389bed465af826687b9c10216ac7a08d")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.10:", type=("build", "run"))
     depends_on("r@2.10.0:", type=("build", "run"), when="@4.2-30:")
     depends_on("r-ade4", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_sets/package.py
+++ b/repos/spack_repo/builtin/packages/r_sets/package.py
@@ -54,5 +54,7 @@ class RSets(RPackage):
     version("0.1-1", sha256="4e41480757e33897a26974e5234801ff1c15f1a3952c96071787b43141a130de")
     version("0.1", sha256="18dda6c9d526a2f41f2b49a472fb27a7f1bb9ce6ea137b8963e8ad6c378825d0")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.6:", type=("build", "run"), when="@0.1:")
     depends_on("r@2.7.0:", type=("build", "run"), when="@0.1-2:")

--- a/repos/spack_repo/builtin/packages/r_seurat/package.py
+++ b/repos/spack_repo/builtin/packages/r_seurat/package.py
@@ -33,6 +33,9 @@ class RSeurat(RPackage):
     version("2.1.0", sha256="7d20d231b979a4aa63cd7dae7e725405212e8975889f12b8d779c6c896c10ac3")
     version("2.0.1", sha256="6aa33aa3afb29a8be364ab083c7071cfbc56ad042a019bcf6f939e0c8c7744f0")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.2.0:", type=("build", "run"))
     depends_on("r@3.4.0:", type=("build", "run"), when="@2.3.1:")
     depends_on("r@3.6.0:", type=("build", "run"), when="@3.2.3:")

--- a/repos/spack_repo/builtin/packages/r_seuratobject/package.py
+++ b/repos/spack_repo/builtin/packages/r_seuratobject/package.py
@@ -27,6 +27,9 @@ class RSeuratobject(RPackage):
     version("4.1.0", sha256="9ca406cb3bd95c588e1a81c5383e3173a446cc0667142b139ca32685b4b20a05")
     version("4.0.4", sha256="585261b7d2045193accf817a29e2e3356e731f57c554bed37d232fa49784088c")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@4.0.0:", type=("build", "run"))
     depends_on("r@4.1.0:", when="@5.0.2:", type=("build", "run"))
     depends_on("r-future", type=("build", "run"), when="@4.1.0:")

--- a/repos/spack_repo/builtin/packages/r_sf/package.py
+++ b/repos/spack_repo/builtin/packages/r_sf/package.py
@@ -30,6 +30,8 @@ class RSf(RPackage):
     version("0.7-7", sha256="d1780cb46a285b30c7cc41cae30af523fbc883733344e53f7291e2d045e150a4")
     version("0.7-5", sha256="53ed0567f502216a116c4848f5a9262ca232810f82642df7b98e0541a2524868")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.3.0:", type=("build", "run"))
     depends_on("r-classint@0.2-1:", type=("build", "run"))
     depends_on("r-classint@0.4-1:", type=("build", "run"), when="@0.9-7:")

--- a/repos/spack_repo/builtin/packages/r_sfheaders/package.py
+++ b/repos/spack_repo/builtin/packages/r_sfheaders/package.py
@@ -22,6 +22,8 @@ class RSfheaders(RPackage):
     version("0.4.2", sha256="ed9fb934c537fb6f126886f8e5997727de856e32fc3d38911b61a3a83faa7b2c")
     version("0.4.0", sha256="86bcd61018a0491fc8a1e7fb0422c918296287b82be299a79ccee8fcb515e045")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r-geometries@0.2.0:", type=("build", "run"))
     depends_on("r-geometries@0.2.2:", type=("build", "run"), when="@0.4.2:")
     depends_on("r-geometries@0.2.4:", type=("build", "run"), when="@0.4.4:")

--- a/repos/spack_repo/builtin/packages/r_signac/package.py
+++ b/repos/spack_repo/builtin/packages/r_signac/package.py
@@ -24,6 +24,8 @@ class RSignac(RPackage):
     version("1.8.0", sha256="9c4b123f4d077111c7e6dd1659483ada984300c8e923672ca924e46fb6a1dd06")
     version("1.7.0", sha256="5e4456eeab29fa2df7f6236b050dec8cb9c073d7652a89ee5030a27f94e5e4bf")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@4.0.0:", type=("build", "run"))
     depends_on("r@4.1.0:", type=("build", "run"), when="@1.14.0:")
     depends_on("r-genomeinfodb@1.29.3:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_sp/package.py
+++ b/repos/spack_repo/builtin/packages/r_sp/package.py
@@ -30,6 +30,8 @@ class RSp(RPackage):
     version("1.2-7", sha256="6d60e03e1abd30a7d4afe547d157ce3dd7a8c166fc5e407fd6d62ae99ff30460")
     version("1.2-3", sha256="58b3a9e395ca664ee61b20b480be4eb61576daca44c3d3f6f9a943bb0155879a")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r@3.2.0:", type=("build", "run"), when="@2.0-0:")
     depends_on("r@3.5.0:", type=("build", "run"), when="@2.1-0:")

--- a/repos/spack_repo/builtin/packages/r_spades_tools/package.py
+++ b/repos/spack_repo/builtin/packages/r_spades_tools/package.py
@@ -27,6 +27,8 @@ class RSpadesTools(RPackage):
     version("0.3.9", sha256="84dc47f55ded58746dcb943fde97fa4a4b852e1d2f45949ab1914cf8454e00f3")
     version("0.3.6", sha256="661f8ee792874e7447be78103775b63f18ec69e773a7b275dd977adb406dd3e5")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.5.0:", type=("build", "run"))
     depends_on("r@3.6:", type=("build", "run"), when="@0.3.9:")
     depends_on("r@4.0:", type=("build", "run"), when="@0.3.10:")

--- a/repos/spack_repo/builtin/packages/r_spam/package.py
+++ b/repos/spack_repo/builtin/packages/r_spam/package.py
@@ -28,6 +28,10 @@ class RSpam(RPackage):
     version("2.6-0", sha256="638fdd658e94f7544b46f6b6568b20a9f390bcd703aff572a3a5249fef66be5c")
     version("2.3-0.2", sha256="848fa95c0a71ac82af6344539af7b1c33563c687f06ead42851a68b621fff533")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@3.1:", type=("build", "run"))
     depends_on("r@3.5:", type=("build", "run"), when="@2.9-1:")
     depends_on("r-dotcall64", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_spatial/package.py
+++ b/repos/spack_repo/builtin/packages/r_spatial/package.py
@@ -22,6 +22,8 @@ class RSpatial(RPackage):
     version("7.3-12", sha256="7639039ee7407bd088e1b253376b2cb4fcdf4cc9124d6b48e4119d5cda872d63")
     version("7.3-11", sha256="624448d2ac22e1798097d09fc5dc4605908a33f490b8ec971fc6ea318a445c11")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.0.0:", type=("build", "run"))
 
     depends_on("r-mass", type=("build", "run"), when="@:7.3-11")

--- a/repos/spack_repo/builtin/packages/r_spatialreg/package.py
+++ b/repos/spack_repo/builtin/packages/r_spatialreg/package.py
@@ -44,6 +44,8 @@ class RSpatialreg(RPackage):
     version("1.1-5", sha256="ddbf0773bad2e99b306116ae99a57bf29eecf723d1735820935a6fb7f331b27d")
     version("1.1-3", sha256="7609cdfcdfe427d2643a0db6b5360be3f6d60ede8229436ab52092d1c9cf0480")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.3.0:", type=("build", "run"))
     depends_on("r-spdata", type=("build", "run"))
     depends_on("r-spdata@2.3.1:", type=("build", "run"), when="@1.3-4:")

--- a/repos/spack_repo/builtin/packages/r_spatstat_core/package.py
+++ b/repos/spack_repo/builtin/packages/r_spatstat_core/package.py
@@ -45,6 +45,8 @@ class RSpatstatCore(RPackage):
     version("2.4-4", sha256="e38c39efe8b14d6e8fdbee8dd870b90c52f78ea571ab7988fd3685f48347d13b")
     version("2.3-2", sha256="7f4d6d997f9187eda71097a53917e7cbe03f8dcfb4e758d86a90fbe42c92f63c")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.5.0:", type=("build", "run"))
     depends_on("r-spatstat-data@2.1-0:", type=("build", "run"))
     depends_on("r-spatstat-geom@2.3-0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_spatstat_explore/package.py
+++ b/repos/spack_repo/builtin/packages/r_spatstat_explore/package.py
@@ -30,6 +30,8 @@ class RSpatstatExplore(RPackage):
     version("3.1-0", sha256="87ef4882652db3b834214bfc776dd7d23d931a9227de12f19722aeb1029d086e")
     version("3.0-3", sha256="137444a46d26d88241336feece63ed7b006a9328cfe3861d4b8ab7b4bed963a7")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.5.0:", type=("build", "run"))
     depends_on("r-spatstat-data@3.0:", type=("build", "run"))
     depends_on("r-spatstat-data@3.0-4:", type=("build", "run"), when="@:")

--- a/repos/spack_repo/builtin/packages/r_spatstat_geom/package.py
+++ b/repos/spack_repo/builtin/packages/r_spatstat_geom/package.py
@@ -33,6 +33,8 @@ class RSpatstatGeom(RPackage):
     version("2.4-0", sha256="32b89a409ce87ffe901e4c8720a26cac9629f9816e163c4ad68b7aa012d69e67")
     version("2.3-1", sha256="f23e58d05a6d6bfab1345951fa528a9865f2a744e162fe4456161e1b0b5172c0")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.5.0:", type=("build", "run"))
     depends_on("r-spatstat-data@2.0-0:", type=("build", "run"))
     depends_on("r-spatstat-data@3.0:", type=("build", "run"), when="@3.0-3:")

--- a/repos/spack_repo/builtin/packages/r_spatstat_linnet/package.py
+++ b/repos/spack_repo/builtin/packages/r_spatstat_linnet/package.py
@@ -45,6 +45,8 @@ class RSpatstatLinnet(RPackage):
     version("2.3-2", sha256="9c78a4b680debfff0f3ae934575c30d03ded49bc9a7179475384af0ebaf13778")
     version("2.3-1", sha256="119ba6e3da651aa9594f70a7a35349209534215aa640c2653aeddc6aa25038c3")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.5.0:", type=("build", "run"))
     depends_on("r-spatstat-model@3.2-1:", type=("build", "run"), when="@3.1-0:")
     depends_on("r-spatstat-model@3.2-11.005:", type=("build", "run"), when="@3.2-1:")

--- a/repos/spack_repo/builtin/packages/r_spatstat_model/package.py
+++ b/repos/spack_repo/builtin/packages/r_spatstat_model/package.py
@@ -36,6 +36,8 @@ class RSpatstatModel(RPackage):
     version("3.3-1", sha256="5c1c969b5f2bbfdfe91ad31cd912f31b91ec9cc7651ecec86c1d7a562161afa7")
     version("3.2-3", sha256="8ad7d2644773571a5c579ceebb98b735dccc97e9b4b109ea39b4ce3faedb14ea")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.5.0:", type=("build", "run"))
     depends_on("r-spatstat-data@3.0:", type=("build", "run"))
     depends_on("r-spatstat-data@3.0-4:", type=("build", "run"), when="@3.2-11:")

--- a/repos/spack_repo/builtin/packages/r_spatstat_random/package.py
+++ b/repos/spack_repo/builtin/packages/r_spatstat_random/package.py
@@ -31,6 +31,9 @@ class RSpatstatRandom(RPackage):
     version("3.0-1", sha256="938c845c063b8781bf894c0a67537e7b2a7c425a4beba4a95ec9d2c37b43e5b6")
     version("2.2-0", sha256="45f0bbdb9dbd53b6c4151c3cdd098451cf787729717ccbb063cd1f33910e604d")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.5.0:", type=("build", "run"))
     depends_on("r-spatstat-data@2.1-0:", type=("build", "run"))
     depends_on("r-spatstat-data@2.2-0.003:", type=("build", "run"), when="@3.0-1:")

--- a/repos/spack_repo/builtin/packages/r_spatstat_sparse/package.py
+++ b/repos/spack_repo/builtin/packages/r_spatstat_sparse/package.py
@@ -22,6 +22,8 @@ class RSpatstatSparse(RPackage):
     version("2.1-1", sha256="9a35ad69715b767b3ae60b02dce05ccf108fcccdf95bbc8f7d02557bcbde7303")
     version("2.1-0", sha256="0019214418668cba9f01ee5901ed7f4dba9cfee5ff62d5c7e1c914adfbea0e91")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.5.0:", type=("build", "run"))
     depends_on("r-matrix", type=("build", "run"))
     depends_on("r-abind", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_spatstat_univar/package.py
+++ b/repos/spack_repo/builtin/packages/r_spatstat_univar/package.py
@@ -20,5 +20,7 @@ class RSpatstatUnivar(RPackage):
 
     version("3.0-0", sha256="00bc501d9bec32231207f0562433193bd680606ce465131caa5e2704b4ff4771")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.5.0:", type=("build", "run"), when="@3.0-0:")
     depends_on("r-spatstat-utils@3.0-5:", type=("build", "run"), when="@2.0-3.011:")

--- a/repos/spack_repo/builtin/packages/r_spatstat_utils/package.py
+++ b/repos/spack_repo/builtin/packages/r_spatstat_utils/package.py
@@ -24,5 +24,7 @@ class RSpatstatUtils(RPackage):
     version("1.17-0", sha256="39cd683ed7f41d8adc9e28af073d91b244aa1cf5ad966dfbb396ee3ee79f0922")
     version("1.15-0", sha256="90e07d730b6939f47f93c939afae10874b2c82bd402960ede4133de67dca2a0c")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.3.0:", type=("build", "run"))
     depends_on("r@3.5.0:", type=("build", "run"), when="@3.1-0:")

--- a/repos/spack_repo/builtin/packages/r_spdep/package.py
+++ b/repos/spack_repo/builtin/packages/r_spdep/package.py
@@ -35,6 +35,8 @@ class RSpdep(RPackage):
     version("1.0-2", sha256="6f9efa4347d5c13b49922b75481ac403431c3c76a65a109af29954aa7bb138b2")
     version("0.6-13", sha256="ed345f4c7ea7ba064b187eb6b25f0ac46f17616f3b56ab89978935cdc67df1c4")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r@3.3.0:", type=("build", "run"), when="@0.7-8:")
     depends_on("r-sp@1.0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_splancs/package.py
+++ b/repos/spack_repo/builtin/packages/r_splancs/package.py
@@ -23,5 +23,8 @@ class RSplancs(RPackage):
     version("2.01-42", sha256="8c0af4764521e20b629dba6afd5c284e7be48786f378c37668eacfa26d2ef0aa")
     version("2.01-40", sha256="79744381ebc4a361740a36dca3c9fca9ae015cfe0bd585b7856a664a3da74363")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@2.10.0:", type=("build", "run"))
     depends_on("r-sp@0.9:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_splines2/package.py
+++ b/repos/spack_repo/builtin/packages/r_splines2/package.py
@@ -22,6 +22,8 @@ class RSplines2(RPackage):
 
     version("0.5.3", sha256="c27e7bd12d615095f765f4c1ed3cb9e39b922653aabbe88c4ca3ac31e6a01ddc")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.2.3:", type=("build", "run"))
 
     depends_on("r-rcpp", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_statnet_common/package.py
+++ b/repos/spack_repo/builtin/packages/r_statnet_common/package.py
@@ -25,6 +25,8 @@ class RStatnetCommon(RPackage):
     version("4.2.0", sha256="1176c3303436ebe858d02979cf0a0c33e4e2d1f3637516b4761d573ccd132461")
     version("3.3.0", sha256="d714c4e7b0cbf71b7a628af443f5be530e74ad1e21f6b04f1b1087f6d7e40fa4")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.5:", type=("build", "run"), when="@4.2.0:")
     depends_on("r-coda", type=("build", "run"), when="@4.1.2:")
 

--- a/repos/spack_repo/builtin/packages/r_stringfish/package.py
+++ b/repos/spack_repo/builtin/packages/r_stringfish/package.py
@@ -24,6 +24,9 @@ class RStringfish(RPackage):
     version("0.15.5", sha256="9df21146a7710e5a9ab4bb53ebc231a580c798b7e541b8d78df53207283f8129")
     version("0.14.2", sha256="9373cfc715cda1527fd20179435977b8e59e19d8c5ef82a31e519f93fb624ced")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.5.0:", type=("build", "run"))
     depends_on("r@3.0.2:", type=("build", "run"), when="@0.15.5:")
     depends_on("r-rcpp@0.12.18.3:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_styler/package.py
+++ b/repos/spack_repo/builtin/packages/r_styler/package.py
@@ -24,6 +24,8 @@ class RStyler(RPackage):
     version("1.6.2", sha256="a62fcc76aac851069f33874f9eaabdd580973b619cfc625d6ec910476015f75c")
     version("1.3.2", sha256="3fcf574382c607c2147479bad4f9fa8b823f54fb1462d19ec4a330e135a44ff1")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.4.0:", type=("build", "run"), when="@1.7.0:")
     depends_on("r@3.5.0:", type=("build", "run"), when="@1.8.0:")
     depends_on("r@3.6.0:", type=("build", "run"), when="@1.10.0:")

--- a/repos/spack_repo/builtin/packages/r_subplex/package.py
+++ b/repos/spack_repo/builtin/packages/r_subplex/package.py
@@ -25,5 +25,8 @@ class RSubplex(RPackage):
     version("1.5-2", sha256="6f8c3ccadf1ccd7f11f3eae28cec16eed3695f14e351b864d807dbaba6cd3ded")
     version("1.4-1", sha256="94b7b961aaa229a6f025151191ed50272af1394be69f1c41146b9e8c786caec6")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@2.5.1:", type=("build", "run"))
     depends_on("r@4.1.0:", type=("build", "run"), when="@1.9:")

--- a/repos/spack_repo/builtin/packages/r_survey/package.py
+++ b/repos/spack_repo/builtin/packages/r_survey/package.py
@@ -29,6 +29,8 @@ class RSurvey(RPackage):
     version("3.35-1", sha256="11e5ddde9c8c21dfaed0b1247036e068ad32782c76ff71f7937eb7585dd364db")
     version("3.30-3", sha256="be45d00b22d857e66905789031f2db1037505f80ce15d4b0ea84dabb03bc9e6d")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@2.14.0:", type=("build", "run"))
     depends_on("r@2.16.0:", type=("build", "run"), when="@3.32:")
     depends_on("r@3.1.0:", type=("build", "run"), when="@3.35:")

--- a/repos/spack_repo/builtin/packages/r_svglite/package.py
+++ b/repos/spack_repo/builtin/packages/r_svglite/package.py
@@ -22,6 +22,8 @@ class RSvglite(RPackage):
     version("2.1.0", sha256="ad40f590c7e80ae83001a3826b6e8394ba733446ed51fd55faeda974ab839c9b")
     version("2.0.0", sha256="76e625fe172a5b7ce99a67b6d631b037b3f7f0021cfe15f2e15e8851b89defa5")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r+X", type=("build", "run"))
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r@3.5.0:", type=("build", "run"), when="@2.1.2:")

--- a/repos/spack_repo/builtin/packages/r_tclust/package.py
+++ b/repos/spack_repo/builtin/packages/r_tclust/package.py
@@ -31,6 +31,8 @@ class RTclust(RPackage):
     version("1.1-03", sha256="b8a62a1d27e69ac7e985ba5ea2ae5d182d2e51665bfbfb178e22b63041709270")
     version("1.1-02", sha256="f73c0d7a495552f901b710cf34e114c0ba401d5a17c48156313245904bcccad4")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@2.12.0:", type=("build", "run"))
     depends_on("r@3.6.2:", type=("build", "run"), when="@1.5-6:")
 

--- a/repos/spack_repo/builtin/packages/r_terra/package.py
+++ b/repos/spack_repo/builtin/packages/r_terra/package.py
@@ -32,6 +32,9 @@ class RTerra(RPackage):
     version("1.5-12", sha256="865cc14ee8c3239037c08170df4011eed27cf638ac1d05f0b7cd704abf97cc19")
     version("1.4-22", sha256="b8eccfa36764577248d7b390e24af6db65fb8824c07f9b782bd6b83c4d2b3976")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.5.0:", type=("build", "run"))
     depends_on("r-rcpp", type=("build", "run"))
     depends_on("r-rcpp@1.0-10:", type=("build", "run"), when="@1.7-29:")

--- a/repos/spack_repo/builtin/packages/r_testthat/package.py
+++ b/repos/spack_repo/builtin/packages/r_testthat/package.py
@@ -30,6 +30,9 @@ class RTestthat(RPackage):
     version("2.1.0", sha256="cf5fa7108111b32b86e70819352f86b57ab4e835221bb1e83642d52a1fdbcdd4")
     version("1.0.2", sha256="0ef7df0ace1fddf821d329f9d9a5d42296085350ae0d94af62c45bd203c8415e")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.1:", type=("build", "run"))
     depends_on("r@3.6.0:", type=("build", "run"), when="@3.2.0:")
     depends_on("r-brio", type=("build", "run"), when="@3.0.1:")

--- a/repos/spack_repo/builtin/packages/r_tidygraph/package.py
+++ b/repos/spack_repo/builtin/packages/r_tidygraph/package.py
@@ -27,6 +27,8 @@ class RTidygraph(RPackage):
     version("1.2.0", sha256="057d6c42fc0144109f3ace7f5058cca7b2fe493c761daa991448b23f86b6129f")
     version("1.1.2", sha256="5642001d4cccb122d66481b7c61a06c724c02007cbd356ee61cb29726a56fafe")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r-tibble", type=("build", "run"))
     depends_on("r-dplyr@0.8:", type=("build", "run"))
     depends_on("r-dplyr@0.8.5:", type=("build", "run"), when="@1.2.0:")

--- a/repos/spack_repo/builtin/packages/r_tiff/package.py
+++ b/repos/spack_repo/builtin/packages/r_tiff/package.py
@@ -24,6 +24,8 @@ class RTiff(RPackage):
     version("0.1-6", sha256="623bd9c16a426df7e6056738c5d91da86ea9b49df375eea6b5127e4e458dc4fb")
     version("0.1-5", sha256="9514e6a9926fcddc29ce1dd12b1072ad8265900373f738de687ef4a1f9124e2b")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@2.9.0:", type=("build", "run"))
     depends_on("libtiff")
     depends_on("jpeg")

--- a/repos/spack_repo/builtin/packages/r_tseries/package.py
+++ b/repos/spack_repo/builtin/packages/r_tseries/package.py
@@ -24,6 +24,9 @@ class RTseries(RPackage):
     version("0.10-46", sha256="12940afd1d466401160e46f993ed4baf28a42cef98d3757b66ee15e916e07222")
     version("0.10-42", sha256="827f79858715c700e8cabd2c27853ba88ad0e05eb043bc94e126b155a75546c4")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@2.10.0:", type=("build", "run"))
     depends_on("r@3.4.0:", type=("build", "run"), when="@0.10-57:")
     depends_on("r-jsonlite", type=("build", "run"), when="@0.10-54:")

--- a/repos/spack_repo/builtin/packages/r_ttr/package.py
+++ b/repos/spack_repo/builtin/packages/r_ttr/package.py
@@ -23,6 +23,8 @@ class RTtr(RPackage):
     version("0.23-3", sha256="2136032c7a2cd2a82518a4412fc655ecb16597b123dbdebe5684caef9f15261f")
     version("0.23-1", sha256="699798f06ceae9663da47b67d1bc8679fc1c0776d12afd054d6ac4d19e05b2ae")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r-xts@0.10-0:", type=("build", "run"))
     depends_on("r-zoo", type=("build", "run"))
     depends_on("r-curl", type=("build", "run"), when="@0.23-4:")

--- a/repos/spack_repo/builtin/packages/r_tweenr/package.py
+++ b/repos/spack_repo/builtin/packages/r_tweenr/package.py
@@ -25,6 +25,9 @@ class RTweenr(RPackage):
     version("1.0.2", sha256="1805f575da6705ca4e5ec1c4605222fc826ba806d9ff9af41770294fe08ff69f")
     version("1.0.1", sha256="efd68162cd6d5a4f6d833dbf785a2bbce1cb7b9f90ba3fb060931a4bd705096b")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.2.0:", type=("build", "run"))
     depends_on("r-farver", type=("build", "run"))
     depends_on("r-magrittr", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_ucminf/package.py
+++ b/repos/spack_repo/builtin/packages/r_ucminf/package.py
@@ -24,4 +24,7 @@ class RUcminf(RPackage):
     version("1.1-4.1", sha256="01a5b6f373ad267d22e2c29b8f7b6e31a1a148e48f4413e6a38e51aa049976b2")
     version("1.1-4", sha256="a2eb382f9b24e949d982e311578518710f8242070b3aa3314a331c1e1e7f6f07")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@3.5.0:", when="@1.2.0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_units/package.py
+++ b/repos/spack_repo/builtin/packages/r_units/package.py
@@ -32,6 +32,8 @@ class RUnits(RPackage):
     version("0.6-2", sha256="5e286775d0712c8e15b6ae3a533d4c4349b0f6410c2d9d897ca519c3d0e5f170")
     version("0.4-6", sha256="db383c9b7ec221a5da29a2ddf4f74f9064c44ea2102ea7e07cc1cc5bb30fa1ef")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.0.2:", type=("build", "run"))
     depends_on("r-rcpp@0.12.10:", type=("build", "run"))
     depends_on("udunits", when="@0.6-0:")

--- a/repos/spack_repo/builtin/packages/r_urca/package.py
+++ b/repos/spack_repo/builtin/packages/r_urca/package.py
@@ -21,5 +21,8 @@ class RUrca(RPackage):
     version("1.3-3", sha256="43baa8b6735f8325a69e6a43686f4fecd77a0eb7f60da25b4fc5c51b9271e9f1")
     version("1.3-0", sha256="621cc82398e25b58b4a16edf000ed0a1484d9a0bc458f734e97b6f371cc76aaa")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@2.0.0:", type=("build", "run"))
     depends_on("r-nlme", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_usethis/package.py
+++ b/repos/spack_repo/builtin/packages/r_usethis/package.py
@@ -26,6 +26,9 @@ class RUsethis(RPackage):
     version("1.6.1", sha256="60339059a97ed07dea7f8908b828b5bb42e0fd0b471165c061bc9660b0d59d6f")
     version("1.5.1", sha256="9e3920a04b0df82adf59eef2c1b2b4d835c4a757a51b3c163b8fc619172f561d")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.2:", type=("build", "run"))
     depends_on("r@3.4:", type=("build", "run"), when="@2.1.5:")
     depends_on("r@3.6:", type=("build", "run"), when="@2.2.0:")

--- a/repos/spack_repo/builtin/packages/r_uwot/package.py
+++ b/repos/spack_repo/builtin/packages/r_uwot/package.py
@@ -31,6 +31,8 @@ class RUwot(RPackage):
     version("0.1.10", sha256="6ee1b6027bce679cd5a35f647f516a5b327632234bcf323c7f3d5b5e10807d23")
     version("0.1.3", sha256="4936e6922444cae8a71735e945b6bb0828a1012232eb94568054f78451c406d7")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r-matrix", type=("build", "run"))
     depends_on("r-rcpp", type=("build", "run"))
     depends_on("r-fnn", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_v8/package.py
+++ b/repos/spack_repo/builtin/packages/r_v8/package.py
@@ -24,6 +24,8 @@ class RV8(RPackage):
     version("4.0.0", sha256="146a4cb671264f865ac2f2e35bfdfb37e2df70e4f6784354fb6e8a80a19dbbc8")
     version("3.6.0", sha256="a3969898bf4a7c13d3130fae0d385cd048d46372ff4a412917b914b159261377")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r-rcpp@0.12.12:", type=("build", "run"))
     depends_on("r-jsonlite@1.0:", type=("build", "run"))
     depends_on("r-curl@1.0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_vcfr/package.py
+++ b/repos/spack_repo/builtin/packages/r_vcfr/package.py
@@ -28,6 +28,8 @@ class RVcfr(RPackage):
     version("1.13.0", sha256="743ce845732ada638f0f8a2cd789cd06aa25d818fec87c8bdb998f7c77089ebc")
     version("1.12.0", sha256="dd87ff010365de363864a44ca49887c0fdad0dd18d0d9c66e44e39c2d4581d52")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.0.1:", type=("build", "run"))
     depends_on("r-ape", type=("build", "run"))
     depends_on("r-dplyr", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_vegan/package.py
+++ b/repos/spack_repo/builtin/packages/r_vegan/package.py
@@ -25,6 +25,9 @@ class RVegan(RPackage):
     version("2.5-4", sha256="5116a440111fca49b5f95cfe888b180ff29a112e6301d5e2ac5cae0e628493e0")
     version("2.4-3", sha256="2556b1281a62e53f32bb57539bc600c00a599d0699867912220535d1a3ebec97")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r@3.1.0:", type=("build", "run"), when="@2.5-1")
     depends_on("r@3.2.0:", type=("build", "run"), when="@2.5-2:")

--- a/repos/spack_repo/builtin/packages/r_vgam/package.py
+++ b/repos/spack_repo/builtin/packages/r_vgam/package.py
@@ -42,6 +42,9 @@ class RVgam(RPackage):
     version("1.0-1", sha256="c066864e406fcee23f383a28299dba3cf83356e5b68df16324885afac87a05ea")
     version("1.0-0", sha256="6acdd7db49c0987c565870afe593160ceba72a6ca4a84e6da3cf6f74d1fa02e1")
 
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r@3.1.0:", type=("build", "run"), when="@1.0-2:")
     depends_on("r@3.4.0:", type=("build", "run"), when="@1.0-4:")

--- a/repos/spack_repo/builtin/packages/r_wgcna/package.py
+++ b/repos/spack_repo/builtin/packages/r_wgcna/package.py
@@ -30,6 +30,9 @@ class RWgcna(RPackage):
     version("1.67", sha256="c9cc9989763b2c80835489eabd38d9ee35b204305044d115ca7c775a103f6824")
     version("1.64-1", sha256="961a890cda40676ba533cd6de2b1d4f692addd16363f874c82ba8b65dd2d0db6")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.0:", type=("build", "run"))
     depends_on("r-dynamictreecut@1.62:", type=("build", "run"))
     depends_on("r-fastcluster", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_wk/package.py
+++ b/repos/spack_repo/builtin/packages/r_wk/package.py
@@ -27,5 +27,8 @@ class RWk(RPackage):
     version("0.6.0", sha256="af2c2837056a6dcc9f64d5ace29601d6d668c95769f855ca0329648d7326eaf5")
     version("0.4.1", sha256="daa7351af0bd657740972016906c686f335b8fa922ba10250e5000ddc2bb8950")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@2.10:", type=("build", "run"), when="@0.7.0:")
     depends_on("r-cpp11", type=("build", "run"), when="@:0.6.0")

--- a/repos/spack_repo/builtin/packages/r_writexl/package.py
+++ b/repos/spack_repo/builtin/packages/r_writexl/package.py
@@ -18,4 +18,6 @@ class RWritexl(RPackage):
 
     version("1.5.0", sha256="e253dc58f00abf51e9b727ae132e8b301e359fb23df0afc40c3ebec3fb096dce")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("zlib-api", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_wru/package.py
+++ b/repos/spack_repo/builtin/packages/r_wru/package.py
@@ -44,6 +44,8 @@ class RWru(RPackage):
     version("0.0-2", sha256="4ad5a09a5663906ea546fd9169444a559643d87ac18115e88b538a9260d40d4d")
     version("0.0-1", sha256="604a3e0f04fa3b1c5ee13543c0e3841f5a050f784f561d7ed8576542a27584ae")
 
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.2.0:", type=("build", "run"), when="@0.0-1:")
     depends_on("r@3.5.0:", type=("build", "run"), when="@0.0-10:")
     depends_on("r@4.1.0:", type=("build", "run"), when="@1.0.0:")

--- a/repos/spack_repo/builtin/packages/r_xgboost/package.py
+++ b/repos/spack_repo/builtin/packages/r_xgboost/package.py
@@ -34,6 +34,9 @@ class RXgboost(RPackage):
     version("0.6-4", sha256="9fc51dd1b910c70930357f617d1ac7a74c5056e8847d4188175db27c09f9d1ed")
     version("0.4-4", sha256="b955fc3352fcdc4894178c82fd62fbaf5e099c9d794f1e9daa2dd7b3494b61ff")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@2.10:", type=("build", "run"))
     depends_on("r@2.15.1:", type=("build", "run"), when="@0.6-0:")
     depends_on("r@3.3.0:", type=("build", "run"), when="@0.6-3:")

--- a/repos/spack_repo/builtin/packages/r_xts/package.py
+++ b/repos/spack_repo/builtin/packages/r_xts/package.py
@@ -27,6 +27,8 @@ class RXts(RPackage):
     version("0.11-2", sha256="12772f6a66aab5b84b0665c470f11a3d8d8a992955c027261cfe8e6077ee13b8")
     version("0.9-7", sha256="f11f7cb98f4b92b7f6632a2151257914130880c267736ef5a264b5dc2dfb7098")
 
+    depends_on("c", type="build")  # generated
+
     depends_on("r@3.6.0:", type=("build", "run"), when="@0.13.0:")
 
     depends_on("r-zoo@1.7-12:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_yaimpute/package.py
+++ b/repos/spack_repo/builtin/packages/r_yaimpute/package.py
@@ -27,5 +27,8 @@ class RYaimpute(RPackage):
     version("1.0-33", sha256="58595262eb1bc9ffeeadca78664c418ea24b4e894744890c00252c5ebd02512c")
     version("1.0-32", sha256="08eee5d851b80aad9c7c80f9531aadd50d60e4b16b3a80657a50212269cd73ff")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("r@3.0:", type=("build", "run"))
     depends_on("r@3.0.0:", type=("build", "run"), when="@1.0-33:")

--- a/repos/spack_repo/builtin/packages/r_zip/package.py
+++ b/repos/spack_repo/builtin/packages/r_zip/package.py
@@ -25,3 +25,5 @@ class RZip(RPackage):
     version("2.2.0", sha256="9f95987c964039834f770ecda2d5f7e3d3a9de553c89db2a5926c4219bf4b9d8")
     version("2.1.1", sha256="11dd417932296d3a25c53aa8d3b908973c4945a496cc473dd321825dfaaa7c2c")
     version("2.0.3", sha256="4a8cb8e41eb630bbf448a0fd56bcaeb752b8484fef98c6419334edf46401317e")
+
+    depends_on("c", type="build")  # generated


### PR DESCRIPTION
This was missed back in July 2024 likely because the R packages failed
to download back then.

It adds generated `depends_on(<language>)` statements for C, C++ and
Fortran to about 250 R packages.

https://github.com/spack/spack/pull/45217
