### PR TITLE
py-fastjsonschema: all versions support all Python versions

### DIFF
--- a/repos/spack_repo/builtin/packages/py_fastjsonschema/package.py
+++ b/repos/spack_repo/builtin/packages/py_fastjsonschema/package.py
@@ -29,9 +29,4 @@ class PyFastjsonschema(PythonPackage):
     version("2.16.2", sha256="01e366f25d9047816fe3d288cbfc3e10541daf0af2044763f3d0ade42476da18")
     version("2.15.1", sha256="671f36d225b3493629b5e789428660109528f373cf4b8a22bac6fa2f8191c2d2")
 
-    depends_on("python@3.3:3.13", when="@2.21:", type=("build", "run"))
-    depends_on("python@3.3:3.12", when="@2.20:", type=("build", "run"))
-    depends_on("python@3.3:3.11", when="@2.16.3:", type=("build", "run"))
-    depends_on("python@3.3:", when="@2.15:", type=("build", "run"))
-
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
@alalazo discovered this packaging bug.

The lack of an upper bound on:
```python
    depends_on("python@3.3:3.11", when="@2.16.3:", type=("build", "run"))
```
meant that newer versions could not be used with newer Python.

I was going to add upper bounds, but I have no idea why the Python versions were ever restricted in the first place. I see no evidence that all versions don't support all Python versions.