### PR TITLE
ML stacks: remove abandoned libraries

### DIFF
--- a/stacks/ml-darwin-aarch64-mps/spack.yaml
+++ b/stacks/ml-darwin-aarch64-mps/spack.yaml
@@ -20,9 +20,6 @@ spack:
       - target=aarch64
 
   specs:
-  # Horovod
-  - py-horovod
-
   # Hugging Face
   - py-transformers
 
@@ -36,53 +33,36 @@ spack:
   # - py-keras backend=tensorflow
   # - py-keras backend=jax
   - py-keras backend=torch
-  - py-keras-applications
-  - py-keras-preprocessing
-  - py-keras2onnx
 
   # PyTorch
   - py-botorch
-  - py-efficientnet-pytorch
   - py-gpytorch
   - py-kornia
   - py-lightning
-  - py-pytorch-gradual-warmup-lr
   - py-pytorch-lightning
   - py-segmentation-models-pytorch
   - py-timm
   - py-torch
-  - py-torch-cluster
   - py-torch-geometric
   - py-torch-nvidia-apex
-  - py-torch-scatter
-  - py-torch-sparse
-  - py-torch-spline-conv
   - py-torchaudio
   - py-torchdata
-  - py-torchfile
   - py-torchgeo
   - py-torchmetrics
-  # fp16 mismatch between openblas and py_torch@2.3.0
-  # - py-torchtext
   - py-torchvision
   - py-vector-quantize-pytorch
 
   # scikit-learn
   - py-scikit-learn
-  - py-scikit-learn-extra
 
   # TensorBoard
   - py-tensorboard
-  - py-tensorboard-data-server
-  - py-tensorboard-plugin-wit
   - py-tensorboardx
 
   # TensorFlow
   # Bazel codesign issues
   # - py-tensorflow
   # - py-tensorflow-datasets
-  # - py-tensorflow-estimator
-  # - py-tensorflow-hub
   # - py-tensorflow-metadata
   # - py-tensorflow-probability
 

--- a/stacks/ml-linux-aarch64-cpu/spack.yaml
+++ b/stacks/ml-linux-aarch64-cpu/spack.yaml
@@ -22,9 +22,6 @@ spack:
       require: "%c,cxx=gcc"
 
   specs:
-    # Horovod
-    - py-horovod
-
     # Hugging Face
     - py-transformers
 
@@ -36,50 +33,35 @@ spack:
     - py-keras backend=tensorflow
     - py-keras backend=jax
     - py-keras backend=torch
-    - py-keras-applications
-    - py-keras-preprocessing
-    - py-keras2onnx
 
     # PyTorch
     - py-botorch
-    - py-efficientnet-pytorch
     - py-gpytorch
     - py-kornia
     - py-lightning
-    - py-pytorch-gradual-warmup-lr
     - py-pytorch-lightning
     - py-segmentation-models-pytorch
     - py-timm
     - py-torch
-    - py-torch-cluster
     - py-torch-geometric
     - py-torch-nvidia-apex
-    - py-torch-scatter
-    - py-torch-sparse
-    - py-torch-spline-conv
     - py-torchaudio
     - py-torchdata
-    - py-torchfile
     - py-torchgeo
     - py-torchmetrics
-    - py-torchtext
     - py-torchvision
     - py-vector-quantize-pytorch
 
     # scikit-learn
     - py-scikit-learn
-    - py-scikit-learn-extra
 
     # TensorBoard
     - py-tensorboard
-    - py-tensorboard-data-server
-    - py-tensorboard-plugin-wit
     - py-tensorboardx
 
     # TensorFlow
     - py-tensorflow
     - py-tensorflow-datasets
-    - py-tensorflow-hub
     - py-tensorflow-metadata
     - py-tensorflow-probability
 

--- a/stacks/ml-linux-aarch64-cuda/spack.yaml
+++ b/stacks/ml-linux-aarch64-cuda/spack.yaml
@@ -33,9 +33,6 @@ spack:
       - "%c,cxx=gcc"
 
   specs:
-    # Horovod
-    - py-horovod
-
     # Hugging Face
     - py-transformers
 
@@ -47,51 +44,35 @@ spack:
     - py-keras backend=tensorflow
     - py-keras backend=jax
     - py-keras backend=torch
-    - py-keras-applications
-    - py-keras-preprocessing
-    - py-keras2onnx
 
     # PyTorch
     - py-botorch
-    - py-efficientnet-pytorch
     - py-gpytorch
     - py-kornia
     - py-lightning
-    - py-pytorch-gradual-warmup-lr
     - py-pytorch-lightning
     - py-segmentation-models-pytorch
     - py-timm
     - py-torch
-    - py-torch-cluster
     - py-torch-geometric
     - py-torch-nvidia-apex
-    - py-torch-scatter
-    - py-torch-sparse
-    - py-torch-spline-conv
     - py-torchaudio
     - py-torchdata
-    - py-torchfile
     - py-torchgeo
     - py-torchmetrics
-    # torchtext requires older pytorch, which requires older cuda, which doesn't support newer GCC
-    # - py-torchtext
     - py-torchvision
     - py-vector-quantize-pytorch
 
     # scikit-learn
     - py-scikit-learn
-    - py-scikit-learn-extra
 
     # TensorBoard
     - py-tensorboard
-    - py-tensorboard-data-server
-    - py-tensorboard-plugin-wit
     - py-tensorboardx
 
     # TensorFlow
     - py-tensorflow
     - py-tensorflow-datasets
-    - py-tensorflow-hub
     - py-tensorflow-metadata
     - py-tensorflow-probability
 

--- a/stacks/ml-linux-x86_64-cpu/spack.yaml
+++ b/stacks/ml-linux-x86_64-cpu/spack.yaml
@@ -20,9 +20,6 @@ spack:
       require: "%c,cxx=gcc"
 
   specs:
-    # Horovod
-    - py-horovod
-
     # Hugging Face
     - py-transformers
 
@@ -34,50 +31,35 @@ spack:
     - py-keras backend=tensorflow
     - py-keras backend=jax
     - py-keras backend=torch
-    - py-keras-applications
-    - py-keras-preprocessing
-    - py-keras2onnx
 
     # PyTorch
     - py-botorch
-    - py-efficientnet-pytorch
     - py-gpytorch
     - py-kornia
     - py-lightning
-    - py-pytorch-gradual-warmup-lr
     - py-pytorch-lightning
     - py-segmentation-models-pytorch
     - py-timm
     - py-torch
-    - py-torch-cluster
     - py-torch-geometric
     - py-torch-nvidia-apex
-    - py-torch-scatter
-    - py-torch-sparse
-    - py-torch-spline-conv
     - py-torchaudio
     - py-torchdata
-    - py-torchfile
     - py-torchgeo
     - py-torchmetrics
-    - py-torchtext
     - py-torchvision
     - py-vector-quantize-pytorch
 
     # scikit-learn
     - py-scikit-learn
-    - py-scikit-learn-extra
 
     # TensorBoard
     - py-tensorboard
-    - py-tensorboard-data-server
-    - py-tensorboard-plugin-wit
     - py-tensorboardx
 
     # TensorFlow
     - py-tensorflow
     - py-tensorflow-datasets
-    - py-tensorflow-hub
     - py-tensorflow-metadata
     - py-tensorflow-probability
 

--- a/stacks/ml-linux-x86_64-cuda/spack.yaml
+++ b/stacks/ml-linux-x86_64-cuda/spack.yaml
@@ -32,9 +32,6 @@ spack:
       - "%c,cxx=gcc"
 
   specs:
-    # Horovod
-    - py-horovod
-
     # Hugging Face
     - py-transformers
 
@@ -46,51 +43,35 @@ spack:
     - py-keras backend=tensorflow
     - py-keras backend=jax
     - py-keras backend=torch
-    - py-keras-applications
-    - py-keras-preprocessing
-    - py-keras2onnx
 
     # PyTorch
     - py-botorch
-    - py-efficientnet-pytorch
     - py-gpytorch
     - py-kornia
     - py-lightning
-    - py-pytorch-gradual-warmup-lr
     - py-pytorch-lightning
     - py-segmentation-models-pytorch
     - py-timm
     - py-torch
-    - py-torch-cluster
     - py-torch-geometric
     - py-torch-nvidia-apex
-    - py-torch-scatter
-    - py-torch-sparse
-    - py-torch-spline-conv
     - py-torchaudio
     - py-torchdata
-    - py-torchfile
     - py-torchgeo
     - py-torchmetrics
-    # torchtext requires older pytorch, which requires older cuda, which doesn't support newer GCC
-    # - py-torchtext
     - py-torchvision
     - py-vector-quantize-pytorch
 
     # scikit-learn
     - py-scikit-learn
-    - py-scikit-learn-extra
 
     # TensorBoard
     - py-tensorboard
-    - py-tensorboard-data-server
-    - py-tensorboard-plugin-wit
     - py-tensorboardx
 
     # TensorFlow
     - py-tensorflow
     - py-tensorflow-datasets
-    - py-tensorflow-hub
     - py-tensorflow-metadata
     - py-tensorflow-probability
 


### PR DESCRIPTION
All of these libraries have not had a new release in 2+ years. The only exception is py-torchtext, which is officially abandoned: https://github.com/pytorch/text/issues/2250.

Many of these require ancient versions of setuptools, resulting in rebuilds and concretizer bugs. By streamlining our ML CI to only maintained packages, we can reduce the total number of builds and save CI money.