### PR TITLE
py-rasterio: fix rpath

### DIFF
--- a/repos/spack_repo/builtin/packages/py_rasterio/package.py
+++ b/repos/spack_repo/builtin/packages/py_rasterio/package.py
@@ -60,6 +60,12 @@ class PyRasterio(PythonPackage):
         # https://github.com/rasterio/rasterio/issues/3024
         depends_on("py-numpy@:1", when="@:1.3.9")
 
+        # From README.rst and setup.py
+        depends_on("gdal@3.5:", when="@1.4:")
+        depends_on("gdal@3.1:", when="@1.3:")
+        depends_on("gdal@2.4:3.3", when="@1.2.7:1.2")
+        depends_on("gdal@2.3:3.2", when="@1.2.0:1.2.6")
+
     with default_args(type=("build", "run")):
         depends_on("py-affine")
         depends_on("py-attrs")
@@ -75,13 +81,13 @@ class PyRasterio(PythonPackage):
         depends_on("py-setuptools", when="@:1.3.9")
         depends_on("py-snuggs@1.4.1:", when="@:1.3")
 
-    # From README.rst and setup.py
-    depends_on("gdal@3.5:", when="@1.4:")
-    depends_on("gdal@3.1:", when="@1.3:")
-    depends_on("gdal@2.4:3.3", when="@1.2.7:1.2")
-    depends_on("gdal@2.3:3.2", when="@1.2.0:1.2.6")
-
     # https://github.com/rasterio/rasterio/issues/3371
     conflicts("^gdal@3.11:", when="@:1.4.3")
     # https://github.com/rasterio/rasterio/pull/3212
     conflicts("^gdal@3.10:", when="@:1.4.1")
+
+    # ensure cython absolutely gets the right gdal and embeds the correct rpaths
+    def setup_build_environment(self, env):
+        gdal = self.spec['gdal']
+        env.set('GDAL_CONFIG', join_path(gdal.prefix.bin, 'gdal-config'))
+        env.prepend_path('LDFLAGS', f"-Wl,-rpath,{gdal.libs.directories[0]}")

--- a/repos/spack_repo/builtin/packages/py_rasterio/package.py
+++ b/repos/spack_repo/builtin/packages/py_rasterio/package.py
@@ -60,6 +60,7 @@ class PyRasterio(PythonPackage):
         # https://github.com/rasterio/rasterio/issues/3024
         depends_on("py-numpy@:1", when="@:1.3.9")
 
+    with default_args(type=("build", "link")):
         # From README.rst and setup.py
         depends_on("gdal@3.5:", when="@1.4:")
         depends_on("gdal@3.1:", when="@1.3:")

--- a/repos/spack_repo/builtin/packages/py_rasterio/package.py
+++ b/repos/spack_repo/builtin/packages/py_rasterio/package.py
@@ -60,12 +60,6 @@ class PyRasterio(PythonPackage):
         # https://github.com/rasterio/rasterio/issues/3024
         depends_on("py-numpy@:1", when="@:1.3.9")
 
-    # From README.rst and setup.py
-    depends_on("gdal@3.5:", when="@1.4:")
-    depends_on("gdal@3.1:", when="@1.3:")
-    depends_on("gdal@2.4:3.3", when="@1.2.7:1.2")
-    depends_on("gdal@2.3:3.2", when="@1.2.0:1.2.6")
-
     with default_args(type=("build", "run")):
         depends_on("py-affine")
         depends_on("py-attrs")
@@ -80,6 +74,12 @@ class PyRasterio(PythonPackage):
         # Historical dependencies
         depends_on("py-setuptools", when="@:1.3.9")
         depends_on("py-snuggs@1.4.1:", when="@:1.3")
+
+    # From README.rst and setup.py
+    depends_on("gdal@3.5:", when="@1.4:")
+    depends_on("gdal@3.1:", when="@1.3:")
+    depends_on("gdal@2.4:3.3", when="@1.2.7:1.2")
+    depends_on("gdal@2.3:3.2", when="@1.2.0:1.2.6")
 
     # https://github.com/rasterio/rasterio/issues/3371
     conflicts("^gdal@3.11:", when="@:1.4.3")

--- a/repos/spack_repo/builtin/packages/py_rasterio/package.py
+++ b/repos/spack_repo/builtin/packages/py_rasterio/package.py
@@ -60,12 +60,11 @@ class PyRasterio(PythonPackage):
         # https://github.com/rasterio/rasterio/issues/3024
         depends_on("py-numpy@:1", when="@:1.3.9")
 
-    with default_args(type=("build", "link")):
-        # From README.rst and setup.py
-        depends_on("gdal@3.5:", when="@1.4:")
-        depends_on("gdal@3.1:", when="@1.3:")
-        depends_on("gdal@2.4:3.3", when="@1.2.7:1.2")
-        depends_on("gdal@2.3:3.2", when="@1.2.0:1.2.6")
+    # From README.rst and setup.py
+    depends_on("gdal@3.5:", when="@1.4:")
+    depends_on("gdal@3.1:", when="@1.3:")
+    depends_on("gdal@2.4:3.3", when="@1.2.7:1.2")
+    depends_on("gdal@2.3:3.2", when="@1.2.0:1.2.6")
 
     with default_args(type=("build", "run")):
         depends_on("py-affine")

--- a/repos/spack_repo/builtin/packages/py_rasterio/package.py
+++ b/repos/spack_repo/builtin/packages/py_rasterio/package.py
@@ -88,7 +88,7 @@ class PyRasterio(PythonPackage):
 
     # ensure cython absolutely gets the right gdal and embeds the correct rpaths
     def setup_build_environment(self, env):
-        gdal = self.spec['gdal']
+        gdal = self.spec["gdal"]
         # looks for this envar in setup.py
-        env.set('GDAL_CONFIG', join_path(gdal.prefix.bin, 'gdal-config'))
-        env.prepend_path('LDFLAGS', f"-Wl,-rpath,{gdal.libs.directories[0]}")
+        env.set("GDAL_CONFIG", join_path(gdal.prefix.bin, "gdal-config"))
+        env.prepend_path("LDFLAGS", f"-Wl,-rpath,{gdal.libs.directories[0]}")

--- a/repos/spack_repo/builtin/packages/py_rasterio/package.py
+++ b/repos/spack_repo/builtin/packages/py_rasterio/package.py
@@ -89,5 +89,6 @@ class PyRasterio(PythonPackage):
     # ensure cython absolutely gets the right gdal and embeds the correct rpaths
     def setup_build_environment(self, env):
         gdal = self.spec['gdal']
+        # looks for this envar in setup.py
         env.set('GDAL_CONFIG', join_path(gdal.prefix.bin, 'gdal-config'))
         env.prepend_path('LDFLAGS', f"-Wl,-rpath,{gdal.libs.directories[0]}")


### PR DESCRIPTION
When using the `rio` cli tools, the cython shared objects don't have a baked in rpath and thus cannot find gdal.

This PR:
- changes gdal to be a run/build/link depend,
- ensures the underlying cython a) uses the correct gdal and b) embeds the rpath.

**maintainer**: @adamjstewart