### PR TITLE
ML CI: Python 3.13+

### DIFF
--- a/stacks/ml-darwin-aarch64-mps/spack.yaml
+++ b/stacks/ml-darwin-aarch64-mps/spack.yaml
@@ -18,6 +18,8 @@ spack:
       require:
       - ~fortran
       - target=aarch64
+    python:
+      require: "@3.13:"
 
   specs:
   # Hugging Face

--- a/stacks/ml-linux-aarch64-cpu/spack.yaml
+++ b/stacks/ml-linux-aarch64-cpu/spack.yaml
@@ -13,6 +13,8 @@ spack:
       - ~rocm
     mpi:
       require: openmpi
+    python:
+      require: "@3.13:"
     py-jaxlib:
       require: "%c,cxx=clang"
     py-tensorflow:

--- a/stacks/ml-linux-aarch64-cuda/spack.yaml
+++ b/stacks/ml-linux-aarch64-cuda/spack.yaml
@@ -18,6 +18,8 @@ spack:
       - target=aarch64
     mpi:
       require: openmpi
+    python:
+      require: "@3.13:"
     py-jaxlib:
       require: "%c,cxx=clang"
     py-tensorflow:

--- a/stacks/ml-linux-x86_64-cpu/spack.yaml
+++ b/stacks/ml-linux-x86_64-cpu/spack.yaml
@@ -12,6 +12,8 @@ spack:
       - ~rocm
     mpi:
       require: openmpi
+    python:
+      require: "@3.13:"
     py-jaxlib:
       require: "%c,cxx=clang"
     py-tensorflow:

--- a/stacks/ml-linux-x86_64-cuda/spack.yaml
+++ b/stacks/ml-linux-x86_64-cuda/spack.yaml
@@ -18,6 +18,8 @@ spack:
       - target=x86_64_v3
     mpi:
       require: openmpi
+    python:
+      require: "@3.13:"
     py-jaxlib:
       require: "%c,cxx=clang"
     py-tensorflow:

--- a/stacks/ml-linux-x86_64-rocm/spack.yaml
+++ b/stacks/ml-linux-x86_64-rocm/spack.yaml
@@ -35,9 +35,6 @@ spack:
       - "%c,cxx=gcc"
 
   specs:
-    # Horovod
-    # - py-horovod
-
     # Hugging Face
     - py-transformers
 
@@ -49,51 +46,36 @@ spack:
     - py-keras backend=tensorflow
     # - py-keras backend=jax
     # - py-keras backend=torch
-    - py-keras-applications
-    - py-keras-preprocessing
-    - py-keras2onnx
 
     # PyTorch
     # Does not yet support Spack-installed ROCm
     # - py-botorch
-    # - py-efficientnet-pytorch
     # - py-gpytorch
     # - py-kornia
     # - py-lightning
-    # - py-pytorch-gradual-warmup-lr
     # - py-pytorch-lightning
     # - py-segmentation-models-pytorch
     # - py-timm
     # - py-torch
-    # - py-torch-cluster
     # - py-torch-geometric
     # - py-torch-nvidia-apex
-    # - py-torch-scatter
-    # - py-torch-sparse
-    # - py-torch-spline-conv
     # - py-torchaudio
     # - py-torchdata
-    # - py-torchfile
     # - py-torchgeo
     # - py-torchmetrics
-    # - py-torchtext
     # - py-torchvision
     # - py-vector-quantize-pytorch
 
     # scikit-learn
     - py-scikit-learn
-    - py-scikit-learn-extra
 
     # TensorBoard
     - py-tensorboard
-    - py-tensorboard-data-server
-    - py-tensorboard-plugin-wit
     - py-tensorboardx
 
     # TensorFlow
     - py-tensorflow
     - py-tensorflow-datasets
-    - py-tensorflow-hub
     - py-tensorflow-metadata
     - py-tensorflow-probability
 

--- a/stacks/ml-linux-x86_64-rocm/spack.yaml
+++ b/stacks/ml-linux-x86_64-rocm/spack.yaml
@@ -19,6 +19,8 @@ spack:
       require: ~ck
     mpi:
       require: openmpi
+    python:
+      require: "@3.13:"
     py-jaxlib:
       require: "%c,cxx=clang"
     py-tensorflow:


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Next up: let's see if we can force all packages to build with Python 3.13+. This will prevent older versions of numpy and setuptools from being pulled in and may result in fewer duplicate package builds.