### PR TITLE
Add Octave 10.x

### DIFF
--- a/repos/spack_repo/builtin/packages/octave/package.py
+++ b/repos/spack_repo/builtin/packages/octave/package.py
@@ -31,6 +31,9 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
 
     license("GPL-3.0-or-later")
 
+    version("10.3.0", sha256="2fcb38dc062e440f1e06c069bbca840ed46dcc8f983e473e1558fcc38384ee6b")
+    version("10.2.0", sha256="07fb6d9339d2f350735c91671be8e874d160018cc6b688f9efd9d558d237f69f")
+    version("10.1.0", sha256="aed449cba379fc1e1186ec3fc3c96e0860789278fbc823ae2cebe60344344b78")
     version("9.4.0", sha256="da9481205bfa717660b7d4a16732d8b2d58aadceab4993d41242a8e2848ea6c1")
     version("9.3.0", sha256="809fa39a7acc84815bf4dc4d2d7e6b228ce75a07f3b2413f3313aa8e0aaa3287")
     version("9.1.0", sha256="3f8c6c6ecfa249a47c97e18e651be4db8499be2f5de1a095a3eea53efc01d6a1")


### PR DESCRIPTION
Octave 10.x is release sometime ago. Just add the new releases. There are no changes in the dependencies. 