### PR TITLE
py-spacy: fix overlapping dep constraints

### DIFF
--- a/repos/spack_repo/builtin/packages/py_spacy/package.py
+++ b/repos/spack_repo/builtin/packages/py_spacy/package.py
@@ -30,7 +30,7 @@ class PySpacy(PythonPackage):
     depends_on("py-preshed@3.0.2:3.0", type=("build", "run"))
     depends_on("py-murmurhash@0.28:1.0", type=("build", "run"))
     depends_on("py-thinc@7.4.0", type=("build", "run"), when="@2.2.4:2.2")
-    depends_on("py-thinc@7.4.1", type=("build", "run"), when="@2.3.0:")
+    depends_on("py-thinc@7.4.1", type=("build", "run"), when="@2.3.2")
     depends_on("py-thinc@7.4.1:7.4", type=("build", "run"), when="@2.3.7:")
     depends_on("py-blis@0.4.0:0.4", type=("build", "run"))
     depends_on("py-blis@0.4.0:0.7", type=("build", "run"), when="@2.3.7:")


### PR DESCRIPTION
This prevented newer thinc from being used.

Discovered by https://github.com/spack/spack/pull/51541