### PR TITLE
Fix OpenMP support in libCEED/MFEM

### DIFF
--- a/repos/spack_repo/builtin/packages/libceed/package.py
+++ b/repos/spack_repo/builtin/packages/libceed/package.py
@@ -39,6 +39,8 @@ class Libceed(MakefilePackage, CudaPackage, ROCmPackage):
     variant("libxsmm", default=False, description="Enable LIBXSMM backend", when="@0.3:")
     variant("magma", default=False, description="Enable MAGMA backend", when="@0.6:")
 
+    variant("openmp", default=False, description="Enable OpenMP support")
+
     conflicts("+rocm", when="@:0.7")
 
     depends_on("c", type="build")  # generated
@@ -145,6 +147,9 @@ class Libceed(MakefilePackage, CudaPackage, ROCmPackage):
 
             if spec.satisfies("+magma"):
                 makeopts += ["MAGMA_DIR=%s" % spec["magma"].prefix]
+
+            if spec.satisfies("+openmp"):
+                makeopts += ["OPENMP=1"]
 
         return makeopts
 

--- a/repos/spack_repo/builtin/packages/mfem/package.py
+++ b/repos/spack_repo/builtin/packages/mfem/package.py
@@ -251,6 +251,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     conflicts("+shared", when="@:3.3.2")
     conflicts("~static~shared")
     conflicts("~threadsafe", when="@:3+openmp")
+    requires("+threadsafe", when="+openmp")
 
     conflicts("+cuda", when="@:3")
     conflicts("+rocm", when="@:4.1")
@@ -465,6 +466,10 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     depends_on("libceed@0.7:0.8", when="@4.2.0+libceed")
     depends_on("libceed@0.8:0.9", when="@4.3.0+libceed")
     depends_on("libceed@0.10.1:", when="@4.4.0:+libceed")
+
+    depends_on("libceed+openmp", when="+libceed+openmp")
+    depends_on("libceed~openmp", when="+libceed~openmp")
+
     for sm_ in CudaPackage.cuda_arch_values:
         depends_on(
             "libceed+cuda cuda_arch={0}".format(sm_),


### PR DESCRIPTION
As I was working on the Palace package.py, I noticed that our tests were failing when the OpenMP variant is
enabled (https://github.com/awslabs/palace/issues/557).

I tracked this down to the libCEED package not building with the `OPENMP=1` option with OpenMP is enabled.

I added a new `+openmp` variant to libCEED to handle this case.

I looked at the dependents and found that mfem should also be updated to propagate the variant.

In this, I also noticed that MFEM describes the `threadsafe` variant with
```
Enable thread safe features. Required for OpenMP. May cause minor performance issues.
```

But does not activate the variant when `+openmp`. I now turn this variant on when mfem is being compiled with OpenMP.
