### PR TITLE
ecmwf_atlas: add new versions, and new dependency versions

### DIFF
--- a/repos/spack_repo/builtin/packages/ecbuild/package.py
+++ b/repos/spack_repo/builtin/packages/ecbuild/package.py
@@ -18,6 +18,11 @@ class Ecbuild(CMakePackage):
 
     license("Apache-2.0")
 
+    version("3.12.0", sha256="70c7fc9b17f736a3312167c2c36d13b3b5833a255fe2b168b2886ad7c743ffdf")
+    version("3.11.0", sha256="38a96bdeb38feb65446b6f95b35492232abd188c41b8a28fd128f9f88e00b05d")
+    version("3.10.0", sha256="7065e1725584b507517cbfc456299ff588e20adf37bc6210ce89fb65a1ad08d0")
+    version("3.9.1", sha256="48c2dbd342865049cc39afd7fe886fce9ce162105ca72b8aef9a09c21d9655ba")
+    version("3.8.5", sha256="aa0c44cab0fffec4c0b3542e91ebcc736b3d41b68a068d30c023ec0df5f93425")
     version("3.7.2", sha256="7a2d192cef1e53dc5431a688b2e316251b017d25808190faed485903594a3fb9")
     version("3.6.5", sha256="98bff3d3c269f973f4bfbe29b4de834cd1d43f15b1c8d1941ee2bfe15e3d4f7f")
     version("3.6.1", sha256="796ccceeb7af01938c2f74eab0724b228e9bf1978e32484aa3e227510f69ac59")
@@ -27,6 +32,7 @@ class Ecbuild(CMakePackage):
     depends_on("fortran", type="build")  # generated
 
     depends_on("cmake@3.11:", type=("build", "run"))
+    depends_on("cmake@3.18:", type=("build", "run"), when="@3.11:")
 
     # See https://github.com/ecmwf/ecbuild/issues/35
     depends_on("cmake@:3.19", type=("build", "run"), when="@:3.6.1")

--- a/repos/spack_repo/builtin/packages/eckit/package.py
+++ b/repos/spack_repo/builtin/packages/eckit/package.py
@@ -21,6 +21,10 @@ class Eckit(CMakePackage):
 
     license("Apache-2.0")
 
+    version("1.32.3", sha256="33e0fac2656cdd2f2d877dbfe7a4751ee657ab732c00dd90bd48a406298a100f")
+    version("1.31.4", sha256="045ebd9aaecf2773dc8c82f4226022776576cb0d911a76f8d1d069c97e9530c8")
+    version("1.30.0", sha256="1f58360dedfaa285a6b8087916768e6d12406e9fda2b6ba0a5c875f7a3db5398")
+    version("1.29.3", sha256="5afb6ac5bd95d68b7b0fdf42bdfe21370515b8e9ef7b3db91a89e021aa9133f2")
     version("1.28.3", sha256="24b2b8d9869849a646aa3fd9d95e4181a92358cd837d95b22e25d718a6ad7738")
     version("1.28.2", sha256="d122db8bb5bcaadf3256a24f0f90d9bcedad35ef8f25e7eccd8c93c506dbdd24")
     version("1.27.0", sha256="499f3f8c9aec8d3f42369e3ceedc98b2b09ac04993cfd38dfdf7d38931703fe7")
@@ -76,6 +80,7 @@ class Eckit(CMakePackage):
     depends_on("cmake@3.12:3.19,3.22:", type="build")
     depends_on("ecbuild@3.5:", when="@:1.20.99", type="build")
     depends_on("ecbuild@3.7:", when="@1.21:", type="build")
+    depends_on("ecbuild@3.11:", when="@1.31:", type="build")
 
     depends_on("mpi", when="+mpi")
     depends_on("llvm-openmp", when="+openmp %apple-clang", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/ecmwf_atlas/package.py
+++ b/repos/spack_repo/builtin/packages/ecmwf_atlas/package.py
@@ -23,6 +23,10 @@ class EcmwfAtlas(CMakePackage):
 
     version("master", branch="master")
     version("develop", branch="develop")
+    version("0.44.1", sha256="d7235ddb0ff827a9942a0c1051e35516778f343a52f70f3efb079d2f087b1c9d")
+    version("0.43.1", sha256="f7dadb40c6f4a6408a0d7932967610f0c6d3d26d3de15b619f6d5b0598ad7e90")
+    version("0.42.0", sha256="66b10e7d20869ea609cd8b6058bdc833771572f04737a8260e9899d1c36fc820")
+    version("0.41.1", sha256="36c7b793e61957aa149279d2449269915e668d878c4e15caf2c14b7a9e46ef0f")
     version("0.40.0", sha256="9aa2c8945a04aff3d50f752147e2b7cf0992c33e7e5a0e7bcd6fe575b0f853b0")
     version("0.39.0", sha256="bdfc37b5f3f871651b1bb47ae4742988b03858037e36fdca775e220e3abe3bd6")
     version("0.38.1", sha256="c6868deb483c1d6c241aae92f8af63f3351062c2611c9163e8a9bbf6c97a9798")
@@ -42,6 +46,7 @@ class EcmwfAtlas(CMakePackage):
 
     depends_on("ecbuild", type=("build"))
     depends_on("ecbuild@3.4:", type=("build"), when="@0.36.0:")
+    depends_on("ecbuild@3.8:", type=("build"), when="@0.41.0:")
     depends_on("eckit@:1.23", when="@:0.33")
     depends_on("eckit@1.24:", when="@0.34:")
     depends_on("boost cxxstd=14 visibility=hidden", when="@0.26.0:0.33.99", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/ectrans/package.py
+++ b/repos/spack_repo/builtin/packages/ectrans/package.py
@@ -24,6 +24,8 @@ class Ectrans(CMakePackage):
 
     version("develop", branch="develop", no_cache=True)
     version("main", branch="main", no_cache=True)
+    version("1.7.0", sha256="224893a8edeaaf76140842340eb30ad4f9ab772591a55aab4e4493a978e086c7")
+    version("1.6.2", sha256="63e01a5106fb4eee70a4e544b84300b104507a3fbeb9b7374964c8c48e06acda")
     version("1.5.0", sha256="8b2b24d1988b92dc3793b29142946614fca9e9c70163ee207d2a123494430fde")
     version("1.4.0", sha256="1364827511a2eb11716aaee85062c3ab0e6b5d5dca7a7b9c364e1c43482b8691")
     version("1.2.0", sha256="2ee6dccc8bbfcc23faada1d957d141f24e41bb077c1821a7bc2b812148dd336c")

--- a/repos/spack_repo/builtin/packages/fckit/package.py
+++ b/repos/spack_repo/builtin/packages/fckit/package.py
@@ -23,6 +23,7 @@ class Fckit(CMakePackage):
 
     version("master", branch="master")
     version("develop", branch="develop")
+    version("0.14.1", sha256="b15c3a30d4c6aaf9b97d8930bf1b7fd94b015746c421daeb3e648170b30bcbcb")
     version("0.13.2", sha256="990623eb4eb999145f2d852da9fbd71a69e2e0be601c655c274e8382750dfda2")
     version("0.13.1", sha256="89a067a7b5b1f2c7909739b567bd43b69f8a2d91e8cbcbac58655fb2d861db51")
     version("0.11.0", sha256="846f5c369940c0a3d42cd12932f7d6155339e79218d149ebbfdd02e759dc86c5")

--- a/repos/spack_repo/builtin/packages/fiat/intel_warnings_v151.patch
+++ b/repos/spack_repo/builtin/packages/fiat/intel_warnings_v151.patch
@@ -1,0 +1,42 @@
+--- a/cmake/fiat_compiler_warnings.cmake
++++ b/cmake/fiat_compiler_warnings.cmake
+@@ -5,15 +5,17 @@
+   ecbuild_add_c_flags("-Wextra"                                NO_FAIL)
+   ecbuild_add_c_flags("-Wno-unused-parameter"                  NO_FAIL)
+   ecbuild_add_c_flags("-Wno-unused-variable"                   NO_FAIL)
+-  ecbuild_add_c_flags("-Wno-gnu-zero-variadic-macro-arguments" NO_FAIL)
++  if (CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
++    ecbuild_add_c_flags("-Wno-gnu-zero-variadic-macro-arguments" NO_FAIL)
++  endif()
+ endif()
+ 
+ # Always disable some warnings
+ ecbuild_add_c_flags("-Wno-deprecated-declarations" NO_FAIL)
+-if( CMAKE_C_COMPILER_ID MATCHES Intel )
+-  ecbuild_add_c_flags("-diag-disable=279")   # controlling expression is constant
+-  ecbuild_add_c_flags("-diag-disable=11076") # inline limits
+-endif()
++#if( CMAKE_C_COMPILER_ID MATCHES Intel )
++#  ecbuild_add_c_flags("-diag-disable=279")   # controlling expression is constant
++#  ecbuild_add_c_flags("-diag-disable=11076") # inline limits
++#endif()
+ if( CMAKE_Fortran_COMPILER_ID MATCHES Cray )
+   ecbuild_add_fortran_flags("-hnomessage=878") # A module named ... has already been directly or indirectly use associated into this scope
+   ecbuild_add_fortran_flags("-hnomessage=867") # Module ... has no public objects declared in the module, therefore nothing can be use associated from the module.
+--- a/src/fiat/CMakeLists.txt
++++ b/src/fiat/CMakeLists.txt
+@@ -26,10 +26,10 @@ endif()
+
+ ### Compilation flags
+
+-if( CMAKE_Fortran_COMPILER_ID MATCHES "Intel" )
+-  ## To disable checking of argument correctness of dummy mpi symbols
+-  ecbuild_add_fortran_flags( -nowarn nointerfaces NO_FAIL )
+-endif()
++#if( CMAKE_Fortran_COMPILER_ID MATCHES "Intel" )
++#  ## To disable checking of argument correctness of dummy mpi symbols
++#  ecbuild_add_fortran_flags( -nowarn nointerfaces NO_FAIL )
++#endif()
+
+ if( CMAKE_Fortran_COMPILER_ID MATCHES "GNU" )
+   ecbuild_add_fortran_flags( -ffree-line-length-none NO_FAIL )

--- a/repos/spack_repo/builtin/packages/fiat/package.py
+++ b/repos/spack_repo/builtin/packages/fiat/package.py
@@ -20,6 +20,8 @@ class Fiat(CMakePackage):
     license("Apache-2.0")
 
     version("main", branch="main", no_cache=True)
+    version("1.6.1", sha256="fec30ac572d626d8f1a8bd0d03c41aac156e6911f9f822e5f7e5991aff91ba37")
+    version("1.5.1", sha256="50834bf5d8cb4bde92df9028f799aeba411a0a16e55ca33da10a329b5d7f55ea")
     version("1.4.1", sha256="7d49316150e59afabd853df0066b457a268731633898ab51f6f244569679c84a")
     version("1.4.0", sha256="5dc5a8bcac5463690529d0d96d2c805cf9c0214d125cd483ee69d36995ff15d3")
     version("1.2.0", sha256="758147410a4a3c493290b87443b4091660b915fcf29f7c4d565c5168ac67745f")
@@ -47,7 +49,8 @@ class Fiat(CMakePackage):
     depends_on("fckit", when="+fckit")
 
     patch("intel_warnings_v110.patch", when="@:1.1.0")
-    patch("intel_warnings_v120.patch", when="@1.2.0:")
+    patch("intel_warnings_v120.patch", when="@1.2.0:1.5.0")
+    patch("intel_warnings_v151.patch", when="@1.5.1:")
 
     def cmake_args(self):
         args = [


### PR DESCRIPTION
Add new versions of ECMWF's Atlas library, as well as new versions of Atlas's ECMWF dependencies:
- atlas 0.41.1 through 0.44.1
- ecbuild 3.8.5 through 3.12.0
- eckit 1.29.3 through 1.32.3
- fckit 0.14.1
- fiat 1.5.1 and 1.6.1
- ectrans 1.6.2 and 1.7.0
