### PR TITLE
chapel: add mason variant

### DIFF
--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -951,15 +951,6 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
             # TODO: Need to update checkChplDoc to work in the spack testing environment
             pass
 
-    def test_mason(self):
-        """Run the mason test"""
-        if not self.spec.satisfies("+mason"):
-            print("Skipping mason test as mason variant is not set")
-            return
-        else:
-            # TODO: Need to create a mason test for the spack testing environment
-            pass
-
     @run_after("install")
     def copy_test_files(self):
         """Copy test files to the install directory"""

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -50,7 +50,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     test_requires_compiler = True
 
     # TODO: Re-enable these once we add determine_version and determine_variants
-    # executables = ["^chpl$", "^chpldoc$"]
+    # executables = ["^chpl$", "^chpldoc$", "^mason$"]
 
     # A list of GitHub accounts to notify when the package is updated.
     # TODO: add chapel-project github account
@@ -186,6 +186,8 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     # TODO: refactor this somehow, this is a separate documentation tool, not a variant of chapel
     variant("chpldoc", default=False, description="Build chpldoc in addition to chpl")
+
+    variant("mason", default=False, description="Enable Mason package manager support")
 
     variant("developer", default=False, description="Enable Chapel developer mode")
 
@@ -559,6 +561,13 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     depends_on("doxygen@1.8.17:", when="+chpldoc")
 
+    requires("+chpldoc", when="+mason", msg="Mason requires chpldoc")
+    # TODO: what would it take to make `comm` be a multi-valued variant?
+    # so even if a user had `comm=ofi +mason`, the concretized spec would be
+    # `comm=ofi,none +mason`
+    requires("comm=none", when="+mason", msg="Mason requires comm=none")
+    requires("re2=bundled", when="+mason", msg="Mason requires re2=bundled")
+
     # TODO: keep up to date with util/chplenv/chpl_llvm.py
     with when("llvm=spack ~rocm"):
         depends_on("llvm@11:17", when="@:2.0.1")
@@ -587,7 +596,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     # but many of these are ALSO run-time dependencies of the executable
     # application built by that Chapel compiler from user-provided sources.
     with default_args(type=("build", "link", "run", "test")):
-        depends_on("cuda@11:12", when="+cuda")
+        depends_on("cuda@11:", when="+cuda")
         depends_on("gmp", when="gmp=spack")
         depends_on("hwloc", when="hwloc=spack")
         depends_on("libfabric", when="libfabric=spack")
@@ -618,6 +627,8 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
             with set_env(CHPL_HOME=self.build_directory):
                 if spec.satisfies("+chpldoc"):
                     make("chpldoc")
+                if spec.satisfies("+mason"):
+                    make("mason")
                 if spec.satisfies("+python-bindings"):
                     make("chapel-py-venv")
                     python("-m", "ensurepip", "--default-pip")
@@ -875,6 +886,8 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
         if self.spec.satisfies("+chpldoc"):
             exes.append("chpldoc")
+        if self.spec.satisfies("+mason"):
+            exes.append("mason")
 
         for exe in exes:
             reason = f"ensure version of {exe} is {self._output_version_long}"
@@ -936,6 +949,15 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
             return
         else:
             # TODO: Need to update checkChplDoc to work in the spack testing environment
+            pass
+
+    def test_mason(self):
+        """Run the mason test"""
+        if not self.spec.satisfies("+mason"):
+            print("Skipping mason test as mason variant is not set")
+            return
+        else:
+            # TODO: Need to create a mason test for the spack testing environment
             pass
 
     @run_after("install")

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -596,7 +596,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     # but many of these are ALSO run-time dependencies of the executable
     # application built by that Chapel compiler from user-provided sources.
     with default_args(type=("build", "link", "run", "test")):
-        depends_on("cuda@11:", when="+cuda")
+        depends_on("cuda@11:12", when="+cuda")
         depends_on("gmp", when="gmp=spack")
         depends_on("hwloc", when="hwloc=spack")
         depends_on("libfabric", when="libfabric=spack")

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -886,8 +886,6 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
         if self.spec.satisfies("+chpldoc"):
             exes.append("chpldoc")
-        if self.spec.satisfies("+mason"):
-            exes.append("mason")
 
         for exe in exes:
             reason = f"ensure version of {exe} is {self._output_version_long}"


### PR DESCRIPTION
Adds a mason variant to the Chapel package to allow building the mason package manager for Chapel

In the future, it would be good to have `+mason` imply `comm=none`, but I think to do that its best to support multiple variants for `comm` so if a user specified `comm=ofi +mason` the concertized spec is `comm=ofi,none +mason`