### PR TITLE
ecflow: require qt +gui

### DIFF
--- a/repos/spack_repo/builtin/packages/ecflow/package.py
+++ b/repos/spack_repo/builtin/packages/ecflow/package.py
@@ -70,7 +70,7 @@ class Ecflow(CMakePackage):
 
     depends_on("openssl@1:", when="@5:")
     depends_on("pkgconfig", type="build", when="+ssl ^openssl ~shared")
-    depends_on("qt@5:", when="+ui")
+    depends_on("qt@5: +gui", when="+ui")
     # Requirement to use the Python3_EXECUTABLE variable
     depends_on("cmake@3.16:", type="build")
 


### PR DESCRIPTION
This PR corrects the ecflow dependency on qt. Specifically, ecflow requires `qt +gui` to build the UI.