### PR TITLE
Update homepage URL for Adios2 package

### DIFF
--- a/repos/spack_repo/builtin/packages/adios2/package.py
+++ b/repos/spack_repo/builtin/packages/adios2/package.py
@@ -18,7 +18,7 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
     """The Adaptable Input Output System version 2,
     developed in the Exascale Computing Program"""
 
-    homepage = "https://csmd.ornl.gov/software/adios2"
+    homepage = "https://adios2.readthedocs.io"
     url = "https://github.com/ornladios/ADIOS2/archive/v2.8.0.tar.gz"
     git = "https://github.com/ornladios/ADIOS2.git"
     test_requires_compiler = True


### PR DESCRIPTION
The adios2 homepage link currently in the package is dead.

@eugeneswalker @maherou @ax3l @vicentebolea  @williamfgc
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
