### PR TITLE
Add support for 2021.16.2 MPI for spack of oneapi_2025.2.5

### DIFF
--- a/repos/spack_repo/builtin/packages/intel_oneapi_mpi/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_mpi/package.py
@@ -29,6 +29,12 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
         expand=False,
     )
     version(
+        "2021.16.2",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/fc0ac5a0-c09e-443f-ba97-a63b7552ca4b/intel-mpi-2021.16.2.916_offline.sh",
+        sha256="4c523de187394a687fd3ec43121c8c00f072df0b2af0caf8d4a237358f2d3f4a",
+        expand=False,
+    )
+    version(
         "2021.16.1",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/203edae7-5269-4124-a1ed-09ad924f8b47/intel-mpi-2021.16.1.804_offline.sh",
         sha256="4165717608e90ae6123397ebf2a9b87a0b070842ce7d13378d1446a08966eb6e",


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
