### PR TITLE
Manual fix packages that were missed. 

### DIFF
--- a/repos/spack_repo/builtin/packages/bat/package.py
+++ b/repos/spack_repo/builtin/packages/bat/package.py
@@ -21,6 +21,8 @@ class Bat(CargoPackage):
     version("0.13.0", sha256="f4aee370013e2a3bc84c405738ed0ab6e334d3a9f22c18031a7ea008cd5abd2a")
     version("0.12.1", sha256="1dd184ddc9e5228ba94d19afc0b8b440bfc1819fef8133fe331e2c0ec9e3f8e2")
 
+    depends_on("rust", type="build") 
+
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/fd/package.py
+++ b/repos/spack_repo/builtin/packages/fd/package.py
@@ -34,6 +34,8 @@ class Fd(CargoPackage):
 
     # Build dependencies
     depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
     depends_on("rust@1.77.2:", type="build", when="@10:")
     depends_on("rust@1.70:", type="build", when="@8.7.1:")
     depends_on("rust@1.64:", type="build", when="@8.7:")

--- a/repos/spack_repo/builtin/packages/navi/package.py
+++ b/repos/spack_repo/builtin/packages/navi/package.py
@@ -19,6 +19,10 @@ class Navi(Package):
 
     version("2.20.1", sha256="92644677dc46e13aa71b049c5946dede06a22064b3b1834f52944d50e3fdb950")
     depends_on("rust")
+    
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
 
     def install(self, spec, prefix):
         cargo = which("cargo")

--- a/repos/spack_repo/builtin/packages/plink/package.py
+++ b/repos/spack_repo/builtin/packages/plink/package.py
@@ -41,7 +41,11 @@ class Plink(Package):
         depends_on("zlib-api", when="@1.9-beta6.27:")
         depends_on("blas", when="@1.9-beta6.27:")
         depends_on("lapack", when="@1.9-beta6.27:")
+
     depends_on("gmake", type="build")
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("blas", type="build")
 
     patch("dynamic_zlib.patch", when="@1.9-beta6.27:1.9-beta6.99")
     patch("dynamic_zlib-1.3.patch", when="@1.9-beta7.7:")

--- a/repos/spack_repo/builtin/packages/r_checkmate/package.py
+++ b/repos/spack_repo/builtin/packages/r_checkmate/package.py
@@ -29,3 +29,6 @@ class RCheckmate(RPackage):
 
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r-backports@1.1.0:", type=("build", "run"))
+
+    depends_on("c", type=("build"))
+    depends_on("fortran", type=("build"))

--- a/repos/spack_repo/builtin/packages/r_filelock/package.py
+++ b/repos/spack_repo/builtin/packages/r_filelock/package.py
@@ -23,3 +23,6 @@ class RFilelock(RPackage):
     depends_on("c", type="build")
 
     depends_on("r@3.4:", type=("build", "run"), when="@1.0.3:")
+
+    depends_on("c", type=("build"))
+    depends_on("fortran", type=("build"))

--- a/repos/spack_repo/builtin/packages/r_genomicfeatures/package.py
+++ b/repos/spack_repo/builtin/packages/r_genomicfeatures/package.py
@@ -66,3 +66,7 @@ class RGenomicfeatures(RPackage):
     depends_on("r-biobase@2.15.1:", type=("build", "run"))
 
     depends_on("r-rmysql", type=("build", "run"), when="@1.30.3")
+
+    depends_on("c", type=("build"))
+    depends_on("cxx", type=("build"))
+    depends_on("fortran", type=("build"))

--- a/repos/spack_repo/builtin/packages/r_kernsmooth/package.py
+++ b/repos/spack_repo/builtin/packages/r_kernsmooth/package.py
@@ -24,3 +24,6 @@ class RKernsmooth(RPackage):
     depends_on("fortran", type="build")
 
     depends_on("r@2.5.0:", type=("build", "run"))
+
+    depends_on("c", type=("build"))
+    depends_on("fortran", type=("build"))

--- a/repos/spack_repo/builtin/packages/r_lme4/package.py
+++ b/repos/spack_repo/builtin/packages/r_lme4/package.py
@@ -53,3 +53,6 @@ class RLme4(RPackage):
 
     # Historical dependencies
     depends_on("r-statmod", type=("build", "run"), when="@1.1-26")
+
+    depends_on("c", type=("build"))
+    depends_on("cxx", type=("build"))

--- a/repos/spack_repo/builtin/packages/r_locfit/package.py
+++ b/repos/spack_repo/builtin/packages/r_locfit/package.py
@@ -30,3 +30,6 @@ class RLocfit(RPackage):
     depends_on("r@3.5.0:", type=("build", "run"), when="@1.5-9.4:")
     depends_on("r@4.1.0:", type=("build", "run"), when="@1.5-9.5:")
     depends_on("r-lattice", type=("build", "run"))
+
+    depends_on("c", type=("build"))
+    depends_on("fortran", type=("build"))

--- a/repos/spack_repo/builtin/packages/r_lubridate/package.py
+++ b/repos/spack_repo/builtin/packages/r_lubridate/package.py
@@ -42,3 +42,6 @@ class RLubridate(RPackage):
     depends_on("r-stringr", type=("build", "run"), when="@:1.7.4")
     depends_on("r-cpp11", type=("build", "run"), when="@:1.8.0")
     depends_on("r-cpp11@0.2.7:", type=("build", "run"), when="@1.8.0")
+
+    depends_on("cxx", type=("build"))
+    depends_on("fortran", type=("build"))

--- a/repos/spack_repo/builtin/packages/r_markdown/package.py
+++ b/repos/spack_repo/builtin/packages/r_markdown/package.py
@@ -35,3 +35,6 @@ class RMarkdown(RPackage):
     depends_on("r-xfun", type=("build", "run"), when="@1.1:")
     depends_on("r-xfun@0.38:", type=("build", "run"), when="@1.6:")
     depends_on("r-mime@0.3:", type=("build", "run"), when="@:1.3")
+
+    depends_on("c", type=("build"))
+    depends_on("fortran", type=("build"))

--- a/repos/spack_repo/builtin/packages/r_matrixstats/package.py
+++ b/repos/spack_repo/builtin/packages/r_matrixstats/package.py
@@ -35,3 +35,6 @@ class RMatrixstats(RPackage):
 
     depends_on("r@2.12.0:", type=("build", "run"))
     depends_on("r@3.4.0:", type=("build", "run"), when="@1.5.0:")
+
+    depends_on("c", type=("build"))
+    depends_on("fortran", type=("build"))

--- a/repos/spack_repo/builtin/packages/r_microbenchmark/package.py
+++ b/repos/spack_repo/builtin/packages/r_microbenchmark/package.py
@@ -23,5 +23,6 @@ class RMicrobenchmark(RPackage):
     version("1.4-7", sha256="268f13c6323dd28cc2dff7e991bb78b814a8873b4a73f4a3645f40423da984f6")
 
     depends_on("c", type="build")
+    depends_on("fortran", type=("build"))
 
     depends_on("r@3.2:", type=("build", "run"), when="@1.5:")

--- a/repos/spack_repo/builtin/packages/r_mvtnorm/package.py
+++ b/repos/spack_repo/builtin/packages/r_mvtnorm/package.py
@@ -31,3 +31,4 @@ class RMvtnorm(RPackage):
 
     depends_on("r@3.5.0:", type=("build", "run"), when="@1.0-9:")
     depends_on("r@1.9.0:", type=("build", "run"))
+

--- a/repos/spack_repo/builtin/packages/r_nloptr/package.py
+++ b/repos/spack_repo/builtin/packages/r_nloptr/package.py
@@ -41,6 +41,10 @@ class RNloptr(RPackage):
     depends_on("nlopt@2.4.0:")
     depends_on("nlopt@2.7.0:", when="@2.0.0:")
 
+    depends_on("c", type=("build"))
+    depends_on("cxx", type=("build"))
+    depends_on("fortran", type=("build"))
+
     def configure_args(self):
         include_flags = self.spec["nlopt"].headers.include_flags
         libs = self.spec["nlopt"].libs.libraries[0]

--- a/repos/spack_repo/builtin/packages/r_nnet/package.py
+++ b/repos/spack_repo/builtin/packages/r_nnet/package.py
@@ -25,6 +25,8 @@ class RNnet(RPackage):
     version("7.3-12", sha256="2723523e8581cc0e2215435ac773033577a16087a3f41d111757dd96b8c5559d")
 
     depends_on("c", type="build")
+    depends_on("fortran", type=("build"))
 
     depends_on("r@3.0.0:", type=("build", "run"), when="@7.3-14:")
     depends_on("r@2.14:", type=("build", "run"))
+

--- a/repos/spack_repo/builtin/packages/r_philentropy/package.py
+++ b/repos/spack_repo/builtin/packages/r_philentropy/package.py
@@ -29,6 +29,7 @@ class RPhilentropy(RPackage):
     version("0.5.0", sha256="b39e9a825458f3377e23b2a133180566780e89019e9d22a6a5b7ca87c49c412f")
     version("0.4.0", sha256="bfd30bf5635aab6a82716299a87d44cf96c7ab7f4ee069843869bcc85c357127")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     depends_on("r@3.1.2:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_plyr/package.py
+++ b/repos/spack_repo/builtin/packages/r_plyr/package.py
@@ -33,3 +33,7 @@ class RPlyr(RPackage):
 
     depends_on("r@3.1.0:", type=("build", "run"))
     depends_on("r-rcpp@0.11.0:", type=("build", "run"))
+
+    depends_on("c", type=("build"))
+    depends_on("cxx", type=("build"))
+    depends_on("fortran", type=("build"))

--- a/repos/spack_repo/builtin/packages/r_pryr/package.py
+++ b/repos/spack_repo/builtin/packages/r_pryr/package.py
@@ -24,10 +24,13 @@ class RPryr(RPackage):
     version("0.1.3", sha256="6acd88341dde4fe247a5cafd3949b281dc6742b7d60f68b57c1feb84b96739ac")
     version("0.1.2", sha256="65c2b7c9f96e2aa683ac9cdab3c215fd3039ecd66a2ba7002a8e77881428c3c6")
 
+    depends_on("c", type=("build"))
     depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type=("build"))
 
     depends_on("r@3.1.0:", type=("build", "run"))
     depends_on("r-stringr", type=("build", "run"))
     depends_on("r-codetools", type=("build", "run"))
     depends_on("r-rcpp@0.11.0:", type=("build", "run"))
     depends_on("r-lobstr", type=("build", "run"), when="@0.1.5:")
+

--- a/repos/spack_repo/builtin/packages/r_quantreg/package.py
+++ b/repos/spack_repo/builtin/packages/r_quantreg/package.py
@@ -50,3 +50,7 @@ class RQuantreg(RPackage):
 
     # Historical dependencies
     depends_on("r-conquer", type=("build", "run"), when="@5.82:5.86")
+
+    depends_on("c", type=("build"))
+    depends_on("cxx", type=("build")) 
+    depends_on("fortran", type=("build"))

--- a/repos/spack_repo/builtin/packages/r_rbibutils/package.py
+++ b/repos/spack_repo/builtin/packages/r_rbibutils/package.py
@@ -29,3 +29,6 @@ class RRbibutils(RPackage):
     depends_on("c", type="build")
 
     depends_on("r@2.10:", type=("build", "run"))
+
+    depends_on("c", type=("build"))
+    depends_on("fortran", type=("build"))

--- a/repos/spack_repo/builtin/packages/r_rcpparmadillo/package.py
+++ b/repos/spack_repo/builtin/packages/r_rcpparmadillo/package.py
@@ -65,3 +65,6 @@ class RRcpparmadillo(RPackage):
     depends_on("r@3.3.0:", type=("build", "run"), when="@0.8.500.0:")
     depends_on("r-rcpp@0.11.0:", type=("build", "run"))
     depends_on("r-rcpp@1.0.8:", type=("build", "run"), when="@0.12.8.4.0:")
+
+    depends_on("cxx", type=("build"))
+    depends_on("fortran", type=("build"))

--- a/repos/spack_repo/builtin/packages/r_rcppeigen/package.py
+++ b/repos/spack_repo/builtin/packages/r_rcppeigen/package.py
@@ -46,3 +46,6 @@ class RRcppeigen(RPackage):
 
     # Historical dependencies
     depends_on("r-matrix@1.1-0:", type=("build", "run"), when="@:0.3.3.9.3")
+
+    depends_on("cxx", type=("build"))
+    depends_on("fortran", type=("build"))

--- a/repos/spack_repo/builtin/packages/r_rcurl/package.py
+++ b/repos/spack_repo/builtin/packages/r_rcurl/package.py
@@ -32,6 +32,7 @@ class RRcurl(RPackage):
     version("1.95-4.8", sha256="e72243251bbbec341bc5864305bb8cc23d311d19c5d0d9310afec7eb35aa2bfb")
 
     depends_on("c", type="build")
+    depends_on("fortran", type=("build"))
 
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r@3.4.0:", type=("build", "run"), when="@1.98:")
@@ -39,3 +40,4 @@ class RRcurl(RPackage):
     depends_on("curl")
     depends_on("gmake", type="build")
     depends_on("icu4c", type=("build", "link", "run"))
+

--- a/repos/spack_repo/builtin/packages/r_rsqlite/package.py
+++ b/repos/spack_repo/builtin/packages/r_rsqlite/package.py
@@ -45,3 +45,7 @@ class RRsqlite(RPackage):
     depends_on("r-bh", type=("build", "run"), when="@:2.2.2")
     depends_on("r-rcpp@0.12.7:", type=("build", "run"), when="@:2.2.18")
     depends_on("r-rcpp@1.0.7:", type=("build", "run"), when="@2.2.9:2.2.18")
+
+    depends_on("c", type=("build"))
+    depends_on("cxx", type=("build"))
+    depends_on("fortran", type=("build"))

--- a/repos/spack_repo/builtin/packages/r_scales/package.py
+++ b/repos/spack_repo/builtin/packages/r_scales/package.py
@@ -44,3 +44,6 @@ class RScales(RPackage):
     depends_on("r-dichromat", type=("build", "run"), when="@:0.5.0")
     depends_on("r-plyr", type=("build", "run"), when="@:0.5.0")
     depends_on("r-rcpp", type=("build", "run"), when="@:1.0.0")
+
+    depends_on("cxx", type=("build"))
+    depends_on("fortran", type=("build"))

--- a/repos/spack_repo/builtin/packages/r_sparsem/package.py
+++ b/repos/spack_repo/builtin/packages/r_sparsem/package.py
@@ -28,3 +28,6 @@ class RSparsem(RPackage):
     depends_on("fortran", type="build")
 
     depends_on("r@2.15:", type=("build", "run"))
+
+    depends_on("c", type=("build"))
+    depends_on("fortran", type=("build"))

--- a/repos/spack_repo/builtin/packages/r_survival/package.py
+++ b/repos/spack_repo/builtin/packages/r_survival/package.py
@@ -38,3 +38,6 @@ class RSurvival(RPackage):
     depends_on("r@3.4:", type=("build", "run"), when="@3.1-12:")
     depends_on("r@2.13.0:", type=("build", "run"))
     depends_on("r-matrix", type=("build", "run"))
+
+    depends_on("c", type=("build"))
+    depends_on("fortran", type=("build"))

--- a/repos/spack_repo/builtin/packages/r_tidyselect/package.py
+++ b/repos/spack_repo/builtin/packages/r_tidyselect/package.py
@@ -48,3 +48,7 @@ class RTidyselect(RPackage):
 
     depends_on("r-purrr", type=("build", "run"), when="@:1.1.2")
     depends_on("r-purrr@0.3.2:", type=("build", "run"), when="@1.1.0:1.1.2")
+
+    depends_on("c", type=("build"))
+    depends_on("cxx", type=("build"))
+    depends_on("fortran", type=("build"))

--- a/repos/spack_repo/builtin/packages/r_xml/package.py
+++ b/repos/spack_repo/builtin/packages/r_xml/package.py
@@ -34,3 +34,6 @@ class RXml(RPackage):
     depends_on("r@2.13.0:", type=("build", "run"))
     depends_on("r@4.0.0:", type=("build", "run"), when="@3.99-0.5:")
     depends_on("libxml2@2.6.3:")
+
+    depends_on("c", type=("build"))
+    depends_on("fortran", type=("build"))

--- a/repos/spack_repo/builtin/packages/rust/package.py
+++ b/repos/spack_repo/builtin/packages/rust/package.py
@@ -38,6 +38,8 @@ class Rust(Package):
     version("nightly")
 
     # Stable versions.
+    version("1.91.0", sha256="327f528151753013f0a2b2c7f48955a033d718f269a4bc586314d675d0d43e8a")
+    version("1.88.0", sha256="3a97544434848ae3d193d1d6bc83d6f24cb85c261ad95f955fde47ec64cfcfbe")
     version("1.86.0", sha256="022a27286df67900a044d227d9db69d4732ec3d833e4ffc259c4425ed71eed80")
     version("1.85.0", sha256="2f4f3142ffb7c8402139cfa0796e24baaac8b9fd3f96b2deec3b94b4045c6a8a")
     version("1.83.0", sha256="722d773bd4eab2d828d7dd35b59f0b017ddf9a97ee2b46c1b7f7fac5c8841c6e")
@@ -87,6 +89,8 @@ class Rust(Package):
     depends_on("rust-bootstrap@nightly", type="build", when="@nightly")
 
     # Stable version dependencies
+    depends_on("rust-bootstrap@1.90:1.91", type="build", when="@1.91")
+    depends_on("rust-bootstrap@1.87:1.88", type="build", when="@1.88")
     depends_on("rust-bootstrap@1.85:1.86", type="build", when="@1.86")
     depends_on("rust-bootstrap@1.84:1.85", type="build", when="@1.85")
     depends_on("rust-bootstrap@1.82:1.83", type="build", when="@1.83")

--- a/repos/spack_repo/builtin/packages/rust_bootstrap/package.py
+++ b/repos/spack_repo/builtin/packages/rust_bootstrap/package.py
@@ -24,6 +24,28 @@ class RustBootstrap(Package):
     # should update these binary releases as bootstrapping requirements are
     # modified by new releases of Rust.
     rust_releases = {
+        "1.91.0": {
+            "darwin": {
+                "x86_64": "b329b458c8074023e5f6934bcd6c0bbef5075ac0090548c3d45a7de82e0c5b0c",
+                "aarch64": "ec42d93940933340ee55e67003699ebe264aa82d7cf0d5ae08100c06b1bfacfa",
+            },
+            "linux": {
+                "x86_64": "bad9a353330d9f409fe9db790da5701074112f804073506bb2808dd97b940b3c",
+                "aarch64": "29c5a608861cc9c06d3f86852a7d7b1a868de2d7ab90d4ff625aeebfb9383390",
+                "powerpc64le": "1a357b1e44f7ec7c2da62461a4180d8d8b599dd06045e7e2b83cd7f93972d6d7",
+            },
+        },
+        "1.88.0": {
+            "darwin": {
+                "x86_64": "b36b0bfac17e0a1f6cc06b9fdc4e2131ad578b4122a67792236b58650ae4c5c8",
+                "aarch64": "dee921b9a41b1c3fbb088ad31dcca3b232de2cb89c268db75f40912eeaa474db",
+            },
+            "linux": {
+                "x86_64": "ad6f0cc845e7fcca17fd451bafd2c04a7bbcb543f8f3ef5bc412fd1fef99ef7b",
+                "aarch64": "dbc75abc31d142eacf15e60d0e51c4f291539974221d217b80786756b0ce1d6b",
+                "powerpc64le": "e1f16b2885237695f3cce7fc2f0128a938fc07462b076cb61bd2f06e5f8baf38",
+            },
+        },
         "1.86.0": {
             "darwin": {
                 "x86_64": "bf8121850b2f6a46566f6c2bbe9fa889b915b1039febf36853ea9d9c4256c67d",


### PR DESCRIPTION
This includes rolling Rust versions forward due to internal Cargo dep requirements for cargo>=1.88.0, and many R packages which depend on fortran (and c for linking)

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
