### PR TITLE
madgraph5amc: drop syscalc dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/madgraph5amc/package.py
+++ b/repos/spack_repo/builtin/packages/madgraph5amc/package.py
@@ -46,7 +46,6 @@ class Madgraph5amc(MakefilePackage):
     depends_on("fortran", type="build")
     depends_on("cxx", type="build")
 
-    depends_on("syscalc")
     depends_on("gosam-contrib", when="+ninja")
     depends_on("collier", when="+collier")
     depends_on("lhapdf")
@@ -75,8 +74,6 @@ class Madgraph5amc(MakefilePackage):
             join_path("input", ".mg5_configuration_default.txt"),
             join_path("input", "mg5_configuration.txt"),
         )
-
-        set_parameter("syscalc_path", spec["syscalc"].prefix.bin)
 
         if "+ninja" in spec:
             set_parameter("ninja", spec["gosam-contrib"].prefix.lib)

--- a/repos/spack_repo/builtin/packages/syscalc/package.py
+++ b/repos/spack_repo/builtin/packages/syscalc/package.py
@@ -18,6 +18,7 @@ class Syscalc(MakefilePackage):
         sha256="ac73df0f9f195eb62601fafc2eede3db17a562750f7971616870d6df4abd1b6c",
         url="https://bazaar.launchpad.net/~mgtools/mg5amcnlo/SysCalc/tarball/17",
         extension=".tgz",
+        deprecated=True,
     )
 
     depends_on("cxx", type="build")  # generated


### PR DESCRIPTION
As discussed in https://github.com/spack/spack-packages/pull/1675, this drops the `syscalc` dependency in the `madgraph5amc` package, and also deprecates the only available version of `syscalc` in preparation of deleting that package down the line.

@oliviermattelaer @wdconinc 