### PR TITLE
kokkos-fft: fix minimal version requirement

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos_fft/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_fft/package.py
@@ -37,8 +37,7 @@ class KokkosFft(CMakePackage):
     variant("tests", default=False, description="Enable tests")
 
     depends_on("cxx", type="build")
-
-    depends_on("cmake@3.22:3", when="@0.3:")
+    depends_on("cmake@3.22:3", type="build")
 
     depends_on("kokkos +complex_align")
     depends_on("kokkos@4.4:4", when="@0.3")

--- a/repos/spack_repo/builtin/packages/kokkos_fft/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_fft/package.py
@@ -38,7 +38,11 @@ class KokkosFft(CMakePackage):
 
     depends_on("cxx", type="build")
 
-    depends_on("kokkos@4.4:4 +complex_align")
+    depends_on("cmake@3.22:3", when="@0.3:")
+
+    depends_on("kokkos +complex_align")
+    depends_on("kokkos@4.4:4", when="@0.3")
+    depends_on("kokkos@4.5:4", when="@0.4:")
     # kokkos-fft currently only supports compilation with the Kokkos nvcc wrapper
     requires("^kokkos +serial", when="host_backend=fftw-serial")
     requires("^kokkos +openmp", when="host_backend=fftw-openmp")


### PR DESCRIPTION
- fix minimal version requirement of Kokkos
- add missing requirement for cmake