### PR TITLE
osu-micro-benchmarks: Add XCCL benchmarks

### DIFF
--- a/repos/spack_repo/builtin/packages/osu_micro_benchmarks/package.py
+++ b/repos/spack_repo/builtin/packages/osu_micro_benchmarks/package.py
@@ -65,12 +65,14 @@ class OsuMicroBenchmarks(AutotoolsPackage, CudaPackage, ROCmPackage):
 
         if "+cuda" in spec:
             config_args.extend(["--enable-cuda", "--with-cuda=%s" % spec["cuda"].prefix])
+            config_args.extend(["--enable-ncclomb", "--with-nccl=%s", spec["cuda"].prefix])
             cuda_arch = spec.variants["cuda_arch"].value
             if "none" not in cuda_arch:
                 config_args.append("NVCCFLAGS=" + " ".join(self.cuda_flags(cuda_arch)))
 
         if "+rocm" in spec:
             config_args.extend(["--enable-rocm", "--with-rocm=%s" % spec["hip"].prefix])
+            config_args.extend(["--enable-rcclomb", "--with-rccl=%s" % spec["hip"].prefix])
             rocm_arch = spec.variants["amdgpu_target"].value
             if "none" not in rocm_arch:
                 config_args.append("HCC_AMDGPU_TARGET=" + self.hip_flags(rocm_arch))

--- a/repos/spack_repo/builtin/packages/osu_micro_benchmarks/package.py
+++ b/repos/spack_repo/builtin/packages/osu_micro_benchmarks/package.py
@@ -98,3 +98,7 @@ class OsuMicroBenchmarks(AutotoolsPackage, CudaPackage, ROCmPackage):
         env.prepend_path("PATH", join_path(mpidir, "pt2pt"))
         env.prepend_path("PATH", join_path(mpidir, "one-sided"))
         env.prepend_path("PATH", join_path(mpidir, "collective"))
+        if self.spec.satisfies("+cuda") or self.spec.satisfies("+rocm"):
+            xccldir = join_path(self.prefix.libexec, "osu-micro-benchmarks", "xccl")
+            env.prepend_path("PATH", join_path(xccldir, "pt2pt"))
+            env.prepend_path("PATH", join_path(xccldir, "collective"))

--- a/repos/spack_repo/builtin/packages/osu_micro_benchmarks/package.py
+++ b/repos/spack_repo/builtin/packages/osu_micro_benchmarks/package.py
@@ -65,7 +65,7 @@ class OsuMicroBenchmarks(AutotoolsPackage, CudaPackage, ROCmPackage):
 
         if "+cuda" in spec:
             config_args.extend(["--enable-cuda", "--with-cuda=%s" % spec["cuda"].prefix])
-            config_args.extend(["--enable-ncclomb", "--with-nccl=%s", spec["cuda"].prefix])
+            config_args.extend(["--enable-ncclomb", "--with-nccl=%s" % spec["cuda"].prefix])
             cuda_arch = spec.variants["cuda_arch"].value
             if "none" not in cuda_arch:
                 config_args.append("NVCCFLAGS=" + " ".join(self.cuda_flags(cuda_arch)))

--- a/repos/spack_repo/builtin/packages/osu_micro_benchmarks/package.py
+++ b/repos/spack_repo/builtin/packages/osu_micro_benchmarks/package.py
@@ -65,14 +65,16 @@ class OsuMicroBenchmarks(AutotoolsPackage, CudaPackage, ROCmPackage):
 
         if "+cuda" in spec:
             config_args.extend(["--enable-cuda", "--with-cuda=%s" % spec["cuda"].prefix])
-            config_args.extend(["--enable-ncclomb", "--with-nccl=%s" % spec["cuda"].prefix])
+            if spec.satisfies("^cuda@11:") or spec.satisfies("^nccl"):
+                config_args.extend(["--enable-ncclomb", "--with-nccl=%s" % spec["cuda"].prefix])
             cuda_arch = spec.variants["cuda_arch"].value
             if "none" not in cuda_arch:
                 config_args.append("NVCCFLAGS=" + " ".join(self.cuda_flags(cuda_arch)))
 
         if "+rocm" in spec:
             config_args.extend(["--enable-rocm", "--with-rocm=%s" % spec["hip"].prefix])
-            config_args.extend(["--enable-rcclomb", "--with-rccl=%s" % spec["hip"].prefix])
+            if spec.satisfies("^hip@3.5:") or spec.satisfies("^rccl"):
+                config_args.extend(["--enable-rcclomb", "--with-rccl=%s" % spec["hip"].prefix])
             rocm_arch = spec.variants["amdgpu_target"].value
             if "none" not in rocm_arch:
                 config_args.append("HCC_AMDGPU_TARGET=" + self.hip_flags(rocm_arch))

--- a/repos/spack_repo/builtin/packages/osu_micro_benchmarks/package.py
+++ b/repos/spack_repo/builtin/packages/osu_micro_benchmarks/package.py
@@ -55,9 +55,13 @@ class OsuMicroBenchmarks(AutotoolsPackage, CudaPackage, ROCmPackage):
     depends_on("mpi")
     variant("papi", description="Enable/Disable support for papi", default=False)
     variant("graphing", description="Enable/Disable support for graphing", default=False)
+    variant("xccl", when="+cuda", description="Enable/Disable XCCL benchmarks", default=True)
+    variant("xccl", when="+rocm", description="Enable/Disable XCCL benchmarks", default=True)
     depends_on("papi", when="+papi")
     depends_on("gnuplot", when="+graphing")
     depends_on("imagemagick", when="+graphing")
+    depends_on("nccl", when="+cuda+xccl")
+    depends_on("rccl", when="+rocm+xccl")
 
     def configure_args(self):
         spec = self.spec
@@ -65,7 +69,7 @@ class OsuMicroBenchmarks(AutotoolsPackage, CudaPackage, ROCmPackage):
 
         if "+cuda" in spec:
             config_args.extend(["--enable-cuda", "--with-cuda=%s" % spec["cuda"].prefix])
-            if spec.satisfies("^cuda@11:") or spec.satisfies("^nccl"):
+            if spec.satisfies("+xccl"):
                 config_args.extend(["--enable-ncclomb", "--with-nccl=%s" % spec["cuda"].prefix])
             cuda_arch = spec.variants["cuda_arch"].value
             if "none" not in cuda_arch:
@@ -73,7 +77,7 @@ class OsuMicroBenchmarks(AutotoolsPackage, CudaPackage, ROCmPackage):
 
         if "+rocm" in spec:
             config_args.extend(["--enable-rocm", "--with-rocm=%s" % spec["hip"].prefix])
-            if spec.satisfies("^hip@3.5:") or spec.satisfies("^rccl"):
+            if spec.satisfies("+xccl"):
                 config_args.extend(["--enable-rcclomb", "--with-rccl=%s" % spec["hip"].prefix])
             rocm_arch = spec.variants["amdgpu_target"].value
             if "none" not in rocm_arch:


### PR DESCRIPTION
Hello @MatthewLieber, @natshineman, and @harisubramoni,

NCCL and RCCL are now included by default in installations of CUDA and HIP, respectively. Therefore, rather than adding another variant, I have added logic to detect the appropriate versions of CUDA or HIP in the DAG and build the XCCL benchmarks automatically. They will also build if NCCL or RCCL are explicitly detected in the DAG. This has been tested on LLNL Tuolumne, Corona, and Matrix. However, I do not have old enough CUDA/ROCm installations to test the version cutoff explicitly.

Please let me know what you think.

Thanks,
Nate