### PR TITLE
Kokkos: fix host backend requirement

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -94,7 +94,9 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         "sycl": [False, "Whether to build the SYCL backend"],
         "openmptarget": [False, "Whether to build the OpenMPTarget backend"],
     }
-    requires("+serial", when="~openmp ~threads", msg="Kokkos requires at least one host backend")
+    requires(
+        "+serial", when="~hpx ~openmp ~threads", msg="Kokkos requires at least one host backend"
+    )
 
     tpls_variants = {
         "hpx": [False, "Whether to enable the HPX library"],


### PR DESCRIPTION
As we also support the experimental backend HPX in the package, I think we should allow a build with only HPX as a host backend.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
