### PR TITLE
clingo: allow cmake@4:

### DIFF
--- a/repos/spack_repo/builtin/packages/clingo/package.py
+++ b/repos/spack_repo/builtin/packages/clingo/package.py
@@ -58,9 +58,6 @@ class Clingo(CMakePackage):
     depends_on("cmake@3.1:", type="build")
     depends_on("cmake@3.18:", type="build", when="@5.5:")
 
-    # 5.7.1 and lower incompatible with cmake 4.0 due to cmake_minimum_required version 3.1
-    depends_on("cmake@:3", type="build", when="@:5.7")
-
     depends_on("doxygen", type="build", when="+docs")
 
     depends_on("re2c@0.13:", type="build")


### PR DESCRIPTION
This upperbound should be redundant due to 7920960bcb1052218c2726948a9040b29316dbd8, which was pointed out in https://github.com/spack/spack/pull/50668.
