### PR TITLE
protobuf dependents: fix versioning in protobuf requires action on dependents

### DIFF
--- a/repos/spack_repo/builtin/packages/gnina/package.py
+++ b/repos/spack_repo/builtin/packages/gnina/package.py
@@ -59,7 +59,7 @@ class Gnina(CMakePackage, CudaPackage):
 
     depends_on("zlib-api")
     depends_on("boost@:1.79" + _boost_extensions)
-    depends_on("protobuf@:3.21.12")
+    depends_on("protobuf@:21.12")
 
     depends_on("libmolgrid")
 

--- a/repos/spack_repo/builtin/packages/lbann/package.py
+++ b/repos/spack_repo/builtin/packages/lbann/package.py
@@ -233,7 +233,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("py-setuptools", type="build", when="+pfe")
     depends_on("py-protobuf@3.10.0:4.21.12", type=("build", "run"), when="+pfe")
 
-    depends_on("protobuf@3.10.0:3.21.12")
+    depends_on("protobuf@3.10.0:21.12")
     depends_on("zlib-api", when="^protobuf@3.11.0:")
 
     # using cereal@1.3.1 and above requires changing the

--- a/repos/spack_repo/builtin/packages/mgard/package.py
+++ b/repos/spack_repo/builtin/packages/mgard/package.py
@@ -95,7 +95,7 @@ class Mgard(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("zstd")
     depends_on("protobuf@3.4:", when="@compat-2022-11-18:")
     # See https://github.com/CODARcode/MGARD/issues/240
-    depends_on("protobuf@:3.28", when="@:1.5.2")
+    depends_on("protobuf@:28", when="@:1.5.2")
     depends_on("libarchive", when="@compat-2021-11-12:")
     depends_on("tclap", when="@compat-2021-11-12")
     depends_on("yaml-cpp", when="@compat-2021-11-12:")
@@ -116,8 +116,8 @@ class Mgard(CMakePackage, CudaPackage, ROCmPackage):
     conflicts(
         "%gcc@:7", when="@compat-2022-11-18:", msg="requires std::optional and other c++17 things"
     )
-    conflicts("protobuf@3.22:", when="target=ppc64le", msg="GCC 9.4 segfault in CI")
-    conflicts("protobuf@3.22:", when="+cuda target=aarch64:", msg="nvcc fails on ARM SIMD headers")
+    conflicts("protobuf@22:", when="target=ppc64le", msg="GCC 9.4 segfault in CI")
+    conflicts("protobuf@22:", when="+cuda target=aarch64:", msg="nvcc fails on ARM SIMD headers")
     # https://github.com/abseil/abseil-cpp/issues/1629
     conflicts("abseil-cpp@20240116.1", when="+cuda", msg="triggers nvcc parser bug")
 

--- a/repos/spack_repo/builtin/packages/mivisionx/package.py
+++ b/repos/spack_repo/builtin/packages/mivisionx/package.py
@@ -154,7 +154,7 @@ class Mivisionx(CMakePackage):
 
     depends_on("cmake@3.5:", type="build")
     depends_on("ffmpeg@4.4:", type="build")
-    depends_on("protobuf@:3", type="build")  # TODO
+    depends_on("protobuf@3.12.4:", type="build")
     depends_on(
         "opencv@4.5:"
         "+calib3d+features2d+highgui+imgcodecs+imgproc"

--- a/repos/spack_repo/builtin/packages/mivisionx/package.py
+++ b/repos/spack_repo/builtin/packages/mivisionx/package.py
@@ -154,7 +154,7 @@ class Mivisionx(CMakePackage):
 
     depends_on("cmake@3.5:", type="build")
     depends_on("ffmpeg@4.4:", type="build")
-    depends_on("protobuf@:3", type="build")
+    depends_on("protobuf@:3", type="build")  # TODO
     depends_on(
         "opencv@4.5:"
         "+calib3d+features2d+highgui+imgcodecs+imgproc"

--- a/repos/spack_repo/builtin/packages/onnx/package.py
+++ b/repos/spack_repo/builtin/packages/onnx/package.py
@@ -64,7 +64,7 @@ class Onnx(CMakePackage):
     depends_on("protobuf")
 
     def patch(self):
-        if self.spec.satisfies("@1.13:1.14 ^protobuf@3.22:"):
+        if self.spec.satisfies("@1.13:1.14 ^protobuf@22:"):
             # CMAKE_CXX_STANDARD is overridden in CMakeLists.txt until 1.14
             cxxstd = self.spec["abseil-cpp"].variants["cxxstd"].value
             filter_file("CMAKE_CXX_STANDARD 11", f"CMAKE_CXX_STANDARD {cxxstd}", "CMakeLists.txt")
@@ -78,7 +78,7 @@ class Onnx(CMakePackage):
             self.define("PY_VERSION", self.spec["python"].version.up_to(2)),
             self.define("ONNX_BUILD_TESTS", self.run_tests),
         ]
-        if self.spec.satisfies("@1.15: ^protobuf@3.22:"):
+        if self.spec.satisfies("@1.15: ^protobuf@22:"):
             # CMAKE_CXX_STANDARD can be set on command line as of 1.15
             cxxstd = self.spec["abseil-cpp"].variants["cxxstd"].value
             args.append(self.define("CMAKE_CXX_STANDARD", cxxstd))

--- a/repos/spack_repo/builtin/packages/paraview/package.py
+++ b/repos/spack_repo/builtin/packages/paraview/package.py
@@ -299,10 +299,10 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     # protobuf requires newer abseil-cpp, which in turn requires C++14,
     # but paraview uses C++11 by default. Use for 5.8+ until ParaView updates
     # its C++ standard level.
-    depends_on("protobuf@3.4:3.21", when="@5.8:%gcc")
-    depends_on("protobuf@3.4:3.21", when="@5.8:%clang")
-    depends_on("protobuf@3.4:3.21", when="@5.11:")
-    depends_on("protobuf@3.4:3.21", when="@master")
+    depends_on("protobuf@3.4:21", when="@5.8:%gcc")
+    depends_on("protobuf@3.4:21", when="@5.8:%clang")
+    depends_on("protobuf@3.4:21", when="@5.11:")
+    depends_on("protobuf@3.4:21", when="@master")
     depends_on("libxml2")
     depends_on("lz4")
     depends_on("xz")

--- a/repos/spack_repo/builtin/packages/protobuf_c/package.py
+++ b/repos/spack_repo/builtin/packages/protobuf_c/package.py
@@ -26,5 +26,5 @@ class ProtobufC(AutotoolsPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    depends_on("protobuf@:3.21.12")
+    depends_on("protobuf@:21.12")
     depends_on("pkgconfig", type="build")

--- a/repos/spack_repo/builtin/packages/py_protobuf/package.py
+++ b/repos/spack_repo/builtin/packages/py_protobuf/package.py
@@ -73,13 +73,13 @@ class PyProtobuf(PythonPackage):
     depends_on("py-setuptools", type=("build", "run"))
     depends_on("py-six@1.9:", when="@3.0:3.17", type=("build", "run"))
 
-    # Minor version must match protobuf
-    for ver in range(32, 33):
+    # https://protobuf.dev/support/version-support/#python
+    for ver in range(30, 33):
         depends_on(f"protobuf@{ver}", when=f"@6.{ver}")
     for ver in range(26, 29):
-        depends_on(f"protobuf@3.{ver}", when=f"@5.{ver}")
-    for ver in range(21, 26):
-        depends_on(f"protobuf@3.{ver}", when=f"@4.{ver}")
+        depends_on(f"protobuf@{ver}", when=f"@5.{ver}")
+    for ver in range(21, 25):
+        depends_on(f"protobuf@{ver}", when=f"@4.{ver}")
     for ver in range(0, 21):
         depends_on(f"protobuf@3.{ver}", when=f"@3.{ver}")
 

--- a/repos/spack_repo/builtin/packages/py_protobuf/package.py
+++ b/repos/spack_repo/builtin/packages/py_protobuf/package.py
@@ -76,9 +76,9 @@ class PyProtobuf(PythonPackage):
     # https://protobuf.dev/support/version-support/#python
     for ver in range(30, 33):
         depends_on(f"protobuf@{ver}", when=f"@6.{ver}")
-    for ver in range(26, 29):
+    for ver in range(26, 30):
         depends_on(f"protobuf@{ver}", when=f"@5.{ver}")
-    for ver in range(21, 25):
+    for ver in range(21, 26):
         depends_on(f"protobuf@{ver}", when=f"@4.{ver}")
     for ver in range(0, 21):
         depends_on(f"protobuf@3.{ver}", when=f"@3.{ver}")

--- a/repos/spack_repo/builtin/packages/py_tf_keras/package.py
+++ b/repos/spack_repo/builtin/packages/py_tf_keras/package.py
@@ -43,7 +43,7 @@ class PyTfKeras(PythonPackage):
 
     depends_on("protobuf@3.20.3", type="build", when="@2.18:")
     # TODO: uncomment for 2.19
-    # depends_on("protobuf@4.23.0", type="build", when="@2.19:")
+    # depends_on("protobuf@23.0", type="build", when="@2.19:")
     # the tf-keras versions are following along with TF versions
     # as defined in oss_setup.py
     for minor_ver in range(18, max_minor + 1):

--- a/repos/spack_repo/builtin/packages/qgis/package.py
+++ b/repos/spack_repo/builtin/packages/qgis/package.py
@@ -155,7 +155,7 @@ class Qgis(CMakePackage):
     depends_on("sqlite@3.0.0: +column_metadata")
     depends_on("pdal", when="+pdal")
     depends_on("protobuf", when="@3.16.4:")
-    depends_on("protobuf@:3.21", when="@:3.28")
+    depends_on("protobuf@:21", when="@:3.28")
     depends_on("zstd", when="@3.22:")
 
     # Runtime python dependencies, not mentioned in install instructions


### PR DESCRIPTION
This is a PR that will be merged into the work going on in #2294 about fixing protobuf versioning.

For more information, have a look at the official documentation here https://protobuf.dev/support/version-support

Long story short: `protobuf` package in spack kept versioning the old way (3.*) and never switched to the new one (21.0). We're trying to fix this one way or another, but the main messages is that since 21.0 included (that comes after 3.20.*):
- `protobuf` version is the `protoc` version (21, 22, ... nowadays 33)
- you might still be interested in language runtime, which use a versioning where the major is the language version, and minor+patch compose the `protoc` version

This change requires some actions also on dependents, that's the mission of this PR.

Guidelines (I'm going to update this message in case other ideas/suggestions comes up)
- dependents should use the new versioning starting from 21.0
- if a dependent needs a specific language runtime compatibility, e.g. c++ 5.x, they have to check the compatibility table and require the right `protobuf` version, e.g. c++ 5 requires `protobuf@26:29`

What I did in this PR: I looked for all dependents and filtered for the ones with any kind of constraint on `protobuf`. It was mostly easy (see e8b4afbbbc26733549186a6d97d7f06b4c5820b8) because of the convenient number (e.g. `:3.21` is semantically equivalent to `:21` with the new versioning).

Specific cases that need attention:
- [x] `mivisionx`