### PR TITLE
lm-sensors: add missing build dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/lm_sensors/package.py
+++ b/repos/spack_repo/builtin/packages/lm_sensors/package.py
@@ -34,6 +34,8 @@ class LmSensors(MakefilePackage):
 
     depends_on("bison", type="build")
     depends_on("flex", type="build")
+    depends_on("which", type="build")
+    depends_on("sed", type="build")
     depends_on("perl", type="run")
 
     @property


### PR DESCRIPTION
Ran into build issues when trying to `spack containerize`.

Edit: looks like Spackbot works properly and assigned the appropriate reviewers.