### PR TITLE
OpenJDK: Update version and preferred_version

### DIFF
--- a/repos/spack_repo/builtin/packages/hazelcast/package.py
+++ b/repos/spack_repo/builtin/packages/hazelcast/package.py
@@ -26,4 +26,6 @@ class Hazelcast(MavenPackage):
     version("3.12.7", sha256="0747de968082bc50202f825b4010be28a3885b3dbcee4b83cbe21b2f8b26a7e0")
     version("3.11.7", sha256="c9f636b8813027d4cc24459bd27740549f89b4f11f62a868079bcb5b41d9b2bb")
 
-    depends_on("java@8:", type=("build", "run"))
+    # Maven 2.0.0 cannot compile for JVM 23+ bytecode
+    # https://github.com/hazelcast/hazelcast/blob/v5.5.0/hazelcast-parent/pom.xml#L103
+    depends_on("java@8:22", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/openjdk/package.py
+++ b/repos/spack_repo/builtin/packages/openjdk/package.py
@@ -18,6 +18,20 @@ from spack.package import *
 #    format returned by platform.system() and 'arch' by platform.machine()
 
 _versions = {
+    "25.0.1_8": {
+        "Linux-x86_64": (
+            "8daf77d1aacffe38c9889689bc224a13557de77559d9a5bb91991e6a298baa0d",
+            "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.1%2B8/OpenJDK25U-jdk_x64_linux_hotspot_25.0.1_8.tar.gz",
+        ),
+        "Linux-aarch64": (
+            "5c83b7d2121ed482fd06831a1eba1633dbab818aba6addddf48e075b97e6e9b8",
+            "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.1%2B8/OpenJDK25U-jdk_aarch64_linux_hotspot_25.0.1_8.tar.gz",
+        ),
+        "Darwin-arm64": (
+            "964ffce1ff9f24e8d29df4e4201b5b96499026dc8387cf35bb39fe969ffea2bb",
+            "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.1%2B8/OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.1_8.tar.gz",
+        ),
+    },
     "21.0.3_9": {
         "Linux-x86_64": (
             "fffa52c22d797b715a962e6c8d11ec7d79b90dd819b5bc51d62137ea4b22a340",
@@ -393,7 +407,7 @@ class Openjdk(Package):
     """The free and opensource java implementation"""
 
     homepage = "https://openjdk.org/"
-    preferred_prefix = "17."
+    preferred_prefix = "25."
 
     preferred_defined = False
     for ver, packages in _versions.items():
@@ -414,6 +428,7 @@ class Openjdk(Package):
         description=("symlink system certs if requested, otherwise use default package version"),
     )
 
+    provides("java@25", when="@25.0:25")
     provides("java@21", when="@21.0:21")
     provides("java@17", when="@17.0:17")
     provides("java@16", when="@16.0:16")


### PR DESCRIPTION
This PR adds the latest 25 LTS version. Additionally it updates the preferred version to 25.

One potential issue that could come from this would be projects that rely on Kotlin. The latest kotlin (2.2.21) is not compatible with JVM 25. This will be fixed in the future 2.3.0 release though [src](https://kotlinlang.org/docs/whatsnew-eap.html#kotlin-jvm-support-for-java-25).

One example of this could be seen in `hazelcast`. Attempting to install using OpenJDK 25 results in an error due to JVM 25 not being recognized. In the case of hazelcast, this is probably a package issue as it version-locks to a specific version of kotlin ([src](https://github.com/hazelcast/hazelcast/blob/v5.5.0/hazelcast-parent/pom.xml#L103)). Because of this, I've also added a version ceiling for hazelcast. There are possibly other packages like this, hazelcast is just one that I found in testing.