### PR TITLE
cached_cmake `self.spec["fortran"]` unguarded access

### DIFF
--- a/repos/spack_repo/builtin/build_systems/cached_cmake.py
+++ b/repos/spack_repo/builtin/build_systems/cached_cmake.py
@@ -107,7 +107,7 @@ class CachedCMakeBuilder(CMakeBuilder):
         spec = self.pkg.spec
 
         # Fortran compiler is optional
-        if "FC" in os.environ:
+        if "FC" in os.environ and self.spec.satisfies("^fortran"):
             spack_fc_entry = cmake_cache_path("CMAKE_Fortran_COMPILER", os.environ["FC"])
             system_fc_entry = cmake_cache_path(
                 "CMAKE_Fortran_COMPILER", self.spec["fortran"].package.fortran

--- a/repos/spack_repo/builtin/build_systems/cached_cmake.py
+++ b/repos/spack_repo/builtin/build_systems/cached_cmake.py
@@ -107,7 +107,7 @@ class CachedCMakeBuilder(CMakeBuilder):
         spec = self.pkg.spec
 
         # Fortran compiler is optional
-        if "FC" in os.environ and self.spec.satisfies("^fortran"):
+        if "FC" in os.environ and self.spec.satisfies("%fortran"):
             spack_fc_entry = cmake_cache_path("CMAKE_Fortran_COMPILER", os.environ["FC"])
             system_fc_entry = cmake_cache_path(
                 "CMAKE_Fortran_COMPILER", self.spec["fortran"].package.fortran


### PR DESCRIPTION
CachedCMakePackage subclass packages fail in initconfig phase when:
 - building a package without a fortran dependency as part of a concretized dag with other packages that do have fortran dependencies
 - using an external compiler with fortran
possibly there are other specific prerequisites, this is just what I have observed

```
==> Installing raja-2025.03.0-odbstoztssqggtuilauewamw62otabat [62/93]
...
==> No patches needed for raja
==> raja: Executing phase: 'initconfig'
==> Error: KeyError: 'No spec with name fortran in raja@2025.03.0/odbstoztssqggtuilauewamw62otabat'

ommitted/.spack-builtin-repo-cache/package_repos/fncqgg4/repos/spack_repo/builtin/build_systems/cached_cmake.py:113, in initconfig_compiler_entries:
        110        if "FC" in os.environ:
        111            spack_fc_entry = cmake_cache_path("CMAKE_Fortran_COMPILER", os.environ["FC"])
        112            system_fc_entry = cmake_cache_path(
  >>    113                "CMAKE_Fortran_COMPILER", self.spec["fortran"].package.fortran
        114            )
        115        else:
        116            spack_fc_entry = "# No Fortran compiler defined in spec"
```

with this patch:

```
==> Installing raja-2025.03.0-odbstoztssqggtuilauewamw62otabat [62/93]
...
==> No patches needed for raja
==> raja: Executing phase: 'initconfig'
==> raja: Executing phase: 'cmake'
==> raja: Executing phase: 'build'
==> raja: Executing phase: 'install'
==> raja: Successfully installed raja-2025.03.0-odbstoztssqggtuilauewamw62otabat
```