### PR TITLE
mathic: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/mathic/package.py
+++ b/repos/spack_repo/builtin/packages/mathic/package.py
@@ -1,0 +1,36 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+
+from spack.package import *
+
+
+class Mathic(AutotoolsPackage):
+    """Mathic is a C++ library providing optimized data structures for
+    Gröbner basis computation. It includes support for ordering
+    S-pairs, divisor queries, and polynomial term ordering during
+    reduction. The library is template-based and can be used with
+    arbitrary monomial and coefficient representations, though it
+    currently works best with dense term representations."""
+
+    homepage = "https://github.com/Macaulay2/mathic"
+    git = "https://github.com/Macaulay2/mathic"
+
+    maintainers("d-torrance")
+
+    license("LGPL-2.0-or-later", checked_by="d-torrance")
+
+    version("1.0.2025.05.13", commit="7abf77e4ce493b3830c7f8cc09722bbd6c03818e")
+
+    depends_on("cxx", type="build")
+
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+
+    depends_on("memtailor")
+
+    def configure_args(self):
+        return ["--enable-shared"]


### PR DESCRIPTION
Mathic is a C++ library providing optimized data structures for Groebner basis computation.  It is a dependency of Macaulay2.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
