### PR TITLE
python: disable tkinter in config_args for Python 3.12+ if ~tkinter in spec

### DIFF
--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -639,11 +639,11 @@ class Python(Package):
                     ),
                 ]
             )
-            
+
         # Disable tkinter module in the configure script for Python 3.12 onwards if ~tkinter
         if spec.satisfies("@3.12:") and spec.satisfies("~tkinter"):
             config_args.append("py_cv_module__tkinter=n/a")
-            
+
         # Disable the nis module in the configure script for Python 3.11 and 3.12. It is deleted
         # in Python 3.13. See ``def patch`` for disabling the nis module in Python 3.10 and older.
         if spec.satisfies("@3.11:3.12"):

--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -639,6 +639,7 @@ class Python(Package):
                     ),
                 ]
             )
+            
         # Disable tkinter module in the configure script for Python 3.12 onwards if ~tkinter
         if spec.satisfies("@3.12:") and spec.satisfies("~tkinter"):
             config_args.append("py_cv_module__tkinter=n/a")

--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -639,7 +639,10 @@ class Python(Package):
                     ),
                 ]
             )
-
+        # Disable tkinter module in the configure script for Python 3.12 onwards if ~tkinter
+        if spec.satisfies("@3.12:") and spec.satisfies("~tkinter"):
+            config_args.append("py_cv_module__tkinter=n/a")
+            
         # Disable the nis module in the configure script for Python 3.11 and 3.12. It is deleted
         # in Python 3.13. See ``def patch`` for disabling the nis module in Python 3.10 and older.
         if spec.satisfies("@3.11:3.12"):


### PR DESCRIPTION
This solves errors such as
```
 Following modules built successfully but were removed because they could not be imported:
 _tkinter
```
in `rockylinux8` and possibly other systems.

by disabling `_tkinter` module in `config_args`. For Python < 3.12 there are patch files that effectively seem to do the same. 

Fixes https://github.com/spack/spack-packages/issues/2067