### PR TITLE
hip: set --gcc-install-dir instead of --gcc-toolchain

### DIFF
--- a/repos/spack_repo/builtin/packages/hip/package.py
+++ b/repos/spack_repo/builtin/packages/hip/package.py
@@ -427,17 +427,19 @@ class Hip(CMakePackage):
         # being used to compile. This is only important for external ROCm
         # installations, which may otherwise pick up the wrong GCC toolchain.
         if self.spec.external and self.spec.satisfies("%gcc"):
-            # This is picked up by hipcc.
-            env.append_path(
-                "HIPCC_COMPILE_FLAGS_APPEND",
-                f"--gcc-toolchain={self.compiler.prefix}",
-                separator=" ",
+            gcc = Executable(self.compiler.cc)
+            libgcc_path = gcc("-print-file-name=libgcc.a", output=str, fail_on_error=False).strip()
+            libgcc_dir = os.path.abspath(os.path.dirname(libgcc_path))
+            gcc_install_dir_flag = (
+                f"--gcc-install-dir={libgcc_dir}" if os.path.exists(libgcc_dir) else None
             )
-            env.append_path(
-                "HIPCC_LINK_FLAGS_APPEND", f"--gcc-toolchain={self.compiler.prefix}", separator=" "
-            )
-            # This is picked up by CMake when using HIP as a CMake language.
-            env.append_path("HIPFLAGS", f"--gcc-toolchain={self.compiler.prefix}", separator=" ")
+
+            if gcc_install_dir_flag:
+                # This is picked up by hipcc.
+                env.append_path("HIPCC_COMPILE_FLAGS_APPEND", gcc_install_dir_flag, separator=" ")
+                env.append_path("HIPCC_LINK_FLAGS_APPEND", gcc_install_dir_flag, separator=" ")
+                # This is picked up by CMake when using HIP as a CMake language.
+                env.append_path("HIPFLAGS", gcc_install_dir_flag, separator=" ")
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         self.set_variables(env)

--- a/repos/spack_repo/builtin/packages/hip/package.py
+++ b/repos/spack_repo/builtin/packages/hip/package.py
@@ -407,16 +407,10 @@ class Hip(CMakePackage):
             # to the hip prefix directory for non-external builds so that the
             # bin/.hipVersion file can still be parsed.
             # See also https://github.com/ROCm/HIP/issues/2223
-            env.append_path(
-                "HIPCC_COMPILE_FLAGS_APPEND", f"--rocm-path={paths['rocm-path']}", separator=" "
-            )
-            env.append_path(
-                "HIPCC_LINK_FLAGS_APPEND", f"--rocm-path={paths['rocm-path']}", separator=" "
-            )
-            env.append_path(
-                "HIPCC_COMPILE_FLAGS_APPEND",
-                f"-isystem {paths['rocm-core']}/include",
-                separator=" ",
+            env.append_flags("HIPCC_COMPILE_FLAGS_APPEND", f"--rocm-path={paths['rocm-path']}")
+            env.append_flags("HIPCC_LINK_FLAGS_APPEND", f"--rocm-path={paths['rocm-path']}")
+            env.append_flags(
+                "HIPCC_COMPILE_FLAGS_APPEND", f"-isystem {paths['rocm-core']}/include"
             )
         elif self.spec.satisfies("+cuda"):
             env.set("CUDA_PATH", self.spec["cuda"].prefix)
@@ -436,10 +430,10 @@ class Hip(CMakePackage):
 
             if gcc_install_dir_flag:
                 # This is picked up by hipcc.
-                env.append_path("HIPCC_COMPILE_FLAGS_APPEND", gcc_install_dir_flag, separator=" ")
-                env.append_path("HIPCC_LINK_FLAGS_APPEND", gcc_install_dir_flag, separator=" ")
+                env.append_flags("HIPCC_COMPILE_FLAGS_APPEND", gcc_install_dir_flag)
+                env.append_flags("HIPCC_LINK_FLAGS_APPEND", gcc_install_dir_flag)
                 # This is picked up by CMake when using HIP as a CMake language.
-                env.append_path("HIPFLAGS", gcc_install_dir_flag, separator=" ")
+                env.append_flags("HIPFLAGS", gcc_install_dir_flag)
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         self.set_variables(env)


### PR DESCRIPTION
The usage of `--gcc-toolchain` has been discouraged by LLVM for some time now (see https://github.com/llvm/llvm-project/pull/77537). While `--gcc-toolchain` still works, this should future proofs the hip dependent package logic.

> [!NOTE]
> The `setup_dependent_build_environment` logic in the `hip` packages depends on a compiler dependency. However, > externals don't automatically gain one during concretization. So this should be better documented.
>
> Externals of `hip` can specify a GCC compiler so that the correct GCC installation is selected for `hipcc`. This becomes > relevant for compilations with newer C++ standards, where the default system GCC might be too old.
>
> ```yaml
> packages:
>   hip:
>     externals:
>     - spec: "hip@6.4.3 %gcc@13.2.0"
>       prefix: /opt/rocm-6.4.3
>     buildable: false
> ```
