### PR TITLE
LIKWID: add version 5.5.0

### DIFF
--- a/repos/spack_repo/builtin/packages/likwid/package.py
+++ b/repos/spack_repo/builtin/packages/likwid/package.py
@@ -26,6 +26,7 @@ class Likwid(Package):
 
     license("GPL-3.0-only")
 
+    version("5.5.0", sha256="688924fe01340707c2c318b7f867ee60fb751b95f4954bc82d3a1f76a3a15056")
     version("5.4.1", sha256="5773851455dbba489e2e3735931e51547377cd1796c982a5ac88d0f2299c0811")
     version("5.4.0", sha256="0f2b671c69caa993fedb48187b3bdcc94c22400ec84c926fd0898dbff68aa03e")
     version("5.3.0", sha256="c290e554c4253124ac2ab8b056e14ee4d23966b8c9fbfa10ba81f75ae543ce4e")


### PR DESCRIPTION
CHANGELOG:

- Add support for AMD Zen5
- Change hashtable to cwisstable
- New internals for error handling and memory management
- Topdown metrics for Intel SPR, ENR and GNR
- Update for Nvidia GPU support
- Less startup overhead by using optimized Uncore discovery for Intel
- A lot of warnings got fixed
- Wider data types for power readings
- Measure energy consumption for Nvidia GPUs
- Better messages when connection to access daemon fails
- Fix for SPR UPI and M3UPI units
- More peakflops benchmarks in likwid-bench
- Fixes for sysfeatures
- Update to buildsystem to allow parallel builds
- Wrapper mode for GPU monitoring
- Memory controllers (UMC) for AMD Zen4
- Minor fixes for Intel SierraForrest and Coffeelake