### PR TITLE
Fix(petsc): Correct hypre dependency constraints

### DIFF
--- a/repos/spack_repo/builtin/packages/petsc/package.py
+++ b/repos/spack_repo/builtin/packages/petsc/package.py
@@ -317,10 +317,10 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     depends_on("hypre~complex", when="+hypre~complex")
     depends_on("hypre+int64", when="+hypre+int64")
     depends_on("hypre~int64", when="+hypre~int64")
-    depends_on("hypre+mpi~internal-superlu", when="+hypre")
+    depends_on("hypre+mpi", when="+hypre")
     depends_on("hypre@2.14:2.22.0", when="@3.14:3.15+hypre")
     depends_on("hypre@2.14:2.28.0", when="@3.16:3.19+hypre")
-    depends_on("hypre@2.14:", when="@3.20+hypre")
+    depends_on("hypre@2.14:", when="@3.20:3.21+hypre")
     depends_on("hypre@2.32:", when="@3.22:+hypre")
     depends_on("hypre@develop", when="@main+hypre")
 


### PR DESCRIPTION
This PR fixes a dependency concretization error for `petsc` when `+hypre` is enabled.

1.  **Removed deprecated `~internal-superlu` dependency:**
    The `internal-superlu` variant only exists in `hypre@:2.12.1`, which directly conflicts with `petsc`'s requirement for `hypre@2.14:`. This change removes the `~internal-superlu` constraint.

2.  **Added missing version constraint for `petsc@3.21`:**
    The dependency `depends_on("hypre@2.14:", when="@3.20+hypre")` was missing the upper bound for `petsc@3.21`. This has been corrected to `when="@3.20:3.21+hypre"`.