### PR TITLE
uwtools: add 'main' and update deps

### DIFF
--- a/repos/spack_repo/builtin/packages/uwtools/package.py
+++ b/repos/spack_repo/builtin/packages/uwtools/package.py
@@ -23,6 +23,7 @@ class Uwtools(PythonPackage):
 
     license("GPL-2.0-or-later", checked_by="WeirAE")
 
+    version("main", branch="main")
     # Latest three minor releases per deprecation policy
     version("2.8.2", sha256="634f7fbc33cd9439f43df00c1d904266b9c51b3f386c2141c26c1229d4d95a34")
     version("2.7.2", sha256="56816d543664792258bfa7dfb7e4cc66f794959dc92dc3710021f40a2b8571a4")
@@ -37,9 +38,10 @@ class Uwtools(PythonPackage):
     depends_on("iotaa@1.1", when="@2.6")
     depends_on("iotaa@1.2", when="@2.7")
     depends_on("iotaa@1.3:2.0", when="@2.8:")
-    depends_on("py-jsonschema@4.18:4.23")
+    depends_on("py-jsonschema@4.17:")
+    depends_on("py-jsonschema@4.18:4.23", when="@:2.11")
     depends_on("py-lxml@5.2", when="@2.7")
-    depends_on("py-lxml@5.2:5.4", when="@2.8")
+    depends_on("py-lxml@5.2:5.4", when="@2.8:")
     depends_on("py-lxml@5.3", when="@:2.6")
     depends_on("py-python-dateutil@2.9:", when="@2.8:")
     depends_on("py-pyyaml@6.0")


### PR DESCRIPTION
This PR:
 - adds 'main' branch to uwtools package.py to facilitate testing etc.
 - ensures py-lxml is always a dependency including when using 'main'
 - allows versions 2.12 onward to use a slightly older, non-rust dependent version of py-jsonschema.