### PR TITLE
cprnc: use placement instead of destination for genf90 resource

### DIFF
--- a/repos/spack_repo/builtin/packages/cprnc/package.py
+++ b/repos/spack_repo/builtin/packages/cprnc/package.py
@@ -36,12 +36,12 @@ class Cprnc(CMakePackage):
         git="https://github.com/PARALLELIO/genf90",
         tag="genf90_200608",
         commit="4816965ba946731352bad195b7d946a5fe682ff5",
-        destination="genf90-resource",
+        placement="genf90",
     )
 
     def cmake_args(self):
         args = [
-            self.define("GENF90_PATH", join_path(self.stage.source_path, "genf90-resource/genf90"))
+            self.define("GENF90_PATH", join_path(self.stage.source_path, "genf90"))
         ]
 
         return args

--- a/repos/spack_repo/builtin/packages/cprnc/package.py
+++ b/repos/spack_repo/builtin/packages/cprnc/package.py
@@ -40,8 +40,6 @@ class Cprnc(CMakePackage):
     )
 
     def cmake_args(self):
-        args = [
-            self.define("GENF90_PATH", join_path(self.stage.source_path, "genf90"))
-        ]
+        args = [self.define("GENF90_PATH", join_path(self.stage.source_path, "genf90"))]
 
         return args


### PR DESCRIPTION
This PR use placement instead of destination for the genf90 resource in cprnc. This seems to be the only way to consistently have the path of the resource be correctly set, especially when using cached source code.