### PR TITLE
llama-cpp and ggml: new packages

### DIFF
--- a/repos/spack_repo/builtin/packages/ggml/package.py
+++ b/repos/spack_repo/builtin/packages/ggml/package.py
@@ -1,0 +1,81 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems.cuda import CudaPackage
+from spack_repo.builtin.build_systems.rocm import ROCmPackage
+
+from spack.package import *
+
+
+class Ggml(CMakePackage, CudaPackage, ROCmPackage):
+    """Tensor library for machine learning"""
+
+    homepage = "https://github.com/ggml-org/ggml"
+    git = "https://github.com/ggml-org/ggml.git"
+
+    maintainers("rbberger")
+
+    license("MIT")
+
+    version("master", branch="master")
+    version("0.9.4", tag="v0.9.4", commit="72632094336524a9c809e129e8b1c52154543a5a")
+
+    variant("shared", default=True, description="build shared libraries")
+    variant("cpu", default=True, description="build CPU backend")
+    variant("blas", default=True, description="build BLAS backend")
+    variant("openmp", default=True, description="build OpenMP backend")
+    variant("cuda", default=False, description="build CUDA backend")
+    variant("rocm", default=False, description="build HIP backend")
+    variant("metal", default=True, description="build Metal backend", when="platform=darwin")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    depends_on("git", type="build")
+
+    depends_on("blas", when="+blas")
+    depends_on("llvm-openmp", when="platform=darwin %apple-clang")
+
+    depends_on("hipblas", when="+rocm")
+    depends_on("rocblas", when="+rocm")
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define_from_variant("GGML_CPU", "cpu"),
+            self.define_from_variant("GGML_BLAS", "blas"),
+            self.define_from_variant("GGML_OPENMP", "openmp"),
+            self.define_from_variant("GGML_CUDA", "cuda"),
+            self.define_from_variant("GGML_ROCM", "rocm"),
+            self.define_from_variant("GGML_METAL", "metal"),
+        ]
+
+        if self.spec.satisfies("+blas"):
+            if self.spec.satisfies("%blas=openblas"):
+                blas_vendor = "OpenBLAS"
+            elif self.spec.satisfies("%blas=intel-oneapi-mkl"):
+                blas_vendor = "Intel"
+            else:
+                blas_vendor = "Generic"
+            args.append(self.define("GGML_BLAS_VENDOR", blas_vendor))
+
+        if self.spec.satisfies("+cuda"):
+            args.append(self.define("CMAKE_CUDA_COMPILER", f"{self.spec['cuda'].prefix}/bin/nvcc"))
+            if not self.spec.satisfies("cuda_arch=none"):
+                archs = self.spec.variants["cuda_arch"].value
+                arch_str = ";".join(archs)
+                args.append(self.define("CMAKE_CUDA_ARCHITECTURES", arch_str))
+
+        if self.spec.satisfies("+rocm"):
+            args.append(
+                self.define(
+                    "CMAKE_HIP_COMPILER", f"{self.spec['llvm-amdgpu'].prefix}/bin/amdclang++"
+                )
+            )
+            if not self.spec.satisfies("amdgpu_target=none"):
+                archs = self.spec.variants["amdgpu_target"].value
+                arch_str = ";".join(archs)
+                args.append(self.define("CMAKE_HIP_ARCHITECTURES", arch_str))
+        return args

--- a/repos/spack_repo/builtin/packages/ggml/package.py
+++ b/repos/spack_repo/builtin/packages/ggml/package.py
@@ -29,6 +29,7 @@ class Ggml(CMakePackage, CudaPackage, ROCmPackage):
     variant("cuda", default=False, description="build CUDA backend")
     variant("rocm", default=False, description="build HIP backend")
     variant("metal", default=True, description="build Metal backend", when="platform=darwin")
+    variant("rpc", default=False, description="build with RPC support")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
@@ -50,6 +51,7 @@ class Ggml(CMakePackage, CudaPackage, ROCmPackage):
             self.define_from_variant("GGML_CUDA", "cuda"),
             self.define_from_variant("GGML_ROCM", "rocm"),
             self.define_from_variant("GGML_METAL", "metal"),
+            self.define_from_variant("GGML_RPC", "rpc"),
         ]
 
         if self.spec.satisfies("+blas"):

--- a/repos/spack_repo/builtin/packages/ggml/package.py
+++ b/repos/spack_repo/builtin/packages/ggml/package.py
@@ -84,6 +84,4 @@ class Ggml(GGMLPackageBase):
     license("MIT")
 
     version("master", branch="master")
-    version("0.9.4-20251120", commit="781baf2a14d9e0aaee542b2e1bb918bfc4132199")
-    version("0.9.4-20251117", commit="c23776f22d616d8cb635145381cad365bac675e7")
     version("0.9.4", tag="v0.9.4", commit="72632094336524a9c809e129e8b1c52154543a5a")

--- a/repos/spack_repo/builtin/packages/ggml/package.py
+++ b/repos/spack_repo/builtin/packages/ggml/package.py
@@ -59,6 +59,8 @@ class Ggml(CMakePackage, CudaPackage, ROCmPackage):
                 blas_vendor = "OpenBLAS"
             elif self.spec.satisfies("%blas=intel-oneapi-mkl"):
                 blas_vendor = "Intel"
+            elif self.spec.satisfies("%blas=veclibfort"):
+                blas_vendor = "Apple"
             else:
                 blas_vendor = "Generic"
             args.append(self.define("GGML_BLAS_VENDOR", blas_vendor))

--- a/repos/spack_repo/builtin/packages/ggml/package.py
+++ b/repos/spack_repo/builtin/packages/ggml/package.py
@@ -20,6 +20,7 @@ class Ggml(CMakePackage, CudaPackage, ROCmPackage):
     license("MIT")
 
     version("master", branch="master")
+    version("0.9.4-20251117", commit="c23776f22d616d8cb635145381cad365bac675e7")
     version("0.9.4", tag="v0.9.4", commit="72632094336524a9c809e129e8b1c52154543a5a")
 
     variant("shared", default=True, description="build shared libraries")

--- a/repos/spack_repo/builtin/packages/ggml/package.py
+++ b/repos/spack_repo/builtin/packages/ggml/package.py
@@ -9,21 +9,7 @@ from spack_repo.builtin.build_systems.rocm import ROCmPackage
 from spack.package import *
 
 
-class Ggml(CMakePackage, CudaPackage, ROCmPackage):
-    """Tensor library for machine learning"""
-
-    homepage = "https://github.com/ggml-org/ggml"
-    git = "https://github.com/ggml-org/ggml.git"
-
-    maintainers("rbberger")
-
-    license("MIT")
-
-    version("master", branch="master")
-    version("0.9.4-20251120", commit="781baf2a14d9e0aaee542b2e1bb918bfc4132199")
-    version("0.9.4-20251117", commit="c23776f22d616d8cb635145381cad365bac675e7")
-    version("0.9.4", tag="v0.9.4", commit="72632094336524a9c809e129e8b1c52154543a5a")
-
+class GGMLPackageBase(CMakePackage, CudaPackage, ROCmPackage):
     variant("shared", default=True, description="build shared libraries")
     variant("cpu", default=True, description="build CPU backend")
     variant("blas", default=True, description="build BLAS backend")
@@ -85,3 +71,19 @@ class Ggml(CMakePackage, CudaPackage, ROCmPackage):
                 arch_str = ";".join(archs)
                 args.append(self.define("CMAKE_HIP_ARCHITECTURES", arch_str))
         return args
+
+
+class Ggml(GGMLPackageBase):
+    """Tensor library for machine learning"""
+
+    homepage = "https://github.com/ggml-org/ggml"
+    git = "https://github.com/ggml-org/ggml.git"
+
+    maintainers("rbberger")
+
+    license("MIT")
+
+    version("master", branch="master")
+    version("0.9.4-20251120", commit="781baf2a14d9e0aaee542b2e1bb918bfc4132199")
+    version("0.9.4-20251117", commit="c23776f22d616d8cb635145381cad365bac675e7")
+    version("0.9.4", tag="v0.9.4", commit="72632094336524a9c809e129e8b1c52154543a5a")

--- a/repos/spack_repo/builtin/packages/ggml/package.py
+++ b/repos/spack_repo/builtin/packages/ggml/package.py
@@ -20,6 +20,7 @@ class Ggml(CMakePackage, CudaPackage, ROCmPackage):
     license("MIT")
 
     version("master", branch="master")
+    version("0.9.4-20251120", commit="781baf2a14d9e0aaee542b2e1bb918bfc4132199")
     version("0.9.4-20251117", commit="c23776f22d616d8cb635145381cad365bac675e7")
     version("0.9.4", tag="v0.9.4", commit="72632094336524a9c809e129e8b1c52154543a5a")
 

--- a/repos/spack_repo/builtin/packages/llama_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/llama_cpp/package.py
@@ -26,7 +26,7 @@ class LlamaCpp(GGMLPackageBase):
     version("7086", tag="b7086", commit="7aaeedc098a77e9323044187101db4f6b69988da")
 
     variant("curl", default=True, description="use curl for model download")
-    variant("system_ggml", default=False, description="build embedded GGML library")
+    variant("system_ggml", default=False, description="use external GGML library")
 
     depends_on("curl", when="+curl")
     depends_on("ggml", when="+system_ggml")

--- a/repos/spack_repo/builtin/packages/llama_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/llama_cpp/package.py
@@ -32,6 +32,13 @@ class LlamaCpp(CMakePackage):
     depends_on("curl", when="+curl")
     depends_on("ggml")
 
+    # Fixes RPC tool install https://github.com/ggml-org/llama.cpp/pull/17149
+    patch(
+        "https://github.com/ggml-org/llama.cpp/commit/d2d626938aa7b0137df6a808e0637151806a9d5a.patch?full_index=1",
+        sha256="ad664f362da58313f5230c2c895da0201b3c2ba120c6d7072563b30f387f8fe3",
+        when="@:7019 ^ggml+rpc",
+    )
+
     def cmake_args(self):
         args = [
             self.define("LLAMA_USE_SYSTEM_GGML", True),

--- a/repos/spack_repo/builtin/packages/llama_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/llama_cpp/package.py
@@ -5,11 +5,14 @@
 import os
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems.cuda import CudaPackage
+from spack_repo.builtin.build_systems.rocm import ROCmPackage
+from spack_repo.builtin.packages.ggml.package import GGMLPackageBase
 
 from spack.package import *
 
 
-class LlamaCpp(CMakePackage):
+class LlamaCpp(GGMLPackageBase):
     """LLM inference in C/C++"""
 
     homepage = "https://github.com/ggml-org/llama.cpp"
@@ -20,34 +23,36 @@ class LlamaCpp(CMakePackage):
     license("MIT")
 
     version("master", branch="master")
+    version("7158", tag="b7158", commit="b3b03a7baf387cfeaf56641bd14c06dbd3d2fcf0")
     version("7086", tag="b7086", commit="7aaeedc098a77e9323044187101db4f6b69988da")
-    version("6999", tag="b6999", commit="cb1adf885105da7ce23db746b4202f4e987aa3e8")
 
-    variant("shared", default=True, description="build shared libraries")
     variant("curl", default=True, description="use curl for model download")
-
-    depends_on("c", type="build")
-    depends_on("cxx", type="build")
-    depends_on("git", type="build")
+    variant("system_ggml", default=False, description="build embedded GGML library")
 
     depends_on("curl", when="+curl")
-    depends_on("ggml")
+    depends_on("ggml", when="+system_ggml")
 
-    depends_on("ggml@0.9.4-20251117:", when="@7086:")
+    depends_on("ggml@0.9.4-20251117:", when="@7086 +system_ggml")
 
-    # Fixes RPC tool install https://github.com/ggml-org/llama.cpp/pull/17149
-    patch(
-        "https://github.com/ggml-org/llama.cpp/commit/d2d626938aa7b0137df6a808e0637151806a9d5a.patch?full_index=1",
-        sha256="ad664f362da58313f5230c2c895da0201b3c2ba120c6d7072563b30f387f8fe3",
-        when="@:7019 ^ggml+rpc",
-    )
+    for v in ("cpu", "blas", "openmp", "cuda", "rocm", "metal", "rpc"):
+        depends_on(f"ggml+{v}", when=f"+system_ggml +{v}")
+        depends_on(f"ggml~{v}", when=f"+system_ggml ~{v}")
+
+    for _flag in list(CudaPackage.cuda_arch_values):
+        depends_on(f"ggml cuda_arch={_flag}", when=f"+cuda+system_ggml cuda_arch={_flag}")
+
+    for _flag in ROCmPackage.amdgpu_targets:
+        depends_on(f"ggml amdgpu_target={_flag}", when=f"+rocm+system_ggml amdgpu_target={_flag}")
 
     def cmake_args(self):
         args = [
-            self.define("LLAMA_USE_SYSTEM_GGML", True),
+            self.define_from_variant("LLAMA_USE_SYSTEM_GGML", "system_ggml"),
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant("LLAMA_USE_CURL", "curl"),
         ]
+
+        if self.spec.satisfies("~system_ggml"):
+            args.extend(super().cmake_args())
         return args
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:

--- a/repos/spack_repo/builtin/packages/llama_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/llama_cpp/package.py
@@ -1,0 +1,39 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class LlamaCpp(CMakePackage):
+    """LLM inference in C/C++"""
+
+    homepage = "https://github.com/ggml-org/llama.cpp"
+    git = "https://github.com/ggml-org/llama.cpp.git"
+
+    maintainers("rbberger")
+
+    license("MIT")
+
+    version("master", branch="master")
+    version("6999", tag="b6999", commit="cb1adf885105da7ce23db746b4202f4e987aa3e8")
+
+    variant("shared", default=True, description="build shared libraries")
+    variant("curl", default=True, description="use curl for model download")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("git", type="build")
+
+    depends_on("curl", when="+curl")
+    depends_on("ggml")
+
+    def cmake_args(self):
+        args = [
+            self.define("LLAMA_USE_SYSTEM_GGML", True),
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define_from_variant("LLAMA_USE_CURL", "curl"),
+        ]
+        return args

--- a/repos/spack_repo/builtin/packages/llama_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/llama_cpp/package.py
@@ -20,7 +20,7 @@ class LlamaCpp(CMakePackage):
     license("MIT")
 
     version("master", branch="master")
-    version("7086" tag="b7086", commit="7aaeedc098a77e9323044187101db4f6b69988da")
+    version("7086", tag="b7086", commit="7aaeedc098a77e9323044187101db4f6b69988da")
     version("6999", tag="b6999", commit="cb1adf885105da7ce23db746b4202f4e987aa3e8")
 
     variant("shared", default=True, description="build shared libraries")

--- a/repos/spack_repo/builtin/packages/llama_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/llama_cpp/package.py
@@ -31,8 +31,6 @@ class LlamaCpp(GGMLPackageBase):
     depends_on("curl", when="+curl")
     depends_on("ggml", when="+system_ggml")
 
-    depends_on("ggml@0.9.4-20251117:", when="@7086 +system_ggml")
-
     for v in ("cpu", "blas", "openmp", "cuda", "rocm", "metal", "rpc"):
         depends_on(f"ggml+{v}", when=f"+system_ggml +{v}")
         depends_on(f"ggml~{v}", when=f"+system_ggml ~{v}")

--- a/repos/spack_repo/builtin/packages/llama_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/llama_cpp/package.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
@@ -37,3 +39,9 @@ class LlamaCpp(CMakePackage):
             self.define_from_variant("LLAMA_USE_CURL", "curl"),
         ]
         return args
+
+    def setup_run_environment(self, env: EnvironmentModifications) -> None:
+        if os.path.exists(self.prefix.lib64):
+            env.set("LLAMA_CPP_LIB_PATH", self.prefix.lib64)
+        else:
+            env.set("LLAMA_CPP_LIB_PATH", self.prefix.lib)

--- a/repos/spack_repo/builtin/packages/llama_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/llama_cpp/package.py
@@ -4,7 +4,6 @@
 
 import os
 
-from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 from spack_repo.builtin.packages.ggml.package import GGMLPackageBase

--- a/repos/spack_repo/builtin/packages/llama_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/llama_cpp/package.py
@@ -20,6 +20,7 @@ class LlamaCpp(CMakePackage):
     license("MIT")
 
     version("master", branch="master")
+    version("7086" tag="b7086", commit="7aaeedc098a77e9323044187101db4f6b69988da")
     version("6999", tag="b6999", commit="cb1adf885105da7ce23db746b4202f4e987aa3e8")
 
     variant("shared", default=True, description="build shared libraries")
@@ -31,6 +32,8 @@ class LlamaCpp(CMakePackage):
 
     depends_on("curl", when="+curl")
     depends_on("ggml")
+
+    depends_on("ggml@0.9.4-20251117:", when="@7086:")
 
     # Fixes RPC tool install https://github.com/ggml-org/llama.cpp/pull/17149
     patch(


### PR DESCRIPTION
This is a useful LLM package for quickly running LLMs without many dependencies. Installing it via Spack allows you to then run something like:

```
llama-server -hf ggml-org/gpt-oss-20b-GGUF --jinja -c 0 --host 127.0.0.1 --port 8033
```

A python interface was added in https://github.com/spack/spack-packages/pull/2441

- [x] ~Depends on: https://github.com/spack/spack-packages/pull/2436~ (merged with this one)

Given the high development velocity of llama-cpp, it makes more sense to build with the embedded GGML, which is why both packages share a common base class for adding GGML build options, variants and dependencies.