### PR TITLE
root: require openblas ~ilp64 symbol_suffix=none when ^openblas

### DIFF
--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -374,7 +374,7 @@ class Root(CMakePackage):
 
     # TMVA
     depends_on("blas", when="+tmva-cpu")
-    requires("^openblas ~ilp64 symbol_suffix=none", when="^openblas")
+    requires("^openblas ~ilp64 symbol_suffix=none", when="^[virtuals=blas] openblas")
     depends_on("cuda", when="+tmva-gpu")
     depends_on("protobuf@3:", when="+tmva-sofie")
 

--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -374,6 +374,7 @@ class Root(CMakePackage):
 
     # TMVA
     depends_on("blas", when="+tmva-cpu")
+    requires("^openblas ~ilp64 symbol_suffix=none", when="^openblas")
     depends_on("cuda", when="+tmva-gpu")
     depends_on("protobuf@3:", when="+tmva-sofie")
 


### PR DESCRIPTION
This PR ensures that `root` depends on the correct `openblas`, i.e. not one that `julia` may have pulled in and has 64-bit integers and symbol suffixes. See also `r` which requires this as well.