### PR TITLE
cdi: change origin to gitlab repo, add version 2.5.4 and add cmake fix for latest versions

### DIFF
--- a/repos/spack_repo/builtin/packages/cdi/cmake-config-libname.patch
+++ b/repos/spack_repo/builtin/packages/cdi/cmake-config-libname.patch
@@ -1,0 +1,11 @@
+--- a/src/cmake/cdi/cdi-config.cmake.in 2025-11-17 12:11:39.815703396 +0100
++++ b/src/cmake/cdi/cdi-config.cmake.in 2025-11-17 12:12:10.614797500 +0100
+@@ -15,7 +15,7 @@
+ mark_as_advanced(CDI_INCLUDE_DIRECTORY)
+
+ find_library(CDI_LIBRARY
+-  NAMES cdilib
++  NAMES cdi
+   PATHS "${CDI_ROOT_DIR}/lib"
+   # use following line instead of previous if this file can be configured
+   # PATHS "@libdir@"

--- a/repos/spack_repo/builtin/packages/cdi/package.py
+++ b/repos/spack_repo/builtin/packages/cdi/package.py
@@ -17,6 +17,7 @@ class Cdi(AutotoolsPackage):
     url = "https://gitlab.dkrz.de/mpim-sw/libcdi/-/archive/cdi-2.4.0/download.tar.gz"
     git = "https://gitlab.dkrz.de/mpim-sw/libcdi"
 
+    version("2.5.4", sha256="605d4a9192e9657d87bdbe544e31c96b81890e9acdfc137ecc8581721ce5390f")
     version("2.5.3", sha256="e6a97e4af7a18afcc8caee13e2018c61e6885d871fd20441b51d7eae123c8305")
     version("2.5.1.1", sha256="922a62c85ea7b7445f13821ec69516ce36f8ef0965e5fa6e6e560db57f264763")
     version("2.5.1", sha256="639985873f82cd11d5cbfc121939e8d6ea24dc8454314845d5a7abd056878f59")

--- a/repos/spack_repo/builtin/packages/cdi/package.py
+++ b/repos/spack_repo/builtin/packages/cdi/package.py
@@ -28,6 +28,13 @@ class Cdi(AutotoolsPackage):
         "netcdf", default=True, description="This is needed to read/write NetCDF files with CDI"
     )
 
+    with default_args(type="build"):
+        depends_on("c")
+
+        depends_on("autoconf")
+        depends_on("automake")
+        depends_on("libtool")
+
     depends_on("netcdf-c", when="+netcdf")
 
     def configure_args(self):

--- a/repos/spack_repo/builtin/packages/cdi/package.py
+++ b/repos/spack_repo/builtin/packages/cdi/package.py
@@ -6,20 +6,6 @@ from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 
 from spack.package import *
 
-# Note:
-# download links are in the form
-# https://code.mpimet.mpg.de/attachments/download/29309/cdi-2.4.0.tar.gz
-# and this maps versions to resource identifiers used internally (e.g. 29309 in the url above)
-# so that `url_for_version` can compose the right url for each version.
-RESOURCE_ID = {
-    "2.5.3": 30033,
-    "2.5.1.1": 29871,
-    "2.5.1": 29860,
-    "2.5.0": 29833,
-    "2.4.3": 29658,
-    "2.4.0": 29309,
-}
-
 
 class Cdi(AutotoolsPackage):
     """
@@ -28,28 +14,21 @@ class Cdi(AutotoolsPackage):
     """
 
     homepage = "https://code.mpimet.mpg.de/projects/cdi"
-    url = "https://code.mpimet.mpg.de/attachments/download/29309/cdi-2.4.0.tar.gz"
+    url = "https://gitlab.dkrz.de/mpim-sw/libcdi/-/archive/cdi-2.4.0/download.tar.gz"
+    git = "https://gitlab.dkrz.de/mpim-sw/libcdi"
 
-    version("2.5.3", sha256="1ebf6098b195c0bb13614015b62a63efd2ef3d4ee94f4c69cadcf236854b2303")
-    version("2.5.1.1", sha256="a78c577324eb99ef461e90f717b75a1843304ac6613ebd168fdad12f84d78539")
-    version("2.5.1", sha256="7e369ed455d153bfbfcb5abd343779dc254b798b0d5ea641cd497a49e39f4de5")
-    version("2.5.0", sha256="19654af187d8b29e708b1c7e4726143cf26547966dceba8cc5b68690281ddad9")
-    version("2.4.3", sha256="7bf3df83968e15d718857a4823c0bae7d9c16ea17ca95524e1e5b68ab73d2c0d")
-    version("2.4.0", sha256="91fca015b04c6841b9eab8b49e7726d35e35b9ec4350922072ec6e9d5eb174ef")
+    version("2.5.3", sha256="e6a97e4af7a18afcc8caee13e2018c61e6885d871fd20441b51d7eae123c8305")
+    version("2.5.1.1", sha256="922a62c85ea7b7445f13821ec69516ce36f8ef0965e5fa6e6e560db57f264763")
+    version("2.5.1", sha256="639985873f82cd11d5cbfc121939e8d6ea24dc8454314845d5a7abd056878f59")
+    version("2.5.0", sha256="511f5fd9414ef68e7f452a4114eae4a319dd8ff45f0e80ab07be2b16d35c79e9")
+    version("2.4.3", sha256="b54e110feff209855cebf00751d5bb912ddf6f177bc1471a48a53ea751b982ab")
+    version("2.4.0", sha256="f7e27fa067177d89ff95080705863025b9e8d2c5e660352c1e193a42bf3c6683")
 
     variant(
         "netcdf", default=True, description="This is needed to read/write NetCDF files with CDI"
     )
 
     depends_on("netcdf-c", when="+netcdf")
-
-    def url_for_version(self, version):
-        resource_id = RESOURCE_ID.get(str(version))
-        if resource_id is None:
-            raise InstallError(f"don't know which url to use to download cdi@{version}")
-        return "https://code.mpimet.mpg.de/attachments/download/{}/cdi-{}.tar.gz".format(
-            resource_id, version
-        )
 
     def configure_args(self):
         args = []

--- a/repos/spack_repo/builtin/packages/cdi/package.py
+++ b/repos/spack_repo/builtin/packages/cdi/package.py
@@ -38,6 +38,12 @@ class Cdi(AutotoolsPackage):
 
     depends_on("netcdf-c", when="+netcdf")
 
+    # note:
+    # starting from 2.5.1 the provided cmake config file looks for `cdi` instead of `libcdi`,
+    # but autotools still builds `cdi`.
+    # cmake build system is going to build `libcdi` in future releases.
+    patch("cmake-config-libname.patch", when="@2.5.1: build_system=autotools")
+
     def configure_args(self):
         args = []
         if "+netcdf" in self.spec:


### PR DESCRIPTION
I discovered there is a gitlab repo available for `cdi`, so I preferred switching the origin to it.

Changelog:
- switched origin for all versions
- differently from release tarballs (used previously), now `autoreconf` is needed
- add `depends_on("c")`
- add 2.5.4
- add a fix for cmake config provided by the package, which looks for the wrong library file (I'm going to report that)