### PR TITLE
Add tag to the latest MOAB version v5.6.0

### DIFF
--- a/repos/spack_repo/builtin/packages/moab/package.py
+++ b/repos/spack_repo/builtin/packages/moab/package.py
@@ -19,7 +19,7 @@ class Moab(AutotoolsPackage):
 
     homepage = "https://sigma.mcs.anl.gov/moab-library"
     git = "https://bitbucket.org/fathomteam/moab.git"
-    url = "https://web.cels.anl.gov/projects/sigma/downloads/moab/moab-5.5.1.tar.gz"
+    url = "https://web.cels.anl.gov/projects/sigma/downloads/moab/moab-5.6.0.tar.gz"
 
     maintainers("vijaysm", "iulian787", "xylar", "andrewdnolan")
 
@@ -27,6 +27,7 @@ class Moab(AutotoolsPackage):
 
     version("develop", branch="develop")
     version("master", branch="master")
+    version("5.6.0", sha256="8d24a38619eb9fd326c7bdf9fdb01466149a0ab7dc3ef1caffda728858bf5a85")
     version("5.5.1", sha256="67b6ed3a13c235cec16f60f8f46f9bf0371fd321cf36dea113d0e09f09d0d438")
     version("5.5.0", sha256="58969f8a1b209ec9036c08c53a6b7078b368eb3bf99d0368a4de5a2f2a8db678")
     version("5.4.1", sha256="3625e25321bf37f88d98438f5d56c280b2774172602d8b6eb6c34eedf37686fc")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Updating hash to point to the latest MOAB v5.6.0 tag.

Additional reviewer: @xylar 