### PR TITLE
OpenMC: add v0.15.2 and v0.15.1

### DIFF
--- a/repos/spack_repo/builtin/packages/openmc/package.py
+++ b/repos/spack_repo/builtin/packages/openmc/package.py
@@ -19,12 +19,14 @@ class Openmc(CMakePackage):
     programming model."""
 
     homepage = "https://docs.openmc.org/"
-    url = "https://github.com/openmc-dev/openmc/tarball/v0.15.0"
+    url = "https://github.com/openmc-dev/openmc/tarball/v0.15.2"
     git = "https://github.com/openmc-dev/openmc.git"
     maintainers("paulromano")
 
     version("develop", branch="develop", submodules=True)
     version("master", branch="master", submodules=True)
+    version("0.15.2", commit="e23760b0264c66fb7bb373aa0596801e5209d920", submodules=True)
+    version("0.15.1", commit="906548db20d4ce3c322e7317992c73b51daeb11d", submodules=True)
     version("0.15.0", commit="55b52b7ef3c9415ce045712132bf31c2a013d8c8", submodules=True)
     version("0.14.0", commit="fa2330103de61a864c958d1a7250f11e5dd91468", submodules=True)
     version("0.13.3", commit="27cb0dc97960fe6d750eb5a93584a9a0ca532ac8", submodules=True)

--- a/repos/spack_repo/builtin/packages/py_openmc/package.py
+++ b/repos/spack_repo/builtin/packages/py_openmc/package.py
@@ -18,12 +18,14 @@ class PyOpenmc(PythonPackage):
     programming model."""
 
     homepage = "https://docs.openmc.org/"
-    url = "https://github.com/openmc-dev/openmc/tarball/v0.15.0"
+    url = "https://github.com/openmc-dev/openmc/tarball/v0.15.2"
     git = "https://github.com/openmc-dev/openmc.git"
     maintainers("paulromano")
 
     version("develop", branch="develop")
     version("master", branch="master")
+    version("0.15.2", commit="e23760b0264c66fb7bb373aa0596801e5209d920", submodules=True)
+    version("0.15.1", commit="906548db20d4ce3c322e7317992c73b51daeb11d", submodules=True)
     version("0.15.0", commit="55b52b7ef3c9415ce045712132bf31c2a013d8c8", submodules=True)
     version("0.14.0", commit="fa2330103de61a864c958d1a7250f11e5dd91468", submodules=True)
     version("0.13.3", commit="27cb0dc97960fe6d750eb5a93584a9a0ca532ac8", submodules=True)
@@ -44,6 +46,8 @@ class PyOpenmc(PythonPackage):
     for ver in [
         "develop",
         "master",
+        "0.15.2",
+        "0.15.1",
         "0.15.0",
         "0.14.0",
         "0.13.3",
@@ -63,7 +67,8 @@ class PyOpenmc(PythonPackage):
         )
 
     depends_on("git", type="build")
-    depends_on("python@3.10:", type=("build", "run"), when="@0.15.0:")
+    depends_on("python@3.11:", type=("build", "run"), when="@0.15.1:")
+    depends_on("python@3.10:", type=("build", "run"), when="@0.15.0")
     depends_on("python@3.7:", type=("build", "run"), when="@0.13.2:0.14.0")
     depends_on("python@3.6:", type=("build", "run"), when="@0.13.0:0.13.1")
     depends_on("python@3.5:", type=("build", "run"), when="@:0.12")
@@ -74,7 +79,7 @@ class PyOpenmc(PythonPackage):
     depends_on("py-lxml", type=("build", "run"))
     depends_on("py-matplotlib", type=("build", "run"))
     depends_on("py-mpi4py", when="+mpi", type=("build", "run"))
-    depends_on("py-numpy@1.9:1.21", type=("build", "run"))
+    depends_on("py-numpy", type=("build", "run"))
     depends_on("py-pandas", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-scipy", type=("build", "run"))


### PR DESCRIPTION
Updating the `openmc` and `py-openmc` package with two releases:

https://github.com/openmc-dev/openmc/releases/tag/v0.15.2
https://github.com/openmc-dev/openmc/releases/tag/v0.15.1
