### PR TITLE
FIX: add +cxx to sirius hdf5 dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/sirius/package.py
+++ b/repos/spack_repo/builtin/packages/sirius/package.py
@@ -96,7 +96,7 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("libxc@4.0.0:", when="@7.2.0:")
     depends_on("libxc@:7", when="@:7.5")
     depends_on("spglib")
-    depends_on("hdf5+hl")
+    depends_on("hdf5+hl+cxx")
     depends_on("pkgconfig", type="build")
     depends_on("fmt", when="@7.8:")
     depends_on("simple-dftd3 build_system=cmake", when="+dftd3")


### PR DESCRIPTION
On SLES15.6 I get the following error when trying to compile sirius with hdf5:

 >> 395    /scratch/svcusr-spack/.spack/spack-stage/spack-stage-sirius-7.8.0-shqlazrrje3f74fk7xvctezs3ysfxtrx/spack-src/src/core/hdf5_tree.hpp:18:10: fatal error: hdf5.h:
             No such file or directory
     396       18 | #include <hdf5.h>
     397          |          ^~~~~~~~
     398    compilation terminated.
  >> 399    make[2]: *** [src/CMakeFiles/sirius_cxx.dir/build.make:306: src/CMakeFiles/sirius_cxx.dir/potential/generate_pw_coeffs.cpp.o] Error 1
     400    make[2]: Leaving directory '/scratch/svcusr-spack/.spack/spack-stage/spack-stage-sirius-7.8.0-shqlazrrje3f74fk7xvctezs3ysfxtrx/spack-build-shqlazr'
  >> 401    make[1]: *** [CMakeFiles/Makefile2:135: src/CMakeFiles/sirius_cxx.dir/all] Error 2
     402    make[1]: Leaving directory '/scratch/svcusr-spack/.spack/spack-stage/spack-stage-sirius-7.8.0-shqlazrrje3f74fk7xvctezs3ysfxtrx/spack-build-shqlazr'
  >> 403    make: *** [Makefile:139: all] Error
  
  Adding "depends_on(hdf5+cxx)" to the sirius package.py solves this problem.
  
