### PR TITLE
JAX: add v0.8.1+

### DIFF
--- a/repos/spack_repo/builtin/packages/py_jax/package.py
+++ b/repos/spack_repo/builtin/packages/py_jax/package.py
@@ -23,6 +23,7 @@ class PyJax(PythonPackage):
 
     tags = ["e4s"]
 
+    version("0.8.2", sha256="1a685ded06a8223a7b52e45e668e406049dbbead02873f2b5a4d881ba7b421ae")
     version("0.8.1", sha256="e53f67b15315f5e154851a7fd77a192b59c6c75b3f7ac56e214296765391cca7")
     version("0.8.0", sha256="0ea5a7be7068c25934450dfd87d7d80a18a5d30e0a53454e7aade525b23accd5")
     version("0.7.2", sha256="71a42b964bc6d52e819311429e6c0f5742e2a4650226dab1a1dd26fd986ca70d")
@@ -105,6 +106,7 @@ class PyJax(PythonPackage):
         # jax/_src/lib/__init__.py
         # https://github.com/google/jax/commit/8be057de1f50756fe7522f7e98b2f30fad56f7e4
         for v in [
+            "0.8.2",
             "0.8.1",
             "0.8.0",
             "0.7.2",
@@ -157,6 +159,7 @@ class PyJax(PythonPackage):
             depends_on(f"py-jaxlib@:{v}", when=f"@{v}")
 
         # See _minimum_jaxlib_version in jax/version.py
+        depends_on("py-jaxlib@0.8.2:", when="@0.8.2:")
         depends_on("py-jaxlib@0.8.1:", when="@0.8.1:")
         depends_on("py-jaxlib@0.8.0:", when="@0.8.0:")
         depends_on("py-jaxlib@0.7.2:", when="@0.7.2:")

--- a/repos/spack_repo/builtin/packages/py_jax/package.py
+++ b/repos/spack_repo/builtin/packages/py_jax/package.py
@@ -23,6 +23,7 @@ class PyJax(PythonPackage):
 
     tags = ["e4s"]
 
+    version("0.8.1", sha256="e53f67b15315f5e154851a7fd77a192b59c6c75b3f7ac56e214296765391cca7")
     version("0.8.0", sha256="0ea5a7be7068c25934450dfd87d7d80a18a5d30e0a53454e7aade525b23accd5")
     version("0.7.2", sha256="71a42b964bc6d52e819311429e6c0f5742e2a4650226dab1a1dd26fd986ca70d")
     version("0.7.1", sha256="118f56338c503361d2791f069d24339d8d44a8db442ed851d2e591222fb7a56d")
@@ -104,6 +105,7 @@ class PyJax(PythonPackage):
         # jax/_src/lib/__init__.py
         # https://github.com/google/jax/commit/8be057de1f50756fe7522f7e98b2f30fad56f7e4
         for v in [
+            "0.8.1",
             "0.8.0",
             "0.7.2",
             "0.7.1",
@@ -155,6 +157,7 @@ class PyJax(PythonPackage):
             depends_on(f"py-jaxlib@:{v}", when=f"@{v}")
 
         # See _minimum_jaxlib_version in jax/version.py
+        depends_on("py-jaxlib@0.8.1:", when="@0.8.1:")
         depends_on("py-jaxlib@0.8.0:", when="@0.8.0:")
         depends_on("py-jaxlib@0.7.2:", when="@0.7.2:")
         depends_on("py-jaxlib@0.7.1:", when="@0.7.1:")

--- a/repos/spack_repo/builtin/packages/py_jaxlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_jaxlib/package.py
@@ -49,6 +49,7 @@ class PyJaxlib(PythonPackage, CudaPackage, ROCmPackage):
     license("Apache-2.0")
     maintainers("adamjstewart", "jonas-eschle")
 
+    version("0.8.2", sha256="f7e5080c97c1aaffb490a17d174cb59a83dd037800d9c41d309287bebd15b0b8")
     version("0.8.1", sha256="38882602112dadfd49a2c74868a0722574ae88e04646a96f32f8c36a7893c548")
     version("0.8.0", sha256="864aa46b5a4475c70195bd3728d32224f5b5ae1c7dd9c70646ef1387b4b0b04b")
     version("0.7.2", sha256="56d92604f1bb60bb3dbd7dc7c7dc21502d10b3474b8b905ce29ce06db6a26e45")

--- a/repos/spack_repo/builtin/packages/py_jaxlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_jaxlib/package.py
@@ -49,6 +49,7 @@ class PyJaxlib(PythonPackage, CudaPackage, ROCmPackage):
     license("Apache-2.0")
     maintainers("adamjstewart", "jonas-eschle")
 
+    version("0.8.1", sha256="38882602112dadfd49a2c74868a0722574ae88e04646a96f32f8c36a7893c548")
     version("0.8.0", sha256="864aa46b5a4475c70195bd3728d32224f5b5ae1c7dd9c70646ef1387b4b0b04b")
     version("0.7.2", sha256="56d92604f1bb60bb3dbd7dc7c7dc21502d10b3474b8b905ce29ce06db6a26e45")
     version("0.7.1", sha256="8b866b775106c712a0c5532775a00941d293a4807cffae8dbcca1e03f54ce1ff")
@@ -125,7 +126,8 @@ class PyJaxlib(PythonPackage, CudaPackage, ROCmPackage):
     with default_args(type="build"):
         # Bazel tends to be backwards-compatible within major versions
         # .bazelversion
-        depends_on("bazel@7.4.1:7", when="@0.5.3:")
+        depends_on("bazel@7.7.0:7", when="@0.8.1:")
+        depends_on("bazel@7.4.1:7", when="@0.5.3:0.8.0")
         depends_on("bazel@6.5.0:6", when="@0.4.28:0.5.2")
         depends_on("bazel@6.1.2:6", when="@0.4.11:0.4.27")
         depends_on("bazel@5.1.1:5", when="@0.3.7:0.4.10")

--- a/repos/spack_repo/builtin/packages/py_jaxlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_jaxlib/package.py
@@ -175,6 +175,11 @@ class PyJaxlib(PythonPackage, CudaPackage, ROCmPackage):
         depends_on("py-ml-dtypes@0.0.3:", when="@0.4.7:")
 
     patch(
+        "https://github.com/jax-ml/jax/commit/0899e024c68254ec520006f51511f9a5e696dc17.patch?full_index=1",
+        sha256="c2509251a8708baf55e56c54fffc1725925720ff2365a0a186764f5dc50e611b",
+        when="@0.8.1:",
+    )
+    patch(
         "https://github.com/jax-ml/jax/commit/a24ae9e9d5380d074058fb862043182327f4547f.patch?full_index=1",
         sha256="2455043e7a412f5c661dfa6a55f145addbe6b0ad53f385a72caee59a4bd1ef72",
         when="@0.7.0",


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
https://github.com/jax-ml/jax/releases/tag/jax-v0.8.1