### PR TITLE
PDI: fix MPI direct dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/pdiplugin_decl_hdf5/package.py
+++ b/repos/spack_repo/builtin/packages/pdiplugin_decl_hdf5/package.py
@@ -38,6 +38,7 @@ class PdipluginDeclHdf5(CMakePackage):
     depends_on("cmake@3.16.3:", type=("build"))
     depends_on("hdf5@1.10.4:1 +shared", type=("build", "link", "run"))
     depends_on("hdf5 +mpi", type=("build", "link", "run"), when="+mpi")
+    depends_on("mpi", when="+mpi")
     for v in Pdi.versions:
         depends_on("pdi@" + str(v), type=("link", "run"), when="@" + str(v))
     depends_on("pkgconfig", type=("build"))

--- a/repos/spack_repo/builtin/packages/pdiplugin_decl_netcdf/package.py
+++ b/repos/spack_repo/builtin/packages/pdiplugin_decl_netcdf/package.py
@@ -31,6 +31,7 @@ class PdipluginDeclNetcdf(CMakePackage):
     depends_on("cxx", type="build")
 
     depends_on("cmake@3.16.3:", type=("build"))
+    depends_on("mpi", when="+mpi")
     depends_on("netcdf-c@4.7.3:4", type=("link"))
     depends_on("netcdf-c+mpi", type=("link"), when="+mpi")
     for v in Pdi.versions:


### PR DESCRIPTION
This PR adds a missing direct dependency for the plugins decl-hdf5 and decl-netcdf, see CMakeLists.txt [here](https://github.com/pdidev/pdi/blob/a1345591a799218d6f7666d772ce78306eaef632/plugins/decl_hdf5/CMakeLists.txt#L65) and [here](https://github.com/pdidev/pdi/blob/a1345591a799218d6f7666d772ce78306eaef632/plugins/decl_netcdf/CMakeLists.txt#L43).

It seems to need to be at least of type `build` and `link` to make it work, `link` only did not work for me. I don't know if it needs `run` as in the plugin mpi, see [here](https://github.com/spack/spack-packages/blob/119680aeee8ea802c6111b7167583bddef97e82f/repos/spack_repo/builtin/packages/pdiplugin_mpi/package.py#L32).