### PR TITLE
Boost: fix pre 1.70.0 container tree insertion

### DIFF
--- a/repos/spack_repo/builtin/packages/boost/container_PR101.patch
+++ b/repos/spack_repo/builtin/packages/boost/container_PR101.patch
@@ -1,0 +1,18 @@
+--- a/boost/container/detail/flat_tree.hpp
++++ b/boost/container/detail/flat_tree.hpp
+@@ -1215,14 +1215,14 @@ class flat_tree
+    template<class C2>
+    BOOST_CONTAINER_FORCEINLINE void merge_unique(flat_tree<Value, KeyOfValue, C2, AllocatorOrContainer>& source)
+    {
+-      this->insert( boost::make_move_iterator(source.begin())
++      this->insert_unique( boost::make_move_iterator(source.begin())
+                   , boost::make_move_iterator(source.end()));
+    }
+ 
+    template<class C2>
+    BOOST_CONTAINER_FORCEINLINE void merge_equal(flat_tree<Value, KeyOfValue, C2, AllocatorOrContainer>& source)
+    {
+-      this->insert( boost::make_move_iterator(source.begin())
++      this->insert_equal( boost::make_move_iterator(source.begin())
+                   , boost::make_move_iterator(source.end()));
+    }

--- a/repos/spack_repo/builtin/packages/boost/package.py
+++ b/repos/spack_repo/builtin/packages/boost/package.py
@@ -378,6 +378,14 @@ class Boost(Package):
         sha256="b6f6ce68282159d46c716a1e6c819c815914bdb096cddc516fa48134209659f2",
     )
 
+    # Fix: "Compile issue with flat_tree insert"
+    # See: https://github.com/boostorg/container/pull/101
+    patch(
+        "container_PR101.patch",
+        when="@1.66.0:1.69.0",
+        sha256="d216bf7c826c577912aa518c76c17697898483f95336cc035ae9ed16b12dc2b0",
+    )
+
     # Fix: "Unable to compile code using boost/process.hpp"
     # See: https://github.com/boostorg/process/issues/116
     # Patch: https://github.com/boostorg/process/commit/6a4d2ff72114ef47c7afaf92e1042aca3dfa41b0.patch


### PR DESCRIPTION
This PR patches a compilation issue with Boost.container tree-based data structures including `flat_set` and `flat_map`.

It was reported for version 1.66.0 in https://github.com/boostorg/container/issues/100.
The fix https://github.com/boostorg/container/pull/101 was released in 1.70.0.