### PR TITLE
precice: Fix compilation of v2.0.0 with GCC 14+

### DIFF
--- a/repos/spack_repo/builtin/packages/precice/edge-incomplete-type.patch
+++ b/repos/spack_repo/builtin/packages/precice/edge-incomplete-type.patch
@@ -1,0 +1,4 @@
+--- a/src/mesh/Edge.hpp
++++ b/src/mesh/Edge.hpp
+@@ -4,0 +5 @@
++#include <array>

--- a/repos/spack_repo/builtin/packages/precice/package.py
+++ b/repos/spack_repo/builtin/packages/precice/package.py
@@ -125,6 +125,13 @@ class Precice(CMakePackage):
     conflicts("%clang@:3.7")
     conflicts("%intel@:16")
 
+    # Fixes missing #include<array> in src/mesh/Edge.hpp
+    patch(
+        "edge-incomplete-type.patch",
+        when="@2.0",
+        sha256="4017a89e4f77f623807a6cd057d9a095788879310f1bddd98837920d252b1ac7",
+    )
+
     def xsdk_tpl_args(self):
         return [
             "-DTPL_ENABLE_BOOST:BOOL=ON",


### PR DESCRIPTION
This PR patches a compilation error for preCICE 2.0.0 which appeared with GCC 14.