### PR TITLE
py-flatbuffers: add v25.9.23

### DIFF
--- a/repos/spack_repo/builtin/packages/py_flatbuffers/package.py
+++ b/repos/spack_repo/builtin/packages/py_flatbuffers/package.py
@@ -21,6 +21,7 @@ class PyFlatbuffers(PythonPackage):
 
     license("Apache-2.0")
 
+    version("25.9.23", sha256="676f9fa62750bb50cf531b42a0a2a118ad8f7f797a511eda12881c016f093b12")
     version("24.3.25", sha256="de2ec5b203f21441716617f38443e0a8ebf3d25bf0d9c0bb0ce68fa00ad546a4")
     version("23.5.26", sha256="9ea1144cac05ce5d86e2859f431c6cd5e66cd9c78c558317c7955fb8d4c78d89")
     version("2.0.7", sha256="0ae7d69c5b82bf41962ca5fde9cc43033bc9501311d975fd5a25e8a7d29c1245")


### PR DESCRIPTION
This PR adds `py-flatbuffers`, v25.9.23. This version works with `py-setuptools` beyond v77 as https://github.com/google/flatbuffers/issues/8376 was fixed in https://github.com/google/flatbuffers/commit/6cb4d671a88e054744ce3029df9e733dc724ee76.

Test build:
```
==> No binary for py-setuptools-80.9.0-4dasaaxcrbuaxkny4ziykjqpg7hjcs22 found: installing from source
==> Installing py-setuptools-80.9.0-4dasaaxcrbuaxkny4ziykjqpg7hjcs22 [37/38]
==> Fetching https://mirror.spack.io/_source-cache/archive/06/062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922.whl
    [100%]    1.20 MB @    7.6 MB/s
==> No patches needed for py-setuptools
==> py-setuptools: Executing phase: 'install'
==> py-setuptools: Successfully installed py-setuptools-80.9.0-4dasaaxcrbuaxkny4ziykjqpg7hjcs22
  Stage: 0.71s.  Install: 1.02s.  Post-install: 0.21s.  Total: 1.98s
[+] /opt/software/linux-x86_64_v2/py-setuptools-80.9.0-4dasaaxcrbuaxkny4ziykjqpg7hjcs22
==> No binary for py-flatbuffers-25.9.23-o3fzoefa2sctmz2xb24qsew23xshdh3o found: installing from source
==> Installing py-flatbuffers-25.9.23-o3fzoefa2sctmz2xb24qsew23xshdh3o [38/38]
==> Fetching https://files.pythonhosted.org/packages/source/f/flatbuffers/flatbuffers-25.9.23.tar.gz
    [100%]   22.07 KB @    4.7 MB/s
==> No patches needed for py-flatbuffers
==> py-flatbuffers: Executing phase: 'install'
==> py-flatbuffers: Successfully installed py-flatbuffers-25.9.23-o3fzoefa2sctmz2xb24qsew23xshdh3o
  Stage: 0.73s.  Install: 0.77s.  Post-install: 0.04s.  Total: 1.58s
[+] /opt/software/linux-x86_64_v2/py-flatbuffers-25.9.23-o3fzoefa2sctmz2xb24qsew23xshdh3o
```

Note: not addressing the duplication between `flatbuffers +python` and `py-flatbuffers`. The latter is used by: `py-onnxruntime`, `py-pytecplot`, `py-tensorflow`, so it would need validation that those can use `flatbuffers +python`.