### PR TITLE
bash: add sed as build dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/bash/package.py
+++ b/repos/spack_repo/builtin/packages/bash/package.py
@@ -31,6 +31,8 @@ class Bash(AutotoolsPackage, GNUMirrorPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
 
+    depends_on("sed", type="build")
+
     depends_on("ncurses")
     depends_on("readline@8.3:", when="@5.3:")
     depends_on("readline@8.2:", when="@5.2:")


### PR DESCRIPTION
Adding `sed` as a build dependency to bash to build in minimal unix environments.