### PR TITLE
nano: add sed as build dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/nano/package.py
+++ b/repos/spack_repo/builtin/packages/nano/package.py
@@ -88,6 +88,8 @@ class Nano(AutotoolsPackage):
 
     depends_on("c", type="build")
 
+    depends_on("sed", type="build")
+
     depends_on("pkgconfig", type="build")
     depends_on("gettext@0.18.3:")
     depends_on("gettext@0.20:", when="@8.1:")


### PR DESCRIPTION
Add `sed` as build dependency for minimal unix environments