### PR TITLE
asio: add actual C++20 standard to variant

### DIFF
--- a/repos/spack_repo/builtin/packages/asio/package.py
+++ b/repos/spack_repo/builtin/packages/asio/package.py
@@ -59,7 +59,7 @@ class Asio(AutotoolsPackage):
         msg="asio v1.22.1 fixed missing includes necessary for gcc v12 and above",
     )
 
-    stds = ("11", "14", "17", "2a", "20")
+    stds = ("11", "14", "17", "20")
     variant(
         "cxxstd",
         default="11",

--- a/repos/spack_repo/builtin/packages/asio/package.py
+++ b/repos/spack_repo/builtin/packages/asio/package.py
@@ -59,7 +59,7 @@ class Asio(AutotoolsPackage):
         msg="asio v1.22.1 fixed missing includes necessary for gcc v12 and above",
     )
 
-    stds = ("11", "14", "17", "2a")
+    stds = ("11", "14", "17", "2a", "20")
     variant(
         "cxxstd",
         default="11",


### PR DESCRIPTION
- [x] Question to maintainers: I wasn't sure if I should completely remove `2a`.