### PR TITLE
Add upcxx 2025.10.0 release

### DIFF
--- a/repos/spack_repo/builtin/packages/upcxx/package.py
+++ b/repos/spack_repo/builtin/packages/upcxx/package.py
@@ -62,6 +62,7 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
     version("develop", branch="develop")
     version("master", branch="master")
 
+    version("2025.10.0", sha256="bb43348d351777b7462e6bbadda358b426cd150e138ac08ee74649b91bba32ec")
     version("2023.9.0", sha256="6bad2976b4bfc0263b497daa967f448159c3c2259827c8376bc96c9bf9171a83")
     version("2023.3.0", sha256="382af3c093decdb51f0533e19efb4cc7536b6617067b2dd89431e323704a1009")
     version("2022.9.0", sha256="dbf15fd9ba38bfe2491f556b55640343d6303048a117c4e84877ceddb64e4c7c")

--- a/repos/spack_repo/builtin/packages/upcxx/package.py
+++ b/repos/spack_repo/builtin/packages/upcxx/package.py
@@ -64,16 +64,17 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
 
     version("2025.10.0", sha256="bb43348d351777b7462e6bbadda358b426cd150e138ac08ee74649b91bba32ec")
     version("2023.9.0", sha256="6bad2976b4bfc0263b497daa967f448159c3c2259827c8376bc96c9bf9171a83")
-    version("2023.3.0", sha256="382af3c093decdb51f0533e19efb4cc7536b6617067b2dd89431e323704a1009")
-    version("2022.9.0", sha256="dbf15fd9ba38bfe2491f556b55640343d6303048a117c4e84877ceddb64e4c7c")
-    version("2022.3.0", sha256="72bccfc9dfab5c2351ee964232b3754957ecfdbe6b4de640e1b1387d45019496")
+    with default_args(deprecated=True):
+        version("2023.3.0", sha256="382af3c093decdb51f0533e19efb4cc7536b6617067b2dd89431e323704a1009")
+        version("2022.9.0", sha256="dbf15fd9ba38bfe2491f556b55640343d6303048a117c4e84877ceddb64e4c7c")
+        version("2022.3.0", sha256="72bccfc9dfab5c2351ee964232b3754957ecfdbe6b4de640e1b1387d45019496")
     # Do NOT add older versions here.
     # UPC++ releases over 2 years old are not supported.
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
     depends_on("gmake", type="build")
 
-    patch("fix_configure_ldflags.patch", when="@2021.9.0:master")
+    patch("fix_configure_ldflags.patch", when="@:2023.9.0")
 
     variant("mpi", default=False, description="Enables MPI-based spawners and mpi-conduit")
 
@@ -94,7 +95,6 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
         "level_zero",
         default=False,
         description="Enables UPC++ support for the Level Zero memory kind on Intel GPUs",
-        when="@2023.3.0:",
     )
 
     variant(
@@ -107,6 +107,11 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
         "cross=none",
         when=is_CrayXC(),
         msg='cross=none is unacceptable on Cray XC. Please specify an appropriate "cross" value',
+    )
+    conflicts(
+        "@2025.10.0:",
+        when=is_CrayXC(),
+        msg='Cray XC support was removed in upcxx@2025.10.0',
     )
 
     # UPC++ always relies on GASNet-EX.
@@ -175,9 +180,6 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
             # the C/C++ compilers must work post-install
             real_cc = join_path(env["CRAYPE_DIR"], "bin", "cc")
             real_cxx = join_path(env["CRAYPE_DIR"], "bin", "CC")
-            # workaround a bug in the UPC++ installer: (issue #346)
-            # this can be removed once the floor version reaches 2020.10.0
-            env["GASNET_CONFIGURE_ARGS"] += " --with-cc=" + real_cc + " --with-cxx=" + real_cxx
             if "+mpi" in spec:
                 env["GASNET_CONFIGURE_ARGS"] += " --with-mpicc=" + real_cc
         else:
@@ -198,17 +200,12 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
                 provider = "verbs;ofi_rxm"
 
             # Append the recommended options for Cray Shasta
-            # This list can be pruned once the floor version reaches 2022.9.0
-            options.append("--with-pmi-version=cray")
             if which("srun"):
                 options.append("--with-pmi-runcmd=srun -n %N -- %C")
             elif which("aprun"):
                 options.append("--with-pmi-runcmd=aprun -n %N %C")
-            options.append("--disable-ibv")
-            options.append("--enable-ofi")
             options.append("--with-default-network=ofi")
             options.append("--with-ofi-provider=" + provider)
-            env["GASNET_CONFIGURE_ARGS"] = "--with-ofi-spawner=pmi " + env["GASNET_CONFIGURE_ARGS"]
 
         if "+gasnet" in spec:
             options.append("--with-gasnet=" + spec["gasnet"].prefix.src)

--- a/repos/spack_repo/builtin/packages/upcxx/package.py
+++ b/repos/spack_repo/builtin/packages/upcxx/package.py
@@ -65,9 +65,15 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
     version("2025.10.0", sha256="bb43348d351777b7462e6bbadda358b426cd150e138ac08ee74649b91bba32ec")
     version("2023.9.0", sha256="6bad2976b4bfc0263b497daa967f448159c3c2259827c8376bc96c9bf9171a83")
     with default_args(deprecated=True):
-        version("2023.3.0", sha256="382af3c093decdb51f0533e19efb4cc7536b6617067b2dd89431e323704a1009")
-        version("2022.9.0", sha256="dbf15fd9ba38bfe2491f556b55640343d6303048a117c4e84877ceddb64e4c7c")
-        version("2022.3.0", sha256="72bccfc9dfab5c2351ee964232b3754957ecfdbe6b4de640e1b1387d45019496")
+        version(
+            "2023.3.0", sha256="382af3c093decdb51f0533e19efb4cc7536b6617067b2dd89431e323704a1009"
+        )
+        version(
+            "2022.9.0", sha256="dbf15fd9ba38bfe2491f556b55640343d6303048a117c4e84877ceddb64e4c7c"
+        )
+        version(
+            "2022.3.0", sha256="72bccfc9dfab5c2351ee964232b3754957ecfdbe6b4de640e1b1387d45019496"
+        )
     # Do NOT add older versions here.
     # UPC++ releases over 2 years old are not supported.
     depends_on("c", type="build")  # generated
@@ -109,9 +115,7 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
         msg='cross=none is unacceptable on Cray XC. Please specify an appropriate "cross" value',
     )
     conflicts(
-        "@2025.10.0:",
-        when=is_CrayXC(),
-        msg='Cray XC support was removed in upcxx@2025.10.0',
+        "@2025.10.0:", when=is_CrayXC(), msg="Cray XC support was removed in upcxx@2025.10.0"
     )
 
     # UPC++ always relies on GASNet-EX.


### PR DESCRIPTION
Adds upcxx 2025.10.0 release, deprecates unsupported versions and adjusts logic appropriately

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
