### PR TITLE
rocmcc pre 7.0 might have amdflang in its prefix

### DIFF
--- a/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
+++ b/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
@@ -72,7 +72,7 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
         "fortran",
         default=True,
         when="@:6.99",
-        description="External instances of llvm-amdgpu before 7 may provide fortran"
+        description="External instances of llvm-amdgpu before 7 may provide fortran",
     )
 
     variant(
@@ -360,7 +360,6 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
 
     @classmethod
     def determine_variants(cls, exes, version_str):
-        #raise Exception("<--- " + str(exes) + " " + version_str)
         compilers = cls.determine_compiler_paths(exes=exes)
         variants = ""
         if "fortran" in compilers and Version(version_str) < Version("7"):

--- a/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
+++ b/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
@@ -68,9 +68,11 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
     provides("fortran", when="@7.0:")
     provides("fortran", when="+fortran")
 
+    # External instances of this package may include a fortran compiler
     variant(
         "fortran",
-        default=True,
+        default=False,
+        sticky=True,
         when="@:6.99",
         description="External instances of llvm-amdgpu before 7 may provide fortran",
     )

--- a/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
+++ b/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
@@ -66,6 +66,14 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
 
     provides("c", "cxx")
     provides("fortran", when="@7.0:")
+    provides("fortran", when="+fortran")
+
+    variant(
+        "fortran",
+        default=True,
+        when="@:6.99",
+        description="External instances of llvm-amdgpu before 7 may provide fortran"
+    )
 
     variant(
         "rocm-device-libs",
@@ -299,7 +307,7 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
     cxx_names = ["amdclang++"]
     fortran_names = ["amdflang"]
     compiler_version_argument = "--version"
-    compiler_version_regex = r"roc-(\d+[._]\d+[._]\d+)"
+    compiler_version_regex = r"rocm?-(\d+[._]\d+[._]\d+)"
 
     # Make sure that the compiler paths are in the LD_LIBRARY_PATH
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
@@ -349,3 +357,12 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
 
     def _fortran_path(self):
         return os.path.join(self.spec.prefix.bin, "amdflang")
+
+    @classmethod
+    def determine_variants(cls, exes, version_str):
+        #raise Exception("<--- " + str(exes) + " " + version_str)
+        compilers = cls.determine_compiler_paths(exes=exes)
+        variants = ""
+        if "fortran" in compilers and Version(version_str) < Version("7"):
+            variants = "+fortran"
+        return variants, {"compilers": compilers}


### PR DESCRIPTION
External instances of rocmcc may have amdflang.

`spack compiler find` for rocmcc < `7.0` can now `provides(fortran)` if 

* it finds `amdflang` in the prefix
* the output includes `rocm-x.y.z`

The latter point is not enforced by rocmcc pre-7.0: the official version string is in terms of Clang. This depends on the user installing rocmcc into a prefix that includes that string. 

The user can add `+fortran` themselves to the compiler entry for `< 7.0` in other cases.