### PR TITLE
chapel: add new comm_ofi_oob variant and support for hpe-cray-xd platform

### DIFF
--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -168,6 +168,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         "darwin",
         "hpe-apollo",
         "hpe-cray-ex",
+        "hpe-cray-xd",
         "linux32",
         "linux64",
         "netbsd32",

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -199,8 +199,8 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     variant(
         "comm_ofi_oob",
-        values=("sockets", "mpi", "pmi2"),
-        default="sockets",
+        values=("sockets", "mpi", "pmi2", "unset"),
+        default="unset",
         description="Select out-of-band support",
         multi=False,
     )

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -201,8 +201,9 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         "comm_ofi_oob",
         values=("sockets", "mpi", "pmi2", "unset"),
         default="unset",
-        description="Select out-of-band support",
+        description="Select out-of-band support (CHPL_COMM_OFI_OOB)",
         multi=False,
+        when="comm=ofi",
     )
 
     variant(

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -203,7 +203,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         default="unset",
         description="Select out-of-band support (CHPL_COMM_OFI_OOB)",
         multi=False,
-        when="comm=ofi",
+        when="@2.2: comm=ofi",
     )
 
     variant(
@@ -562,6 +562,13 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
             "+python-bindings",
             msg="Python bindings require building with LLVM, see "
             "https://chapel-lang.org/docs/tools/chapel-py/chapel-py.html#installation",
+        )
+
+    for target in ["host", "target"]:
+        conflicts(
+            f"{target}_platform=hpe-cray-xd",
+            when="@:2.4",
+            msg="Platform hpe-cray-xd requires Chapel 2.5.0 or later",
         )
 
     # Add dependencies

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -197,6 +197,14 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     )
 
     variant(
+        "comm_ofi_oob",
+        values=("sockets", "mpi", "pmi2"),
+        default="sockets",
+        description="Select out-of-band support",
+        multi=False,
+    )
+
+    variant(
         "comm_substrate",
         default="unset",
         description="Build Chapel with GASNet multi-locale support using the "
@@ -431,6 +439,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         "CHPL_ATOMICS",
         "CHPL_AUX_FILESYS",
         "CHPL_COMM",
+        "CHPL_COMM_OFI_OOB",
         "CHPL_COMM_SUBSTRATE",
         "CHPL_CUDA_PATH",
         "CHPL_DEVELOPER",


### PR DESCRIPTION
New chapel variant comm_ofi_oob which was useful to set when platform not supported, might be useful for future.  Also added the hpe-cray-xd platform.

Maintainers: @arezaii   @bonachea  @arifthpe 
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
