### PR TITLE
precice: fix python usage for pre-2 versions

### DIFF
--- a/repos/spack_repo/builtin/packages/precice/package.py
+++ b/repos/spack_repo/builtin/packages/precice/package.py
@@ -155,8 +155,13 @@ class Precice(CMakePackage):
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant(mpi_option, "mpi"),
             self.define_from_variant(petsc_option, "petsc"),
-            self.define_from_variant(python_option, "python"),
         ]
+
+        # Python 3 is only supported after version 2
+        if spec.satisfies("@2:"):
+            cmake_args.append(self.define_from_variant(python_option, "python"))
+        else:
+            cmake_args.append("-DPYTHON=OFF")
 
         # The xSDK installation policies were implemented after 1.5.2.
         # The TPL arguments were removed in 3.0.0.


### PR DESCRIPTION
This PR fixes 27a5ac2bbdd30e6f9e5d017502cd19a728fbac96 breaking the preCICE package for versions 1.x.x.

These versions only support Python 2. Whilst the python variant was disabled for 1 versions, the compilation was enabled by default, leading to CMake errors.
We now always disable python for versions prior to 2.0.0.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
