### PR TITLE
py-fprettify: Patch v0.3.7

### DIFF
--- a/repos/spack_repo/builtin/packages/py_fprettify/fprettify370_pr176.patch
+++ b/repos/spack_repo/builtin/packages/py_fprettify/fprettify370_pr176.patch
@@ -1,0 +1,13 @@
+diff --git a/fprettify/__init__.py b/fprettify/__init__.py
+index d6450a3..76add49 100644
+--- a/fprettify/__init__.py
++++ b/fprettify/__init__.py
+@@ -269,7 +269,7 @@ class plusminus_parser(parser_re):
+ LR_OPS_RE = [REL_OP_RE, LOG_OP_RE, plusminus_parser(PLUSMINUS_RE), MULTDIV_RE, PRINT_RE]
+ 
+ USE_RE = re.compile(
+-    SOL_STR + "USE(\s+|(,.+?)?::\s*)\w+?((,.+?=>.+?)+|,\s*only\s*:.+?)?$" + EOL_STR, RE_FLAGS)
++    SOL_STR + r"USE(\s+|(,.+?)?::\s*)\w+?((,.+?=>.+?)+|,\s*only\s*:.+?)?$" + EOL_STR, RE_FLAGS)
+ 
+ # markups to deactivate formatter
+ NO_ALIGN_RE = re.compile(SOL_STR + r"&\s*[^\s*]+")

--- a/repos/spack_repo/builtin/packages/py_fprettify/package.py
+++ b/repos/spack_repo/builtin/packages/py_fprettify/package.py
@@ -21,4 +21,5 @@ class PyFprettify(PythonPackage):
     depends_on("py-setuptools", type="build")
     depends_on("py-configargparse", type=("build", "run"))
 
+    # https://github.com/fortran-lang/fprettify/pull/176
     patch("fprettify370_pr176.patch", when="@0.3.7")

--- a/repos/spack_repo/builtin/packages/py_fprettify/package.py
+++ b/repos/spack_repo/builtin/packages/py_fprettify/package.py
@@ -20,3 +20,5 @@ class PyFprettify(PythonPackage):
 
     depends_on("py-setuptools", type="build")
     depends_on("py-configargparse", type=("build", "run"))
+
+    patch("fprettify370_pr176.patch", when="@0.3.7")


### PR DESCRIPTION
* This patch for v 0.3.7 fixes the warning `SyntaxWarning: invalid escape sequence '\s' warning at line 272 of __init__.py` by converting to raw string.
* See https://github.com/fortran-lang/fprettify/pull/176 for full details. 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
