### PR TITLE
py-triton: add v3.5.1 and conflicts with glibc

### DIFF
--- a/repos/spack_repo/builtin/packages/py_triton/package.py
+++ b/repos/spack_repo/builtin/packages/py_triton/package.py
@@ -17,6 +17,7 @@ class PyTriton(PythonPackage):
     license("MIT")
 
     version("main", branch="main")
+    version("3.5.1", sha256="03d7c41f6f2dc1dfa3445776c4a893dc34b1e0ece42b953f036c071ff6409b80")
     version("3.4.0", sha256="a96e87a911794c907fab30e0c7a3f96ef4e9e8fdc8812cd8bbc6f0457619072f")
     version("3.3.1", sha256="9dc77d9205933bf2fc05eb054f4f1d92acd79a963826174d57fe9cfd58ba367b")
     version("3.2.0", sha256="04eb07e2ff1b87bf4b26e132d696177248bfb9c71cecd4864e561a9c103de9b3")
@@ -37,6 +38,8 @@ class PyTriton(PythonPackage):
     depends_on("py-filelock", type=("build", "run"))
     depends_on("zlib-api", type="link")
     conflicts("^openssl@3.3.0")
+    # the prebuilt llvm depends on glibc@2.34:
+    conflicts("^glibc@:2.33", when="@3.4.0:")
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         """Set environment variables used to control the build"""


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Note that after @3.4.0, the prebuilt llvm download by triton (as <https://github.com/triton-lang/triton> said, "LLVM does not have a stable API, so the Triton build will not work at an arbitrary LLVM version") depends on glibc@2.34:

```plain_text
...
  -- Generating done (1.1s)
  CMake Warning:
    Manually-specified variables were not used by the project:

      JSON_SYSPATH
      LLVM_ENABLE_WERROR


  -- Build files have been written to: /tmp/mizuno-ai/spack-stage/spack-stage-py-triton-3.5.1-33xpsqw3rjeqevvhnheqywygyut6b7cv/spack-src/build/cmake.linux-x86_64-cpython-3.12
  creating symlink: /tmp/mizuno-ai/spack-stage/spack-stage-py-triton-3.5.1-33xpsqw3rjeqevvhnheqywygyut6b7cv/spack-src/compile_commands.json -> /tmp/mizuno-ai/spack-stage/spack-stage-py-triton-3.5.1-33xpsqw3rjeqevvhnheqywygyut6b7cv/spack-src/build/cmake.linux-x86_64-cpython-3.12/compile_commands.json
  [1/441] Building Dialect.cpp.inc...
  FAILED: include/triton/Dialect/TritonGPU/IR/Dialect.cpp.inc /tmp/mizuno-ai/spack-stage/spack-stage-py-triton-3.5.1-33xpsqw3rjeqevvhnheqywygyut6b7cv/spack-src/build/cmake.linux-x86_64-cpython-3.12/include/triton/Dialect/TritonGPU/IR/Dialect.cpp.inc
  cd /tmp/mizuno-ai/spack-stage/spack-stage-py-triton-3.5.1-33xpsqw3rjeqevvhnheqywygyut6b7cv/spack-src/build/cmake.linux-x86_64-cpython-3.12/include/triton/Dialect/TritonGPU/IR && /mnt/sda/2022-0526/home/mizuno-ai/.triton/llvm/llvm-7d5de303-ubuntu-x64/bin/mlir-tblgen -gen-dialect-defs -dialect=ttg -I/tmp/mizuno-ai/spack-stage/spack-stage-py-triton-3.5.1-33xpsqw3rjeqevvhnheqywygyut6b7cv/spack-src/include/triton/Dialect/TritonGPU/IR -I/tmp/mizuno-ai/spack-stage/spack-stage-py-triton-3.5.1-33xpsqw3rjeqevvhnheqywygyut6b7cv/spack-src/include -I/tmp/mizuno-ai/spack-stage/spack-stage-py-triton-3.5.1-33xpsqw3rjeqevvhnheqywygyut6b7cv/spack-src/. -I/mnt/sda/2022-0526/home/mizuno-ai/.triton/llvm/llvm-7d5de303-ubuntu-x64/include -I/mnt/sda/2022-0526/home/mizuno-ai/.triton/llvm/llvm-7d5de303-ubuntu-x64/include -I/tmp/mizuno-ai/spack-stage/spack-stage-py-triton-3.5.1-33xpsqw3rjeqevvhnheqywygyut6b7cv/spack-src/include -I/tmp/mizuno-ai/spack-stage/spack-stage-py-triton-3.5.1-33xpsqw3rjeqevvhnheqywygyut6b7cv/spack-src/build/cmake.linux-x86_64-cpython-3.12/include -I/tmp/mizuno-ai/spack-stage/spack-stage-py-triton-3.5.1-33xpsqw3rjeqevvhnheqywygyut6b7cv/spack-src/third_party -I/tmp/mizuno-ai/spack-stage/spack-stage-py-triton-3.5.1-33xpsqw3rjeqevvhnheqywygyut6b7cv/spack-src/build/cmake.linux-x86_64-cpython-3.12/third_party /tmp/mizuno-ai/spack-stage/spack-stage-py-triton-3.5.1-33xpsqw3rjeqevvhnheqywygyut6b7cv/spack-src/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td --write-if-changed -o /tmp/mizuno-ai/spack-stage/spack-stage-py-triton-3.5.1-33xpsqw3rjeqevvhnheqywygyut6b7cv/spack-src/build/cmake.linux-x86_64-cpython-3.12/include/triton/Dialect/TritonGPU/IR/Dialect.cpp.inc
  /mnt/sda/2022-0526/home/mizuno-ai/.triton/llvm/llvm-7d5de303-ubuntu-x64/bin/mlir-tblgen: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /mnt/sda/2022-0526/home/mizuno-ai/.triton/llvm/llvm-7d5de303-ubuntu-x64/bin/mlir-tblgen)
  /mnt/sda/2022-0526/home/mizuno-ai/.triton/llvm/llvm-7d5de303-ubuntu-x64/bin/mlir-tblgen: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /mnt/sda/2022-0526/home/mizuno-ai/.triton/llvm/llvm-7d5de303-ubuntu-x64/bin/mlir-tblgen)
  /mnt/sda/2022-0526/home/mizuno-ai/.triton/llvm/llvm-7d5de303-ubuntu-x64/bin/mlir-tblgen: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /mnt/sda/2022-0526/home/mizuno-ai/.triton/llvm/llvm-7d5de303-ubuntu-x64/bin/mlir-tblgen)
  [2/441] Building Dialect.h.inc...
  FAILED: 
...
```
