### PR TITLE
fflas-ffpack: Add pkgconfig as build dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/fflas_ffpack/package.py
+++ b/repos/spack_repo/builtin/packages/fflas_ffpack/package.py
@@ -25,6 +25,7 @@ class FflasFfpack(AutotoolsPackage):
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
+    depends_on("pkgconfig", type="build")
 
     depends_on("blas")
     depends_on("givaro")


### PR DESCRIPTION
It's used (via the PKG_CHECK_MODULES autoconf macro) to detect givaro.

https://github.com/linbox-team/fflas-ffpack/blob/07e41b2d6c52f8509a3e08a83879270bf3b2547c/configure.ac#L132

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
