### PR TITLE
Mpi cmake find hints

### DIFF
--- a/repos/spack_repo/builtin/build_systems/cmake.py
+++ b/repos/spack_repo/builtin/build_systems/cmake.py
@@ -60,6 +60,13 @@ def _maybe_set_python_hints(pkg: PackageBase, args: List[str]) -> None:
     )
 
 
+def _dependencies_cmake_extra_args(pkg: PackageBase, args: List[str]) -> None:
+    for dep in pkg.spec.traverse(deptype=("build", "link")):
+        extra_args = getattr(dep.package, "cmake_extra_args", None)
+        if extra_args:
+            args.extend(extra_args)
+
+
 def _supports_compilation_databases(pkg: PackageBase) -> bool:
     """Check if this package (and CMake) can support compilation databases."""
 
@@ -406,6 +413,7 @@ class CMakeBuilder(BuilderWithDefaults):
 
         _conditional_cmake_defaults(pkg, args)
         _maybe_set_python_hints(pkg, args)
+        _dependencies_cmake_extra_args(pkg, args)
 
         return args
 

--- a/repos/spack_repo/builtin/build_systems/cmake.py
+++ b/repos/spack_repo/builtin/build_systems/cmake.py
@@ -42,29 +42,12 @@ def _extract_primary_generator(generator):
     return _primary_generator_extractor.match(generator).group(1)
 
 
-def _maybe_set_python_hints(pkg: PackageBase, args: List[str]) -> None:
-    """Set the PYTHON_EXECUTABLE, Python_EXECUTABLE, and Python3_EXECUTABLE CMake variables
-    if the package has Python as build or link dep and ``find_python_hints`` is set to True. See
-    ``find_python_hints`` for context."""
-    if not getattr(pkg, "find_python_hints", False) or not pkg.spec.dependencies(
-        "python", deptype=("build", "link")
-    ):
-        return
-    python_executable = pkg.spec["python"].command.path
-    args.extend(
-        [
-            define("PYTHON_EXECUTABLE", python_executable),
-            define("Python_EXECUTABLE", python_executable),
-            define("Python3_EXECUTABLE", python_executable),
-        ]
-    )
-
-
 def _dependencies_cmake_extra_args(pkg: PackageBase, args: List[str]) -> None:
-    for dep in pkg.spec.traverse(deptype=("build", "link")):
-        extra_args = getattr(dep.package, "cmake_extra_args", None)
-        if extra_args:
-            args.extend(extra_args)
+    for dep in pkg.spec.dependencies(deptype=("build", "link")):
+        try:
+            dep.package.set_dependent_cmake_args(pkg, args)
+        except Exception:
+            continue
 
 
 def _supports_compilation_databases(pkg: PackageBase) -> bool:
@@ -185,13 +168,6 @@ class CMakePackage(PackageBase):
 
     #: Legacy buildsystem attribute used to deserialize and install old specs
     default_buildsystem = "cmake"
-
-    #: When this package depends on Python and ``find_python_hints`` is set to True, pass the
-    #: defines {Python3,Python,PYTHON}_EXECUTABLE explicitly, so that CMake locates the right
-    #: Python in its builtin FindPython3, FindPython, and FindPythonInterp modules. Spack does
-    #: CMake's job because CMake's modules by default only search for Python versions known at the
-    #: time of release.
-    find_python_hints = True
 
     build_system("cmake")
 
@@ -412,7 +388,6 @@ class CMakeBuilder(BuilderWithDefaults):
             )
 
         _conditional_cmake_defaults(pkg, args)
-        _maybe_set_python_hints(pkg, args)
         _dependencies_cmake_extra_args(pkg, args)
 
         return args

--- a/repos/spack_repo/builtin/packages/adiak/package.py
+++ b/repos/spack_repo/builtin/packages/adiak/package.py
@@ -39,8 +39,6 @@ class Adiak(CMakePackage):
     def cmake_args(self):
         args = []
         if self.spec.satisfies("+mpi"):
-            args.append(f"-DMPI_CXX_COMPILER={self.spec['mpi'].mpicxx}")
-            args.append(f"-DMPI_C_COMPILER={self.spec['mpi'].mpicc}")
             args.append("-DENABLE_MPI=ON")
         else:
             args.append("-DENABLE_MPI=OFF")

--- a/repos/spack_repo/builtin/packages/amr_wind/package.py
+++ b/repos/spack_repo/builtin/packages/amr_wind/package.py
@@ -152,8 +152,6 @@ class AmrWind(CMakePackage, CudaPackage, ROCmPackage):
 
         if spec.satisfies("+mpi"):
             args.append(define("MPI_HOME", spec["mpi"].prefix))
-            args.append(define("MPI_CXX_COMPILER", spec["mpi"].mpicxx))
-            args.append(define("MPI_C_COMPILER", spec["mpi"].mpicc))
 
         if spec.satisfies("+hdf5"):
             args.append(define("AMR_WIND_ENABLE_HDF5", True))

--- a/repos/spack_repo/builtin/packages/amrex/package.py
+++ b/repos/spack_repo/builtin/packages/amrex/package.py
@@ -440,9 +440,6 @@ class Amrex(CMakePackage, CudaPackage, ROCmPackage):
 
         args = ["-S{0}".format(join_path(".", "cache", "amrex", "Tests", "SpackSmokeTest"))]
         args.append("-DAMReX_ROOT=" + self.prefix)
-        if self.spec.satisfies("+mpi"):
-            args.append("-DMPI_C_COMPILER=" + self.spec["mpi"].mpicc)
-            args.append("-DMPI_CXX_COMPILER=" + self.spec["mpi"].mpicxx)
 
         if self.spec.satisfies("+cuda"):
             args.append("-DCMAKE_CUDA_COMPILER=" + join_path(self.spec["cuda"].prefix.bin, "nvcc"))

--- a/repos/spack_repo/builtin/packages/apple_glu/package.py
+++ b/repos/spack_repo/builtin/packages/apple_glu/package.py
@@ -14,3 +14,8 @@ class AppleGlu(AppleGlBase):
     provides("glu@1.3")
 
     requires("platform=darwin", msg="Apple-GL is only available on Darwin")
+
+    def setup_dependent_build_environment(
+        self, env: EnvironmentModifications, dependent_spec: Spec
+    ):
+        env.prepend_path("OpenGL_ROOT", self.prefix)

--- a/repos/spack_repo/builtin/packages/ascent/package.py
+++ b/repos/spack_repo/builtin/packages/ascent/package.py
@@ -57,6 +57,10 @@ class Ascent(CMakePackage, CudaPackage, ROCmPackage):
     url = "https://github.com/Alpine-DAV/ascent/releases/download/v0.5.1/ascent-v0.5.1-src-with-blt.tar.gz"
     tags = ["radiuss", "e4s"]
 
+    # Don't use the automatic hints in favor of building the hostconfig
+    find_mpi_hints = False
+    find_python_hints = False
+
     maintainers("cyrush")
 
     license("BSD-3-Clause")

--- a/repos/spack_repo/builtin/packages/axl/package.py
+++ b/repos/spack_repo/builtin/packages/axl/package.py
@@ -82,8 +82,6 @@ class Axl(CMakePackage):
         args.append(self.define("WITH_KVTREE_PREFIX", spec["kvtree"].prefix))
 
         args.append(self.define_from_variant("MPI"))
-        if spec.satisfies("+mpi"):
-            args.append(self.define("MPI_C_COMPILER", spec["mpi"].mpicc))
 
         if spec.satisfies("@:0.3.0"):
             apis = list(spec.variants["async_api"].value)

--- a/repos/spack_repo/builtin/packages/cairo/package.py
+++ b/repos/spack_repo/builtin/packages/cairo/package.py
@@ -143,7 +143,7 @@ class Cairo(AutotoolsPackage, MesonPackage):
     # patch from https://gitlab.freedesktop.org/cairo/cairo/issues/346
     patch("fontconfig.patch", when="@1.16.0:1.17.2")
     # Don't regenerate docs to avoid a dependency on gtk-doc
-    patch("disable-gtk-docs.patch", when="build_system=autotools ^autoconf@2.70:")
+    patch("disable-gtk-docs.patch", when="build_system=autotools")
 
 
 class MesonBuilder(meson.MesonBuilder):

--- a/repos/spack_repo/builtin/packages/cardioid/package.py
+++ b/repos/spack_repo/builtin/packages/cardioid/package.py
@@ -43,8 +43,6 @@ class Cardioid(CMakePackage):
             "-DENABLE_OPENMP:BOOL=ON",
             "-DENABLE_MPI:BOOL=ON",
             "-DENABLE_FIND_MPI:BOOL=OFF",
-            "-DMPI_C_COMPILER:STRING=" + spec["mpi"].mpicc,
-            "-DMPI_CXX_COMPILER:STRING=" + spec["mpi"].mpicxx,
             "-DCMAKE_C_COMPILER:STRING=" + spec["mpi"].mpicc,
             "-DCMAKE_CXX_COMPILER:STRING=" + spec["mpi"].mpicxx,
         ]

--- a/repos/spack_repo/builtin/packages/chameleon/package.py
+++ b/repos/spack_repo/builtin/packages/chameleon/package.py
@@ -107,15 +107,6 @@ class Chameleon(CMakePackage, CudaPackage):
                 ]
             )
 
-        if spec.satisfies("+mpi ~simgrid"):
-            args.extend(
-                [
-                    self.define("MPI_C_COMPILER", self.spec["mpi"].mpicc),
-                    self.define("MPI_CXX_COMPILER", self.spec["mpi"].mpicxx),
-                    self.define("MPI_Fortran_COMPILER", self.spec["mpi"].mpifc),
-                ]
-            )
-
         if spec.satisfies("^[virtuals=blas,lapack] intel-oneapi-mkl threads=none"):
             args.extend([self.define("BLA_VENDOR", "Intel10_64lp_seq")])
         elif spec.satisfies("^[virtuals=blas,lapack] intel-oneapi-mkl"):

--- a/repos/spack_repo/builtin/packages/conduit/package.py
+++ b/repos/spack_repo/builtin/packages/conduit/package.py
@@ -39,6 +39,10 @@ class Conduit(CMakePackage):
 
     license("BSD-3-Clause")
 
+    # Don't use the automatic hints in favor of building the hostconfig
+    find_mpi_hints = False
+    find_python_hints = False
+
     version("develop", branch="develop", submodules=True)
     # note: the main branch in conduit was renamed to develop, this next entry
     # is to bridge any spack dependencies that are still using the name master

--- a/repos/spack_repo/builtin/packages/dealii/package.py
+++ b/repos/spack_repo/builtin/packages/dealii/package.py
@@ -537,13 +537,6 @@ class Dealii(CMakePackage, CudaPackage):
         # MPI
         options.append(self.define_from_variant("DEAL_II_WITH_MPI", "mpi"))
         if spec.satisfies("+mpi"):
-            options.extend(
-                [
-                    self.define("MPI_C_COMPILER", spec["mpi"].mpicc),
-                    self.define("MPI_CXX_COMPILER", spec["mpi"].mpicxx),
-                    self.define("MPI_Fortran_COMPILER", spec["mpi"].mpifc),
-                ]
-            )
             # FIXME: Fix issues with undefined references in MPI. e.g,
             # libmpi.so: undefined reference to `opal_memchecker_base_isaddressable'
             if spec.satisfies("^openmpi"):

--- a/repos/spack_repo/builtin/packages/er/package.py
+++ b/repos/spack_repo/builtin/packages/er/package.py
@@ -60,7 +60,6 @@ class Er(CMakePackage):
     def cmake_args(self):
         spec = self.spec
         args = []
-        args.append(self.define("MPI_C_COMPILER", spec["mpi"].mpicc))
         args.append(self.define("WITH_KVTREE_PREFIX", spec["kvtree"].prefix))
         args.append(self.define("WITH_REDSET_PREFIX", spec["redset"].prefix))
         args.append(self.define("WITH_SHUFFILE_PREFIX", spec["shuffile"].prefix))

--- a/repos/spack_repo/builtin/packages/exago/package.py
+++ b/repos/spack_repo/builtin/packages/exago/package.py
@@ -209,8 +209,6 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
         else:
             args.append(self.define("CMAKE_C_COMPILER", spec["mpi"].mpicc))
             args.append(self.define("CMAKE_CXX_COMPILER", spec["mpi"].mpicxx))
-            args.append(self.define("MPI_C_COMPILER", spec["mpi"].mpicc))
-            args.append(self.define("MPI_CXX_COMPILER", spec["mpi"].mpicxx))
             if spec.satisfies("+cuda"):
                 args.append(self.define("MPI_CXX_HEADER_DIR", spec["mpi"].prefix.include))
 

--- a/repos/spack_repo/builtin/packages/filo/package.py
+++ b/repos/spack_repo/builtin/packages/filo/package.py
@@ -28,7 +28,6 @@ class Filo(CMakePackage):
 
     def cmake_args(self):
         args = []
-        args.append("-DMPI_C_COMPILER=%s" % self.spec["mpi"].mpicc)
         args.append("-DWITH_AXL_PREFIX=%s" % self.spec["axl"].prefix)
         args.append("-DWITH_KVTREE_PREFIX=%s" % self.spec["kvtree"].prefix)
         args.append("-DWITH_SPATH_PREFIX=%s" % self.spec["spath"].prefix)

--- a/repos/spack_repo/builtin/packages/fujitsu_mpi/package.py
+++ b/repos/spack_repo/builtin/packages/fujitsu_mpi/package.py
@@ -65,14 +65,6 @@ class FujitsuMpi(Package):
         env.set("OMPI_CXX", dependent_module.spack_cxx)
         env.set("OMPI_FC", dependent_module.spack_fc)
         env.set("OMPI_F77", dependent_module.spack_f77)
-        if self.spec.satisfies("%gcc"):
-            env.set("MPI_C_COMPILER", self.prefix.bin.mpicc)
-            env.set("MPI_CXX_COMPILER", self.prefix.bin.mpicxx)
-            env.set("MPI_Fortran_COMPILER", self.prefix.bin.mpifort)
-        else:
-            env.set("MPI_C_COMPILER", self.prefix.bin.mpifcc)
-            env.set("MPI_CXX_COMPILER", self.prefix.bin.mpiFCC)
-            env.set("MPI_Fortran_COMPILER", self.prefix.bin.mpifrt)
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         # Because MPI are both compilers and runtimes, we set up the compilers

--- a/repos/spack_repo/builtin/packages/gromacs/package.py
+++ b/repos/spack_repo/builtin/packages/gromacs/package.py
@@ -532,8 +532,6 @@ class CMakeBuilder(cmake.CMakeBuilder):
                     [
                         "-DCMAKE_C_COMPILER=%s" % spack_cc,
                         "-DCMAKE_CXX_COMPILER=%s" % spack_cxx,
-                        "-DMPI_C_COMPILER=%s" % self.spec["mpi"].mpicc,
-                        "-DMPI_CXX_COMPILER=%s" % self.spec["mpi"].mpicxx,
                     ]
                 )
         else:

--- a/repos/spack_repo/builtin/packages/hdf5/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5/package.py
@@ -556,17 +556,6 @@ class Hdf5(CMakePackage):
         if api != "default":
             args.append(self.define("DEFAULT_API_VERSION", api))
 
-        # MSMPI does not provide compiler wrappers
-        # and pointing these variables at the MSVC compilers
-        # breaks CMake's mpi detection for MSMPI.
-        if spec.satisfies("+mpi") and "msmpi" not in spec:
-            if spec.satisfies("+cxx"):
-                args.append("-DMPI_CXX_COMPILER:PATH=%s" % spec["mpi"].mpicxx)
-            args.append("-DMPI_C_COMPILER:PATH=%s" % spec["mpi"].mpicc)
-
-            if spec.satisfies("+fortran"):
-                args.extend(["-DMPI_Fortran_COMPILER:PATH=%s" % spec["mpi"].mpifc])
-
         # work-around for https://github.com/HDFGroup/hdf5/issues/1320
         if spec.satisfies("@1.10.8,1.13.0"):
             args.append(self.define("HDF5_INSTALL_CMAKE_DIR", "share/cmake/hdf5"))

--- a/repos/spack_repo/builtin/packages/hiop/package.py
+++ b/repos/spack_repo/builtin/packages/hiop/package.py
@@ -243,9 +243,6 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
             args.extend(
                 [
                     self.define("MPI_HOME", spec["mpi"].prefix),
-                    self.define("MPI_C_COMPILER", spec["mpi"].mpicc),
-                    self.define("MPI_CXX_COMPILER", spec["mpi"].mpicxx),
-                    self.define("MPI_Fortran_COMPILER", spec["mpi"].mpifc),
                 ]
             )
             # NOTE: On Cray platforms, libfabric is occasionally not picked up

--- a/repos/spack_repo/builtin/packages/kvtree/package.py
+++ b/repos/spack_repo/builtin/packages/kvtree/package.py
@@ -58,8 +58,6 @@ class Kvtree(CMakePackage):
         spec = self.spec
         args = []
         args.append(self.define_from_variant("MPI"))
-        if spec.satisfies("+mpi"):
-            args.append(self.define("MPI_C_COMPILER", spec["mpi"].mpicc))
 
         args.append(self.define_from_variant("KVTREE_FILE_LOCK", "file_lock"))
 

--- a/repos/spack_repo/builtin/packages/mesa/package.py
+++ b/repos/spack_repo/builtin/packages/mesa/package.py
@@ -177,6 +177,10 @@ class Mesa(MesonPackage):
         return super().flag_handler(name, flags)
 
     @property
+    def cmake_extra_args(self):
+        return ["-DOpenGL_GL_PREFERENCE:STRING=LEGACY"]
+
+    @property
     def libglx_headers(self):
         return find_headers("GL/glx", root=self.spec.prefix.include, recursive=False)
 

--- a/repos/spack_repo/builtin/packages/mesa/package.py
+++ b/repos/spack_repo/builtin/packages/mesa/package.py
@@ -176,9 +176,8 @@ class Mesa(MesonPackage):
                 flags.append("-std=c99")
         return super().flag_handler(name, flags)
 
-    @property
-    def cmake_extra_args(self):
-        return ["-DOpenGL_GL_PREFERENCE:STRING=LEGACY"]
+    def set_dependent_cmake_args(self, pkg: PackageBase, args: List[str]):
+        args.append("-DOpenGL_GL_PREFERENCE:STRING=LEGACY")
 
     @property
     def libglx_headers(self):

--- a/repos/spack_repo/builtin/packages/mesa_glu/package.py
+++ b/repos/spack_repo/builtin/packages/mesa_glu/package.py
@@ -26,6 +26,11 @@ class MesaGlu(AutotoolsPackage):
     # patch switches all instances of register long to long to fix this.
     patch("register-long.patch")
 
+    def setup_dependent_build_environment(
+        self, env: EnvironmentModifications, dependent_spec: Spec
+    ):
+        env.prepend_path("OpenGL_ROOT", self.prefix)
+
     def configure_args(self):
         args = ["--disable-libglvnd"]
 

--- a/repos/spack_repo/builtin/packages/mpi/package.py
+++ b/repos/spack_repo/builtin/packages/mpi/package.py
@@ -5,9 +5,9 @@
 import os
 
 from spack_repo.builtin.build_systems.generic import Package
+from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
-
 
 class Mpi(Package):
     """Virtual package for the Message Passing Interface."""
@@ -16,7 +16,19 @@ class Mpi(Package):
     virtual = True
 
     def set_dependent_cmake_args(self, pkg: PackageBase, args: List[str]) -> None:
-        if not getattr(pkg, "find_mpi_hints", False):
+        if not getattr(pkg, "find_mpi_hints", True):
+            return
+
+        args.extend([
+            "-DMPIEXEC:FILEPATH=%s/bin/mpiexec" % spec["mpi"].prefix,
+            "-DMPIEXEC_EXECUTABLE:FILEPATH=%s/bin/mpiexec" % spec["mpi"].prefix,
+            "-DMPI_HOME:PATH=%s", spec["mpi"].prefix),
+        ]
+
+        # MSMPI does not provide compiler wrappers
+        # and pointing these variables at the MSVC compilers
+        # breaks CMake's mpi detection for MSMPI.
+        if "msmpi" in self.spec:
             return
 
         if "c" in pkg.spec:
@@ -24,6 +36,7 @@ class Mpi(Package):
         if "cxx" in pkg.spec:
             args.append(pkg.define("MPI_CXX_COMPILER", pkg.spec["mpi"].mpicxx))
         if "fortran" in pkg.spec:
+            # By default use the generic fortran wrapper not F77
             if getattr(pkg, "find_mpi_fortan77", False):
                 args.append(pkg.define("MPI_Fortran_COMPILER", pkg.spec["mpi"].mpif77))
             else:

--- a/repos/spack_repo/builtin/packages/mpi/package.py
+++ b/repos/spack_repo/builtin/packages/mpi/package.py
@@ -15,6 +15,20 @@ class Mpi(Package):
     homepage = "https://www.mpi-forum.org/"
     virtual = True
 
+    def set_dependent_cmake_args(self, pkg: PackageBase, args: List[str]) -> None:
+        if not getattr(pkg, "find_mpi_hints", False):
+            return
+
+        if "c" in pkg.spec:
+            args.append(pkg.define("MPI_C_COMPILER", pkg.spec["mpi"].mpicc))
+        if "cxx" in pkg.spec:
+            args.append(pkg.define("MPI_CXX_COMPILER", pkg.spec["mpi"].mpicxx))
+        if "fortran" in pkg.spec:
+            if getattr(pkg, "find_mpi_fortan77", False):
+                args.append(pkg.define("MPI_Fortran_COMPILER", pkg.spec["mpi"].mpif77))
+            else:
+                args.append(pkg.define("MPI_Fortran_COMPILER", pkg.spec["mpi"].mpifc))
+
     def test_mpi_hello(self):
         """build and run mpi hello world"""
         for lang in ("c", "f"):

--- a/repos/spack_repo/builtin/packages/nalu/package.py
+++ b/repos/spack_repo/builtin/packages/nalu/package.py
@@ -67,9 +67,6 @@ class Nalu(CMakePackage):
                 "-DCMAKE_C_COMPILER=%s" % spec["mpi"].mpicc,
                 "-DCMAKE_CXX_COMPILER=%s" % spec["mpi"].mpicxx,
                 "-DCMAKE_Fortran_COMPILER=%s" % spec["mpi"].mpifc,
-                "-DMPI_C_COMPILER=%s" % spec["mpi"].mpicc,
-                "-DMPI_CXX_COMPILER=%s" % spec["mpi"].mpicxx,
-                "-DMPI_Fortran_COMPILER=%s" % spec["mpi"].mpifc,
                 self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
             ]
         )

--- a/repos/spack_repo/builtin/packages/omnitrace/package.py
+++ b/repos/spack_repo/builtin/packages/omnitrace/package.py
@@ -187,10 +187,6 @@ class Omnitrace(CMakePackage):
             tau_root = spec["tau"].prefix
             args.append(self.define("TAU_ROOT_DIR", tau_root))
 
-        if "+mpi" in spec:
-            args.append(self.define("MPI_C_COMPILER", spec["mpi"].mpicc))
-            args.append(self.define("MPI_CXX_COMPILER", spec["mpi"].mpicxx))
-
         if spec.satisfies("@1.8:,rocm-6.2:0"):
             args.append(self.define("dl_LIBRARY", "dl"))
             args.append(

--- a/repos/spack_repo/builtin/packages/openfast/package.py
+++ b/repos/spack_repo/builtin/packages/openfast/package.py
@@ -106,9 +106,6 @@ class Openfast(CMakePackage):
                     self.define("CMAKE_CXX_COMPILER", spec["mpi"].mpicxx),
                     self.define("CMAKE_C_COMPILER", spec["mpi"].mpicc),
                     self.define("CMAKE_Fortran_COMPILER", spec["mpi"].mpifc),
-                    self.define("MPI_CXX_COMPILER", spec["mpi"].mpicxx),
-                    self.define("MPI_C_COMPILER", spec["mpi"].mpicc),
-                    self.define("MPI_Fortran_COMPILER", spec["mpi"].mpifc),
                     self.define("HDF5_ROOT", spec["hdf5"].prefix),
                     self.define("YAML_ROOT", spec["yaml-cpp"].prefix),
                     # The following expects that HDF5 was built with CMake.

--- a/repos/spack_repo/builtin/packages/openglu/package.py
+++ b/repos/spack_repo/builtin/packages/openglu/package.py
@@ -64,6 +64,11 @@ class Openglu(Package):
     def fetcher(self):
         _ = self.fetcher
 
+    def setup_dependent_build_environment(
+        self, env: EnvironmentModifications, dependent_spec: Spec
+    ):
+        env.prepend_path("OpenGL_ROOT", self.prefix)
+
     @property
     def libs(self):
         return find_libraries("libGLU", self.prefix, shared=True, recursive=True)

--- a/repos/spack_repo/builtin/packages/paraview/package.py
+++ b/repos/spack_repo/builtin/packages/paraview/package.py
@@ -646,17 +646,6 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
             cmake_args.append("-DPARAVIEW_ENABLE_PYTHON:BOOL=OFF")
 
         cmake_args.append("-DPARAVIEW_USE_MPI:BOOL=%s" % variant_bool("+mpi"))
-        if "+mpi" in spec:
-            mpi_args = ["-DMPIEXEC:FILEPATH=%s/bin/mpiexec" % spec["mpi"].prefix]
-            if not sys.platform == "win32":
-                mpi_args.extend(
-                    [
-                        "-DMPI_CXX_COMPILER:PATH=%s" % spec["mpi"].mpicxx,
-                        "-DMPI_C_COMPILER:PATH=%s" % spec["mpi"].mpicc,
-                        "-DMPI_Fortran_COMPILER:PATH=%s" % spec["mpi"].mpifc,
-                    ]
-                )
-            cmake_args.extend(mpi_args)
 
         cmake_args.append("-DPARAVIEW_BUILD_SHARED_LIBS:BOOL=%s" % variant_bool("+shared"))
 

--- a/repos/spack_repo/builtin/packages/pastix/package.py
+++ b/repos/spack_repo/builtin/packages/pastix/package.py
@@ -96,13 +96,4 @@ class Pastix(CMakePackage, CudaPackage):
         elif spec.satisfies("^[virtuals=lapack] openblas"):
             args.extend([self.define("BLA_VENDOR", "OpenBLAS")])
 
-        if spec.satisfies("+mpi"):
-            args.extend(
-                [
-                    self.define("MPI_C_COMPILER", self.spec["mpi"].mpicc),
-                    self.define("MPI_CXX_COMPILER", self.spec["mpi"].mpicxx),
-                    self.define("MPI_Fortran_COMPILER", self.spec["mpi"].mpifc),
-                ]
-            )
-
         return args

--- a/repos/spack_repo/builtin/packages/pdc/package.py
+++ b/repos/spack_repo/builtin/packages/pdc/package.py
@@ -48,7 +48,6 @@ class Pdc(CMakePackage):
 
     def cmake_args(self):
         args = [
-            self.define("MPI_C_COMPILER", self.spec["mpi"].mpicc),
             self.define("BUILD_MPI_TESTING", "ON"),
             self.define("BUILD_SHARED_LIBS", "ON"),
             self.define("BUILD_TESTING", "ON"),

--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -1280,6 +1280,28 @@ print(json.dumps(config))
         module.python_platlib = join_path(dependent_spec.prefix, self.platlib)
         module.python_purelib = join_path(dependent_spec.prefix, self.purelib)
 
+    def set_dependent_cmake_args(self, pkg: PackageBase, args: List[str]) -> None:
+        """Set the {Python3,Python,PYTHON}_EXECUTABLE CMake variables explicitly if the package
+        has the variable ``find_python_hints`` set to True. This ensures that CMake locates the
+        right Python in its builtin FindPython3, FindPython, and FindPythonInterp modules.
+        Spack does CMake's job here because CMake's modules only search for Python versions known
+        at the time of release by default.
+        """
+
+        # Allow packages to disable these hints be setting a the member variable
+        # ``find_python_hints`` to False. By default this is always applied.
+        if not getattr(pkg, "find_python_hints", True):
+            return
+
+        python_executable = pkg.spec["python"].command.path
+        args.extend(
+            [
+                define("PYTHON_EXECUTABLE", python_executable),
+                define("Python_EXECUTABLE", python_executable),
+                define("Python3_EXECUTABLE", python_executable),
+            ]
+        )
+
     def add_files_to_view(self, view, merge_map, skip_if_exists=True):
         """Make the view a virtual environment if it isn't one already.
 

--- a/repos/spack_repo/builtin/packages/rankstr/package.py
+++ b/repos/spack_repo/builtin/packages/rankstr/package.py
@@ -37,7 +37,6 @@ class Rankstr(CMakePackage):
     def cmake_args(self):
         spec = self.spec
         args = []
-        args.append(self.define("MPI_C_COMPILER", spec["mpi"].mpicc))
 
         if spec.satisfies("@0.1.0:"):
             args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))

--- a/repos/spack_repo/builtin/packages/redset/package.py
+++ b/repos/spack_repo/builtin/packages/redset/package.py
@@ -55,7 +55,6 @@ class Redset(CMakePackage, CudaPackage):
     def cmake_args(self):
         spec = self.spec
         args = []
-        args.append(self.define("MPI_C_COMPILER", spec["mpi"].mpicc))
         args.append(self.define("WITH_KVTREE_PREFIX", spec["kvtree"].prefix))
         args.append(self.define("WITH_RANKSTR_PREFIX", spec["rankstr"].prefix))
 

--- a/repos/spack_repo/builtin/packages/rocprofiler_systems/package.py
+++ b/repos/spack_repo/builtin/packages/rocprofiler_systems/package.py
@@ -228,10 +228,6 @@ class RocprofilerSystems(CMakePackage):
             tau_root = spec["tau"].prefix
             args.append(self.define("TAU_ROOT_DIR", tau_root))
 
-        if "+mpi" in spec:
-            args.append(self.define("MPI_C_COMPILER", spec["mpi"].mpicc))
-            args.append(self.define("MPI_CXX_COMPILER", spec["mpi"].mpicxx))
-
         if spec.satisfies("@6.3:"):
             args.append(self.define("dl_LIBRARY", "dl"))
             args.append(

--- a/repos/spack_repo/builtin/packages/sensei/package.py
+++ b/repos/spack_repo/builtin/packages/sensei/package.py
@@ -131,8 +131,6 @@ class Sensei(CMakePackage):
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define("SENSEI_USE_EXTERNAL_pugixml", True),
             self.define(f"{prefix}ENABLE_SENSEI", True),
-            self.define("MPI_C_COMPILER", spec["mpi"].mpicc),
-            self.define("MPI_CXX_COMPILER", spec["mpi"].mpicxx),
             # Don"t rely on MPI found in cray environment for cray systems.
             # On non-cray systems this should be a no-op
             self.define(f"{prefix}ENABLE_CRAY_MPICH", False),

--- a/repos/spack_repo/builtin/packages/shuffile/package.py
+++ b/repos/spack_repo/builtin/packages/shuffile/package.py
@@ -44,7 +44,6 @@ class Shuffile(CMakePackage):
     def cmake_args(self):
         spec = self.spec
         args = []
-        args.append(self.define("MPI_C_COMPILER", spec["mpi"].mpicc))
         args.append(self.define("WITH_KVTREE_PREFIX", spec["kvtree"].prefix))
 
         if spec.satisfies("@0.1.0:"):

--- a/repos/spack_repo/builtin/packages/spath/package.py
+++ b/repos/spack_repo/builtin/packages/spath/package.py
@@ -41,8 +41,6 @@ class Spath(CMakePackage):
         spec = self.spec
         args = []
         args.append(self.define_from_variant("MPI"))
-        if "+mpi" in spec:
-            args.append(self.define("MPI_C_COMPILER", spec["mpi"].mpicc))
 
         if spec.satisfies("@0.1.0:"):
             args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))

--- a/repos/spack_repo/builtin/packages/timemory/package.py
+++ b/repos/spack_repo/builtin/packages/timemory/package.py
@@ -327,10 +327,6 @@ class Timemory(CMakePackage, PythonExtension):
             self.define_from_variant("TIMEMORY_USE_ALLINEA_MAP", "allinea_map"),
         ]
 
-        if "+mpi" in spec:
-            args.append(self.define("MPI_C_COMPILER", spec["mpi"].mpicc))
-            args.append(self.define("MPI_CXX_COMPILER", spec["mpi"].mpicxx))
-
         if "+cuda" in spec:
             # newer versions use 'TIMEMORY_CUDA_ARCH'
             key = "CUDA_ARCH" if spec.satisfies("@:3.0.1") else "TIMEMORY_CUDA_ARCH"

--- a/repos/spack_repo/builtin/packages/ufs_utils/package.py
+++ b/repos/spack_repo/builtin/packages/ufs_utils/package.py
@@ -71,11 +71,5 @@ class UfsUtils(CMakePackage):
     depends_on("w3emc")
     depends_on("zlib-api")
 
-    def cmake_args(self):
-        return [
-            "-DMPI_C_COMPILER=%s" % self.spec["mpi"].mpicc,
-            "-DMPI_Fortran_COMPILER=%s" % self.spec["mpi"].mpifc,
-        ]
-
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         env.set("ESMFMKFILE", join_path(self.spec["esmf"].prefix.lib, "esmf.mk"))

--- a/repos/spack_repo/builtin/packages/vtk_h/package.py
+++ b/repos/spack_repo/builtin/packages/vtk_h/package.py
@@ -35,6 +35,9 @@ class VtkH(CMakePackage, CudaPackage):
     url = "https://github.com/Alpine-DAV/vtk-h/releases/download/v0.5.8/vtkh-v0.5.8.tar.gz"
     git = "https://github.com/Alpine-DAV/vtk-h.git"
 
+    # Don't use the automatic MPI hints in favor of building the hostconfig
+    find_mpi_hints = False
+
     maintainers("cyrush")
 
     version("develop", branch="develop", submodules=True)

--- a/repos/spack_repo/builtin/packages/warpx/package.py
+++ b/repos/spack_repo/builtin/packages/warpx/package.py
@@ -206,11 +206,6 @@ class Warpx(CMakePackage, PythonExtension):
         args.append("-DWarpX_amrex_internal=OFF")
         args.append(self.define_from_variant("WarpX_FFT", "fft"))
 
-        # FindMPI needs an extra hint sometimes, particularly on cray systems
-        if "+mpi" in spec:
-            args.append(self.define("MPI_C_COMPILER", spec["mpi"].mpicc))
-            args.append(self.define("MPI_CXX_COMPILER", spec["mpi"].mpicxx))
-
         if "+openpmd" in spec:
             args.append("-DWarpX_openpmd_internal=OFF")
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Replace per-package hacks for FindMPI hints with an automatic method.

Based on changes in #2057 which does a similar thing for configuring FindOpenGL for spack installed Mesa.

