### PR TITLE
py-typer-slim: new package (and discussion)

### DIFF
--- a/repos/spack_repo/builtin/packages/py_typer_slim/package.py
+++ b/repos/spack_repo/builtin/packages/py_typer_slim/package.py
@@ -1,0 +1,23 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyTyperSlim(PythonPackage):
+    """Typer, build great CLIs. Easy to code. Based on Python type hints."""
+
+    homepage = "https://github.com/fastapi/typer"
+    pypi = "typer_slim/typer_slim-0.20.0.tar.gz"
+
+    license("MIT")
+
+    version("0.20.0", sha256="9fc6607b3c6c20f5c33ea9590cbeb17848667c51feee27d9e314a579ab07d1a3")
+
+    depends_on("python@3.8:", type=("build", "run"))
+    depends_on("py-pdm-backend", type="build")
+    depends_on("py-click@8", type=("build", "run"))
+    depends_on("py-typing-extensions@3.7.4.3:", type=("build", "run"))


### PR DESCRIPTION
What is the best way to handle this package? Per [the readme][1] (what would be) `py-typer-slim+standard` is the same as the package `py-typer`. 

Options: 

1. Accept this package and have 2 packages that need to be updated and maintained, and potentially creating weird conflicts down the line as both import with `import typer`.
2. Update `py-typer` to have `provides("py-typer-slim")`, potentially adding unnecessary dependencies when `depends_on("py-typer-slim")` is specified.
3. When packaging dependent packages, specify `depends_on("py-typer")` instead of `depends_on("py-typer-slim")`.
4. Get rid of `py-typer` entirely and replace with `py-typer-slim` with a variant `+standard` and possibly `provides("py-typer", when="+standard")`

Personally, I lean towards option 2 even though this PR implements option 1, but I wanted to have some sort of discussion before I made that change. I'm happy to implement whatever is decided.

[1]: https://github.com/fastapi/typer/blob/master/README.md#typer-slim