### PR TITLE
gaudi: add v40.1, disable variants removed in v40.0

### DIFF
--- a/repos/spack_repo/builtin/packages/gaudi/package.py
+++ b/repos/spack_repo/builtin/packages/gaudi/package.py
@@ -18,6 +18,7 @@ class Gaudi(CMakePackage, CudaPackage):
     tags = ["hep"]
 
     version("master", branch="master")
+    version("40.1", sha256="f02010c865717d397b8fc8b8bf5d904e711ee2e416f3d12330cf04deaa7a4343")
     version("40.0", sha256="0cfe696967067b23382968a5c5ab1b4b7f38a7dd3ee2e321d1bff0dd8f99d2f9")
     version("39.4", sha256="dd698e0788811fa8325ed5f37ecf3fd9bde55720489224a517b52360819564d7")
     version("39.3", sha256="009a306a7413f3207f0d5fa19034186c0bb3c8de0c807d38f515338a41a8a0bc")
@@ -75,11 +76,17 @@ class Gaudi(CMakePackage, CudaPackage):
     variant("docs", default=False, description="Build documentation with Doxygen")
     variant("examples", default=False, description="Build examples")
     variant("gaudialg", default=False, description="Build GaudiAlg support", when="@37.0:38")
-    variant("gperftools", default=False, description="Build with Google PerfTools support")
+    variant(
+        "gperftools", default=False, description="Build with Google PerfTools support", when="@:39"
+    )
     variant("heppdt", default=False, description="Build with HEP Particle Data Table support")
-    variant("jemalloc", default=False, description="Build with jemalloc allocator support")
-    variant("unwind", default=False, description="Build with unwind call-chains")
-    variant("vtune", default=False, description="Build with Intel VTune profiler support")
+    variant(
+        "jemalloc", default=False, description="Build with jemalloc allocator support", when="@:39"
+    )
+    variant("unwind", default=False, description="Build with unwind call-chains", when="@:39")
+    variant(
+        "vtune", default=False, description="Build with Intel VTune profiler support", when="@:39"
+    )
     variant("xercesc", default=False, description="Build with Xerces-C XML support")
 
     patch("fmt_fix.patch", when="@36.6:36.12 ^fmt@10:")
@@ -150,7 +157,8 @@ class Gaudi(CMakePackage, CudaPackage):
 
     depends_on("clhep")
     depends_on("cmake", type="build")
-    depends_on("cmake@3.19:", type="build", when="@39:")
+    depends_on("cmake@3.19:", type="build", when="@39:40.0")
+    depends_on("cmake@3.29:", type="build", when="@40.1:")
     depends_on("cppgsl")
     depends_on("fmt@:8", when="@:36.9")
     depends_on("fmt@:10")


### PR DESCRIPTION
GaudiProfiling using jemalloc/gperftools/unwind/vtune was removed in v40.0
