### PR TITLE
medcoupling: restore rpc dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/salome_medcoupling/package.py
+++ b/repos/spack_repo/builtin/packages/salome_medcoupling/package.py
@@ -55,6 +55,7 @@ class SalomeMedcoupling(CMakePackage):
 
     depends_on("cmake@2.8.11:3", type="build")
 
+    depends_on("rpc")
     depends_on("libxml2@2.9.1:")
     depends_on("cppunit", type="test")
     depends_on("python@3.6.5:", when="@:9.12")


### PR DESCRIPTION
Dependency on rpc was incorrectly removed by https://github.com/spack/spack-packages/pull/2106

Instead of depending on a particular implementation of rpc (libtirpc), we now depend on the virtual rpc package.