### PR TITLE
libgdsii: depends on c

### DIFF
--- a/repos/spack_repo/builtin/packages/libgdsii/package.py
+++ b/repos/spack_repo/builtin/packages/libgdsii/package.py
@@ -20,7 +20,8 @@ class Libgdsii(AutotoolsPackage):
 
     version("0.21", sha256="1adc571c6b53df4c08d108f9ac4f4a7fd6fbefd4bc56f74e0b7b2801353671b8")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type"build")
+    depends_on("cxx", type="build")
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")

--- a/repos/spack_repo/builtin/packages/libgdsii/package.py
+++ b/repos/spack_repo/builtin/packages/libgdsii/package.py
@@ -20,7 +20,7 @@ class Libgdsii(AutotoolsPackage):
 
     version("0.21", sha256="1adc571c6b53df4c08d108f9ac4f4a7fd6fbefd4bc56f74e0b7b2801353671b8")
 
-    depends_on("c", type"build")
+    depends_on("c", type="build")
     depends_on("cxx", type="build")
 
     depends_on("autoconf", type="build")


### PR DESCRIPTION
Discovered in a debugging session with @wadudmiah

Adding to backports even though it adds a dependency because the package is unusable without it.