### PR TITLE
difftastic: add v0.67.0

### DIFF
--- a/repos/spack_repo/builtin/packages/difftastic/package.py
+++ b/repos/spack_repo/builtin/packages/difftastic/package.py
@@ -17,7 +17,12 @@ class Difftastic(CargoPackage):
 
     license("MIT")
 
+    version("0.67.0", sha256="a6a15d6ca9f9ab7c034d1770417d1829deb3fbe9dcf4731b9cba867e50e78437")
     version("0.64.0", sha256="54c7c93309ff9a2cbe87153ac1d16e80bacac4042c80f6b7206e9b71a6f10d0b")
     version("0.63.0", sha256="f96bcf4fc961921d52cd9fe5aa94017924abde3d5a3b5a4727b103e9c2d4b416")
 
-    depends_on("rust@1.74.1:", type="build", when="@0.62.0:")
+    depends_on("rust@1.76:", type="build", when="@0.67:")
+    depends_on("rust@1.75:", type="build", when="@0.65:")
+    depends_on("rust@1.74.1:", type="build", when="@0.62:")
+
+    depends_on("gmake", type="build")


### PR DESCRIPTION
https://github.com/Wilfred/difftastic/releases/tag/0.67.0

Also adding `gmake` as a build dependency since it is used and leaked from system installs.