### PR TITLE
fd: add gmake as build dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/fd/package.py
+++ b/repos/spack_repo/builtin/packages/fd/package.py
@@ -22,7 +22,6 @@ class Fd(CargoPackage):
 
     license("Apache-2.0 OR MIT")
 
-    # Versions from newest to oldest
     version("master", branch="master")
     version("10.3.0", sha256="2edbc917a533053855d5b635dff368d65756ce6f82ddefd57b6c202622d791e9")
     version("10.2.0", sha256="73329fe24c53f0ca47cd0939256ca5c4644742cb7c14cf4114c8c9871336d342")
@@ -32,11 +31,13 @@ class Fd(CargoPackage):
     version("8.4.0", sha256="d0c2fc7ddbe74e3fd88bf5bb02e0f69078ee6d2aeea3d8df42f508543c9db05d")
     version("7.4.0", sha256="33570ba65e7f8b438746cb92bb9bc4a6030b482a0d50db37c830c4e315877537")
 
-    # Build dependencies
     depends_on("c", type="build")
+
     depends_on("rust@1.77.2:", type="build", when="@10:")
     depends_on("rust@1.70:", type="build", when="@8.7.1:")
     depends_on("rust@1.64:", type="build", when="@8.7:")
+
+    depends_on("gmake", type="build")
 
     @run_after("install")
     def install_completions(self):


### PR DESCRIPTION
Add `gmake` as a build dependency because it is used and leaked from system installs in the build.