### PR TITLE
libctl: build system tests for F77

### DIFF
--- a/repos/spack_repo/builtin/packages/libctl/package.py
+++ b/repos/spack_repo/builtin/packages/libctl/package.py
@@ -26,7 +26,8 @@ class Libctl(AutotoolsPackage):
         url="http://ab-initio.mit.edu/libctl/libctl-3.2.2.tar.gz",
     )
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
 
     depends_on("guile")
 


### PR DESCRIPTION
It doesn't appear to include any fortran code, but the libctl build system fails without fortran present.

Found in a debugging session with @wadudmiah