### PR TITLE
meep: depends on python@:3.11

### DIFF
--- a/repos/spack_repo/builtin/packages/meep/package.py
+++ b/repos/spack_repo/builtin/packages/meep/package.py
@@ -74,7 +74,7 @@ class Meep(AutotoolsPackage):
     depends_on("hdf5+mpi", when="+hdf5+mpi")
     depends_on("gsl", when="+gsl")
     with when("+python"):
-        depends_on("python")
+        depends_on("python@:3.11")
         depends_on("py-numpy")
         depends_on("swig")
         depends_on("py-mpi4py", when="+mpi")


### PR DESCRIPTION
meep uses imp which is removed in python 3.12.

Found in a debugging session with @wadudmiah