### PR TITLE
onnx: conflict with abseil-cpp cxxstd=11,14

### DIFF
--- a/repos/spack_repo/builtin/packages/onnx/package.py
+++ b/repos/spack_repo/builtin/packages/onnx/package.py
@@ -69,7 +69,7 @@ class Onnx(CMakePackage):
     depends_on("cmake@3.26:", type="build", when="@1.20:")
     depends_on("python", type="build")
     depends_on("protobuf")
-    
+
     # ONNX uses the cxxstd from abseil-cpp, which is a dependency of protobuf
     conflicts("^abseil-cpp cxxstd=11", when="@1.19:", msg="ONNX 1.19+ requires Abseil with C++17")
     conflicts("^abseil-cpp cxxstd=14", when="@1.19:", msg="ONNX 1.19+ requires Abseil with C++17")

--- a/repos/spack_repo/builtin/packages/onnx/package.py
+++ b/repos/spack_repo/builtin/packages/onnx/package.py
@@ -69,6 +69,10 @@ class Onnx(CMakePackage):
     depends_on("cmake@3.26:", type="build", when="@1.20:")
     depends_on("python", type="build")
     depends_on("protobuf")
+    
+    # ONNX uses the cxxstd from abseil-cpp, which is a dependency of protobuf
+    conflicts("^abseil-cpp cxxstd=11", when="@1.19:", msg="ONNX 1.19+ requires Abseil with C++17")
+    conflicts("^abseil-cpp cxxstd=14", when="@1.19:", msg="ONNX 1.19+ requires Abseil with C++17")
 
     # Allow conversion from OpSchema to OpSchemaRegisterOnce (needed for onnxruntime)
     # Ref: https://github.com/onnx/onnx/pull/7390


### PR DESCRIPTION
As of 1.19 ([commit](https://github.com/onnx/onnx/commit/51df8fd8e66dfc446b8216a7ec081e3f2b7dd2ef)), `onnx` requires C++17 or better. Since `onnx` gets its `CMAKE_CXX_STANDARD` standard from `abseil-cpp` (via `protobuf`), this PR adds a conflict.