### PR TITLE
Constrain java version for qualimap

### DIFF
--- a/repos/spack_repo/builtin/packages/qualimap/package.py
+++ b/repos/spack_repo/builtin/packages/qualimap/package.py
@@ -23,6 +23,8 @@ class Qualimap(Package):
 
     depends_on("java", type="run")
 
+    conflicts("java@17:")
+
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         env.prepend_path("PATH", prefix)
 


### PR DESCRIPTION
In the [wrapper](https://bitbucket.org/kokonech/qualimap/src/32f3ca5519a6f92910a8bbeeecc5355e134a9182/cli/qualimap#lines-42) that launches Qualimap, the `-XX:MemPerSize` JVM option is used. Per the [Java docs](https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html#removed-java-options), this option was removed as of Java 17. Thus, we add a conflict to the `qualimap` package for `java@17:`.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
