### PR TITLE
flecsi: docs need py-sphinx-rtd-theme@:2

### DIFF
--- a/repos/spack_repo/builtin/packages/flecsi/package.py
+++ b/repos/spack_repo/builtin/packages/flecsi/package.py
@@ -96,7 +96,7 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
 
     # FleCSI documentation dependencies
     depends_on("py-sphinx", when="+doc")
-    depends_on("py-sphinx-rtd-theme", when="+doc")
+    depends_on("py-sphinx-rtd-theme@:2", when="+doc")
     depends_on("py-recommonmark", when="@:2.2 +doc")
     depends_on("doxygen", when="+doc")
     depends_on("graphviz", when="+doc")


### PR DESCRIPTION
Due to https://github.com/readthedocs/sphinx_rtd_theme/issues/1624 we need to keep py-sphinx-rtd-theme below 3.x.