### PR TITLE
Fix static builds in libceed

### DIFF
--- a/repos/spack_repo/builtin/packages/libceed/package.py
+++ b/repos/spack_repo/builtin/packages/libceed/package.py
@@ -41,6 +41,8 @@ class Libceed(MakefilePackage, CudaPackage, ROCmPackage):
 
     variant("openmp", default=False, description="Enable OpenMP support")
 
+    variant("shared", default=True, description="Build shared libraries")
+
     conflicts("+rocm", when="@:0.7")
 
     depends_on("c", type="build")  # generated
@@ -60,10 +62,12 @@ class Libceed(MakefilePackage, CudaPackage, ROCmPackage):
         depends_on("occa+cuda", when="+cuda")
         depends_on("occa~cuda", when="~cuda")
 
-    depends_on("libxsmm", when="+libxsmm")
+    depends_on("libxsmm~shared", when="+libxsmm~shared")
+    depends_on("libxsmm+shared", when="+libxsmm+shared")
     depends_on("blas", when="+libxsmm", type="link")
 
-    depends_on("magma", when="+magma")
+    depends_on("magma~shared", when="+magma~shared")
+    depends_on("magma+shared", when="+magma+shared")
 
     patch("libceed-v0.8-hip.patch", when="@0.8+rocm")
     patch("pkgconfig-version-0.4.diff", when="@0.4")
@@ -150,6 +154,9 @@ class Libceed(MakefilePackage, CudaPackage, ROCmPackage):
 
             if spec.satisfies("+openmp"):
                 makeopts += ["OPENMP=1"]
+
+            if spec.satisfies("~shared"):
+                makeopts += ["STATIC=1"]
 
         return makeopts
 


### PR DESCRIPTION
`libceed` did not have the `shared` variant and it was not possible to compile `libceed` as part of a static build. The reasons for this are two:

1. `libceed` has a build flag `STATIC `that has to turned on to build `libceed` as a static library
2. the dependencies of `libceed` were not compiled as static libraries (unless forced to).

This resulted in errors like:
```cpp
relocation R_X86_64_PC32 against symbol `magma2lapack_constants' can not be used when making a shared object; recompile with -fPIC
```
when building `libceed` as part of a static build.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
