### PR TITLE
acts dependencies: new versions as of 2025/11/27

### DIFF
--- a/repos/spack_repo/builtin/packages/covfie/package.py
+++ b/repos/spack_repo/builtin/packages/covfie/package.py
@@ -23,6 +23,7 @@ class Covfie(CMakePackage, CudaPackage, ROCmPackage):
     license("MPL-2.0")
 
     version("main", branch="main")
+    version("0.15.4", sha256="9a69f57c4a48acefedc7e8bc2cb38f688584a0535d79bb7eab9c0cc5c8c7290c")
     version("0.15.3", sha256="72da1147c44731caf9163f3931de78d7605a44f056f22a2f6ea024ad02a1ba71")
     version("0.15.2", sha256="6eff65e05118d3007c689e3529a62bb1674348ac1b0f0f32afd953c62d1b8890")
     version("0.15.1", sha256="809f1207ee9c96c6065fc9da796abfe9bdeab1bb987526da787f26b1d628ce7a")

--- a/repos/spack_repo/builtin/packages/detray/package.py
+++ b/repos/spack_repo/builtin/packages/detray/package.py
@@ -21,6 +21,7 @@ class Detray(CMakePackage):
 
     license("MPL-2.0", checked_by="stephenswat")
 
+    version("0.106.0", sha256="9695430a1537e86c06b1423054dfd3b5ae717c9b84e1b233ae48fc3fd859b27a")
     version("0.105.1", sha256="100f5954560426a14258a5debe1c1f25ae491611eec557d6733fa821889abbb7")
     version("0.105.0", sha256="a2c5758420a1544a745e58cb2aa0eaac02cd4548a9a527b8b58d94759e5d38c7")
     version("0.104.1", sha256="b75b3f2a27d4a03a69e66815b34ef2e7f6973919c8d9b1daff32d1135a28c0c6")

--- a/repos/spack_repo/builtin/packages/geomodel/package.py
+++ b/repos/spack_repo/builtin/packages/geomodel/package.py
@@ -19,6 +19,7 @@ class Geomodel(CMakePackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    version("6.22.0", sha256="6e23db099c3c7603d13c13dfac1152db484a69c0b9b962ec0ab495ae3299f2cd")
     version("6.21.0", sha256="44712cbe821eadfd74b187906686b52cf16d824c330d93a98d00f29c3e683314")
     version("6.20.0", sha256="e8ecb860658d94a6582be4b607111d9b81f3c38c9e46b8d6f4aae88573b5b878")
     version("6.19.0", sha256="d78e9035bd520c5aae007ee5806116ac0a9077b99927bd8810ced49295e1f44d")


### PR DESCRIPTION
This commit adds a new version of covfie (0.15.4), detray (0.106.0), and Geomodel (6.22.0).