### PR TITLE
root: add v6.38.00

### DIFF
--- a/repos/spack_repo/builtin/packages/civetweb/package.py
+++ b/repos/spack_repo/builtin/packages/civetweb/package.py
@@ -21,7 +21,7 @@ class Civetweb(CMakePackage):
     version("1.16", sha256="f0e471c1bf4e7804a6cfb41ea9d13e7d623b2bcc7bc1e2a4dd54951a24d60285")
 
     variant("shared", default=False, description="Build shared libraries instead of static ones")
-    
+
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 

--- a/repos/spack_repo/builtin/packages/civetweb/package.py
+++ b/repos/spack_repo/builtin/packages/civetweb/package.py
@@ -13,7 +13,7 @@ class Civetweb(CMakePackage):
 
     homepage = "https://github.com/civetweb/civetweb"
     url = "https://github.com/civetweb/civetweb/archive/refs/tags/v1.16.tar.gz"
-
+    git = "https://github.com/civetweb/civetweb.git"
     maintainers("wdconinc")
 
     license("MIT", checked_by="wdconinc")

--- a/repos/spack_repo/builtin/packages/civetweb/package.py
+++ b/repos/spack_repo/builtin/packages/civetweb/package.py
@@ -1,0 +1,46 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class Civetweb(CMakePackage):
+    """CivetWeb is an easy to use, powerful, C (C/C++) embeddable
+    web server with optional CGI, SSL and Lua support."""
+
+    homepage = "https://github.com/civetweb/civetweb"
+    url = "https://github.com/civetweb/civetweb/archive/refs/tags/v1.16.tar.gz"
+
+    maintainers("wdconinc")
+
+    license("MIT", checked_by="wdconinc")
+
+    version("1.16", sha256="f0e471c1bf4e7804a6cfb41ea9d13e7d623b2bcc7bc1e2a4dd54951a24d60285")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    depends_on("lua")
+    depends_on("openssl")
+    depends_on("zlib-api")
+
+    def cmake_args(self):
+        args = [
+            self.define("CIVETWEB_BUILD_TESTING", self.run_tests),
+            self.define("CIVETWEB_ENABLE_SERVER_EXECUTABLE", True),
+            self.define("CIVETWEB_ENABLE_CXX", True),
+            self.define("CIVETWEB_ENABLE_HTTP2", True),
+            self.define("CIVETWEB_ENABLE_IPV6", True),
+            self.define("CIVETWEB_ENABLE_WEBSOCKETS", True),
+            self.define("CIVETWEB_ENABLE_X_DOM_SOCKET", True),
+            self.define("CIVETWEB_ENABLE_LUA", False),
+            self.define("CIVETWEB_ENABLE_ZLIB", True),
+            self.define("CIVETWEB_ENABLE_SSL", True),
+        ]
+        args.append(self.define("CIVETWEB_SSL_OPENSSL_API_1_0", self.spec.satisfies("^openssl@1.0")))
+        args.append(self.define("CIVETWEB_SSL_OPENSSL_API_1_1", self.spec.satisfies("^openssl@1.1")))
+        args.append(self.define("CIVETWEB_SSL_OPENSSL_API_3_0", self.spec.satisfies("^openssl@3:")))
+        return args

--- a/repos/spack_repo/builtin/packages/civetweb/package.py
+++ b/repos/spack_repo/builtin/packages/civetweb/package.py
@@ -20,6 +20,8 @@ class Civetweb(CMakePackage):
 
     version("1.16", sha256="f0e471c1bf4e7804a6cfb41ea9d13e7d623b2bcc7bc1e2a4dd54951a24d60285")
 
+    variant("shared", default=False, description="Build shared libraries instead of static ones")
+    
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
@@ -39,6 +41,7 @@ class Civetweb(CMakePackage):
             self.define("CIVETWEB_ENABLE_LUA", False),
             self.define("CIVETWEB_ENABLE_ZLIB", True),
             self.define("CIVETWEB_ENABLE_SSL", True),
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
         ]
         args.append(
             self.define("CIVETWEB_SSL_OPENSSL_API_1_0", self.spec.satisfies("^openssl@1.0"))

--- a/repos/spack_repo/builtin/packages/civetweb/package.py
+++ b/repos/spack_repo/builtin/packages/civetweb/package.py
@@ -18,6 +18,7 @@ class Civetweb(CMakePackage):
 
     license("MIT", checked_by="wdconinc")
 
+    version("1.16-213-g5864b55a", commit="5864b55a94f4b5238155cbf2baec707f0fa2ba6d")
     version("1.16", sha256="f0e471c1bf4e7804a6cfb41ea9d13e7d623b2bcc7bc1e2a4dd54951a24d60285")
 
     variant("shared", default=False, description="Build shared libraries instead of static ones")

--- a/repos/spack_repo/builtin/packages/civetweb/package.py
+++ b/repos/spack_repo/builtin/packages/civetweb/package.py
@@ -40,7 +40,13 @@ class Civetweb(CMakePackage):
             self.define("CIVETWEB_ENABLE_ZLIB", True),
             self.define("CIVETWEB_ENABLE_SSL", True),
         ]
-        args.append(self.define("CIVETWEB_SSL_OPENSSL_API_1_0", self.spec.satisfies("^openssl@1.0")))
-        args.append(self.define("CIVETWEB_SSL_OPENSSL_API_1_1", self.spec.satisfies("^openssl@1.1")))
-        args.append(self.define("CIVETWEB_SSL_OPENSSL_API_3_0", self.spec.satisfies("^openssl@3:")))
+        args.append(
+            self.define("CIVETWEB_SSL_OPENSSL_API_1_0", self.spec.satisfies("^openssl@1.0"))
+        )
+        args.append(
+            self.define("CIVETWEB_SSL_OPENSSL_API_1_1", self.spec.satisfies("^openssl@1.1"))
+        )
+        args.append(
+            self.define("CIVETWEB_SSL_OPENSSL_API_3_0", self.spec.satisfies("^openssl@3:"))
+        )
         return args

--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -435,7 +435,7 @@ class Root(CMakePackage):
 
     # Optional dependencies
     depends_on("arrow", when="+arrow")
-    depends_on("civetweb", when="+http")
+    depends_on("civetweb +shared", when="+http")
     depends_on("cuda", when="+cuda")
     depends_on("cuda", when="+cudnn")
     depends_on("cudnn", when="+cudnn")

--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -55,25 +55,57 @@ class Root(CMakePackage):
 
     # 6.34 (through 2025-06-30)
     with default_args(deprecated=True):
-        version("6.34.08", sha256="806045b156de03fe8f5661a670eab877f2e4d2da6c234dc3e31e98e2d7d96fe8")
-        version("6.34.06", sha256="a799d632dae5bb1ec87eae6ebc046a12268c6849f2a8837921c118fc51b6cff3")
-        version("6.34.04", sha256="e320c5373a8e87bb29b7280954ca8355ad8c4295cf49235606f0c8b200acb374")
-        version("6.34.02", sha256="166bec562e420e177aaf3133fa3fb09f82ecddabe8a2e1906345bad442513f94")
-        version("6.34.00", sha256="f3b00f3db953829c849029c39d7660a956468af247efd946e89072101796ab03")
+        version(
+            "6.34.08", sha256="806045b156de03fe8f5661a670eab877f2e4d2da6c234dc3e31e98e2d7d96fe8"
+        )
+        version(
+            "6.34.06", sha256="a799d632dae5bb1ec87eae6ebc046a12268c6849f2a8837921c118fc51b6cff3"
+        )
+        version(
+            "6.34.04", sha256="e320c5373a8e87bb29b7280954ca8355ad8c4295cf49235606f0c8b200acb374"
+        )
+        version(
+            "6.34.02", sha256="166bec562e420e177aaf3133fa3fb09f82ecddabe8a2e1906345bad442513f94"
+        )
+        version(
+            "6.34.00", sha256="f3b00f3db953829c849029c39d7660a956468af247efd946e89072101796ab03"
+        )
 
     # Older release series
     with default_args(deprecated=True):
-        version("6.30.08", sha256="8bb8594867b9ded20a65e59f2cb6da965aa30851b8960f8cbf76293aec046b69")
-        version("6.30.06", sha256="300db7ed1b678ed2fb9635ca675921a1945c7c2103da840033b493091f55700c")
-        version("6.30.04", sha256="2b4180b698f39cc65d91084d833a884515b325bc5f673c8e39abe818b025d8cc")
-        version("6.30.02", sha256="7965a456d1ad1ee0d5fe4769bf5a8fec291af684ed93db0f3080a9c362435183")
-        version("6.30.00", sha256="0592c066954cfed42312957c9cb251654456064fe2d8dabdcb8826f1c0099d71")
-        version("6.28.12", sha256="fcd325267d238e9c6008f56a3a7e7c87fd864b1e633b0ffcf1f82b7e7ad3d249")
-        version("6.28.10", sha256="69d6fdeb607e6b20bd02c757fa6217024c0b6132c1e9b1dff4d85d9a2bb7e51e")
-        version("6.28.06", sha256="af3b673b9aca393a5c9ae1bf86eab2672aaf1841b658c5c6e7a30ab93c586533")
-        version("6.28.04", sha256="70f7f86a0cd5e3f2a0befdc59942dd50140d990ab264e8e56c7f17f6bfe9c965")
-        version("6.28.02", sha256="6643c07710e68972b00227c68b20b1016fec16f3fba5f44a571fa1ce5bb42faa")
-        version("6.28.00", sha256="afa1c5c06d0915411cb9492e474ea9ab12b09961a358e7e559013ed63b5d8084")
+        version(
+            "6.30.08", sha256="8bb8594867b9ded20a65e59f2cb6da965aa30851b8960f8cbf76293aec046b69"
+        )
+        version(
+            "6.30.06", sha256="300db7ed1b678ed2fb9635ca675921a1945c7c2103da840033b493091f55700c"
+        )
+        version(
+            "6.30.04", sha256="2b4180b698f39cc65d91084d833a884515b325bc5f673c8e39abe818b025d8cc"
+        )
+        version(
+            "6.30.02", sha256="7965a456d1ad1ee0d5fe4769bf5a8fec291af684ed93db0f3080a9c362435183"
+        )
+        version(
+            "6.30.00", sha256="0592c066954cfed42312957c9cb251654456064fe2d8dabdcb8826f1c0099d71"
+        )
+        version(
+            "6.28.12", sha256="fcd325267d238e9c6008f56a3a7e7c87fd864b1e633b0ffcf1f82b7e7ad3d249"
+        )
+        version(
+            "6.28.10", sha256="69d6fdeb607e6b20bd02c757fa6217024c0b6132c1e9b1dff4d85d9a2bb7e51e"
+        )
+        version(
+            "6.28.06", sha256="af3b673b9aca393a5c9ae1bf86eab2672aaf1841b658c5c6e7a30ab93c586533"
+        )
+        version(
+            "6.28.04", sha256="70f7f86a0cd5e3f2a0befdc59942dd50140d990ab264e8e56c7f17f6bfe9c965"
+        )
+        version(
+            "6.28.02", sha256="6643c07710e68972b00227c68b20b1016fec16f3fba5f44a571fa1ce5bb42faa"
+        )
+        version(
+            "6.28.00", sha256="afa1c5c06d0915411cb9492e474ea9ab12b09961a358e7e559013ed63b5d8084"
+        )
 
     # ###################### Patches ##########################
 
@@ -236,7 +268,9 @@ class Root(CMakePackage):
     variant("qt6", when="@6.26:", default=False, description="Enable Qt6 web-based display")
     variant("r", default=False, description="Enable R ROOT bindings")
     variant("rpath", default=True, description="Enable RPATH")
-    conflicts("~rpath", when="@6.38:", msg="RPATHs are always applied if operating systems supports it")
+    conflicts(
+        "~rpath", when="@6.38:", msg="RPATHs are always applied if operating systems supports it"
+    )
     variant("roofit", default=True, description="Build the libRooFit advanced fitting package")
     variant("root7", default=False, description="Enable ROOT 7 support")
     variant("shadow", default=False, description="Enable shadow password support")

--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -50,25 +50,30 @@ class Root(CMakePackage):
     version("6.32.00", sha256="12f203681a59041c474ce9523761e6f0e8861b3bee78df5f799a8db55189e5d2")
 
     # Supported STS release series
+    # 6.38 (through 2026-06-30)
+    version("6.38.00", sha256="a4429422c460f832cde514a580dd202b1d3c96e8919c24363c3d42f8cf5accdc")
+
     # 6.34 (through 2025-06-30)
-    version("6.34.08", sha256="806045b156de03fe8f5661a670eab877f2e4d2da6c234dc3e31e98e2d7d96fe8")
-    version("6.34.06", sha256="a799d632dae5bb1ec87eae6ebc046a12268c6849f2a8837921c118fc51b6cff3")
-    version("6.34.04", sha256="e320c5373a8e87bb29b7280954ca8355ad8c4295cf49235606f0c8b200acb374")
-    version("6.34.02", sha256="166bec562e420e177aaf3133fa3fb09f82ecddabe8a2e1906345bad442513f94")
-    version("6.34.00", sha256="f3b00f3db953829c849029c39d7660a956468af247efd946e89072101796ab03")
+    with default_args(deprecated=True):
+        version("6.34.08", sha256="806045b156de03fe8f5661a670eab877f2e4d2da6c234dc3e31e98e2d7d96fe8")
+        version("6.34.06", sha256="a799d632dae5bb1ec87eae6ebc046a12268c6849f2a8837921c118fc51b6cff3")
+        version("6.34.04", sha256="e320c5373a8e87bb29b7280954ca8355ad8c4295cf49235606f0c8b200acb374")
+        version("6.34.02", sha256="166bec562e420e177aaf3133fa3fb09f82ecddabe8a2e1906345bad442513f94")
+        version("6.34.00", sha256="f3b00f3db953829c849029c39d7660a956468af247efd946e89072101796ab03")
 
     # Older release series
-    version("6.30.08", sha256="8bb8594867b9ded20a65e59f2cb6da965aa30851b8960f8cbf76293aec046b69")
-    version("6.30.06", sha256="300db7ed1b678ed2fb9635ca675921a1945c7c2103da840033b493091f55700c")
-    version("6.30.04", sha256="2b4180b698f39cc65d91084d833a884515b325bc5f673c8e39abe818b025d8cc")
-    version("6.30.02", sha256="7965a456d1ad1ee0d5fe4769bf5a8fec291af684ed93db0f3080a9c362435183")
-    version("6.30.00", sha256="0592c066954cfed42312957c9cb251654456064fe2d8dabdcb8826f1c0099d71")
-    version("6.28.12", sha256="fcd325267d238e9c6008f56a3a7e7c87fd864b1e633b0ffcf1f82b7e7ad3d249")
-    version("6.28.10", sha256="69d6fdeb607e6b20bd02c757fa6217024c0b6132c1e9b1dff4d85d9a2bb7e51e")
-    version("6.28.06", sha256="af3b673b9aca393a5c9ae1bf86eab2672aaf1841b658c5c6e7a30ab93c586533")
-    version("6.28.04", sha256="70f7f86a0cd5e3f2a0befdc59942dd50140d990ab264e8e56c7f17f6bfe9c965")
-    version("6.28.02", sha256="6643c07710e68972b00227c68b20b1016fec16f3fba5f44a571fa1ce5bb42faa")
-    version("6.28.00", sha256="afa1c5c06d0915411cb9492e474ea9ab12b09961a358e7e559013ed63b5d8084")
+    with default_args(deprecated=True):
+        version("6.30.08", sha256="8bb8594867b9ded20a65e59f2cb6da965aa30851b8960f8cbf76293aec046b69")
+        version("6.30.06", sha256="300db7ed1b678ed2fb9635ca675921a1945c7c2103da840033b493091f55700c")
+        version("6.30.04", sha256="2b4180b698f39cc65d91084d833a884515b325bc5f673c8e39abe818b025d8cc")
+        version("6.30.02", sha256="7965a456d1ad1ee0d5fe4769bf5a8fec291af684ed93db0f3080a9c362435183")
+        version("6.30.00", sha256="0592c066954cfed42312957c9cb251654456064fe2d8dabdcb8826f1c0099d71")
+        version("6.28.12", sha256="fcd325267d238e9c6008f56a3a7e7c87fd864b1e633b0ffcf1f82b7e7ad3d249")
+        version("6.28.10", sha256="69d6fdeb607e6b20bd02c757fa6217024c0b6132c1e9b1dff4d85d9a2bb7e51e")
+        version("6.28.06", sha256="af3b673b9aca393a5c9ae1bf86eab2672aaf1841b658c5c6e7a30ab93c586533")
+        version("6.28.04", sha256="70f7f86a0cd5e3f2a0befdc59942dd50140d990ab264e8e56c7f17f6bfe9c965")
+        version("6.28.02", sha256="6643c07710e68972b00227c68b20b1016fec16f3fba5f44a571fa1ce5bb42faa")
+        version("6.28.00", sha256="afa1c5c06d0915411cb9492e474ea9ab12b09961a358e7e559013ed63b5d8084")
 
     # ###################### Patches ##########################
 
@@ -231,6 +236,7 @@ class Root(CMakePackage):
     variant("qt6", when="@6.26:", default=False, description="Enable Qt6 web-based display")
     variant("r", default=False, description="Enable R ROOT bindings")
     variant("rpath", default=True, description="Enable RPATH")
+    conflicts("~rpath", when="@6.38:", msg="RPATHs are always applied if operating systems supports it")
     variant("roofit", default=True, description="Build the libRooFit advanced fitting package")
     variant("root7", default=False, description="Enable ROOT 7 support")
     variant("shadow", default=False, description="Enable shadow password support")
@@ -395,6 +401,7 @@ class Root(CMakePackage):
 
     # Optional dependencies
     depends_on("arrow", when="+arrow")
+    depends_on("civetweb", when="+http")
     depends_on("cuda", when="+cuda")
     depends_on("cuda", when="+cudnn")
     depends_on("cudnn", when="+cudnn")
@@ -688,6 +695,7 @@ class Root(CMakePackage):
 
         options += [
             define("builtin_cfitsio", False),
+            define("builtin_civetweb", False),
             define("builtin_davix", False),
             define("builtin_fftw3", False),
             define("builtin_freetype", False),


### PR DESCRIPTION
This PR adds `root`, v6.38.00 ([release notes](https://root.cern/doc/v638/release-notes.html)). Removed build options `mysql`, `odbc`, `pgsql`. Now always built with RPATHs, so `rpath` is no-op. New `builtin_civetweb` for RHTTP, which is our `http` variant.

Marked some older out-of-support ROOT versions as deprecated.

Added `civetweb` as a new dependency package.