### PR TITLE
xtensor: fix constraints

### DIFF
--- a/repos/spack_repo/builtin/packages/xtensor/package.py
+++ b/repos/spack_repo/builtin/packages/xtensor/package.py
@@ -14,7 +14,7 @@ class Xtensor(CMakePackage):
     url = "https://github.com/QuantStack/xtensor/archive/0.13.1.tar.gz"
     git = "https://github.com/QuantStack/xtensor.git"
 
-    maintainers("ax3l")
+    maintainers("ax3l", "gouarin")
 
     license("BSD-3-Clause")
 
@@ -40,19 +40,19 @@ class Xtensor(CMakePackage):
     depends_on("cxx", type="build")  # generated
 
     depends_on("xtl", when="@develop")
-    depends_on("xtl@0.8.0:0.8", when="@0.26.0:")
-    depends_on("xtl@0.7.5:0.7", when="@0.24.5:")
-    depends_on("xtl@0.7.2:0.7", when="@0.23.2:")
+    depends_on("xtl@0.8.0:0.8", when="@0.26:")
+    depends_on("xtl@0.7.5:0.7", when="@0.24.5:0.25")
+    depends_on("xtl@0.7.2:0.7", when="@0.23")
     depends_on("xtl@0.6.4:0.6", when="@0.20.7")
     depends_on("xtl@0.4.0:0.4", when="@0.15.1")
     depends_on("xtl@0.3.3:0.3", when="@0.13.1")
     depends_on("xsimd", when="@develop")
 
     depends_on("xsimd@13.2.0:", when="@0.26.0: +xsimd")
-    depends_on("xsimd@11.0.0:", when="@0.25.0: +xsimd")
-    depends_on("xsimd@10.0.0:", when="@0.24.4: +xsimd")
-    depends_on("xsimd@9.0.1:", when="@0.24.3: +xsimd")
-    depends_on("xsimd@8.0.5:", when="@0.24.1: +xsimd")
+    depends_on("xsimd@11.0.0:", when="@0.25 +xsimd")
+    depends_on("xsimd@10.0.0:", when="@0.24.4:0.24 +xsimd")
+    depends_on("xsimd@9.0.1:", when="@0.24.3:0.24 +xsimd")
+    depends_on("xsimd@8.0.5:", when="@0.24.1:0.24 +xsimd")
     depends_on("xsimd@8.0.2:", when="@0.24.0 +xsimd")
     depends_on("xsimd@7.4.10:7", when="@0.23.4:0.23 +xsimd")
     depends_on("xsimd@7.4.9:7", when="@0.23.2 +xsimd")


### PR DESCRIPTION
The constraints set in the package definition are not well defined. 

What we have before was:

```py
    depends_on("xtl@0.8.0:0.8", when="@0.26.0:")
    depends_on("xtl@0.7.5:0.7", when="@0.24.5:")
    depends_on("xtl@0.7.2:0.7", when="@0.23.2:")
```

It seems that if we don't finalize the constraint on the second line as `when="@0.24.5:0.25"`, the `0.8` is not chosen for a package I am developing. This PR resolves the issue.
