### PR TITLE
gcc: backport fixincludes fix from GCC 15

### DIFF
--- a/repos/spack_repo/builtin/packages/gcc/fixincludes-gcc-12.1.patch
+++ b/repos/spack_repo/builtin/packages/gcc/fixincludes-gcc-12.1.patch
@@ -1,0 +1,42 @@
+diff --git i/fixincludes/fixincl.x w/fixincludes/fixincl.x
+index bad490453b7..ead33dc5693 100644
+--- i/fixincludes/fixincl.x
++++ w/fixincludes/fixincl.x
+@@ -7224,8 +7224,15 @@ tSCC zPthread_Incomplete_Struct_ArgumentList[] =
+ tSCC zPthread_Incomplete_Struct_ArgumentSelect0[] =
+        "struct __jmp_buf_tag";
+ 
+-#define    PTHREAD_INCOMPLETE_STRUCT_ARGUMENT_TEST_CT  1
++/*
++ *  content bypass pattern - skip fix if pattern found
++ */
++tSCC zPthread_Incomplete_Struct_ArgumentBypass0[] =
++       "bits/types/struct___jmp_buf_tag.h";
++
++#define    PTHREAD_INCOMPLETE_STRUCT_ARGUMENT_TEST_CT  2
+ static tTestDesc aPthread_Incomplete_Struct_ArgumentTests[] = {
++  { TT_NEGREP,   zPthread_Incomplete_Struct_ArgumentBypass0, (regex_t*)NULL },
+   { TT_EGREP,    zPthread_Incomplete_Struct_ArgumentSelect0, (regex_t*)NULL }, };
+ 
+ /*
+@@ -10872,7 +10879,7 @@ static const char* apzX11_SprintfPatch[] = {
+  *
+  *  List of all fixes
+  */
+-#define REGEX_COUNT          305
++#define REGEX_COUNT          306
+ #define MACH_LIST_SIZE_LIMIT 187
+ #define FIX_COUNT            267
+ 
+diff --git i/fixincludes/inclhack.def w/fixincludes/inclhack.def
+index 7605ac89aa2..43fa4a4df1c 100644
+--- i/fixincludes/inclhack.def
++++ w/fixincludes/inclhack.def
+@@ -3626,6 +3626,7 @@ fix = {
+     hackname  = pthread_incomplete_struct_argument;
+     files     = pthread.h;
+     select    = "struct __jmp_buf_tag";
++    bypass    = "bits/types/struct___jmp_buf_tag.h";
+     c_fix     = format;
+     c_fix_arg = "%1 *%2%3";
+     c_fix_arg = "^(extern int __sigsetjmp \\(struct __jmp_buf_tag) "

--- a/repos/spack_repo/builtin/packages/gcc/fixincludes-gcc-12.4.patch
+++ b/repos/spack_repo/builtin/packages/gcc/fixincludes-gcc-12.4.patch
@@ -1,0 +1,42 @@
+diff --git i/fixincludes/fixincl.x w/fixincludes/fixincl.x
+index 0e65c60955b..fbc446521a0 100644
+--- i/fixincludes/fixincl.x
++++ w/fixincludes/fixincl.x
+@@ -7311,8 +7311,15 @@ tSCC zPthread_Incomplete_Struct_ArgumentList[] =
+ tSCC zPthread_Incomplete_Struct_ArgumentSelect0[] =
+        "struct __jmp_buf_tag";
+ 
+-#define    PTHREAD_INCOMPLETE_STRUCT_ARGUMENT_TEST_CT  1
++/*
++ *  content bypass pattern - skip fix if pattern found
++ */
++tSCC zPthread_Incomplete_Struct_ArgumentBypass0[] =
++       "bits/types/struct___jmp_buf_tag.h";
++
++#define    PTHREAD_INCOMPLETE_STRUCT_ARGUMENT_TEST_CT  2
+ static tTestDesc aPthread_Incomplete_Struct_ArgumentTests[] = {
++  { TT_NEGREP,   zPthread_Incomplete_Struct_ArgumentBypass0, (regex_t*)NULL },
+   { TT_EGREP,    zPthread_Incomplete_Struct_ArgumentSelect0, (regex_t*)NULL }, };
+ 
+ /*
+@@ -10959,7 +10966,7 @@ static const char* apzX11_SprintfPatch[] = {
+  *
+  *  List of all fixes
+  */
+-#define REGEX_COUNT          307
++#define REGEX_COUNT          308
+ #define MACH_LIST_SIZE_LIMIT 187
+ #define FIX_COUNT            269
+ 
+diff --git i/fixincludes/inclhack.def w/fixincludes/inclhack.def
+index f217ae978d2..a5f2af0ba2a 100644
+--- i/fixincludes/inclhack.def
++++ w/fixincludes/inclhack.def
+@@ -3675,6 +3675,7 @@ fix = {
+     hackname  = pthread_incomplete_struct_argument;
+     files     = pthread.h;
+     select    = "struct __jmp_buf_tag";
++    bypass    = "bits/types/struct___jmp_buf_tag.h";
+     c_fix     = format;
+     c_fix_arg = "%1 *%2%3";
+     c_fix_arg = "^(extern int __sigsetjmp \\(struct __jmp_buf_tag) "

--- a/repos/spack_repo/builtin/packages/gcc/fixincludes-gcc-13-14.patch
+++ b/repos/spack_repo/builtin/packages/gcc/fixincludes-gcc-13-14.patch
@@ -1,0 +1,42 @@
+diff --git i/fixincludes/fixincl.x w/fixincludes/fixincl.x
+index 45d65f4872a..3e1b959829a 100644
+--- i/fixincludes/fixincl.x
++++ w/fixincludes/fixincl.x
+@@ -7514,8 +7514,15 @@ tSCC zPthread_Incomplete_Struct_ArgumentList[] =
+ tSCC zPthread_Incomplete_Struct_ArgumentSelect0[] =
+        "struct __jmp_buf_tag";
+ 
+-#define    PTHREAD_INCOMPLETE_STRUCT_ARGUMENT_TEST_CT  1
++/*
++ *  content bypass pattern - skip fix if pattern found
++ */
++tSCC zPthread_Incomplete_Struct_ArgumentBypass0[] =
++       "bits/types/struct___jmp_buf_tag.h";
++
++#define    PTHREAD_INCOMPLETE_STRUCT_ARGUMENT_TEST_CT  2
+ static tTestDesc aPthread_Incomplete_Struct_ArgumentTests[] = {
++  { TT_NEGREP,   zPthread_Incomplete_Struct_ArgumentBypass0, (regex_t*)NULL },
+   { TT_EGREP,    zPthread_Incomplete_Struct_ArgumentSelect0, (regex_t*)NULL }, };
+ 
+ /*
+@@ -11169,7 +11176,7 @@ static const char* apzX11_SprintfPatch[] = {
+  *
+  *  List of all fixes
+  */
+-#define REGEX_COUNT          313
++#define REGEX_COUNT          314
+ #define MACH_LIST_SIZE_LIMIT 187
+ #define FIX_COUNT            274
+ 
+diff --git i/fixincludes/inclhack.def w/fixincludes/inclhack.def
+index 67a1082f926..97eeb4d16a2 100644
+--- i/fixincludes/inclhack.def
++++ w/fixincludes/inclhack.def
+@@ -3808,6 +3808,7 @@ fix = {
+     hackname  = pthread_incomplete_struct_argument;
+     files     = pthread.h;
+     select    = "struct __jmp_buf_tag";
++    bypass    = "bits/types/struct___jmp_buf_tag.h";
+     c_fix     = format;
+     c_fix_arg = "%1 *%2%3";
+     c_fix_arg = "^(extern int __sigsetjmp \\(struct __jmp_buf_tag) "

--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -431,8 +431,9 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     # the installed GCC not portable across different glibc versions. Original
     # GCC bug report: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=118009. For
     # GCC 15 we can directly use the upstream patch. For GCC 12-14 the patch
-    # has been backported. For GCC 11 the fix should actually be applied and
-    # older versions have not been tested.
+    # has been backported. The patch is not applied to GCC 11 since the "fixinclude"
+    # is in fact needed for that version (see GCC commit description). Older versions
+    # have not been checked or tested.
     patch(
         "https://github.com/gcc-mirror/gcc/commit/ea2798892de373b14f9fc7ae8a0d820eaddca98c.patch?full_index=1",
         sha256="0999dbf856725566373f25a6f192a3520ea036db8e1f31928aae9750e6e38be7",

--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -425,6 +425,23 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     # https://github.com/iains/gcc-12-branch/issues/6
     conflicts("@:12", when="%apple-clang@14:14.0")
 
+    # Applies
+    # https://github.com/gcc-mirror/gcc/commit/ea2798892de373b14f9fc7ae8a0d820eaddca98c,
+    # which fixes an incorrectly applied fixincludes rule for pthread.h, making
+    # the installed GCC not portable across different glibc versions. Original
+    # GCC bug report: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=118009. For
+    # GCC 15 we can directly use the upstream patch. For GCC 12-14 the patch
+    # has been backported. For GCC 11 the fix should actually be applied and
+    # older versions have not been tested.
+    patch(
+        "https://github.com/gcc-mirror/gcc/commit/ea2798892de373b14f9fc7ae8a0d820eaddca98c.patch?full_index=1",
+        sha256="0999dbf856725566373f25a6f192a3520ea036db8e1f31928aae9750e6e38be7",
+        when="@15:15.2",
+    )
+    patch("fixincludes-gcc-13-14.patch", when="@13:14")
+    patch("fixincludes-gcc-12.4.patch", when="@12.4:12")
+    patch("fixincludes-gcc-12.1.patch", when="@12:12.3")
+
     if sys.platform == "darwin":
         # Fix parallel build on APFS filesystem
         # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81797


### PR DESCRIPTION
GCC generates "fixed" headers that override system headers when it deems the system headers aren't usable (https://github.com/gcc-mirror/gcc/blob/master/fixincludes/README).

However, GCC had a bug in how it detects when the fixes should be generated: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=118009. In our case the manifestation was that GCC generates a "fixed" `pthread.h`, which overrides the system one. This makes GCC dependent on the exact glibc that was used when building (or at least a range of glibc versions). We updated glibc, and GCC that was compiled against an older glibc stopped being able to compile files with the value of `PTHREAD_COND_INITIALIZER` being different in the "fixed" `pthread.h` and the one provided by the newer system glibc. The issue is essentially the same as https://sourceware.org/bugzilla/show_bug.cgi?id=32625.

The broken fixincludes rule was fixed on the GCC 15 release branch, but is not yet in a release (15.2.0 is the latest release at the time of this PR). The patch that fixes the rule is https://github.com/gcc-mirror/gcc/commit/ea2798892de373b14f9fc7ae8a0d820eaddca98c.

In this PR I'm applying the above patch to 15.1 and 15.2. I'm also backporting the patch to 12-14 (line numbers have changed between versions). I'm not applying the patch to 11 since apparently the "fixed" include should actually be used for that version (see GCC commit description). I haven't even attempted to patch this for older versions. If someone needs it backported there I invite them to open a separate PR.

# Alternative

The fact that GCC even attempts to fix includes seems to be a bit controversial (opinionated writing from 2013: https://ewontfix.com/12/; not my text, but gives a bit of useful context around the feature). GCC comes with a `--disable-fixincludes` flag (see e.g. https://www.linuxfromscratch.org/lfs/view/development/chapter08/gcc.html and https://gcc.gnu.org/pipermail/gcc-patches/2022-May/595495.html, there doesn't seem to be any official documentation about it). This is a bit more nuclear, but the spack build of GCC could set `--disable-fixincludes` or introduce a variant to set it.

However, I think `--disable-fixincludes` is something that can be added independently of the patches in this PR if there's interest in it. I'd love to hear others' opinion (and maybe experience) about `--disable-fixincludes` before considering that though. 

# Testing

I've tested building GCC 15.2.0, 14.3.0, 13.4.0, and 12.5.0 on a system where we noticed `pthread.h` was generated. On develop `pthread.h` is indeed generated with all four versions, and with this PR `pthread.h` is not generated.

I've additionally tested "installing" all GCC versions from 12.1.0 to 15.2.0 until the configure stage to check that the patches actually apply cleanly.