### PR TITLE
gaudi: Allow builds against newer fmt versions

### DIFF
--- a/repos/spack_repo/builtin/packages/gaudi/package.py
+++ b/repos/spack_repo/builtin/packages/gaudi/package.py
@@ -162,6 +162,7 @@ class Gaudi(CMakePackage, CudaPackage):
     depends_on("cppgsl")
     depends_on("fmt@:8", when="@:36.9")
     depends_on("fmt@:10")
+    depends_on("fmt@10:11", when="@39:")
     depends_on("intel-tbb@:2020.3", when="@:37.0")
     depends_on("tbb", when="@37.1:")
     depends_on("uuid")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Gaudi seems to be buildable without problems against `fmt@11`, but not against `fmt@12`. I have tested `gaudi@40.1` and `gaudi@39.4`. It's possible that even older versions build against `fmt@11`, but I could not as easily test them currently.