### PR TITLE
podio: ensure Python.h is found in ROOT ACLiC

### DIFF
--- a/repos/spack_repo/builtin/packages/podio/package.py
+++ b/repos/spack_repo/builtin/packages/podio/package.py
@@ -129,7 +129,7 @@ class Podio(CMakePackage):
 
         # Pythonizations require Python.h accessible for ACLiC
         if self.spec.satisfies("@1.5:"):
-            env.prepend_path("ROOT_INCLUDE_PATH", self.spec["python"].headers.directories)
+            env.prepend_path("ROOT_INCLUDE_PATH", self.spec["python"].headers.directories[0])
 
     def setup_dependent_build_environment(
         self, env: EnvironmentModifications, dependent_spec: Spec

--- a/repos/spack_repo/builtin/packages/podio/package.py
+++ b/repos/spack_repo/builtin/packages/podio/package.py
@@ -127,6 +127,10 @@ class Podio(CMakePackage):
         # Frame header needs to be available for python bindings
         env.prepend_path("ROOT_INCLUDE_PATH", self.prefix.include)
 
+        # Pythonizations require Python.h accessible for ACLiC
+        if self.spec.satisfies("@1.5:"):
+            env.prepend_path("ROOT_INCLUDE_PATH", self.spec["python"].headers.directories)
+
     def setup_dependent_build_environment(
         self, env: EnvironmentModifications, dependent_spec: Spec
     ) -> None:


### PR DESCRIPTION
This PR ensures that `Python.h` in `podio` headers is found when the header is used from within a ROOT session.

Intends to resolve errors like https://eicweb.phy.anl.gov/EIC/benchmarks/physics_benchmarks/-/jobs/6873367#L72