### PR TITLE
py-zfit, py-zfit-physics: add new versions

### DIFF
--- a/repos/spack_repo/builtin/packages/py_zfit/package.py
+++ b/repos/spack_repo/builtin/packages/py_zfit/package.py
@@ -21,6 +21,8 @@ class PyZfit(PythonPackage):
 
     tags = ["likelihood", "statistics", "inference", "fitting", "hep"]
 
+    version("0.28.0", sha256="80fb7b0ef5700a38f8dd4e592f3fdf5adb2fe828b1df42ebfba49c22625af55c")
+    version("0.27.1", sha256="27b16be9ed4619fe437c3f533a671e44329a1172231d87f94ed93d958b7691b9")
     version("0.26.0", sha256="c61e55177055e775fefb6d985b643a7db8e8eb16e872d8dc66434b36f15c0b36")
     version("0.25.0", sha256="ac5a92bc284094eae55dd9afe1fe2c8f3f67a402dfc7a8ad6087a9ea29ff2b41")
     version("0.24.3", sha256="0efe47a5c597f7c730ac25495625f8bb4460f2fa4a0f4c387f503339ac8e91b5")
@@ -44,8 +46,10 @@ class PyZfit(PythonPackage):
     version("0.14.1", sha256="66d1e349403f1d6c6350138d0f2b422046bcbdfb34fd95453dadae29a8b0c98a")
 
     depends_on("python@3.9:", type=("build", "run"))
+    depends_on("python@3.10:", type=("build", "run"), when="@0.27:")
     depends_on("python@:3.11", type=("build", "run"), when="@:0.18")
     depends_on("python@:3.12", type=("build", "run"), when="@0.20:")
+    depends_on("python@:3.13", type=("build", "run"), when="@0.28:")
 
     depends_on("py-hatchling", type="build", when="@0.26:")
     depends_on("py-hatch-vcs", type="build", when="@0.26:")
@@ -62,8 +66,11 @@ class PyZfit(PythonPackage):
         depends_on("py-tensorflow")
         depends_on("py-tensorflow-probability")
 
-        depends_on("py-tensorflow@2.16.2:2.19", when="@0.25.0:")
-        depends_on("py-tensorflow-probability@0.25:0.26", when="@0.25.0:")
+        depends_on("py-tensorflow@2.16.2:2", when="@0.28:")
+        depends_on("py-tensorflow-probability@0.24:0", when="@0.28:")
+
+        depends_on("py-tensorflow@2.16.2:2.19", when="@0.25.0:0.27")
+        depends_on("py-tensorflow-probability@0.24:0.26", when="@0.25.0:0.27")
 
         depends_on("py-tensorflow@2.16.2:2.18", when="@0.24.3:0.24")
         depends_on("py-tensorflow@2.18", when="@0.24:0.24.2")

--- a/repos/spack_repo/builtin/packages/py_zfit_physics/package.py
+++ b/repos/spack_repo/builtin/packages/py_zfit_physics/package.py
@@ -19,13 +19,19 @@ class PyZfitPhysics(PythonPackage):
 
     tags = ["likelihood", "statistics", "inference", "fitting", "hep"]
 
+    version("0.9.0", sha256="e59b64ead1c92ca43efc4852b40ba345828ff91f47a1e5c0e519c1f27f40c3d4")
+    version("0.8.1", sha256="8e2c2549665798d806c789943f3cf8a82cf2f93b178e93dbd302bb642fa0fff7")
     version("0.7.0", sha256="5d65becff7265a12d9b62a8476c5359e75ec10d6ac0fd84dfa39eb82b6693cda")
 
-    depends_on("py-setuptools@42:", type="build")
-    depends_on("py-setuptools-scm@3.4:+toml", type="build")
-    depends_on("py-setuptools-scm-git-archive", type="build")
+    depends_on("py-hatchling@1.17.1:", type="build", when="@0.8:")
+    depends_on("py-hatch-vcs", type="build", when="@0.8:")
+
+    depends_on("py-setuptools@42:", type="build", when="@:0.7")
+    depends_on("py-setuptools-scm@3.4:+toml", type="build", when="@:0.7")
+    depends_on("py-setuptools-scm-git-archive", type="build", when="@:0.7")
 
     # TODO: remove "build" once fixed in spack that tests need "run", not "build"
     with default_args(type=("build", "run")):
+        depends_on("python@3.10:", when="@0.8:")
         depends_on("python@3.9:", when="@0.7:")
         depends_on("py-zfit@0.20:", when="@0.7:")


### PR DESCRIPTION
This PR adds `py-zfit` and `py-zfit-physics` versions 0.28.0, 0.27.1, respectively 0.8.1, 0.9.0. Updated the dependencies.