### PR TITLE
py-mplhep(-data): add new versions

### DIFF
--- a/repos/spack_repo/builtin/packages/py_mplhep/package.py
+++ b/repos/spack_repo/builtin/packages/py_mplhep/package.py
@@ -15,6 +15,7 @@ class PyMplhep(PythonPackage):
 
     license("MIT", checked_by="wdconinc")
 
+    version("0.4.1", sha256="86e2d99680bdb19598e847ff5b24f3bf1c63f164b99f076be98255acd738ee48")
     version("0.4.0", sha256="485d67db2dd7a1091eee86580fe46cf32dd0b0fc34d6db6246b1ef59346a810c")
     version("0.3.59", sha256="06f4b3a799e92fe6982ed3939dd648d0f972781aca3dc814a83e5bbd970649fe")
     version("0.3.58", sha256="fed8b5d5fee92c7aa40cfe70e5b8d2b2bb8ed7aeb7a2c272d73b241279e1adba")

--- a/repos/spack_repo/builtin/packages/py_mplhep_data/package.py
+++ b/repos/spack_repo/builtin/packages/py_mplhep_data/package.py
@@ -15,6 +15,7 @@ class PyMplhepData(PythonPackage):
 
     license("MIT")
 
+    version("0.0.5", sha256="4e5c4eae3e423762eb3d4ad542060f1be7f122c18a17164f7fcfedcf943fac7d")
     version("0.0.4", sha256="cd1f3ad3af9dbff33aef9e7406d2130d624a0bd1d5aa5970fc713a6421165a4e")
     version("0.0.3", sha256="b54d257f3f53c93a442cda7a6681ce267277e09173c0b41fd78820f78321772f")
 


### PR DESCRIPTION
This PR adds new versions to `py-mplhep` and `py-mplhep-data`. Minor versions, no changes to dependencies.