### PR TITLE
boost: add v1.89.0

### DIFF
--- a/repos/spack_repo/builtin/packages/boost/package.py
+++ b/repos/spack_repo/builtin/packages/boost/package.py
@@ -31,6 +31,7 @@ class Boost(Package):
     license("BSL-1.0")
 
     version("develop", branch="develop", submodules=True)
+    version("1.89.0", sha256="85a33fa22621b4f314f8e85e1a5e2a9363d22e4f4992925d4bb3bc631b5a0c7a")
     version("1.88.0", sha256="46d9d2c06637b219270877c9e16155cbd015b6dc84349af064c088e9b5b12f7b")
     version("1.87.0", sha256="af57be25cb4c4f4b413ed692fe378affb4352ea50fbe294a11ef548f4d527d89")
     version("1.86.0", sha256="1bed88e40401b2cb7a1f76d4bab499e352fa4d0c5f31c0dbae64e24d34d7513b")


### PR DESCRIPTION
This PR adds `boost`, v1.89.0 (https://www.boost.org/releases/1.89.0/, https://github.com/boostorg/boost/compare/boost-1.88.0...boost-1.89.0). This adds a new library (`bloom`) which is header-only. No dependency changes.

Test build:
```
-- linux-ubuntu25.10-skylake / %c,cxx=gcc@15.2.0 ----------------
g4kd5nw boost@1.89.0+atomic~charconv+chrono~clanglibcpp~cobalt~container+context~contract~conversion~coroutine~date_time~debug+exception+fiber+filesystem+graph~graph_parallel+icu+iostreams~json+locale+log+math~mpi~mqtt5+multithreaded+nowide~numpy~pic+program_options+python~random+regex~serialization+shared~signals2~singlethreaded~stacktrace+system~taggedlayout+test+thread~timer~type_erasure~url~versionedlayout~wave build_system=generic context-impl=fcontext cxxstd=20 patches:=a440f96,b8569d7 visibility=hidden
==> 1 installed package
```