### PR TITLE
faketime: add v0.9.12

### DIFF
--- a/repos/spack_repo/builtin/packages/faketime/package.py
+++ b/repos/spack_repo/builtin/packages/faketime/package.py
@@ -17,6 +17,7 @@ class Faketime(MakefilePackage):
 
     license("GPL-2.0-only", checked_by="wdconinc")
 
+    version("0.9.12", sha256="4fc32218697c052adcdc5ee395581f2554ca56d086ac817ced2be0d6f1f8a9fa")
     version("0.9.10", sha256="729ad33b9c750a50d9c68e97b90499680a74afd1568d859c574c0fe56fe7947f")
 
     depends_on("c", type="build")


### PR DESCRIPTION
This PR adds `faketime`, v0.9.12 ([diff](https://github.com/wolfcw/libfaketime/compare/v0.9.10...v0.9.12)). Just bugfixes.