### PR TITLE
xrootd: add v5.9.1

### DIFF
--- a/repos/spack_repo/builtin/packages/xrootd/package.py
+++ b/repos/spack_repo/builtin/packages/xrootd/package.py
@@ -24,6 +24,7 @@ class Xrootd(CMakePackage):
 
     license("LGPL-3.0-only")
 
+    version("5.9.1", sha256="39946509a50e790ab3fcc77ba0f4c9b66abef221262756aa8bb2494f00a0e321")
     version("5.8.4", sha256="d8716bf764a7e8103aab83fbf4906ea2cc157646b1a633d99f91edbf204ff632")
     version("5.7.3", sha256="3a90fda99a53cb6005ebecf7d6125ce382cedb0a27fb453e44a2c13bade0a90f")
     version("5.7.1", sha256="c28c9dc0a2f5d0134e803981be8b1e8b1c9a6ec13b49f5fa3040889b439f4041")


### PR DESCRIPTION
This PR adds `xrootd`, v5.9.1 ([diff](https://github.com/xrootd/xrootd/compare/v5.8.4...v5.9.1)). No build system changes or new features to be supported with variants.

Test build (ok, it's 5.9.0, but I don't want to rebuild `root` for the xrootd patch release right now):
```
-- linux-ubuntu25.10-skylake / %c,cxx=gcc@15.2.0 ----------------
wxgjfbp xrootd@5.9.0+client_only+davix+ec+http+ipo+krb5+python+readline+scitokens-cpp build_system=cmake build_type=Release cxxstd=20 generator=make patches:=0d03eed
==> 1 installed package
```

This package will be built in CI.