### PR TITLE
cyrus-sasl: add v2.1.28-148 with gcc@15 support

### DIFF
--- a/repos/spack_repo/builtin/packages/cyrus_sasl/package.py
+++ b/repos/spack_repo/builtin/packages/cyrus_sasl/package.py
@@ -33,11 +33,21 @@ class CyrusSasl(AutotoolsPackage):
 
     # CVE-2022-24407
     with default_args(deprecated=True):
-        version("2.1.27", sha256="b564d773803dc4cff42d2bdc04c80f2b105897a724c247817d4e4a99dd6b9976")
-        version("2.1.26", sha256="7c14d1b5bd1434adf2dd79f70538617e6aa2a7bde447454b90b84ac5c4d034ba")
-        version("2.1.25", sha256="8bfd4fa4def54c760e5061f2a74c278384c3b9807f02c4b07dab68b5894cc7c1")
-        version("2.1.24", sha256="1df15c492f7ecb90be49531a347b3df21b041c2e0325dcc4fc5a6e98384c40dd")
-        version("2.1.23", sha256="b1ec43f62d68446a6a5879925c63d94e26089c5a46cd83e061dd685d014c7d1f")
+        version(
+            "2.1.27", sha256="b564d773803dc4cff42d2bdc04c80f2b105897a724c247817d4e4a99dd6b9976"
+        )
+        version(
+            "2.1.26", sha256="7c14d1b5bd1434adf2dd79f70538617e6aa2a7bde447454b90b84ac5c4d034ba"
+        )
+        version(
+            "2.1.25", sha256="8bfd4fa4def54c760e5061f2a74c278384c3b9807f02c4b07dab68b5894cc7c1"
+        )
+        version(
+            "2.1.24", sha256="1df15c492f7ecb90be49531a347b3df21b041c2e0325dcc4fc5a6e98384c40dd"
+        )
+        version(
+            "2.1.23", sha256="b1ec43f62d68446a6a5879925c63d94e26089c5a46cd83e061dd685d014c7d1f"
+        )
 
     # ensure include time.h, https://github.com/cyrusimap/cyrus-sasl/pull/709
     patch(

--- a/repos/spack_repo/builtin/packages/cyrus_sasl/package.py
+++ b/repos/spack_repo/builtin/packages/cyrus_sasl/package.py
@@ -14,23 +14,39 @@ class CyrusSasl(AutotoolsPackage):
 
     homepage = "https://github.com/cyrusimap/cyrus-sasl"
     url = "https://github.com/cyrusimap/cyrus-sasl/archive/cyrus-sasl-2.1.27.tar.gz"
+    git = "https://github.com/cyrusimap/cyrus-sasl.git"
 
     license("custom")
 
-    version("2.1.28", sha256="3e38933a30b9ce183a5488b4f6a5937a702549cde0d3287903d80968ad4ec341")
-    version("2.1.27", sha256="b564d773803dc4cff42d2bdc04c80f2b105897a724c247817d4e4a99dd6b9976")
-    version("2.1.26", sha256="7c14d1b5bd1434adf2dd79f70538617e6aa2a7bde447454b90b84ac5c4d034ba")
-    version("2.1.25", sha256="8bfd4fa4def54c760e5061f2a74c278384c3b9807f02c4b07dab68b5894cc7c1")
-    version("2.1.24", sha256="1df15c492f7ecb90be49531a347b3df21b041c2e0325dcc4fc5a6e98384c40dd")
-    version("2.1.23", sha256="b1ec43f62d68446a6a5879925c63d94e26089c5a46cd83e061dd685d014c7d1f")
+    # Since the latest release of cyrus-sasl is old and not supported on gcc-15,
+    # we add a newer version on the master branch.
+    # As 2.1.28 was not tagged on the master branch, we identify as equivalent
+    # commit fdcd13ceaef8de684dc69008011fa865c5b4a3ac, and describe from there.
+    version("2.1.28-148-ge256dd0c", commit="e256dd0cc61d60cbb905b601241077f0a2ba0907")
+
+    # Official releases are preferred
+    version(
+        "2.1.28",
+        sha256="3e38933a30b9ce183a5488b4f6a5937a702549cde0d3287903d80968ad4ec341",
+        preferred=True,
+    )
+
+    # CVE-2022-24407
+    with default_args(deprecated=True):
+        version("2.1.27", sha256="b564d773803dc4cff42d2bdc04c80f2b105897a724c247817d4e4a99dd6b9976")
+        version("2.1.26", sha256="7c14d1b5bd1434adf2dd79f70538617e6aa2a7bde447454b90b84ac5c4d034ba")
+        version("2.1.25", sha256="8bfd4fa4def54c760e5061f2a74c278384c3b9807f02c4b07dab68b5894cc7c1")
+        version("2.1.24", sha256="1df15c492f7ecb90be49531a347b3df21b041c2e0325dcc4fc5a6e98384c40dd")
+        version("2.1.23", sha256="b1ec43f62d68446a6a5879925c63d94e26089c5a46cd83e061dd685d014c7d1f")
 
     # ensure include time.h, https://github.com/cyrusimap/cyrus-sasl/pull/709
     patch(
         "https://github.com/cyrusimap/cyrus-sasl/commit/266f0acf7f5e029afbb3e263437039e50cd6c262.patch?full_index=1",
         sha256="819342fe68475ac1690136ff4ce9b73c028f433ae150898add36f724a8e2274b",
-        when="@2.1.27:2.1.28",
+        when="@2.1.27:2.1.28-0",
     )
     conflicts("%gcc@14:", when="@:2.1.26")
+    conflicts("%gcc@15:", when="@:2.1.28-147")
 
     depends_on("c", type="build")
 


### PR DESCRIPTION
This PR adds `cyrus-sasl`, v2.1.28-148-ge256dd0c.

There has been no `cyrus-sasl` release since 2022, and this affects the ability to use this package with modern compilers. `gcc@15` support was added in https://github.com/cyrusimap/cyrus-sasl/commit/e256dd0cc61d60cbb905b601241077f0a2ba0907, so this PR adds that as a custom (non-preferred) version that will be picked only when `gcc@15` is used.

This PR also deprecates the older versions due to CVE-2022-24407 (high severity).

Test build:
```
==> No binary for cyrus-sasl-2.1.28-148-ge256dd0c-unbef72ltp55xzsdqlgofueo2udoomsr found: installing from source
==> Installing cyrus-sasl-2.1.28-148-ge256dd0c-unbef72ltp55xzsdqlgofueo2udoomsr [32/32]
==> No patches needed for cyrus-sasl
==> cyrus-sasl: Executing phase: 'autoreconf'
==> cyrus-sasl: Executing phase: 'configure'
==> cyrus-sasl: Executing phase: 'build'
==> cyrus-sasl: Executing phase: 'install'
==> cyrus-sasl: Successfully installed cyrus-sasl-2.1.28-148-ge256dd0c-unbef72ltp55xzsdqlgofueo2udoomsr
  Stage: 3.57s.  Autoreconf: 6.07s.  Configure: 10.89s.  Build: 7.87s.  Install: 0.83s.  Post-install: 0.15s.  Total: 29.62s
[+] /opt/software/linux-skylake/cyrus-sasl-2.1.28-148-ge256dd0c-unbef72ltp55xzsdqlgofueo2udoomsr
```