### PR TITLE
pythia8: add v8.316

### DIFF
--- a/repos/spack_repo/builtin/packages/pythia8/package.py
+++ b/repos/spack_repo/builtin/packages/pythia8/package.py
@@ -23,6 +23,7 @@ class Pythia8(AutotoolsPackage):
 
     license("GPL-2.0-only")
 
+    version("8.316", sha256="1d99301aafd6896b57435edd73850e53f368f0021a647b12cf25584d77313489")
     version("8.315", sha256="4b2fe7341e33e90b7226fdcaa2a7bf9327987b3354e84c04f1fd9256863690ae")
     version("8.314", sha256="4f853fceb0291f2472c6d3cd3a31f9a2ffff4435a02a24124304ca6aac8caabe")
     version("8.313", sha256="d07e801501c4dcb76d948dc63285375f597453c1d6ec65e71287603dc776718c")


### PR DESCRIPTION
This PR adds `pythia8`, v8.316 ([diff](https://gitlab.com/Pythia8/releases/-/compare/pythia8315...pythia8316?from_project_id=12340057)). No changes to build options or requirements.

Test build:
```
==> No binary for pythia8-8.316-cvs3v3psfiixyqeoz5mfowiuojzvx6cx found: installing from source
==> Installing pythia8-8.316-cvs3v3psfiixyqeoz5mfowiuojzvx6cx [138/138]
==> Fetching https://pythia.org/download/pythia83/pythia8316.tgz
    [100%]   30.43 MB @    6.0 MB/s
==> No patches needed for pythia8
==> pythia8: Executing phase: 'autoreconf'
==> pythia8: Executing phase: 'configure'
==> pythia8: Executing phase: 'build'
==> pythia8: Executing phase: 'install'
==> pythia8: Successfully installed pythia8-8.316-cvs3v3psfiixyqeoz5mfowiuojzvx6cx
  Stage: 6.44s.  Autoreconf: 0.00s.  Configure: 4.59s.  Build: 9m 3.44s.  Install: 1.35s.  Post-install: 0.96s.  Total: 9m 16.93s
[+] /opt/software/linux-skylake/pythia8-8.316-cvs3v3psfiixyqeoz5mfowiuojzvx6cx
```

This package is builtin in CI.