### PR TITLE
velvet: Add c dependency and use of zlib.h from zlib-api

### DIFF
--- a/repos/spack_repo/builtin/packages/velvet/package.py
+++ b/repos/spack_repo/builtin/packages/velvet/package.py
@@ -51,6 +51,8 @@ class Velvet(MakefilePackage):
     variant("openmp", default=False, description="Enable multithreading")
     variant("single_cov_cat", default=False, description="Per-library coverage")
 
+    depends_on("c")
+
     depends_on("zlib-api")
 
     def edit(self, spec, prefix):
@@ -59,6 +61,7 @@ class Velvet(MakefilePackage):
             makefile.filter("-m64", "")
         maxkmerlength = self.spec.variants["maxkmerlength"].value
         categories = self.spec.variants["categories"].value
+        makefile.filter(r"^CFLAGS\s*=\s*", f"CFLAGS = -I{self.spec['zlib-api'].prefix.include} ")
         makefile.filter(r"^MAXKMERLENGTH\s*=\s*.*", f"MAXKMERLENGTH = {maxkmerlength}")
         makefile.filter(r"^CATEGORIES\s*=\s*.*", f"CATEGORIES = {categories}")
         if "+bigassembly" in self.spec:


### PR DESCRIPTION
- `velvet` is a C application and requires a dependency on `c`. If a Spack instance has been populated with all of `velvet`'s build dependencies from a binary mirror (and thus never installing a compiler as a build dependency), the `velvet` build will fail as there's no compiler. We add `depends_on("c")`.
- `velvet` depends on `zlib-api`, but does not actually use the `zlib.h` header from the Spack-installed package and thus fails to compile on a host that does not have a zlib devel package installed. We add `-L{spec['zlib-api'].prefix.include}` to `CFLAGS` in the `velvet` `Makefile` to ensure `zlib.h` can be found.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
