### PR TITLE
Added GIL removal as option for python

### DIFF
--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -642,9 +642,8 @@ class Python(Package):
                 ]
             )
 
-        if self.version >= Version("3.14.0"):
-            if "~gil" in spec:
-                config_args.append("--disable-gil")
+        if "~gil" in spec:
+            config_args.append("--disable-gil")
 
         # Disable tkinter module in the configure script for Python 3.12 onwards if ~tkinter
         if spec.satisfies("@3.12:") and spec.satisfies("~tkinter"):

--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -173,7 +173,7 @@ class Python(Package):
     variant("tix", default=False, description="Build Tix module", when="+tkinter")
     variant("crypt", default=True, description="Build crypt module", when="@:3.12 platform=linux")
     variant("crypt", default=True, description="Build crypt module", when="@:3.12 platform=darwin")
-    variant("gil", default=True, description="Build with Global Interpreter Lock")
+    variant("gil", default=True, description="Build with Global Interpreter Lock", when="@3.13:")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")

--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -173,7 +173,12 @@ class Python(Package):
     variant("tix", default=False, description="Build Tix module", when="+tkinter")
     variant("crypt", default=True, description="Build crypt module", when="@:3.12 platform=linux")
     variant("crypt", default=True, description="Build crypt module", when="@:3.12 platform=darwin")
-    variant("freethreading", default=False, description="Removes the Global Interpreter Lock", when="@3.13:")
+    variant(
+        "freethreading",
+        default=False,
+        description="Removes the Global Interpreter Lock",
+        when="@3.13:",
+    )
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")

--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -173,7 +173,7 @@ class Python(Package):
     variant("tix", default=False, description="Build Tix module", when="+tkinter")
     variant("crypt", default=True, description="Build crypt module", when="@:3.12 platform=linux")
     variant("crypt", default=True, description="Build crypt module", when="@:3.12 platform=darwin")
-    variant("gil", default=True, description="Build with Global Interpreter Lock")
+    variant("freethreading", default=False, description="Removes the Global Interpreter Lock", when="@3.13:")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
@@ -642,9 +642,8 @@ class Python(Package):
                 ]
             )
 
-        if self.version >= Version("3.14.0"):
-            if "~gil" in spec:
-                config_args.append("--disable-gil")
+        if "+freethreading" in spec:
+            config_args.append("--disable-gil")
 
         # Disable tkinter module in the configure script for Python 3.12 onwards if ~tkinter
         if spec.satisfies("@3.12:") and spec.satisfies("~tkinter"):

--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -173,6 +173,7 @@ class Python(Package):
     variant("tix", default=False, description="Build Tix module", when="+tkinter")
     variant("crypt", default=True, description="Build crypt module", when="@:3.12 platform=linux")
     variant("crypt", default=True, description="Build crypt module", when="@:3.12 platform=darwin")
+    variant("gil", default=True, description="Build with Global Interpreter Lock")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
@@ -640,6 +641,10 @@ class Python(Package):
                     ),
                 ]
             )
+
+        if self.version >= Version("3.14.0"):
+            if "~gil" in spec:
+                config_args.append("--disable-gil")
 
         # Disable tkinter module in the configure script for Python 3.12 onwards if ~tkinter
         if spec.satisfies("@3.12:") and spec.satisfies("~tkinter"):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
--> 
Python 3.14 now supports true concurrency. For that you need to set the `--disable-gil` flag.
For that I added the option `gil` that is true as default. When set to false, the `--disable-gil` flag is configured.
