### PR TITLE
libssh: add v0.11.3

### DIFF
--- a/repos/spack_repo/builtin/packages/libssh/package.py
+++ b/repos/spack_repo/builtin/packages/libssh/package.py
@@ -11,11 +11,12 @@ class Libssh(CMakePackage):
     """libssh: the SSH library"""
 
     homepage = "https://www.libssh.org"
-    url = "https://www.libssh.org/files/0.11/libssh-0.11.2.tar.xz"
+    url = "https://www.libssh.org/files/0.11/libssh-0.11.3.tar.xz"
     list_url = "https://www.libssh.org/files"
     list_depth = 1
 
-    version("0.11.2", sha256="69529fc18f5b601f0baf0e5a4501a2bc26df5e2f116f5f8f07f19fafaa6d04e7")
+    version("0.11.3", sha256="7d8a1361bb094ec3f511964e78a5a4dba689b5986e112afabe4f4d0d6c6125c3")
+    # Previous versions removed because of CVEs
 
     variant("gssapi", default=True, description="Build with gssapi support")
 
@@ -23,7 +24,6 @@ class Libssh(CMakePackage):
     depends_on("cxx", type="build")
     depends_on("cmake@3.12:", type="build")
     depends_on("openssl@1.1.1:")
-    depends_on("openssl")
     depends_on("zlib-api")
     depends_on("krb5", when="+gssapi")
 


### PR DESCRIPTION
Replacing libssh v0.11.2 with v0.11.3 because of CVEs.

https://www.libssh.org/security/advisories/CVE-2025-8114.txt
https://www.libssh.org/security/advisories/CVE-2025-8277.txt