### PR TITLE
Fixed missing C dependency in Alembic's package.py and added support for new versions.

### DIFF
--- a/repos/spack_repo/builtin/packages/alembic/package.py
+++ b/repos/spack_repo/builtin/packages/alembic/package.py
@@ -18,6 +18,10 @@ class Alembic(CMakePackage):
 
     license("BSD-3-Clause")
 
+    version("1.8.10", sha256="06c9172faf29e9fdebb7be99621ca18b32b474f8e481238a159c87d16b298553")
+    version("1.8.9", sha256="8c59c10813feee917d262c71af77d6fa3db1acaf7c5fecfd4104167077403955")
+    version("1.8.8", sha256="ba1f34544608ef7d3f68cafea946ec9cc84792ddf9cda3e8d5590821df71f6c6")
+    version("1.8.7", sha256="6de0b97cd14dcfb7b2d0d788c951b6da3c5b336c47322ea881d64f18575c33da")
     version("1.8.6", sha256="c572ebdea3a5f0ce13774dd1fceb5b5815265cd1b29d142cf8c144b03c131c8c")
     version("1.8.5", sha256="180a12f08d391cd89f021f279dbe3b5423b1db751a9898540c8059a45825c2e9")
     version("1.7.16", sha256="2529586c89459af34d27a36ab114ad1d43dafd44061e65cfcfc73b7457379e7c")
@@ -25,6 +29,7 @@ class Alembic(CMakePackage):
     variant("python", default=False, description="Python support")
     variant("hdf5", default=False, description="HDF5 support")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     depends_on("cmake@2.8.11:", type="build")


### PR DESCRIPTION
Whenever I tried installing Alembic, I got the following error:
[spack cc]: Error: SPACK_CC_* variables not set: this usually means a missing `depends_on("c", type="build")` in package.py

I added that line to Alembic's package.py file as suggested and that fixed the error. I'd thought that Alembic was a C++ project and that the existing `depends_on("cxx", type="build")` line would've been enough, but apparently not.

I also added checksums for versions 1.8.7-1.8.10 while I was in there.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
