### PR TITLE
bedops updates

### DIFF
--- a/repos/spack_repo/builtin/packages/bedops/package.py
+++ b/repos/spack_repo/builtin/packages/bedops/package.py
@@ -18,9 +18,9 @@ class Bedops(MakefilePackage):
 
     maintainers("jacorvar")
 
-    # More regarding the peculiar license() directive: bedops is licensed under the GPL v2, but the
-    # bedops source bundles source for bzlip2, jansson, and zlib, and its LICENSE has the licenses
-    # for those source codes appended.
+    # Regarding the peculiar license() directive: bedops is licensed under the GPL v2,
+    # but the bedops source bundles source for bzlip2, jansson, and zlib, and its
+    # LICENSE has the licenses for those source codes appended.
     license("GPL-2.0-only AND bzip2-1.0.6 AND MIT AND Zlib")
 
     version("2.4.42", sha256="9daa0c098e37490a07f84664d2c61ff8909689995cf7e1673d259ccd4f1c453c")

--- a/repos/spack_repo/builtin/packages/bedops/package.py
+++ b/repos/spack_repo/builtin/packages/bedops/package.py
@@ -18,6 +18,9 @@ class Bedops(MakefilePackage):
 
     maintainers("jacorvar")
 
+    # More regarding the peculiar license() directive: bedops is licensed under the GPL v2, but the
+    # bedops source bundles source for bzlip2, jansson, and zlib, and its LICENSE has the licenses
+    # for those source codes appended.
     license("GPL-2.0-only AND bzip2-1.0.6 AND MIT AND Zlib")
 
     version("2.4.42", sha256="9daa0c098e37490a07f84664d2c61ff8909689995cf7e1673d259ccd4f1c453c")

--- a/repos/spack_repo/builtin/packages/bedops/package.py
+++ b/repos/spack_repo/builtin/packages/bedops/package.py
@@ -18,8 +18,9 @@ class Bedops(MakefilePackage):
 
     maintainers("jacorvar")
 
-    license("bzip2-1.0.6")
+    license("GPL-2.0-only AND bzip2-1.0.6 AND MIT AND Zlib")
 
+    version("2.4.42", sha256="9daa0c098e37490a07f84664d2c61ff8909689995cf7e1673d259ccd4f1c453c")
     version("2.4.41", sha256="3b868c820d59dd38372417efc31e9be3fbdca8cf0a6b39f13fb2b822607d6194")
     version("2.4.40", sha256="8c01db76669dc58c595e2e1b9bdb6d462f3363fc569b15c460a63a63b8b6bf30")
     version("2.4.39", sha256="f8bae10c6e1ccfb873be13446c67fc3a54658515fb5071663883f788fc0e4912")
@@ -29,6 +30,8 @@ class Bedops(MakefilePackage):
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
+
+    depends_on("python", type="run")
 
     @property
     def build_targets(self):


### PR DESCRIPTION
- Add BEDOPS 2.4.42
- Add a run-time dependency on `python`. BEDOPS includes multiple Python scripts that end up in prefix.bin, including `starch-diff`, `update-sort-bed-migrate-candidates`, `update-sort-bed-slurm`, `update-sort-bed-starch-slurm`.
- Correct license directive. Though the BEDOPS suite _includes_ bzip2, its license is GPL 2.0. The updated directive indicates licenses for all code that appears to be in the BEDOPS source, including the `bzip2-1.0.6` license identifier for bzip2, the `MIT` license identifier for jansson, and the `Zlib` license identifier for Zlib.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
