### PR TITLE
arrow: depend on snappy only with +snappy, do not request ~shared

### DIFF
--- a/repos/spack_repo/builtin/packages/arrow/package.py
+++ b/repos/spack_repo/builtin/packages/arrow/package.py
@@ -79,8 +79,7 @@ class Arrow(CMakePackage, CudaPackage):
     depends_on("re2+shared", when="+compute")
     depends_on("re2+shared", when="+gandiva")
     depends_on("re2+shared", when="+python")
-    depends_on("snappy~shared", when="+snappy @9:")
-    depends_on("snappy~shared", when="@8:")
+    depends_on("snappy", when="+snappy @8:")
     # thrift isn't found if it is built with autotools
     depends_on("thrift@0.11:+cpp build_system=cmake", when="+parquet")
     depends_on("utf8proc@2.7.0: +shared", when="+compute")


### PR DESCRIPTION
There is nothing in the documentation requesting that the snappy shared libraries should not be built: https://arrow.apache.org/docs/developers/cpp/building.html. For example, on Arch Linux they are built: https://gitlab.archlinux.org/archlinux/packaging/packages/snappy/-/blob/main/PKGBUILD?ref_type=heads, and I was able to build `arrow` with `snappy+shared`.

Then, I don't know if `+snappy @9:` has precedence over `@8:` (it seems not, as trying to build a recent version of arrow will pull snappy without `+snappy` for me), but in any case version 8 also has the cmake option `ARROW_WITH_SNAPPY` to build snappy so it doesn't have to be built unconditionally.