### PR TITLE
mariadb: request snappy with +shared since otherwise the build fails

### DIFF
--- a/repos/spack_repo/builtin/packages/mariadb/package.py
+++ b/repos/spack_repo/builtin/packages/mariadb/package.py
@@ -68,7 +68,7 @@ class Mariadb(CMakePackage):
     depends_on("msgpack-c")
     depends_on("openssl")
     depends_on("krb5")
-    depends_on("snappy", when="@11.8.3:")
+    depends_on("snappy+shared", when="@11.8.3:")
     depends_on("pcre2", when="@11.8.3:")
     depends_on("fmt@11:", when="@11:")
     depends_on("fmt@:8", when="@:10")


### PR DESCRIPTION
Our nightly builds failed today with the same errors on Alma 9 with GCC 14 and Ubuntu 24.04 with GCC 13, and this is caused by snappy being built with `~shared` when also building `arrow` (see https://github.com/spack/spack-packages/pull/2659). These are some of the errors:

```
29 errors found in build log:
     6306    [ 43%] Linking C shared module provider_lz4.so
     6307    cd /tmp/root/spack-stage/spack-stage-mariadb-12.1.1-h4b2p7hqgivofv
             zchvittllyy6amtu5c/spack-build-h4b2p7h/plugin/provider_lz4 && /cvm
             fs/sw-nightlies.hsf.org/key4hep/releases/2025-09-21/x86_64-almalin
             ux9-gcc14.2.0-opt/cmake/3.31.8-36nqaa/bin/cmake -E cmake_link_scri
             pt CMakeFiles/provider_lz4.dir/link.txt --verbose=1
     6308    [ 43%] Linking C shared module provider_snappy.so
     6309    cd /tmp/root/spack-stage/spack-stage-mariadb-12.1.1-h4b2p7hqgivofv
             zchvittllyy6amtu5c/spack-build-h4b2p7h/plugin/provider_snappy && /
             cvmfs/sw-nightlies.hsf.org/key4hep/releases/2025-09-21/x86_64-alma
             linux9-gcc14.2.0-opt/cmake/3.31.8-36nqaa/bin/cmake -E cmake_link_s
             cript CMakeFiles/provider_snappy.dir/link.txt --verbose=1
     6310    /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2025-09-21/x86_64-alm
             alinux9-gcc14.2.0-opt/compiler-wrapper/1.0-i2d2gg/libexec/spack/gc
             c/gcc -fPIC  -pie -fPIC -fstack-protector --param=ssp-buffer-size=
             4 -O3 -DNDEBUG -D_FORTIFY_SOURCE=2 -DDBUG_OFF  -Wl,-z,relro,-z,now
              -shared  -o provider_lz4.so CMakeFiles/provider_lz4.dir/plugin.c.
             o  -Wl,-rpath,/cvmfs/sw-nightlies.hsf.org/key4hep/releases/2025-09
             -21/x86_64-almalinux9-gcc14.2.0-opt/lz4/1.10.0-nqyhhe/lib:::::::::
             ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
             ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
             ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
             ::::::::::::::::::::::: ../../libservices/libmysqlservices.a /cvmf
             s/sw-nightlies.hsf.org/key4hep/releases/2025-09-21/x86_64-almalinu
             x9-gcc14.2.0-opt/lz4/1.10.0-nqyhhe/lib/liblz4.so -Wl,--no-undefine
             d
     6311    /usr/bin/ld: /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2025-12-
             04/x86_64-almalinux9-gcc14.2.0-opt/snappy/1.2.1-garjap/lib/libsnap
             py.a(snappy.cc.o): in function `snappy::internal::WorkingMemory::W
             orkingMemory(unsigned long)':
  >> 6312    snappy.cc:(.text+0x139): undefined reference to `operator new(unsi
             gned long)'
  >> 6313    /usr/bin/ld: snappy.cc:(.text+0x161): undefined reference to `std:
             :__throw_bad_alloc()'
     6314    /usr/bin/ld: /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2025-12-
             04/x86_64-almalinux9-gcc14.2.0-opt/snappy/1.2.1-garjap/lib/libsnap
             py.a(snappy.cc.o): in function `snappy::Compress(char const*, unsi
             gned long, std::__cxx11::basic_string<char, std::char_traits<char>
             , std::allocator<char> >*, snappy::CompressionOptions)':
  >> 6315    snappy.cc:(.text+0x36a7): undefined reference to `std::__cxx11::ba
             sic_string<char, std::char_traits<char>, std::allocator<char> >::r
             esize(unsigned long, char)'
```
...