### PR TITLE
py-catalogue: added version 2.0.10

### DIFF
--- a/repos/spack_repo/builtin/packages/py_catalogue/package.py
+++ b/repos/spack_repo/builtin/packages/py_catalogue/package.py
@@ -16,6 +16,7 @@ class PyCatalogue(PythonPackage):
 
     license("MIT")
 
+    version("2.0.10", sha256="4f56daa940913d3f09d589c191c74e5a6d51762b3a9e37dd53b7437afd6cda15")
     version("2.0.8", sha256="b325c77659208bfb6af1b0d93b1a1aa4112e1bb29a4c5ced816758a722f0e388")
     version("2.0.0", sha256="34f8416ec5e7ed08e55c10414416e67c3f4d66edf83bc67320c3290775293816")
     version("1.0.0", sha256="d74d1d856c6b36a37bf14aa6dbbc27d0582667b7ab979a6108e61a575e8723f5")
@@ -26,3 +27,6 @@ class PyCatalogue(PythonPackage):
     depends_on("py-importlib-metadata@0.20:", when="@:2.0.0^python@:3.7", type=("build", "run"))
     depends_on("py-zipp@0.5:", when="@2.0.8:^python@:3.7", type=("build", "run"))
     depends_on("py-typing-extensions@3.6.4:", when="@2.0.8:^python@3.7", type=("build", "run"))
+
+    # AttributeError: 'EntryPoints' object has no attribute 'get'
+    conflicts("python@3.12:", when="@:2.0.8")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
