### PR TITLE
Add necessary language support for gadap and grads

### DIFF
--- a/repos/spack_repo/builtin/packages/gadap/package.py
+++ b/repos/spack_repo/builtin/packages/gadap/package.py
@@ -19,7 +19,8 @@ class Gadap(AutotoolsPackage):
 
     version("2.0", sha256="ae9a989ca00ec29fb40616383d170883f07c022456db338399982a8a94ec0100")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("curl@7.18.0:")
     depends_on("libdap4")

--- a/repos/spack_repo/builtin/packages/grads/package.py
+++ b/repos/spack_repo/builtin/packages/grads/package.py
@@ -40,7 +40,8 @@ class Grads(AutotoolsPackage):
     variant("hdf4", default=True, when="@2.2.2:", description="Enable HDF4 support")
     variant("netcdf", default=True, when="@2.2.2:", description="Enable NetCDF support")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("hdf5", when="+hdf5")
     depends_on("hdf", when="+hdf4")
@@ -82,6 +83,14 @@ class Grads(AutotoolsPackage):
             # Can use newer versions of HDF5, but 1.10 is the last API GrADS supports
             if "hdf5" in spec and spec["hdf5"].satisfies("@1.12:"):
                 flags.append("-DH5_USE_110_API")
+
+            if (
+                self.spec.satisfies("%apple-clang@15:")
+                or self.spec.satisfies("%clang@16:")
+                or self.spec.satisfies("%oneapi")
+                or self.spec.satisfies("%gcc@14:")
+            ):
+                flags.append("-Wno-error=implicit-function-declaration")
 
         return (flags, None, None)
 


### PR DESCRIPTION
These two packages have likely been broken since the 1.0 release. The `gadap` package only has a `cxx` dependency but needs `c` as well. Meanwhile, the opposite is the case for `grads`. Grads also has some implicitly declared functions for which we now bypass checks in relevant situations.