### PR TITLE
geant4: add v11.4.0 and versions of other packages needed

### DIFF
--- a/repos/spack_repo/builtin/packages/g4channeling/package.py
+++ b/repos/spack_repo/builtin/packages/g4channeling/package.py
@@ -19,6 +19,7 @@ class G4channeling(Package):
     maintainers("drbenmorgan")
 
     # Only versions relevant to Geant4 releases built by spack are added
+    version("2.0", sha256="662159288644e07b79d7fe091efbebba52b59546b3dc6f5d285b976ad12f2d06")
     version("1.0", sha256="203e3c69984ca09acd181a1d31a9b0efafad4bc12e6c608f0b05e695120d67f2")
 
     def install(self, spec, prefix):

--- a/repos/spack_repo/builtin/packages/g4emlow/package.py
+++ b/repos/spack_repo/builtin/packages/g4emlow/package.py
@@ -19,6 +19,7 @@ class G4emlow(Package):
     maintainers("drbenmorgan")
 
     # Only versions relevant to Geant4 releases built by spack are added
+    version("8.8", sha256="b60cfd63176f5d16107e2a25b35b235155032d1735d749670ca50fede12624cf")
     version("8.6.1", sha256="4a93588d26080ce1d336b94f76fadabe4905fb8f1cba2415795023d6cd8f4a8a")
     version("8.6", sha256="fb7abed0d1db1d8b9ea364279b95e228d7bf3e3a5dc8d449b81665cada4a1a9e")
     version("8.5", sha256="66baca49ac5d45e2ac10c125b4fb266225e511803e66981909ce9cd3e9bcef73")

--- a/repos/spack_repo/builtin/packages/g4incl/package.py
+++ b/repos/spack_repo/builtin/packages/g4incl/package.py
@@ -20,6 +20,7 @@ class G4incl(Package):
     maintainers("drbenmorgan")
 
     # Only versions relevant to Geant4 releases built by spack are added
+    version("1.3", sha256="e4b3dbe52acef53536454e22443091212843821bd23628eed846d299599f3bf9")
     version("1.2", sha256="f880b16073ee0a92d7494f3276a6d52d4de1d3677a0d4c7c58700396ed0e1a7e")
     version("1.1", sha256="5d82e71db5f5a1b659937506576be58db7de7753ec5913128141ae7fce673b44")
     version("1.0", sha256="716161821ae9f3d0565fbf3c2cf34f4e02e3e519eb419a82236eef22c2c4367d")

--- a/repos/spack_repo/builtin/packages/g4particlexs/package.py
+++ b/repos/spack_repo/builtin/packages/g4particlexs/package.py
@@ -20,6 +20,7 @@ class G4particlexs(Package):
     maintainers("drbenmorgan")
 
     # Only versions relevant to Geant4 releases built by spack are added
+    version("4.2", sha256="c52bbf86aaa589b78aba80b16ab0adf1041ea300de5395865b97fcee6eb55851")
     version("4.1", sha256="07ae1e048e9ac8e7f91f6696497dd55bd50ccc822d97af1a0b9e923212a6d7d1")
     version("4.0", sha256="9381039703c3f2b0fd36ab4999362a2c8b4ff9080c322f90b4e319281133ca95")
     version("3.1.1", sha256="66c17edd6cb6967375d0497add84c2201907a25e33db782ebc26051d38f2afda")

--- a/repos/spack_repo/builtin/packages/g4photonevaporation/package.py
+++ b/repos/spack_repo/builtin/packages/g4photonevaporation/package.py
@@ -19,6 +19,7 @@ class G4photonevaporation(Package):
     maintainers("drbenmorgan")
 
     # Only versions relevant to Geant4 releases built by spack are added
+    version("6.1.2", sha256="02149c0ab91d88ee24e78532558777e39a068b9fcdd199136101ff58e635e742")
     version("6.1", sha256="5ffc1f99a81d50c9020186d59874af73c53ba24c1842b3b82b3188223bb246f2")
     version("5.7", sha256="761e42e56ffdde3d9839f9f9d8102607c6b4c0329151ee518206f4ee9e77e7e5")
     version("5.5", sha256="5995dda126c18bd7f68861efde87b4af438c329ecbe849572031ceed8f5e76d7")

--- a/repos/spack_repo/builtin/packages/geant4/package.py
+++ b/repos/spack_repo/builtin/packages/geant4/package.py
@@ -26,6 +26,7 @@ class Geant4(CMakePackage):
 
     maintainers("drbenmorgan", "sethrj")
 
+    version("11.4.0", sha256="a6d78cf70ba46902cb74ff65d09dc2d1e46b4ab9325862f84e439f0d4ec329fb")
     version("11.3.2", sha256="077edca6aa3b3940f351cf9a948457cad3fb117f215b88c52cce315e1a07fd7a")
     version("11.3.1", sha256="9059da076928f25cab1ff1f35e0f611a4d7fe005e374e9b8d7f3ff2434b7af54")
     version("11.3.0", sha256="d9d71daff8890a7b5e0e33ea9a65fe6308ad6713000b43ba6705af77078e7ead")
@@ -141,7 +142,8 @@ class Geant4(CMakePackage):
         "11.1",
         "11.2.0:11.2.1",
         "11.2.2:11.2",
-        "11.3:",
+        "11.3",
+        "11.4:",
     ]:
         depends_on("geant4-data@" + _vers, type="run", when="+data @" + _vers)
 
@@ -157,6 +159,7 @@ class Geant4(CMakePackage):
     extends("python", when="+python")
 
     # CLHEP version requirements to be reviewed
+    depends_on("clhep@2.4.7.2:", when="@11.4:")
     depends_on("clhep@2.4.7.1:", when="@11.3:")
     depends_on("clhep@2.4.6.0:", when="@11.1:")
     depends_on("clhep@2.4.5.1:", when="@11.0.0:")
@@ -166,6 +169,7 @@ class Geant4(CMakePackage):
 
     # Vecgeom specific versions for each Geant4 version
     with when("+vecgeom"):
+        depends_on("vecgeom@2.0.0:", when="@11.4:")
         depends_on("vecgeom@1.2.8:", when="@11.3:")
         depends_on("vecgeom@1.2.6:", when="@11.2:")
         depends_on("vecgeom@1.2.0:", when="@11.1")
@@ -198,7 +202,8 @@ class Geant4(CMakePackage):
             depends_on("qt-base +accessibility +gui +opengl")
         with when("^[virtuals=qmake] qt"):
             depends_on("qt@5: +opengl")
-            depends_on("qt@5.9:", when="@11.2:")
+            depends_on("qt@5.9:", when="@11.2:11.3")
+            depends_on("qt@6:", when="@11.4:")
     conflicts("@:11.1 ^[virtuals=qmake] qt-base", msg="Qt6 not supported before 11.2")
 
     # CMAKE PROBLEMS #

--- a/repos/spack_repo/builtin/packages/geant4/package.py
+++ b/repos/spack_repo/builtin/packages/geant4/package.py
@@ -203,7 +203,6 @@ class Geant4(CMakePackage):
         with when("^[virtuals=qmake] qt"):
             depends_on("qt@5: +opengl")
             depends_on("qt@5.9:", when="@11.2:11.3")
-            depends_on("qt@6:", when="@11.4:")
     conflicts("@:11.1 ^[virtuals=qmake] qt-base", msg="Qt6 not supported before 11.2")
 
     # CMAKE PROBLEMS #

--- a/repos/spack_repo/builtin/packages/geant4/package.py
+++ b/repos/spack_repo/builtin/packages/geant4/package.py
@@ -169,8 +169,6 @@ class Geant4(CMakePackage):
 
     # Vecgeom specific versions for each Geant4 version
     with when("+vecgeom"):
-        depends_on("vecgeom@2.0.0:", when="@11.4:")
-        depends_on("vecgeom@1.2.8:", when="@11.3:")
         depends_on("vecgeom@1.2.6:", when="@11.2:")
         depends_on("vecgeom@1.2.0:", when="@11.1")
         depends_on("vecgeom@1.1.18:1.1", when="@11.0.0:11.0")

--- a/repos/spack_repo/builtin/packages/geant4/package.py
+++ b/repos/spack_repo/builtin/packages/geant4/package.py
@@ -203,6 +203,7 @@ class Geant4(CMakePackage):
         with when("^[virtuals=qmake] qt"):
             depends_on("qt@5: +opengl")
             depends_on("qt@5.9:", when="@11.2:11.3")
+    conflicts("@11.4: ^[virtuals=qmake] qt", msg="Qt5 not supported in 11.4 and later")
     conflicts("@:11.1 ^[virtuals=qmake] qt-base", msg="Qt6 not supported before 11.2")
 
     # CMAKE PROBLEMS #

--- a/repos/spack_repo/builtin/packages/geant4_data/package.py
+++ b/repos/spack_repo/builtin/packages/geant4_data/package.py
@@ -18,6 +18,7 @@ class Geant4Data(BundlePackage):
 
     tags = ["hep"]
 
+    version("11.4.0")
     version("11.3.0")
     version("11.2.2")
     version("11.2.0")
@@ -45,6 +46,20 @@ class Geant4Data(BundlePackage):
     # they generally don't change on the patch level
     # Can move to declaring on a dataset basis if needed
     _datasets = {
+        "11.4.0:11.4": [
+            "g4ndl@4.7.1",
+            "g4emlow@8.8",
+            "g4photonevaporation@6.1.2",
+            "g4radioactivedecay@6.1.2",
+            "g4particlexs@4.2",
+            "g4pii@1.3",
+            "g4realsurface@2.2",
+            "g4saiddata@2.0",
+            "g4abla@3.3",
+            "g4incl@1.3",
+            "g4ensdfstate@3.0",
+            "g4channeling@2.0",
+        ],
         "11.3.0:11.3": [
             "g4ndl@4.7.1",
             "g4emlow@8.6.1",
@@ -196,7 +211,7 @@ class Geant4Data(BundlePackage):
             depends_on(_d, type=("build", "run"), when=_vers)
 
     _datasets_tendl = {
-        "11.0:11.3": "g4tendl@1.4",
+        "11.0:11.4": "g4tendl@1.4",
         "10.4:10.7": "g4tendl@1.3.2",
         "10.3:10.3": "g4tendl@1.3",
     }
@@ -205,10 +220,10 @@ class Geant4Data(BundlePackage):
     with when("+tendl"):
         for _vers, _d in _datasets_tendl.items():
             depends_on(_d, type=("build", "run"), when="@" + _vers)
-    variant("nudexlib", default=True, when="@11.3.0:11.3", description="Enable G4NUDEXLIB")
+    variant("nudexlib", default=True, when="@11.3:", description="Enable G4NUDEXLIB")
     with when("+nudexlib"):
         depends_on("g4nudexlib@1.0", type=("build", "run"))
-    variant("urrpt", default=True, when="@11.3.0:11.3", description="Enable G4URRPT")
+    variant("urrpt", default=True, when="@11.3:", description="Enable G4URRPT")
     with when("+urrpt"):
         depends_on("g4urrpt@1.1", type=("build", "run"))
 


### PR DESCRIPTION
Release notes: https://geant4.web.cern.ch/download/release-notes/notes-v11.4.0.html:

> New data sets G4PhotonEvaporation-6.1.2, G4CHANNELING-2.0, G4INCL-1.3, G4EMLOW-8.8, G4PARTICLEXS-4.2.

- Needs https://github.com/spack/spack-packages/pull/2799 for `clhep@2.4.7.2`.