### PR TITLE
Update FEniCS packages

### DIFF
--- a/repos/spack_repo/builtin/packages/fenics_basix/package.py
+++ b/repos/spack_repo/builtin/packages/fenics_basix/package.py
@@ -18,7 +18,9 @@ class FenicsBasix(CMakePackage):
     license("MIT")
 
     version("main", branch="main", no_cache=True)
-    version("0.10.0.post0", sha256="11a6482fb8d7204fbd77aaf457a9ae3e75db1707b3e30ea2c938eccfee925ea4")
+    version(
+        "0.10.0.post0", sha256="11a6482fb8d7204fbd77aaf457a9ae3e75db1707b3e30ea2c938eccfee925ea4"
+    )
     version("0.10.0", sha256="b93221dac7d3fea8c10e77617f6201036de35d0c5437440b718de69a28c3773f")
     version("0.9.0", sha256="60e96b2393084729b261cb10370f0e44d12735ab3dbd1f15890dec23b9e85329")
     version("0.8.0", sha256="b299af82daf8fa3e4845e17f202491fe71b313bf6ab64c767a5287190b3dd7fe")

--- a/repos/spack_repo/builtin/packages/fenics_basix/package.py
+++ b/repos/spack_repo/builtin/packages/fenics_basix/package.py
@@ -18,6 +18,7 @@ class FenicsBasix(CMakePackage):
     license("MIT")
 
     version("main", branch="main", no_cache=True)
+    version("0.10.0.post0", sha256="11a6482fb8d7204fbd77aaf457a9ae3e75db1707b3e30ea2c938eccfee925ea4")
     version("0.10.0", sha256="b93221dac7d3fea8c10e77617f6201036de35d0c5437440b718de69a28c3773f")
     version("0.9.0", sha256="60e96b2393084729b261cb10370f0e44d12735ab3dbd1f15890dec23b9e85329")
     version("0.8.0", sha256="b299af82daf8fa3e4845e17f202491fe71b313bf6ab64c767a5287190b3dd7fe")

--- a/repos/spack_repo/builtin/packages/fenics_dolfinx/0.8-boost-filesystem.patch
+++ b/repos/spack_repo/builtin/packages/fenics_dolfinx/0.8-boost-filesystem.patch
@@ -1,0 +1,11 @@
+--- a/cpp/cmake/templates/DOLFINXConfig.cmake.in
++++ b/cpp/cmake/templates/DOLFINXConfig.cmake.in
+@@ -17,7 +17,7 @@ if(DEFINED ENV{BOOST_ROOT} OR DEFINED BOOST_ROOT)
+ endif()
+ set(Boost_USE_MULTITHREADED $ENV{BOOST_USE_MULTITHREADED})
+ set(Boost_VERBOSE TRUE)
+-find_dependency(Boost 1.70 REQUIRED COMPONENTS timer filesystem)
++find_dependency(Boost 1.70 REQUIRED COMPONENTS timer)
+ 
+ if(@ufcx_FOUND@)
+   find_dependency(ufcx)

--- a/repos/spack_repo/builtin/packages/fenics_dolfinx/package.py
+++ b/repos/spack_repo/builtin/packages/fenics_dolfinx/package.py
@@ -14,15 +14,20 @@ class FenicsDolfinx(CMakePackage):
     git = "https://github.com/FEniCS/dolfinx.git"
     url = "https://github.com/FEniCS/dolfinx/archive/v0.1.0.tar.gz"
     maintainers("chrisrichardson", "garth-wells", "nate-sime", "jhale")
-
     license("LGPL-3.0-or-later")
 
     version("main", branch="main", no_cache=True)
+    version("0.10.0.post4", sha256="3f827a88ab52843fbd7a5cc7814ecba165bdec65fd10df05eb031c286e8cd605")
+    version(
+        "0.10.0.post2", sha256="eae83794fee8141c80c59c03a2f4ac208af2b62c8f36e5d19c93e0d279029f52"
+    )
     version("0.9.0", sha256="b266c74360c2590c5745d74768c04568c965b44739becca4cd6b5aa58cdbbbd1")
     version("0.8.0", sha256="acf3104d9ecc0380677a6faf69eabfafc58d0cce43f7777e1307b95701c7cad9")
     with default_args(deprecated=True):
         version("0.7.2", sha256="7d9ce1338ce66580593b376327f23ac464a4ce89ef63c105efc1a38e5eae5c0b")
         version("0.6.0", sha256="eb8ac2bb2f032b0d393977993e1ab6b4101a84d54023a67206e3eac1a8d79b80")
+
+    patch("0.8-boost-filesystem.patch", when="@0.8")
 
     # CMake build types
     variant(
@@ -44,6 +49,8 @@ class FenicsDolfinx(CMakePackage):
     depends_on("c", type="build")  # HDF5 dependency requires C in CMake config
     depends_on("cxx", type="build")
 
+    conflicts("%gcc@:12", when="@0.10:")
+
     # Graph partitioner dependencies
     depends_on("kahip@3.12:", when="partitioners=kahip")
     depends_on("parmetis", when="partitioners=parmetis")
@@ -52,6 +59,8 @@ class FenicsDolfinx(CMakePackage):
     variant("slepc", default=False, description="SLEPc support")
     variant("adios2", default=False, description="ADIOS2 support")
     variant("petsc", default=False, description="PETSc support")
+
+    conflicts("~petsc", when="+slepc", msg="+slepc requires +petsc")
 
     depends_on("cmake@3.21:", when="@0.9:", type="build")
     depends_on("cmake@3.19:", when="@:0.8", type="build")
@@ -68,9 +77,11 @@ class FenicsDolfinx(CMakePackage):
         depends_on("petsc+mpi+shared")
         depends_on("slepc")
 
-    depends_on("adios2@2.8.1:+mpi", when="@0.9: +adios2")
+    depends_on("adios2@:2.10", when="@:0.9 +adios2")
+    depends_on("adios2@2.8.1:", when="@0.9: +adios2")
     depends_on("adios2+mpi", when="+adios2")
-    for ver in ("main", "0.9", "0.8", "0.7", "0.6"):
+
+    for ver in ("main", "0.10", "0.9", "0.8", "0.7", "0.6"):
         depends_on(f"fenics-ufcx@{ver}", when=f"@{ver}")
         depends_on(f"fenics-basix@{ver}", when=f"@{ver}")
         depends_on(f"py-fenics-ffcx@{ver}", when=f"@{ver}", type="test")
@@ -80,6 +91,7 @@ class FenicsDolfinx(CMakePackage):
 
     def cmake_args(self):
         return [
+            self.define_from_variant("CMAKE_BUILD_TYPE", "build_type"),
             self.define("DOLFINX_SKIP_BUILD_TESTS", True),
             self.define_from_variant("DOLFINX_ENABLE_PETSC", "petsc"),
             self.define_from_variant("DOLFINX_ENABLE_SLEPC", "slepc"),

--- a/repos/spack_repo/builtin/packages/fenics_dolfinx/package.py
+++ b/repos/spack_repo/builtin/packages/fenics_dolfinx/package.py
@@ -17,7 +17,9 @@ class FenicsDolfinx(CMakePackage):
     license("LGPL-3.0-or-later")
 
     version("main", branch="main", no_cache=True)
-    version("0.10.0.post4", sha256="3f827a88ab52843fbd7a5cc7814ecba165bdec65fd10df05eb031c286e8cd605")
+    version(
+        "0.10.0.post4", sha256="3f827a88ab52843fbd7a5cc7814ecba165bdec65fd10df05eb031c286e8cd605"
+    )
     version(
         "0.10.0.post2", sha256="eae83794fee8141c80c59c03a2f4ac208af2b62c8f36e5d19c93e0d279029f52"
     )

--- a/repos/spack_repo/builtin/packages/fenics_ufcx/package.py
+++ b/repos/spack_repo/builtin/packages/fenics_ufcx/package.py
@@ -28,5 +28,6 @@ class FenicsUfcx(CMakePackage):
         version("0.6.0", sha256="076fad61d406afffd41019ae1abf6da3f76406c035c772abad2156127667980e")
 
     depends_on("cmake@3.19:", type="build")
+    depends_on("c", type="build")
 
     root_cmakelists_dir = "cmake"

--- a/repos/spack_repo/builtin/packages/py_fenics_basix/package.py
+++ b/repos/spack_repo/builtin/packages/py_fenics_basix/package.py
@@ -51,9 +51,6 @@ class PyFenicsBasix(PythonPackage):
     depends_on("py-scikit-build-core+pyproject@0.5.0:", when="@0.8:0.9", type="build")
 
     def config_settings(self, spec, prefix):
-        return {
-            "build.tool-args": f"-j{make_jobs}",
-            "build.verbose": "true",
-        }
+        return {"build.tool-args": f"-j{make_jobs}", "build.verbose": "true"}
 
     build_directory = "python"

--- a/repos/spack_repo/builtin/packages/py_fenics_basix/package.py
+++ b/repos/spack_repo/builtin/packages/py_fenics_basix/package.py
@@ -18,6 +18,8 @@ class PyFenicsBasix(PythonPackage):
     license("MIT")
 
     version("main", branch="main", no_cache=True)
+    version("0.10.0.post0", sha256="11a6482fb8d7204fbd77aaf457a9ae3e75db1707b3e30ea2c938eccfee925ea4")
+    version("0.10.0", sha256="b93221dac7d3fea8c10e77617f6201036de35d0c5437440b718de69a28c3773f")
     version("0.9.0", sha256="60e96b2393084729b261cb10370f0e44d12735ab3dbd1f15890dec23b9e85329")
     version("0.8.0", sha256="b299af82daf8fa3e4845e17f202491fe71b313bf6ab64c767a5287190b3dd7fe")
     with default_args(deprecated=True):
@@ -26,7 +28,7 @@ class PyFenicsBasix(PythonPackage):
 
     depends_on("cxx", type="build")
 
-    for ver in ("main", "0.9.0", "0.8.0", "0.7.0", "0.6.0"):
+    for ver in ("main", "0.10.0.post0", "0.10.0", "0.9.0", "0.8.0", "0.7.0", "0.6.0"):
         depends_on(f"fenics-basix@{ver}", type=("build", "run"), when=f"@{ver}")
 
     # See python/CMakeLists.txt
@@ -40,12 +42,16 @@ class PyFenicsBasix(PythonPackage):
     depends_on("py-numpy@1.21:", type=("build", "run"))
     depends_on("py-pybind11@2.9.1:", when="@:0.7", type="build")
     depends_on("py-setuptools@42:", when="@:0.7", type="build")
-    depends_on("py-nanobind@2:", when="@0.10:", type="build")
+    depends_on("py-nanobind@2.5:", when="@0.10:", type="build")
+    depends_on("py-nanobind@2:", when="@0.9:", type="build")
     depends_on("py-nanobind@1.6.0:", when="@0.8:0.9", type="build")
     depends_on("py-scikit-build-core+pyproject@0.10:", when="@0.10:", type="build")
     depends_on("py-scikit-build-core+pyproject@0.5.0:", when="@0.8:0.9", type="build")
 
     def config_settings(self, spec, prefix):
-        return {"build.tool-args": f"-j{make_jobs}", "build.verbose": "true"}
+        return {
+            "build.tool-args": f"-j{make_jobs}",
+            "build.verbose": "true",
+        }
 
     build_directory = "python"

--- a/repos/spack_repo/builtin/packages/py_fenics_basix/package.py
+++ b/repos/spack_repo/builtin/packages/py_fenics_basix/package.py
@@ -18,7 +18,9 @@ class PyFenicsBasix(PythonPackage):
     license("MIT")
 
     version("main", branch="main", no_cache=True)
-    version("0.10.0.post0", sha256="11a6482fb8d7204fbd77aaf457a9ae3e75db1707b3e30ea2c938eccfee925ea4")
+    version(
+        "0.10.0.post0", sha256="11a6482fb8d7204fbd77aaf457a9ae3e75db1707b3e30ea2c938eccfee925ea4"
+    )
     version("0.10.0", sha256="b93221dac7d3fea8c10e77617f6201036de35d0c5437440b718de69a28c3773f")
     version("0.9.0", sha256="60e96b2393084729b261cb10370f0e44d12735ab3dbd1f15890dec23b9e85329")
     version("0.8.0", sha256="b299af82daf8fa3e4845e17f202491fe71b313bf6ab64c767a5287190b3dd7fe")

--- a/repos/spack_repo/builtin/packages/py_fenics_dolfinx/package.py
+++ b/repos/spack_repo/builtin/packages/py_fenics_dolfinx/package.py
@@ -19,7 +19,9 @@ class PyFenicsDolfinx(PythonPackage):
     license("LGPL-3.0-or-later")
 
     version("main", branch="main", no_cache=True)
-    version("0.10.0.post4", sha256="3f827a88ab52843fbd7a5cc7814ecba165bdec65fd10df05eb031c286e8cd605")
+    version(
+        "0.10.0.post4", sha256="3f827a88ab52843fbd7a5cc7814ecba165bdec65fd10df05eb031c286e8cd605"
+    )
     version("0.9.0", sha256="b266c74360c2590c5745d74768c04568c965b44739becca4cd6b5aa58cdbbbd1")
     version("0.8.0", sha256="acf3104d9ecc0380677a6faf69eabfafc58d0cce43f7777e1307b95701c7cad9")
     with default_args(deprecated=True):
@@ -53,7 +55,7 @@ class PyFenicsDolfinx(PythonPackage):
     depends_on("python@3.9:", when="@0.8:", type=("build", "run"))
     depends_on("python@3.8:", when="@0.7", type=("build", "run"))
     depends_on("python@3.8:3.10", when="@0.6.0", type=("build", "run"))
-    
+
     for ver in ["main", "0.10.0.post4", "0.9.0", "0.8.0", "0.7.2", "0.6.0"]:
         depends_on(f"fenics-dolfinx@{ver}", when=f"@{ver}")
 

--- a/repos/spack_repo/builtin/packages/py_fenics_dolfinx/package.py
+++ b/repos/spack_repo/builtin/packages/py_fenics_dolfinx/package.py
@@ -19,6 +19,7 @@ class PyFenicsDolfinx(PythonPackage):
     license("LGPL-3.0-or-later")
 
     version("main", branch="main", no_cache=True)
+    version("0.10.0.post4", sha256="3f827a88ab52843fbd7a5cc7814ecba165bdec65fd10df05eb031c286e8cd605")
     version("0.9.0", sha256="b266c74360c2590c5745d74768c04568c965b44739becca4cd6b5aa58cdbbbd1")
     version("0.8.0", sha256="acf3104d9ecc0380677a6faf69eabfafc58d0cce43f7777e1307b95701c7cad9")
     with default_args(deprecated=True):
@@ -48,22 +49,23 @@ class PyFenicsDolfinx(PythonPackage):
     depends_on("hdf5", type="build")
     depends_on("pkgconfig", type="build")
 
+    depends_on("python@3.10:", when="@0.10:", type=("build", "run"))
     depends_on("python@3.9:", when="@0.8:", type=("build", "run"))
     depends_on("python@3.8:", when="@0.7", type=("build", "run"))
     depends_on("python@3.8:3.10", when="@0.6.0", type=("build", "run"))
-
-    for ver in ["main", "0.9.0", "0.8.0", "0.7.2", "0.6.0"]:
+    
+    for ver in ["main", "0.10.0.post4", "0.9.0", "0.8.0", "0.7.2", "0.6.0"]:
         depends_on(f"fenics-dolfinx@{ver}", when=f"@{ver}")
 
-    for ver in ["main", "0.9", "0.8"]:
-        depends_on(f"py-fenics-basix@{ver}", type=("build", "run"), when=f"@{ver}")
-
-    for ver in ["main", "0.9", "0.8", "0.7", "0.6"]:
+    for ver in ["main", "0.10", "0.9", "0.8", "0.7", "0.6"]:
         depends_on(f"fenics-basix@{ver}", type=("build", "link"), when=f"@{ver}")
-        depends_on(f"py-fenics-ffcx@{ver}", type=("build", "link"), when=f"@{ver}")
+        depends_on(f"py-fenics-basix@{ver}", type=("build", "run"), when=f"@{ver}")
+        depends_on(f"py-fenics-ffcx@{ver}", type=("build", "run"), when=f"@{ver}")
 
+    depends_on("py-fenics-ufl@main", when="@main")
     for ufl_ver, ver in [
         ("main", "main"),
+        ("2025.2", "0.10"),
         ("2024.2", "0.9"),
         ("2024.1", "0.8"),
         ("2023.2", "0.7"),
@@ -74,6 +76,8 @@ class PyFenicsDolfinx(PythonPackage):
     depends_on("py-numpy@1.21:", type=("build", "run"))
     depends_on("py-mpi4py", type=("build", "run"))
 
+    conflicts("~petsc4py", when="@:0.8", msg="+petsc4py is required for versions 0.8 and lower")
+    conflicts("~petsc4py", when="+slepc4py", msg="+slepc4py requires +petsc4py")
     with when("+petsc4py"):
         depends_on("fenics-dolfinx +petsc")
         depends_on("py-petsc4py", type=("build", "run"))
@@ -82,11 +86,12 @@ class PyFenicsDolfinx(PythonPackage):
         depends_on("py-petsc4py", type=("build", "run"))
         depends_on("py-slepc4py", type=("build", "run"))
 
-    depends_on("py-cffi@:1.16", type=("build", "run"))
+    depends_on("py-cffi", type=("build", "run"))
 
+    depends_on("py-nanobind@2.5:", when="@0.10:", type="build")
     depends_on("py-nanobind@2:", when="@0.9:", type="build")
     depends_on("py-nanobind@1.8:1.9", when="@0.8", type="build")
-    depends_on("py-scikit-build-core@0.10: +pyproject", when="@0.10:", type="build")
+    depends_on("py-scikit-build-core@0.10: +pyproject", when="@0.9:", type="build")
     depends_on("py-scikit-build-core@0.5: +pyproject", when="@0.8:0.9", type="build")
 
     depends_on("py-pybind11@2.7.0:", when="@:0.7", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_fenics_ffcx/package.py
+++ b/repos/spack_repo/builtin/packages/py_fenics_ffcx/package.py
@@ -18,7 +18,9 @@ class PyFenicsFfcx(PythonPackage):
     license("LGPL-3.0-or-later")
 
     version("main", branch="main", no_cache=True)
-    version("0.10.1.post0", sha256="91e15e2586390d0a0b0e9993d63b47b7ae9657e5141fc30271291ea1a2d55d5e")
+    version(
+        "0.10.1.post0", sha256="91e15e2586390d0a0b0e9993d63b47b7ae9657e5141fc30271291ea1a2d55d5e"
+    )
     version("0.9.0", sha256="afa517272a3d2249f513cb711c50b77cf8368dd0b8f5ea4b759142229204a448")
     version("0.8.0", sha256="8a854782dbd119ec1c23c4522a2134d5281e7f1bd2f37d64489f75da055282e3")
     with default_args(deprecated=True):

--- a/repos/spack_repo/builtin/packages/py_fenics_ffcx/package.py
+++ b/repos/spack_repo/builtin/packages/py_fenics_ffcx/package.py
@@ -18,6 +18,7 @@ class PyFenicsFfcx(PythonPackage):
     license("LGPL-3.0-or-later")
 
     version("main", branch="main", no_cache=True)
+    version("0.10.1.post0", sha256="91e15e2586390d0a0b0e9993d63b47b7ae9657e5141fc30271291ea1a2d55d5e")
     version("0.9.0", sha256="afa517272a3d2249f513cb711c50b77cf8368dd0b8f5ea4b759142229204a448")
     version("0.8.0", sha256="8a854782dbd119ec1c23c4522a2134d5281e7f1bd2f37d64489f75da055282e3")
     with default_args(deprecated=True):
@@ -35,12 +36,14 @@ class PyFenicsFfcx(PythonPackage):
     depends_on("py-numpy@1.21:", type=("build", "run"))
 
     depends_on("py-fenics-ufl@main", type=("build", "run"), when="@main")
-    depends_on("py-fenics-ufl@2024.2.0:", type=("build", "run"), when="@0.9")
-    depends_on("py-fenics-ufl@2024.1.0:", type=("build", "run"), when="@0.8")
-    depends_on("py-fenics-ufl@2023.2.0", type=("build", "run"), when="@0.7")
+    depends_on("py-fenics-ufl@2025.2", type=("build", "run"), when="@0.10")
+    depends_on("py-fenics-ufl@2024.2", type=("build", "run"), when="@0.9")
+    depends_on("py-fenics-ufl@2024.1", type=("build", "run"), when="@0.8")
+    depends_on("py-fenics-ufl@2023.2", type=("build", "run"), when="@0.7")
     depends_on("py-fenics-ufl@2023.1", type=("build", "run"), when="@0.6")
 
     depends_on("py-fenics-basix@main", type=("build", "run"), when="@main")
+    depends_on("py-fenics-basix@0.10", type=("build", "run"), when="@0.10")
     depends_on("py-fenics-basix@0.9", type=("build", "run"), when="@0.9")
     depends_on("py-fenics-basix@0.8", type=("build", "run"), when="@0.8")
     depends_on("py-fenics-basix@0.7", type=("build", "run"), when="@0.7")


### PR DESCRIPTION
Contains a multitude of bug fixes, caught by newly introduced CI based integration testing at https://github.com/fenics/spack-fenics, debugged with @jhale.

Adds `...@0.10` versions (and/or post-releases) for the whole FEniCS stack.
