### PR TITLE
Don't add binutils on rhel 7-8 systems when using mold.

### DIFF
--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -413,10 +413,10 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     # Ditto for RHEL7/8: OpenBLAS uses flags which the RHEL system-binutils don't have:
     # https://github.com/xianyi/OpenBLAS/issues/3805#issuecomment-1319878852
     conflicts(
-        "~binutils", when="@10: os=rhel7", msg="gcc: Add +binutils - preinstalled as might be old"
+        "~binutils", when="@10: os=rhel7 ~mold", msg="gcc: Add +binutils - preinstalled as might be old"
     )
     conflicts(
-        "~binutils", when="@10: os=rhel8", msg="gcc: Add +binutils - preinstalled as might be old"
+        "~binutils", when="@10: os=rhel8 ~mold", msg="gcc: Add +binutils - preinstalled as might be old"
     )
 
     # GCC 11 requires GCC 4.8 or later (https://gcc.gnu.org/gcc-11/changes.html)

--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -413,10 +413,14 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     # Ditto for RHEL7/8: OpenBLAS uses flags which the RHEL system-binutils don't have:
     # https://github.com/xianyi/OpenBLAS/issues/3805#issuecomment-1319878852
     conflicts(
-        "~binutils", when="@10: os=rhel7 ~mold", msg="gcc: Add +binutils - preinstalled as might be old"
+        "~binutils",
+        when="@10: os=rhel7 ~mold",
+        msg="gcc: Add +binutils - preinstalled as might be old",
     )
     conflicts(
-        "~binutils", when="@10: os=rhel8 ~mold", msg="gcc: Add +binutils - preinstalled as might be old"
+        "~binutils",
+        when="@10: os=rhel8 ~mold",
+        msg="gcc: Add +binutils - preinstalled as might be old",
     )
 
     # GCC 11 requires GCC 4.8 or later (https://gcc.gnu.org/gcc-11/changes.html)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
The gcc package forces +binutils when a rhel 7 or 8 system is detected even when mold is selected as the linker.  This behavior is undesirable and causes linking errors because binutils gets added to the search path (see `if self.spec.satisfies("+binutils")`).

Behavior on develop
```sh
$ spack spec gcc+mold
 -   gcc@15.2.0+binutils+bootstrap~graphite+mold~nvptx~piclibs~profiled~strip build_system=autotools build_type=RelWithDebInfo languages:='c,c++,fortran' platform=linux os=rhel8 target=skylake_avx512 %c,cxx=gcc@8.5.0
```
Behavior on gcc-fix-mold-on-rhel7-8
```sh
$ spack spec gcc+mold
 -   gcc@15.2.0~binutils+bootstrap~graphite+mold~nvptx~piclibs~profiled~strip build_system=autotools build_type=RelWithDebInfo languages:='c,c++,fortran' platform=linux os=rhel8 target=skylake_avx512 %c,cxx=gcc@8.5.0
```