### PR TITLE
MFEM: fix an issue when installing examples and/or miniapps with a shared build

### DIFF
--- a/repos/spack_repo/builtin/packages/mfem/package.py
+++ b/repos/spack_repo/builtin/packages/mfem/package.py
@@ -1284,9 +1284,11 @@ class Mfem(Package, CudaPackage, ROCmPackage):
             with working_dir("config"):
                 os.rename("config.mk", "config.mk.orig")
                 copy(str(self.config_mk), "config.mk")
-                # Add '/mfem' to MFEM_INC_DIR for miniapps that include directly
-                # headers like "general/forall.hpp":
-                filter_file("(MFEM_INC_DIR.*)$", "\\1/mfem", "config.mk")
+                # Replace the definition of MFEM_INC_DIR with '$(MFEM_DIR)' for
+                # miniapps that include directly headers like
+                # "general/forall.hpp" and to avoid mixing source-tree and
+                # install-tree headers that use '#prgma once'.
+                filter_file("(MFEM_INC_DIR.*)=.*$", "\\1= $(MFEM_DIR)", "config.mk")
                 shutil.copystat("config.mk.orig", "config.mk")
                 # TODO: miniapps linking to libmfem-common.* will not work.
 


### PR DESCRIPTION
Update the MFEM package to work with headers that use `#pragma once` when installing examples and/or miniapps with a shared build.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
