### PR TITLE
Add libxcrypt dependency for GNU screen

### DIFF
--- a/repos/spack_repo/builtin/packages/screen/package.py
+++ b/repos/spack_repo/builtin/packages/screen/package.py
@@ -45,3 +45,4 @@ class Screen(AutotoolsPackage, GNUMirrorPackage):
     depends_on("autoconf", type="build", when="@4.9.0:")
     depends_on("automake", type="build", when="@4.9.0:")
     depends_on("libtool", type="build", when="@4.9.0:")
+    depends_on("libxcrypt", type=("build", "link"), when="@3.9:")


### PR DESCRIPTION
`screen` is linked to `libcrypt` for versions 3.9 and higher. In `screen` 3.7, the `configure` script only checks for `libcrypt.a` in `/usr` and `/usr/build` and does not use `-lcrypt` if neither are found (thus I conclude that it's optional). It is not optional for newer versions and the build fails if `libcrypt` isn't found. If a compiler provided by the OS is used, the `libxcrypt-devel` (or equivalent) OS package might be installed, and `screen` ends up linked to that, rather than to a libcrypt provided by Spack. Thus for `screen` 3.9 and newer, we add a dependency on the `libxcrypt` package.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
