### PR TITLE
Add py-urllib3 dependency to httpie

### DIFF
--- a/repos/spack_repo/builtin/packages/httpie/package.py
+++ b/repos/spack_repo/builtin/packages/httpie/package.py
@@ -12,7 +12,7 @@ class Httpie(PythonPackage):
 
     homepage = "https://httpie.io/"
     pypi = "httpie/httpie-2.6.0.tar.gz"
-    maintainers("BoboTiG")
+    maintainers("ebagrenrut")
 
     license("BSD-3-Clause")
 

--- a/repos/spack_repo/builtin/packages/httpie/package.py
+++ b/repos/spack_repo/builtin/packages/httpie/package.py
@@ -16,6 +16,7 @@ class Httpie(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("3.2.4", sha256="302ad436c3dc14fd0d1b19d4572ef8d62b146bcd94b505f3c2521f701e2e7a2a")
     version("3.2.1", sha256="c9c0032ca3a8d62492b7231b2dd83d94becf3b71baf8a4bbcd9ed1038537e3ec")
     version("2.6.0", sha256="ef929317b239bbf0a5bb7159b4c5d2edbfc55f8a0bcf9cd24ce597daec2afca5")
     version("2.5.0", sha256="fe6a8bc50fb0635a84ebe1296a732e39357c3e1354541bf51a7057b4877e47f9")
@@ -33,3 +34,6 @@ class Httpie(PythonPackage):
     depends_on("py-importlib-metadata@1.4.0:", when="@3: ^python@:3.7", type=("build", "run"))
     depends_on("py-rich@9.10.0:", when="@3.2.1:", type=("build", "run"))
     depends_on("py-colorama@0.2.4:", when="platform=windows", type=("build", "run"))
+    depends_on("py-urllib3", type=("build", "run"))
+
+    conflicts("py-urllib3@2:", when="@:3.2.1")


### PR DESCRIPTION
Adds `httpie` 3.2.4.

As far as I can tell, the `urllib3` dependency was added to `httpie` in version 2.2.0. Thus, we add a dependency.

Per [this issue](https://github.com/httpie/cli/issues/1499), httpie < 3.2.1 requires urllib3 1.x, while 3.2.2+ are compatible with urllib3 2.x. Thus, we add a conflict with `py-urllib3@2:` when installing `httpie@:3.2.1`.

@BoboTiG 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
