### PR TITLE
trilinos: update cxxstd variant default

### DIFF
--- a/repos/spack_repo/builtin/packages/trilinos/package.py
+++ b/repos/spack_repo/builtin/packages/trilinos/package.py
@@ -95,7 +95,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     variant("cuda_rdc", default=False, description="Turn on RDC for CUDA build")
     variant("rocm_rdc", default=False, description="Turn on RDC for ROCm build")
     variant(
-        "cxxstd", default="14", description="C++ standard", values=["11", "14", "17"], multi=False
+        "cxxstd", default="17", description="C++ standard", values=["11", "14", "17"], multi=False
     )
     variant("debug", default=False, description="Enable runtime safety and debug checks")
     variant(


### PR DESCRIPTION
In this way the default version of trilinos gets the default value of the variant

Discovered using https://github.com/spack/spack/pull/51674
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
