### PR TITLE
glib: ensure no system glib is used

### DIFF
--- a/repos/spack_repo/builtin/packages/glib/package.py
+++ b/repos/spack_repo/builtin/packages/glib/package.py
@@ -118,7 +118,6 @@ class Glib(MesonPackage):
     depends_on("iconv")
     depends_on("elf")  # bin/gresource
 
-
     # glib prefers the libc version of gettext, which breaks the build if the
     # external version is also found.
     patch("meson-gettext.patch", when="@:2.64")

--- a/repos/spack_repo/builtin/packages/glib/package.py
+++ b/repos/spack_repo/builtin/packages/glib/package.py
@@ -97,6 +97,12 @@ class Glib(MesonPackage):
         depends_on("pkgconfig")
         depends_on("gobject-introspection@1.80:", when="+introspection")
 
+        # needs to mask any system glib~introspection that the meson build accidentally finds
+        depends_on("glib-bootstrap", when="+introspection")
+
+        # meson build looks for cmake and will use a system on if we don't include this
+        depends_on("cmake")
+
     depends_on("libffi")
     depends_on("zlib-api")
     depends_on("gettext")
@@ -111,6 +117,7 @@ class Glib(MesonPackage):
     depends_on("util-linux", when="+libmount")
     depends_on("iconv")
     depends_on("elf")  # bin/gresource
+
 
     # glib prefers the libc version of gettext, which breaks the build if the
     # external version is also found.


### PR DESCRIPTION
This fixes https://github.com/spack/spack-packages/issues/2706.

Although `gobject-introspection` correctly uses the `glib-bootstrap`, `glib`'s meson build seems to pick up system glib (which may be too old), and fails to build.

Checking what pkg-config thinks the glib version is
```
$ spack load gobject-introspection
$ spack load pkgconfig
$ pkg-config --cflags glib-2.0
-I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include -I/usr/include/sysprof-4 -pthread
```

This also adds a depdency on `cmake` as the meson build explicitly looks for it and will fall back to a system cmake if a spack cmake is not provided:
```
Found CMake: /usr/bin/cmake (3.26.5)
Run-time dependency gobject-introspection-1.0 found: NO (tried cmake)
```

/cc @michaelkuhn