### PR TITLE
hugo: Add cxx dependency for extended edition

### DIFF
--- a/repos/spack_repo/builtin/packages/hugo/package.py
+++ b/repos/spack_repo/builtin/packages/hugo/package.py
@@ -46,9 +46,7 @@ class Hugo(GoPackage):
     depends_on("go@1.20:", type="build", when="@0.123:")
     depends_on("go@1.18:", type="build", when="@0.106:")
     depends_on("go@1.11:", type="build", when="@0.48:")
-
-    with when("+extended"):
-        depends_on("cxx", type="build")
+    depends_on("cxx", type="build", when="+extended")
 
     variant("extended", default=False, description="Enable extended features")
 

--- a/repos/spack_repo/builtin/packages/hugo/package.py
+++ b/repos/spack_repo/builtin/packages/hugo/package.py
@@ -47,6 +47,9 @@ class Hugo(GoPackage):
     depends_on("go@1.18:", type="build", when="@0.106:")
     depends_on("go@1.11:", type="build", when="@0.48:")
 
+    with when("+extended"):
+        depends_on("cxx", type="build")
+
     variant("extended", default=False, description="Enable extended features")
 
     phases = ["build", "install"]

--- a/repos/spack_repo/builtin/packages/hugo/package.py
+++ b/repos/spack_repo/builtin/packages/hugo/package.py
@@ -46,6 +46,7 @@ class Hugo(GoPackage):
     depends_on("go@1.20:", type="build", when="@0.123:")
     depends_on("go@1.18:", type="build", when="@0.106:")
     depends_on("go@1.11:", type="build", when="@0.48:")
+    depends_on("c", type="build", when="+extended")
     depends_on("cxx", type="build", when="+extended")
 
     variant("extended", default=False, description="Enable extended features")


### PR DESCRIPTION
Per the `hugo` [README](https://github.com/gohugoio/hugo?tab=readme-ov-file#build-from-source), a compiler is needed when building the extended edition (using the `+extended` variant), but the package is missing this dependency. I've found that when building `hugo+extended`, a build dependency on `cxx` is sufficient to ensure that the binary is successfully linked to libstdc++ and libgcc_s from the `gcc-runtime` package, and the binary is successfully relocated when installed from buildcache.

@alecbcs 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
