### PR TITLE
kokkos: cxxstd cleanup

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -289,16 +289,27 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("+wrapper", when="~cuda")
     conflicts("+wrapper", when="+cmake_lang")
 
-    cxxstds = ["14", "17", "20", "23"]
     variant(
         "cxxstd",
         default="17",
-        values=(
-            conditional("14", when="@:3"),
-            conditional("17", when="@:4"),
-            "20",
-            conditional("23", when="@4:"),
-        ),
+        values=("14", "17", "20"),
+        when="@3",
+        multi=False,
+        description="C++ standard",
+    )
+    variant(
+        "cxxstd",
+        default="17",
+        values=("17", "20", "23"),
+        when="@4",
+        multi=False,
+        description="C++ standard",
+    )
+    variant(
+        "cxxstd",
+        default="20",
+        values=("20", "23"),
+        when="@5",
         multi=False,
         description="C++ standard",
     )
@@ -312,19 +323,13 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     variant("alloc_async", default=False, description="Use CudaMallocAsync", when="@4.2: +cuda")
 
     # SYCL and OpenMPTarget require C++17 or higher
-    for cxxstdver in cxxstds[: cxxstds.index("17")]:
-        conflicts(
-            "+sycl", when="cxxstd={0}".format(cxxstdver), msg="SYCL requires C++17 or higher"
-        )
-        conflicts(
-            "+openmptarget",
-            when="cxxstd={0}".format(cxxstdver),
-            msg="OpenMPTarget requires C++17 or higher",
-        )
+    conflicts("+sycl", when="cxxstd=14", msg="SYCL requires C++17 or higher")
+    conflicts("+openmptarget", when="cxxstd=14", msg="OpenMPTarget requires C++17 or higher")
 
     # HPX should use the same C++ standard
-    for cxxstd in cxxstds[: cxxstds.index("23")]:
-        depends_on("hpx cxxstd={0}".format(cxxstd), when="+hpx cxxstd={0}".format(cxxstd))
+    for cxxstd in ["14", "17", "20"]:
+        depends_on(f"hpx cxxstd={cxxstd}", when=f"+hpx cxxstd={cxxstd}")
+    conflicts("+hpx", when="cxxstd=23", msg="hpx package does not yet support cxxstd=23")
 
     # HPX version constraints
     depends_on("hpx@1.7:", when="+hpx")

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -307,9 +307,8 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("+openmptarget", when="cxxstd=14", msg="OpenMPTarget requires C++17 or higher")
 
     # HPX should use the same C++ standard
-    for cxxstd in ["14", "17", "20"]:
+    for cxxstd in ["14", "17", "20", "23"]:
         depends_on(f"hpx cxxstd={cxxstd}", when=f"+hpx cxxstd={cxxstd}")
-    conflicts("+hpx", when="cxxstd=23", msg="hpx package does not yet support cxxstd=23")
 
     # HPX version constraints
     depends_on("hpx@1.7:", when="+hpx")

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -290,12 +290,19 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("+wrapper", when="+cmake_lang")
 
     cxxstds = ["14", "17", "20", "23"]
-    variant("cxxstd", default="17", values=cxxstds, multi=False, description="C++ standard")
+    variant(
+        "cxxstd",
+        default="17",
+        values=(
+            conditional("14", when="@:3"),
+            conditional("17", when="@:4"),
+            "20",
+            conditional("23", when="@4:"),
+        ),
+        multi=False,
+        description="C++ standard",
+    )
     variant("pic", default=False, description="Build position independent code")
-
-    conflicts("cxxstd=14", when="@4:")
-    conflicts("cxxstd=17", when="@5:")
-    conflicts("cxxstd=23", when="@:3")
 
     conflicts("+cuda", when="cxxstd=17 ^cuda@:10")
     conflicts("+cuda", when="cxxstd=20 ^cuda@:11")

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -316,7 +316,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         )
 
     # HPX should use the same C++ standard
-    for cxxstd in cxxstds:
+    for cxxstd in cxxstds[: cxxstds.index("23")]:
         depends_on("hpx cxxstd={0}".format(cxxstd), when="+hpx cxxstd={0}".format(cxxstd))
 
     # HPX version constraints

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -289,30 +289,10 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("+wrapper", when="~cuda")
     conflicts("+wrapper", when="+cmake_lang")
 
-    variant(
-        "cxxstd",
-        default="17",
-        values=("14", "17", "20"),
-        when="@3",
-        multi=False,
-        description="C++ standard",
-    )
-    variant(
-        "cxxstd",
-        default="17",
-        values=("17", "20", "23"),
-        when="@4",
-        multi=False,
-        description="C++ standard",
-    )
-    variant(
-        "cxxstd",
-        default="20",
-        values=("20", "23"),
-        when="@5",
-        multi=False,
-        description="C++ standard",
-    )
+    with default_args(multi=False, description="C++ standard"):
+        variant("cxxstd", default="17", values=("14", "17", "20"), when="@3")
+        variant("cxxstd", default="17", values=("17", "20", "23"), when="@4")
+        variant("cxxstd", default="20", values=("20", "23"), when="@5")
     variant("pic", default=False, description="Build position independent code")
 
     conflicts("+cuda", when="cxxstd=17 ^cuda@:10")

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -289,13 +289,13 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("+wrapper", when="~cuda")
     conflicts("+wrapper", when="+cmake_lang")
 
-    cxxstds = ["11", "14", "17", "20"]
+    cxxstds = ["14", "17", "20", "23"]
     variant("cxxstd", default="17", values=cxxstds, multi=False, description="C++ standard")
     variant("pic", default=False, description="Build position independent code")
 
-    conflicts("cxxstd=11")
-    conflicts("cxxstd=14", when="@4.0:")
+    conflicts("cxxstd=14", when="@4:")
     conflicts("cxxstd=17", when="@5:")
+    conflicts("cxxstd=23", when="@:3")
 
     conflicts("+cuda", when="cxxstd=17 ^cuda@:10")
     conflicts("+cuda", when="cxxstd=20 ^cuda@:11")


### PR DESCRIPTION
- remove the always in conflict variant cxxstd=11
- add variant cxxstd=23 starting from [Kokkos 4](https://github.com/kokkos/kokkos/blob/develop/CHANGELOG.md#build-system-changes-9)