### PR TITLE
Add procps dependency to lmod

### DIFF
--- a/repos/spack_repo/builtin/packages/lmod/package.py
+++ b/repos/spack_repo/builtin/packages/lmod/package.py
@@ -69,6 +69,8 @@ class Lmod(AutotoolsPackage):
 
     depends_on("pkgconfig", type="build")
 
+    depends_on("procps", type="build")
+
     # GNU sed is required instead of bsd sed on macOS
     depends_on("sed", type="build", when="platform=darwin")
 


### PR DESCRIPTION
Way back in Lmod 6.0.12, with [this commit](https://github.com/TACC/Lmod/commit/0ddb7bd2fdc462915205bf4855b18b9229a57548), Lmod added a dependency on the `ps` command. I encountered a failure to build Lmod when building in a container that did not have `ps` available. Thus, we add a dependency on `procps`.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
