### PR TITLE
udunits: set UDUNITS2_XML_PATH in environment

### DIFF
--- a/repos/spack_repo/builtin/packages/udunits/package.py
+++ b/repos/spack_repo/builtin/packages/udunits/package.py
@@ -34,3 +34,7 @@ class Udunits(AutotoolsPackage):
 
     def configure_args(self):
         return self.enable_or_disable("shared")
+
+    def setup_run_environment(self, env: EnvironmentModifications) -> None:
+        # We need to set UDUNITS2_XML_PATH so that udunits can find its default units file.
+        env.set("UDUNITS2_XML_PATH", join_path(self.prefix.share.udunits, "udunits2.xml"))


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

In trying to run some unit tests that use udunits2 in MAPL with spack, I found that `spack load udunits` doesn't set `UDUNITS2_XML_PATH` (see https://github.com/JCSDA/spack-stack/issues/1842).

Spack installs it at `prefix/share/udunits/udunits2.xml` and this PR seems to set it for me.