### PR TITLE
adds v2025.09.30 to arkouda and py_arkouda

### DIFF
--- a/repos/spack_repo/builtin/packages/arkouda/package.py
+++ b/repos/spack_repo/builtin/packages/arkouda/package.py
@@ -28,6 +28,9 @@ class Arkouda(MakefilePackage):
     version("main", branch="main")
 
     version(
+        "2025.09.30", sha256="10f488a3ff3482b66f1b1e8a4235d72e91ad07acb932eca85d1e695f0f6155a2"
+    )
+    version(
         "2025.08.20", sha256="3e305930905397ff3a7a28a5d8cc2c9adca4194ca7f6ee51f749f427a2dea92c"
     )
     version(
@@ -56,16 +59,32 @@ class Arkouda(MakefilePackage):
         type=("build", "link", "run", "test"),
     )
     depends_on(
+        "chapel@2.0:2.5 +hdf5 +zmq", when="@2025.09.30:", type=("build", "link", "run", "test")
+    )
+    depends_on(
         "chapel@2.1: +hdf5 +zmq", when="@:2025.01.13", type=("build", "link", "run", "test")
     )
 
     depends_on("cmake@3.13.4:", type="build")
-    depends_on("python@3.9:", type=("build", "link", "run", "test"))
+    depends_on("python@3.9:3.12.3", type=("build", "link", "run", "test"), when="@:2025.01.13")
+    depends_on(
+        "python@3.9:3.13", type=("build", "link", "run", "test"), when="@2025.07.03:2025.08.20"
+    )
+    depends_on("python@3.10:3.13", type=("build", "link", "run", "test"), when="@2025.09.30:")
     depends_on("libzmq@4.2.5:", type=("build", "link", "run", "test"))
     depends_on("hdf5+hl~mpi", type=("build", "link", "run", "test"))
     depends_on("libiconv", type=("build", "link", "run", "test"))
     depends_on("libidn2", type=("build", "link", "run", "test"))
-    depends_on("arrow@:19+brotli+bz2+lz4+parquet+snappy+zlib+zstd", type=("build", "link", "run"))
+    depends_on(
+        "arrow@:19+brotli+bz2+lz4+parquet+snappy+zlib+zstd",
+        type=("build", "link", "run"),
+        when="@:2025.01.13",
+    )
+    depends_on(
+        "arrow@15:19+brotli+bz2+lz4+parquet+snappy+zlib+zstd",
+        type=("build", "link", "run"),
+        when="@2025.07.03:",
+    )
 
     # force lz4 to use cmake (add as a direct dep to control its variant)
     depends_on("lz4 build_system=cmake", type="build")

--- a/repos/spack_repo/builtin/packages/py_arkouda/package.py
+++ b/repos/spack_repo/builtin/packages/py_arkouda/package.py
@@ -28,6 +28,9 @@ class PyArkouda(PythonPackage):
     version("main", branch="main")
 
     version(
+        "2025.09.30", sha256="10f488a3ff3482b66f1b1e8a4235d72e91ad07acb932eca85d1e695f0f6155a2"
+    )
+    version(
         "2025.08.20", sha256="3e305930905397ff3a7a28a5d8cc2c9adca4194ca7f6ee51f749f427a2dea92c"
     )
     version(
@@ -47,15 +50,16 @@ class PyArkouda(PythonPackage):
     variant("dev", default=False, description="Include arkouda developer extras")
 
     depends_on("python@3.9:3.12.3", type=("build", "run"), when="@:2025.01.13")
-    depends_on("python@3.9:3.13", type=("build", "run"), when="@2025.07.03:")
+    depends_on("python@3.9:3.13", type=("build", "run"), when="@2025.07.03:2025.08.20")
+    depends_on("python@3.10:3.13", type=("build", "run"), when="@2025.09.30:")
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy@1.25:1", when="@:2025.01.13", type=("build", "run"))
     depends_on("py-numpy@2", when="@2025.07.03:", type=("build", "run"))
     depends_on("py-pandas@2.2.3:", when="@2025.07.03:")
     depends_on("py-pandas@1.4.0:", type=("build", "run"))
     conflicts("^py-pandas@2.2.0", msg="arkouda client not compatible with pandas 2.2.0")
-    depends_on("py-pyarrow@:19", type=("build", "run"))
-    depends_on("py-pyarrow@15:19", when="@2025.07.03:")
+    depends_on("py-pyarrow@:19", type=("build", "run"), when="@:2025.01.13")
+    depends_on("py-pyarrow@15:19", type=("build", "run"), when="@2025.07.03:")
     depends_on("py-pyzmq@20:", type=("build", "run"))
     depends_on("py-scipy@:1.13.1", type=("build", "run"), when="@:2025.01.13")
     depends_on("py-scipy@1.14:", when="@2025.07.03:")


### PR DESCRIPTION
## PR Description

This PR adds the **v2025.09.30** release of both `arkouda` and `py-arkouda` to the Spack builtin repository and updates dependency constraints to align with the versions tested in CI and supported by the upstream project.

## Key changes

### 1. Add new versions
- Introduces `arkouda@2025.09.30`
- Introduces `py-arkouda@2025.09.30`

Both entries include verified `sha256` checksums.

## Dependency updates (Python, Chapel, Arrow)

This PR formalizes compatibility windows that were previously implicit, ensuring that Spack concretizes environments consistent with upstream-supported versions.

### Python support aligned with CI

- **≤ 2025.01.13:** `python@3.9:3.12.3`
- **2025.07.03–2025.08.20:** `python@3.9:3.13`
- **2025.09.30+:** `python@3.10:3.13`

### Updated Chapel ranges

- `2025.07.03–2025.08.20`: `chapel@2.0:2.4 +hdf5 +zmq`
- `2025.09.30+`: `chapel@2.0:2.5 +hdf5 +zmq`

### Arrow version alignment

For newer releases (`2025.07.03+`):

```
arrow@15:19 +brotli +bz2 +lz4 +parquet +snappy +zlib +zstd
```
