### PR TITLE
Fix preseq package and add 3.2.0

### DIFF
--- a/repos/spack_repo/builtin/packages/preseq/package.py
+++ b/repos/spack_repo/builtin/packages/preseq/package.py
@@ -72,5 +72,6 @@ class Preseq(MakefilePackage, AutotoolsPackage):
     def configure(self, spec, prefix):
         return
 
-    with when("+hts"):
-        configure_args=["--enable-hts"]
+    @when("+hts")
+    def configure_args(self):
+        return ["--enable-hts"]

--- a/repos/spack_repo/builtin/packages/preseq/package.py
+++ b/repos/spack_repo/builtin/packages/preseq/package.py
@@ -45,9 +45,9 @@ class Preseq(MakefilePackage, AutotoolsPackage):
     # As of 3.0.2, preseq does not use gsl
     depends_on("gsl", when="@:3.0.1")
 
-    with when("+hts"):
-        depends_on("htslib")
-        conflicts("gcc@13:")
+    depends_on("htslib", when="+hts")
+
+    conflicts("gcc@13:", when="+hts")
 
     def url_for_version(self, version):
         """

--- a/repos/spack_repo/builtin/packages/preseq/package.py
+++ b/repos/spack_repo/builtin/packages/preseq/package.py
@@ -43,9 +43,6 @@ class Preseq(MakefilePackage, AutotoolsPackage):
     # As of 3.0, preseq does not link libefence
     depends_on("libefence", when="@:2")
 
-    # As of 3.0, preseq does not require samtools
-    depends_on("samtools", when="@:2")
-
     # As of 3.0.2, preseq does not use gsl
     depends_on("gsl", when="@:3.0.1")
 

--- a/repos/spack_repo/builtin/packages/preseq/package.py
+++ b/repos/spack_repo/builtin/packages/preseq/package.py
@@ -16,7 +16,6 @@ class Preseq(MakefilePackage, AutotoolsPackage):
     initial sequencing experiment."""
 
     homepage = "https://github.com/smithlabcode/preseq"
-    url = "https://github.com/smithlabcode/preseq/releases/download/v2.0.2/preseq_v2.0.2.tar.bz2"
 
     license("GPL-3.0-only")
 
@@ -49,11 +48,21 @@ class Preseq(MakefilePackage, AutotoolsPackage):
     with when("+hts"):
         depends_on("htslib")
 
+    def url_for_version(self, version):
+        """
+        preseq 2 tarball has an _ and is bzipped while preseq 3 tarball has a - and is
+        gzipped
+        """
+        uri = f"https://github.com/smithlabcode/preseq/releases/download/v{version}"
+        if version < Version("3.0"):
+            return f"{uri}/preseq_v{version}.tar.bz2"
+        else:
+            return f"{uri}/preseq-{version}.tar.gz"
+
     @when("@:2")
     def setup_build_environment(self, env):
         env.set("PREFIX", self.prefix)
 
-    @when("@3:")
     @when("+hts")
     def setup_build_environment(self, env):
         env.set("CPPFLAGS", f"-I{self.spec["htslib"].prefix.include}")

--- a/repos/spack_repo/builtin/packages/preseq/package.py
+++ b/repos/spack_repo/builtin/packages/preseq/package.py
@@ -54,10 +54,10 @@ class Preseq(MakefilePackage, AutotoolsPackage):
         env.set("PREFIX", self.prefix)
 
     @when("@3:")
+    @when("+hts")
     def setup_build_environment(self, env):
-        with when("+hts"):
-            env.set("CPPFLAGS", f"-I{self.spec["htslib"].prefix.include}")
-            env.set("LDFLAGS", f"-L{self.spec["htslib"].prefix.lib}")
+        env.set("CPPFLAGS", f"-I{self.spec["htslib"].prefix.include}")
+        env.set("LDFLAGS", f"-L{self.spec["htslib"].prefix.lib}")
 
     @when("@:2")
     def configure(self, spec, prefix):

--- a/repos/spack_repo/builtin/packages/preseq/package.py
+++ b/repos/spack_repo/builtin/packages/preseq/package.py
@@ -47,6 +47,7 @@ class Preseq(MakefilePackage, AutotoolsPackage):
 
     with when("+hts"):
         depends_on("htslib")
+        conflicts("gcc@13:")
 
     def url_for_version(self, version):
         """

--- a/repos/spack_repo/builtin/packages/preseq/package.py
+++ b/repos/spack_repo/builtin/packages/preseq/package.py
@@ -66,8 +66,8 @@ class Preseq(MakefilePackage, AutotoolsPackage):
 
     @when("+hts")
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        env.set("CPPFLAGS", f"-I{self.spec["htslib"].prefix.include}")
-        env.set("LDFLAGS", f"-L{self.spec["htslib"].prefix.lib}")
+        env.set("CPPFLAGS", f"-I{self.spec['htslib'].prefix.include}")
+        env.set("LDFLAGS", f"-L{self.spec['htslib'].prefix.lib}")
 
     @when("@:2")
     def configure(self, spec, prefix):

--- a/repos/spack_repo/builtin/packages/preseq/package.py
+++ b/repos/spack_repo/builtin/packages/preseq/package.py
@@ -30,8 +30,14 @@ class Preseq(MakefilePackage, AutotoolsPackage):
         default="autotools",
     )
 
-    variant("hts", default=False, description="Enable HTSlib to support BAM files", when="@3:")
+    variant(
+        "hts",
+        default=False,
+        description="Use HTSlib to support BAM to mapped read conversions",
+        when="@3:",
+    )
 
+    depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
     # As of 3.0, preseq does not link libefence

--- a/repos/spack_repo/builtin/packages/preseq/package.py
+++ b/repos/spack_repo/builtin/packages/preseq/package.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
 
 from spack.package import *
 
 
-class Preseq(MakefilePackage):
+class Preseq(MakefilePackage, AutotoolsPackage):
     """The preseq package is aimed at predicting and estimating the complexity
     of a genomic sequencing library, equivalent to predicting and
     estimating the number of redundant reads from a given sequencing depth
@@ -19,14 +20,40 @@ class Preseq(MakefilePackage):
 
     license("GPL-3.0-only")
 
+    version("3.2.0", sha256="95b81c9054e0d651de398585c7e96b807ad98f0bdc541b3e46665febbe2134d9")
     version("2.0.3", sha256="747ddd4227515a96a45fcff0709f26130386bff3458c829c7bc1f3306b4f3d91")
     version("2.0.2", sha256="1d7ea249bf4e5826e09697256643e6a2473bc302cd455f31d4eb34c23c10b97c")
+
+    variant("hts", default=False, description="Enable HTSlib to support BAM files", when="@3:")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    depends_on("samtools")
-    depends_on("gsl")
+    # As of 3.0, preseq does not link libefence
+    depends_on("libefence", when="@:2")
 
-    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+    # As of 3.0, preseq does not require samtools
+    depends_on("samtools", when="@:2")
+
+    # As of 3.0.2, preseq does not use gsl
+    depends_on("gsl", when="@:3.0.1")
+
+    with when("+hts"):
+        depends_on("htslib")
+
+    @when("@:2")
+    def setup_build_environment(self, env):
         env.set("PREFIX", self.prefix)
+
+    @when("@3:")
+    def setup_build_environment(self, env):
+        with when("+hts"):
+            env.set("CPPFLAGS", f"-I{self.spec["htslib"].prefix.include}")
+            env.set("LDFLAGS", f"-L{self.spec["htslib"].prefix.lib}")
+
+    @when("@:2")
+    def configure(self, spec, prefix):
+        return
+
+    with when("+hts"):
+        configure_args=["--enable-hts"]

--- a/repos/spack_repo/builtin/packages/preseq/package.py
+++ b/repos/spack_repo/builtin/packages/preseq/package.py
@@ -60,11 +60,11 @@ class Preseq(MakefilePackage, AutotoolsPackage):
             return f"{uri}/preseq-{version}.tar.gz"
 
     @when("@:2")
-    def setup_build_environment(self, env):
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
         env.set("PREFIX", self.prefix)
 
     @when("+hts")
-    def setup_build_environment(self, env):
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
         env.set("CPPFLAGS", f"-I{self.spec["htslib"].prefix.include}")
         env.set("LDFLAGS", f"-L{self.spec["htslib"].prefix.lib}")
 

--- a/repos/spack_repo/builtin/packages/preseq/package.py
+++ b/repos/spack_repo/builtin/packages/preseq/package.py
@@ -24,9 +24,14 @@ class Preseq(MakefilePackage, AutotoolsPackage):
     version("2.0.3", sha256="747ddd4227515a96a45fcff0709f26130386bff3458c829c7bc1f3306b4f3d91")
     version("2.0.2", sha256="1d7ea249bf4e5826e09697256643e6a2473bc302cd455f31d4eb34c23c10b97c")
 
+    build_system(
+        conditional("makefile", when="@:2"),
+        conditional("autotools", when="@3:"),
+        default="autotools",
+    )
+
     variant("hts", default=False, description="Enable HTSlib to support BAM files", when="@3:")
 
-    depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
     # As of 3.0, preseq does not link libefence


### PR DESCRIPTION
Though I didn't initially intend it to be so, this is effectively an overhaul of the `preseq` package.

- Add `preseq` 3.2.0
- Add a missing `libefence` dependency for `preseq` 2.x and earlier. The `libefence` requirement was dropped in `preseq` 3.0.
- Remove the `samtools` dependency. `preseq` 3 does not use `samtools` while building. It turns out that `preseq` 2 does not have an external `samtools` dependency at all, and the Spack-built `samtools` is not sufficient in any case (as it merely builds and isntalls the samtools binaries and not the samtools source code). `preseq` 2 requires the raw `samtools` source, and it includes it in its release tarball.
- Constrain `gsl` dependency to `preseq` 3.0.2 and earlier. Per the `preseq` changelog, 3.0.2 does not use `gsl` at all.
- The `Preseq` class now also extends the `AutotoolsPackage` class. While `preseq` 2.x and earlier simply use a Makefile, `preseq` 3.0 adopted autotools. When building `preseq` 2.x, select functions of `AutotoolsPackage`/`AutotoolsBuilder` are overridden to ensure that they do not cause the build to fail for autotools-related reason (e.g. a missing `configure` script).
- Add the `hts` variant. `preseq` 3.0 and newer can optionally use `htslib` while converting BAM inputs to mapped read format. Despite using autotools, one cannot pass the location of `htslib`'s includes and libs via options to `configure` and must add `CPPFLAGS` and `LDFLAGS`, respectively.
- When `+hts`, add a conflict with `gcc@13:`. The `preseq` code that interfaces with HTSlib does not compile beginning with gcc 13.


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
