### PR TITLE
libfabric: add variants for gdrcopy-dlopen and cuda-dlopen

### DIFF
--- a/repos/spack_repo/builtin/packages/libfabric/package.py
+++ b/repos/spack_repo/builtin/packages/libfabric/package.py
@@ -113,6 +113,8 @@ class Libfabric(AutotoolsPackage, CudaPackage, ROCmPackage):
     variant("uring", default=False, when="@1.17.0:", description="Enable uring support")
     variant("level_zero", default=False, description="Enable Level Zero support")
     variant("gdrcopy", default=False, when="@1.12: +cuda", description="Enable gdrcopy support")
+    variant("cuda_dlopen", default=False, description="Enable dlopen of CUDA libraries")
+    variant("gdrcopy_dlopen", default=False, description="Enable dlopen of gdr libraries")
 
     variant("asan", default=False, when="@1.12:", description="Enable AddressSanitizer (ASan)")
     variant("lsan", default=False, when="@1.20:", description="Enable LeakSanitizer (LSan)")
@@ -231,6 +233,8 @@ class Libfabric(AutotoolsPackage, CudaPackage, ROCmPackage):
     def configure_args(self):
         args = [
             *self.enable_or_disable("debug"),
+            *self.enable_or_disable("cuda_dlopen"),
+            *self.enable_or_disable("gdrcopy_dlopen"),
             *self.enable_or_disable("asan"),
             *self.enable_or_disable("lsan"),
             *self.enable_or_disable("tsan"),

--- a/repos/spack_repo/builtin/packages/libfabric/package.py
+++ b/repos/spack_repo/builtin/packages/libfabric/package.py
@@ -113,8 +113,15 @@ class Libfabric(AutotoolsPackage, CudaPackage, ROCmPackage):
     variant("uring", default=False, when="@1.17.0:", description="Enable uring support")
     variant("level_zero", default=False, description="Enable Level Zero support")
     variant("gdrcopy", default=False, when="@1.12: +cuda", description="Enable gdrcopy support")
-    variant("cuda_dlopen", default=False, when="+cuda", description="Enable dlopen of CUDA libraries")
-    variant("gdrcopy_dlopen", default=False, when="+gdrcopy", description="Enable dlopen of gdr libraries")
+    variant(
+        "cuda_dlopen", default=False, when="+cuda", description="Enable dlopen of CUDA libraries"
+    )
+    variant(
+        "gdrcopy_dlopen",
+        default=False,
+        when="+gdrcopy",
+        description="Enable dlopen of gdr libraries",
+    )
 
     variant("asan", default=False, when="@1.12:", description="Enable AddressSanitizer (ASan)")
     variant("lsan", default=False, when="@1.20:", description="Enable LeakSanitizer (LSan)")

--- a/repos/spack_repo/builtin/packages/libfabric/package.py
+++ b/repos/spack_repo/builtin/packages/libfabric/package.py
@@ -113,8 +113,8 @@ class Libfabric(AutotoolsPackage, CudaPackage, ROCmPackage):
     variant("uring", default=False, when="@1.17.0:", description="Enable uring support")
     variant("level_zero", default=False, description="Enable Level Zero support")
     variant("gdrcopy", default=False, when="@1.12: +cuda", description="Enable gdrcopy support")
-    variant("cuda_dlopen", default=False, description="Enable dlopen of CUDA libraries")
-    variant("gdrcopy_dlopen", default=False, description="Enable dlopen of gdr libraries")
+    variant("cuda_dlopen", default=False, when="+cuda", description="Enable dlopen of CUDA libraries")
+    variant("gdrcopy_dlopen", default=False, when="+gdrcopy", description="Enable dlopen of gdr libraries")
 
     variant("asan", default=False, when="@1.12:", description="Enable AddressSanitizer (ASan)")
     variant("lsan", default=False, when="@1.20:", description="Enable LeakSanitizer (LSan)")


### PR DESCRIPTION
These variants expose additional libfabric configuration options.

They allow e.g. `libcudart.so` to be `dlopen`'d at runtime.