### PR TITLE
cubelib: set --with-nocross-compiler-suite in configure step

### DIFF
--- a/repos/spack_repo/builtin/packages/cubelib/package.py
+++ b/repos/spack_repo/builtin/packages/cubelib/package.py
@@ -33,7 +33,21 @@ class Cubelib(AutotoolsPackage):
 
         return url.format(version.up_to(2), version)
 
+    def clean_compiler(self, compiler):
+        renames = {
+            "cce": "cray",
+            "rocmcc": "amdclang",
+            "intel-oneapi-compilers": "oneapi",
+            "llvm": "clang",
+        }
+        if compiler in renames:
+            return renames[compiler]
+        return compiler
+
+
     def configure_args(self):
+        cname = self.clean_compiler(self.spec.compiler.name)
+        configure_args.append("--with-nocross-compiler-suite={0}".format(cname))
         configure_args = ["--enable-shared"]
         configure_args.append("--with-frontend-zlib=%s" % self.spec["zlib-api"].prefix.lib)
         return configure_args

--- a/repos/spack_repo/builtin/packages/cubelib/package.py
+++ b/repos/spack_repo/builtin/packages/cubelib/package.py
@@ -46,10 +46,10 @@ class Cubelib(AutotoolsPackage):
 
 
     def configure_args(self):
-        cname = self.clean_compiler(self.spec.compiler.name)
-        configure_args.append("--with-nocross-compiler-suite={0}".format(cname))
         configure_args = ["--enable-shared"]
         configure_args.append("--with-frontend-zlib=%s" % self.spec["zlib-api"].prefix.lib)
+        cname = self.clean_compiler(self.spec.compiler.name)
+        configure_args.append("--with-nocross-compiler-suite={0}".format(cname))
         return configure_args
 
     def install(self, spec, prefix):

--- a/repos/spack_repo/builtin/packages/cubelib/package.py
+++ b/repos/spack_repo/builtin/packages/cubelib/package.py
@@ -44,7 +44,6 @@ class Cubelib(AutotoolsPackage):
             return renames[compiler]
         return compiler
 
-
     def configure_args(self):
         configure_args = ["--enable-shared"]
         configure_args.append("--with-frontend-zlib=%s" % self.spec["zlib-api"].prefix.lib)


### PR DESCRIPTION
Cubelib currently does not respect the selected compiler and will fall back to GCC, even if LLVM is specified.
This is because `--with-nocross-compiler-suite` is not set in the `configure` command.
This patch fixes this, adopting the implementation already present in the `scorep` package.
I've simply copied `clean_compiler` from there, not sure if there is a cleaner option that avoids code duplication.
@wrwilliams 