### PR TITLE
Compiler wrapper: Fix for calling compiler wrapper with non-empty 'mode' variable

### DIFF
--- a/repos/spack_repo/builtin/packages/compiler_wrapper/cc.sh
+++ b/repos/spack_repo/builtin/packages/compiler_wrapper/cc.sh
@@ -296,6 +296,9 @@ fi
 # including version checks (SPACK_XFLAGS variants are not applied
 # for version checks).
 mode=""
+vdep=""
+lang_flags=""
+debug_flags=""
 command="${0##*/}"
 comp="CC"
 vcheck_flags=""

--- a/repos/spack_repo/builtin/packages/compiler_wrapper/cc.sh
+++ b/repos/spack_repo/builtin/packages/compiler_wrapper/cc.sh
@@ -295,6 +295,7 @@ fi
 # Note. SPACK_ALWAYS_XFLAGS are applied for all compiler invocations,
 # including version checks (SPACK_XFLAGS variants are not applied
 # for version checks).
+mode=""
 command="${0##*/}"
 comp="CC"
 vcheck_flags=""

--- a/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
+++ b/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
@@ -40,7 +40,7 @@ class CompilerWrapper(Package):
     if sys.platform != "win32":
         version(
             "1.0",
-            sha256="a5ff4fcdbeda284a7993b87f294b6338434cffc84ced31e4d04008ed5ea389bf",
+            sha256="c7b816479554fd32f677db15ceec6627b91c86074a5d65498688afcbe2796188",
             expand=False,
         )
     else:

--- a/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
+++ b/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
@@ -34,7 +34,7 @@ class CompilerWrapper(Package):
     tags = ["runtime"]
 
     maintainers("haampie")
-    
+
     license("Apache-2.0 OR MIT")
 
     if sys.platform != "win32":

--- a/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
+++ b/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
@@ -33,6 +33,8 @@ class CompilerWrapper(Package):
     # this node from auto-generated rules
     tags = ["runtime"]
 
+    maintainers("haampie")
+    
     license("Apache-2.0 OR MIT")
 
     if sys.platform != "win32":


### PR DESCRIPTION
Where the compiler wrapper determines the `mode`, the `mode` variable was not emptied beforehand. This caused an issue: I was creating a Makefile package, where the Makefile takes an argument that was unfortunately also called `mode`, i.e., in `package.py`:
```
@property
def build_targets(self):
    return ["mode=my_arg"]
```
(this is exactly as explained in the docs: [https://spack.readthedocs.io/en/latest/build_systems/makefilepackage.html#command-line-arguments](https://spack.readthedocs.io/en/latest/build_systems/makefilepackage.html#command-line-arguments))

It turns out that the variable `mode` is then propagated to the compiler wrapper, such that the compiler wrapper script did not determine the correct mode (it was kept at the value that was passed to the Makefile). This finally prevented applying the correct `SPACK_TARGET_ARGS_FORTRAN`, which is how I noticed this in the first place. You can check this propagation easily: Create a tiny Makefile:
```make
all:
	./script.sh
```
and script.sh with `echo "var = ${var}"`; then just call `make var=some_value`. It will print `var = some_value`.

In this PR, `mode` is just set to an empty string before it is actually determined.