### PR TITLE
py-sphinx-book-theme, ...: New versions 1.1.0 - 1.1.4

### DIFF
--- a/repos/spack_repo/builtin/packages/hpctoolkit/package.py
+++ b/repos/spack_repo/builtin/packages/hpctoolkit/package.py
@@ -192,9 +192,9 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
     depends_on("zlib+shared", when="^[virtuals=zlib-api] zlib")
 
     depends_on("py-docutils", type="build", when="@2025:")
-    depends_on("py-sphinx@6:8", type="build", when="+docs")
+    depends_on("py-sphinx@6:9", type="build", when="+docs")
     depends_on("py-myst-parser@3:4", type="build", when="+docs")
-    depends_on("py-sphinx-book-theme@1", type="build", when="+docs")
+    depends_on("py-sphinx-book-theme@1.1:1", type="build", when="+docs")
 
     depends_on("cuda", when="+cuda")
     depends_on("oneapi-level-zero", when="+level_zero")
@@ -229,8 +229,9 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
         # similar tricks to avoid rpath conflicts.
         depends_on("hip@4.5:", when="+rocm")
         depends_on("hsa-rocr-dev@4.5:", when="+rocm")
-        depends_on("roctracer-dev@4.5:", when="+rocm")
-        depends_on("rocprofiler-dev@4.5:", when="+rocm")
+        depends_on("roctracer-dev@4.5:", when="@:2025.0 +rocm")
+        depends_on("rocprofiler-dev@4.5:", when="@:2025.0 +rocm")
+        depends_on("rocprofiler-sdk@6.2:", when="@2025.1: +rocm")
 
     conflicts("%gcc@:7", when="@2022.10:", msg="hpctoolkit requires gnu gcc 8.x or later")
     conflicts("%gcc@:6", when="@2021.00:2022.06", msg="hpctoolkit requires gnu gcc 7.x or later")

--- a/repos/spack_repo/builtin/packages/py_pydata_sphinx_theme/package.py
+++ b/repos/spack_repo/builtin/packages/py_pydata_sphinx_theme/package.py
@@ -15,16 +15,27 @@ class PyPydataSphinxTheme(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.16.1", sha256="a08b7f0b7f70387219dc659bff0893a7554d5eb39b59d3b8ef37b8401b7642d7")
+    version("0.16.0", sha256="721dd26e05fa8b992d66ef545536e6cbe0110afb9865820a08894af1ad6f7707")
+    version("0.15.4", sha256="7762ec0ac59df3acecf49fd2f889e1b4565dbce8b88b2e29ee06fdd90645a06d")
+    version("0.15.3", sha256="f26ed9b676f61d1b2ae9289f3d7e496e8678dd56f2568b27a66fa4ad1f164efd")
+    version("0.15.2", sha256="4243fee85b3afcfae9df64f83210a04e7182e53bc3db8841ffff6d21d95ae320")
+    version("0.15.1", sha256="4606f7d59765ae06ff7cb5e07dead4286ea2ff2164deeee63922481eddf1083c")
+    version("0.14.4", sha256="f5d7a2cb7a98e35b9b49d3b02cec373ad28958c2ed5c9b1ffe6aff6c56e9de5b")
+    version("0.14.3", sha256="bd474f347895f3fc5b6ce87390af64330ee54f11ebf9660d5bc3f87d532d4e5c")
+    version("0.14.2", sha256="53860c95686f2b4fd8823ff977116a0dd654cceb01ff63c415cfeb5f19736753")
     version("0.14.1", sha256="d8d4ac81252c16a002e835d21f0fea6d04cf3608e95045c816e8cc823e79b053")
 
     depends_on("python@3.8:", type=("build", "run"))
+    depends_on("python@3.9:", type=("build", "run"), when="@0.15.0:")
 
     depends_on("py-sphinx-theme-builder", type="build")
 
     depends_on("py-sphinx@5:", type=("build", "run"))
+    depends_on("py-sphinx@6.1:", type=("build", "run"), when="@0.16.0:")
     depends_on("py-beautifulsoup4", type=("build", "run"))
     depends_on("py-docutils@:0.16,0.17.1:", type=("build", "run"))
-    depends_on("py-packaging", type=("build", "run"))
+    depends_on("py-packaging", type=("build", "run"), when="@:0.15")
     depends_on("py-babel", type=("build", "run"))
     depends_on("py-pygments@2.7:", type=("build", "run"))
     depends_on("py-accessible-pygments", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_sphinx_book_theme/package.py
+++ b/repos/spack_repo/builtin/packages/py_sphinx_book_theme/package.py
@@ -15,11 +15,27 @@ class PySphinxBookTheme(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.1.4", sha256="73efe28af871d0a89bd05856d300e61edce0d5b2fbb7984e84454be0fedfe9ed")
+    version("1.1.3", sha256="1f25483b1846cb3d353a6bc61b3b45b031f4acf845665d7da90e01ae0aef5b4d")
+    version("1.1.2", sha256="7f3abcd146ca82e6f39d6db53711102b1c1d328d12f65e3e47ad9bf842614a49")
+    version("1.1.1", sha256="e4d1058dbcc2b693c8dfa76110fa122c8219a81b3fb35c6929f23d5da9befd3e")
+    version("1.1.0", sha256="ad4f92998e53e24751ecd0978d3eb79fdaa59692f005b1b286ecdd6146ebc9c1")
     version("1.0.1", sha256="927b399a6906be067e49c11ef1a87472f1b1964075c9eea30fb82c64b20aedee")
 
     depends_on("python@3.7:", type=("build", "run"))
 
     depends_on("py-sphinx-theme-builder@0.2.0a7:", type="build")
 
-    depends_on("py-sphinx@4:6", type=("build", "run"))
-    depends_on("py-pydata-sphinx-theme@0.13.3:", type=("build", "run"))
+    depends_on("py-sphinx@4:6", type=("build", "run"), when="@:1.0")
+    depends_on("py-pydata-sphinx-theme@0.13.3:", type=("build", "run"), when="@:1.0")
+
+    depends_on("py-sphinx@5:", type=("build", "run"), when="@1.1.0:")
+    depends_on("py-pydata-sphinx-theme@0.14:", type=("build", "run"), when="@1.1.0:")
+    depends_on("py-pydata-sphinx-theme@0.15.2:", type=("build", "run"), when="@1.1.3:")
+    depends_on("py-pydata-sphinx-theme@0.15.4", type=("build", "run"), when="@1.1.4:")
+
+    # https://github.com/executablebooks/sphinx-book-theme/issues/865
+    conflicts(
+        "py-pydata-sphinx-theme@0.16:",
+        msg="Known bug that prevents sidebar from collapsing properly",
+    )

--- a/repos/spack_repo/builtin/packages/py_sphinx_theme_builder/package.py
+++ b/repos/spack_repo/builtin/packages/py_sphinx_theme_builder/package.py
@@ -18,6 +18,9 @@ class PySphinxThemeBuilder(PythonPackage):
 
     version("0.2.0b2", sha256="e9cd98c2bb35bf414fe721469a043cdcc10f0808d1ffcf606acb4a6282a6f288")
 
+    # https://github.com/pradyunsg/sphinx-theme-builder/pull/51
+    conflicts("python@3.14:", msg="Depends on deprecated classes removed in Python 3.14")
+
     depends_on("py-flit-core@3.2:3", type="build")
 
     depends_on("py-pyproject-metadata", type=("build", "run"))


### PR DESCRIPTION
- Add new versions 1.1.0 - 1.1.4 for `py-sphinx-book-theme`
- Add new versions 0.14.2 - 0.16.1 for `py-pydata-sphinx-theme` to satisfy dependencies from `py-sphinx-book-theme`
- Add `conflict()` in `py-sphinx-theme-builder` to avoid build failure with Python 3.14

All updated dependency information is copied from the `pyproject.toml` for the added versions.