### PR TITLE
harfbuzz: ensure a meson cairo is used

### DIFF
--- a/repos/spack_repo/builtin/packages/harfbuzz/package.py
+++ b/repos/spack_repo/builtin/packages/harfbuzz/package.py
@@ -102,6 +102,7 @@ class Harfbuzz(MesonPackage, AutotoolsPackage, CMakePackage):
         # harfbuzz's Meson only supports autotools based
         # freetype
         depends_on("freetype build_system=autotools")
+        depends_on("cairo build_system=meson")
 
     for plat in ["linux", "darwin", "freebsd"]:
         with when(f"platform={plat}"):


### PR DESCRIPTION
Harfbuzz requires meson dependencies when `build_system=meson`