### PR TITLE
chapel: add v2.7

### DIFF
--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -11,7 +11,6 @@ from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
 from spack.package import *
-from spack.util.environment import is_system_path  # avoid deprecation warnings
 
 
 def slingshot_network():

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -68,7 +68,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     version(
         "2.7.0",
         url="https://chapel-lang.org/tmp/chapel-2.7.0.tar.gz",
-        sha256="85e2fe7fcffb7f71e9173abb455678c14a1a8aa4997e10ed4d96d29d81672d0e",
+        sha256="5e3269babdae334c80fc3f25114698fdfe53e84ea06626af22d2b54eeb75bee6",
     )
     version("2.6.0", sha256="e469c35be601cf1f59af542ab885e8a14aa2b087b79af0d5372a4421976c74b6")
     version("2.5.0", sha256="020220ca9bf52b9f416e9a029bdc465bb1f635c1e274c6ca3c18d1f83e41fce1")

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -483,6 +483,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     conflicts("+rocm", when="+cuda", msg="Chapel must be built with either CUDA or ROCm, not both")
 
+    # CUDA conflicts and dependencies
     conflicts(
         "^llvm@20",
         when="@:2.5 +cuda",
@@ -490,6 +491,9 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         "https://github.com/chapel-lang/chapel/issues/27273",
     )
 
+    conflicts("cuda@12.9:", when="+cuda") # deprecation warnings otherwise
+
+    # ROCm conflicts and dependencies
     conflicts("+rocm", when="@:2.1", msg="ROCm support in spack requires Chapel 2.2.0 or later")
     # Chapel restricts the allowable ROCm versions
     with when("@2.2: +rocm"):

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -68,7 +68,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     version(
         "2.7.0",
         url="https://chapel-lang.org/tmp/chapel-2.7.0.tar.gz",
-        sha256="85e2fe7fcffb7f71e9173abb455678c14a1a8aa4997e10ed4d96d29d81672d0e"
+        sha256="85e2fe7fcffb7f71e9173abb455678c14a1a8aa4997e10ed4d96d29d81672d0e",
     )
     version("2.6.0", sha256="e469c35be601cf1f59af542ab885e8a14aa2b087b79af0d5372a4421976c74b6")
     version("2.5.0", sha256="020220ca9bf52b9f416e9a029bdc465bb1f635c1e274c6ca3c18d1f83e41fce1")

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -79,6 +79,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         version("2.2.0", sha256="bb16952a87127028031fd2b56781bea01ab4de7c3466f7b6a378c4d8895754b6")
         version("2.1.0", sha256="72593c037505dd76e8b5989358b7580a3fdb213051a406adb26a487d26c68c60")
         version("2.0.1", sha256="19ebcd88d829712468cfef10c634c3e975acdf78dd1a57671d11657574636053")
+        version("2.0.0", sha256="b5387e9d37b214328f422961e2249f2687453c2702b2633b7d6a678e544b9a02")
 
     sanity_check_is_dir = ["bin", join_path("lib", "chapel"), join_path("share", "chapel")]
     sanity_check_is_file = [join_path("bin", "chpl")]

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -79,7 +79,6 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         version("2.2.0", sha256="bb16952a87127028031fd2b56781bea01ab4de7c3466f7b6a378c4d8895754b6")
         version("2.1.0", sha256="72593c037505dd76e8b5989358b7580a3fdb213051a406adb26a487d26c68c60")
         version("2.0.1", sha256="19ebcd88d829712468cfef10c634c3e975acdf78dd1a57671d11657574636053")
-        version("2.0.0", sha256="b5387e9d37b214328f422961e2249f2687453c2702b2633b7d6a678e544b9a02")
 
     sanity_check_is_dir = ["bin", join_path("lib", "chapel"), join_path("share", "chapel")]
     sanity_check_is_file = [join_path("bin", "chpl")]

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -65,6 +65,8 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     version("main", branch="main")
 
+    version("2.7.0", url="https://chapel-lang.org/tmp/chapel-2.7.0.tar.gz",
+            sha256="85e2fe7fcffb7f71e9173abb455678c14a1a8aa4997e10ed4d96d29d81672d0e")
     version("2.6.0", sha256="e469c35be601cf1f59af542ab885e8a14aa2b087b79af0d5372a4421976c74b6")
     version("2.5.0", sha256="020220ca9bf52b9f416e9a029bdc465bb1f635c1e274c6ca3c18d1f83e41fce1")
     version("2.4.0", sha256="a51a472488290df12d1657db2e7118ab519743094f33650f910d92b54c56f315")

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -72,9 +72,9 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     )
     version("2.6.0", sha256="e469c35be601cf1f59af542ab885e8a14aa2b087b79af0d5372a4421976c74b6")
     version("2.5.0", sha256="020220ca9bf52b9f416e9a029bdc465bb1f635c1e274c6ca3c18d1f83e41fce1")
-    version("2.4.0", sha256="a51a472488290df12d1657db2e7118ab519743094f33650f910d92b54c56f315")
 
     with default_args(deprecated=True):
+        version("2.4.0", sha256="a51a472488290df12d1657db2e7118ab519743094f33650f910d92b54c56f315")
         version("2.3.0", sha256="0185970388aef1f1fae2a031edf060d5eac4eb6e6b1089e7e3b15a130edd8a31")
         version("2.2.0", sha256="bb16952a87127028031fd2b56781bea01ab4de7c3466f7b6a378c4d8895754b6")
         version("2.1.0", sha256="72593c037505dd76e8b5989358b7580a3fdb213051a406adb26a487d26c68c60")

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -12,7 +12,7 @@ from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
 # TODO be more selective in importing packages
 from spack.package import *
-from spack.util.environment import is_system_path # avoid deprecation warnings
+from spack.util.environment import is_system_path  # avoid deprecation warnings
 
 
 def slingshot_network():
@@ -65,8 +65,11 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     version("main", branch="main")
 
-    version("2.7.0", url="https://chapel-lang.org/tmp/chapel-2.7.0.tar.gz",
-            sha256="85e2fe7fcffb7f71e9173abb455678c14a1a8aa4997e10ed4d96d29d81672d0e")
+    version(
+            "2.7.0",
+            url="https://chapel-lang.org/tmp/chapel-2.7.0.tar.gz",
+            sha256="85e2fe7fcffb7f71e9173abb455678c14a1a8aa4997e10ed4d96d29d81672d0e"
+    )
     version("2.6.0", sha256="e469c35be601cf1f59af542ab885e8a14aa2b087b79af0d5372a4421976c74b6")
     version("2.5.0", sha256="020220ca9bf52b9f416e9a029bdc465bb1f635c1e274c6ca3c18d1f83e41fce1")
     version("2.4.0", sha256="a51a472488290df12d1657db2e7118ab519743094f33650f910d92b54c56f315")
@@ -495,7 +498,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         "https://github.com/chapel-lang/chapel/issues/27273",
     )
 
-    conflicts("cuda@12.9:", when="+cuda") # deprecation warnings otherwise
+    conflicts("cuda@12.9:", when="+cuda")  # deprecation warnings otherwise
 
     # ROCm conflicts and dependencies
     conflicts("+rocm", when="@:2.1", msg="ROCm support in spack requires Chapel 2.2.0 or later")

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -10,7 +10,9 @@ from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
+# TODO be more selective in importing packages
 from spack.package import *
+from spack.util.environment import is_system_path # avoid deprecation warnings
 
 
 def slingshot_network():

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -66,9 +66,9 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     version("main", branch="main")
 
     version(
-            "2.7.0",
-            url="https://chapel-lang.org/tmp/chapel-2.7.0.tar.gz",
-            sha256="85e2fe7fcffb7f71e9173abb455678c14a1a8aa4997e10ed4d96d29d81672d0e"
+        "2.7.0",
+        url="https://chapel-lang.org/tmp/chapel-2.7.0.tar.gz",
+        sha256="85e2fe7fcffb7f71e9173abb455678c14a1a8aa4997e10ed4d96d29d81672d0e"
     )
     version("2.6.0", sha256="e469c35be601cf1f59af542ab885e8a14aa2b087b79af0d5372a4421976c74b6")
     version("2.5.0", sha256="020220ca9bf52b9f416e9a029bdc465bb1f635c1e274c6ca3c18d1f83e41fce1")

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -65,11 +65,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     version("main", branch="main")
 
-    version(
-        "2.7.0",
-        url="https://chapel-lang.org/tmp/chapel-2.7.0.tar.gz",
-        sha256="5e3269babdae334c80fc3f25114698fdfe53e84ea06626af22d2b54eeb75bee6",
-    )
+    version("2.7.0", sha256="5e3269babdae334c80fc3f25114698fdfe53e84ea06626af22d2b54eeb75bee6")
     version("2.6.0", sha256="e469c35be601cf1f59af542ab885e8a14aa2b087b79af0d5372a4421976c74b6")
     version("2.5.0", sha256="020220ca9bf52b9f416e9a029bdc465bb1f635c1e274c6ca3c18d1f83e41fce1")
 

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -56,7 +56,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     # A list of GitHub accounts to notify when the package is updated.
     # TODO: add chapel-project github account
-    maintainers("arezaii", "bonachea", "arifthpe")
+    maintainers("arezaii", "bonachea", "arifthpe", "e-kayrakli")
 
     tags = ["e4s"]
 

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -10,7 +10,6 @@ from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
-# TODO be more selective in importing packages
 from spack.package import *
 from spack.util.environment import is_system_path  # avoid deprecation warnings
 

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -579,7 +579,8 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         depends_on("llvm@11:17", when="@:2.0.1")
         depends_on("llvm@11:18", when="@2.1:2.2")
         depends_on("llvm@11:19", when="@2.3:2.4")
-        depends_on("llvm@11:20", when="@2.5:")
+        depends_on("llvm@11:20", when="@2.5")
+        depends_on("llvm@14:20", when="@2.6:")
 
     # Based on docs https://chapel-lang.org/docs/technotes/gpu.html#requirements
     depends_on("llvm@16:", when="llvm=spack +cuda ^cuda@12:")


### PR DESCRIPTION
Add the Chapel 2.7 release.

Besides the new version, this PR:

- Adds a conflict with CUDA 12.9 which triggers a lot deprecation warnings that need to be fixed in the Chapel runtime
- Adds an `import` (and a `TODO`) to avoid a deprecation warning with newer Package APIs
