### PR TITLE
hdf-eos2: fix url and hdf4 linking, add fortran

### DIFF
--- a/repos/spack_repo/builtin/packages/hdf_eos2/package.py
+++ b/repos/spack_repo/builtin/packages/hdf_eos2/package.py
@@ -17,48 +17,55 @@ class HdfEos2(AutotoolsPackage):
     """
 
     homepage = "https://hdfeos.org"
-    # Starting with @3, download requires authentication.  So reverting
-    # to a manual download
-    url = "file://{0}/hdf-eos2-3.0-src.tar.gz".format(os.getcwd())
+    url = "https://git.earthdata.nasa.gov/projects/DAS/repos/hdfeos"
+    local_url = "file://{0}/hdf-eos2-{1}-src.tar.gz"
     manual_download = True
 
-    # The download URLs for @2 versions are messing, and include sha256 checksum.
-    # Templates for url_for_version. 0 is sha256 checksum, 1 is filename
-    # This is just a template.  See version_list and url_for_version below
-    v2url = "https://git.earthdata.nasa.gov/rest/git-lfs/storage/DAS/hdfeos/{0}?response-content-disposition=attachment%3B%20filename%3D%22{1}%22%3B%20filename*%3Dutf-8%27%27{1}"
+    # The old_url for archives is messy and is no longer used
+    old_url = "https://git.earthdata.nasa.gov/rest/git-lfs/storage/DAS/hdfeos/{0}?response-content-disposition=attachment%3B%20filename%3D%22{1}%22%3B%20filename*%3Dutf-8%27%27{1}"
 
-    maintainers("climbfuji")
+    maintainers("climbfuji", "danrosen25")
 
-    # Crazy URL scheme, differing with each version, and including the
-    # sha256 checksum in the URL.  Yuck
-    # The data in version_list is used to generate versions and urls
-    # In basename expansions, 0 is raw version,
-    # 1 is for version with dots => underscores
+    # Archives are committed to a branch related to the version
+    # but the branch name and archive name are subject to change
+    # from version to version
     version_list = [
         {
             "version": "3.0",
-            "basename": "hdf-eos2-{0}-src.tar.gz",
+            "branch": "HDFEOS2_3.0",
+            "archive": "hdf-eos2-3.0-src.tar.gz",
             "sha256": "3a5564b4d69b541139ff7dfdad948696cf31d9d1a6ea8af290c91a4c0ee37188",
-            "can_auto_download": False,
+            "can_auto_download": True,
         },
         {
             "version": "2.20v1.00",
+            "branch": "HDFEOS2.20",
+            "archive": "HDF-EOS2.20v1.00.tar.Z",
             "sha256": "cb0f900d2732ab01e51284d6c9e90d0e852d61bba9bce3b43af0430ab5414903",
-            "basename": "HDF-EOS{0}.tar.Z",
+            "can_auto_download": True,
+        },
+        {
+            "version": "2.19v1.00",
+            "branch": "HDFEOS2.19",
+            "archive": "HDF-EOS2.19v1.00.tar.Z",
+            "sha256": "3fffa081466e85d2b9436d984bc44fe97bbb33ad9d8b7055a322095dc4672e31",
             "can_auto_download": True,
         },
         {
             "version": "2.19b",
+            "branch": "HDFEOS2.19",
+            "archive": "hdfeos2_19b.zip",
             "sha256": "a69993508dbf5fa6120bac3c906ab26f1ad277348dfc2c891305023cfdf5dc9d",
-            "basename": "hdfeos{1}.zip",
             "can_auto_download": True,
+            "deprecated": True
         },
     ]
 
     for vrec in version_list:
         ver = vrec["version"]
         sha256 = vrec["sha256"]
-        version(ver, sha256=sha256)
+        deprecated = vrec.get("deprecated", False)
+        version(ver, sha256=sha256, deprecated=deprecated)
 
     variant(
         "shared", default=True, description="Build shared libraries (can be used with +static)"
@@ -66,17 +73,20 @@ class HdfEos2(AutotoolsPackage):
     variant(
         "static", default=True, description="Build static libraries (can be used with +shared)"
     )
+    variant("fortran", default=False, description="Enable Fortran support")
 
     conflicts("~static", when="~shared", msg="At least one of +static or +shared must be set")
+    conflicts('%gcc@14:', when='@:2', msg="GCC 14+ is only supported for version 3.0+")
 
     depends_on("c", type="build")
+    depends_on("fortran", type="build", when="+fortran")
 
     # Build dependencies
     depends_on("hdf")
     # Because hdf always depends on zlib and jpeg in spack, the tests below in configure_args
     # (if self.spec.satisfies("^jpeg"):) always returns true and hdf-eos2 wants zlib and jpeg, too.
-    depends_on("zlib-api")
-    depends_on("jpeg")
+    depends_on("zlib-api", when="^hdf")
+    depends_on("jpeg", when="^hdf")
     depends_on("szip", when="^hdf +szip")
 
     # Fix some problematic logic in stock configure script
@@ -93,13 +103,14 @@ class HdfEos2(AutotoolsPackage):
     def url_for_version(self, version):
         vrec = [x for x in self.version_list if x["version"] == version.dotted.string]
         if vrec:
-            fname = vrec[0]["basename"].format(version.dotted, version.underscored)
-            sha256 = vrec[0]["sha256"]
+            branch = vrec[0]["branch"]
+            archive = vrec[0]["archive"]
             can_auto_download = vrec[0].get("can_auto_download", False)
             if can_auto_download:
-                myurl = self.v2url.format(sha256, fname)
+                myurl = f"{self.url}/raw/{archive}?at=refs%2Fheads%2F{branch}"
             else:
-                myurl = self.url
+                myurl = self.local_url.format(os.getcwd(), self.version)
+
             return myurl
         else:
             sys.exit(
@@ -125,7 +136,12 @@ class HdfEos2(AutotoolsPackage):
     def flag_handler(self, name, flags):
         if name == "cflags":
             flags.append(self.compiler.cc_pic_flag)
-            if self.spec.compiler.name in ["apple-clang", "oneapi"]:
+            if (
+                self.spec.satisfies("%clang@16:")
+                or self.spec.satisfies("%apple-clang@15:")
+                or self.spec.satisfies("%oneapi")
+                or self.spec.satisfies("%gcc@14:")
+            ):
                 flags.append("-Wno-error=implicit-function-declaration")
                 flags.append("-Wno-error=implicit-int")
 
@@ -140,6 +156,17 @@ class HdfEos2(AutotoolsPackage):
             extra_ldflags.append(tmp)
         # Set LDFLAGS
         env.set("LDFLAGS", " ".join(extra_ldflags))
+        # Use h4cc compiler wrapper and flags
+        if self.spec.satisfies("^hdf"):
+            tmp = self.spec["hdf"].prefix
+            env.set("CC", os.path.join(tmp.bin, "h4cc"))
+            if (
+                self.spec.satisfies("%clang@16:")
+                or self.spec.satisfies("%apple-clang@15:")
+                or self.spec.satisfies("%oneapi")
+                or self.spec.satisfies("%gcc@14:")
+            ):
+                env.set("CFLAGS", "-Wno-error=implicit-function-declaration -Wno-error=implicit-int")
 
     def configure_args(self):
         extra_args = []
@@ -152,17 +179,27 @@ class HdfEos2(AutotoolsPackage):
         extra_args.extend(self.enable_or_disable("shared"))
         extra_args.extend(self.enable_or_disable("static"))
 
+        # Set fortran
+        extra_args.extend(self.enable_or_disable("fortran"))
+
         # Provide config args for dependencies
-        extra_args.append("--with-hdf4={0}".format(self.spec["hdf"].prefix))
+        if self.spec.satisfies("^hdf"):
+            tmp = self.spec["hdf"].libs.directories
+            if tmp:
+                extra_args.append("--with-hdf4={0}".format(tmp[0]))
         if self.spec.satisfies("^jpeg"):
             # Allow handling whatever provider of jpeg are using
             tmp = self.spec["jpeg"].libs.directories
             if tmp:
-                tmp = tmp[0]
-                extra_args.append("--with-jpeg={0}".format(tmp))
+                extra_args.append("--with-jpeg={0}".format(tmp[0]))
         if self.spec.satisfies("^szip"):
-            extra_args.append("--with-szlib={0}".format(self.spec["szip"].prefix))
-        if self.spec.satisfies("^zlib"):
-            extra_args.append("--with-zlib={0}".format(self.spec["zlib-api"].prefix))
+            tmp = self.spec["szip"].libs.directories
+            if tmp:
+                extra_args.append("--with-szlib={0}".format(tmp[0]))
+        if self.spec.satisfies("^zlib-api"):
+            # Allow handling whatever provider of zlib-api are using
+            tmp = self.spec["zlib-api"].libs.directories
+            if tmp:
+                extra_args.append("--with-zlib={0}".format(tmp[0]))
 
         return extra_args

--- a/repos/spack_repo/builtin/packages/hdf_eos2/package.py
+++ b/repos/spack_repo/builtin/packages/hdf_eos2/package.py
@@ -57,7 +57,7 @@ class HdfEos2(AutotoolsPackage):
             "archive": "hdfeos2_19b.zip",
             "sha256": "a69993508dbf5fa6120bac3c906ab26f1ad277348dfc2c891305023cfdf5dc9d",
             "can_auto_download": True,
-            "deprecated": True
+            "deprecated": True,
         },
     ]
 
@@ -76,7 +76,7 @@ class HdfEos2(AutotoolsPackage):
     variant("fortran", default=False, description="Enable Fortran support")
 
     conflicts("~static", when="~shared", msg="At least one of +static or +shared must be set")
-    conflicts('%gcc@14:', when='@:2', msg="GCC 14+ is only supported for version 3.0+")
+    conflicts("%gcc@14:", when="@:2", msg="GCC 14+ is only supported for version 3.0+")
 
     depends_on("c", type="build")
     depends_on("fortran", type="build", when="+fortran")
@@ -166,7 +166,9 @@ class HdfEos2(AutotoolsPackage):
                 or self.spec.satisfies("%oneapi")
                 or self.spec.satisfies("%gcc@14:")
             ):
-                env.set("CFLAGS", "-Wno-error=implicit-function-declaration -Wno-error=implicit-int")
+                env.set(
+                    "CFLAGS", "-Wno-error=implicit-function-declaration -Wno-error=implicit-int"
+                )
 
     def configure_args(self):
         extra_args = []

--- a/repos/spack_repo/builtin/packages/hdf_eos2/package.py
+++ b/repos/spack_repo/builtin/packages/hdf_eos2/package.py
@@ -18,11 +18,6 @@ class HdfEos2(AutotoolsPackage):
 
     homepage = "https://hdfeos.org"
     url = "https://git.earthdata.nasa.gov/projects/DAS/repos/hdfeos"
-    local_url = "file://{0}/hdf-eos2-{1}-src.tar.gz"
-    manual_download = True
-
-    # The old_url for archives is messy and is no longer used
-    old_url = "https://git.earthdata.nasa.gov/rest/git-lfs/storage/DAS/hdfeos/{0}?response-content-disposition=attachment%3B%20filename%3D%22{1}%22%3B%20filename*%3Dutf-8%27%27{1}"
 
     maintainers("climbfuji", "danrosen25")
 
@@ -35,28 +30,24 @@ class HdfEos2(AutotoolsPackage):
             "branch": "HDFEOS2_3.0",
             "archive": "hdf-eos2-3.0-src.tar.gz",
             "sha256": "3a5564b4d69b541139ff7dfdad948696cf31d9d1a6ea8af290c91a4c0ee37188",
-            "can_auto_download": True,
         },
         {
             "version": "2.20v1.00",
             "branch": "HDFEOS2.20",
             "archive": "HDF-EOS2.20v1.00.tar.Z",
             "sha256": "cb0f900d2732ab01e51284d6c9e90d0e852d61bba9bce3b43af0430ab5414903",
-            "can_auto_download": True,
         },
         {
             "version": "2.19v1.00",
             "branch": "HDFEOS2.19",
             "archive": "HDF-EOS2.19v1.00.tar.Z",
             "sha256": "3fffa081466e85d2b9436d984bc44fe97bbb33ad9d8b7055a322095dc4672e31",
-            "can_auto_download": True,
         },
         {
             "version": "2.19b",
             "branch": "HDFEOS2.19",
             "archive": "hdfeos2_19b.zip",
             "sha256": "a69993508dbf5fa6120bac3c906ab26f1ad277348dfc2c891305023cfdf5dc9d",
-            "can_auto_download": True,
             "deprecated": True,
         },
     ]
@@ -105,12 +96,7 @@ class HdfEos2(AutotoolsPackage):
         if vrec:
             branch = vrec[0]["branch"]
             archive = vrec[0]["archive"]
-            can_auto_download = vrec[0].get("can_auto_download", False)
-            if can_auto_download:
-                myurl = f"{self.url}/raw/{archive}?at=refs%2Fheads%2F{branch}"
-            else:
-                myurl = self.local_url.format(os.getcwd(), self.version)
-
+            myurl = f"{self.url}/raw/{archive}?at=refs%2Fheads%2F{branch}"
             return myurl
         else:
             sys.exit(
@@ -158,8 +144,7 @@ class HdfEos2(AutotoolsPackage):
         env.set("LDFLAGS", " ".join(extra_ldflags))
         # Use h4cc compiler wrapper and flags
         if self.spec.satisfies("^hdf"):
-            tmp = self.spec["hdf"].prefix
-            env.set("CC", os.path.join(tmp.bin, "h4cc"))
+            env.set("CC", os.path.join(self.spec["hdf"].prefix.bin, "h4cc"))
             if (
                 self.spec.satisfies("%clang@16:")
                 or self.spec.satisfies("%apple-clang@15:")


### PR DESCRIPTION
Fix hdf-eos2 package builds and add support for Fortran
https://github.com/spack/spack-packages/issues/2728

* download archive via web raw interface instead or rest api
* add danrosen25 to maintainers
* add variant for fortran support
* add conflict for gcc 14+
* add compiler flag to ignore implicit-function-declaration (newer compilers)
* add compiler flag to ignore implicit-int (newer compilers)
* use h4cc to set CC in order to fix hdf4 linking issues
* fix passing dependency library directories to configure args

@climbfuji - I think I've addressed everything that we discussed but please let me know if you find issues. Thank you!
