### PR TITLE
mmseqs2: add missing include when +cuda

### DIFF
--- a/repos/spack_repo/builtin/packages/mmseqs2/package.py
+++ b/repos/spack_repo/builtin/packages/mmseqs2/package.py
@@ -49,6 +49,12 @@ class Mmseqs2(CMakePackage, CudaPackage):
         level=1,
     )
 
+    @when("@18-8cc5c+cuda")
+    def patch(self):
+        filter_file(
+            r'^(#include "GpuUtil.h")', "\\1\n#include <thread>\n", "src/util/gpuserver.cpp"
+        )
+
     # apple-clang will build with +openmp with llvm-openmp as a dependency
     # however when running with real data, it threw segmentation faults
     conflicts("%apple-clang", when="+openmp")


### PR DESCRIPTION
I ran into a compilation issue when building `+cuda`. It seems to be a small refactoring error. I've put in a PR upstream (https://github.com/soedinglab/MMseqs2/pull/1069) with the same change this makes, hopefully we'll only need this for the current version.
