### PR TITLE
Fix libceed compilation with gcc on apple silicon

### DIFF
--- a/repos/spack_repo/builtin/packages/libceed/package.py
+++ b/repos/spack_repo/builtin/packages/libceed/package.py
@@ -89,7 +89,7 @@ class Libceed(MakefilePackage, CudaPackage, ROCmPackage):
         if spec.satisfies("@:0.2"):
             makeopts += ["NDEBUG=%s" % ("" if spec.satisfies("+debug") else "1")]
 
-        elif spec.satisfies("@0.4:"):
+        elif spec.satisfies("@0.4:0.12"):
             # Determine options based on the compiler:
             if spec.satisfies("+debug"):
                 opt = "-g"


### PR DESCRIPTION
As discussed in:
https://github.com/CEED/libCEED/issues/1808

Implements the suggestion in:
https://github.com/CEED/libCEED/issues/1808#issuecomment-2887074274

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
