### PR TITLE
ripgrep: add pcre2 variant

### DIFF
--- a/repos/spack_repo/builtin/packages/ripgrep/package.py
+++ b/repos/spack_repo/builtin/packages/ripgrep/package.py
@@ -33,15 +33,14 @@ class Ripgrep(CargoPackage):
     depends_on("rust@1.72:1.84", type="build", when="@14")
     depends_on("c", type="build")
 
-    build_args=["--release"]
-
     with when("+pcre2"):
-        build_args.append("--features 'pcre2'")
+        build_args=["--features", "pcre2"]
         depends_on("pcre2", type="build")
         depends_on("pkgconfig", type="build")
 
     @when("+pcre2")
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        super().setup_build_environment
         env.set("PCRE2_SYS_STATIC", "1")
 
     @run_after("install")

--- a/repos/spack_repo/builtin/packages/ripgrep/package.py
+++ b/repos/spack_repo/builtin/packages/ripgrep/package.py
@@ -20,14 +20,29 @@ class Ripgrep(CargoPackage):
 
     license("MIT OR Unlicense")
 
+    version("15.1.0", sha256="046fa01a216793b8bd2750f9d68d4ad43986eb9c0d6122600f993906012972e8")
     version("14.1.1", sha256="4dad02a2f9c8c3c8d89434e47337aa654cb0e2aa50e806589132f186bf5c2b66")
     version("14.1.0", sha256="33c6169596a6bbfdc81415910008f26e0809422fda2d849562637996553b2ab6")
     version("14.0.3", sha256="f5794364ddfda1e0411ab6cad6dd63abe3a6b421d658d9fee017540ea4c31a0e")
     version("13.0.0", sha256="0fb17aaf285b3eee8ddab17b833af1e190d73de317ff9648751ab0660d763ed2")
     version("11.0.2", sha256="0983861279936ada8bc7a6d5d663d590ad34eb44a44c75c2d6ccd0ab33490055")
 
-    depends_on("rust@1.72:", type="build", when="@14:")
+    variant("pcre2", default=False, description="Add support for Perl-style regex via PCRE2")
+
+    depends_on("rust@1.85:", type="build", when="@15:")
+    depends_on("rust@1.72:1.84", type="build", when="@14")
     depends_on("c", type="build")
+
+    build_args=["--release"]
+
+    with when("+pcre2"):
+        build_args.append("--features 'pcre2'")
+        depends_on("pcre2", type="build")
+        depends_on("pkgconfig", type="build")
+
+    @when("+pcre2")
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        env.set("PCRE2_SYS_STATIC", "1")
 
     @run_after("install")
     def install_completions(self):

--- a/repos/spack_repo/builtin/packages/ripgrep/package.py
+++ b/repos/spack_repo/builtin/packages/ripgrep/package.py
@@ -35,7 +35,7 @@ class Ripgrep(CargoPackage):
     depends_on("c", type="build")
 
     with when("+pcre2"):
-        build_args=["--features pcre2"]
+        build_args=["--features", "pcre2"]
         depends_on("pcre2")
         depends_on("pkgconfig", type="build")
 

--- a/repos/spack_repo/builtin/packages/ripgrep/package.py
+++ b/repos/spack_repo/builtin/packages/ripgrep/package.py
@@ -30,11 +30,12 @@ class Ripgrep(CargoPackage):
     variant("pcre2", default=False, description="Add support for Perl-style regex via PCRE2")
 
     depends_on("rust@1.85:", type="build", when="@15:")
-    depends_on("rust@1.72:1.84", type="build", when="@14")
+    depends_on("rust@1.72:", type="build", when="@14")
+    depends_on("rust@1.31:", type="build", when="@:13")
     depends_on("c", type="build")
 
     with when("+pcre2"):
-        build_args=["--features", "pcre2"]
+        build_args=["--features pcre2"]
         depends_on("pcre2")
         depends_on("pkgconfig", type="build")
 

--- a/repos/spack_repo/builtin/packages/ripgrep/package.py
+++ b/repos/spack_repo/builtin/packages/ripgrep/package.py
@@ -35,13 +35,8 @@ class Ripgrep(CargoPackage):
 
     with when("+pcre2"):
         build_args=["--features", "pcre2"]
-        depends_on("pcre2", type="build")
+        depends_on("pcre2")
         depends_on("pkgconfig", type="build")
-
-    @when("+pcre2")
-    def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        super().setup_build_environment
-        env.set("PCRE2_SYS_STATIC", "1")
 
     @run_after("install")
     def install_completions(self):

--- a/repos/spack_repo/builtin/packages/ripgrep/package.py
+++ b/repos/spack_repo/builtin/packages/ripgrep/package.py
@@ -47,7 +47,7 @@ class Ripgrep(CargoPackage):
 
     @run_after("install")
     def install_completions(self):
-        with when("@14:"):
+        if self.spec.satisfies("@14:"):
             rg = Executable(self.prefix.bin.rg)
 
             mkdirp(bash_completion_path(self.prefix))

--- a/repos/spack_repo/builtin/packages/ripgrep/package.py
+++ b/repos/spack_repo/builtin/packages/ripgrep/package.py
@@ -35,9 +35,15 @@ class Ripgrep(CargoPackage):
     depends_on("c", type="build")
 
     with when("+pcre2"):
-        build_args=["--features", "pcre2"]
         depends_on("pcre2")
         depends_on("pkgconfig", type="build")
+
+    @property
+    def build_args(self):
+        if self.spec.satisfies("+pcre2"):
+            return ["--features", "pcre2"]
+
+        return []
 
     @run_after("install")
     def install_completions(self):

--- a/repos/spack_repo/builtin/packages/ripgrep/package.py
+++ b/repos/spack_repo/builtin/packages/ripgrep/package.py
@@ -45,19 +45,19 @@ class Ripgrep(CargoPackage):
 
         return []
 
-    @when("@14:")
     @run_after("install")
     def install_completions(self):
-        rg = Executable(self.prefix.bin.rg)
+        with when("@14:"):
+            rg = Executable(self.prefix.bin.rg)
 
-        mkdirp(bash_completion_path(self.prefix))
-        with open(bash_completion_path(self.prefix) / "rg", "w") as file:
-            rg("--generate", "complete-bash", output=file)
+            mkdirp(bash_completion_path(self.prefix))
+            with open(bash_completion_path(self.prefix) / "rg", "w") as file:
+                rg("--generate", "complete-bash", output=file)
 
-        mkdirp(fish_completion_path(self.prefix))
-        with open(fish_completion_path(self.prefix) / "rg.fish", "w") as file:
-            rg("--generate", "complete-fish", output=file)
+            mkdirp(fish_completion_path(self.prefix))
+            with open(fish_completion_path(self.prefix) / "rg.fish", "w") as file:
+                rg("--generate", "complete-fish", output=file)
 
-        mkdirp(zsh_completion_path(self.prefix))
-        with open(zsh_completion_path(self.prefix) / "_rg", "w") as file:
-            rg("--generate", "complete-zsh", output=file)
+            mkdirp(zsh_completion_path(self.prefix))
+            with open(zsh_completion_path(self.prefix) / "_rg", "w") as file:
+                rg("--generate", "complete-zsh", output=file)

--- a/repos/spack_repo/builtin/packages/ripgrep/package.py
+++ b/repos/spack_repo/builtin/packages/ripgrep/package.py
@@ -29,35 +29,34 @@ class Ripgrep(CargoPackage):
 
     variant("pcre2", default=False, description="Add support for Perl-style regex via PCRE2")
 
-    depends_on("rust@1.85:", type="build", when="@15:")
-    depends_on("rust@1.72:", type="build", when="@14")
-    depends_on("rust@1.31:", type="build", when="@:13")
     depends_on("c", type="build")
+    depends_on("pkgconfig", type="build", when="+pcre2")
+    depends_on("rust@1.85:", type="build", when="@15:")
+    depends_on("rust@1.72:", type="build", when="@14:")
+    depends_on("rust@1.31:", type="build")
 
-    with when("+pcre2"):
-        depends_on("pcre2")
-        depends_on("pkgconfig", type="build")
+    depends_on("pcre2", when="+pcre2")
 
     @property
     def build_args(self):
+        args = []
         if self.spec.satisfies("+pcre2"):
-            return ["--features", "pcre2"]
+            args.extend(["--features", "pcre2"])
 
-        return []
+        return args
 
-    @run_after("install")
+    @run_after("install", when="@14:")
     def install_completions(self):
-        if self.spec.satisfies("@14:"):
-            rg = Executable(self.prefix.bin.rg)
+        rg = Executable(self.prefix.bin.rg)
 
-            mkdirp(bash_completion_path(self.prefix))
-            with open(bash_completion_path(self.prefix) / "rg", "w") as file:
-                rg("--generate", "complete-bash", output=file)
+        mkdirp(bash_completion_path(self.prefix))
+        with open(bash_completion_path(self.prefix) / "rg", "w") as file:
+            rg("--generate", "complete-bash", output=file)
 
-            mkdirp(fish_completion_path(self.prefix))
-            with open(fish_completion_path(self.prefix) / "rg.fish", "w") as file:
-                rg("--generate", "complete-fish", output=file)
+        mkdirp(fish_completion_path(self.prefix))
+        with open(fish_completion_path(self.prefix) / "rg.fish", "w") as file:
+            rg("--generate", "complete-fish", output=file)
 
-            mkdirp(zsh_completion_path(self.prefix))
-            with open(zsh_completion_path(self.prefix) / "_rg", "w") as file:
-                rg("--generate", "complete-zsh", output=file)
+        mkdirp(zsh_completion_path(self.prefix))
+        with open(zsh_completion_path(self.prefix) / "_rg", "w") as file:
+            rg("--generate", "complete-zsh", output=file)

--- a/repos/spack_repo/builtin/packages/ripgrep/package.py
+++ b/repos/spack_repo/builtin/packages/ripgrep/package.py
@@ -45,6 +45,7 @@ class Ripgrep(CargoPackage):
 
         return []
 
+    @when("@14:")
     @run_after("install")
     def install_completions(self):
         rg = Executable(self.prefix.bin.rg)


### PR DESCRIPTION
- Add `ripgrep` 15.1.0, which requires `rust` 2024 edition
- Add a `pcre2` variant. Per the [CHANGELOG](https://github.com/BurntSushi/ripgrep/blob/master/CHANGELOG.md#0100-2018-09-07), `ripgrep` has had optional support for PCRE2 since version 0.10.0. This is much older than any of the versions supported by this package, so the `pcre2` variant applies to any version supported by the package. PCRE2 support requires a provider of `pkgconfig` and the PCRE2 library. The user can now `+pcre2` to enable PCRE2 support during the `ripgrep` build.

@alecbcs 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
