### PR TITLE
cargo-c: add the cargo-c package, a dependency for librsvg and a patch

### DIFF
--- a/repos/spack_repo/builtin/packages/cargo_c/package.py
+++ b/repos/spack_repo/builtin/packages/cargo_c/package.py
@@ -9,12 +9,15 @@ from spack.package import *
 class CargoC(CargoPackage):
     """A package to build and install C-compatible libraries"""
 
-    git = "https://github.com/lu-zero/cargo-c.git"
+    homepage = "https://github.com/lu-zero/cargo-c"
     url = "https://github.com/lu-zero/cargo-c/archive/refs/tags/v0.10.18.tar.gz"
+    git = "https://github.com/lu-zero/cargo-c.git"
 
     license("MIT", checked_by="jmcarcell")
 
     version("0.10.18", sha256="0f2b699be7ad5cac05624701065ae521c7f6b8159bdbcb8103445fc2440d1a7e")
     version("0.10.17", sha256="a92b752f35e3ef54c992b2ba382466eb58a11020d13e62a25a4101bc055d5146")
     version("0.10.16", sha256="c0ebb3175393da5b55c3cd83ba1ae9d42d32e2aece6ceff1424239ffb68eb3e3")
-    depends_on("rust@1.89:", type="build")
+    
+    depends_on("rust@1.89:", type="build", when="@0.10.17:")
+    depends_on("rust@1.88:", type="build", when="@0.10.16:")

--- a/repos/spack_repo/builtin/packages/cargo_c/package.py
+++ b/repos/spack_repo/builtin/packages/cargo_c/package.py
@@ -18,6 +18,6 @@ class CargoC(CargoPackage):
     version("0.10.18", sha256="0f2b699be7ad5cac05624701065ae521c7f6b8159bdbcb8103445fc2440d1a7e")
     version("0.10.17", sha256="a92b752f35e3ef54c992b2ba382466eb58a11020d13e62a25a4101bc055d5146")
     version("0.10.16", sha256="c0ebb3175393da5b55c3cd83ba1ae9d42d32e2aece6ceff1424239ffb68eb3e3")
-    
+
     depends_on("rust@1.89:", type="build", when="@0.10.17:")
     depends_on("rust@1.88:", type="build", when="@0.10.16:")

--- a/repos/spack_repo/builtin/packages/cargo_c/package.py
+++ b/repos/spack_repo/builtin/packages/cargo_c/package.py
@@ -1,0 +1,20 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack_repo.builtin.build_systems.cargo import CargoPackage
+
+from spack.package import *
+
+
+class CargoC(CargoPackage):
+    """A package to build and install C-compatible libraries"""
+
+    git = "https://github.com/lu-zero/cargo-c.git"
+    url = "https://github.com/lu-zero/cargo-c/archive/refs/tags/v0.10.18.tar.gz"
+
+    license("MIT", checked_by="jmcarcell")
+
+    version("0.10.18", sha256="0f2b699be7ad5cac05624701065ae521c7f6b8159bdbcb8103445fc2440d1a7e")
+    version("0.10.17", sha256="a92b752f35e3ef54c992b2ba382466eb58a11020d13e62a25a4101bc055d5146")
+    version("0.10.16", sha256="c0ebb3175393da5b55c3cd83ba1ae9d42d32e2aece6ceff1424239ffb68eb3e3")
+    depends_on("rust@1.89:", type="build")

--- a/repos/spack_repo/builtin/packages/librsvg/gdk-pixbuf-query-loaders-install.patch
+++ b/repos/spack_repo/builtin/packages/librsvg/gdk-pixbuf-query-loaders-install.patch
@@ -1,0 +1,22 @@
+diff --git a/gdk-pixbuf-loader/meson.build b/gdk-pixbuf-loader/meson.build
+index 6fa10a68b..ff0ef46b4 100644
+--- a/gdk-pixbuf-loader/meson.build
++++ b/gdk-pixbuf-loader/meson.build
+@@ -36,13 +36,11 @@ pixbuf_thumbnailer = configure_file(
+   install_dir: get_option('datadir') / 'thumbnailers'
+ )
+ 
+-if meson.can_run_host_binaries()
+-  gdk_pixbuf_query_loaders = find_program(pixbuf_dep.get_variable(pkgconfig: 'gdk_pixbuf_query_loaders', default_value: 'gdk-pixbuf-query-loaders'))
+-endif
++gdk_pixbuf_query_loaders = find_program(pixbuf_dep.get_variable(pkgconfig: 'gdk_pixbuf_query_loaders', default_value: 'gdk-pixbuf-query-loaders'))
+ 
+ pixbufloader_svg_install_args = [
+   '--gdk-pixbuf-moduledir',
+   pixbuf_dep.get_variable(pkgconfig: 'gdk_pixbuf_moduledir', pkgconfig_define: ['prefix', prefix]),
+-  pixbuf_dep.get_variable(pkgconfig: 'gdk_pixbuf_query_loaders', pkgconfig_define: ['prefix', prefix]),
++  gdk_pixbuf_query_loaders.path(),
+   pixbuf_dep.get_variable(pkgconfig: 'gdk_pixbuf_cache_file', pkgconfig_define: ['prefix', prefix])
+ ]
+
+ 

--- a/repos/spack_repo/builtin/packages/librsvg/package.py
+++ b/repos/spack_repo/builtin/packages/librsvg/package.py
@@ -64,6 +64,7 @@ class Librsvg(AutotoolsPackage, MesonPackage):
     depends_on("gtk-doc", type="build", when="+doc")
 
     # requirements according to `meson.build` or `configure` file
+    depends_on("cargo-c@0.9.19:", when="@2.59:", type="build")
     depends_on("cairo@1.18:", when="@2.59:")
     depends_on("cairo@1.17:", when="@2.57:")
     depends_on("cairo@1.16:", when="@2.50:")
@@ -85,6 +86,8 @@ class Librsvg(AutotoolsPackage, MesonPackage):
 
     # Historical dependencies
     depends_on("libcroco@0.6.1:", when="@:2.44.14")
+
+    patch("gdk-pixbuf-query-loaders-install.patch", when="@2.59:")
 
     def url_for_version(self, version):
         url = "https://download.gnome.org/sources/librsvg/"


### PR DESCRIPTION
This fixes https://github.com/spack/spack-packages/issues/2740 for me.
Needs https://github.com/spack/spack-packages/pull/2737, because otherwise there is not a recent enough version of rust for `cargo-c`.

The patch is needed because of: https://gitlab.gnome.org/GNOME/librsvg/-/issues/1216

Edit: The patch is now merged, see the issue above.