### PR TITLE
ginkgo: add v1.11.0

### DIFF
--- a/repos/spack_repo/builtin/packages/ginkgo/package.py
+++ b/repos/spack_repo/builtin/packages/ginkgo/package.py
@@ -142,6 +142,10 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
     # Add missing include statement
     patch("thrust-count-header.patch", when="+rocm @1.5.0")
 
+    # Revert the fix from github.com/ginkgo-project/ginkgo/pull/1954/changes
+    # This only affects the benchmark part of Ginkgo, which is not built by spack anyway
+    patch("remove_finding_thrust.patch", when="@1.11.0 +cuda")
+
     # Correctly find rocthrust through CMake
     patch(
         "https://github.com/ginkgo-project/ginkgo/commit/369b12a5f4431577d60a61e67f2b0537b428abca.patch?full_index=1",

--- a/repos/spack_repo/builtin/packages/ginkgo/package.py
+++ b/repos/spack_repo/builtin/packages/ginkgo/package.py
@@ -30,6 +30,7 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
     version("develop", branch="develop")
     version("main", branch="main")
     version("master", branch="master", deprecated=True)
+    version("1.11.0", commit="4c77a5d826bd1597fd093f39c47688f8cc735690")  # v1.11.0
     version("1.10.0", commit="d4e0e9f8c8eb36cc2044189834d82742b925f27e")  # v1.10.0
     version("1.9.0", commit="20cfd68795f58078898da9890baa311b46845a8b")  # v1.9.0
     version("1.8.0", commit="586b1754058d7a32d4bd1b650f9603484c2a8927")  # v1.8.0
@@ -86,11 +87,10 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
     # ROCPRIM is not a direct dependency, but until we have reviewed our CMake
     # setup for rocthrust, this needs to also be added here.
     depends_on("rocprim", when="+rocm")
-    # error due to change in warpSize constant definition in ROCm 7.0
-    depends_on("hip@:6", when="+rocm")
+    depends_on("hip", when="+rocm")
     depends_on("hwloc@2.1:", when="+hwloc")
-    # TODO: replace with the next PAPI version when available (>7.0.1.0)
-    depends_on("papi@master+sde", when="+sde")
+    depends_on("papi@master+sde", when="+sde @:1.10.0")
+    depends_on("papi@7.1.0: +sde", when="+sde @1.11.0:")
 
     depends_on("googletest", type="test")
     depends_on("numactl", type="test", when="+hwloc")
@@ -125,6 +125,10 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
 
     # https://github.com/ginkgo-project/ginkgo/pull/1926
     conflicts("^cuda@13:", when="@:1.10.0 +cuda")
+
+    # error due to change in warpSize constant definition in ROCm 7.0 prior to v.1.11.0
+    # https://github.com/ginkgo-project/ginkgo/pull/1954
+    conflicts("^hip@7:", when="@:1.10.0 +rocm")
 
     # https://github.com/ginkgo-project/ginkgo/pull/1524
     patch("ginkgo-sycl-pr1524.patch", when="@1.7.0 +sycl %oneapi@2024:")

--- a/repos/spack_repo/builtin/packages/ginkgo/remove_finding_thrust.patch
+++ b/repos/spack_repo/builtin/packages/ginkgo/remove_finding_thrust.patch
@@ -1,0 +1,58 @@
+Subject: [PATCH] remove_finding_thrust
+---
+Index: cuda/CMakeLists.txt
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/cuda/CMakeLists.txt b/cuda/CMakeLists.txt
+--- a/cuda/CMakeLists.txt	(revision 4c77a5d826bd1597fd093f39c47688f8cc735690)
++++ b/cuda/CMakeLists.txt	(date 1770048537701)
+@@ -156,9 +156,6 @@
+         CUDA::cufft
+         nvtx::nvtx
+ )
+-if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL 13)
+-    target_link_libraries(ginkgo_cuda PRIVATE Thrust)
+-endif()
+ # NVTX3 is header-only and requires dlopen/dlclose in static builds
+ target_link_libraries(ginkgo_cuda PUBLIC ginkgo_device ${CMAKE_DL_LIBS})
+ 
+Index: benchmark/CMakeLists.txt
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/benchmark/CMakeLists.txt b/benchmark/CMakeLists.txt
+--- a/benchmark/CMakeLists.txt	(revision 4c77a5d826bd1597fd093f39c47688f8cc735690)
++++ b/benchmark/CMakeLists.txt	(date 1770048537691)
+@@ -40,9 +40,6 @@
+         cusparse_linops_${type}
+         PRIVATE Ginkgo::ginkgo CUDA::cudart CUDA::cublas CUDA::cusparse
+     )
+-    if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL 13)
+-        target_link_libraries(cusparse_linops_${type} PRIVATE Thrust)
+-    endif()
+     ginkgo_compile_features(cusparse_linops_${type})
+ endfunction()
+ 
+Index: cmake/cuda.cmake
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/cmake/cuda.cmake b/cmake/cuda.cmake
+--- a/cmake/cuda.cmake	(revision 4c77a5d826bd1597fd093f39c47688f8cc735690)
++++ b/cmake/cuda.cmake	(date 1770048537709)
+@@ -14,11 +14,6 @@
+ 
+ find_package(NVTX REQUIRED)
+ 
+-if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL 13)
+-    find_package(Thrust REQUIRED)
+-    thrust_create_target(Thrust)
+-endif()
+-
+ if(
+     CMAKE_CUDA_HOST_COMPILER
+     AND NOT CMAKE_CXX_COMPILER STREQUAL CMAKE_CUDA_HOST_COMPILER


### PR DESCRIPTION
This PR adds Ginkgo v1.11.0.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
