### PR TITLE
root: avoid non-determinism of cxxstd

### DIFF
--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -353,7 +353,7 @@ class Root(CMakePackage):
 
     variant(
         "cxxstd",
-        default="11",
+        default="17",
         values=("11", "14", "17", "20", "23"),
         multi=False,
         description="Use the specified C++ standard when building.",


### PR DESCRIPTION
The default is `cxxstd=11`, but it conflicts with all recent versions of root:

```python
    conflicts("cxxstd=11", when="@6.25.02:", msg="This version of root requires at least C++14")
    conflicts("cxxstd=14", when="@6.30.00:", msg="This version of root requires at least C++17")
```

That leads to non-determinism of the default value thanks to
https://github.com/spack/spack/issues/51112.

So, for now pick a default value of C++17 to get something that's
deterministic when picking recent versions of root.
