### PR TITLE
py-geopandas: pandas 3 not yet supported

### DIFF
--- a/repos/spack_repo/builtin/packages/py_geopandas/package.py
+++ b/repos/spack_repo/builtin/packages/py_geopandas/package.py
@@ -62,6 +62,8 @@ class PyGeopandas(PythonPackage):
         depends_on("py-pandas@0.24:", when="@0.9:")
         depends_on("py-pandas@0.23:", when="@0.6:")
         depends_on("py-pandas")
+        # https://github.com/geopandas/geopandas/pull/3621
+        depends_on("py-pandas@:2", when="@:1.1.1")
         depends_on("py-pyproj@3.5:", when="@1.1:")
         depends_on("py-pyproj@3.3:", when="@0.14:")
         depends_on("py-pyproj@2.6.1.post1:", when="@0.11:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Pandas 3 is coming soon. Already noticed some incompatibilities.