### PR TITLE
texlive: add a variant to install (or not) the documentation and source files

### DIFF
--- a/repos/spack_repo/builtin/packages/texlive/package.py
+++ b/repos/spack_repo/builtin/packages/texlive/package.py
@@ -115,6 +115,9 @@ class Texlive(AutotoolsPackage):
 
     build_directory = "spack-build"
 
+    variant("doc", default=False, description="Install the documentation files")
+    variant("src", default=False, description="Install the source files")
+
     def tex_arch(self):
         tex_arch = "{0}-{1}".format(platform.machine(), platform.system().lower())
         return tex_arch
@@ -155,7 +158,18 @@ class Texlive(AutotoolsPackage):
         with working_dir("spack-build"):
             make("texlinks")
 
-        copy_tree("texlive-{0}-texmf".format(self.version.string), self.prefix)
+        ignore_doc = "~doc" in self.spec
+        ignore_src = "~src" in self.spec
+
+        ignore = lambda f: (
+            len(f.split(os.sep)) > 1
+            and (
+                (ignore_doc and f.split(os.sep)[1] == "doc")
+                or (ignore_src and f.split(os.sep)[1] == "source")
+            )
+        )
+
+        copy_tree("texlive-{0}-texmf".format(self.version.string), self.prefix, ignore=ignore)
 
         # Create and run setup utilities
         fmtutil_sys = Executable(join_path(self.prefix.bin, self.tex_arch(), "fmtutil-sys"))


### PR DESCRIPTION
How it works is that all the files that are in `texlive-{version}-texmf/doc` and `texmf-{version}-texmf/source` are not installed.

In most packages in Spack installing the documentation is off by default. Here, it is a total of close to 50k files and 4.5 GB, and these files are not needed to have a functioning installation, at least I can't find them in my local installation in my system.