### PR TITLE
bbmap: add 39.59; fixes/improvements

### DIFF
--- a/repos/spack_repo/builtin/packages/bbmap/package.py
+++ b/repos/spack_repo/builtin/packages/bbmap/package.py
@@ -32,7 +32,8 @@ class Bbmap(MakefilePackage, SourceforgePackage):
     )
 
     # Building BBMap's jni libraries requires gcc, per the BBMap docs
-    depends_on("gcc", type="build", when="+usejni")
+    depends_on("c", type="build", when="+usejni")
+    requires("%c=gcc", when="+usejni")
     depends_on("java@8:", type=("build", "link", "run"))
 
     def edit(self, spec, prefix):

--- a/repos/spack_repo/builtin/packages/bbmap/package.py
+++ b/repos/spack_repo/builtin/packages/bbmap/package.py
@@ -22,11 +22,21 @@ class Bbmap(MakefilePackage, SourceforgePackage):
     version("37.78", sha256="f2da19f64d2bfb7db4c0392212668b425c96a27c77bd9d88d8f0aea90a193509")
     version("37.36", sha256="befe76d7d6f3d0f0cd79b8a01004a2283bdc0b5ab21b0743e9dbde7c7d79e8a9")
 
+    variant(
+        "usejni",
+        default=False,
+        description=(
+            "Compile the libbbtoolsjni library for accelerated versions of BBMap, Dedupe, "
+            "BBMerge, and IceCreamFinder"
+        )
+    )
+
     # Building BBMap's jni libraries requires gcc, per the BBMap docs
-    depends_on("gcc", type="build")
-    depends_on("gmake", type="build")
+    depends_on("gcc", type="build", when="+usejni")
+    depends_on("gmake", type="build", when="+usejni")
     depends_on("java@8:", type=("build", "link", "run"))
 
+    @when("+usejni")
     def edit(self, spec, prefix):
         makefile = "makefile.linux"
 
@@ -36,6 +46,7 @@ class Bbmap(MakefilePackage, SourceforgePackage):
         with working_dir(f"{self.build_directory}/jni"):
             rename(makefile, "Makefile")
 
+    @when("+usejni")
     def build(self, spec, prefix):
         with working_dir(f"{self.build_directory}/jni"):
             # BBMap comes with a pre-compiled x86_64 library that must first be removed

--- a/repos/spack_repo/builtin/packages/bbmap/package.py
+++ b/repos/spack_repo/builtin/packages/bbmap/package.py
@@ -7,6 +7,7 @@ from spack_repo.builtin.build_systems.sourceforge import SourceforgePackage
 
 from spack.package import *
 
+
 class Bbmap(MakefilePackage, SourceforgePackage):
     """Short read aligner for DNA and RNA-seq data."""
 

--- a/repos/spack_repo/builtin/packages/bbmap/package.py
+++ b/repos/spack_repo/builtin/packages/bbmap/package.py
@@ -41,19 +41,19 @@ class Bbmap(MakefilePackage, SourceforgePackage):
         if spec.satisfies("platform=darwin"):
             makefile = "makefile.osx"
 
-        with working_dir(f"{self.build_directory}/jni"):
+        with working_dir(join_path(self.build_directory, "jni")):
             rename(makefile, "Makefile")
 
     @when("+usejni")
     def build(self, spec, prefix):
-        with working_dir(f"{self.build_directory}/jni"):
+        with working_dir(join_path(self.build_directory, "jni")):
             # BBMap comes with a pre-compiled x86_64 library that must first be removed
             make("clean")
             make()
 
     @when("~usejni")
     def build(self, spec, prefix):
-        with working_dir(f"{self.build_directory}/jni"):
+        with working_dir(join_path(self.build_directory, "jni")):
             # When not building libbbtoolsjni, we should still remove the pre-compiled
             # library for x86_64, as it may fail on other platforms.
             make("clean")

--- a/repos/spack_repo/builtin/packages/bbmap/package.py
+++ b/repos/spack_repo/builtin/packages/bbmap/package.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack_repo.builtin.build_systems.generic import Package
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
 from spack_repo.builtin.build_systems.sourceforge import SourceforgePackage
 
 from spack.package import *
 
+import os
 
-class Bbmap(Package, SourceforgePackage):
+class Bbmap(MakefilePackage, SourceforgePackage):
     """Short read aligner for DNA and RNA-seq data."""
 
     homepage = "https://sourceforge.net/projects/bbmap/"
@@ -16,14 +17,35 @@ class Bbmap(Package, SourceforgePackage):
 
     license("BSD-3-Clause-LBNL")
 
+    version("39.59", sha256="a657b6f04f35125b31e431317927d3adc0a3d3655a36014aceb0e3fceb0d4cb0")
     version("39.01", sha256="98608da50130c47f3abd095b889cc87f60beeb8b96169b664bc9d849abe093e6")
     version("38.63", sha256="089064104526c8d696164aefa067f935b888bc71ef95527c72a98c17ee90a01f")
     version("37.78", sha256="f2da19f64d2bfb7db4c0392212668b425c96a27c77bd9d88d8f0aea90a193509")
     version("37.36", sha256="befe76d7d6f3d0f0cd79b8a01004a2283bdc0b5ab21b0743e9dbde7c7d79e8a9")
 
-    depends_on("c", type="build")  # generated
+    # Building BBMap's jni libraries requires gcc, per the BBMap docs
+    depends_on("gcc", type="build")
+    depends_on("gmake", type="build")
+    depends_on("java@8:", type=("build", "link", "run"))
 
-    depends_on("java")
+    @property
+    def build_directory(self):
+        return f"{self.pkg.stage.source_path}/jni"
+
+    def edit(self, spec, prefix):
+        makefile="makefile.linux"
+
+        if spec.satisfies("platform=darwin"):
+            makefile="makefile.osx"
+
+        with working_dir(self.build_directory):
+            rename(makefile, "Makefile")
+
+    def build(self, spec, prefix):
+        with working_dir(self.build_directory):
+            # BBMap comes with a pre-compiled library that must first be removed
+            self.pkg.module.make("clean")
+            self.pkg.module.make()
 
     def install(self, spec, prefix):
         install_tree(".", prefix.bin)

--- a/repos/spack_repo/builtin/packages/bbmap/package.py
+++ b/repos/spack_repo/builtin/packages/bbmap/package.py
@@ -36,7 +36,6 @@ class Bbmap(MakefilePackage, SourceforgePackage):
     depends_on("gmake", type="build", when="+usejni")
     depends_on("java@8:", type=("build", "link", "run"))
 
-    @when("+usejni")
     def edit(self, spec, prefix):
         makefile = "makefile.linux"
 
@@ -52,6 +51,13 @@ class Bbmap(MakefilePackage, SourceforgePackage):
             # BBMap comes with a pre-compiled x86_64 library that must first be removed
             make("clean")
             make()
+
+    @when("~usejni")
+    def build(self, spec, prefix):
+        with working_dir(f"{self.build_directory}/jni"):
+            # When not building libbbtoolsjni, we should still remove the pre-compiled
+            # library for x86_64, as it may fail on other platforms.
+            make("clean")
 
     def install(self, spec, prefix):
         install_tree(".", prefix.bin)

--- a/repos/spack_repo/builtin/packages/bbmap/package.py
+++ b/repos/spack_repo/builtin/packages/bbmap/package.py
@@ -28,24 +28,20 @@ class Bbmap(MakefilePackage, SourceforgePackage):
     depends_on("gmake", type="build")
     depends_on("java@8:", type=("build", "link", "run"))
 
-    @property
-    def build_directory(self):
-        return f"{self.pkg.stage.source_path}/jni"
-
     def edit(self, spec, prefix):
         makefile="makefile.linux"
 
         if spec.satisfies("platform=darwin"):
             makefile="makefile.osx"
 
-        with working_dir(self.build_directory):
+        with working_dir(f"{self.build_directory}/jni"):
             rename(makefile, "Makefile")
 
     def build(self, spec, prefix):
-        with working_dir(self.build_directory):
-            # BBMap comes with a pre-compiled library that must first be removed
-            self.pkg.module.make("clean")
-            self.pkg.module.make()
+        with working_dir(f"{self.build_directory}/jni"):
+            # BBMap comes with a pre-compiled x86_64 library that must first be removed
+            make("clean")
+            make()
 
     def install(self, spec, prefix):
         install_tree(".", prefix.bin)

--- a/repos/spack_repo/builtin/packages/bbmap/package.py
+++ b/repos/spack_repo/builtin/packages/bbmap/package.py
@@ -7,8 +7,6 @@ from spack_repo.builtin.build_systems.sourceforge import SourceforgePackage
 
 from spack.package import *
 
-import os
-
 class Bbmap(MakefilePackage, SourceforgePackage):
     """Short read aligner for DNA and RNA-seq data."""
 
@@ -29,10 +27,10 @@ class Bbmap(MakefilePackage, SourceforgePackage):
     depends_on("java@8:", type=("build", "link", "run"))
 
     def edit(self, spec, prefix):
-        makefile="makefile.linux"
+        makefile = "makefile.linux"
 
         if spec.satisfies("platform=darwin"):
-            makefile="makefile.osx"
+            makefile = "makefile.osx"
 
         with working_dir(f"{self.build_directory}/jni"):
             rename(makefile, "Makefile")

--- a/repos/spack_repo/builtin/packages/bbmap/package.py
+++ b/repos/spack_repo/builtin/packages/bbmap/package.py
@@ -33,7 +33,6 @@ class Bbmap(MakefilePackage, SourceforgePackage):
 
     # Building BBMap's jni libraries requires gcc, per the BBMap docs
     depends_on("gcc", type="build", when="+usejni")
-    depends_on("gmake", type="build", when="+usejni")
     depends_on("java@8:", type=("build", "link", "run"))
 
     def edit(self, spec, prefix):

--- a/repos/spack_repo/builtin/packages/bbmap/package.py
+++ b/repos/spack_repo/builtin/packages/bbmap/package.py
@@ -28,7 +28,7 @@ class Bbmap(MakefilePackage, SourceforgePackage):
         description=(
             "Compile the libbbtoolsjni library for accelerated versions of BBMap, Dedupe, "
             "BBMerge, and IceCreamFinder"
-        )
+        ),
     )
 
     # Building BBMap's jni libraries requires gcc, per the BBMap docs

--- a/repos/spack_repo/builtin/packages/bbmap/package.py
+++ b/repos/spack_repo/builtin/packages/bbmap/package.py
@@ -11,7 +11,7 @@ from spack.package import *
 class Bbmap(MakefilePackage, SourceforgePackage):
     """Short read aligner for DNA and RNA-seq data."""
 
-    homepage = "https://sourceforge.net/projects/bbmap/"
+    homepage = "https://bbmap.org/tools/bbmap"
     sourceforge_mirror_path = "bbmap/BBMap_38.63.tar.gz"
 
     license("BSD-3-Clause-LBNL")


### PR DESCRIPTION
- Add BBMap 39.59
- Change home page to https://bbmap.org/tools/bbmap, the current homepage for BBMap
- `Bbmap` class now extends `MakefilePackage`
- Add `usejni` variant that, when true, will cause the package to build libbbtoolsjni.so for acceleration.
- Constrain the compiler dependency to `gcc`. Per the [BBMap docs](https://github.com/bbushnell/BBTools/blob/master/jni/README.txt), and the contents of the makefile(s), gcc should be used.
- BBMap requires Java 8 or later, and it is also a run-time dependency. The `java` dependency has been updated accordingly.
- The BBMap source comes with makefiles for Linux and macOS (OS/X). The `edit` function is overridden to rename, based on the spec's `platform`, the appropriate file to `Makefile`.
- The `build` function has been overridden to first run `make clean`, as the BBMap distribution ships with a pre-compiled library that is only for x86_64.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
