### PR TITLE
libfabric: add v2.4.0

### DIFF
--- a/repos/spack_repo/builtin/packages/libfabric/package.py
+++ b/repos/spack_repo/builtin/packages/libfabric/package.py
@@ -26,6 +26,7 @@ class Libfabric(AutotoolsPackage, CudaPackage, ROCmPackage):
     license("BSD-2-Clause OR GPL-2.0-only")
 
     version("main", branch="main")
+    version("2.4.0", sha256="13f508e1d770c44f872c4117d9bcbfc102dc9d7532d3292455e0e0e5ef7b3bba")
     version("2.3.1", sha256="2e939f17ce4d30a999d0445f741d3055b19dfd894eff70450e23470fe774f35a")
     version("2.3.0", sha256="1d18fce868f8fef68b42fccd1f5df2555369739e8cb7c148532a0529a308eb09")
     version("2.2.0", sha256="ff6d05240b4a9753bb3d1eaf962f5a06205038df5142374a6ef40f931bb55ecc")


### PR DESCRIPTION
The release: https://github.com/ofiwg/libfabric/releases/tag/v2.4.0

Installation test:

```
$ spack install libfabric@2.4.0 fabrics=sockets,tcp,verbs,rxd,rxm
[+] /usr (external glibc-2.28-iyhte7x7am7ap6asyuvzpe5hklifmvq5)
[+] /usr (external rdma-core-57.0-gqfiqxqq4uyc7ccaw5ajvddofyqhjwt3)
[+] /lustre/linsword_google_com/spack/opt/spack/linux-zen2/gcc-runtime-15.2.0-kapfd7dg3lfwdjquod5m5vuucj7renty
[+] /lustre/linsword_google_com/spack/opt/spack/linux-zen2/libfabric-2.4.0-csaykl5ivor2bcz7qioatmfb64y5ydrc
```

Also performed test runs with tcp and rxm.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
