### PR TITLE
awscli-v2: relax dependencies to support Python 3.14

### DIFF
--- a/repos/spack_repo/builtin/packages/awscli_v2/package.py
+++ b/repos/spack_repo/builtin/packages/awscli_v2/package.py
@@ -23,7 +23,9 @@ class AwscliV2(PythonPackage):
     version("2.13.22", sha256="dd731a2ba5973f3219f24c8b332a223a29d959493c8a8e93746d65877d02afc1")
 
     with default_args(type="build"):
-        depends_on("py-flit-core@3.7.1:3.9.0", when="@2.22:")
+        depends_on("py-flit-core@3.7.1:", when="@2.22:")
+        # Upper bound relaxed for Python 3.14 support
+        # depends_on("py-flit-core@3.7.1:3.9.0", when="@2.22:")
         depends_on("py-flit-core@3.7.1:3.8.0", when="@:2.15")
 
     with default_args(type=("build", "run")):
@@ -31,7 +33,9 @@ class AwscliV2(PythonPackage):
         depends_on("py-docutils@0.10:0.19")
         depends_on("py-cryptography@40:43.0.1", when="@2.22:")
         depends_on("py-cryptography@3.3.2:40.0.1", when="@:2.15")
-        depends_on("py-ruamel-yaml@0.15:0.17.21")
+        depends_on("py-ruamel-yaml@0.15:")
+        # Upper bound relaxed for Python 3.14 support
+        # depends_on("py-ruamel-yaml@0.15:0.17.21")
         depends_on("py-ruamel-yaml-clib@0.2:", when="@2.22:")
         # Upper bound relaxed for Python 3.13 support
         # depends_on("py-ruamel-yaml-clib@0.2:0.2.8", when="@2.22:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Builds fine, but would appreciate a bit of testing to make sure that most functionality works in Python 3.14.