### PR TITLE
py-flit-core: mark Python 3.14 support

### DIFF
--- a/repos/spack_repo/builtin/packages/py_flit_core/package.py
+++ b/repos/spack_repo/builtin/packages/py_flit_core/package.py
@@ -42,7 +42,7 @@ class PyFlitCore(PythonPackage):
         depends_on("python@3.4:", when="@3.0:")
         depends_on("python@2.7,3.4:", when="@2.3:")
         # https://github.com/pypa/flit/pull/684
-        depends_on("python@:3.13", when="@:3.10")
+        depends_on("python@:3.13", when="@:3.9")
 
     # flit_core/build_thyself.py
     depends_on("py-tomli", when="@3.4:3.5", type="run")

--- a/repos/spack_repo/builtin/packages/py_flit_core/package.py
+++ b/repos/spack_repo/builtin/packages/py_flit_core/package.py
@@ -41,6 +41,8 @@ class PyFlitCore(PythonPackage):
         depends_on("python@3.6:", when="@3.4:")
         depends_on("python@3.4:", when="@3.0:")
         depends_on("python@2.7,3.4:", when="@2.3:")
+        # https://github.com/pypa/flit/pull/684
+        depends_on("python@:3.13", when="@:3.10")
 
     # flit_core/build_thyself.py
     depends_on("py-tomli", when="@3.4:3.5", type="run")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Discovered when the concretizer chose an older version and it didn't build.