### PR TITLE
demuxlet: Modify LDFLAGS based on htslib dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/demuxlet/package.py
+++ b/repos/spack_repo/builtin/packages/demuxlet/package.py
@@ -34,15 +34,18 @@ class Demuxlet(AutotoolsPackage):
         filter_file("-I ../htslib/", "", "Makefile.am", string=True)
         filter_file("../htslib/libhts.a", "-lhts", "Makefile.am", string=True)
 
-        # Add -ldeflate to LDFLAGS When depending on htslib with libdeflate
+        # Add -ldeflate to LDFLAGS when depending on htslib with libdeflate
         if self.spec.satisfies("^htslib+libdeflate"):
             filter_file("-lcrypto", "-lcrypto -ldeflate", "Makefile.am", string=True)
 
         # Remove -lcurl from LDFLAGS when depending on htslib sans libcurl
-        if not self.spec.satisfies("^htslib+libcurl"):
+        if self.spec.satisfies("^htslib~libcurl"):
             filter_file("-lcurl", "", "Makefile.am", string=True)
 
-        # Remove -lcrypto from LDFLAGS when depending on htslib sans S3 URL support
+        # Remove -lcrypto from LDFLAGS when depending on htslib sans S3 URL support.
+        # htslib's s3 variant is conditional and ~s3 will not be in its spec when
+        # ~libcurl is in its spec, so we must check for the case in which +s3 is not
+        # explicit.
         if not self.spec.satisfies("^htslib+s3"):
             filter_file("-lcrypto", "", "Makefile.am", string=True)
 

--- a/repos/spack_repo/builtin/packages/demuxlet/package.py
+++ b/repos/spack_repo/builtin/packages/demuxlet/package.py
@@ -33,8 +33,18 @@ class Demuxlet(AutotoolsPackage):
         filter_file("-I ../../htslib/htslib", "", "Makefile.am", string=True)
         filter_file("-I ../htslib/", "", "Makefile.am", string=True)
         filter_file("../htslib/libhts.a", "-lhts", "Makefile.am", string=True)
+
+        # Add -ldeflate to LDFLAGS When depending on htslib with libdeflate
         if self.spec.satisfies("^htslib+libdeflate"):
             filter_file("-lcrypto", "-lcrypto -ldeflate", "Makefile.am", string=True)
+
+        # Remove -lcurl from LDFLAGS when depending on htslib sans libcurl
+        if not self.spec.satisfies("^htslib+libcurl"):
+            filter_file("-lcurl", "", "Makefile.am", string=True)
+
+        # Remove -lcrypto from LDFLAGS when depending on htslib sans S3 URL support
+        if not self.spec.satisfies("^htslib+s3"):
+            filter_file("-lcrypto", "", "Makefile.am", string=True)
 
     def autoreconf(self, spec, prefix):
         which("autoreconf")("-vfi")


### PR DESCRIPTION
- Remove `-lcurl` from LDFLAGS when depending on `htslib` sans `libcurl`
- Remove `-lcrypto` from LDFLAGS when depending on `htslib` sans S3 URL support

I found when concretizing a unified environment that contained `demuxlet` and `htslib~libcurl` that `demuxlet` would fail to link because it had a `-lcrypto` in its `LDFLAGS` while the `openssl` package was not installed. The proposed changes ensure that does not happen, and also ensure that `-lcurl` is not in `LDFLAGS` when `htslib~libcurl` is in the graph.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
