### PR TITLE
rocprofiler-systems: add boost version constraint because of cmake issue

### DIFF
--- a/repos/spack_repo/builtin/packages/rocprofiler_systems/package.py
+++ b/repos/spack_repo/builtin/packages/rocprofiler_systems/package.py
@@ -158,7 +158,7 @@ class RocprofilerSystems(CMakePackage):
     depends_on("dyninst@:12", when="@6 ~internal-dyninst")
     depends_on("dyninst@13", when="@7 ~internal-dyninst")
     depends_on(
-        "boost+atomic+chrono+date_time+filesystem+system+thread+timer+container+random+exception",
+        "boost@:1.88+atomic+chrono+date_time+filesystem+system+thread+timer+container+random+exception",
         when="+internal-dyninst",
     )
     depends_on("libiberty+pic", when="+internal-dyninst")

--- a/repos/spack_repo/builtin/packages/rocprofiler_systems/package.py
+++ b/repos/spack_repo/builtin/packages/rocprofiler_systems/package.py
@@ -158,7 +158,8 @@ class RocprofilerSystems(CMakePackage):
     depends_on("dyninst@:12", when="@6 ~internal-dyninst")
     depends_on("dyninst@13", when="@7 ~internal-dyninst")
     depends_on(
-        "boost@:1.88+atomic+chrono+date_time+filesystem+system+thread+timer+container+random+exception",
+        "boost@:1.88"
+        "+atomic+chrono+date_time+filesystem+system+thread+timer+container+random+exception",
         when="+internal-dyninst",
     )
     depends_on("libiberty+pic", when="+internal-dyninst")


### PR DESCRIPTION
Adding a version constraint because of this cmake configuration issue reported upstream: https://github.com/ROCm/rocm-systems/issues/2356. rocprofiler-systems with `+internal-dyninst` does not recognize boost because it expects boost system to be found. However, boost's system stub library was removed in 1.89.