### PR TITLE
r-ggpattern: Add new package

### DIFF
--- a/repos/spack_repo/builtin/packages/r_cpp11/package.py
+++ b/repos/spack_repo/builtin/packages/r_cpp11/package.py
@@ -19,6 +19,7 @@ class RCpp11(RPackage):
 
     license("MIT")
 
+    version("0.5.2", sha256="0e8ac07f9d599b82e7a811f9d084e5125ae787b1ba04e5ba57f79e2642af091b")
     version("0.4.7", sha256="801d1266824c3972642bce2db2a5fd0528a65ec845c58eb5a886edf082264344")
     version("0.4.3", sha256="f1a60e4971a86dbbcf6a16bbd739b59bb66d9c45d93cfd8dedc2a87e302598f1")
     version("0.4.2", sha256="403ce0bf82358d237176053b0fb1e958cb6bfa4d0fb3555bf5801db6a6939b99")
@@ -27,4 +28,5 @@ class RCpp11(RPackage):
 
     depends_on("cxx", type="build")  # generated
 
-    depends_on("r@3.5.0:", when="@0.4.6:", type=("build", "run"))
+    depends_on("r@3.5.0:", when="@0.4.6:0.4", type=("build", "run"))
+    depends_on("r@4.0.0:", when="@0.5.1:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_ggpattern/package.py
+++ b/repos/spack_repo/builtin/packages/r_ggpattern/package.py
@@ -1,0 +1,31 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.r import RPackage
+
+from spack.package import *
+
+
+class RGgpattern(RPackage):
+    """Provides 'ggplot2' geoms filled with various patterns.
+    Includes a patterned version of every 'ggplot2' geom that has a region that can be
+    filled with a pattern. Provides a suite of 'ggplot2' aesthetics and scales for
+    controlling pattern appearances. Supports over a dozen builtin patterns (every
+    pattern implemented by 'gridpattern') as well as allowing custom user-defined patterns.
+    """
+
+    cran = "ggpattern"
+
+    license("MIT")
+
+    version("1.2.1", sha256="bf6d4df5636c791b1cb8f4d96ac97cc56f9d7f502088de7116f2f795f4ea5827")
+
+    depends_on("r-cli", type=("build", "run"))
+    depends_on("r-ggplot2@3.5.1:", type=("build", "run"))
+    depends_on("r-glue", type=("build", "run"))
+    depends_on("r-gridpattern@1.2.2:", type=("build", "run"))
+    depends_on("r-lifecycle", type=("build", "run"))
+    depends_on("r-rlang@1.1.3:", type=("build", "run"))
+    depends_on("r-scales", type=("build", "run"))
+    depends_on("r-vctrs", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_gridpattern/package.py
+++ b/repos/spack_repo/builtin/packages/r_gridpattern/package.py
@@ -1,0 +1,27 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.r import RPackage
+
+from spack.package import *
+
+
+class RGridpattern(RPackage):
+    """Provides 'grid' grobs that fill in a user-defined area with various patterns.
+    Includes enhanced versions of the geometric and image-based patterns originally
+    contained in the 'ggpattern' package as well as original 'pch', 'polygon_tiling',
+    'regular_polygon', 'rose', 'text', 'wave', and 'weave' patterns plus support for
+    custom user-defined patterns."""
+
+    cran = "gridpattern"
+
+    license("MIT")
+
+    version("1.3.1", sha256="2e67ff7c4e381a4ce60fbc368d1fd01917503a970f3179641501ccbb7d8acea5")
+
+    depends_on("r-glue", type=("build", "run"))
+    depends_on("r-memoise", type=("build", "run"))
+    depends_on("r-png", type=("build", "run"))
+    depends_on("r-rlang", type=("build", "run"))
+    depends_on("r-sf", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_sf/package.py
+++ b/repos/spack_repo/builtin/packages/r_sf/package.py
@@ -20,6 +20,7 @@ class RSf(RPackage):
 
     license("GPL-2.0-only OR MIT")
 
+    version("1.0-23", sha256="4a44abad6e94b648b8a31269fa5a5ff862f69a9dfcdd60b8958a5b9ee3bddceb")
     version("1.0-16", sha256="e96e191011cdf2a073c773bdfc50ffd4a5d80f1da0ba1aa05db8015da45a9987")
     version("1.0-12", sha256="3778ebf58d824b1dfa6297ca8363714d5d85eda04c55ab2bf39597cac1d91287")
     version("1.0-9", sha256="85c0c71a0a64750281e79aa96e36d13e6285927008b2d37d699e52aba7d8013b")
@@ -30,7 +31,8 @@ class RSf(RPackage):
     version("0.7-7", sha256="d1780cb46a285b30c7cc41cae30af523fbc883733344e53f7291e2d045e150a4")
     version("0.7-5", sha256="53ed0567f502216a116c4848f5a9262ca232810f82642df7b98e0541a2524868")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("r@3.3.0:", type=("build", "run"))
     depends_on("r-classint@0.2-1:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/r_wk/package.py
+++ b/repos/spack_repo/builtin/packages/r_wk/package.py
@@ -21,6 +21,7 @@ class RWk(RPackage):
 
     license("MIT")
 
+    version("0.9.4", sha256="b973dd5fa9aed94efc7ea4027146e804ba54df818a71278d6a5b7df0ae9e348b")
     version("0.9.2", sha256="33675edd9baedb09bf69a3a55fec3190e2bf57a5f4f63f94bc06861b5e83e5f8")
     version("0.7.2", sha256="6f8b72f54e2efea62fda8bc897124b43a39b81cffa9569103d06d95f946eab2f")
     version("0.7.0", sha256="e24327d38f2ff2d502c67c60eba3b4e44079a64ed8b805df64f231dc4712a2de")


### PR DESCRIPTION
- adds the new `r-ggpattern` and required `r-gridpattern` packages
- updates a couple of the dependencies
- fixes missing compiler for `r-sf`