### PR TITLE
chapel package -- add requires for gcc version

### DIFF
--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -477,6 +477,12 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     conflicts("platform=windows")  # Support for windows is through WSL only
 
+    requires(
+        "%gcc@9:12",
+        msg="Chapel requires GCC 9–12 due to LLVM and libstdc++ compatibility"
+    )
+
+
     # Ensure GPU support is Sticky: never allow the concretizer to choose this
     variant("rocm", default=False, sticky=True, description="Enable AMD ROCm GPU support")
     variant("cuda", default=False, sticky=True, description="Enable Nvidia CUDA GPU support")

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -478,7 +478,9 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     conflicts("platform=windows")  # Support for windows is through WSL only
 
     # Only apply if concretizer picked gcc
-    conflicts("%gcc@:7.3", when="%gcc", msg="Chapel requires GCC >= 7.4 (C++17) per Chapel prerequisites")
+    conflicts(
+        "%gcc@:7.3", when="%gcc", msg="Chapel requires GCC >= 7.4 (C++17) per Chapel prerequisites"
+    )
 
     # Ensure GPU support is Sticky: never allow the concretizer to choose this
     variant("rocm", default=False, sticky=True, description="Enable AMD ROCm GPU support")

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -477,11 +477,8 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     conflicts("platform=windows")  # Support for windows is through WSL only
 
-    requires(
-        "%gcc@9:12",
-        msg="Chapel requires GCC 9–12 due to LLVM and libstdc++ compatibility"
-    )
-
+    # Only apply if concretizer picked gcc
+    conflicts("%gcc@:7.3", when="%gcc", msg="Chapel requires GCC >= 7.4 (C++17) per Chapel prerequisites")
 
     # Ensure GPU support is Sticky: never allow the concretizer to choose this
     variant("rocm", default=False, sticky=True, description="Enable AMD ROCm GPU support")


### PR DESCRIPTION
Add GCC compiler constraints to the Chapel Spack package to prevent unsupported compiler configurations and avoid LLVM/libstdc++ incompatibility issues.
