### PR TITLE
gaudi: workaround test-dependency bug with a `when`

### DIFF
--- a/repos/spack_repo/builtin/packages/gaudi/package.py
+++ b/repos/spack_repo/builtin/packages/gaudi/package.py
@@ -165,7 +165,7 @@ class Gaudi(CMakePackage, CudaPackage):
     depends_on("fmt@:8", when="@:36.9")
     depends_on("fmt@:10", when="@:38")
     depends_on("fmt@:11", when="@:39")
-    depends_on("fmt@:10", type="test")  # https://gitlab.cern.ch/gaudi/Gaudi/-/issues/345
+    depends_on("fmt@:10", when="@36.15:", type="test")  # https://gitlab.cern.ch/gaudi/Gaudi/-/issues/345
     depends_on("intel-tbb@:2020.3", when="@:37.0")
     depends_on("tbb", when="@37.1:")
     depends_on("uuid")

--- a/repos/spack_repo/builtin/packages/gaudi/package.py
+++ b/repos/spack_repo/builtin/packages/gaudi/package.py
@@ -165,9 +165,11 @@ class Gaudi(CMakePackage, CudaPackage):
     depends_on("fmt@:8", when="@:36.9")
     depends_on("fmt@:10", when="@:38")
     depends_on("fmt@:11", when="@:39")
-    depends_on(
-        "fmt@:10", when="@36.15:", type="test"
-    )  # https://gitlab.cern.ch/gaudi/Gaudi/-/issues/345
+    with when("@36.15:"):
+        # GaudiKernel/tests/src/test_PropertyHolder.cpp
+        # https://gitlab.cern.ch/gaudi/Gaudi/-/issues/345
+        depends_on("fmt@:10", type="test")
+        depends_on("fmt@:10", when="+examples")
     depends_on("intel-tbb@:2020.3", when="@:37.0")
     depends_on("tbb", when="@37.1:")
     depends_on("uuid")

--- a/repos/spack_repo/builtin/packages/gaudi/package.py
+++ b/repos/spack_repo/builtin/packages/gaudi/package.py
@@ -165,7 +165,9 @@ class Gaudi(CMakePackage, CudaPackage):
     depends_on("fmt@:8", when="@:36.9")
     depends_on("fmt@:10", when="@:38")
     depends_on("fmt@:11", when="@:39")
-    depends_on("fmt@:10", when="@36.15:", type="test")  # https://gitlab.cern.ch/gaudi/Gaudi/-/issues/345
+    depends_on(
+        "fmt@:10", when="@36.15:", type="test"
+    )  # https://gitlab.cern.ch/gaudi/Gaudi/-/issues/345
     depends_on("intel-tbb@:2020.3", when="@:37.0")
     depends_on("tbb", when="@37.1:")
     depends_on("uuid")


### PR DESCRIPTION
In #68 we added a more restrictive `fmt@:10` test dependency compared to the build/link/run dependency which is merely `fmt`. Both are declared without a `when` clause. That causes them to be [merged incorrectly](https://github.com/spack/spack/issues/51775) and we end up imposing the restrictive `fmt@:10` as build/link/run/test dependency.

Since dependencies are now [indexed by `when` clause](https://github.com/spack/spack/pull/40326), we can avoid this dependency merging bug by splitting the two problematic `depends_on` directives so they don't have the same `when` clause. This PR does exactly that and imposes the test dependency only for versions of `gaudi` where [the problematic check was included](https://gitlab.cern.ch/gaudi/Gaudi/-/commit/4dc10ab6ad578366d60e361fa8cbd3c54d726d27).

With this change, the reproducer in https://github.com/spack/spack/issues/51775 concretizes without conflicts and indeed gives a `gaudi ^fmt@11` solution.