### PR TITLE
namd: Fixing missing space in flags for intel/intel-oneapi-compilers

### DIFF
--- a/repos/spack_repo/builtin/packages/namd/package.py
+++ b/repos/spack_repo/builtin/packages/namd/package.py
@@ -157,7 +157,7 @@ class Namd(MakefilePackage, CudaPackage, ROCmPackage):
                         "gcc": m64
                         + "-O3 -fexpensive-optimizations -ffast-math -lpthread "
                         + archopt,
-                        "intel": "-O2 -ip -qopenmp-simd" + archopt,
+                        "intel": "-O2 -ip -qopenmp-simd " + archopt,
                         "clang": m64 + "-O3 -ffast-math -fopenmp " + archopt,
                         "aocc": m64 + "-O3 -ffp-contract=fast -ffast-math -fopenmp " + archopt,
                     }
@@ -170,7 +170,7 @@ class Namd(MakefilePackage, CudaPackage, ROCmPackage):
                         "clang": m64 + "-O3 -ffast-math -fopenmp " + archopt,
                         "aocc": m64 + "-O3 -ffp-contract=fast -ffast-math " + archopt,
                         "intel-oneapi-compilers": m64
-                        + "-O3 -ffp-contract=fast -ffast-math"
+                        + "-O3 -ffp-contract=fast -ffast-math "
                         + archopt,
                     }
 


### PR DESCRIPTION
The `namd` package configuration for intel/intel-oneapi-compilers produces invalid compiler flags due to a missing space separator.

This causes the optimization flags and the architecture flags (contained in archopt) to be concatenated without a space. For example, if archopt is `-march=skylake-avx512`, the resulting flag becomes `-ffast-math-march=skylake-avx512`, which causes the build to fail.

**Proposed Change**: Add a trailing space

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
