### PR TITLE
gaudi: disentangle tests and examples as of 38.2

### DIFF
--- a/repos/spack_repo/builtin/packages/gaudi/package.py
+++ b/repos/spack_repo/builtin/packages/gaudi/package.py
@@ -184,10 +184,11 @@ class Gaudi(CMakePackage, CudaPackage):
     depends_on("py-pytest-cov", when="@39:")
 
     # Testing dependencies
-    # Note: gaudi only builds examples when testing enabled
     for pv in (["catch2", "@36.8:"], ["py-nose", "@35:37"], ["py-pytest", "@36.2:"]):
         depends_on(pv[0], when=pv[1], type="test")
-        depends_on(pv[0], when=pv[1] + " +examples")
+        with when("@:38.1"):
+            # Note: until 38.1 gaudi only builds examples when testing enabled
+            depends_on(pv[0], when=pv[1] + " +examples")
 
     # Adding these dependencies triggers the build of most optional components
     depends_on("cppunit", when="+cppunit")
@@ -214,8 +215,8 @@ class Gaudi(CMakePackage, CudaPackage):
 
     def cmake_args(self):
         args = [
-            # Note: gaudi only builds examples when testing enabled
-            self.define("BUILD_TESTING", self.run_tests or self.spec.satisfies("+examples")),
+            # Note: until 38.1, gaudi only builds examples when testing enabled
+            self.define("BUILD_TESTING", self.run_tests or self.spec.satisfies("@:38.1 +examples")),
             self.define_from_variant("GAUDI_BUILD_EXAMPLES", "examples"),
             self.define_from_variant("GAUDI_USE_AIDA", "aida"),
             self.define_from_variant("GAUDI_USE_CPPUNIT", "cppunit"),

--- a/repos/spack_repo/builtin/packages/gaudi/package.py
+++ b/repos/spack_repo/builtin/packages/gaudi/package.py
@@ -216,7 +216,9 @@ class Gaudi(CMakePackage, CudaPackage):
     def cmake_args(self):
         args = [
             # Note: until 38.1, gaudi only builds examples when testing enabled
-            self.define("BUILD_TESTING", self.run_tests or self.spec.satisfies("@:38.1 +examples")),
+            self.define(
+                "BUILD_TESTING", self.run_tests or self.spec.satisfies("@:38.1 +examples")
+            ),
             self.define_from_variant("GAUDI_BUILD_EXAMPLES", "examples"),
             self.define_from_variant("GAUDI_USE_AIDA", "aida"),
             self.define_from_variant("GAUDI_USE_CPPUNIT", "cppunit"),


### PR DESCRIPTION
This PR disentangles the `gaudi` variant `examples`, and the testing dependencies. This was changed in time for 38.2, https://gitlab.cern.ch/gaudi/Gaudi/-/commit/ed42ae5fa, when the previous GaudiExamples was renamed to GaudiTestSuite, and a new GaudiExamples collection was started which is independent of the test suite. As of 38.2, we can build examples independently of setting `BUILD_TESTING=ON`.

See also discussion at https://github.com/spack/spack-packages/pull/2825.