### PR TITLE
Python: more changes for free-threaded support

### DIFF
--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -306,6 +306,14 @@ class Python(Package):
         else:
             variants += "~pythoncmd"
 
+        if Version(version_str) >= Version("3.13"):
+            for exe in exes:
+                if exe.endswith("t"):
+                    variants += "+freethreading"
+                    break
+            else:
+                variants += "~freethreading"
+
         for module in [
             "readline",
             "sqlite3",
@@ -857,12 +865,18 @@ class Python(Package):
         # installed python, several different commands could be located
         # in the same directory. Be as specific as possible. Search for:
         #
-        # * python3.11
+        # * python3.14t
+        # * python3.14
         # * python3
         # * python
         #
-        # in that order if using python@3.11.0, for example.
-        suffixes = [self.spec.version.up_to(2), self.spec.version.up_to(1), ""]
+        # in that order if using python@3.14.0, for example.
+        suffixes = [
+            self.spec.version.up_to(2) + "t",
+            self.spec.version.up_to(2),
+            self.spec.version.up_to(1),
+            "",
+        ]
         ext = "" if sys.platform != "win32" else ".exe"
         filenames = [f"python{ver}{ext}" for ver in suffixes]
         root = self.prefix.bin if sys.platform != "win32" else self.prefix

--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -872,9 +872,9 @@ class Python(Package):
         #
         # in that order if using python@3.14.0, for example.
         suffixes = [
-            self.spec.version.up_to(2) + "t",
-            self.spec.version.up_to(2),
-            self.spec.version.up_to(1),
+            str(self.spec.version.up_to(2)) + "t",
+            str(self.spec.version.up_to(2)),
+            str(self.spec.version.up_to(1)),
             "",
         ]
         ext = "" if sys.platform != "win32" else ".exe"


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Follow-up to #2632 

There are probably other places we should change too, like `site-packages` becomes `pythonX.Yt`, but we can fix things as we discover bugs.

@BaLinuss @wdconinc @rgommers 