### PR TITLE
boost: better oneapi support

### DIFF
--- a/repos/spack_repo/builtin/packages/boost/oneapi_pthread.patch
+++ b/repos/spack_repo/builtin/packages/boost/oneapi_pthread.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/build/src/engine/build.sh b/tools/build/src/engine/build.sh
+index 29d08fcbe..48fefb8e6 100755
+--- a/tools/build/src/engine/build.sh
++++ b/tools/build/src/engine/build.sh
+@@ -180,7 +180,7 @@ check_toolset ()
+     fi
+     # Intel oneAPI (intel-linux)
+     if test_toolset intel-linux && test_path icpx ; then
+-        if test_compiler icpx -x c++ -std=c++11 ; then B2_TOOLSET=intel-linux ; return ${TRUE} ; fi
++        if test_compiler icpx -x c++ -std=c++11 -pthread; then B2_TOOLSET=intel-linux ; return ${TRUE} ; fi
+     fi
+     if test_toolset intel-linux && test_path icc ; then
+         if test_compiler icc -x c++ -std=c++11 ; then B2_TOOLSET=intel-linux ; return ${TRUE} ; fi

--- a/repos/spack_repo/builtin/packages/boost/package.py
+++ b/repos/spack_repo/builtin/packages/boost/package.py
@@ -320,6 +320,9 @@ class Boost(Package):
     # (https://github.com/spack/spack/pull/32879#issuecomment-1265933265)
     conflicts("%oneapi", when="@1.80")
 
+    # Boost did not support the oneapi compilers prior to 1.76
+    conflicts("%oneapi@2023:", when="@:1.75")
+
     # Boost 1.85.0 stacktrace added a hard compilation error that has to
     # explicitly be suppressed on some platforms:
     # https://github.com/boostorg/stacktrace/pull/150. This conflict could be
@@ -465,6 +468,13 @@ class Boost(Package):
 
     # https://www.intel.com/content/www/us/en/developer/articles/technical/building-boost-with-oneapi.html
     patch("intel-oneapi-linux-jam.patch", when="@1.76: %oneapi")
+
+    # https://github.com/spack/spack/issues/44003
+    patch(
+        "oneapi_pthread.patch",
+        sha256="7845717c5d916fabc0e62eb6e1f5ad8f13baaf4a4b71b99b19847703386064c4",
+        when="@1.76: %oneapi@2022:",
+    )
 
     # https://github.com/boostorg/phoenix/issues/111
     patch("boost_phoenix_1.81.0.patch", level=2, when="@1.81.0:1.82.0")


### PR DESCRIPTION
This adds a patch to boost so the bootstrapping process can more reliably test the icpx compiler.
It also adds a `conflicts` statement since oneapi support wasn't added to boost until later.

I have not done an extensive test of all the versions of boost and oneapi, but this was sufficient to work in my case.
I worked out the patch based on the suggestion in [an old issue](https://github.com/spack/spack/issues/44003).
I was able to figure out which version of boost added support for oneapi based on the date on the [blame of the line that the patch is affecting](https://github.com/boostorg/build/blame/be69c44857e34fae250aa1321808a05c1d88bfde/src/engine/build.sh#L183), and the dates of the [boost releases](https://sourceforge.net/projects/boost/files/boost/).
I [determined that](https://share.google/aimode/yuAMlx9ZICbpa15tL) `icpx` was added to the oneapi distribution in 2022, so that's probably when the patch should be used.
I also [determined that](https://share.google/aimode/63Qiy1Cm3WPlCvXcu) `icc` was dropped from the oneapi distribution in 2023, so boost versions that don't support `icpx` probably won't work.

I'll also note that there might be some additional cases when the patch might not be strictly necessary, as I heard from someone that they were able to build boost with oneapi distributions without it. Not quite sure why it didn't work on my system then, but this did fix it, and while it might be superfluous in other cases, it shouldn't hurt anything.