### PR TITLE
gaudi: add v40.2, disable cppunit variant

### DIFF
--- a/repos/spack_repo/builtin/packages/gaudi/package.py
+++ b/repos/spack_repo/builtin/packages/gaudi/package.py
@@ -73,7 +73,7 @@ class Gaudi(CMakePackage, CudaPackage):
     variant("cxxstd", default="20", when="@39:", **_cxxstd_common)
 
     variant("aida", default=False, description="Build AIDA interfaces support")
-    variant("cppunit", default=False, description="Build with CppUnit unit testing")
+    variant("cppunit", default=False, description="Build with CppUnit unit testing", when="@:40.0")
     variant("docs", default=False, description="Build documentation with Doxygen")
     variant("examples", default=False, description="Build examples")
     variant("gaudialg", default=False, description="Build GaudiAlg support", when="@37.0:38")

--- a/repos/spack_repo/builtin/packages/gaudi/package.py
+++ b/repos/spack_repo/builtin/packages/gaudi/package.py
@@ -18,6 +18,7 @@ class Gaudi(CMakePackage, CudaPackage):
     tags = ["hep"]
 
     version("master", branch="master")
+    version("40.2", sha256="93bf0ae5e33d7d3a5aa36504840ed62aeab9f6f8ddddd4ea1b23bc5455b51e41")
     version("40.1", sha256="f02010c865717d397b8fc8b8bf5d904e711ee2e416f3d12330cf04deaa7a4343")
     version("40.0", sha256="0cfe696967067b23382968a5c5ab1b4b7f38a7dd3ee2e321d1bff0dd8f99d2f9")
     version("39.4", sha256="dd698e0788811fa8325ed5f37ecf3fd9bde55720489224a517b52360819564d7")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Dependency on `cppunit` was removed in v40.1 https://gitlab.cern.ch/gaudi/Gaudi/-/merge_requests/1827