### PR TITLE
thrift: make sure the python variant exists for CMake

### DIFF
--- a/repos/spack_repo/builtin/packages/thrift/package.py
+++ b/repos/spack_repo/builtin/packages/thrift/package.py
@@ -52,7 +52,6 @@ class Thrift(CMakePackage, AutotoolsPackage):
         "python",
         default=True,
         description="Build support for python",
-        when="build_system=autotools",
     )
 
     build_system("cmake", "autotools", default="autotools")

--- a/repos/spack_repo/builtin/packages/thrift/package.py
+++ b/repos/spack_repo/builtin/packages/thrift/package.py
@@ -48,11 +48,7 @@ class Thrift(CMakePackage, AutotoolsPackage):
     variant("java", default=False, description="Build support for java")
     variant("javascript", default=False, description="Build Javascript library")
     variant("nodejs", default=False, description="Build NodeJS library")
-    variant(
-        "python",
-        default=True,
-        description="Build support for python",
-    )
+    variant("python", default=True, description="Build support for python")
 
     build_system("cmake", "autotools", default="autotools")
 


### PR DESCRIPTION
Currently, compilation with CMake will fail because `py-setuptools` is not found. This happens because the python variant doesn't exist with CMake and `WITH_PYTHON` is set to True. Now, with CMake the python variant has to be set to False because of the conflict.