### PR TITLE
geant4: disable the timemory variant starting with 11.3.0

### DIFF
--- a/repos/spack_repo/builtin/packages/geant4/package.py
+++ b/repos/spack_repo/builtin/packages/geant4/package.py
@@ -78,7 +78,7 @@ class Geant4(CMakePackage):
     variant("hdf5", default=False, description="Enable HDF5 support", when="@10.4:")
     variant("python", default=False, description="Enable Python bindings", when="@10.6.2:11.0")
     variant("tbb", default=False, description="Use TBB as a tasking backend", when="@11:")
-    variant("timemory", default=False, description="Use TiMemory for profiling", when="@9.5:")
+    variant("timemory", default=False, description="Use TiMemory for profiling", when="@9.5:11.2")
     variant("vtk", default=False, description="Enable VTK support", when="@11:")
 
     # For most users, obtaining the Geant4 data via Spack will be useful; the


### PR DESCRIPTION
This variant has been removed in Geant4 11.3.0. See https://geant4-data.web.cern.ch/ReleaseNotes/ReleaseNotes.11.3.html.