### PR TITLE
adds v2025.12.16 support to the arkouda and py_arkouda packages

### DIFF
--- a/repos/spack_repo/builtin/packages/arkouda/makefile-fpic-2025.12.16.patch
+++ b/repos/spack_repo/builtin/packages/arkouda/makefile-fpic-2025.12.16.patch
@@ -1,0 +1,23 @@
+diff --git a/make/Prologue.mk b/make/Prologue.mk
+index 13a9c4be1..099896ec9 100644
+--- a/make/Prologue.mk
++++ b/make/Prologue.mk
+@@ -236,15 +236,15 @@ compile-arrow-cpp:
+
+ .PHONY: compile-arrow-write
+ compile-arrow-write:
+-	$(CHPL_CXX) -O3 -std=c++17 -c $(ARROW_WRITE_CPP) -o $(ARROW_WRITE_O) $(INCLUDE_FLAGS) $(ARROW_SANITIZE)
++	$(CHPL_CXX) -O3 -std=c++17 -fPIC -c $(ARROW_WRITE_CPP) -o $(ARROW_WRITE_O) $(INCLUDE_FLAGS) $(ARROW_SANITIZE)
+
+ .PHONY: compile-arrow-read
+ compile-arrow-read:
+-	$(CHPL_CXX) -O3 -std=c++17 -c $(ARROW_READ_CPP) -o $(ARROW_READ_O) $(INCLUDE_FLAGS) $(ARROW_SANITIZE)
++	$(CHPL_CXX) -O3 -std=c++17 -fPIC -c $(ARROW_READ_CPP) -o $(ARROW_READ_O) $(INCLUDE_FLAGS) $(ARROW_SANITIZE)
+
+ .PHONY: compile-arrow-util
+ compile-arrow-util:
+-	$(CHPL_CXX) -O3 -std=c++17 -c $(ARROW_UTIL_CPP) -o $(ARROW_UTIL_O) $(INCLUDE_FLAGS) $(ARROW_SANITIZE)
++	$(CHPL_CXX) -O3 -std=c++17 -fPIC -c $(ARROW_UTIL_CPP) -o $(ARROW_UTIL_O) $(INCLUDE_FLAGS) $(ARROW_SANITIZE)
+
+ $(ARROW_UTIL_O): $(ARROW_UTIL_CPP) $(ARROW_UTIL_H)
+ 	make compile-arrow-util

--- a/repos/spack_repo/builtin/packages/arkouda/package.py
+++ b/repos/spack_repo/builtin/packages/arkouda/package.py
@@ -28,6 +28,9 @@ class Arkouda(MakefilePackage):
     version("main", branch="main")
 
     version(
+        "2025.12.16", sha256="72638e9d8aa1889b6bafa76c6e8060e0c8aab0871be2693f8fb10f57cd4acbfa"
+    )
+    version(
         "2025.09.30", sha256="10f488a3ff3482b66f1b1e8a4235d72e91ad07acb932eca85d1e695f0f6155a2"
     )
     version(
@@ -76,6 +79,11 @@ class Arkouda(MakefilePackage):
     depends_on("libiconv", type=("build", "link", "run", "test"))
     depends_on("libidn2", type=("build", "link", "run", "test"))
     depends_on(
+        "arrow+brotli+bz2+lz4+parquet+snappy+zlib+zstd",
+        type=("build", "link", "run"),
+        when="@2025.12.16:",
+    )
+    depends_on(
         "arrow@:19+brotli+bz2+lz4+parquet+snappy+zlib+zstd",
         type=("build", "link", "run"),
         when="@:2025.01.13",
@@ -101,7 +109,8 @@ class Arkouda(MakefilePackage):
 
     # Some systems need explicit -fPIC flag when building the Arrow functions
     patch("makefile-fpic-2024.06.21.patch", when="@2024.06.21")
-    patch("makefile-fpic-2024.10.02.patch", when="@2024.10.02:")
+    patch("makefile-fpic-2024.10.02.patch", when="@2024.10.02:2025.09.30")
+    patch("makefile-fpic-2025.12.16.patch", when="@2025.12.16")
 
     sanity_check_is_file = [join_path("bin", "arkouda_server")]
 

--- a/repos/spack_repo/builtin/packages/py_arkouda/package.py
+++ b/repos/spack_repo/builtin/packages/py_arkouda/package.py
@@ -28,6 +28,9 @@ class PyArkouda(PythonPackage):
     version("main", branch="main")
 
     version(
+        "2025.12.16", sha256="72638e9d8aa1889b6bafa76c6e8060e0c8aab0871be2693f8fb10f57cd4acbfa"
+    )
+    version(
         "2025.09.30", sha256="10f488a3ff3482b66f1b1e8a4235d72e91ad07acb932eca85d1e695f0f6155a2"
     )
     version(
@@ -58,6 +61,7 @@ class PyArkouda(PythonPackage):
     depends_on("py-pandas@2.2.3:", when="@2025.07.03:")
     depends_on("py-pandas@1.4.0:", type=("build", "run"))
     conflicts("^py-pandas@2.2.0", msg="arkouda client not compatible with pandas 2.2.0")
+    depends_on("py-pyarrow", type=("build", "run"), when="@2025.12.16:")
     depends_on("py-pyarrow@:19", type=("build", "run"), when="@:2025.01.13")
     depends_on("py-pyarrow@15:19", type=("build", "run"), when="@2025.07.03:")
     depends_on("py-pyzmq@20:", type=("build", "run"))


### PR DESCRIPTION
Add Spack support for Arkouda 2025.12.16, including updated Arrow and pyarrow dependencies and a version-specific -fPIC patch for Arrow utility objects. This ensures successful builds with modern Arrow while preserving existing patch behavior for earlier Arkouda releases. 