### PR TITLE
GROMACS: patch v2025.0

### DIFF
--- a/repos/spack_repo/builtin/packages/gromacs/package.py
+++ b/repos/spack_repo/builtin/packages/gromacs/package.py
@@ -365,7 +365,8 @@ class Gromacs(CMakePackage, CudaPackage):
         sha256="9372c235719ca04d6dd418fb5943f773e03f05246e3e059a8578089b14b2420c",
         when="@2025.0",
     )
-    # 2025.0 
+    # https://gitlab.com/gromacs/gromacs/-/issues/5289
+    # https://gitlab.com/gromacs/gromacs/-/merge_requests/4965
     patch("pr4965-2025.0.patch", when="@2025.0")
 
     filter_compiler_wrappers(

--- a/repos/spack_repo/builtin/packages/gromacs/package.py
+++ b/repos/spack_repo/builtin/packages/gromacs/package.py
@@ -365,6 +365,8 @@ class Gromacs(CMakePackage, CudaPackage):
         sha256="9372c235719ca04d6dd418fb5943f773e03f05246e3e059a8578089b14b2420c",
         when="@2025.0",
     )
+    # 2025.0 
+    patch("pr4965-2025.0.patch", when="@2025.0")
 
     filter_compiler_wrappers(
         "*.cmake", relative_root=os.path.join("share", "cmake", "gromacs_mpi")

--- a/repos/spack_repo/builtin/packages/gromacs/pr4965-2025.0.patch
+++ b/repos/spack_repo/builtin/packages/gromacs/pr4965-2025.0.patch
@@ -1,0 +1,16 @@
+diff --git a/src/gromacs/domdec/ga2la.cpp b/src/gromacs/domdec/ga2la.cpp
+index f8de0a23f92f0bf50afbd996e4c062e9909b74e8..32999842220b671fc6e93ce9418f938f083666cd 100644
+--- a/src/gromacs/domdec/ga2la.cpp
++++ b/src/gromacs/domdec/ga2la.cpp
+@@ -80,8 +80,9 @@ gmx_ga2la_t::gmx_ga2la_t(int numAtomsTotal, int numAtomsLocal) :
+     }
+     else
+     {
+-        new (&(data_.hashed))
+-                gmx::HashedMap<Entry>(numAtomsLocal, gmx_omp_nthreads_get(ModuleMultiThread::Domdec));
++        // We would like to be able to use more than 1 thread for clearing the hashed map,
++        // but the gmx_omp_nthreads might not be initialized at this point. See #5289
++        new (&(data_.hashed)) gmx::HashedMap<Entry>(numAtomsLocal);
+     }
+ }
+ 


### PR DESCRIPTION
https://gitlab.com/gromacs/gromacs/-/merge_requests/4965

(The PR can't be applied directly because applying the patch fails due to the release note changes.)