### PR TITLE
Axom: Update ROCm root var

### DIFF
--- a/repos/spack_repo/builtin/packages/axom/package.py
+++ b/repos/spack_repo/builtin/packages/axom/package.py
@@ -374,7 +374,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
 
             hip_link_flags = ""
 
-            rocm_root = spec["llvm-amdgpu"].prefix
+            rocm_root = os.path.dirname(spec["llvm-amdgpu"].prefix)
             entries.append(cmake_cache_path("ROCM_ROOT_DIR", rocm_root))
 
             # Recommended MPI flags

--- a/repos/spack_repo/builtin/packages/mfem/package.py
+++ b/repos/spack_repo/builtin/packages/mfem/package.py
@@ -767,7 +767,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
                     hypre_rocm_libs += hypre["rocsparse"].libs
                 if "^rocrand" in hypre:
                     hypre_rocm_libs += hypre["rocrand"].libs
-                if hypre.satisfies("@2.26.0:"):
+                if hypre.satisfies("@2.29.0:"):
                     if "^rocsolver" in hypre:
                         hypre_rocm_libs += hypre["rocsolver"].libs
                     if "^rocblas" in hypre:

--- a/repos/spack_repo/builtin/packages/mfem/package.py
+++ b/repos/spack_repo/builtin/packages/mfem/package.py
@@ -767,7 +767,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
                     hypre_rocm_libs += hypre["rocsparse"].libs
                 if "^rocrand" in hypre:
                     hypre_rocm_libs += hypre["rocrand"].libs
-                if hypre.satisfies("@2.39.0:"):
+                if hypre.satisfies("@2.29.0:"):
                     if "^rocsolver" in hypre:
                         hypre_rocm_libs += hypre["rocsolver"].libs
                     if "^rocblas" in hypre:

--- a/repos/spack_repo/builtin/packages/mfem/package.py
+++ b/repos/spack_repo/builtin/packages/mfem/package.py
@@ -767,7 +767,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
                     hypre_rocm_libs += hypre["rocsparse"].libs
                 if "^rocrand" in hypre:
                     hypre_rocm_libs += hypre["rocrand"].libs
-                if hypre.satisfies("@2.29.0:"):
+                if hypre.satisfies("@2.26.0:"):
                     if "^rocsolver" in hypre:
                         hypre_rocm_libs += hypre["rocsolver"].libs
                     if "^rocblas" in hypre:


### PR DESCRIPTION
Similar to https://github.com/spack/spack-packages/pull/2365, this PR updates Axom var `rocm_root` to move a previous directory back from `llvm-amdgpu` prefix. The assumption is the prefix is `/opt/rocm-6.4.2/llvm`.

If other's set the `llvm-amdgpu` prefix differently than below, maybe we can handle both cases.

```yaml
    llvm-amdgpu:
      externals:
      - spec: llvm-amdgpu@6.4.2
        prefix: /opt/rocm-6.4.2/llvm
        extra_attributes:
          compilers:
            c: /opt/rocm-6.4.2/llvm/bin/amdclang
            cxx: /opt/rocm-6.4.2/llvm/bin/amdclang++
            fortran: /opt/rocm-6.4.2/llvm/bin/amdflang
```

Also adds unrelated fix to an incorrect version in MFEM from a previous PR of mine https://github.com/spack/spack-packages/pull/2363#discussion_r2562195648