### PR TITLE
nlohmann-json: patch method for c++20 module support

### DIFF
--- a/repos/spack_repo/builtin/packages/nlohmann_json/package.py
+++ b/repos/spack_repo/builtin/packages/nlohmann_json/package.py
@@ -58,6 +58,7 @@ class NlohmannJson(CMakePackage):
     def patch(self):
         if self.spec.satisfies("@3.11.0:3.12.0"):
             # Ensure no TU-local entities for C++20 modules
+            # (https://github.com/nlohmann/json/pull/4764)
             for f in [
                 "include/nlohmann/detail/input/binary_reader.hpp",
                 "single_include/nlohmann/json.hpp",

--- a/repos/spack_repo/builtin/packages/nlohmann_json/package.py
+++ b/repos/spack_repo/builtin/packages/nlohmann_json/package.py
@@ -55,6 +55,25 @@ class NlohmannJson(CMakePackage):
     conflicts("%gcc@:4.8", when="@:3.2.9")
     conflicts("%intel@:16")
 
+    def patch(self):
+        if self.spec.satisfies("@3.11.0:3.12.0"):
+            # Ensure no TU-local entities for C++20 modules
+            for f in [
+                "include/nlohmann/detail/input/binary_reader.hpp",
+                "single_include/nlohmann/json.hpp",
+            ]:
+                filter_file(
+                    "static inline bool little_endianness",
+                    "inline bool little_endianness",
+                    f,
+                    string=True,
+                )
+            for f in [
+                "include/nlohmann/detail/string_escape.hpp",
+                "single_include/nlohmann/json.hpp",
+            ]:
+                filter_file("static void unescape", "inline void unescape", f, string=True)
+
     def cmake_args(self):
         return [
             self.define_from_variant("JSON_MultipleHeaders", "multiple_headers"),


### PR DESCRIPTION
This PR adds to `nlohmann-json` two changes from static to inline to allow the latest release to be used in C++20 modules, see https://github.com/nlohmann/json/pull/4764.