### PR TITLE
HEP: set URL fetch method to curl with retry

### DIFF
--- a/stacks/hep/spack.yaml
+++ b/stacks/hep/spack.yaml
@@ -7,6 +7,10 @@ spack:
   concretizer:
     static_analysis: true
 
+  config:
+    # ROOT fails downloads frequentlysleads
+    url_fetch_method: curl --continue-at - --retry 3 --retry-all-errors
+
   packages:
     all:
       target: ["x86_64_v3"]

--- a/stacks/hep/spack.yaml
+++ b/stacks/hep/spack.yaml
@@ -8,7 +8,7 @@ spack:
     static_analysis: true
 
   config:
-    # ROOT fails downloads frequentlysleads
+    # ROOT fails downloads frequently
     url_fetch_method: curl --continue-at - --retry 3 --retry-all-errors
 
   packages:


### PR DESCRIPTION
This PR explicitly defines a `url_fetch_strategy` for the HEP stack to ensure retry with continuation to get around the flaky `root` download server (and lack of spack source caching) leading to CI errors, e.g. https://gitlab.spack.io/spack/spack-packages/-/jobs/19672806.