### PR TITLE
globus-*: Grid Community Toolkit package updates to v6.2.20251212 bundle

### DIFF
--- a/repos/spack_repo/builtin/packages/globus_common/package.py
+++ b/repos/spack_repo/builtin/packages/globus_common/package.py
@@ -24,6 +24,7 @@ class GlobusCommon(AutotoolsPackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    version("18.15", sha256="b47485bbf1118976f347dcfe539a2116725f6c202d438c4ef109d282340464d5")
     version("18.14", sha256="22368942a78e608d8fe6d9f7379abc628e2bd7af54a98c7d2bddc265d6f0ba45")
 
     depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/globus_ftp_client/package.py
+++ b/repos/spack_repo/builtin/packages/globus_ftp_client/package.py
@@ -24,6 +24,7 @@ class GlobusFtpClient(AutotoolsPackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    version("9.9", sha256="3ac4c2f9a50bed8e17b590c37363110c7b34bb44bb4dd356dca7cc6273c87db6")
     version("9.8", sha256="aa83229f70352e106fc29f28cef4fc8fdab37c794603e7b425f193d947e5926c")
 
     depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/globus_gass_transfer/package.py
+++ b/repos/spack_repo/builtin/packages/globus_gass_transfer/package.py
@@ -24,6 +24,7 @@ class GlobusGassTransfer(AutotoolsPackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    version("9.5", sha256="748f41997c7fd08166d9fda52d2418e89b2655a529ea079c8e3e5f2bfda564de")
     version("9.4", sha256="c5ad54d0e4959f7dc4131918ad9d40d49db2823b84aec8229127826a9601fbf9")
 
     depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/globus_gsi_credential/package.py
+++ b/repos/spack_repo/builtin/packages/globus_gsi_credential/package.py
@@ -24,6 +24,7 @@ class GlobusGsiCredential(AutotoolsPackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    version("8.5", sha256="abbcc12163299437bedad81de777b6cc36d3fb228fd37de414ca738f6ad14486")
     version("8.4", sha256="19e8fde9d4b335d60a021ac58c7559e5c34981e9332a8e574eda0b44ec160fa7")
 
     depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/globus_gsi_proxy_ssl/package.py
+++ b/repos/spack_repo/builtin/packages/globus_gsi_proxy_ssl/package.py
@@ -24,6 +24,7 @@ class GlobusGsiProxySsl(AutotoolsPackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    version("6.6", sha256="2b26087089993bf69d6827e9ce01c1afbc34d9ca8bf9d63cbcd55b5aae370f5b")
     version("6.5", sha256="4f20042d80a1fe28b40d9f7f4a1fc9f2790645e9b3f426a659b0c3f01eb04259")
 
     depends_on("c", type="build")


### PR DESCRIPTION
This PR adds the new versions of the client packages of the Grid Community Toolkit v6.2.20251212 that are in spack. Diff of this maintenance release is at https://github.com/gridcf/gct/compare/v6.2.20240202...v6.2.20251212.