### PR TITLE
cargo-c: fix compilation by depending on c and opennsl

### DIFF
--- a/repos/spack_repo/builtin/packages/cargo_c/package.py
+++ b/repos/spack_repo/builtin/packages/cargo_c/package.py
@@ -19,5 +19,13 @@ class CargoC(CargoPackage):
     version("0.10.17", sha256="a92b752f35e3ef54c992b2ba382466eb58a11020d13e62a25a4101bc055d5146")
     version("0.10.16", sha256="c0ebb3175393da5b55c3cd83ba1ae9d42d32e2aece6ceff1424239ffb68eb3e3")
 
+    depends_on("c", type="build")
+
+    depends_on("openssl", type="build")
     depends_on("rust@1.89:", type="build", when="@0.10.17:")
     depends_on("rust@1.88:", type="build", when="@0.10.16:")
+
+    def setup_dependent_build_environment(
+        self, env: EnvironmentModifications, dependent_spec: Spec
+    ) -> None:
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["openssl"].libs.directories[0])

--- a/repos/spack_repo/builtin/packages/cargo_c/package.py
+++ b/repos/spack_repo/builtin/packages/cargo_c/package.py
@@ -24,8 +24,3 @@ class CargoC(CargoPackage):
     depends_on("openssl")
     depends_on("rust@1.89:", type="build", when="@0.10.17:")
     depends_on("rust@1.88:", type="build", when="@0.10.16:")
-
-    def setup_dependent_build_environment(
-        self, env: EnvironmentModifications, dependent_spec: Spec
-    ) -> None:
-        env.prepend_path("LD_LIBRARY_PATH", self.spec["openssl"].libs.directories[0])

--- a/repos/spack_repo/builtin/packages/cargo_c/package.py
+++ b/repos/spack_repo/builtin/packages/cargo_c/package.py
@@ -21,7 +21,7 @@ class CargoC(CargoPackage):
 
     depends_on("c", type="build")
 
-    depends_on("openssl", type="build")
+    depends_on("openssl")
     depends_on("rust@1.89:", type="build", when="@0.10.17:")
     depends_on("rust@1.88:", type="build", when="@0.10.16:")
 


### PR DESCRIPTION
This fixes two issues. Compiling on Alma 9, I saw an error related to missing a linker for cc (similar to https://github.com/spack/spack-packages/pull/1606). Then, when compiling on Ubuntu 24.04 one of the crates complains about not finding OpenSSL:

```
2 errors found in build log:
     421       Compiling curl-sys v0.4.84+curl-8.17.0
     422       Compiling der v0.7.10
     423       Compiling filetime v0.2.26
     424       Compiling ryu v1.0.21
     425       Compiling libssh2-sys v0.3.1
     426    warning: openssl-sys@0.9.111: Could not find directory of OpenSSL installation, and this `-sys` crate cannot proceed without this k
            nowledge. If OpenSSL is installed and this crate had trouble finding it,  you can set the `OPENSSL_DIR` environment variable for th
            e compilation process. See stderr section below for further information.
  >> 427    error: failed to run custom build command for `openssl-sys v0.9.111`
     428
     429    Caused by:
     430      process didn't exit successfully: `/tmp/root/spack-stage/spack-stage-cargo-c-0.10.18-ucasmekvz5upojl65p63fyqvkjuiud2u/spack-src/t
            arget/release/build/openssl-sys-daf36cef7366224a/build-script-main` (exit status: 101)
     431      --- stdout
     432      cargo:rustc-check-cfg=cfg(osslconf, values("OPENSSL_NO_OCB", "OPENSSL_NO_SM4", "OPENSSL_NO_SEED", "OPENSSL_NO_CHACHA", "OPENSSL_N
            O_CAST", "OPENSSL_NO_IDEA", "OPENSSL_NO_CAMELLIA", "OPENSSL_NO_RC4", "OPENSSL_NO_BF", "OPENSSL_NO_PSK", "OPENSSL_NO_DEPRECATED_3_0"
            , "OPENSSL_NO_SCRYPT", "OPENSSL_NO_SM3", "OPENSSL_NO_RMD160", "OPENSSL_NO_EC2M", "OPENSSL_NO_OCSP", "OPENSSL_NO_CMS", "OPENSSL_NO_C
            OMP", "OPENSSL_NO_SOCK", "OPENSSL_NO_STDIO", "OPENSSL_NO_EC", "OPENSSL_NO_SSL3_METHOD", "OPENSSL_NO_KRB5", "OPENSSL_NO_TLSEXT", "OP
            ENSSL_NO_SRP", "OPENSSL_NO_SRTP", "OPENSSL_NO_RFC3779", "OPENSSL_NO_SHA", "OPENSSL_NO_NEXTPROTONEG", "OPENSSL_NO_ENGINE", "OPENSSL_
            NO_BUF_FREELISTS", "OPENSSL_NO_RC2"))
     433      cargo:rustc-check-cfg=cfg(openssl)

     ...

     543      $HOST = x86_64-unknown-linux-gnu
     544      $TARGET = x86_64-unknown-linux-gnu
     545      openssl-sys = 0.9.111
     546
     547
     548    warning: build failed, waiting for other jobs to finish...
  >> 549    error: failed to compile `cargo-c v0.10.18+cargo-0.92.0 (/tmp/root/spack-stage/spack-stage-cargo-c-0.10.18-ucasmekvz5upojl65p63fyqv
            kjuiud2u/spack-src)`, intermediate artifacts can be found at `/tmp/root/spack-stage/spack-stage-cargo-c-0.10.18-ucasmekvz5upojl65p6
            3fyqvkjuiud2u/spack-src/target`.
     550    To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

See build log for details:
  /tmp/root/spack-stage/spack-stage-cargo-c-0.10.18-ucasmekvz5upojl65p63fyqvkjuiud2u/spack-build-out.txt

```

and the dependent build environment is needed when building `librsvg`:
```
  >> 17    ../spack-src/meson.build:27:10: ERROR: Command `cargo-c/0.10.18-ukhhbp/bin/cargo-cbuild --version` failed with status 1.
```
which fails with:
```
/cargo-c/0.10.18-ukhhbp/bin/cargo-cbuild: /lib/x86_64-linux-gnu/libssl.so.3: version `OPENSSL_3.2.0' not found (required by /cargo-c/0.10.18-ukhhbp/bin/cargo-cbuild)
```