### PR TITLE
root: fix downstream dd4hep build when +rpath

### DIFF
--- a/repos/spack_repo/builtin/packages/dd4hep/package.py
+++ b/repos/spack_repo/builtin/packages/dd4hep/package.py
@@ -230,8 +230,10 @@ class Dd4hep(CMakePackage):
         env.set("DD4HEP", self.prefix.examples)
         env.set("DD4hep_DIR", self.prefix)
         env.set("DD4hep_ROOT", self.prefix)
-        if len(self.libs.directories) > 0:
-            env.prepend_path("LD_LIBRARY_PATH", self.libs.directories[0])
+
+    def setup_dependent_run_environment(self, env: EnvironmentModifications) -> None:
+        # Make plugins discoverable to ROOT
+        env.prepend_path("ROOT_LIBRARY_PATH", self.libs.directories[0])
 
     def url_for_version(self, version):
         # dd4hep releases are dashes and padded with a leading zero

--- a/repos/spack_repo/builtin/packages/dd4hep/package.py
+++ b/repos/spack_repo/builtin/packages/dd4hep/package.py
@@ -231,10 +231,6 @@ class Dd4hep(CMakePackage):
         env.set("DD4hep_DIR", self.prefix)
         env.set("DD4hep_ROOT", self.prefix)
 
-    def setup_dependent_run_environment(self, env: EnvironmentModifications) -> None:
-        # Make plugins discoverable to ROOT
-        env.prepend_path("ROOT_LIBRARY_PATH", self.libs.directories[0])
-
     def url_for_version(self, version):
         # dd4hep releases are dashes and padded with a leading zero
         # the patch version is omitted when 0

--- a/repos/spack_repo/builtin/packages/dd4hep/package.py
+++ b/repos/spack_repo/builtin/packages/dd4hep/package.py
@@ -230,6 +230,8 @@ class Dd4hep(CMakePackage):
         env.set("DD4HEP", self.prefix.examples)
         env.set("DD4hep_DIR", self.prefix)
         env.set("DD4hep_ROOT", self.prefix)
+        if len(self.libs.directories) > 0:
+            env.prepend_path("LD_LIBRARY_PATH", self.libs.directories[0])
 
     def url_for_version(self, version):
         # dd4hep releases are dashes and padded with a leading zero

--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -609,7 +609,8 @@ class Root(CMakePackage):
         _add_variant(v, f, "roofit", "+roofit")
         # webui feature renamed to webgui in 6.18
         _add_variant(v, f, ("root7", "webgui"), "+webgui")
-        _add_variant(v, f, "rpath", "+rpath")
+        if Version(version_str) < Version("6.38"):
+            _add_variant(v, f, "rpath", "+rpath")
         _add_variant(v, f, "runtime_cxxmodules", "+cxxmodules")
         _add_variant(v, f, "shadowpw", "+shadow")
         _add_variant(v, f, "spectrum", "+spectrum")
@@ -928,10 +929,6 @@ class Root(CMakePackage):
         # https://github.com/root-project/root/issues/18949
         if "+cxxmodules +vc" in self.spec:
             env.prepend_path("ROOT_INCLUDE_PATH", self.spec["vc"].prefix.include)
-
-        # Also set up include and library paths since downstream packages may
-        # require libCling etc.
-        self.setup_dependent_run_environment(env, dependent_spec)
 
     def setup_dependent_run_environment(self, env: EnvironmentModifications, dependent_spec):
         env.prepend_path("ROOT_INCLUDE_PATH", dependent_spec.prefix.include)

--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -895,6 +895,12 @@ class Root(CMakePackage):
             # warnings when building against ROOT
             env.unset("MACOSX_DEPLOYMENT_TARGET")
 
+    @property
+    def root_library_path(self):
+        # This used to be version-dependent, but such old versions are no
+        # longer supported by Spack
+        return "ROOT_LIBRARY_PATH"
+
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         env.set("ROOTSYS", self.prefix)
         env.set("ROOT_VERSION", "v{0}".format(self.version.up_to(1)))
@@ -903,10 +909,10 @@ class Root(CMakePackage):
         env.set("CLING_STANDARD_PCH", "none")
         env.set("CPPYY_API_PATH", "none")
         env.set("CPPYY_BACKEND_LIBRARY", self.prefix.lib.root.libcppyy_backend)
-        env.prepend_path("ROOT_LIBRARY_PATH", self.prefix.lib.root)
+        env.prepend_path(self.root_library_path, self.prefix.lib.root)
 
         # https://github.com/root-project/root/issues/18949
-        if "+cxxmodules" in self.spec and "+vc" in self.spec:
+        if "+cxxmodules +vc" in self.spec:
             env.prepend_path("ROOT_INCLUDE_PATH", self.spec["vc"].prefix.include)
 
     def setup_dependent_build_environment(self, env: EnvironmentModifications, dependent_spec):
@@ -936,4 +942,4 @@ class Root(CMakePackage):
         # versions).
         for lib_path in [dependent_spec.prefix.lib, dependent_spec.prefix.lib64]:
             if os.path.exists(lib_path):
-                env.prepend_path("ROOT_LIBRARY_PATH", lib_path)
+                env.prepend_path(self.root_library_path, lib_path)

--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -898,8 +898,9 @@ class Root(CMakePackage):
 
     @property
     def root_library_path(self):
-        # This used to be version-dependent, but such old versions are no
-        # longer supported by Spack
+        # The ROOT_LIBRARY_PATH environment variable was added to ROOT 6.26.
+        # For previous versions (no longer supported by Spack) it was
+        # LD_LIBRARY_PATH.
         return "ROOT_LIBRARY_PATH"
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
@@ -926,6 +927,9 @@ class Root(CMakePackage):
         if "platform=darwin" in self.spec:
             # Newer deployment targets cause fatal errors in rootcling
             env.unset("MACOSX_DEPLOYMENT_TARGET")
+
+        # Note that setup_dependent_run_environment will add include and
+        # library path
 
         # https://github.com/root-project/root/issues/18949
         if "+cxxmodules" in self.spec and "+vc" in self.spec:

--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -910,6 +910,7 @@ class Root(CMakePackage):
         env.set("CLING_STANDARD_PCH", "none")
         env.set("CPPYY_API_PATH", "none")
         env.set("CPPYY_BACKEND_LIBRARY", self.prefix.lib.root.libcppyy_backend)
+        # Always define ROOT's library path for downstream usage
         env.prepend_path(self.root_library_path, self.prefix.lib.root)
 
         # https://github.com/root-project/root/issues/18949
@@ -931,7 +932,9 @@ class Root(CMakePackage):
             env.prepend_path("ROOT_INCLUDE_PATH", self.spec["vc"].prefix.include)
 
     def setup_dependent_run_environment(self, env: EnvironmentModifications, dependent_spec):
+        # Set up runtime dependencies *of downstream packages* that use ROOT
         env.prepend_path("ROOT_INCLUDE_PATH", dependent_spec.prefix.include)
+
         # For dependents that build dictionaries, ROOT needs to know where the
         # dictionaries have been installed.  This can be facilitated by
         # automatically prepending dependent package library paths to

--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -914,7 +914,7 @@ class Root(CMakePackage):
         env.prepend_path(self.root_library_path, self.prefix.lib.root)
 
         # https://github.com/root-project/root/issues/18949
-        if "+cxxmodules +vc" in self.spec:
+        if "+cxxmodules" in self.spec and "+vc" in self.spec:
             env.prepend_path("ROOT_INCLUDE_PATH", self.spec["vc"].prefix.include)
 
     def setup_dependent_build_environment(self, env: EnvironmentModifications, dependent_spec):
@@ -928,7 +928,7 @@ class Root(CMakePackage):
             env.unset("MACOSX_DEPLOYMENT_TARGET")
 
         # https://github.com/root-project/root/issues/18949
-        if "+cxxmodules +vc" in self.spec:
+        if "+cxxmodules" in self.spec and "+vc" in self.spec:
             env.prepend_path("ROOT_INCLUDE_PATH", self.spec["vc"].prefix.include)
 
     def setup_dependent_run_environment(self, env: EnvironmentModifications, dependent_spec):

--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -895,11 +895,6 @@ class Root(CMakePackage):
             # warnings when building against ROOT
             env.unset("MACOSX_DEPLOYMENT_TARGET")
 
-    @property
-    def root_library_path(self):
-        # The ROOT_LIBRARY_PATH environment variable was added to ROOT 6.26.
-        return "ROOT_LIBRARY_PATH"
-
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         env.set("ROOTSYS", self.prefix)
         env.set("ROOT_VERSION", "v{0}".format(self.version.up_to(1)))
@@ -908,8 +903,7 @@ class Root(CMakePackage):
         env.set("CLING_STANDARD_PCH", "none")
         env.set("CPPYY_API_PATH", "none")
         env.set("CPPYY_BACKEND_LIBRARY", self.prefix.lib.root.libcppyy_backend)
-        if "+rpath" not in self.spec:
-            env.prepend_path(self.root_library_path, self.prefix.lib.root)
+        env.prepend_path("ROOT_LIBRARY_PATH", self.prefix.lib.root)
 
         # https://github.com/root-project/root/issues/18949
         if "+cxxmodules" in self.spec and "+vc" in self.spec:
@@ -921,16 +915,17 @@ class Root(CMakePackage):
         env.prepend_path("PYTHONPATH", self.prefix.lib.root)
         env.prepend_path("PATH", self.prefix.bin)
         env.append_path("CMAKE_MODULE_PATH", self.prefix.cmake)
-        env.prepend_path("ROOT_INCLUDE_PATH", dependent_spec.prefix.include)
-        if "+rpath" not in self.spec:
-            env.prepend_path(self.root_library_path, self.prefix.lib.root)
         if "platform=darwin" in self.spec:
             # Newer deployment targets cause fatal errors in rootcling
             env.unset("MACOSX_DEPLOYMENT_TARGET")
 
         # https://github.com/root-project/root/issues/18949
-        if "+cxxmodules" in self.spec and "+vc" in self.spec:
+        if "+cxxmodules +vc" in self.spec:
             env.prepend_path("ROOT_INCLUDE_PATH", self.spec["vc"].prefix.include)
+
+        # Also set up include and library paths since downstream packages may
+        # require libCling etc.
+        self.setup_dependent_run_environment(env, dependent_spec)
 
     def setup_dependent_run_environment(self, env: EnvironmentModifications, dependent_spec):
         env.prepend_path("ROOT_INCLUDE_PATH", dependent_spec.prefix.include)
@@ -941,4 +936,4 @@ class Root(CMakePackage):
         # versions).
         for lib_path in [dependent_spec.prefix.lib, dependent_spec.prefix.lib64]:
             if os.path.exists(lib_path):
-                env.prepend_path(self.root_library_path, lib_path)
+                env.prepend_path("ROOT_LIBRARY_PATH", lib_path)


### PR DESCRIPTION
When building
```
dd4hep@1.33+ddalign+ddcad+ddcond+dddetectors+dddigi~ddeve+ddg4+ddrec~debug~doc+edm4hep~geant4units~hepmc3~ipo~lcio~tbb~utilityapps~xercesc
^root@6.38.00~aqua~arrow~cuda~cudnn~cxxmodules~daos~davix~dcache~emacs~examples~fftw~fits~fortran+gdml+geom~geombuilder+gminimal~graphviz+gsl~http~ipo+math+minuit~mlp~opengl~pythia8+python~qt6~r+roofit+root7+rpath~shadow~spectrum~sqlite~ssl~tbb+tiff~tmva~tmva-cpu+tmva-cudnn~tmva-gpu~tmva-pymva~tmva-sofie+tpython+unuran~vc+vdt~veccore~webgui~x+xml~xrootd build_system=cmake build_type=Release cxxstd=20 generator=make patches:=22af347 platform=darwin os=tahoe target=m2 %c,cxx=apple-clang@17.0.0
```
the final plugin build fails with:
```
[9/21] Generating libDDCoreGraphics.components
FAILED: [code=1] DDCore/libDDCoreGraphics.components /private/var/folders/n9/mqnx20b929z469f6p3fbq7c40000gn/T/seth/spack-stage/spack-stage-dd4hep-1.33-z7jy2mn65v76gsa5dyg3dlpkevocmuow/spack-build-z7jy2mn/DDCore/libDDCoreGraphics.components
cd /private/var/folders/n9/mqnx20b929z469f6p3fbq7c40000gn/T/seth/spack-stage/spack-stage-dd4hep-1.33-z7jy2mn65v76gsa5dyg3dlpkevocmuow/spack-build-z7jy2mn/lib && DYLD_LIBRARY_PATH=/private/var/folders/n9/mqnx20b929z469f6p3fbq7c40000gn/T/seth/spack-stage/spack-stage-dd4hep-1.33-z7jy2mn65v76gsa5dyg3dlpkevocmuow/spack-build-z7jy2mn/lib:/private/var/folders/n9/mqnx20b929z469f6p3fbq7c40000gn/T/seth/spack-stage/spack-stage-dd4hep-1.33-z7jy2mn65v76gsa5dyg3dlpkevocmuow/spack-build-z7jy2mn/lib: /private/var/folders/n9/mqnx20b929z469f6p3fbq7c40000gn/T/seth/spack-stage/spack-stage-dd4hep-1.33-z7jy2mn65v76gsa5dyg3dlpkevocmuow/spack-build-z7jy2mn/bin/listcomponents_dd4hep -o libDDCoreGraphics.components libDDCoreGraphics.dylib
Error in <UnknownClass::FindDynamicLibrary>: libRIO[.so | .dll | .dylib | .sl | .dl | .a] does not exist in /opt/spack/opt/spack/tahoe/edm4hep/0.99.4/4lpkeqx/lib:/opt/spack/opt/spack/tahoe/podio/1.6/sj3ympx/lib:/private/var/folders/n9/mqnx20b929z469f6p3fbq7c40000gn/T/seth/spack-stage/spack-stage-dd4hep-1.33-z7jy2mn65v76gsa5dyg3dlpkevocmuow/spack-build-z7jy2mn/lib:/private/var/folders/n9/mqnx20b929z469f6p3fbq7c40000gn/T/seth/spack-stage/spack-stage-dd4hep-1.33-z7jy2mn65v76gsa5dyg3dlpkevocmuow/spack-build-z7jy2mn/lib::/opt/spack/opt/spack/tahoe/edm4hep/0.99.4/4lpkeqx/lib:/opt/spack/opt/spack/tahoe/podio/1.6/sj3ympx/lib:/opt/spack/opt/spack/tahoe/podio/1.6/sj3ympx/lib::.:/usr/local/lib:/usr/X11R6/lib:/usr/lib:/lib:/lib/x86_64-linux-gnu:/usr/local/lib64:/usr/lib64:/lib64:
Error in <UnknownClass::FindDynamicLibrary>: libCling[.so | .dll | .dylib | .sl | .dl | .a] does not exist in /opt/spack/opt/spack/tahoe/edm4hep/0.99.4/4lpkeqx/lib:/opt/spack/opt/spack/tahoe/podio/1.6/sj3ympx/lib:/private/var/folders/n9/mqnx20b929z469f6p3fbq7c40000gn/T/seth/spack-stage/spack-stage-dd4hep-1.33-z7jy2mn65v76gsa5dyg3dlpkevocmuow/spack-build-z7jy2mn/lib:/private/var/folders/n9/mqnx20b929z469f6p3fbq7c40000gn/T/seth/spack-stage/spack-stage-dd4hep-1.33-z7jy2mn65v76gsa5dyg3dlpkevocmuow/spack-build-z7jy2mn/lib::/opt/spack/opt/spack/tahoe/edm4hep/0.99.4/4lpkeqx/lib:/opt/spack/opt/spack/tahoe/podio/1.6/sj3ympx/lib:/opt/spack/opt/spack/tahoe/podio/1.6/sj3ympx/lib::.:/usr/local/lib:/usr/X11R6/lib:/usr/lib:/lib:/lib/x86_64-linux-gnu:/usr/local/lib64:/usr/lib64:/lib64:
Fatal in <TROOT::InitInterpreter>: cannot load symbol dlsym(RTLD_DEFAULT, CreateInterpreter): symbol not found
```

This appears to be because the ROOT lib path needs to be explicitly defined in `ROOT_LIBRARY_PATH`, even for rpath builds. See https://github.com/spack/spack/pull/16899, https://github.com/spack/spack/pull/45109 .

Since Spack no longer builds anything older than ROOT 6.28, I've also eliminated the `root_library_path` property.