### PR TITLE
texlive: add missing import os from https://github.com/spack/spack-packages/pull/2771

### DIFF
--- a/repos/spack_repo/builtin/packages/texlive/package.py
+++ b/repos/spack_repo/builtin/packages/texlive/package.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 import platform
 import re
 


### PR DESCRIPTION
Needed in https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/packages/texlive/package.py#L165