### PR TITLE
Logic to install plugins for cmake netcdf-c builds

### DIFF
--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -394,15 +394,18 @@ class CMakeBuilder(AnyBuilder, cmake.CMakeBuilder):
         else:
             base_cmake_args.append(self.define(nc + "FIND_SHARED_LIBS", False))
 
-        if self.spec.satisfies("@4.9.0:+shared"):
-            # The plugins are not built when the shared libraries are disabled:
-            if self.spec.satisfies("@4.9.3:"):
-                # This toggle is not defined in the top-level CMake parameters but is still
-                # used by the plugin config; so we work around this bug for now
-                base_cmake_args.append(self.define("ENABLE_PLUGIN_INSTALL", True))
-                base_cmake_args.append(self.define("NETCDF_WITH_PLUGIN_DIR", self.prefix.plugins))
-            else:
-                base_cmake_args.append(self.define("PLUGIN_INSTALL_DIR", self.prefix.plugins))
+        # The plugins are not built when the shared libraries are disabled:
+        if self.spec.satisfies("@4.9.3:+shared"):
+            # This toggle is not defined in the top-level CMake parameters but is still
+            # used by the plugin config; so we work around this bug for now
+            base_cmake_args.extend(
+                [
+                    self.define("ENABLE_PLUGIN_INSTALL", True),
+                    self.define("NETCDF_WITH_PLUGIN_DIR", self.prefix.plugins),
+                ]
+            )
+        elif self.spec.satisfies("@4.9.0:+shared"):
+            base_cmake_args.append(self.define("PLUGIN_INSTALL_DIR", self.prefix.plugins))
         return base_cmake_args
 
     @run_after("install")

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -393,6 +393,16 @@ class CMakeBuilder(AnyBuilder, cmake.CMakeBuilder):
             base_cmake_args.append(self.define(nc + "FIND_SHARED_LIBS", True))
         else:
             base_cmake_args.append(self.define(nc + "FIND_SHARED_LIBS", False))
+
+        if self.spec.satisfies("@4.9.0:+shared"):
+            # The plugins are not built when the shared libraries are disabled:
+            if self.spec.satisfies("@4.9.3:"):
+                # This toggle is not defined in the top-level CMake parameters but is still
+                # used by the plugin config; so we work around this bug for now
+                base_cmake_args.append(self.define("ENABLE_PLUGIN_INSTALL", True))
+                base_cmake_args.append(self.define("NETCDF_WITH_PLUGIN_DIR", self.prefix.plugins))
+            else:
+                base_cmake_args.append(self.define("PLUGIN_INSTALL_DIR", self.prefix.plugins))
         return base_cmake_args
 
     @run_after("install")


### PR DESCRIPTION
While plugin installation support is provided for the autotools build method, this was apparently not implemented for CMake builds of `netcdf-c`. This PR aims to rectify this inconsistency. As with many configurations, the process for turning plugin install on changed in 4.9.3.

From 4.9.0 to 4.9.2, setting `PLUGIN_INSTALL_DIR` to the desired directory is all that is required (assuming we are building a shared library).

Meanwhile, in 4.9.3, a new variable is introduced and documented which serves the same purpose - `NETCDF_WITH_PLUGIN_DIR`. However, setting this doesn't seem to be sufficient as there is no logic in the top-level CMakeLists.txt to set `ENABLE_PLUGIN_INSTALL`, which is required for plugin libraries to be installed in the `plugins` subdirectory. This seems like a bug, but we can work around it by setting this manually.