### PR TITLE
DBCSR: Fix bug building CMake args

### DIFF
--- a/repos/spack_repo/builtin/packages/dbcsr/package.py
+++ b/repos/spack_repo/builtin/packages/dbcsr/package.py
@@ -187,7 +187,7 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
 
         lapack, blas = spec["lapack"], spec["blas"]
         if blas.name != "intel-oneapi-mkl":
-            args = [
+            args += [
                 "-DBLAS_FOUND=true",
                 "-DBLAS_LIBRARIES=%s" % (blas.libs.joined(";")),
                 "-DLAPACK_FOUND=true",


### PR DESCRIPTION
This fixes a typo introduced by https://github.com/spack/spack-packages/pull/480.