### PR TITLE
openblas: require ~ilp64 symbol_suffix=none when cmake

### DIFF
--- a/repos/spack_repo/builtin/packages/openblas/package.py
+++ b/repos/spack_repo/builtin/packages/openblas/package.py
@@ -288,8 +288,8 @@ class Openblas(CMakePackage, MakefilePackage):
     )
 
     # ilp64 and symbol suffixes are not supported with CMake build system
-    require("~ilp64", when="build_system=cmake")
-    require("symbol_suffix=none", when="build_system=cmake")
+    requires("~ilp64", when="build_system=cmake")
+    requires("symbol_suffix=none", when="build_system=cmake")
 
     # Requires support for -mtune=generic
     conflicts("%fortran=clang %llvm@18")

--- a/repos/spack_repo/builtin/packages/openblas/package.py
+++ b/repos/spack_repo/builtin/packages/openblas/package.py
@@ -287,7 +287,7 @@ class Openblas(CMakePackage, MakefilePackage):
         when="@0.3.27 %oneapi",
     )
 
-    # Require automake for +ilp64 and symbol suffixes
+    # ilp64 and symbol suffixes are not supported with CMake build system
     require("~ilp64", when="build_system=cmake")
     require("symbol_suffix=none", when="build_system=cmake")
 

--- a/repos/spack_repo/builtin/packages/openblas/package.py
+++ b/repos/spack_repo/builtin/packages/openblas/package.py
@@ -287,6 +287,10 @@ class Openblas(CMakePackage, MakefilePackage):
         when="@0.3.27 %oneapi",
     )
 
+    # Require automake for +ilp64 and symbol suffixes
+    require("~ilp64", when="build_system=cmake")
+    require("symbol_suffix=none", when="build_system=cmake")
+
     # Requires support for -mtune=generic
     conflicts("%fortran=clang %llvm@18")
 


### PR DESCRIPTION
This PR requires `openblas` to use `~ilp64` and `symbol_suffix=none` when the build system is CMake. Separate `requires` directives since different causes and can be fixed independently of each other.
- `ilp64`: apparently not supported at all in the [CMakeLists.txt](https://github.com/OpenMathLib/OpenBLAS/blob/develop/CMakeLists.txt),
- `symbol_suffix!=none` not passed to the CMake configuration (and LIBNAMESUFFIX only after 0.3.29).

This leads to failure to find `libs` since default name libraries are installed but suffixed libraries are expected by the package.