### PR TITLE
libceed: Fix libceed +cuda, +openmp, +shared for > 0.12

### DIFF
--- a/repos/spack_repo/builtin/packages/libceed/package.py
+++ b/repos/spack_repo/builtin/packages/libceed/package.py
@@ -124,6 +124,7 @@ class Libceed(MakefilePackage, CudaPackage, ROCmPackage):
             if spec.satisfies("@:0.7") and "avx" in self.spec.target:
                 makeopts.append("AVX=1")
 
+        if spec.satisfies("@0.4:"):
             if spec.satisfies("+cuda"):
                 makeopts += ["CUDA_DIR=%s" % spec["cuda"].prefix]
                 makeopts += ["CUDA_ARCH=sm_%s" % spec.variants["cuda_arch"].value]


### PR DESCRIPTION
In #2755, I missed that certain build options should be still set even when after 0.12. This fixes compilation for a few variants on `@develop`.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
