### PR TITLE
openloops: add v2.1.5

### DIFF
--- a/repos/spack_repo/builtin/packages/openloops/package.py
+++ b/repos/spack_repo/builtin/packages/openloops/package.py
@@ -22,6 +22,7 @@ class Openloops(Package):
     tags = ["hep"]
 
     license("GPL-3.0-only")
+    version("2.1.5", sha256="dbb2bdf160725dca4e80d85403ce6d1f55a15754ba863fcc62febc42efc34bc2")
     version("2.1.4", sha256="3423688d016ffcda3b738de89418338e95249276ac634e77f356a20deb57daaa")
     version("2.1.3", sha256="b26ee805d63b781244a5bab4db09f4a7a5a5c9ed371ead0d5260f00a0a94b233")
     version("2.1.2", sha256="f52575cae3d70b6b51a5d423e9cd0e076ed5961afcc015eec00987e64529a6ae")


### PR DESCRIPTION
This PR adds `openloops`, v2.1.5, [diff](https://gitlab.com/openloops/OpenLoops/-/compare/OpenLoops-2.1.4...OpenLoops-2.1.5). No build system changes. This package is built in CI.