### PR TITLE
pandora*: add v4 versions

### DIFF
--- a/repos/spack_repo/builtin/packages/pandoramonitoring/package.py
+++ b/repos/spack_repo/builtin/packages/pandoramonitoring/package.py
@@ -21,6 +21,9 @@ class Pandoramonitoring(CMakePackage):
     maintainers("jmcarcell", "wdconinc")
 
     version("master", branch="master")
+    version("4.0.3", sha256="00830b83b99e6da9e9f70b4bfeaebca2a1af6a10fb6dbf8324bc6e9d6f1224e2")  
+    version("3.7.0", sha256="3d0ba671bdf9ed408ac410c054e67ad93d46cd8690113f1fd34ab133a1658467")
+    version("3.6.3", sha256="c6859c60b75bf467dcee983085a2613921872aabf914769d4701a0d2ee68bf97")
     version("3.6.0", sha256="5fc9574faa3e90d96e5d2a27dea46b55f844499cf21e39060acb1e4c080dec77")
     version("3.5.0", sha256="274562abb7c797194634d5460a56227444a1de07a240c88ae35ca806abcbaf60")
 
@@ -29,6 +32,7 @@ class Pandoramonitoring(CMakePackage):
 
     depends_on("root@6.18.04: +geom +opengl +x")
     depends_on("pandorasdk")
+    depends_on("pandorasdk@4:", when="@4:")
 
     # https://github.com/PandoraPFA/PandoraMonitoring/pull/13
     @when("@:3.6.0")

--- a/repos/spack_repo/builtin/packages/pandoramonitoring/package.py
+++ b/repos/spack_repo/builtin/packages/pandoramonitoring/package.py
@@ -21,7 +21,7 @@ class Pandoramonitoring(CMakePackage):
     maintainers("jmcarcell", "wdconinc")
 
     version("master", branch="master")
-    version("4.0.3", sha256="00830b83b99e6da9e9f70b4bfeaebca2a1af6a10fb6dbf8324bc6e9d6f1224e2")  
+    version("4.0.3", sha256="00830b83b99e6da9e9f70b4bfeaebca2a1af6a10fb6dbf8324bc6e9d6f1224e2")
     version("3.7.0", sha256="3d0ba671bdf9ed408ac410c054e67ad93d46cd8690113f1fd34ab133a1658467")
     version("3.6.3", sha256="c6859c60b75bf467dcee983085a2613921872aabf914769d4701a0d2ee68bf97")
     version("3.6.0", sha256="5fc9574faa3e90d96e5d2a27dea46b55f844499cf21e39060acb1e4c080dec77")

--- a/repos/spack_repo/builtin/packages/pandorapfa/package.py
+++ b/repos/spack_repo/builtin/packages/pandorapfa/package.py
@@ -22,6 +22,12 @@ class Pandorapfa(Package):
     maintainers("jmcarcell", "wdconinc")
 
     version("master", branch="master")
+    version("4.17.4", sha256="c8c35258cb447372ddb17b8647b4a7ce912e74ee9b0cbad470daadf669888393")
+    version("4.16.3", sha256="68b149449fcc5b1c21567092cdebc723c2c150cd2d73689453a081fb05619f36")
+    version("4.15.2", sha256="ed52c05e70452548ca97015ea255437698c9b97637c2da6a7d452bc2d16b980b")
+    version("4.14.1", sha256="db43a2232435de4f4990f69ed2b263b741693942d8b18542d9d4a1f61ca41e02")
+    version("4.13.1", sha256="6075f6d9f988be37b301e4f5dbae78e23f6e0b97cda7da42608bb81f6d6b3d73")
+    version("4.12.0", sha256="bdfdfd40a9bf5a63a9ad3383ccbba4f676119166a9eb3d021a7c40752b1a6036")
     version("4.11.2", sha256="02b0e8c1844ec515055cb85f9d14d9d13eda28607c634611a59d767eb08a8b34")
     version("4.3.1", sha256="2f4757a6ed2e10d3effc300b330f67ba13c499dbf21ba720b29b50527332fcdb")
     version("4.3.0", sha256="a794022c33b3a5afc1272740ac385e0c4ab96a112733012e7dfcbe80b5a3b445")

--- a/repos/spack_repo/builtin/packages/pandorasdk/package.py
+++ b/repos/spack_repo/builtin/packages/pandorasdk/package.py
@@ -20,6 +20,8 @@ class Pandorasdk(CMakePackage):
     maintainers("jmcarcell", "wdconinc")
 
     version("master", branch="master")
+    version("4.0.2", sha256="9c8e051dbfd3be711dc7940658b78558277e2ec1c6305c0f7c7bb271abd3e4a8")
+    version("3.4.3", sha256="7590cfa27df47dce99c6fecf4a178f1bb1fa025aaf7d7da9c6176787f66a04be")
     version("3.4.2", sha256="e076adb2e3d28d3ac5dcc06bcc6e96815d23ef7782e1a87842b1e3e96e194994")
     version("3.4.1", sha256="9607bf52a9d79d88d28c45d4f3336e066338b36ab81b4d2d125226f4ad3a7aaf")
     version("3.4.0", sha256="1e30db056d4a43f8659fccdda00270af14593425d933f91e91d5c97f1e124c6b")


### PR DESCRIPTION
This PR adds new versions of the pandora suite: pandorasdk, pandoramonitoring, and pandorapfa. No build system changes. These packages are built in CI. 