### PR TITLE
xictools: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/xictools/Makefile.in.patch
+++ b/repos/spack_repo/builtin/packages/xictools/Makefile.in.patch
@@ -1,0 +1,43 @@
+--- a/KLU/Makefile.in
++++ b/KLU/Makefile.in
+@@ -169,19 +169,24 @@ patch: unpack
+ 
+ depend: unpack patch
+ 
+-AMD/Lib/libamd.a ::
++# Ensure source is unpacked before building libraries
++AMD/Lib/libamd.a :: AMD/Lib
+ 	@$(MAKE) -C AMD/Lib CC="$(CC)" CF="$(CFLAGS)"
+ 
+-BTF/Lib/libbtf.a ::
++BTF/Lib/libbtf.a :: BTF/Lib
+ 	@$(MAKE) -C BTF/Lib CC="$(CC)" CF="$(CFLAGS)"
+ 
+-COLAMD/Lib/libcolamd.a ::
++COLAMD/Lib/libcolamd.a :: COLAMD/Lib
+ 	@$(MAKE) -C COLAMD/Lib CC="$(CC)" CF="$(CFLAGS)"
+ 
+-KLU/Lib/libklu.a ::
++KLU/Lib/libklu.a :: KLU/Lib
+ 	@$(MAKE) -C KLU/Lib CC="$(CC)" CF="$(CFLAGS)"
+ 
+-SuiteSparse_config/SuiteSparse_config.o : \
++# These directory targets trigger unpack/patch if directories don't exist
++AMD/Lib BTF/Lib COLAMD/Lib KLU/Lib SuiteSparse_config:
++	@$(MAKE) patch
++
++SuiteSparse_config/SuiteSparse_config.o : SuiteSparse_config \
+  SuiteSparse_config/SuiteSparse_config.c
+ 	$(CC) $(CFLAGS) -c SuiteSparse_config/SuiteSparse_config.c -o $@
+
+--- a/mozy/Makefile.in
++++ b/mozy/Makefile.in
+@@ -222,6 +222,7 @@ install_test::
+ # Settings/Update & Security/For Developers
+ 
+ install_links::
++	@$(BASE)/util/mkdirpth $(toolbin)
+ 	@if [ -n "$(EXESUFFIX)" ]; then \
+ 	    $(BASE)/util/make_link $(toolbin)/hlp2latex$(EXESUFFIX) \
+  $(dst_bin)/hlp2latex$(EXESUFFIX); \
+ 

--- a/repos/spack_repo/builtin/packages/xictools/README.md
+++ b/repos/spack_repo/builtin/packages/xictools/README.md
@@ -1,0 +1,81 @@
+This report provides a summary of licenses found in xictools-4.3.23, including
+expanded tarball content. Short-form SPDX license identifiers are used in this
+document where possible.
+
+## Summary
+
+1. The XicTools codebase is primarily released under **Apache-2.0**, with
+   specific exceptions for third-party components and inherited code. The
+   `license/header` file contains the standard **Apache-2.0** header used
+   throughout the codebase.
+2. `xt_base/` is required when building xictools. Most files are licensed under
+   **Apache-2.0**. Some files are licensed under **Spencer-94 AND BSD-4-Clause-UC**, 
+   see `xt_base/regex/COPYRIGHT`. `xt_base/miscutil/randval.cc` contains both
+   **Apache-2.0** and **BSD-4-Clause-UC** text. `xt_base/sparse/` contains code
+   derived from Berkeley's Sparse package used in SPICE3 under a historical
+   license similar to **HPND-UC** but with additional attribution requirements. 
+3. Building WRspice will include several GPL and LGPL components:
+    1. `adms/` contains **GPL-3.0-or-later** licensed code.
+    2. `KLU/SuiteSparse/` expanded from `KLU/SuiteSparse-4.4.6.tar.gz` contains
+       components with **LGPL-2.1-or-later**, **GPL-2.0-or-later**, and
+       **BSD-3-Clause** licenses. Only the **LGPL-2.1-or-later code** is used by
+       WRspice (see `KLU/Makefile.sample`).
+    3. `vl/` contains code derived from UC Berkeley that requires propagating a
+       copyright notice. Some examples are licensed under **GPL-2.0-or-later**.
+       WRspice requires `vl`, xic does not. 
+    4. `wrspice/mmjco/` contains **GPL-3.0-or-later** licensed code.
+       `wrspice/mmjco/cmpfit-1.4/` contains **Minpack** licensed code.
+    5. Some files contain UC Berkeley copyright notices (from SPICE3) requiring
+       propagation of the copyright notice, similar to `vl`.
+4. `mozy/` provides the help system and viewer and contains
+   **LGPL-2.0-or-later** licensed code in `mozy/src/htm/`. 
+5. `fastcap/` and `fasthenry/` contain permissively licensed code without a SPDX
+   identifier. The license is identical to
+   https://www.rle.mit.edu/cpg/copyright_disclaimer.htm. However, `fasthenry` 
+   depends on `KLU` and is built with **LGPL-2.1-or-later** code.
+6. `mrouter/` contains **Apache-2.0** licensed code. Code in tarballs in
+   `mrouter/source.lefdef/` is from Cadence and also **Apache-2.0** licensed. 
+7. `secure/` contains **Apache-2.0** licensed code. This is legacy license
+   server code not built by package.py. 
+
+## KLU/ details
+
+The `SuiteSparse/` directory expanded from SuiteSparse-4.4.6.tar.gz contains
+multiple components with different licenses. Only the AMD, BTF, COLAMD, KLU, and
+SuiteSparse_config folders are used for WRspice. No licensing restrictions apply 
+to SuiteSparse_config/ per SuiteSparse_config.h.
+
+### **LGPL-2.1-or-later** Components
+- `AMD/`
+- `BTF/`
+- `CAMD/`
+- `CCOLAMD/`
+- `CHOLMOD/Check/`
+- `CHOLMOD/Cholesky/`
+- `CHOLMOD/Core/`
+- `CHOLMOD/Partition/`
+- `COLAMD/`
+- `CSparse/`
+- `CXSparse/`
+- `CXSparse_newfiles/`
+- `KLU/`
+- `LDL/`
+
+### **GPL-2.0-or-later** Components
+- `CHOLMOD/Demo/`
+- `CHOLMOD/GPU/`
+- `CHOLMOD/Include`
+- `CHOLMOD/MatrixOps/`
+- `CHOLMOD/Modify/`
+- `CHOLMOD/Supernodal/`
+- `GPUQREngine/`
+- `RBio/`
+- `SPQR/`
+- `SuiteSparse_GPURuntime/`
+- `UMFPACK/`
+
+### **BSD-3-Clause**
+- `UFget/UFhelp.html`
+
+### No Licensing Information
+- `MATLAB_Tools/`

--- a/repos/spack_repo/builtin/packages/xictools/malloc-2.8.6.c.patch
+++ b/repos/spack_repo/builtin/packages/xictools/malloc-2.8.6.c.patch
@@ -1,0 +1,11 @@
+--- a/xt_base/malloc/malloc-2.8.6.c
++++ b/xt_base/malloc/malloc-2.8.6.c
+@@ -763,7 +763,7 @@ MAX_RELEASE_CHECK_RATE   default: 4095 unless not HAVE_MMAP
+ /* #define HAVE_USR_INCLUDE_MALLOC_H */
+ 
+ #ifdef HAVE_USR_INCLUDE_MALLOC_H
+-#include "/usr/include/malloc.h"
++#include <malloc.h>
+ #else /* HAVE_USR_INCLUDE_MALLOC_H */
+ #ifndef STRUCT_MALLINFO_DECLARED
+ /* HP-UX (and others?) redefines mallinfo unless _STRUCT_MALLINFO is defined */

--- a/repos/spack_repo/builtin/packages/xictools/package.py
+++ b/repos/spack_repo/builtin/packages/xictools/package.py
@@ -1,0 +1,131 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import shutil
+
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
+
+from spack.package import *
+
+
+class Xictools(MakefilePackage):
+    """
+    Suite of integrated circuit design tools including Xic (graphical editor)
+    and WRspice (circuit simulator) for small and medium scale digital and
+    analog integrated circuits. (from http://wrcad.com/products.html)
+    """
+
+    homepage = "http://wrcad.com/xictools/index.html"
+    url = "https://github.com/wrcad/xictools/archive/refs/tags/xt-4.3.23.tar.gz"
+
+    # See README.md for details
+    license(
+        "Apache-2.0 AND Spencer-94 AND BSD-4-Clause-UC AND https://www.rle.mit.edu/cpg/copyright_disclaimer.htm AND HPND-UC",
+        when="~gpl",
+        checked_by="kllrak",
+    )
+    license(
+        "Apache-2.0 AND Spencer-94 AND BSD-4-Clause-UC AND https://www.rle.mit.edu/cpg/copyright_disclaimer.htm AND HPND-UC AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND GPL-3.0-or-later AND Minpack",
+        when="+gpl",
+        checked_by="kllrak",
+    )
+
+    version("4.3.23", sha256="f329d71bf637ed09921de6b0f6fdc38443d1a97617ca528a4eafa1be37c99e72")
+
+    # Set as sticky since most will expect WRspice and GUI to be included
+    variant(
+        "gpl",
+        default=True,
+        description="Build xictools with LGPL- and GPL-licensed code for WRspice and help system.",
+        sticky=True,
+    )
+    variant("qt", default=True, description="Build xictools with Qt5 GUI.", sticky=True)
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    # Build tools
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+    depends_on("m4", type="build")
+    depends_on("bison", type="build")
+    depends_on("flex", type="build")
+    depends_on("git", type="build")
+
+    # Library dependencies
+    depends_on("gsl")
+    depends_on("libjpeg")
+    depends_on("libtiff")
+    depends_on("ncurses")
+    depends_on("qt@5+opengl", when="+qt")
+
+    build_targets = ["all"]
+    install_targets = ["install"]
+
+    # Parallel builds seen as unreliable...
+    # See https://github.com/JuliaPackaging/Yggdrasil/pull/8155#discussion_r1500792779
+    # and https://github.com/wrcad/xictools/issues/28
+    parallel = False
+
+    # Remove stray include that breaks building +qt~gpl
+    patch("qtmain.cc.patch", when="@4:")
+
+    # Missing function stub for PopUpHelp with +qt~gpl
+    patch("qtinterf.cc.patch", when="@4:")
+
+    # Avoid hardcoding path to malloc.h
+    patch("malloc-2.8.6.c.patch", when="@4:")
+
+    # 1. fasthenry build assumes that KLU tarball has been unpacked and patched already.
+    #    This probably doesn't become apparent unless you accidentally include fasthenry
+    #    in a ~gpl build, but was found when constructing this package.py file.
+    # 2. xictools/bin assumed to exist before it does during a +qt+gpl build.
+    patch("Makefile.in.patch", when="@4:")
+
+    def edit(self, spec: Spec, prefix: Prefix) -> None:
+
+        # Copy Makefile.sample to Makefile
+        shutil.copy("Makefile.sample", "Makefile")
+
+        # Configure the Makefile
+        makefile = FileFilter("Makefile")
+
+        # Set PREFIX to Spack installation prefix (command-line argument format)
+        makefile.filter(r"^PREFIX\s*=.*", f"PREFIX = --prefix={prefix}")
+
+        # Enable direct installation without packaging (command-line argument format)
+        makefile.filter(r"^#?\s*ITOPOK\s*=.*", "ITOPOK = --enable-itopok=yes")
+
+        # Set Qt5 graphics location using Spack's qt prefix
+        if spec.satisfies("+qt"):
+            # since we're only building Qt, just assume its our preference.
+            filter_file(r"grpref=GTK2", "grpref=QT5", "xic/bin/xic.sh")
+            filter_file(r"grpref=GTK2", "grpref=QT5", "wrspice/bin/wrspice.sh")
+            filter_file(r"grpref=GTK2", "grpref=QT5", "mozy/bin/mozy.sh")
+            filter_file(r"grpref=GTK2", "grpref=QT5", "mozy/bin/xeditor.sh")
+            qt_prefix = spec["qt"].prefix
+            makefile.filter(r"^#?\s*GFXLOC\s*=.*", f"GFXLOC = --enable-qt5={qt_prefix}")
+
+        if spec.satisfies("~gpl"):
+            makefile.filter(r"^#?\s*NOMOZY\s*=.*", "NOMOZY = --enable-nomozy=yes")
+
+        # Build SUBDIRS based on variants
+        subdirs = ["xt_base"]
+        if spec.satisfies("+gpl"):
+            subdirs.append("$(MOZY)")
+            subdirs.append("$(WRSPICE)")
+        subdirs.append("$(XIC)")
+        subdirs.append("fastcap")
+
+        # Uses KLU, contains LGPL-2.1-or-later components
+        if spec.satisfies("+gpl"):
+            subdirs.append("fasthenry")
+
+        makefile.filter(r"^SUBDIRS\s*=.*", f"SUBDIRS = {' '.join(subdirs)}")
+
+        make("config")
+
+    def setup_run_environment(self, env):
+        env.prepend_path("PATH", join_path(self.prefix, "xictools", "bin"))

--- a/repos/spack_repo/builtin/packages/xictools/qtinterf.cc.patch
+++ b/repos/spack_repo/builtin/packages/xictools/qtinterf.cc.patch
@@ -1,0 +1,31 @@
+--- a/xt_base/qtinterf/qtinterf.cc
++++ b/xt_base/qtinterf/qtinterf.cc
+@@ -38,6 +38,7 @@
+  $Id:$
+  *========================================================================*/
+ 
++#include "config.h"
+ #include "qtinterf.h"
+ #include "qtfile.h"
+ #include "qtfont.h"
+@@ -1721,6 +1722,20 @@ QTbag::SetErrorLogName(const char *fname)
+ }
+ 
+ 
++#ifndef HAVE_MOZY
++
++// Resolve help pop-up when mozy is not included.
++//
++bool
++QTbag::PopUpHelp(const char*)
++{
++    PopUpErr(MODE_ON, "Help system is not available in this executable.");
++    return (false);
++}
++
++#endif
++
++
+ // Static function.
+ // Return a QColor, initialized with the given attr color.  Used
+ // with the QTbag popups, main color functions are in QTdev.

--- a/repos/spack_repo/builtin/packages/xictools/qtmain.cc.patch
+++ b/repos/spack_repo/builtin/packages/xictools/qtmain.cc.patch
@@ -1,0 +1,10 @@
+--- a/xic/src/qtxic/qtmain.cc
++++ b/xic/src/qtxic/qtmain.cc
+@@ -72,7 +72,6 @@
+ #include "cd_celldb.h"
+ #include "miscutil/pathlist.h"
+ #include "miscutil/tvals.h"
+-#include "help/help_context.h"
+ #include "qtinterf/qtidleproc.h"
+ #ifdef HAVE_MOZY
+ #include "editif.h"


### PR DESCRIPTION
Supports xictools 4.3.23 (latest version). This package builds a number of applications. Rather than provide fine-grained control over which to build, the variants allow the user to specify whether they want to include LGPL and GPL components, and/or GUI support via Qt. A README.md file is included to explain the licensing situation as best as I could discern. While xictools can be built with different GUI libraries, the xictools README suggests this is temporary and only Qt may be supported in the future. Hence, only a `qt` variant is provided in the package.py file. 

For my system, I verified that all four variants `xictools±gpl±qt` completed their builds with no errors coming from `make`. Command-line applications provided help prompts, GUI applications opened and appeared as expected. I did not do detailed testing beyond that. 

`spack debug report`:

```
* **Spack:** 1.1.0 (https://github.com/spack/spack/commit/89b3f0baae13477ee5384cd30ebf512489a69890)
* **Builtin repo:** https://github.com/spack/spack-packages/commit/4b8bb3514838ce9e8bbc2ca7f98e62dbd7100c63
* **Python:** 3.10.12
* **Platform:** linux-ubuntu22.04-sapphirerapids
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
