### PR TITLE
ucx: add v1.20.0

### DIFF
--- a/repos/spack_repo/builtin/packages/ucx/package.py
+++ b/repos/spack_repo/builtin/packages/ucx/package.py
@@ -21,12 +21,20 @@ class Ucx(AutotoolsPackage, CudaPackage):
 
     license("BSD-3-Clause")
 
+    def url_for_version(self, version):
+        if version >= Version("1.20.0"):
+            version_prefix = ""
+        else:
+            version_prefix = "v"
+        return f"https://github.com/openucx/ucx/releases/download/{version_prefix}{version}/ucx-{version}.tar.gz"
+
     version("master", branch="master", submodules=True)
 
     # Current
-    version("1.19.1", sha256="dea5d821fce05b6ffe175a74e6e148386dd85791409fc71242f3d1369100fd8a")
+    version("1.20.0", sha256="8a2776c3e8d7da8aa45abe640a6956b33f71b59cf4120566a888ee2b0ecfe667")
 
     # Still supported
+    version("1.19.1", sha256="dea5d821fce05b6ffe175a74e6e148386dd85791409fc71242f3d1369100fd8a")
     version("1.19.0", sha256="9af07d55281059542f20c5b411db668643543174e51ac71f53f7ac839164f285")
     version("1.18.1", sha256="8018dd75f11b5e8d6e57dcdb5b798d2c1f000982c353efde1f3170025c6c3b4c")
     version("1.18.0", sha256="fa75070f5fa7442731b4ef5fc9549391e147ed3d859afeb1dad2d4513b39dc33")


### PR DESCRIPTION
The release: https://github.com/openucx/ucx/releases/tag/1.20.0.

Not sure if it's intentional or not, but this release's download url deviates slightly from previous convention, the added `url_for_version` reflects the difference.

Test runs:

```
$ spack install ucx@1.20.0 +verbs +rdmacm +rc +ud +thread_multiple target=zen5
[+] /lustre/linsword_google_com/spack/opt/spack/linux-zen2/compiler-wrapper-1.0-4ozd6rhxuipkdmlr52gd2lhtty6a77c3
[+] /lustre/linsword_google_com/spack/opt/spack/linux-x86_64/gcc-14.3.0-t46w6z5rql55hyyjs7whafxualezfbew (external gcc-14.3.0-wjcomsbhf3bamljstvtoo6cctbibkezn)
[+] /usr (external glibc-2.28-iyhte7x7am7ap6asyuvzpe5hklifmvq5)
[+] /usr (external glibc-2.28-vuczjrbyzfif5nzgt5gqbrdrzaioihy6)
[+] /usr (external rdma-core-57.0-2ejh7dq7y2ushy4wxmiy5xfxztoaqkdh)
[+] /lustre/linsword_google_com/spack/opt/spack/linux-zen2/gcc-runtime-14.3.0-7lay63sgvqe5ylhgxpgfly6eqlzrfmat
[+] /lustre/linsword_google_com/spack/opt/spack/linux-x86_64/gcc-runtime-14.3.0-quuksszcwh4funqfewc7tqop5uqypyq2
[+] /lustre/linsword_google_com/spack/opt/spack/linux-x86_64/gmake-4.4.1-upybf342f34zfytnfmsnsdpgaumqglcy
[+] /lustre/linsword_google_com/spack/opt/spack/linux-x86_64/pkgconf-2.5.1-che7g33wjej32qxmg6sqpkzrts243eta
==> No binary for ucx-1.20.0-psfo35hdvx5jkv772zuekngc7omo6c76 found: installing from source
==> Installing ucx-1.20.0-psfo35hdvx5jkv772zuekngc7omo6c76 [10/10]
==> Fetching https://github.com/openucx/ucx/releases/download/1.20.0/ucx-1.20.0.tar.gz
    [100%]    3.50 MB @   44.2 MB/s
==> Ran patch() for ucx
==> ucx: Executing phase: 'autoreconf'
==> ucx: Executing phase: 'configure'
==> ucx: Executing phase: 'build'
==> ucx: Executing phase: 'install'
==> ucx: Successfully installed ucx-1.20.0-psfo35hdvx5jkv772zuekngc7omo6c76
  Stage: 0.91s.  Autoreconf: 0.00s.  Configure: 27.85s.  Build: 1m 14.14s.  Install: 4.42s.  Post-install: 0.74s.  Total: 1m 48.24s
[+] /lustre/linsword_google_com/spack/opt/spack/linux-zen5/ucx-1.20.0-psfo35hdvx5jkv772zuekngc7omo6c76

$ spack install ucx@1.19.1 +verbs +rdmacm +rc +ud +thread_multiple target=zen5
[+] /usr (external rdma-core-57.0-2ejh7dq7y2ushy4wxmiy5xfxztoaqkdh)
[+] /usr (external glibc-2.28-vuczjrbyzfif5nzgt5gqbrdrzaioihy6)
[+] /lustre/linsword_google_com/spack/opt/spack/linux-x86_64/gcc-14.3.0-t46w6z5rql55hyyjs7whafxualezfbew (external gcc-14.3.0-wjcomsbhf3bamljstvtoo6cctbibkezn)
[+] /usr (external glibc-2.28-iyhte7x7am7ap6asyuvzpe5hklifmvq5)
[+] /lustre/linsword_google_com/spack/opt/spack/linux-zen2/compiler-wrapper-1.0-4ozd6rhxuipkdmlr52gd2lhtty6a77c3
[+] /lustre/linsword_google_com/spack/opt/spack/linux-x86_64/gcc-runtime-14.3.0-quuksszcwh4funqfewc7tqop5uqypyq2
[+] /lustre/linsword_google_com/spack/opt/spack/linux-zen2/gcc-runtime-14.3.0-7lay63sgvqe5ylhgxpgfly6eqlzrfmat
[+] /lustre/linsword_google_com/spack/opt/spack/linux-x86_64/gmake-4.4.1-upybf342f34zfytnfmsnsdpgaumqglcy
[+] /lustre/linsword_google_com/spack/opt/spack/linux-x86_64/pkgconf-2.5.1-che7g33wjej32qxmg6sqpkzrts243eta
==> No binary for ucx-1.19.1-tjebukg57ibnoaruyvs43d7be5lj7zrg found: installing from source
==> Installing ucx-1.19.1-tjebukg57ibnoaruyvs43d7be5lj7zrg [10/10]
==> Fetching https://github.com/openucx/ucx/releases/download/v1.19.1/ucx-1.19.1.tar.gz
    [100%]    3.44 MB @   44.2 MB/s
==> Ran patch() for ucx
==> ucx: Executing phase: 'autoreconf'
==> ucx: Executing phase: 'configure'
==> ucx: Executing phase: 'build'
==> ucx: Executing phase: 'install'
==> ucx: Successfully installed ucx-1.19.1-tjebukg57ibnoaruyvs43d7be5lj7zrg
  Stage: 0.78s.  Autoreconf: 0.00s.  Configure: 25.71s.  Build: 1m 14.30s.  Install: 4.99s.  Post-install: 0.70s.  Total: 1m 46.69s
[+] /lustre/linsword_google_com/spack/opt/spack/linux-zen5/ucx-1.19.1-tjebukg57ibnoaruyvs43d7be5lj7zrg
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
