### PR TITLE
mercury: add variant to build perf tests

### DIFF
--- a/repos/spack_repo/builtin/packages/mercury/package.py
+++ b/repos/spack_repo/builtin/packages/mercury/package.py
@@ -91,10 +91,12 @@ class Mercury(CMakePackage):
         spec = self.spec
         define = self.define
         define_from_variant = self.define_from_variant
+        build_tests = self.run_tests or self.spec.satisfies("@2.3.0:+perf")
         parallel_tests = "+mpi" in spec and self.run_tests
 
         cmake_args = [
             define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            define("BUILD_TESTING", build_tests),
             define("MERCURY_USE_BOOST_PP", True),
             define_from_variant("MERCURY_USE_CHECKSUMS", "checksum"),
             define("MERCURY_USE_SYSTEM_MCHECKSUM", False),
@@ -102,7 +104,6 @@ class Mercury(CMakePackage):
             define_from_variant("NA_USE_BMI", "bmi"),
             define_from_variant("NA_USE_MPI", "mpi"),
             define_from_variant("NA_USE_SM", "sm"),
-            define("BUILD_TESTING", self.run_tests),
         ]
 
         if "@2.3.0:" in spec:

--- a/repos/spack_repo/builtin/packages/mercury/package.py
+++ b/repos/spack_repo/builtin/packages/mercury/package.py
@@ -57,7 +57,6 @@ class Mercury(CMakePackage):
     variant(
         "hwloc", default=False, when="@2.2.0:", description="Use hwloc to retrieve NIC information"
     )
-    variant("tests", default=True, description="Build and install perf tests")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
@@ -102,12 +101,12 @@ class Mercury(CMakePackage):
             define_from_variant("NA_USE_BMI", "bmi"),
             define_from_variant("NA_USE_MPI", "mpi"),
             define_from_variant("NA_USE_SM", "sm"),
-            define_from_variant("BUILD_TESTING", "tests"),
-            define_from_variant("BUILD_TESTING_PERF", "tests"),
+            define("BUILD_TESTING", self.run_tests),
         ]
 
         if "@2.3.0:" in spec:
             cmake_args.append(define("BUILD_TESTING_UNIT", self.run_tests))
+            cmake_args.append(define("BUILD_TESTING_PERF", self.run_tests))
 
         if "@2.2.0:" in spec:
             cmake_args.extend(

--- a/repos/spack_repo/builtin/packages/mercury/package.py
+++ b/repos/spack_repo/builtin/packages/mercury/package.py
@@ -57,6 +57,7 @@ class Mercury(CMakePackage):
     variant(
         "hwloc", default=False, when="@2.2.0:", description="Use hwloc to retrieve NIC information"
     )
+    variant("perf", default=True, when="@2.3.0:", description="Build performance tests")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
@@ -106,7 +107,7 @@ class Mercury(CMakePackage):
 
         if "@2.3.0:" in spec:
             cmake_args.append(define("BUILD_TESTING_UNIT", self.run_tests))
-            cmake_args.append(define("BUILD_TESTING_PERF", self.run_tests))
+            cmake_args.append(define_from_variant("BUILD_TESTING_PERF", "perf"))
 
         if "@2.2.0:" in spec:
             cmake_args.extend(

--- a/repos/spack_repo/builtin/packages/mercury/package.py
+++ b/repos/spack_repo/builtin/packages/mercury/package.py
@@ -57,6 +57,7 @@ class Mercury(CMakePackage):
     variant(
         "hwloc", default=False, when="@2.2.0:", description="Use hwloc to retrieve NIC information"
     )
+    variant("tests", default=True, description="Build and install perf tests")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
@@ -101,6 +102,8 @@ class Mercury(CMakePackage):
             define_from_variant("NA_USE_BMI", "bmi"),
             define_from_variant("NA_USE_MPI", "mpi"),
             define_from_variant("NA_USE_SM", "sm"),
+            define_from_variant("BUILD_TESTING", "tests"),
+            define_from_variant("BUILD_TESTING_PERF", "tests")
         ]
 
         if "@2.3.0:" in spec:

--- a/repos/spack_repo/builtin/packages/mercury/package.py
+++ b/repos/spack_repo/builtin/packages/mercury/package.py
@@ -103,7 +103,7 @@ class Mercury(CMakePackage):
             define_from_variant("NA_USE_MPI", "mpi"),
             define_from_variant("NA_USE_SM", "sm"),
             define_from_variant("BUILD_TESTING", "tests"),
-            define_from_variant("BUILD_TESTING_PERF", "tests")
+            define_from_variant("BUILD_TESTING_PERF", "tests"),
         ]
 
         if "@2.3.0:" in spec:


### PR DESCRIPTION
Hello @soumagne,

This PR adds a variant that builds and persistently installs the performance tests for Mercury.
Please let me know in which versions these CMake flags were introduced.

Preliminary results from a system similar to El Capitan at LLNL (200Gbps/HSA):

```
na_bw_get -c ofi -p cxi -b -l 1000
...
# [859097.930837] mercury->op [warning] /var/tmp/nhanford/spack-stage/spack-stage-mercury-master-ks4eadvpsbbqrwjxzxkebaxqymczvpry/spack-src/src/na/na_ofi.c:6950 na_ofi_cq_readerr() fi_cq_readerr() got err: 5 (Input/output error), prov_errno: 18 (ENTRY_NOT_FOUND)
# [859097.930842] mercury->op [error] /var/tmp/nhanford/spack-stage/spack-stage-mercury-master-ks4eadvpsbbqrwjxzxkebaxqymczvpry/spack-src/src/na/na_ofi.c:7137 na_ofi_cq_process_error() error event on operation ID 0x555555667670 (NA_CB_GET), fi_readmsg(iov_count=1, desc[0]=0x555555608680, msg_iov[0].iov_base=0x5555976f1000, msg_iov[0].iov_len=16384, addr=1, rma_iov_count=1, rma_iov[0].addr=0x3e000000, rma_iov[0].len=16384, rma_iov[0].key=0x900006b999e70000, context=0x5555556678b0, data=0) failed, rc: 5 (Input/output error)
16384                     15224.32                    1.03
32768                     22036.48                    1.42
65536                     22591.44                    2.77
131072                    22581.05                    5.54
262144                    23008.03                   10.87
524288                    23060.44                   21.68
1048576                   23117.53                   43.26
2097152                   23139.96                   86.43
4194304                   23152.97                  172.76
8388608                   23159.87                  345.43
16777216                  23163.12                  690.75
```

Thanks,
Nate