### PR TITLE
openblas: patch for +dynamic_dispatch target=aarch64

### DIFF
--- a/repos/spack_repo/builtin/packages/openblas/package.py
+++ b/repos/spack_repo/builtin/packages/openblas/package.py
@@ -287,6 +287,13 @@ class Openblas(CMakePackage, MakefilePackage):
         when="@0.3.27 %oneapi",
     )
 
+    # Fix arm64 HAVE_SME setting for DYNAMIC_ARCH builds using CMake
+    patch(
+        "https://github.com/OpenMathLib/OpenBLAS/commit/cdebb4fd4b2bbbf856e5abdcedbe9a5cf348ef8e.patch?full_index=1",
+        sha256="0df81a8f5c1460d3db461e2309e5ac0b70c7745a97a10e617f109b4a5811e043",
+        when="@0.3.30 +dynamic_dispatch target=aarch64:",
+    )
+
     # Requires support for -mtune=generic
     conflicts("%fortran=clang %llvm@18")
 


### PR DESCRIPTION
This PR adds to `openblas` a patch which fixes compilation for `@0.3.30 +dynamic_dispatch target=aarch64`. 

Test builds (on arm64):
```
#19 128.2 ==> No binary for openblas-0.3.30-t5t22rzflemnlqgamafzxdi5rqpmraho found: installing from source
#19 129.7 ==> Fetching https://mirror.spack.io/_source-cache/archive/27/27342cff518646afb4c2b976d809102e368957974c250a25ccc965e53063c95d.tar.gz
#19 129.7 ==> Fetching https://github.com/OpenMathLib/OpenBLAS/commit/cdebb4fd4b2bbbf856e5abdcedbe9a5cf348ef8e.patch?full_index=1
#19 129.7 ==> Applied patch https://github.com/OpenMathLib/OpenBLAS/commit/cdebb4fd4b2bbbf856e5abdcedbe9a5cf348ef8e.patch?full_index=1
#19 139.1 ==> openblas: Executing phase: 'cmake'
#19 139.1 ==> openblas: Executing phase: 'build'
#19 686.6 ==> openblas: Executing phase: 'install'
#19 698.0 ==> Pushed openblas@0.3.30/t5t22rz: sha256:81a94608c1ec1da060be1cf635a3d74bd22ae9014eb2e99123dcc7d549454da7 (1.37s, 7.73 MB/s)
#19 698.0 ==> Uploading manifests
#19 699.5 ==> Tagged openblas@0.3.30/t5t22rz as ghcr.io/eic/spack-v2025.11.0:openblas-0.3.30-t5t22rzflemnlqgamafzxdi5rqpmraho.spack
#19 699.5 ==> openblas: Pushed to build cache: 'eicweb'
#19 700.6 ==> Pushed openblas@0.3.30/t5t22rz: sha256:81a94608c1ec1da060be1cf635a3d74bd22ae9014eb2e99123dcc7d549454da7 (0.10s, 105.24 MB/s)
#19 700.6 ==> Uploading manifests
#19 702.4 ==> Tagged openblas@0.3.30/t5t22rz as ghcr.io/eic/spack-v2025.11.0:openblas-0.3.30-t5t22rzflemnlqgamafzxdi5rqpmraho.spack
#19 702.4 ==> openblas: Pushed to build cache: 'ghcr'
#19 703.2 ==> openblas: Successfully installed openblas-0.3.30-t5t22rzflemnlqgamafzxdi5rqpmraho
#19 703.2   Stage: 1.46s.  Cmake: 9.37s.  Build: 9m 7.46s.  Install: 8.72s.  Post-install: 6.89s.  Total: 9m 34.11s
#19 703.2 [+] /opt/software/linux-aarch64/openblas-0.3.30-t5t22rzflemnlqgamafzxdi5rqpmraho
```