### PR TITLE
ESMF: Set CMAKE_MODULE_PATH in dependent build environment

### DIFF
--- a/repos/spack_repo/builtin/packages/esmf/package.py
+++ b/repos/spack_repo/builtin/packages/esmf/package.py
@@ -452,6 +452,7 @@ class MakefileBuilder(makefile.MakefileBuilder):
         self, env: EnvironmentModifications, dependent_spec: Spec
     ) -> None:
         env.set("ESMFMKFILE", os.path.join(self.prefix.lib, "esmf.mk"))
+        env.prepend_path("CMAKE_MODULE_PATH", self.prefix.cmake)
 
     def install(self, pkg, spec, prefix):
         make("install")


### PR DESCRIPTION
This PR sets adds <esmf prefix>/cmake to CMAKE_MODULE_PATH so that dependents (namely, ufs-weather-model) can find it via CMake/find_package(). Setting ESMF_ROOT would also work for ufs-weather-model specifically, but this feels like the more general/safe solution.