### PR TITLE
podio, edm4hep, dd4hep: conflicts ^python +freethreading

### DIFF
--- a/repos/spack_repo/builtin/packages/dd4hep/package.py
+++ b/repos/spack_repo/builtin/packages/dd4hep/package.py
@@ -176,6 +176,11 @@ class Dd4hep(CMakePackage):
     # See https://github.com/AIDASoft/DD4hep/issues/1210
     conflicts("^root@6.31.1:", when="@:1.27")
 
+    # See https://github.com/AIDASoft/DD4hep/pull/1547
+    conflicts(
+        "^python +freethreading", when="@:1.34", msg="python free-threading requires dd4hep@1.35:"
+    )
+
     @property
     def libs(self):
         # We need to override libs here, because we don't build a libdd4hep so

--- a/repos/spack_repo/builtin/packages/edm4hep/package.py
+++ b/repos/spack_repo/builtin/packages/edm4hep/package.py
@@ -77,7 +77,11 @@ class Edm4hep(CMakePackage):
     extends("python", when="@0.10.6:")
 
     conflicts("%clang@:16", when="@0.99.1:", msg="Incomplete consteval support in clang")
-    conflicts("^python +freethreading", when="@:0.99.4", msg="python free-threading requires @0.99.5:")
+    conflicts(
+        "^python +freethreading",
+        when="@:0.99.4",
+        msg="python free-threading requires edm4hep@0.99.5:",
+    )
 
     # Fix missing nljson import
     # NOTE that downstream packages (dd4hep) may fail for 0.99 and before

--- a/repos/spack_repo/builtin/packages/edm4hep/package.py
+++ b/repos/spack_repo/builtin/packages/edm4hep/package.py
@@ -77,6 +77,7 @@ class Edm4hep(CMakePackage):
     extends("python", when="@0.10.6:")
 
     conflicts("%clang@:16", when="@0.99.1:", msg="Incomplete consteval support in clang")
+    conflicts("^python +freethreading", when="@:0.99.4", msg="python free-threading requires @0.99.5:")
 
     # Fix missing nljson import
     # NOTE that downstream packages (dd4hep) may fail for 0.99 and before

--- a/repos/spack_repo/builtin/packages/podio/package.py
+++ b/repos/spack_repo/builtin/packages/podio/package.py
@@ -91,6 +91,7 @@ class Podio(CMakePackage):
 
     conflicts("+rntuple ^root@6.32:", when="@:0.99", msg="rntuple API change requires podio@1:")
     conflicts("+rntuple ^root@6.34:", when="@:1.1", msg="rntuple API change requires podio@1.2:")
+    conflicts("^python +freethreading", when="@:1.6", msg="python free-threading requires @1.7:")
 
     # See https://github.com/AIDASoft/podio/pull/600
     patch(

--- a/repos/spack_repo/builtin/packages/podio/package.py
+++ b/repos/spack_repo/builtin/packages/podio/package.py
@@ -91,7 +91,9 @@ class Podio(CMakePackage):
 
     conflicts("+rntuple ^root@6.32:", when="@:0.99", msg="rntuple API change requires podio@1:")
     conflicts("+rntuple ^root@6.34:", when="@:1.1", msg="rntuple API change requires podio@1.2:")
-    conflicts("^python +freethreading", when="@:1.6", msg="python free-threading requires podio@1.7:")
+    conflicts(
+        "^python +freethreading", when="@:1.6", msg="python free-threading requires podio@1.7:"
+    )
 
     # See https://github.com/AIDASoft/podio/pull/600
     patch(

--- a/repos/spack_repo/builtin/packages/podio/package.py
+++ b/repos/spack_repo/builtin/packages/podio/package.py
@@ -91,7 +91,7 @@ class Podio(CMakePackage):
 
     conflicts("+rntuple ^root@6.32:", when="@:0.99", msg="rntuple API change requires podio@1:")
     conflicts("+rntuple ^root@6.34:", when="@:1.1", msg="rntuple API change requires podio@1.2:")
-    conflicts("^python +freethreading", when="@:1.6", msg="python free-threading requires @1.7:")
+    conflicts("^python +freethreading", when="@:1.6", msg="python free-threading requires podio@1.7:")
 
     # See https://github.com/AIDASoft/podio/pull/600
     patch(


### PR DESCRIPTION
This PR marks explicit conflicts between `podio`, `edm4hep`, and `dd4hep` and `^python +freethreading`. To be resolved in next releases (https://github.com/AIDASoft/podio/pull/911, https://github.com/key4hep/EDM4hep/pull/469, https://github.com/AIDASoft/DD4hep/pull/1547).