### PR TITLE
Add property libs to hpcx_mpi package spec

### DIFF
--- a/repos/spack_repo/builtin/packages/hpcx_mpi/package.py
+++ b/repos/spack_repo/builtin/packages/hpcx_mpi/package.py
@@ -40,6 +40,11 @@ class HpcxMpi(Package):
         env.prepend_path("LD_LIBRARY_PATH", prefix.lib)
         env.set("OPAL_PREFIX", prefix)
 
+    @property
+    def libs(self):
+    libraries = ["libmpi"]
+        return find_libraries(libraries, root=self.prefix, shared=True, recursive=True)
+
     def setup_dependent_build_environment(
         self, env: EnvironmentModifications, dependent_spec: Spec
     ) -> None:

--- a/repos/spack_repo/builtin/packages/hpcx_mpi/package.py
+++ b/repos/spack_repo/builtin/packages/hpcx_mpi/package.py
@@ -42,7 +42,7 @@ class HpcxMpi(Package):
 
     @property
     def libs(self):
-    libraries = ["libmpi"]
+        libraries = ["libmpi"]
         return find_libraries(libraries, root=self.prefix, shared=True, recursive=True)
 
     def setup_dependent_build_environment(


### PR DESCRIPTION
## Description ##

Add property `libs` for package `hpcx_mpi` spec

Closes [#2908](https://github.com/spack/spack-packages/issues/2908)

As `HPC-X` is `Open MPI`-based, this mimics [openmpi/package.py](https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/packages/openmpi/package.py#L981-989)

Tested on a host with `hpc-x/2.18.1` installed.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
