### PR TITLE
mfem: Add camp to libraries

### DIFF
--- a/repos/spack_repo/builtin/packages/mfem/package.py
+++ b/repos/spack_repo/builtin/packages/mfem/package.py
@@ -1137,6 +1137,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
             umpire_libs = umpire.libs
             if "^camp" in umpire:
                 umpire_opts += umpire["camp"].headers
+                umpire_libs += umpire["camp"].libs
             if "^fmt" in umpire:
                 umpire_opts += umpire["fmt"].headers
                 umpire_libs += umpire["fmt"].libs


### PR DESCRIPTION
When MFEM is build with `+umpire~shared~examples`, MFEM still calls
```
make("-C", "examples", "ex1p" if ("+mpi" in self.spec) else "ex1", parallel=False)
```
This compilation fails with errors like:
```
/usr/bin/ld: /home/ubuntu/opt/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_plac/linux-x86_64_v3/umpire-2025.09.0-l6vuanc7nlbfgjkteq2movqh24nhrafo/lib/libumpire.a(ResourceAwarePool.cpp.o): in function `umpire::strategy::ResourceAwarePool::allocate_resource(unsigned long, camp::resources::v1::Resource)':
ResourceAwarePool.cpp:(.text+0x7683): undefined reference to `camp::throw_re(char const*)'
/usr/bin/ld: /home/ubuntu/opt/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_plac/linux-x86_64_v3/umpire-2025.09.0-l6vuanc7nlbfgjkteq2movqh24nhrafo/lib/libumpire.a(ResourceAwarePool.cpp.o): in function `umpire::strategy::ResourceAwarePool::deallocate_resource(void*, camp::resources::v1::Resource, unsigned long)':
ResourceAwarePool.cpp:(.text+0xae45): undefined reference to `camp::throw_re(char const*)'
/usr/bin/ld: /home/ubuntu/opt/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_plac/linux-x86_64_v3/umpire-2025.09.0-l6vuanc7nlbfgjkteq2movqh24nhrafo/lib/libumpire.a(ResourceAwarePool.cpp.o): in function `camp::resources::v1::Resource::ContextModel<camp::resources::v1::Host>::compare(camp::resources::v1::Resource const&) const':
ResourceAwarePool.cpp:(.text._ZNK4camp9resources2v18Resource12ContextModelINS1_4HostEE7compareERKS2_[_ZNK4camp9resources2v18Resource12ContextModelINS1_4HostEE7compareERKS2_]+0x3c): undefined reference to `camp::throw_re(char const*)'
collect2: error: ld returned 1 exit status
make: *** [makefile:86: ex1p] Error 1
make: Leaving directory '/tmp/ubuntu/spack-stage/spack-stage-mfem-develop-bqp7664gmcfp6szafha3xabjyvcwv3ig/spack-src/examples'
```

This does not occur for shared builds because of transitive linking (I guess). A simple way to fix this is ensuring that camp is explicitely linked when available.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
