### PR TITLE
git-filter-repo: add v2.4.7

### DIFF
--- a/repos/spack_repo/builtin/packages/git_filter_repo/package.py
+++ b/repos/spack_repo/builtin/packages/git_filter_repo/package.py
@@ -18,10 +18,12 @@ class GitFilterRepo(Package):
 
     license("MIT")
 
+    version("2.47.0", sha256="4662cbe5918196a9f1b5b3e1211a32e61cff1812419c21df4f47c5439f09e902")
     version("2.38.0", sha256="db954f4cae9e47c6be3bd3161bc80540d44f5379cb9cf9df498f4e019f0a41a9")
     version("2.34.0", sha256="b1bf46af1e6a91a54056d0254e480803db8e40f631336c559a1a94d2a08389c4")
 
     depends_on("git@2.22.0:", type="run")
+    depends_on("python@3.6:", when="@2.47:", type="run")
     depends_on("python@3.5:", type="run")
 
     def install(self, spec, prefix):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Thanks again @haampie for introducing me to such a useful tool! I tested this release with a couple of rather complex use cases:

* https://github.com/adamjstewart/paper/wiki/Creation
* https://github.com/adamjstewart/ssl4eo/wiki/Creation