### PR TITLE
dd4hep: use dyld path for macos

### DIFF
--- a/repos/spack_repo/builtin/packages/dd4hep/package.py
+++ b/repos/spack_repo/builtin/packages/dd4hep/package.py
@@ -231,7 +231,13 @@ class Dd4hep(CMakePackage):
         env.set("DD4hep_DIR", self.prefix)
         env.set("DD4hep_ROOT", self.prefix)
         if len(self.libs.directories) > 0:
-            env.prepend_path("LD_LIBRARY_PATH", self.libs.directories[0])
+            # Plugin lookup mechanism is system-dependent
+            libvar = (
+                "DYLD_LIBRARY_PATH"
+                if self.spec.satisfies("platform=darwin")
+                else "LD_LIBRARY_PATH"
+            )
+            env.prepend_path(libvar, self.libs.directories[0])
 
     def url_for_version(self, version):
         # dd4hep releases are dashes and padded with a leading zero


### PR DESCRIPTION
The plugin path used for dd4hep is platform dependent, and the existing value is hardcoded for linux.