### PR TITLE
m4: add C11 flag for Intel Classic

### DIFF
--- a/repos/spack_repo/builtin/packages/m4/package.py
+++ b/repos/spack_repo/builtin/packages/m4/package.py
@@ -128,6 +128,10 @@ class M4(AutotoolsPackage, GNUMirrorPackage):
         if spec.satisfies("%intel@:18"):
             args.append("CFLAGS=-no-gcc")
 
+        # Use C11 std to ensure two-arg static_assert (no C23 for Intel Classic)
+        if spec.satisfies("@1.4.10: %intel"):
+            args.append("CFLAGS=-std=c11")
+
         if "+sigsegv" in spec:
             args.append("--with-libsigsegv-prefix={0}".format(spec["libsigsegv"].prefix))
         else:


### PR DESCRIPTION
This PR allows the m4 package to be built with intel classic. Currently, it will fail on account of not supporting one-arg static_assert. This PR adds '-std=c11' to ensure two-arg static_assert is used.