### PR TITLE
diffutils: use c11 std for Intel Classic w/recent pkg versions

### DIFF
--- a/repos/spack_repo/builtin/packages/diffutils/package.py
+++ b/repos/spack_repo/builtin/packages/diffutils/package.py
@@ -49,6 +49,7 @@ class Diffutils(AutotoolsPackage, GNUMirrorPackage):
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("%fj"):
             env.append_flags("CFLAGS", "-Qunused-arguments")
+        # Use C11 std to ensure two-arg static_assert (no C23 for Intel Classic)
         if self.spec.satisfies("@3.10: %intel"):
             env.append_flags("CFLAGS", "-std=c11")
 

--- a/repos/spack_repo/builtin/packages/diffutils/package.py
+++ b/repos/spack_repo/builtin/packages/diffutils/package.py
@@ -49,6 +49,8 @@ class Diffutils(AutotoolsPackage, GNUMirrorPackage):
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("%fj"):
             env.append_flags("CFLAGS", "-Qunused-arguments")
+        if self.spec.satisfies("@3.10: %intel"):
+            env.append_flags("CFLAGS", "-std=c11")
 
     @classmethod
     def determine_version(cls, exe):


### PR DESCRIPTION
This PR allows recent versions of diffutils to be built with intel classic. Currently it fails due to lack of support for one-arg static_assert (C23).