### PR TITLE
Update notary image

### DIFF
--- a/.ci/gitlab/configs/ci.yaml
+++ b/.ci/gitlab/configs/ci.yaml
@@ -59,7 +59,7 @@ ci:
 
   - signing-job:
       image:
-        name: ghcr.io/spack/notary@sha256:8b685186de3e26bfacbdfea27cf3802c853e2f1311e833e4d857247791a636dc
+        name: ghcr.io/spack/notary@sha256:a1e2575e12a1d60083a65f0a1b35abf0df85d7086e7f8b10c2a9926614a46127
         entrypoint: [""]
       tags: ["aws"]
       script:


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
update the notary image to latest version.

Fixes: https://gitlab.spack.io/spack/spack/-/jobs/19702869#L34
ref. curl needed: https://github.com/spack/spack-infrastructure/pull/1286
image: https://github.com/spack/spack-infrastructure/pkgs/container/notary/625682550?tag=0.0.4