### PR TITLE
mapl: add v2.64.1

### DIFF
--- a/repos/spack_repo/builtin/packages/mapl/package.py
+++ b/repos/spack_repo/builtin/packages/mapl/package.py
@@ -40,6 +40,7 @@ class Mapl(CMakePackage):
     version("main", branch="main")
 
     # Remember if there is a new ESMA_cmake, to update the resources too
+    version("2.64.1", sha256="205eac5600c223aa59e359f5b75a462a03302d58e7294f98fb87f29d544ef5a8")
     version("2.64.0", sha256="dab66884ca459c56b8bc2199fe334fd5ada131c4f66f48b2ee44965d3dbf90f3")
     version("2.63.1", sha256="c91cf72bc4bf48a52f12a2356ace0ba59463cbe36060ecacbac9193d99233306")
     version("2.63.0", sha256="5a170980e114d94cc1249d328b166e2048bfc1081a52323d81e2294fb2f08742")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This adds MAPL v2.64.1. Restores a workaround for GNU that went missing at some point.