### PR TITLE
Update glow

### DIFF
--- a/repos/spack_repo/builtin/packages/glow/package.py
+++ b/repos/spack_repo/builtin/packages/glow/package.py
@@ -23,6 +23,7 @@ class Glow(GoPackage):
 
     license("MIT")
 
+    version("2.1.1", sha256="f13e1d6be1ab4baf725a7fedc4cd240fc7e5c7276af2d92f199e590e1ef33967")
     version("1.5.1", sha256="b4ecf269b7c6447e19591b1d23f398ef2b38a6a75be68458390b42d3efc44b92")
     version("1.5.0", sha256="66f2a876eba15d71cfd08b56667fb07e1d49d383aa17d31696a39e794e23ba92")
     version("1.4.1", sha256="ff6dfd7568f0bac5144ffa3a429ed956dcbdb531487ef6e38ac61365322c9601")
@@ -33,6 +34,25 @@ class Glow(GoPackage):
     version("1.1.0", sha256="c9a72e2267b95e39033e845961ad45675c9f0d86080b138c6a2fbf2a5d3428d1")
     version("1.0.2", sha256="2d98c1e780d750b83d8da094de4c2a999c324021906e6d813b7c75d0320243c8")
     version("1.0.1", sha256="78d163bea8e6c13fb343f1e3586e93e0392e5052c408a248cc2f0fcc7aa38618")
+
+    # Based on go.mod
+    depends_on("go@1.24.1:", when="@2.1.1:")
+    depends_on("go@1.23.6:", when="@2.1.0:")
+    depends_on("go@1.21.4:", when="@2.0.0:")
+    depends_on("go@1.16:", when="@1.5.0:")
+    depends_on("go@1.13:", when="@1.0.0:")
+
+    @property
+    def build_args(self):
+        return [
+            "-p",
+            str(self.module.make_jobs),
+            "-modcacherw",
+            "-ldflags",
+            f"-s -w -X main.Version={self.version}",
+            "-o",
+            f"{self.name}",
+        ]
 
     @run_after("install")
     def install_completions(self):

--- a/repos/spack_repo/builtin/packages/glow/package.py
+++ b/repos/spack_repo/builtin/packages/glow/package.py
@@ -40,7 +40,7 @@ class Glow(GoPackage):
     depends_on("go@1.23.6:", when="@2.1.0:")
     depends_on("go@1.21.4:", when="@2.0.0:")
     depends_on("go@1.16:", when="@1.5.0:")
-    depends_on("go@1.13:", when="@1.0.0:")
+    depends_on("go@1.13:")
 
     @property
     def build_args(self):

--- a/repos/spack_repo/builtin/packages/glow/package.py
+++ b/repos/spack_repo/builtin/packages/glow/package.py
@@ -46,7 +46,7 @@ class Glow(GoPackage):
     def build_args(self):
         return [
             "-p",
-            str(self.module.make_jobs),
+            str(make_jobs),
             "-modcacherw",
             "-ldflags",
             f"-s -w -X main.Version={self.version}",


### PR DESCRIPTION
- Add `glow` 2.1.1
- Set `go` version dependencies based on contents of `go.mod` at each tag in the upstream project
- Ensure the `glow` version is set and reported by `glow --version` by passing the `-X main.Version` ldflag. Previously, the version was reported as "version unknown".

/cc @harrysharma1 @alecbcs 
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
