### PR TITLE
p4est: add explicit -lm to fix link failures with newer toolchains

### DIFF
--- a/repos/spack_repo/builtin/packages/p4est/package.py
+++ b/repos/spack_repo/builtin/packages/p4est/package.py
@@ -71,6 +71,7 @@ class P4est(AutotoolsPackage):
             "--without-blas",
             "CPPFLAGS=-DSC_LOG_PRIORITY=SC_LP_ESSENTIAL",
             "CFLAGS=-O2",
+            "LIBS=-lm",
         ]
 
         if "~mpi" in self.spec:


### PR DESCRIPTION
Some example targets (e.g. v4l2) use math functions such as sin(), but libm was not listed explicitly on the link line. Older toolchains linked this transitively, but newer GCC/binutils reject this with “DSO missing from command line”. Add -lm explicitly to make the link robust and portable.

This should also fix this [issue](https://github.com/spack/spack-packages/issues/1942).