### PR TITLE
openfoam: update to v2512

### DIFF
--- a/repos/spack_repo/builtin/packages/openfoam/common/spack-Allwmake
+++ b/repos/spack_repo/builtin/packages/openfoam/common/spack-Allwmake
@@ -19,6 +19,13 @@ then
     ./Allwmake-spack $@   # Pass arguments
 else
     ./Allwmake $@         # Pass arguments
+
+    # Build any additional plugins (if the sources exist)
+    if [ -x ./Allwmake-plugins ]
+    then
+        ./Allwmake-plugins -k $@  # Pass arguments
+    fi
+
     ##echo "Disabled build of openfoam"   # When testing environment only
 
     # Generate manpages

--- a/repos/spack_repo/builtin/packages/openfoam/package.py
+++ b/repos/spack_repo/builtin/packages/openfoam/package.py
@@ -424,13 +424,13 @@ class Openfoam(Package):
     patch("1612-spack-patches.patch", when="@1612")
     # kahip patch (wmake)
     patch(
-        "https://develop.openfoam.com/Development/openfoam/commit/8831dfc58b0295d0d301a78341dd6f4599073d45.patch",
+        "https://gitlab.com/openfoam/core/openfoam/commit/8831dfc58b0295d0d301a78341dd6f4599073d45.patch",
         when="@1806",
         sha256="531146be868dd0cda70c1cf12a22110a38a30fd93b5ada6234be3d6c9256c6cf",
     )
     # Fix: missing std::array include (searchable sphere)
     patch(
-        "https://develop.openfoam.com/Development/openfoam/commit/b4324b1297761545d5b10f50b60ab29e71c172aa.patch",
+        "https://gitlab.com/openfoam/core/openfoam/commit/b4324b1297761545d5b10f50b60ab29e71c172aa.patch",
         when="@2012_220610",
         sha256="bad4b0e80fd26ea702bce9ccfb925edbbaa3308f70392fe6da2c7671b1d39bea",
     )
@@ -907,7 +907,7 @@ class Openfoam(Package):
 
     # Executables like decomposePar require interface libraries for optional dependencies, but if
     # the dependency is missing, an dummy library is used and put in lib/dummy. Allow this until
-    # the https://develop.openfoam.com/Development/openfoam/-/issues/3283 is resolved.
+    # the https://gitlab.com/openfoam/core/openfoam/-/issues/3283 is resolved.
     unresolved_libraries = [
         "libkahipDecomp.so",
         "libmetisDecomp.so",

--- a/repos/spack_repo/builtin/packages/openfoam/package.py
+++ b/repos/spack_repo/builtin/packages/openfoam/package.py
@@ -267,6 +267,7 @@ class Openfoam(Package):
 
     version("develop", branch="develop", submodules="True")
     version("master", branch="master", submodules="True")
+    version("2512", sha256="ae9a0a133a2e996b88bd1d0f3cc229e3c49968c368feae61bd3ec63deaf337aa")
     version("2506", sha256="63d26f48ae7ee9a7806a0ceb339ef8a0ba485a4714d54fbfb31e78e1a4849965")
     version("2412", sha256="c353930105c39b75dac7fa7cfbfc346390caa633a868130fd8c9816ef5f732cd")
     version("2406", sha256="8d1450fb89eec1e7cecc55c3bb7bc486ccbf63d069379d1d5d7518fa16a4686a")

--- a/repos/spack_repo/builtin/packages/openfoam/package.py
+++ b/repos/spack_repo/builtin/packages/openfoam/package.py
@@ -246,9 +246,9 @@ def mplib_content(spec, pre=None):
 
 def submodules(package):
     submodules = []
-    if package.spec.satisfies("plugins=avalanche"):
+    if package is not None and package.spec.satisfies("plugins=avalanche"):
         submodules.append("plugins/avalanche")
-    if package.spec.satisfies("plugins=cfmesh"):
+    if package is not None and package.spec.satisfies("plugins=cfmesh"):
         submodules.append("plugins/cfmesh")
     return submodules
 

--- a/repos/spack_repo/builtin/packages/openfoam/package.py
+++ b/repos/spack_repo/builtin/packages/openfoam/package.py
@@ -259,7 +259,7 @@ class Openfoam(Package):
     maintainers("olesenm")
     homepage = "https://www.openfoam.com/"
     url = "https://sourceforge.net/projects/openfoam/files/v1906/OpenFOAM-v1906.tgz"
-    git = "https://develop.openfoam.com/Development/openfoam.git"
+    git = "https://gitlab.com/openfoam/core/openfoam.git"
     list_url = "https://sourceforge.net/projects/openfoam/files/"
     list_depth = 2
 

--- a/repos/spack_repo/builtin/packages/openfoam/package.py
+++ b/repos/spack_repo/builtin/packages/openfoam/package.py
@@ -277,10 +277,10 @@ class Openfoam(Package):
     version("develop", branch="develop", submodules="True")
     version("master", branch="master", submodules="True")
     version(
-        "2512", 
+        "2512",
         tag="OpenFOAM-v2512",
         commit="87ed40d256d22ea38fcc648dfc82a22162427b18",
-        submodules=submodules
+        submodules=submodules,
     )
     version("2506", sha256="63d26f48ae7ee9a7806a0ceb339ef8a0ba485a4714d54fbfb31e78e1a4849965")
     version("2412", sha256="c353930105c39b75dac7fa7cfbfc346390caa633a868130fd8c9816ef5f732cd")

--- a/repos/spack_repo/builtin/packages/openfoam/package.py
+++ b/repos/spack_repo/builtin/packages/openfoam/package.py
@@ -244,6 +244,15 @@ def mplib_content(spec, pre=None):
     return info
 
 
+def submodules(package):
+    submodules = []
+    if package.spec.satisfies("plugins=avalanche"):
+        submodules.append("plugins/avalanche")
+    if package.spec.satisfies("plugins=cfmesh"):
+        submodules.append("plugins/cfmesh")
+    return submodules
+
+
 # -----------------------------------------------------------------------------
 
 
@@ -267,7 +276,12 @@ class Openfoam(Package):
 
     version("develop", branch="develop", submodules="True")
     version("master", branch="master", submodules="True")
-    version("2512", sha256="ae9a0a133a2e996b88bd1d0f3cc229e3c49968c368feae61bd3ec63deaf337aa")
+    version(
+        "2512", 
+        tag="OpenFOAM-v2512",
+        commit="87ed40d256d22ea38fcc648dfc82a22162427b18",
+        submodules=submodules
+    )
     version("2506", sha256="63d26f48ae7ee9a7806a0ceb339ef8a0ba485a4714d54fbfb31e78e1a4849965")
     version("2412", sha256="c353930105c39b75dac7fa7cfbfc346390caa633a868130fd8c9816ef5f732cd")
     version("2406", sha256="8d1450fb89eec1e7cecc55c3bb7bc486ccbf63d069379d1d5d7518fa16a4686a")
@@ -355,6 +369,14 @@ class Openfoam(Package):
         description="Precision option",
         values=("sp", "dp", conditional("spdp", when="@1906:")),
         multi=False,
+    )
+
+    variant(
+        "plugins",
+        default="none",
+        description="With optional plugins",
+        values=("none", conditional("avalanche", "cfmesh", when="@2512:")),
+        multi=True,
     )
 
     depends_on("c", type="build")  # generated


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

+ Make latest OpenFOAM v2512 release available ([release notes](https://www.openfoam.com/news/main-news/openfoam-v2512))
+ Update URL following the recent OpenFOAM migration to GitLab ([OpenFOAM news](https://www.openfoam.com/news/main-news/openfoam-v2512/usability#gitlab))