### PR TITLE
orca: add versions 6.1.1 and avx2-6.1.1

### DIFF
--- a/repos/spack_repo/builtin/packages/orca/package.py
+++ b/repos/spack_repo/builtin/packages/orca/package.py
@@ -25,6 +25,10 @@ class Orca(Package):
     license("LGPL-2.1-or-later")
 
     version(
+        "avx2-6.1.1", sha256="5eaf676f9711a38835d609264321a30266b487b65477547802dedee982bc82d5"
+    )
+    version("6.1.1", sha256="a0bc1d6d2c3c00620367bbc5dbf2b3a7018abc92d1ff65f06cec46f75350b9be")
+    version(
         "avx2-6.0.1", sha256="f31f98256a0c6727b6ddfe50aa3ac64c45549981138d670a57e90114b4b9c9d2"
     )
     version("6.0.1", sha256="5e9b49588375e0ce5bc32767127cc725f5425917804042cdecdfd5c6b965ef61")
@@ -49,8 +53,10 @@ class Orca(Package):
         "5.0.4": "4.1.2",
         "6.0.0": "4.1.6",
         "6.0.1": "4.1.6",
+        "6.1.1": "4.1.8",
         "avx2-6.0.0": "4.1.6",
         "avx2-6.0.1": "4.1.6",
+        "avx2-6.1.1": "4.1.8",
     }
     for orca_version, openmpi_version in openmpi_versions.items():
         depends_on(
@@ -63,13 +69,10 @@ class Orca(Package):
             openmpi_version = "411"
 
         ver_parts = version.string.split("-")
-        ver_underscored = ver_parts[-1].replace(".", "_")
-        features = ver_parts[:-1] + ["shared"]
-        feature_text = "_".join(features)
 
-        url = f"file://{os.getcwd()}/orca_{ver_underscored}_linux_x86-64_{feature_text}_openmpi{openmpi_version}.tar.xz"
-        if self.spec.satisfies("@=avx2-6.0.1"):
-            url = f"file://{os.getcwd()}/orca_{ver_underscored}_linux_x86-64_shared_openmpi{openmpi_version}_avx2.tar.xz"
+        url = f"file://{os.getcwd()}/orca_{version.underscored}_linux_x86-64_shared_openmpi{openmpi_version}{'_avx2' if 'avx2' in ver_parts else ''}.tar.xz"
+        if self.spec.satisfies("@=avx2-6.0.0"):
+            url = f"file://{os.getcwd()}/orca_{version.underscored}_linux_x86-64_avx2_shared_openmpi{openmpi_version}.tar.xz"
 
         return url
 

--- a/repos/spack_repo/builtin/packages/orca/package.py
+++ b/repos/spack_repo/builtin/packages/orca/package.py
@@ -69,10 +69,11 @@ class Orca(Package):
             openmpi_version = "411"
 
         ver_parts = version.string.split("-")
+        ver_underscored = ver_parts[-1].replace(".", "_")
 
-        url = f"file://{os.getcwd()}/orca_{version.underscored}_linux_x86-64_shared_openmpi{openmpi_version}{'_avx2' if 'avx2' in ver_parts else ''}.tar.xz"
+        url = f"file://{os.getcwd()}/orca_{ver_underscored}_linux_x86-64_shared_openmpi{openmpi_version}{'_avx2' if 'avx2' in ver_parts else ''}.tar.xz"
         if self.spec.satisfies("@=avx2-6.0.0"):
-            url = f"file://{os.getcwd()}/orca_{version.underscored}_linux_x86-64_avx2_shared_openmpi{openmpi_version}.tar.xz"
+            url = f"file://{os.getcwd()}/orca_{ver_underscored}_linux_x86-64_avx2_shared_openmpi{openmpi_version}.tar.xz"
 
         return url
 


### PR DESCRIPTION
Add the latest ORCA versions: 6.1.1 and avx2-6.1.1.

Issue [#47489](https://github.com/spack/spack/pull/47489) discusses a change in ORCA’s filename scheme compared to earlier releases, and suggests treating avx2-6.0.1 as a temporary edge case until a later release clarified which scheme would be used going forward.
Based on the currently available releases, it seems that ORCA is continuing to use the avx2-6.0.1 filename scheme:

    avx2-6.0.0    orca_6_0_0_linux_x86-64_avx2_shared_openmpi416.tar.xz
    avx2-6.0.1    orca_6_0_1_linux_x86-64_shared_openmpi416_avx2.tar.xz
    avx2-6.1.1    orca_6_1_1_linux_x86-64_shared_openmpi418_avx2.tar.xz

So I’ve also modified the URL construction logic to treat avx2-6.0.0 as the edge case instead, and to use the newer filename scheme for later versions.