### PR TITLE
ci: remove sha256 long args

### DIFF
--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -239,7 +239,7 @@ dotenv:
   - export WRITE_DOTENV_SCRIPT_REF="0f92f8bcd4dd94fc7379eef8db5c9ed6f1935402"
   - export WRITE_DOTENV_SCRIPT_SHA256="124d80ef595b9ddc2fca3f202a70ee15378547ad5e887fe7d3b248669c5ee54a"
   - curl -LSsO https://raw.githubusercontent.com/spack/spack-packages/$WRITE_DOTENV_SCRIPT_REF/.ci/gitlab/scripts/common/write_dotenv.py
-  - echo "$WRITE_DOTENV_SCRIPT_SHA256 write_dotenv.py" | sha256sum --check --status
+  - echo "$WRITE_DOTENV_SCRIPT_SHA256 write_dotenv.py" | sha256sum -c
   - python3 write_dotenv.py .ci/env
   - cat env
 

--- a/.ci/gitlab/configs/ci.yaml
+++ b/.ci/gitlab/configs/ci.yaml
@@ -150,7 +150,7 @@ ci:
         - nproc || true
       # Clone the other repo
       - - curl -LSsO https://raw.githubusercontent.com/spack/spack-packages/$REMOTE_SCRIPT_REF/.ci/gitlab/scripts/common/clone_spack.sh
-        - echo "$REMOTE_SCRIPT_CLONE_SPACK_SHA256 clone_spack.sh" | sha256sum --check --status
+        - echo "$REMOTE_SCRIPT_CLONE_SPACK_SHA256 clone_spack.sh" | sha256sum -c
         - sh clone_spack.sh
       - - . "${SPACK_CI_SPACK_ROOT}/share/spack/setup-env.sh"
         - spack --version

--- a/.ci/gitlab/configs/linux/x86_64_v4/ci.yaml
+++ b/.ci/gitlab/configs/linux/x86_64_v4/ci.yaml
@@ -3,8 +3,4 @@ ci:
   - build-job:
       variables:
         SPACK_CI_TARGET: x86_64_v4
-      before_script:
-      - - curl -LfsS "https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz" -o gmake.tar.gz
-        - printf "fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz" | sha256sum --check --strict --quiet
-        - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
       tags: ["x86_64_v4"]


### PR DESCRIPTION
Also remove a script that was used to install a newer make, which is redundant.