### PR TITLE
surfer: add v0.5.0 and v0.4.0

### DIFF
--- a/repos/spack_repo/builtin/packages/surfer/package.py
+++ b/repos/spack_repo/builtin/packages/surfer/package.py
@@ -21,10 +21,17 @@ class Surfer(CargoPackage):
     version("main", branch="main", submodules=True)
 
     version(
+        "0.5.0", tag="v0.5.0", commit="0be6f8ad869060791ad0864d77f2f842cd27ee65", submodules=True
+    )
+    version(
+        "0.4.0", tag="v0.4.0", commit="9198cc497aec2249ff7459df03fed628c9996578", submodules=True
+    )
+    version(
         "0.3.0", tag="v0.3.0", commit="1a6b34c44ea0e5089bd55d0bce1297aa1a02e6ef", submodules=True
     )
 
-    depends_on("rust@1.82:")
+    depends_on("rust@1.92:", when="@:0.4.0")
+    depends_on("rust@1.82:", when="@:0.3.0")
     depends_on("c", type="build")
     depends_on("openssl")
 


### PR DESCRIPTION
Add v0.5.0 and v.0.4.0

Also upreved the versions of rust, not all versions of rust are available