### PR TITLE
tau: fix hash for v2.35.1

### DIFF
--- a/repos/spack_repo/builtin/packages/tau/package.py
+++ b/repos/spack_repo/builtin/packages/tau/package.py
@@ -29,7 +29,7 @@ class Tau(Package):
     license("MIT")
 
     version("master", branch="master")
-    version("2.35.1", sha256="6eadcf9e2a267d75d7dcae07cf24ab5975576de7ebd6eacb43e65a375eb8468e")
+    version("2.35.1", sha256="fee7c0ae49c370c23489b7c14b312af4611bb06cdb212464a2b0798721e9811f")
     version("2.35", sha256="b13c6a0579da59853f8e6482d5f3aaed482bc1306c4eb91411c1568f647bf348")
     version("2.34.1", sha256="0e90726372fa1b6f726eb62b0840350070a00215144853ee07a852a99458c619")
     version("2.34", sha256="229ab425e0532e635a0be76d60b8aa613adf7596d15a9ced0b87e7f243bb2132")


### PR DESCRIPTION
Hash changed on remote tarball. This fixes it. @nchaimov @sameershende 