### PR TITLE
Allow hip component to have an associated compiler when used as an external

### DIFF
--- a/repos/spack_repo/builtin/packages/hipblas_common/package.py
+++ b/repos/spack_repo/builtin/packages/hipblas_common/package.py
@@ -16,6 +16,8 @@ class HipblasCommon(CMakePackage):
 
     maintainers("srekolam", "renjithravindrankannath", "afzpatel")
 
+    depends_on("c", type="build")
+
     license("MIT")
     version("7.1.0", sha256="6c00bb9335ad2ad3d4730eb41ebc704b0207162d5f98da1cdce3eea1087c3944")
     version("7.0.2", sha256="7b8007784831d895fb0a432f366388bc7d212443a25ea9f14eb2aa0a7b4ad5d7")


### PR DESCRIPTION
This source code only appears to consist of one header file, but is stored on a per-rocm-version basis

Assigning`depends_on(c, type=build)` is needed to associate a compiler with an external listing of `hipblas-common` e.g. like:

```
packages:
  hipblas-common:
    externals:
    - spec: hipblas-common %llvm-amdgpu@6.4.1
      prefix...
    - spec: hipblas-common %llvm-amdgpu@6.2.0
```

An alternative is transforming something like:

```
 packages
   hipblas:
     externals:
     - spec: hipblas@6.4.1 %llvm-amdgpu@6.4.1
       prefix: /opt/rocm-6.4.1
     buildable: false
   hipblas-common:
     externals:
     # Works well with concretizer:compiler_mixing:false
     - spec: hipblas-common@6.4.1 %llvm-amdgpu@6.4.1
       prefix: /opt/rocm-6.4.1
     buildable: false
```

to

```
 packages
   hipblas:
     externals:
     - spec: hipblas@6.4.1
       prefix: /opt/rocm-6.4.1
       dependencies:
       - spec: hipblas-common@6.4.1
       - spec: llvm-amdgpu@6.4.1
         virtuals: "c"
     buildable: false
   hipblas-common:
     externals:
     - spec: hipblas-common@6.4.1
       prefix: /opt/rocm-6.4.1
     buildable: false
```

(while the hipblas package has version synchronization constraints on hipblas-common, they don't apply when hipblas is external, so they have to be reapplied manually as in this example)