### PR TITLE
mfem: fix hypre version constraint

### DIFF
--- a/repos/spack_repo/builtin/packages/mfem/package.py
+++ b/repos/spack_repo/builtin/packages/mfem/package.py
@@ -767,7 +767,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
                     hypre_rocm_libs += hypre["rocsparse"].libs
                 if "^rocrand" in hypre:
                     hypre_rocm_libs += hypre["rocrand"].libs
-                if hypre.satisfies("@2.39.0:"):
+                if hypre.satisfies("@2.29.0:"):
                     if "^rocsolver" in hypre:
                         hypre_rocm_libs += hypre["rocsolver"].libs
                     if "^rocblas" in hypre:


### PR DESCRIPTION
This PR fixes the hypre version check in MFEM, so that the libs are added to the list of hypre rocm libs to all versions necessary. Fixes this PR https://github.com/spack/spack-packages/pull/2363