### PR TITLE
osu_micro_benchmarks: add version 7.5.2

### DIFF
--- a/repos/spack_repo/builtin/packages/osu_micro_benchmarks/package.py
+++ b/repos/spack_repo/builtin/packages/osu_micro_benchmarks/package.py
@@ -23,6 +23,7 @@ class OsuMicroBenchmarks(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     maintainers("natshineman", "harisubramoni", "MatthewLieber")
 
+    version("7.5.2", sha256="618de3d0b1122f73a9229177d2da1e5cd62e431190580cb915f2605849cbbbdc")
     version("7.5.1", sha256="160d0d5e3c3cb022520ecb247e9875bb0973b1d3cadccd6c17624f8407c52e22")
     version("7.5", sha256="1cf84ac5419456202757a757c5f9a4f5c6ecd05c65783c7976421cfd6020b3b3")
     version("7.4", sha256="1edd0c2efa61999409bfb28740a7f39689a5b42b1a1b4c66d1656e5637f7cefc")


### PR DESCRIPTION
Add version `7.5.2` for the `osu_micro_benchmarks` package.
