### PR TITLE
rocm: add amdgpu_targets for RDNA 3.5 & 4

### DIFF
--- a/repos/spack_repo/builtin/build_systems/rocm.py
+++ b/repos/spack_repo/builtin/build_systems/rocm.py
@@ -131,6 +131,14 @@ class ROCmPackage(PackageBase):
         "gfx1101",
         "gfx1102",
         "gfx1103",
+        "gfx1150",
+        "gfx1151",
+        "gfx1152",
+        "gfx1153",
+        "gfx1200",
+        "gfx1201",
+        "gfx1250",
+        "gfx1251",
     )
 
     variant("rocm", default=False, description="Enable ROCm support")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Refer to [the page describing AMD GPU arch](https://llvm.org/docs/AMDGPUUsage.html) and add them to rocm.py, so that users can specify amdgpu_target with their newer AMD GPUs.