### PR TITLE
AOCL: add version 5.2

### DIFF
--- a/repos/spack_repo/builtin/packages/amd_aocl/package.py
+++ b/repos/spack_repo/builtin/packages/amd_aocl/package.py
@@ -25,6 +25,7 @@ class AmdAocl(BundlePackage):
 
     maintainers("amd-toolchain-support")
 
+    version("5.2")
     version("5.1")
     version("5.0")
     version("4.2")
@@ -64,7 +65,7 @@ class AmdAocl(BundlePackage):
         depends_on("aocl-da ~openmp")
         depends_on("aocl-compression ~openmp")
 
-    for vers in ["2.2", "3.0", "3.1", "3.2", "4.0", "4.1", "4.2", "5.0", "5.1"]:
+    for vers in ["2.2", "3.0", "3.1", "3.2", "4.0", "4.1", "4.2", "5.0", "5.1", "5.2"]:
         with when(f"@={vers}"):
             depends_on(f"amdblis@={vers}")
             depends_on(f"amdfftw@={vers}")

--- a/repos/spack_repo/builtin/packages/amd_aocl/package.py
+++ b/repos/spack_repo/builtin/packages/amd_aocl/package.py
@@ -79,3 +79,5 @@ class AmdAocl(BundlePackage):
                 depends_on(f"aocl-libmem@={vers}")
             if Version(vers) >= Version("5.0"):
                 depends_on(f"aocl-da@={vers}")
+            if Version(vers) >= Version("5.2"):
+                depends_on(f"aocl-dlp@={vers}")

--- a/repos/spack_repo/builtin/packages/amdblis/package.py
+++ b/repos/spack_repo/builtin/packages/amdblis/package.py
@@ -36,6 +36,7 @@ class Amdblis(BlisBase):
 
     license("BSD-3-Clause")
 
+    version("5.2", sha256="c553bd543eedc87920df9b82634ae4c02662145ed737f51fdf4c9bca5e588028")
     version("5.1", sha256="4ab210cea8753f4be9646a3ad8e6b42c7d19380084a66312497c97278b8c76a4")
     version("5.0", sha256="5abb34972b88b2839709d0af8785662bc651c7806ccfa41d386d93c900169bc2")
     version("4.2", sha256="0e1baf850ba0e6f99e79f64bbb0a59fcb838ddb5028e24527f52b407c3c62963")

--- a/repos/spack_repo/builtin/packages/amdfftw/package.py
+++ b/repos/spack_repo/builtin/packages/amdfftw/package.py
@@ -39,6 +39,7 @@ class Amdfftw(FftwBase):
 
     license("GPL-2.0-only")
 
+    version("5.2", sha256="143c7a936fd197a94551aa1c67d7ae7cbf7d96338947aa21d3007df7aea46c78")
     version("5.1", sha256="4cc0d6985afc5ce14cafc195ad46d9876ac4f35b959861b41a3b681385d7320d")
     version("5.0", sha256="bead6c08309a206f8a6258971272affcca07f11eb57b5ecd8496e2e7e3ead877")
     version("4.2", sha256="391ef7d933e696762e3547a35b58ab18d22a6cf3e199c74889bcf25a1d1fc89b")

--- a/repos/spack_repo/builtin/packages/amdlibflame/package.py
+++ b/repos/spack_repo/builtin/packages/amdlibflame/package.py
@@ -48,6 +48,7 @@ class Amdlibflame(CMakePackage, LibflameBase):
 
     license("BSD-3-Clause")
 
+    version("5.2", sha256="fb5fe5128f718050c9911443fcf7ed91b60538a40d57084ed0124bb91afabb9b")
     version("5.1", sha256="25524ba78b5952303369fa0859d217e44071144fd122a9dc3f72ed0bd73e3b2d")
     version("5.0", sha256="3bee3712459a8c5bd728a521d8a4c8f46735730bf35d48c878d2fc45fc000918")
     version("4.2", sha256="93a433c169528ffba74a99df0ba3ce3d5b1fab9bf06ce8d2fd72ee84768ed84c")
@@ -101,7 +102,7 @@ class Amdlibflame(CMakePackage, LibflameBase):
     depends_on("python+pythoncmd", type="build")
     depends_on("gmake@4:", when="@3.0.1,3.1:", type="build")
 
-    for vers in ["4.1", "4.2", "5.0", "5.1"]:
+    for vers in ["4.1", "4.2", "5.0", "5.1", "5.2"]:
         with when(f"@{vers}"):
             depends_on(f"aocl-utils@{vers}")
 

--- a/repos/spack_repo/builtin/packages/amdlibm/package.py
+++ b/repos/spack_repo/builtin/packages/amdlibm/package.py
@@ -102,8 +102,8 @@ class Amdlibm(SConsPackage, CMakePackage):
         spec = self.spec
 
         args = [
-            self.define("LIBAOCLUTILS_INCLUDE_PATH", spec["aocl-utils"].prefix.include),
-            f"-DLIBAOCLUTILS_LIBRARY_PATH={spec['aocl-utils'].libs}",
+            self.define("AOCL_UTILS_INCLUDE_DIR", spec["aocl-utils"].prefix.include),
+            f"-DAOCL_UTILS_LIB={spec['aocl-utils'].libs}",
         ]
         return args
 

--- a/repos/spack_repo/builtin/packages/amdlibm/package.py
+++ b/repos/spack_repo/builtin/packages/amdlibm/package.py
@@ -46,7 +46,15 @@ class Amdlibm(SConsPackage, CMakePackage):
     variant("verbose", default=False, description="Building with verbosity", when="@:4.1")
 
     # Build system
-    build_system(conditional("cmake", when="@5.1:"), "scons", default="scons")
+    # - For version 5.2: both 'cmake' and 'scons' are supported, with 'cmake' as default.
+    # - For version 5.1: both 'scons' and 'cmake' are supported, with 'scons' as default.
+    # - For versions below 5.1: only 'scons' is supported.
+    with when("@5.2"):
+        build_system("cmake", "scons", default="cmake")
+
+    with when("@:5.1"):
+        build_system("scons", conditional("cmake", when="@5.1:"), default="scons")
+
     # Mandatory dependencies
     depends_on("c", type="build")
     depends_on("cxx", type="build")

--- a/repos/spack_repo/builtin/packages/amdlibm/package.py
+++ b/repos/spack_repo/builtin/packages/amdlibm/package.py
@@ -32,6 +32,7 @@ class Amdlibm(SConsPackage, CMakePackage):
 
     license("BSD-3-Clause")
 
+    version("5.2", sha256="5cec8d30dc1083923c332c80808eda637ebd385b02a0cebf65ce72b5c8cbc029")
     version("5.1", sha256="7acf2c98469353b60a59fad167a98e1ae689055a3faf8352a254832145c9d59e")
     version("5.0", sha256="ba1d50c068938c9a927e37e5630f683b6149d7d5a95efffeb76e7c9a8bcb2b5e")
     version("4.2", sha256="58847b942e998b3f52eb41ae26403c7392d244fcafa707cbf23165aac24edd9e")
@@ -54,7 +55,7 @@ class Amdlibm(SConsPackage, CMakePackage):
     depends_on("scons@3.1.2:4.8.1", type=("build"))
     depends_on("cmake@3.26:3.30.6", type="build", when="build_system=cmake")
     depends_on("mpfr", type=("link"))
-    for vers in ["4.1", "4.2", "5.0", "5.1"]:
+    for vers in ["4.1", "4.2", "5.0", "5.1", "5.2"]:
         with when(f"@{vers}"):
             depends_on(f"aocl-utils@{vers}")
 
@@ -63,7 +64,7 @@ class Amdlibm(SConsPackage, CMakePackage):
     # Patch to update the SCons environment with newly introduced
     # Spack build environment variables.
     patch("libm-ose-SconsSpack.patch", when="@3.1:4.2")
-    patch("libm-ose-SconsSpack-5.patch", when="@5.0:")
+    patch("libm-ose-SconsSpack-5.patch", when="@5.0:5.1")
 
     conflicts("%gcc@:9.1.0", msg="Minimum supported GCC version is 9.2.0")
     conflicts("%clang@:11.1", msg="Minimum supported Clang version is 12.0")

--- a/repos/spack_repo/builtin/packages/amdscalapack/package.py
+++ b/repos/spack_repo/builtin/packages/amdscalapack/package.py
@@ -34,6 +34,7 @@ class Amdscalapack(ScalapackBase):
 
     license("BSD-3-Clause-Open-MPI")
 
+    version("5.2", sha256="ff01f0f39c9e6d44fa493e1c68d9862d2600f425e9caaec1fe5179c10debf1d9")
     version("5.1", sha256="92f6f6b2081e27731c8b9e96c742203777cc7f2a848b96ca7511f4d259142b37")
     version("5.0", sha256="a33cf16c51cfd65c7acb5fbdb8884a5c147cdefea73931b07863c56d54f812cc")
     version("4.2", sha256="c6e9a846c05cdc05252b0b5f264164329812800bf13f9d97c77114dc138e6ccb")

--- a/repos/spack_repo/builtin/packages/aocl_compression/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_compression/package.py
@@ -44,6 +44,7 @@ class AoclCompression(CMakePackage):
 
     maintainers("amd-toolchain-support")
 
+    version("5.2", sha256="93a4eddd0a70e6d8701ecf2c55a06ab341d987ccd2e87c50a5c7e1efb37e033e")
     version("5.1", sha256="9462c6898350d66a5d9ce0236c432c94b4c9393b638ddf6511628b784eb02720")
     version("5.0", sha256="50bfb2c4a4738b96ed6d45627062b17bb9d0e1787c7d83ead2841da520327fa4")
     version("4.2", sha256="a18b3e7f64a8105c1500dda7b4c343e974b5e26bfe3dd838a1c1acf82a969c6f")

--- a/repos/spack_repo/builtin/packages/aocl_crypto/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_crypto/package.py
@@ -38,6 +38,7 @@ class AoclCrypto(CMakePackage):
 
     maintainers("amd-toolchain-support")
 
+    version("5.2", sha256="a08da78287a05b6e48fc2870ef15053bb67d539ba83cf233ad8dcdc65f892d89")
     version("5.1", sha256="a2f768b7d37516c5c29cca0034aba90b91d02e477c762f2fa0fe4b1c30613973")
     version("5.0", sha256="b15e609943f9977e13f2d5839195bb7411c843839a09f0ad47f78f57e8821c23")
     version("4.2", sha256="2bdbedd8ab1b28632cadff237f4abd776e809940ad3633ad90fc52ce225911fe")
@@ -59,7 +60,7 @@ class AoclCrypto(CMakePackage):
     depends_on("openssl@3.1.5:")
     depends_on("intel-oneapi-ippcp@2021.12.0:", when="+ipp")
     depends_on("p7zip", type="build")
-    for vers in ["4.2", "5.0", "5.1"]:
+    for vers in ["4.2", "5.0", "5.1", "5.2"]:
         with when(f"@={vers}"):
             depends_on(f"aocl-utils@={vers}")
 

--- a/repos/spack_repo/builtin/packages/aocl_da/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_da/package.py
@@ -34,6 +34,7 @@ class AoclDa(CMakePackage):
 
     maintainers("amd-toolchain-support")
 
+    version("5.2", sha256="faaa250de44d0b7d15a75b26121d457ac895b5cddd87ae1d81882a685ca81eb9")
     version("5.1", sha256="93cdb789c948bf750e531f95618bae4370d53eddc88960744ff02c9acbfe9ef5")
     version("5.0", sha256="3458adc7be39c78a08232c887f32838633149df0a69ccea024327c3edc5a5c1d")
 
@@ -61,7 +62,7 @@ class AoclDa(CMakePackage):
     depends_on("cmake@3.22:", when="@:5.0", type="build")
     depends_on("cmake@3.26:", when="@5.1:", type="build")
     depends_on("boost@1.66.0:", when="@5.1:", type="build")
-    for vers in ["5.0", "5.1"]:
+    for vers in ["5.0", "5.1", "5.2"]:
         with when(f"@={vers}"):
             depends_on(f"aocl-utils@={vers} +shared", when="+shared")
             depends_on(f"aocl-utils@={vers} ~shared", when="~shared")

--- a/repos/spack_repo/builtin/packages/aocl_dlp/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_dlp/package.py
@@ -21,7 +21,6 @@ class AoclDlp(CMakePackage):
 
     maintainers("amd-toolchain-support")
 
-
     version("5.2", sha256="1eec26eeaf427cb2377ec21415ddce6e1bc62d4eab8ec51630a9c02711019c1c")
 
     # Feature toggles mapping directly to AOCL-DLP CMake options

--- a/repos/spack_repo/builtin/packages/aocl_dlp/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_dlp/package.py
@@ -1,0 +1,66 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class AoclDlp(CMakePackage):
+    """AOCL-DLP is a library designed to provide optimized deep learning primitives for AMD processors. 
+    It implements Low Precision GEMM (LPGEMM) and batch GEMM for deep learning applications, supporting 
+    multiple data types as well as pre-operations and post-operations. The library is tailored to leverage 
+    the full potential of AMD hardware, ensuring efficient computation, scalability, and accelerated 
+    deep learning workloads."""
+
+    _name = "aocl-dlp"
+    homepage = "https://www.amd.com/en/developer/aocl/dlp.html"
+    git = "https://github.com/amd/aocl-dlp"
+    url = "https://github.com/amd/aocl-dlp/archive/refs/tags/5.2.tar.gz"
+
+    maintainers("amd-toolchain-support")
+
+
+    version("5.2", sha256="1eec26eeaf427cb2377ec21415ddce6e1bc62d4eab8ec51630a9c02711019c1c")
+
+    # Feature toggles mapping directly to AOCL-DLP CMake options
+    variant("benchmarks", default=True, description="Build benchmarks (BUILD_BENCHMARKS)")
+    variant("tests", default=True, description="Enable tests (BUILD_TESTING)")
+    variant(
+        "ctest", default=False, description="Set DLP_CTEST_DISABLED=ON to skip CTest invocation"
+    )
+    variant("examples", default=True, description="Build examples (BUILD_EXAMPLES)")
+    variant("shared", default=True, description="Build shared libraries (BUILD_SHARED_LIBS)")
+
+    # Threading model selection (maps to DLP_THREADING_MODEL)
+    variant(
+        "threads",
+        default="none",
+        values=("none", "openmp", "pthread"),
+        description="Select threading backend for AOCL-DLP",
+    )
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("cmake@3.26:", type="build")
+
+    def cmake_args(self):
+        spec = self.spec
+        args = []
+
+        # Map multi-valued 'threads' variant to CMake var DLP_THREADING_MODEL
+        tmodel = spec.variants["threads"].value  # 'none' | 'openmp' | 'pthread'
+        args.append(self.define("DLP_THREADING_MODEL", tmodel))
+
+        # Straight boolean mappings
+        args.append(self.define_from_variant("BUILD_BENCHMARKS", "benchmarks"))
+        args.append(self.define_from_variant("BUILD_TESTING", "tests"))
+        args.append(
+            self.define("DLP_CTEST_DISABLED", "OFF" if spec.variants["ctest"].value else "ON")
+        )
+        args.append(self.define_from_variant("BUILD_EXAMPLES", "examples"))
+        args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+
+        return args
+

--- a/repos/spack_repo/builtin/packages/aocl_dlp/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_dlp/package.py
@@ -24,13 +24,11 @@ class AoclDlp(CMakePackage):
     version("5.2", sha256="1eec26eeaf427cb2377ec21415ddce6e1bc62d4eab8ec51630a9c02711019c1c")
 
     # Feature toggles mapping directly to AOCL-DLP CMake options
-    variant("benchmarks", default=True, description="Build benchmarks (BUILD_BENCHMARKS)")
-    variant("tests", default=True, description="Enable tests (BUILD_TESTING)")
-    variant(
-        "ctest", default=False, description="Set DLP_CTEST_DISABLED=ON to skip CTest invocation"
-    )
-    variant("examples", default=True, description="Build examples (BUILD_EXAMPLES)")
-    variant("shared", default=True, description="Build shared libraries (BUILD_SHARED_LIBS)")
+    variant("benchmarks", default=True, description="Build benchmarks")
+    variant("tests", default=True, description="Enable tests")
+    variant("ctest", default=False, description="Enable ctest")
+    variant("examples", default=True, description="Build examples")
+    variant("shared", default=True, description="Build shared libraries")
 
     # Threading model selection (maps to DLP_THREADING_MODEL)
     variant(

--- a/repos/spack_repo/builtin/packages/aocl_dlp/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_dlp/package.py
@@ -8,10 +8,10 @@ from spack.package import *
 
 
 class AoclDlp(CMakePackage):
-    """AOCL-DLP is a library designed to provide optimized deep learning primitives for AMD processors. 
-    It implements Low Precision GEMM (LPGEMM) and batch GEMM for deep learning applications, supporting 
-    multiple data types as well as pre-operations and post-operations. The library is tailored to leverage 
-    the full potential of AMD hardware, ensuring efficient computation, scalability, and accelerated 
+    """AOCL-DLP is a library designed to provide optimized deep learning primitives for AMD processors.
+    It implements Low Precision GEMM (LPGEMM) and batch GEMM for deep learning applications, supporting
+    multiple data types as well as pre-operations and post-operations. The library is tailored to leverage
+    the full potential of AMD hardware, ensuring efficient computation, scalability, and accelerated
     deep learning workloads."""
 
     _name = "aocl-dlp"
@@ -63,4 +63,3 @@ class AoclDlp(CMakePackage):
         args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
 
         return args
-

--- a/repos/spack_repo/builtin/packages/aocl_dlp/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_dlp/package.py
@@ -8,11 +8,11 @@ from spack.package import *
 
 
 class AoclDlp(CMakePackage):
-    """AOCL-DLP is a library designed to provide optimized deep learning primitives for AMD processors.
-    It implements Low Precision GEMM (LPGEMM) and batch GEMM for deep learning applications, supporting
-    multiple data types as well as pre-operations and post-operations. The library is tailored to leverage
-    the full potential of AMD hardware, ensuring efficient computation, scalability, and accelerated
-    deep learning workloads."""
+    """AOCL-DLP is a library designed to provide optimized deep learning primitives for AMD
+    processors. It implements Low Precision GEMM (LPGEMM) and batch GEMM for deep learning
+    applications, supporting multiple data types as well as pre-operations and post-operations.
+    The library is tailored to leverage the full potential of AMD hardware, ensuring efficient
+    computation, scalability, and accelerated deep learning workloads."""
 
     _name = "aocl-dlp"
     homepage = "https://www.amd.com/en/developer/aocl/dlp.html"

--- a/repos/spack_repo/builtin/packages/aocl_libmem/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_libmem/package.py
@@ -34,6 +34,7 @@ class AoclLibmem(CMakePackage):
 
     maintainers("amd-toolchain-support")
 
+    version("5.2", sha256="06b56596fe32a4528a93d18a827bd5cbd814115d16390c6f2ae93d6b5715d41d")
     version("5.1", sha256="e03bc712a576b3e14ae433a696558e121dc67aac7fc1b4dca9b727605784e994")
     version("5.0", sha256="d3148db1a57fec4f3468332c775cade356e8133bf88385991964edd7534b7e22")
     version("4.2", sha256="4ff5bd8002e94cc2029ef1aeda72e7cf944b797c7f07383656caa93bcb447569")

--- a/repos/spack_repo/builtin/packages/aocl_sparse/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_sparse/package.py
@@ -31,6 +31,7 @@ class AoclSparse(CMakePackage):
 
     license("MIT")
 
+    version("5.2", sha256="7de4ccb22b9bdf4733e621b44ebde1951dae5333841b02148fae382a8859f550")
     version("5.1", sha256="a5fff94f9144cb5e5e0f4702cc0d48a20215ccccd06cbed915e566e5d901fa0a")
     version("5.0", sha256="7528970f41ae60563df9fe1f8cc74a435be1566c01868a603ab894e9956c3c94")
     version("4.2", sha256="03cd67adcfea4a574fece98b60b4aba0a6e5a9c8f608ff1ccc1fb324a7185538")
@@ -57,7 +58,7 @@ class AoclSparse(CMakePackage):
     )
     variant("openmp", default=True, when="@4.2:", description="Enable OpenMP support")
 
-    for vers in ["4.1", "4.2", "5.0", "5.1"]:
+    for vers in ["4.1", "4.2", "5.0", "5.1", "5.2"]:
         with when(f"@={vers}"):
             depends_on(f"amdblis@={vers}")
             depends_on(f"amdlibflame@={vers}")

--- a/repos/spack_repo/builtin/packages/aocl_utils/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_utils/package.py
@@ -36,6 +36,7 @@ class AoclUtils(CMakePackage):
 
     license("BSD-3-Clause")
 
+    version("5.2", sha256="db0d807170a6eb73fcccd720a65a3e3aa8a787ae656c46479f7d9b4e1f9ed08a")
     version("5.1", sha256="68d75e04013abe90ea8308a9bc99b99532233b6c7f937f35381563f4124c20a5")
     version("5.0", sha256="ee2e5d47f33a3f673b3b6fcb88a7ef1a28648f407485ad07b6e9bf1b86159c59")
     version("4.2", sha256="1294cdf275de44d3a22fea6fc4cd5bf66260d0a19abb2e488b898aaf632486bd")


### PR DESCRIPTION
Summary of changes in PR:
- Add new version 5.2 for AOCL libraries (refer https://www.amd.com/en/developer/aocl.html)
- Add a new AOCL library `aocl-dlp` (refer https://www.amd.com/en/developer/aocl/dlp.html)

> AOCL-DLP (Deep Learning Primitives) is a high-performance library that provides optimized deep learning primitives for AMD processors
- Fix `aocl-utils` configuration in `amdlibm` recipe for cmake build support
- Update `amdlibm` recipe to use `cmake` as default build_system for `amdlibm@5.2`