### PR TITLE
Update MET: set LD_LIBRARY_PATH to find Python libraries at runtime, add variant shared-intel, find g2c libraries

### DIFF
--- a/repos/spack_repo/builtin/packages/met/package.py
+++ b/repos/spack_repo/builtin/packages/met/package.py
@@ -42,6 +42,15 @@ class Met(AutotoolsPackage):
     variant("modis", default=False, description="Enable compilation of modis")
     variant("graphics", default=False, description="Enable compilation of mode_graphics")
 
+    # JCSDA fork only
+    variant(
+        "shared-intel",
+        default=False,
+        when="%oneapi",
+        description="Enable linking to shared intel libraries (libintlc instead of libirc)",
+    )
+
+    depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
@@ -66,6 +75,7 @@ class Met(AutotoolsPackage):
     depends_on("py-numpy", when="+python", type=("build", "run"))
     depends_on("py-xarray", when="+python", type=("build", "run"))
     depends_on("py-pandas", when="+python", type=("build", "run"))
+    depends_on("patchelf@0.13:", when="platform=linux", type="build")
 
     patch("openmp_shape_patch.patch", when="@10.1.0")
 
@@ -96,6 +106,8 @@ class Met(AutotoolsPackage):
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         spec = self.spec
         cppflags = []
+        fflags = []
+        fcflags = []
         ldflags = []
         libs = []
 
@@ -107,10 +119,16 @@ class Met(AutotoolsPackage):
         ldflags.append(netcdfcxx.libs.ld_flags)
         libs.append(netcdfcxx.libs.link_flags)
 
+        if spec.satisfies("%oneapi") and spec.satisfies("+shared-intel"):
+            fflags.append("-shared-intel")
+            fcflags.append("-shared-intel")
+
         netcdfc = spec["netcdf-c"]
         if netcdfc.satisfies("+shared"):
             cppflags.append("-I" + netcdfc.prefix.include)
+            # This returns "/path/to/netcdf-c/lib" but we need ".../lib64"
             ldflags.append("-L" + netcdfc.prefix.lib)
+            ldflags.append("-L" + netcdfc.prefix.lib64)
             libs.append(netcdfc.libs.link_flags)
         else:
             nc_config = which(os.path.join(netcdfc.prefix.bin, "nc-config"), required=True)
@@ -133,7 +151,11 @@ class Met(AutotoolsPackage):
 
         if "+grib2" in spec:
             g2c = spec["g2c"]
-            env.set("MET_GRIB2CLIB", g2c.libs.directories[0])
+            shared_g2c = True if "+shared" in g2c else False
+            g2c_libdir = find_libraries(
+                "libg2c", root=g2c.prefix, shared=shared_g2c, recursive=True
+            ).directories[0]
+            env.set("MET_GRIB2CLIB", g2c_libdir)
             env.set("MET_GRIB2CINC", g2c.prefix.include)
             env.set("GRIB2CLIB_NAME", "-lg2c")
 
@@ -169,6 +191,10 @@ class Met(AutotoolsPackage):
             env.set("MET_FREETYPE", freetype.prefix)
 
         env.set("CPPFLAGS", " ".join(cppflags))
+        if fflags:
+            env.set("FFLAGS", " ".join(fflags))
+        if fcflags:
+            env.set("FCFLAGS", " ".join(fcflags))
         env.set("LIBS", " ".join(libs))
         env.set("LDFLAGS", " ".join(ldflags))
 
@@ -186,6 +212,21 @@ class Met(AutotoolsPackage):
 
         return args
 
+    # Adding the Python rpaths to the MET binaries randomly causes
+    # segmentation faults for different versions of MET and for
+    # different compilers - set LD_LIBRARY_PATH instead below
+    # (https://github.com/JCSDA/spack-stack/issues/1839)
+    #@run_after("install", when="+python platform=linux")
+    #def fixup_rpaths(self):
+    #    # set rpaths of binaries Python's lib directory
+    #    rpaths = self.spec["python"].libs.directories
+    #
+    #    for binary in find(self.prefix.bin, "*"):
+    #        patchelf = Executable("patchelf")
+    #        patchelf("--add-rpath", ":".join(rpaths), binary)
 
-#    def setup_run_environment(self, env: EnvironmentModifications) -> None:
-#        env.set('MET_BASE', self.prefix)
+    def setup_run_environment(self, env: EnvironmentModifications) -> None:
+        if self.spec.satisfies("+python"): 
+            for libpath in self.spec["python"].libs.directories:
+                env.append_path("LD_LIBRARY_PATH", libpath)
+

--- a/repos/spack_repo/builtin/packages/met/package.py
+++ b/repos/spack_repo/builtin/packages/met/package.py
@@ -42,7 +42,6 @@ class Met(AutotoolsPackage):
     variant("modis", default=False, description="Enable compilation of modis")
     variant("graphics", default=False, description="Enable compilation of mode_graphics")
 
-    # JCSDA fork only
     variant(
         "shared-intel",
         default=False,
@@ -75,7 +74,6 @@ class Met(AutotoolsPackage):
     depends_on("py-numpy", when="+python", type=("build", "run"))
     depends_on("py-xarray", when="+python", type=("build", "run"))
     depends_on("py-pandas", when="+python", type=("build", "run"))
-    depends_on("patchelf@0.13:", when="platform=linux", type="build")
 
     patch("openmp_shape_patch.patch", when="@10.1.0")
 

--- a/repos/spack_repo/builtin/packages/met/package.py
+++ b/repos/spack_repo/builtin/packages/met/package.py
@@ -214,8 +214,8 @@ class Met(AutotoolsPackage):
     # segmentation faults for different versions of MET and for
     # different compilers - set LD_LIBRARY_PATH instead below
     # (https://github.com/JCSDA/spack-stack/issues/1839)
-    #@run_after("install", when="+python platform=linux")
-    #def fixup_rpaths(self):
+    # @run_after("install", when="+python platform=linux")
+    # def fixup_rpaths(self):
     #    # set rpaths of binaries Python's lib directory
     #    rpaths = self.spec["python"].libs.directories
     #
@@ -224,7 +224,6 @@ class Met(AutotoolsPackage):
     #        patchelf("--add-rpath", ":".join(rpaths), binary)
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
-        if self.spec.satisfies("+python"): 
+        if self.spec.satisfies("+python"):
             for libpath in self.spec["python"].libs.directories:
                 env.append_path("LD_LIBRARY_PATH", libpath)
-


### PR DESCRIPTION
## Description

This PR updates the MET package from the JCSDA spack-stack-dev fork. This package is being used extensively by the spack-stack partners and verified to work.

Notes.
1. To fix the missing Python libraries in the MET executables, we initially tried to use RPATH (the recommended way) using the commented-out logic in this PR. This, however, led to segfaults for many platforms/compilers. Thus, we went for the LD_LIBRARY_PATH route.
2. The `shared-intel` variant allows users to link against `libintlc.so` instead of the legacy `libirc.so`, which can also lead to segmentation faults because of missing symbols (there is a history for this in the old spack packages repository).
