### PR TITLE
g2c and wgrib2: add g2c@2.3.0, g2c@2.20 and wgrib2@3.8.0, wgrib2@3.7.0

### DIFF
--- a/repos/spack_repo/builtin/packages/g2c/package.py
+++ b/repos/spack_repo/builtin/packages/g2c/package.py
@@ -19,6 +19,8 @@ class G2c(CMakePackage):
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett")
 
     version("develop", branch="develop")
+    version("2.3.0", sha256="8520a24c066500cfd0d07a05c6b7b0cb92383d1a4737cf6e79d9f4919c8e79ab")
+    version("2.2.0", sha256="cf0ac8f75aed662ccc64f4c44fbe46a70307bc27cbe95417fdfb6caf75245457")
     version("2.1.0", sha256="74e3ef381f0339dc181bc3afaa54c98f76257508375ff664d243d76825006605")
     version("2.0.0", sha256="39c23bf1219c60101548c8525e3a879c84119558f768081779d404a8caf4cec9")
     version("1.9.0", sha256="5554276e18bdcddf387a08c2dd23f9da310c6598905df6a2a244516c22ded9aa")

--- a/repos/spack_repo/builtin/packages/wgrib2/package.py
+++ b/repos/spack_repo/builtin/packages/wgrib2/package.py
@@ -59,6 +59,8 @@ class Wgrib2(MakefilePackage, CMakePackage):
     )
 
     version("develop", branch="develop")
+    version("3.8.0", sha256="39faebada36da5457c75f0980bb68fa299b221b3e6b335bb7d29006a35830c54")
+    version("3.7.0", sha256="b741a07710a8195c99a7d50de05bde90182ab4334f5c4a0d6d057c4e20cc6a75")
     version("3.6.0", sha256="55913cb58f2b329759de17f5a84dd97ad1844d7a93956d245ec94f4264d802be")
     version("3.5.0", sha256="b27b48228442a08bddc3d511d0c6335afca47252ae9f0e41ef6948f804afa3a1")
     version("3.4.0", sha256="ecbce2209c09bd63f1bca824f58a60aa89db6762603bda7d7d3fa2148b4a0536")
@@ -151,6 +153,18 @@ class Wgrib2(MakefilePackage, CMakePackage):
         when="@:3.1",
     )
     variant(
+        "g2c_low",
+        default=True,
+        description="Include NCEP g2clib (png,jpeg2000)",
+        when="@3.7:",
+    )
+    variant(
+        "g2c_high",
+        default=False,
+        description="Include NCEP g2clib (add -g2clib 2)",
+        when="@3.7:",
+    )
+    variant(
         "disable_timezone", default=False, description="Some machines do not support timezones"
     )
     variant(
@@ -158,8 +172,18 @@ class Wgrib2(MakefilePackage, CMakePackage):
         default=False,
         description="Some machines do not support the alarm to terminate wgrib2",
     )
-    variant("png", default=True, description="PNG encoding")
-    variant("jasper", default=True, description="JPEG compression using Jasper")
+    variant(
+        "png",
+        default=True,
+        description="PNG encoding",
+        when="@:3.8"
+    )
+    variant(
+        "jasper",
+        default=True,
+        description="JPEG compression using Jasper",
+        when="@:3.8"
+    )
     variant("openmp", default=True, description="OpenMP parallelization")
     variant("wmo_validation", default=False, description="WMO validation")
     #    variant("shared", default=False, description="Enable shared library", when="+lib")
@@ -172,11 +196,15 @@ class Wgrib2(MakefilePackage, CMakePackage):
     conflicts("+netcdf3", when="+netcdf4")
     conflicts("+netcdf3", when="+netcdf")
     conflicts("+openmp", when="%apple-clang")
+    conflicts("~g2c_low", when="+g2c_high")
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")
 
-    depends_on("ip@5.1:", when="@3.5: +ipolates")
+    depends_on("ip", when="@3.4: +ipolates")
+    depends_on("ip@5.1:", when="@3.4:3.6 +ipolates")
+    depends_on("ip@5.2:", when="@3.7: +ipolates")
+    depends_on("ip@5.2:", when="@develop +ipolates")
     depends_on("lapack", when="@3.5: +ipolates")
     depends_on("libaec@1.0.6:", when="@3.2: +aec")
     # Options to use netcdf3 or netcdf4 merged into a single option with v3.4.0
@@ -260,7 +288,7 @@ class MakefileBuilder(makefile.MakefileBuilder):
     def build(self, pkg, spec, prefix):
         make("-j1")
 
-        # Move wgrib2 executable to a tempoary directory
+        # Move wgrib2 executable to a temporary directory
         mkdir("install")
         mkdir(join_path("install", "bin"))
         move(join_path("wgrib2", "wgrib2"), join_path("install", "bin"))

--- a/repos/spack_repo/builtin/packages/wgrib2/package.py
+++ b/repos/spack_repo/builtin/packages/wgrib2/package.py
@@ -153,16 +153,10 @@ class Wgrib2(MakefilePackage, CMakePackage):
         when="@:3.1",
     )
     variant(
-        "g2c_low",
-        default=True,
-        description="Include NCEP g2clib (png,jpeg2000)",
-        when="@3.7:",
+        "g2c_low", default=True, description="Include NCEP g2clib (png,jpeg2000)", when="@3.7:"
     )
     variant(
-        "g2c_high",
-        default=False,
-        description="Include NCEP g2clib (add -g2clib 2)",
-        when="@3.7:",
+        "g2c_high", default=False, description="Include NCEP g2clib (add -g2clib 2)", when="@3.7:"
     )
     variant(
         "disable_timezone", default=False, description="Some machines do not support timezones"
@@ -172,18 +166,8 @@ class Wgrib2(MakefilePackage, CMakePackage):
         default=False,
         description="Some machines do not support the alarm to terminate wgrib2",
     )
-    variant(
-        "png",
-        default=True,
-        description="PNG encoding",
-        when="@:3.8"
-    )
-    variant(
-        "jasper",
-        default=True,
-        description="JPEG compression using Jasper",
-        when="@:3.8"
-    )
+    variant("png", default=True, description="PNG encoding", when="@:3.8")
+    variant("jasper", default=True, description="JPEG compression using Jasper", when="@:3.8")
     variant("openmp", default=True, description="OpenMP parallelization")
     variant("wmo_validation", default=False, description="WMO validation")
     #    variant("shared", default=False, description="Enable shared library", when="+lib")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR adds versions for `g2c` and `wgrib2` packages. For `wgrib2`, it also adds a new `g2c`-related variant, more clearly specifies versioning for the 

These package are being used by the spack-stack partners and verified to work.

Notes:

For `wgrib2`, also adds:

- new `g2c`-related variants and a corresponding `conflicts()` restraint
- more clearly specifies versioning for the `jasper` and `png` variants
- the dependency on `ip` is spelled out per `README` and `CMakeLists.txt` requirements detailed in tagged releases in the [wgrib2 repository](https://github.com/NOAA-EMC/wgrib2/tree/develop).