### PR TITLE
vtk-m: add conflict for Kokkos 5

### DIFF
--- a/repos/spack_repo/builtin/packages/vtk_m/package.py
+++ b/repos/spack_repo/builtin/packages/vtk_m/package.py
@@ -107,6 +107,7 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
     # VTK-m uses the default Kokkos backend
     depends_on("kokkos", when="+kokkos")
     depends_on("kokkos@3.7:3.9", when="@2.0 +kokkos")
+    conflicts("^kokkos@5:", when="+kokkos", msg="vtk-m doesn't compile with C++20")
     # VTK-m native CUDA and Kokkos CUDA backends are not compatible
     depends_on("kokkos ~cuda", when="+kokkos +cuda +cuda_native")
     depends_on("kokkos +cuda", when="+kokkos +cuda ~cuda_native")


### PR DESCRIPTION
Kokkos 5 requires C++20. vtk-m fails to compile with it. I was considering explicitly directing people to use viskores, but I don't know too much about it and how compatible they are.

> [!NOTE]
> Viskores has the appropriate changes for C++20, so should probably be used moving forward. See this [changelog](https://github.com/Viskores/viskores/blob/c854a593a47fc4e55e35090f18de9187aeac39b1/docs/changelog/memory-order-constants.md).
