### PR TITLE
mmseqs2: Fix typo

### DIFF
--- a/repos/spack_repo/builtin/packages/mmseqs2/package.py
+++ b/repos/spack_repo/builtin/packages/mmseqs2/package.py
@@ -38,7 +38,9 @@ class Mmseqs2(CMakePackage, CudaPackage):
     conflicts("@:15 +cuda")
     conflicts("cuda_arch=none", when="+cuda", msg="CUDA architecture is required")
     conflicts(
-        "cmake@3.14:,:4", when="@18-8cc5c", msg="CMake >=3.15 and <4 is required to compile MMseqs2"
+        "cmake@3.14:,:4",
+        when="@18-8cc5c",
+        msg="CMake >=3.15 and <4 is required to compile MMseqs2",
     )
 
     # patch to support building with gcc@13:

--- a/repos/spack_repo/builtin/packages/mmseqs2/package.py
+++ b/repos/spack_repo/builtin/packages/mmseqs2/package.py
@@ -38,7 +38,7 @@ class Mmseqs2(CMakePackage, CudaPackage):
     conflicts("@:15 +cuda")
     conflicts("cuda_arch=none", when="+cuda", msg="CUDA architecture is required")
     conflicts(
-        "cmake@3.14:,:4", when="@18-8cc5c", msg="Cuda >=3.15 and <4 is required to compile MMseqs2"
+        "cmake@3.14:,:4", when="@18-8cc5c", msg="CMake >=3.15 and <4 is required to compile MMseqs2"
     )
 
     # patch to support building with gcc@13:


### PR DESCRIPTION
Ultra small commit. Initially wrote "cuda" instead of "cmake" when I last updated this package. Whoops.