### PR TITLE
vecmem: add v1.22.0

### DIFF
--- a/repos/spack_repo/builtin/packages/vecmem/package.py
+++ b/repos/spack_repo/builtin/packages/vecmem/package.py
@@ -19,6 +19,7 @@ class Vecmem(CMakePackage, CudaPackage):
 
     license("MPL-2.0-no-copyleft-exception")
 
+    version("1.22.0", sha256="478ae60f5a64650cadb955f7fd4bb3c0b02658dd6821077a0724e58bb745cc66")
     version("1.21.0", sha256="a6e30da7dcb9a792eb0f2c0ceb821f52cf867c9745a65468b2ce6f026b23a49d")
     version("1.20.0", sha256="73c817b2a1a0961e357a2ca204ad610c8892b2697a6af2b1d794d0760a1009bf")
     version("1.19.0", sha256="0a1c77f0cee40f0b111ceab28cc77bfae4cfee29fea0aa3f7d91d2a58ff70236")


### PR DESCRIPTION
This commit adds version 1.22.0 of the vecmem package.