### PR TITLE
ROOT: use pcre2 for newer versions

### DIFF
--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -384,7 +384,8 @@ class Root(CMakePackage):
     depends_on("ncurses")
     depends_on("nlohmann-json", when="@6.24:")
     depends_on("nlohmann-json@:3.10", when="@6.24:6.26.07")
-    depends_on("pcre")
+    depends_on("pcre", when="@:6.33")
+    depends_on("pcre2", when="@6.34:")
     depends_on("xxhash", when="@6.13.02:")  # See cmake_args, below.
     depends_on("xz")
     depends_on("zlib-api")


### PR DESCRIPTION
As of https://github.com/root-project/root/pull/13771 and  https://github.com/root-project/root/pull/19851, ROOT has had support for PCRE2 (in addition to the old PCRE). See  https://github.com/root-project/root/commit/4e77730208ccaaf95fb472d760f4aba3de8ff060#diff-d2db5be43e703287f436f304b0f6eb75f76c66e20e1c64b3f26223ba436e8e54

Since the CMake implementation *prefers* looking for a new version of PCRE2, and until now spack only added PCRE as a dependency, ROOT would preferably pick up a system installation of PCRE2 , leading to downstream link errors errors (as @hhollenb discovered).

This updates the recipe to *require* PCRE2 rather than PCRE for all versions of ROOT that support it, ensuring it picks up the correct dependency.

CC @pcanal