### PR TITLE
fftw: add check before removing 'neon' list item

### DIFF
--- a/repos/spack_repo/builtin/packages/fftw/package.py
+++ b/repos/spack_repo/builtin/packages/fftw/package.py
@@ -158,7 +158,8 @@ class FftwBase(AutotoolsPackage):
 
         # GCC on apple silicon does not support Neon intrinsics
         if self.spec.satisfies("platform=darwin target=aarch64: %gcc"):
-            float_simd_features.remove("neon")
+            if "neon" in float_simd_features:
+                float_simd_features.remove("neon")
 
         simd_options = []
         for feature in simd_features:


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
In SHA `d13c881b1a3` on 12/3/25, the following was added:
```
         # GCC on apple silicon does not support Neon intrinsics
         if self.spec.satisfies("platform=darwin target=aarch64: %gcc"):
                 float_simd_features.remove("neon")
```
It is possible that "neon" is not in float_simd_features. Adding:
```
             if "neon" in float_simd_features:
```