### PR TITLE
Add array_nd_max to arkouda package

### DIFF
--- a/repos/spack_repo/builtin/packages/arkouda/package.py
+++ b/repos/spack_repo/builtin/packages/arkouda/package.py
@@ -57,6 +57,14 @@ class Arkouda(MakefilePackage):
     )
 
     variant(
+        "array_nd_max",
+        default="1",
+        values=("1", "2", "3"),
+        multi=False,
+        description="Set ARRAY_ND_MAX used by Arkouda build",
+    )
+
+    variant(
         "slurm-gasnet_ibv", default=False, description="Configure Chapel for Slurm + GASNet (ibv)"
     )
 
@@ -149,6 +157,9 @@ class Arkouda(MakefilePackage):
             f.write("$(eval $(call add-path,{0}))\n".format(spec["libidn2"].prefix))
 
     def build(self, spec, prefix):
+        nd = spec.variants["array_nd_max"].value
+        make_args = [f"ARRAY_ND_MAX={nd}"]
+
         # Detect distributed builds and skip the dependency checks built into
         # the Arkouda Makefile. These checks will try to spawn multiple jobs which may
         # cause the build to fail in situations where the user is constrained
@@ -156,9 +167,9 @@ class Arkouda(MakefilePackage):
         if spec.satisfies("+distributed"):
             with set_env(ARKOUDA_SKIP_CHECK_DEPS="1"):
                 tty.warn("Distributed build detected. Skipping dependency checks")
-                make()
+                make(*make_args)
         else:
-            make()
+            make(*make_args)
 
     # Arkouda does not have an install target in its Makefile
     def install(self, spec, prefix):


### PR DESCRIPTION
Add a new Spack variant, `array_nd_max`, to control the `ARRAY_ND_MAX` build setting for Arkouda. The variant supports values 1, 2, or 3 (default 1) and passes the selected value through to the Makefile during the build, for both distributed and non-distributed configurations. This enables building explicit 1D/2D/3D variants of Arkouda directly via Spack.