### PR TITLE
Fix specified directory for Conduit unit tests.

### DIFF
--- a/repos/spack_repo/builtin/packages/conduit/package.py
+++ b/repos/spack_repo/builtin/packages/conduit/package.py
@@ -264,7 +264,7 @@ class Conduit(CMakePackage):
     @run_after("build")
     @on_package_attributes(run_tests=True)
     def build_test(self):
-        with working_dir("spack-build"):
+        with working_dir(self.build_directory):
             print("Running Conduit Unit Tests...")
             make("test")
 


### PR DESCRIPTION
The hard-coded directory 'spack-build' can cause the tests to fail to run.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

