### PR TITLE
add specfem3d-globe v8.1.0 with a patch for gfortran

### DIFF
--- a/repos/spack_repo/builtin/packages/specfem3d_globe/0001-fix-compilation-flags.patch
+++ b/repos/spack_repo/builtin/packages/specfem3d_globe/0001-fix-compilation-flags.patch
@@ -1,0 +1,25 @@
+From 305cd5794a59ffc5e52c89fb3714530a142cc084 Mon Sep 17 00:00:00 2001
+From: Simon Pintarelli <simonpi@daint-ln004.cscs.ch>
+Date: Wed, 14 Jan 2026 09:33:14 +0100
+Subject: [PATCH] fix compilation flags
+
+---
+ flags.guess | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/flags.guess b/flags.guess
+index 32aa9dc..5a676d8 100644
+--- a/flags.guess
++++ b/flags.guess
+@@ -116,7 +116,7 @@ case $my_FC in
+ # with some versions of gfortran/gcc you make get errors about unused functions when compiling with the options below;
+ # if so, either change -Wunused to -Wunused -Werror=no-unused-function, or remove -Wunused, or remove -Werror
+ #
+-        DEF_FFLAGS="-std=gnu -fimplicit-none -fmax-errors=10 -pedantic -pedantic-errors -Waliasing -Wampersand -Wcharacter-truncation -Wline-truncation -Wsurprising -Wno-tabs -Wunderflow -ffpe-trap=invalid,zero,overflow -Wunused" # -mcmodel=medium
++        DEF_FFLAGS="-std=gnu -fimplicit-none -fmax-errors=10 -fallow-argument-mismatch -Waliasing -Wampersand -Wcharacter-truncation -Wline-truncation -Wsurprising -Wno-tabs -Wunderflow -ffpe-trap=invalid,zero,overflow -Wunused" # -mcmodel=medium
+         OPT_FFLAGS="-O3 -finline-functions"
+         DEBUG_FFLAGS="-g -O0 -ggdb -fbacktrace -fbounds-check -frange-check -Werror"
+         # useful to track loss of accuracy because of automatic double to single precision conversion:  -Wconversion  (this may generate many warnings...)
+-- 
+2.35.3
+

--- a/repos/spack_repo/builtin/packages/specfem3d_globe/package.py
+++ b/repos/spack_repo/builtin/packages/specfem3d_globe/package.py
@@ -52,7 +52,7 @@ class Specfem3dGlobe(AutotoolsPackage, CudaPackage):
         spec = self.spec
 
         if "+cuda" in spec:
-            args.append("--with-cuda")
+            args.append("--with-cuda=cuda{0}".format(spec["cuda"].version[0]))
             args.append("CUDA_LIB={0}".format(spec["cuda"].libs.directories[0]))
             args.append("CUDA_INC={0}".format(spec["cuda"].prefix.include))
             args.append("MPI_INC={0}".format(spec["mpi"].prefix.include))

--- a/repos/spack_repo/builtin/packages/specfem3d_globe/package.py
+++ b/repos/spack_repo/builtin/packages/specfem3d_globe/package.py
@@ -18,6 +18,7 @@ class Specfem3dGlobe(AutotoolsPackage, CudaPackage):
 
     license("GPL-3.0-only")
 
+    version("8.1.0", sha256="6492d02067e78c549ee688488f39c1ec659f0468572ecd6753dbd40e08dc17f4")
     version("8.0.0", sha256="3e234e66fce4cc5484c651584187b255f951ee6cd1ec057e6aa6d42aced9052d")
     version("7.0.2", sha256="78b4cfbe4e5121927ab82a8c2e821b65cdfff3e94d017303bf21af7805186d9b")
 
@@ -31,6 +32,9 @@ class Specfem3dGlobe(AutotoolsPackage, CudaPackage):
 
     depends_on("mpi")
     depends_on("opencl", when="+opencl")
+
+    # fix compilation error in MPI calls for gfortran, adding `-fallow-argument-mismatch` and remove `-pedantic`
+    patch("0001-fix-compilation-flags.patch", when="@8.1.0 %fortran=gcc")
 
     # When building with the gcc compiler,'Werror' is added to FFLAGS.
     # In the case of using the gcc compiler and the default simulation

--- a/repos/spack_repo/builtin/packages/specfem3d_globe/package.py
+++ b/repos/spack_repo/builtin/packages/specfem3d_globe/package.py
@@ -33,7 +33,8 @@ class Specfem3dGlobe(AutotoolsPackage, CudaPackage):
     depends_on("mpi")
     depends_on("opencl", when="+opencl")
 
-    # fix compilation error in MPI calls for gfortran, adding `-fallow-argument-mismatch` and remove `-pedantic`
+    # fix compilation error in MPI calls for gfortran,
+    # adding `-fallow-argument-mismatch` and remove `-pedantic`
     patch("0001-fix-compilation-flags.patch", when="@8.1.0 %fortran=gcc")
 
     # When building with the gcc compiler,'Werror' is added to FFLAGS.


### PR DESCRIPTION
- add checksum for v8.1.0
- add a patch to fix compilation with gfortran, removing `-pedantic`, `-pedantic-error` and adding `-fallow-argument-mismatch`.
- pass cuda major version explicitly to `--with-cuda` configure option. If the cuda version is left unspecified, it tries to compile for `sm_30` (for example on `sm_90`).

