### PR TITLE
dakota: add versions 6.21, 6.22, 6.23

### DIFF
--- a/repos/spack_repo/builtin/packages/dakota/dakota_6.18_tolerance_cmath.patch
+++ b/repos/spack_repo/builtin/packages/dakota/dakota_6.18_tolerance_cmath.patch
@@ -1,0 +1,32 @@
+diff --git a/src/unit/test_tolerance_intervals.cpp b/src/unit/test_tolerance_intervals.cpp
+index c8c133c2e..694fca054 100644
+--- a/src/unit/test_tolerance_intervals.cpp
++++ b/src/unit/test_tolerance_intervals.cpp
+@@ -16,6 +16,7 @@
+ 
+ #include <cassert>
+ #include <iostream>
++#include <cmath>
+ 
+ namespace Dakota {
+ namespace TestToleranceIntervals {
+@@ -517,8 +518,8 @@ void test_DSTIEN_valid_input_04_noValidResponseSamples()
+   // ************************************************************************
+   BOOST_CHECK( num_valid_samples == 0 );
+   for (size_t k = 0; k < num_fns; ++k) {
+-    BOOST_CHECK( isnan(computed_dstien_mus   [k]) );
+-    BOOST_CHECK( isnan(computed_dstien_sigmas[k]) );
++    BOOST_CHECK( std::isnan(computed_dstien_mus   [k]) );
++    BOOST_CHECK( std::isnan(computed_dstien_sigmas[k]) );
+   }
+ }
+ 
+@@ -587,7 +588,7 @@ void test_DSTIEN_valid_input_05_justOneValidResponseSample()
+   BOOST_CHECK( num_valid_samples == 1 );
+   for (size_t k = 0; k < num_fns; ++k) {
+     BOOST_CHECK( computed_dstien_mus[k] == expected_dstien_mus[k] );
+-    BOOST_CHECK( isnan(computed_dstien_sigmas[k]) );
++    BOOST_CHECK( std::isnan(computed_dstien_sigmas[k]) );
+   }
+ }
+ 

--- a/repos/spack_repo/builtin/packages/dakota/dakota_data_types_cstdint.patch
+++ b/repos/spack_repo/builtin/packages/dakota/dakota_data_types_cstdint.patch
@@ -1,0 +1,12 @@
+diff --git a/src/dakota_data_types.hpp b/src/dakota_data_types.hpp
+index e770d180e..a45b518f0 100644
+--- a/src/dakota_data_types.hpp
++++ b/src/dakota_data_types.hpp
+@@ -22,6 +22,7 @@
+ #include <map>
+ #include <memory>
+ #include <set>
++#include <cstdint>
+ 
+ namespace Dakota {
+ 

--- a/repos/spack_repo/builtin/packages/dakota/dakota_tolerance_cmath.patch
+++ b/repos/spack_repo/builtin/packages/dakota/dakota_tolerance_cmath.patch
@@ -1,0 +1,32 @@
+diff --git a/src/unit/dakota_tolerance_intervals/test_tolerance_intervals.cpp b/src/unit/dakota_tolerance_intervals/test_tolerance_intervals.cpp
+index a7b4bfa26..00790f10e 100644
+--- a/src/unit/dakota_tolerance_intervals/test_tolerance_intervals.cpp
++++ b/src/unit/dakota_tolerance_intervals/test_tolerance_intervals.cpp
+@@ -16,6 +16,7 @@
+ 
+ #include <cassert>
+ #include <iostream>
++#include <cmath>
+ 
+ namespace Dakota {
+ namespace TestToleranceIntervals {
+@@ -517,8 +518,8 @@ void test_DSTIEN_valid_input_04_noValidResponseSamples()
+   // ************************************************************************
+   BOOST_CHECK( num_valid_samples == 0 );
+   for (size_t k = 0; k < num_fns; ++k) {
+-    BOOST_CHECK( isnan(computed_dstien_mus   [k]) );
+-    BOOST_CHECK( isnan(computed_dstien_sigmas[k]) );
++    BOOST_CHECK( std::isnan(computed_dstien_mus   [k]) );
++    BOOST_CHECK( std::isnan(computed_dstien_sigmas[k]) );
+   }
+ }
+ 
+@@ -587,7 +588,7 @@ void test_DSTIEN_valid_input_05_justOneValidResponseSample()
+   BOOST_CHECK( num_valid_samples == 1 );
+   for (size_t k = 0; k < num_fns; ++k) {
+     BOOST_CHECK( computed_dstien_mus[k] == expected_dstien_mus[k] );
+-    BOOST_CHECK( isnan(computed_dstien_sigmas[k]) );
++    BOOST_CHECK( std::isnan(computed_dstien_sigmas[k]) );
+   }
+ }
+ 

--- a/repos/spack_repo/builtin/packages/dakota/package.py
+++ b/repos/spack_repo/builtin/packages/dakota/package.py
@@ -89,16 +89,16 @@ class Dakota(CMakePackage):
     variant("hdf5", default=False, description="Add hdf5 support")
 
     variant(
-        "python-direct-interface", 
-        default=False, 
+        "python-direct-interface",
+        default=False,
         when="+python",
-        description="Activate direct python interface"
+        description="Activate direct python interface",
     )
     variant(
-        "python-wrapper", 
-        default=False, 
+        "python-wrapper",
+        default=False,
         when="+python",
-        description="Top-level dakota.environment Python wrapper"
+        description="Top-level dakota.environment Python wrapper",
     )
     variant(
         "python-surrogates",

--- a/repos/spack_repo/builtin/packages/dakota/package.py
+++ b/repos/spack_repo/builtin/packages/dakota/package.py
@@ -143,7 +143,7 @@ class Dakota(CMakePackage):
         when="~python-wrapper ~python-direct-interface",
         msg=(
             "Use either +python-wrapper or +python-direct-interface ",
-            "in combination with +python-surrogates."
+            "in combination with +python-surrogates.",
         ),
     )
 

--- a/repos/spack_repo/builtin/packages/dakota/package.py
+++ b/repos/spack_repo/builtin/packages/dakota/package.py
@@ -145,13 +145,13 @@ class Dakota(CMakePackage):
     )
 
     # enable modern compilers with older versions
-    patch('teuchos_cstdint.patch', when='@:6.21', working_dir='packages/external')
+    patch("teuchos_cstdint.patch", when="@:6.21", working_dir="packages/external")
 
-    patch('dakota_data_types_cstdint.patch', when='@:6.22')
+    patch("dakota_data_types_cstdint.patch", when="@:6.22")
 
-    patch('dakota_tolerance_cmath.patch', when='@6.19')
+    patch("dakota_tolerance_cmath.patch", when="@6.19")
 
-    patch('dakota_6.18_tolerance_cmath.patch', when='@:6.18')
+    patch("dakota_6.18_tolerance_cmath.patch", when="@:6.18")
 
     def flag_handler(self, name, flags):
         # from gcc@10, dakota@:6.12 need an extra flag
@@ -194,4 +194,3 @@ class Dakota(CMakePackage):
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         env.prepend_path("PYTHONPATH", join_path(self.prefix, "share/dakota/Python"))
-

--- a/repos/spack_repo/builtin/packages/dakota/package.py
+++ b/repos/spack_repo/builtin/packages/dakota/package.py
@@ -44,6 +44,24 @@ class Dakota(CMakePackage):
     license("LGPL-2.1-or-later")
 
     version(
+        "6.23.0",
+        tag="v6.23.0",
+        commit="85fea9f46d0d292877233b257d5f9791b082bd82",
+        submodules=submodules,
+    )
+    version(
+        "6.22.0",
+        tag="v6.22.0",
+        commit="688b1bcf32fc88e9adfcd6055caed750433b21d0",
+        submodules=submodules,
+    )
+    version(
+        "6.21.0",
+        tag="v6.21.0",
+        commit="9efbad2baf416dc53a5a1d4cc17e3ae39a029632",
+        submodules=submodules,
+    )
+    version(
         "6.20.0",
         tag="v6.20.0",
         commit="494027b37264ec9268f2de8649d071de0232c534",
@@ -70,47 +88,80 @@ class Dakota(CMakePackage):
     variant("python", default=True, description="Add Python dependency for dakota.interfacing API")
     variant("hdf5", default=False, description="Add hdf5 support")
 
+    variant("python-direct-interface", default=False, description="Activate direct python interace")
+    variant("python-wrapper", default=False, description="Top-level dakota.environment Python wrapper")
+    variant("python-surrogates", default=False, description="Dakota Python interface to surrogate module")
+
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
 
     # Generic 'lapack' provider won't work, dakota searches for
     # 'LAPACKConfig.cmake' or 'lapack-config.cmake' on the path
-    depends_on("netlib-lapack")
+    depends_on("netlib-lapack +shared")
 
-    depends_on("blas")
     depends_on("mpi", when="+mpi")
-
-    depends_on("trilinos+rol")
-    depends_on("trilinos@13:", when="@6.13:")
 
     depends_on("hdf5@1.10.4:1.10 +hl+cxx", when="+hdf5")
     depends_on("python", when="+python")
+    depends_on("py-numpy", when="+python-direct-interface")
+    depends_on("py-numpy@:1.26.4", when="@:6.20")
     depends_on("perl-data-dumper", type="build", when="@6.12:")
-    depends_on("boost@:1.68.0", when="@:6.12")
-    depends_on("boost@1.69.0:1.84.0", when="@6.18:6.20")
-    depends_on("boost +filesystem +program_options +regex +serialization +system")
 
     # TODO: replace this with an explicit list of components of Boost,
     # for instance depends_on('boost +filesystem')
     # See https://github.com/spack/spack/pull/22303 for reference
     depends_on(Boost.with_default_variants, when="@:6.12")
-    depends_on("cmake@2.8.9:", type="build")
+    depends_on("boost@:1.68.0", when="@:6.12")
+    depends_on("boost@1.69.0:1.84.0", when="@6.18:6.20")
+    depends_on("boost +filesystem +program_options +regex +serialization +system")
+
+    depends_on("cmake@2.8.9:", type="build", when="@:6.12")
     depends_on("cmake@3.17:", type="build", when="@6.18:")
 
-    # dakota@:6.20 don't compile with gcc@13, and it is currently the latest version:
-    conflicts("%gcc@13:")
-    # dakota@:6.12 don't compile with gcc@12:
+    # dakota@:6.18 has broken pybind11/CMake support
+    conflicts("+python", when="@:6.18")
+    conflicts("+python-direct-interface", when="@:6.18")
+    conflicts("+python-surrogates", when="@:6.18")
+    conflicts("+python-wrapper", when="@:6.18")
+    # dakota@:6.12 does not compile with gcc@12:
     conflicts("%gcc@12:", when="@:6.12")
-    # dakota@:6.9 don't compile with gcc@11:
+    # dakota@:6.9 does not compile with gcc@11:
     conflicts("%gcc@11:", when="@:6.9")
+
+    # cannot have python surrogates without python direct interface or python wrapper
+    conflicts(
+            "+python-surrogates", 
+            when="~python-wrapper ~python-direct-interface",
+            msg="Use either +python-wrapper or +python-direct-interface in combination with +python-surrogates"
+    )
+
+    # enable modern compilers with older versions
+    patch('teuchos_cstdint.patch',
+        when='@:6.21',
+        working_dir='packages/external'
+        )
+
+    patch('dakota_data_types_cstdint.patch',
+          when='@:6.22'
+          )
+
+    patch('dakota_tolerance_cmath.patch',
+          when='@6.19'
+          )
+
+    patch('dakota_6.18_tolerance_cmath.patch',
+          when='@:6.18'
+          )
 
     def flag_handler(self, name, flags):
         # from gcc@10, dakota@:6.12 need an extra flag
         if self.spec.satisfies("@:6.12 %gcc@10:") and name == "fflags":
             flags.append("-fallow-argument-mismatch")
-        if name == "cxxflags":
+        if name == "cxxflags" and self.spec.satisfies("@:6.20.0"):
             flags.append(self["cxx"].standard_flag(language="cxx", standard="14"))
+        if name == "cxxflags" and self.spec.satisfies("@6.21.0:"):
+            flags.append(self["cxx"].standard_flag(language="cxx", standard="17"))
         return (flags, None, None)
 
     def cmake_args(self):
@@ -119,6 +170,12 @@ class Dakota(CMakePackage):
         args = [
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant("DAKOTA_PYTHON", "python"),
+            self.define_from_variant("DAKOTA_PYTHON_DIRECT_INTERFACE", "python-direct-interface"),
+            self.define_from_variant("DAKOTA_PYTHON_WRAPPER", "python-wrapper"),
+            self.define_from_variant("DAKOTA_PYTHON_SURROGATES", "python-wrapper"),
+            "-DBLAS_LIBS:STRING={}/lib64/libblas.so".format(spec["netlib-lapack"].prefix),
+            "-DLAPACK_LIBS:STRING={}/lib64/liblapack.so".format(spec["netlib-lapack"].prefix),
+            #"-DBOOST_INCLUDE_DIR:STRING={}".format(spec["boost"].prefix.include),
         ]
 
         if spec.satisfies("+mpi"):
@@ -129,7 +186,14 @@ class Dakota(CMakePackage):
                 ]
             )
 
+        if spec.satisfies("+python-direct-interface") or spec.satisfies("+python-wrapper"):
+            args.append("-DDAKOTA_PYBIND11:BOOL=ON")
+
         if self.run_tests:
             args += ["-DCMAKE_CTEST_ARGUMENTS=-L;Accept"]
 
         return args
+
+    def setup_run_environment(self, env: EnvironmentModifications) -> None:
+        env.prepend_path("PYTHONPATH", join_path(self.prefix, "share/dakota/Python"))
+

--- a/repos/spack_repo/builtin/packages/dakota/package.py
+++ b/repos/spack_repo/builtin/packages/dakota/package.py
@@ -89,14 +89,21 @@ class Dakota(CMakePackage):
     variant("hdf5", default=False, description="Add hdf5 support")
 
     variant(
-        "python-direct-interface", default=False, description="Activate direct python interface"
+        "python-direct-interface", 
+        default=False, 
+        when="+python",
+        description="Activate direct python interface"
     )
     variant(
-        "python-wrapper", default=False, description="Top-level dakota.environment Python wrapper"
+        "python-wrapper", 
+        default=False, 
+        when="+python",
+        description="Top-level dakota.environment Python wrapper"
     )
     variant(
         "python-surrogates",
         default=False,
+        when="+python",
         description="Dakota Python interface to surrogate module",
     )
 
@@ -129,9 +136,6 @@ class Dakota(CMakePackage):
 
     # dakota@:6.18 has broken pybind11/CMake support
     conflicts("+python", when="@:6.18")
-    conflicts("+python-direct-interface", when="@:6.18")
-    conflicts("+python-surrogates", when="@:6.18")
-    conflicts("+python-wrapper", when="@:6.18")
     # dakota@:6.12 does not compile with gcc@12:
     conflicts("%gcc@12:", when="@:6.12")
     # dakota@:6.9 does not compile with gcc@11:

--- a/repos/spack_repo/builtin/packages/dakota/package.py
+++ b/repos/spack_repo/builtin/packages/dakota/package.py
@@ -141,7 +141,10 @@ class Dakota(CMakePackage):
     conflicts(
         "+python-surrogates",
         when="~python-wrapper ~python-direct-interface",
-        msg="Use either +python-wrapper or +python-direct-interface in combination with +python-surrogates",
+        msg=(
+            "Use either +python-wrapper or +python-direct-interface ",
+            "in combination with +python-surrogates."
+        ),
     )
 
     # enable modern compilers with older versions

--- a/repos/spack_repo/builtin/packages/dakota/package.py
+++ b/repos/spack_repo/builtin/packages/dakota/package.py
@@ -88,9 +88,17 @@ class Dakota(CMakePackage):
     variant("python", default=True, description="Add Python dependency for dakota.interfacing API")
     variant("hdf5", default=False, description="Add hdf5 support")
 
-    variant("python-direct-interface", default=False, description="Activate direct python interace")
-    variant("python-wrapper", default=False, description="Top-level dakota.environment Python wrapper")
-    variant("python-surrogates", default=False, description="Dakota Python interface to surrogate module")
+    variant(
+        "python-direct-interface", default=False, description="Activate direct python interface"
+    )
+    variant(
+        "python-wrapper", default=False, description="Top-level dakota.environment Python wrapper"
+    )
+    variant(
+        "python-surrogates",
+        default=False,
+        description="Dakota Python interface to surrogate module",
+    )
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
@@ -131,28 +139,19 @@ class Dakota(CMakePackage):
 
     # cannot have python surrogates without python direct interface or python wrapper
     conflicts(
-            "+python-surrogates", 
-            when="~python-wrapper ~python-direct-interface",
-            msg="Use either +python-wrapper or +python-direct-interface in combination with +python-surrogates"
+        "+python-surrogates",
+        when="~python-wrapper ~python-direct-interface",
+        msg="Use either +python-wrapper or +python-direct-interface in combination with +python-surrogates",
     )
 
     # enable modern compilers with older versions
-    patch('teuchos_cstdint.patch',
-        when='@:6.21',
-        working_dir='packages/external'
-        )
+    patch('teuchos_cstdint.patch', when='@:6.21', working_dir='packages/external')
 
-    patch('dakota_data_types_cstdint.patch',
-          when='@:6.22'
-          )
+    patch('dakota_data_types_cstdint.patch', when='@:6.22')
 
-    patch('dakota_tolerance_cmath.patch',
-          when='@6.19'
-          )
+    patch('dakota_tolerance_cmath.patch', when='@6.19')
 
-    patch('dakota_6.18_tolerance_cmath.patch',
-          when='@:6.18'
-          )
+    patch('dakota_6.18_tolerance_cmath.patch', when='@:6.18')
 
     def flag_handler(self, name, flags):
         # from gcc@10, dakota@:6.12 need an extra flag
@@ -175,7 +174,6 @@ class Dakota(CMakePackage):
             self.define_from_variant("DAKOTA_PYTHON_SURROGATES", "python-wrapper"),
             "-DBLAS_LIBS:STRING={}/lib64/libblas.so".format(spec["netlib-lapack"].prefix),
             "-DLAPACK_LIBS:STRING={}/lib64/liblapack.so".format(spec["netlib-lapack"].prefix),
-            #"-DBOOST_INCLUDE_DIR:STRING={}".format(spec["boost"].prefix.include),
         ]
 
         if spec.satisfies("+mpi"):

--- a/repos/spack_repo/builtin/packages/dakota/teuchos_cstdint.patch
+++ b/repos/spack_repo/builtin/packages/dakota/teuchos_cstdint.patch
@@ -1,0 +1,12 @@
+diff --git a/trilinos/packages/teuchos/core/src/Teuchos_BigUIntDecl.hpp b/trilinos/packages/teuchos/core/src/Teuchos_BigUIntDecl.hpp
+index e82e8be9..b41b0d03 100644
+--- a/trilinos/packages/teuchos/core/src/Teuchos_BigUIntDecl.hpp
++++ b/trilinos/packages/teuchos/core/src/Teuchos_BigUIntDecl.hpp
+@@ -43,6 +43,7 @@
+ #define TEUCHOS_BIG_UINT_DECL_HPP
+ 
+ #include <iosfwd>
++#include <cstdint>
+ 
+ /*! \file Teuchos_BigUIntDecl.hpp
+     \brief Arbitrary-precision unsigned integer declaration.

--- a/repos/spack_repo/builtin/packages/nmad/package.py
+++ b/repos/spack_repo/builtin/packages/nmad/package.py
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
-from spack.package import *
 from spack_repo.builtin.packages.puk.package import Puk
+
+from spack.package import *
 
 
 class Nmad(AutotoolsPackage):

--- a/repos/spack_repo/builtin/packages/padicotm/package.py
+++ b/repos/spack_repo/builtin/packages/padicotm/package.py
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
-from spack.package import *
 from spack_repo.builtin.packages.puk.package import Puk
+
+from spack.package import *
 
 
 class Padicotm(AutotoolsPackage):

--- a/repos/spack_repo/builtin/packages/pioman/package.py
+++ b/repos/spack_repo/builtin/packages/pioman/package.py
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
-from spack.package import *
 from spack_repo.builtin.packages.puk.package import Puk
+
+from spack.package import *
 
 
 class Pioman(AutotoolsPackage):

--- a/repos/spack_repo/builtin/packages/puk/package.py
+++ b/repos/spack_repo/builtin/packages/puk/package.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+
 from spack.package import *
 
 

--- a/repos/spack_repo/builtin/packages/pukabi/package.py
+++ b/repos/spack_repo/builtin/packages/pukabi/package.py
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
-from spack.package import *
 from spack_repo.builtin.packages.puk.package import Puk
+
+from spack.package import *
 
 
 class Pukabi(AutotoolsPackage):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This adds recent releases and patches older versions for modern compiler compatibility:
+ versions 6.21, 6.22, 6.23 are added (see [website](https://dakota.sandia.gov/) for changelog)
+ older releases are now patched and work with gcc@13
+ The numpy dependency has a version constraint to fix build of dakota@:6.20
+ variants for building Dakota's direct python interface, python surrogates and the python wrappers are added
