### PR TITLE
simgrid: add python variant, fix compilation with gcc 14 for v3.34

### DIFF
--- a/repos/spack_repo/builtin/packages/simgrid/package.py
+++ b/repos/spack_repo/builtin/packages/simgrid/package.py
@@ -102,9 +102,7 @@ class Simgrid(CMakePackage):
     def cmake_args(self):
         spec = self.spec
         define = self.define
-        args = [
-            define("enable_python", spec.satisfies("+python"))
-        ]
+        args = [define("enable_python", spec.satisfies("+python"))]
 
         if not spec.satisfies("+doc"):
             args.append("-Denable_documentation=OFF")

--- a/repos/spack_repo/builtin/packages/simgrid/package.py
+++ b/repos/spack_repo/builtin/packages/simgrid/package.py
@@ -72,10 +72,12 @@ class Simgrid(CMakePackage):
     variant("examples", default=False, description="Install examples")
     variant("mc", default=False, description="Model checker")
     variant("msg", default=False, description="Enables the old MSG interface")
+    variant("python", default=False, description="Enables the Python bindings")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
+    extends("python", when="+python")  # generated
 
     # does not build correctly with some old compilers -> rely on packages
     depends_on("boost@:1.69.0", when="@:3.21")
@@ -99,7 +101,10 @@ class Simgrid(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
-        args = []
+        define = self.define
+        args = [
+            define("enable_python", spec.satisfies("+python"))
+        ]
 
         if not spec.satisfies("+doc"):
             args.append("-Denable_documentation=OFF")

--- a/repos/spack_repo/builtin/packages/simgrid/package.py
+++ b/repos/spack_repo/builtin/packages/simgrid/package.py
@@ -92,6 +92,13 @@ class Simgrid(CMakePackage):
 
     conflicts("+msg", when="@3.34:", msg="MSG was removed from SimGrid v3.33.")
 
+    # fix compilation with GCC 14 for v3.34
+    patch(
+        "https://github.com/simgrid/simgrid/commit/e4ecb51dcdf597fb02340d7855dafd0da9bd9018.patch?full_index=1",
+        sha256="80cbe0eed635ff1864f0c2945763c8561b86c08c0c2b60d2ee5a57e1659ccc3d",
+        when="@3.34"
+    )
+
     def setup_dependent_package(self, module, dep_spec):
         if self.spec.satisfies("+smpi"):
             self.spec.smpicc = join_path(self.prefix.bin, "smpicc")

--- a/repos/spack_repo/builtin/packages/simgrid/package.py
+++ b/repos/spack_repo/builtin/packages/simgrid/package.py
@@ -108,8 +108,7 @@ class Simgrid(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
-        define = self.define
-        args = [define("enable_python", spec.satisfies("+python"))]
+        args = [self.define_from_variant("enable_python", "python")]
 
         if not spec.satisfies("+doc"):
             args.append("-Denable_documentation=OFF")

--- a/repos/spack_repo/builtin/packages/simgrid/package.py
+++ b/repos/spack_repo/builtin/packages/simgrid/package.py
@@ -96,7 +96,7 @@ class Simgrid(CMakePackage):
     patch(
         "https://github.com/simgrid/simgrid/commit/e4ecb51dcdf597fb02340d7855dafd0da9bd9018.patch?full_index=1",
         sha256="80cbe0eed635ff1864f0c2945763c8561b86c08c0c2b60d2ee5a57e1659ccc3d",
-        when="@3.34"
+        when="@3.34",
     )
 
     def setup_dependent_package(self, module, dep_spec):


### PR DESCRIPTION
Currently, the install fails for me as it tries to install the Python bindings in a system location:

```
  >> 3701    CMake Error at cmake_install.cmake:120 (file):
     3702      file INSTALL cannot copy file
     3703      "[...]/spack-stage/spack-stage-simgrid-4.1-y3zo54ri5ezjhniditkibg2moq24u22m/spack-build-y3zo54r/lib/simgrid.cpy
             thon-314-x86_64-linux-gnu.so"
     3704      to
     3705      "/usr/lib/python3.14/site-packages/simgrid.cpython-314-x86_64-linux-gnu.so":
     3706      Permission denied.
     3707    
```

This PR adds a variant for the Python bindings and uses `extends("python")` to fix the Python install path. Piggybacking on this, it fixes compilation with GCC version for Simgrid v3.34 by applying a patch that adds header includes.

CC maintainer @viniciusvgp