### PR TITLE
Bug fixes for pixman: find libpng when built statically and/or when build_system is meson; add variant pic

### DIFF
--- a/repos/spack_repo/builtin/packages/pixman/libpng.patch
+++ b/repos/spack_repo/builtin/packages/pixman/libpng.patch
@@ -1,0 +1,9 @@
+--- a/meson.build
++++ b/meson.build
+@@ -440,6 +440,7 @@
+   foreach png_ver : [ '16', '15', '14', '13', '12', '10' ]
+     if not dep_png.found()
+       dep_png = cc.find_library('libpng@0@'.format(png_ver), has_headers : ['png.h'], required : false)
++      dep_png = cc.find_library('png@0@'.format(png_ver), has_headers : ['png.h'], required : false)
+     endif
+   endforeach

--- a/repos/spack_repo/builtin/packages/pixman/package.py
+++ b/repos/spack_repo/builtin/packages/pixman/package.py
@@ -61,6 +61,9 @@ class Pixman(AutotoolsPackage, MesonPackage):
     patch("clang.patch", when="@0.34%apple-clang@9.1.0:")
     patch("clang.patch", when="@0.34%clang@5.0.0:")
 
+    # https://github.com/spack/spack-packages/issues/3032
+    patch("libpng.patch", when="build_system=meson")
+
     @run_before("build")
     def patch_config_h_for_intel(self):
         config_h = join_path(self.stage.source_path, "config.h")

--- a/repos/spack_repo/builtin/packages/pixman/package.py
+++ b/repos/spack_repo/builtin/packages/pixman/package.py
@@ -52,6 +52,7 @@ class Pixman(AutotoolsPackage, MesonPackage):
     depends_on("libpng")
 
     variant("shared", default=True, description="Build shared library")
+    variant("pic", default=False, description="Enable position-independent code")
 
     # As discussed here:
     # https://bugs.freedesktop.org/show_bug.cgi?id=104886
@@ -126,6 +127,14 @@ class AutotoolsBuilder(autotools.AutotoolsBuilder):
             #  https://gitlab.freedesktop.org/pixman/pixman/-/issues/69
             if self.spec.target.family == "aarch64":
                 args.append("--disable-arm-a64-neon")
+
+        args.extend(self.with_or_without("pic"))
+
+        png = self.spec["libpng"]
+        if png.satisfies("libs=static") and not png.satisfies("libs=shared"):
+            args.append(
+                "LIBS=%s" % which("libpng-config")("--static", "--ldflags", output=str).strip()
+            )
 
         # The Fujitsu compiler does not support assembler macros.
         if self.spec.satisfies("%fj"):

--- a/repos/spack_repo/builtin/packages/pixman/package.py
+++ b/repos/spack_repo/builtin/packages/pixman/package.py
@@ -131,7 +131,7 @@ class AutotoolsBuilder(autotools.AutotoolsBuilder):
         args.extend(self.with_or_without("pic"))
 
         png = self.spec["libpng"]
-        if png.satisfies("libs=static") and not png.satisfies("libs=shared"):
+        if not png.satisfies("libs=shared"):
             args.append(
                 "LIBS=%s" % which("libpng-config")("--static", "--ldflags", output=str).strip()
             )


### PR DESCRIPTION
## Description

This PR fixes https://github.com/spack/spack-packages/issues/3032 (cannot find `libpng` when `build_system=meson`, regardless of how `libpng` is built). The issue is that meson is looking for `libpng` with a find-library command, which then looks for `-llibpng`. Apparently, this must work or have worked in the past at least on some systems, because this is how it was and still is in the authoritative pixman code base. On many systems, however, including when building `libpng` with Spack, one needs to look for library `png` so that meson tries `-lpng`.

The additional updates here are the addition of a `pic` variant when building `pixman` statically, and additional updates when trying to find static `libpng` libraries with the legacy autotools builder.

## Issues

Fixes https://github.com/spack/spack-packages/issues/3032

## Testing

These bug fixes are actively used in spack-stack.