### PR TITLE
grib-util: Disable G2C_COMPARE

### DIFF
--- a/repos/spack_repo/builtin/packages/grib_util/package.py
+++ b/repos/spack_repo/builtin/packages/grib_util/package.py
@@ -56,7 +56,7 @@ class GribUtil(CMakePackage):
         args = [
             self.define_from_variant("OPENMP", "openmp"),
             self.define("BUILD_TESTING", self.run_tests),
-            self.define("G2C_COMPARE", self.run_tests),
+            self.define("G2C_COMPARE", False),
         ]
         return args
 


### PR DESCRIPTION
The g2c_compare detection logic in grib-util is unreliable, and the upstream package configs needed to provide it are persnickety. This PR disables it, which only has the effect of disabling copygb2 testing.