### PR TITLE
mfem: add v4.9

### DIFF
--- a/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
+++ b/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
@@ -67,7 +67,7 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
     version("5.7.0", sha256="4abdf00b297a77c5886cedb37e63acda2ba11cb9f4c0a64e133b05800aadfcf0")
 
     provides("c", "cxx")
-    provides("fortran", when="@7.0:")
+    provides("fortran", when="@6:")
 
     variant(
         "rocm-device-libs",

--- a/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
+++ b/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
@@ -67,7 +67,7 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
     version("5.7.0", sha256="4abdf00b297a77c5886cedb37e63acda2ba11cb9f4c0a64e133b05800aadfcf0")
 
     provides("c", "cxx")
-    provides("fortran", when="@6:")
+    provides("fortran", when="@7.0:")
 
     variant(
         "rocm-device-libs",

--- a/repos/spack_repo/builtin/packages/mfem/mfem-4.9.patch
+++ b/repos/spack_repo/builtin/packages/mfem/mfem-4.9.patch
@@ -1,0 +1,114 @@
+diff --git a/fem/fe/fe_base.cpp b/fem/fe/fe_base.cpp
+index 535fdaca8b..281de35fac 100644
+--- a/fem/fe/fe_base.cpp
++++ b/fem/fe/fe_base.cpp
+@@ -382,11 +382,7 @@ const DofToQuad &FiniteElement::GetDofToQuad(const IntegrationRule &ir,
+    #pragma omp critical (DofToQuad)
+ #endif
+    {
+-      for (int i = 0; i < dof2quad_array.Size(); i++)
+-      {
+-         d2q = dof2quad_array[i];
+-         if (d2q->IntRule != &ir || d2q->mode != mode) { d2q = nullptr; }
+-      }
++      d2q = DofToQuad::SearchArray(dof2quad_array, ir, mode);
+       if (!d2q)
+       {
+ #ifdef MFEM_THREAD_SAFE
+@@ -661,14 +657,22 @@ void ScalarFiniteElement::ScalarLocalL2Restriction(
+ void NodalFiniteElement::CreateLexicographicFullMap(const IntegrationRule &ir)
+ const
+ {
++   // Get the FULL version of the map. This call contains omp critical region,
++   // so it is done before the critical region below.
++   auto &d2q = GetDofToQuad(ir, DofToQuad::FULL);
+ 
+ #if defined(MFEM_THREAD_SAFE) && defined(MFEM_USE_OPENMP)
+    #pragma omp critical (DofToQuad)
+ #endif
+    {
+-      // Get the FULL version of the map.
+-      auto &d2q = GetDofToQuad(ir, DofToQuad::FULL);
+-      //Undo the native ordering which is what FiniteElement::GetDofToQuad returns.
++      // If the new Dof2Quad is already present, e.g. added in a previous call
++      // or added by another omp thread, return.
++      if (DofToQuad::SearchArray(dof2quad_array, ir,
++                                 DofToQuad::LEXICOGRAPHIC_FULL))
++      { return; }
++
++      // Undo the native ordering which is what FiniteElement::GetDofToQuad
++      // returns.
+       auto *d2q_new = new DofToQuad(d2q);
+       d2q_new->mode = DofToQuad::LEXICOGRAPHIC_FULL;
+       const int nqpt = ir.GetNPoints();
+@@ -724,13 +728,7 @@ const DofToQuad &NodalFiniteElement::GetDofToQuad(const IntegrationRule &ir,
+    #pragma omp critical (DofToQuad)
+ #endif
+    {
+-      //Should make this loop a function of FiniteElement
+-      for (int i = 0; i < dof2quad_array.Size(); i++)
+-      {
+-         d2q = dof2quad_array[i];
+-         if (d2q->IntRule == &ir && d2q->mode == mode) { break; }
+-         d2q = nullptr;
+-      }
++      d2q = DofToQuad::SearchArray(dof2quad_array, ir, mode);
+    }
+    if (d2q) { return *d2q; }
+    if (mode != DofToQuad::LEXICOGRAPHIC_FULL)
+@@ -2631,15 +2629,7 @@ const DofToQuad &TensorBasisElement::GetTensorDofToQuad(
+    #pragma omp critical (DofToQuad)
+ #endif
+    {
+-      for (int i = 0; i < dof2quad_array.Size(); i++)
+-      {
+-         auto* d2q_ = dof2quad_array[i];
+-         if (d2q_->IntRule == &ir && d2q_->mode == mode)
+-         {
+-            d2q = d2q_;
+-            break;
+-         }
+-      }
++      d2q = DofToQuad::SearchArray(dof2quad_array, ir, mode);
+       if (!d2q)
+       {
+          d2q = new DofToQuad;
+diff --git a/fem/fe/fe_base.hpp b/fem/fe/fe_base.hpp
+index a579faf835..ad356bcd2d 100644
+--- a/fem/fe/fe_base.hpp
++++ b/fem/fe/fe_base.hpp
+@@ -222,6 +222,12 @@ public:
+ 
+    /// Returns absolute value of the maps
+    DofToQuad Abs() const;
++
++   /// Auxiliary function for searching DofToQuad arrays.
++   static inline DofToQuad *SearchArray(
++      const Array<DofToQuad*> &dof2quad_array,
++      const IntegrationRule &ir,
++      DofToQuad::Mode mode);
+ };
+ 
+ /// Describes the function space on each element
+@@ -1376,6 +1382,21 @@ public:
+ void InvertLinearTrans(ElementTransformation &trans,
+                        const IntegrationPoint &pt, Vector &x);
+ 
++
++// static inline method
++inline DofToQuad *DofToQuad::SearchArray(
++   const Array<DofToQuad*> &dof2quad_array,
++   const IntegrationRule &ir,
++   DofToQuad::Mode mode)
++{
++   for (int i = 0; i < dof2quad_array.Size(); i++)
++   {
++      DofToQuad *d2q = dof2quad_array[i];
++      if (d2q->IntRule == &ir && d2q->mode == mode) { return d2q; }
++   }
++   return nullptr;
++}
++
+ } // namespace mfem
+ 
+ #endif

--- a/repos/spack_repo/builtin/packages/mfem/package.py
+++ b/repos/spack_repo/builtin/packages/mfem/package.py
@@ -53,6 +53,9 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     # other version.
     version("develop", branch="master")
 
+    # TODO: update source after the release
+    version("4.9.0", branch="mfem-4.9-dev")
+
     version(
         "4.8.0",
         sha256="49bd2a076b0d87863092cb55f8524b5292d9afb2e48c19f80222ada367819016",

--- a/repos/spack_repo/builtin/packages/mfem/package.py
+++ b/repos/spack_repo/builtin/packages/mfem/package.py
@@ -310,6 +310,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     depends_on("mpi", when="+mpi")
     depends_on("hipsparse", when="@4.4.0:+rocm")
     depends_on("hipblas", when="@4.8.0:+rocm")
+    depends_on("hipcub", when="@4.9.0:+rocm")
 
     with when("+mpi"):
         depends_on("hypre")
@@ -1061,6 +1062,9 @@ class Mfem(Package, CudaPackage, ROCmPackage):
                 hipblas = spec["hipblas"]
                 hip_headers += self.all_headers(hipblas)
                 hip_libs += hipblas.libs
+            if "^hipcub" in spec:  # hipcub is needed @4.9.0:+rocm
+                hipcub = spec["hipcub"]
+                hip_headers += self.all_headers(hipcub)
             if "%cce" in spec:
                 # We assume the proper Cray CCE module (cce) is loaded:
                 proc = str(spec.target.family)

--- a/repos/spack_repo/builtin/packages/mfem/package.py
+++ b/repos/spack_repo/builtin/packages/mfem/package.py
@@ -53,8 +53,12 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     # other version.
     version("develop", branch="master")
 
-    # TODO: update source after the release
-    version("4.9.0", branch="mfem-4.9-dev")
+    version(
+        "4.9.0",
+        sha256="6904974c8d5a6bcd127419c7b7adff873170d397ed2f0bccdf438e940e713af2",
+        url="https://bit.ly/mfem-4-9",
+        extension="tar.gz",
+    )
 
     version(
         "4.8.0",
@@ -327,14 +331,14 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     depends_on("blas", when="+lapack")
     depends_on("lapack@3.0:", when="+lapack")
 
-    depends_on("sundials@2.7.0:", when="@3.3.2:+sundials~mpi")
-    depends_on("sundials@2.7.0:+mpi+hypre", when="@3.3.2:+sundials+mpi")
+    depends_on("sundials@2.7.0:", when="@3.3.2:4.0+sundials~mpi")
+    depends_on("sundials@2.7.0:+mpi+hypre", when="@3.3.2:4.0+sundials+mpi")
     depends_on("sundials@5.0.0:5", when="@4.1.0:4.4+sundials~mpi")
     depends_on("sundials@5.0.0:5+mpi+hypre", when="@4.1.0:4.4+sundials+mpi")
     depends_on("sundials@5.0.0:6.7.0", when="@4.5.0:4.6+sundials~mpi")
     depends_on("sundials@5.0.0:6.7.0+mpi+hypre", when="@4.5.0:4.6+sundials+mpi")
     depends_on("sundials@5.0.0:", when="@4.7.0:+sundials~mpi")
-    depends_on("sundials@5.0.0:+mpi+hypre", when="@4.7.0:+sundials+mpi")
+    depends_on("sundials@5.0.0:+mpi", when="@4.7.0:+sundials+mpi")
     conflicts("cxxstd=11", when="^sundials@6.4.0:")
     for sm_ in CudaPackage.cuda_arch_values:
         depends_on(
@@ -548,6 +552,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     patch("mfem-4.7.patch", when="@4.7.0")
     patch("mfem-4.7-sundials-7.patch", when="@4.7.0+sundials ^sundials@7:")
     patch("mfem-4.8-nvcc-c++17.patch", when="@4.8.0+cuda")
+    patch("mfem-4.9.patch", when="@4.9.0")
 
     phases = ["configure", "build", "install"]
 
@@ -757,9 +762,12 @@ class Mfem(Package, CudaPackage, ROCmPackage):
         if "+mpi" in spec:
             options += ["MPICXX=%s" % spec["mpi"].mpicxx]
             hypre = spec["hypre"]
+            all_hypre_headers = hypre.headers
             all_hypre_libs = hypre.libs
             if "+lapack" in hypre:
                 all_hypre_libs += hypre["lapack"].libs + hypre["blas"].libs
+            if "+umpire" in hypre:
+                all_hypre_headers += hypre["umpire"].headers
 
             hypre_gpu_libs = ""
             if "+cuda" in hypre:
@@ -777,7 +785,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
                         hypre_rocm_libs += hypre["rocblas"].libs
                 hypre_gpu_libs = " " + ld_flags_from_library_list(hypre_rocm_libs)
             options += [
-                "HYPRE_OPT=-I%s" % hypre.prefix.include,
+                "HYPRE_OPT=%s" % all_hypre_headers.cpp_flags,
                 "HYPRE_LIB=%s%s" % (ld_flags_from_library_list(all_hypre_libs), hypre_gpu_libs),
             ]
 

--- a/repos/spack_repo/builtin/packages/mfem/test_builds.sh
+++ b/repos/spack_repo/builtin/packages/mfem/test_builds.sh
@@ -14,9 +14,9 @@ rocm_arch="gfx908"
 spack_jobs=''
 # spack_jobs='-j 128'
 
-mfem='mfem@4.7.0'${compiler}
+mfem='mfem@4.9.0'${compiler}
 # mfem_dev='mfem@develop'${compiler}
-mfem_dev='mfem@4.7.0'${compiler}
+mfem_dev='mfem@4.9.0'${compiler}
 
 backends='+occa+raja+libceed'
 backends_specs='^occa~cuda ^raja~openmp'

--- a/repos/spack_repo/builtin/packages/visit/package.py
+++ b/repos/spack_repo/builtin/packages/visit/package.py
@@ -191,6 +191,7 @@ class Visit(CMakePackage):
     depends_on("conduit~mpi", when="+conduit~mpi")
 
     depends_on("mfem@4.4:", when="+mfem")
+    depends_on("mfem@:4.8", when="@:3.4.1+mfem")  # mfem v4.9 requires c++17
     depends_on("mfem+shared+exceptions+fms+conduit", when="+mfem")
     depends_on("libfms@0.2:", when="+mfem")
 


### PR DESCRIPTION
Adding `mfem` v4.9 with a relevant patch and some tweaks.

This change is now reverted: ~~Also updates the `llvm-amdgpu` package to provide `"fortran"` starting with v6 instead of v7.~~

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
