### PR TITLE
ci: soft preference for trilinos +thyra

### DIFF
--- a/stacks/e4s-oneapi/spack.yaml
+++ b/stacks/e4s-oneapi/spack.yaml
@@ -42,7 +42,7 @@ spack:
       variants: +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext
         +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu
         +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos
-        +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
+        +teko +tempus +thyra +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
     xz:
       variants: +pic
     gcc-runtime:

--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -54,7 +54,7 @@ spack:
       variants: +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext
         +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu
         +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos
-        +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
+        +teko +tempus +thyra +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
     mpich:
       require:
       - '~wrapperrpath ~hwloc'


### PR DESCRIPTION
Trilinos is configured with a soft preference for `+stratimikos`, which
implies `+thyra`. The concretizer takes a penalty whether it respects
the soft preference or not: in either case one variant has to be flipped.
That leads to non-determinism in the solver.

Fix with a soft preference for both.