### PR TITLE
git-lfs: add 3.7.1

### DIFF
--- a/repos/spack_repo/builtin/packages/git_lfs/package.py
+++ b/repos/spack_repo/builtin/packages/git_lfs/package.py
@@ -27,6 +27,7 @@ class GitLfs(MakefilePackage):
 
     license("MIT")
 
+    version("3.7.1", sha256="0e83566a9e2477e03627e7fd6bf81f01fadbf93dcaf6abd2686fca90f6bac7dd")
     version("3.7.0", sha256="ab173702840627feb5f8a408dd5406fa322f3eadaa69938d9226b183d5be25a6")
     version("3.6.1", sha256="d682a12c0bc48d08d28834dd0d575c91d53dd6c6db63c45c2db7c3dd2fb69ea4")
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

git-lfs older than 3.7.1 apparently has a bad security issue:

https://github.com/git-lfs/git-lfs/security/advisories/GHSA-6pvw-g552-53c5

and per that page:

> This problem exists in all versions since 0.5.2 and is patched in v3.7.1. All users should upgrade to v3.7.1.

ETA: Also. Should we *deprecate* every version but 3.7.1 given that CVE?
