### PR TITLE
trilinos: +shylu conflicts with ~tpetra

### DIFF
--- a/repos/spack_repo/builtin/packages/trilinos/package.py
+++ b/repos/spack_repo/builtin/packages/trilinos/package.py
@@ -286,6 +286,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         conflicts("+dtk")
         conflicts("+ifpack2")
         conflicts("+muelu")
+        conflicts("+shylu")
         conflicts("+teko")
         conflicts("+zoltan2")
 


### PR DESCRIPTION
Discovered while debugging a trilinos build failure for an LLNL code team.
