### PR TITLE
py-dask: fix bounds of python dep

### DIFF
--- a/repos/spack_repo/builtin/packages/py_dask/package.py
+++ b/repos/spack_repo/builtin/packages/py_dask/package.py
@@ -49,7 +49,7 @@ class PyDask(PythonPackage):
     depends_on("python@3.8:", type=("build", "run"), when="@:2023.4.1")
 
     # python@3.14 breaks py-dask@:2025.7.0
-    depends_on("py-python@:3.13", type=("build", "run"), when="@:2025.7.0")
+    depends_on("python@:3.13", type=("build", "run"), when="@:2025.7.0")
 
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools@62.6:", type="build", when="@2023.4.1:")

--- a/repos/spack_repo/builtin/packages/py_dask/package.py
+++ b/repos/spack_repo/builtin/packages/py_dask/package.py
@@ -49,7 +49,7 @@ class PyDask(PythonPackage):
     depends_on("python@3.8:", type=("build", "run"), when="@:2023.4.1")
 
     # python@3.14 breaks py-dask@:2025.7.0
-    depends_on("python@:3.13", type=("build", "run"), when="@:2025.7.0")
+    depends_on("python@:3.13", type=("build", "run"), when="@:2025.12")
 
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools@62.6:", type="build", when="@2023.4.1:")

--- a/repos/spack_repo/builtin/packages/py_dask/package.py
+++ b/repos/spack_repo/builtin/packages/py_dask/package.py
@@ -44,9 +44,10 @@ class PyDask(PythonPackage):
 
     conflicts("~array", when="@2023.8: +dataframe", msg="From 2023.8, +dataframe requires +array")
 
+    depends_on("python@3.10:3.13", type=("build", "run"), when="@2024.12.0:2025.7.0")
+    depends_on("python@3.10:3.12", type=("build", "run"), when="@2024.8.1:2024.11.2")
+    depends_on("python@3.9:3.12", type=("build", "run"), when="@2024.7.1")
     depends_on("python@3.8:", type=("build", "run"), when="@:2023.4.1")
-    depends_on("python@3.9:", type=("build", "run"), when="@2024.7.1")
-    depends_on("python@3.10:", type=("build", "run"), when="@2024.8.1:")
 
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools@62.6:", type="build", when="@2023.4.1:")

--- a/repos/spack_repo/builtin/packages/py_dask/package.py
+++ b/repos/spack_repo/builtin/packages/py_dask/package.py
@@ -44,10 +44,12 @@ class PyDask(PythonPackage):
 
     conflicts("~array", when="@2023.8: +dataframe", msg="From 2023.8, +dataframe requires +array")
 
-    depends_on("python@3.10:3.13", type=("build", "run"), when="@2024.12.0:2025.7.0")
-    depends_on("python@3.10:3.12", type=("build", "run"), when="@2024.8.1:2024.11.2")
-    depends_on("python@3.9:3.12", type=("build", "run"), when="@2024.7.1")
+    depends_on("python@3.10:", type=("build", "run"), when="@2024.8.1:")
+    depends_on("python@3.9:", type=("build", "run"), when="@2024.7.1")
     depends_on("python@3.8:", type=("build", "run"), when="@:2023.4.1")
+
+    # python@3.14 breaks py-dask@:2025.7.0
+    depends_on("py-python@:3.13", type=("build", "run"), when="@:2025.7.0")
 
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools@62.6:", type="build", when="@2023.4.1:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Python version bounds seem important to Dask. For instance, Python 3.14 breaks `py-dask@2025.7.0`.