### PR TITLE
py-pycompadre: add pybind11 dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pycompadre/package.py
+++ b/repos/spack_repo/builtin/packages/py_pycompadre/package.py
@@ -50,6 +50,7 @@ class PyPycompadre(PythonPackage):
     depends_on("python@3.6:", type=("build", "link", "run"), when="@1.6:")
     depends_on("py-setuptools", type="build")
     depends_on("py-cython@0.23:", type="build")
+    depends_on("py-pybind11", type="build")
 
     # fixes duplicate symbol issue with static library build
     patch(


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Adding `py-pybind11` as a build dependency.