### PR TITLE
Openblas: Add AOCC patch for compiler detection

### DIFF
--- a/repos/spack_repo/builtin/packages/openblas/openblas-0.3.21-0.3.26_aocc.patch
+++ b/repos/spack_repo/builtin/packages/openblas/openblas-0.3.21-0.3.26_aocc.patch
@@ -1,0 +1,15 @@
+--- a/f_check	2025-12-03 06:29:33.000000000 +0000
++++ b/f_check	2025-12-03 06:32:11.000000000 +0000
+@@ -86,7 +86,11 @@
+ 		vendor=CRAY
+ 		openmp='-fopenmp'
+ 		;;		
+-            *GNU*|*GCC*)
++            *Arm\ F90*|*F90\ Flang*|*F90\ AOCC*)
++               vendor=FLANG
++               openmp='-fopenmp'
++               ;;
++            *GNU*|*GCC*)	    
+ 
+                 v="${data#*GCC: *\) }"
+                 v="${v%%\"*}"

--- a/repos/spack_repo/builtin/packages/openblas/openblas-0.3.27_aocc.patch
+++ b/repos/spack_repo/builtin/packages/openblas/openblas-0.3.27_aocc.patch
@@ -1,0 +1,11 @@
+--- a/f_check	2024-04-04 20:26:04.000000000 +0000
++++ b/f_check	2025-12-03 01:13:59.000000000 +0000
+@@ -86,7 +86,7 @@
+ 		vendor=CRAY
+ 		openmp='-fopenmp'
+ 		;;
+-   	    *Arm\ F90*)
++	    *Arm\ F90*|*F90\ Flang*|*F90\ AOCC*)
+ 		vendor=FLANG
+ 		openmp='-fopenmp'
+ 		;;	

--- a/repos/spack_repo/builtin/packages/openblas/openblas-aocc-0.3.28-plus.patch
+++ b/repos/spack_repo/builtin/packages/openblas/openblas-aocc-0.3.28-plus.patch
@@ -1,0 +1,11 @@
+--- a/f_check	2024-08-08 20:41:46.000000000 +0000
++++ b/f_check	2025-12-03 01:12:10.000000000 +0000
+@@ -86,7 +86,7 @@
+ 		vendor=CRAY
+ 		openmp='-fopenmp'
+ 		;;
+-   	    *Arm\ F90*|*F90\ Flang*)
++	    *Arm\ F90*|*F90\ Flang*|*F90\ AOCC*)
+ 		vendor=FLANG
+ 		openmp='-fopenmp'
+ 		;;	

--- a/repos/spack_repo/builtin/packages/openblas/package.py
+++ b/repos/spack_repo/builtin/packages/openblas/package.py
@@ -297,6 +297,11 @@ class Openblas(CMakePackage, MakefilePackage):
     # ilp64 and symbol suffixes are not supported with CMake build system
     requires("~ilp64", when="build_system=cmake")
     requires("symbol_suffix=none", when="build_system=cmake")
+    
+    # AOCC compiler detection adjustments
+    patch("openblas-aocc-0.3.28-plus.patch", when="@0.3.28: %aocc@5.1.0:")
+    patch("openblas-0.3.27_aocc.patch", when="@0.3.27 %aocc@5.0.0:")
+    patch("openblas-0.3.21-0.3.26_aocc.patch", when="@0.3.21:0.3.26 %aocc@5.0.0:")
 
     # Requires support for -mtune=generic
     conflicts("%fortran=clang %llvm@18")

--- a/repos/spack_repo/builtin/packages/openblas/package.py
+++ b/repos/spack_repo/builtin/packages/openblas/package.py
@@ -297,7 +297,7 @@ class Openblas(CMakePackage, MakefilePackage):
     # ilp64 and symbol suffixes are not supported with CMake build system
     requires("~ilp64", when="build_system=cmake")
     requires("symbol_suffix=none", when="build_system=cmake")
-    
+
     # AOCC compiler detection adjustments
     patch("openblas-aocc-0.3.28-plus.patch", when="@0.3.28: %aocc@5.1.0:")
     patch("openblas-0.3.27_aocc.patch", when="@0.3.27 %aocc@5.0.0:")


### PR DESCRIPTION
Different versions of the AOCC compiler are derived from different upstream LLVM versions, and AOCC's internal identification strings vary across releases. OpenBLAS currently uses low-level compiler detection mechanisms that are not robust enough to handle these variations, which can cause it to use incorrect calling conventions when invoking test code. This results in Spack build failures.

This PR patches the compiler detection code to ensure recent versions of AOCC work seamlessly with recent versions of OpenBLAS.
