### PR TITLE
podio: Add link dependency for python for 1.7 upwards

### DIFF
--- a/repos/spack_repo/builtin/packages/podio/package.py
+++ b/repos/spack_repo/builtin/packages/podio/package.py
@@ -77,7 +77,8 @@ class Podio(CMakePackage):
         )
 
     depends_on("cmake@3.12:", type="build")
-    depends_on("python", type=("build", "run"))
+    depends_on("python", type=("build", "run"), when="@:1.6")
+    depends_on("python", type=("build", "link", "run"), when="@1.7:")
     depends_on("py-pyyaml", type=("build", "run"))
     depends_on("py-jinja2@2.10.1:", type=("build", "run"))
     depends_on("sio", type=("build", "link"), when="+sio")


### PR DESCRIPTION
This is necessary to build podio@1.7 on macOS

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

@paulgessinger FYI