### PR TITLE
Add Parallelio 2.6.8

### DIFF
--- a/repos/spack_repo/builtin/packages/parallelio/package.py
+++ b/repos/spack_repo/builtin/packages/parallelio/package.py
@@ -20,6 +20,7 @@ class Parallelio(CMakePackage):
 
     license("Apache-2.0")
 
+    version("2.6.8", sha256="ed6c92129b8a5e2d77587fd9656abc0aa7cf82a26a5ad21f8c6a9a79afa2c301")
     version("2.6.6", sha256="e32e018a521d38c9424940c7cfa7e9b1931b605f3511ee7ab3a718b69faeeb04")
     version("2.6.5", sha256="6ae51aa3f76e597a3a840a292ae14eca21359b1a4ea75e476a93aa2088c0677a")
     version("2.6.4", sha256="cba53e4ca62ff76195b6f76374fbd1530fba18649c975ae2628ddec7fe55fb31")


### PR DESCRIPTION
Adds new parallelio version 

@seanbryan51 - just confirming that cmake @3.7 is ok as minimum version [with the CMake exports](https://github.com/NCAR/ParallelIO/pull/2012/files) ?

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
