### PR TITLE
Update Fiat and ecTrans recipes

### DIFF
--- a/repos/spack_repo/builtin/packages/ectrans/package.py
+++ b/repos/spack_repo/builtin/packages/ectrans/package.py
@@ -51,8 +51,12 @@ class Ectrans(CMakePackage):
     variant("mkl", default=False, description="Use MKL")
     variant("fftw", default=True, description="Use FFTW")
 
-    variant("etrans", default=False, when="@1.6.0:",
-            description="Compile limited-area-model transform library etrans")
+    variant(
+        "etrans",
+        default=False,
+        when="@1.6.0:",
+        description="Compile limited-area-model transform library etrans",
+    )
     variant("transi", default=True, description="Compile TransI C-interface to trans")
 
     depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/ectrans/package.py
+++ b/repos/spack_repo/builtin/packages/ectrans/package.py
@@ -8,11 +8,15 @@ from spack.package import *
 
 
 class Ectrans(CMakePackage):
-    """Ectrans is the global spherical Harmonics transforms library,
-    extracted from the IFS. It is using a hybrid of MPI and OpenMP
-    parallelisation strategies. The package contains both single- and double precision
-    Fortran libraries (trans_sp, trans_dp), as well as a
-    C interface to the double-precision version (transi_dp)."""
+    """ecTrans is a library for performing efficient and scalable spectral transformations. It is
+    used for transforming fields from a grid point space on the sphere (e.g. latitude-longitude) to
+    a spectral space based on spherical harmonics (for global transformations) or bifourier
+    harmonics (for limited area transformations), which constitutes a direct transform. A
+    corresponding inverse transform can also be performed. A transform consists of a Fourier
+    transform in the longitudinal direction and either a Legendre transform (global) or another
+    Fourier transform (limited area) in the latitudinal direction. ecTrans can also operate on
+    fields which are distributed across separate MPI tasks and performs the necessary communication
+    to ensure all data needed for a particular transform are resident on a local task."""
 
     homepage = "https://github.com/ecmwf-ifs/ectrans"
     git = "https://github.com/ecmwf-ifs/ectrans.git"

--- a/repos/spack_repo/builtin/packages/ectrans/package.py
+++ b/repos/spack_repo/builtin/packages/ectrans/package.py
@@ -51,6 +51,8 @@ class Ectrans(CMakePackage):
     variant("mkl", default=False, description="Use MKL")
     variant("fftw", default=True, description="Use FFTW")
 
+    variant("etrans", default=False, when="@1.6.0:",
+            description="Compile limited-area-model transform library etrans")
     variant("transi", default=True, description="Compile TransI C-interface to trans")
 
     depends_on("c", type="build")
@@ -92,6 +94,7 @@ class Ectrans(CMakePackage):
             self.define_from_variant("ENABLE_SINGLE_PRECISION", "single_precision"),
             self.define_from_variant("ENABLE_FFTW", "fftw"),
             self.define_from_variant("ENABLE_MKL", "mkl"),
+            self.define_from_variant("ENABLE_ETRANS", "etrans"),
             self.define_from_variant("ENABLE_TRANSI", "transi"),
             # Turn off use of contiguous keyword in Fortran because a number
             # of compilers have issues with it, and the hardcoded list of "bad"

--- a/repos/spack_repo/builtin/packages/ectrans/package.py
+++ b/repos/spack_repo/builtin/packages/ectrans/package.py
@@ -22,7 +22,7 @@ class Ectrans(CMakePackage):
     git = "https://github.com/ecmwf-ifs/ectrans.git"
     url = "https://github.com/ecmwf-ifs/ectrans/archive/1.1.0.tar.gz"
 
-    maintainers("climbfuji")
+    maintainers("climbfuji", "samhatfield")
 
     license("Apache-2.0")
 

--- a/repos/spack_repo/builtin/packages/fiat/package.py
+++ b/repos/spack_repo/builtin/packages/fiat/package.py
@@ -20,6 +20,7 @@ class Fiat(CMakePackage):
     license("Apache-2.0")
 
     version("main", branch="main", no_cache=True)
+    version("1.6.2", sha256="772394f531fabc6965997407309074481ff2e2b1bca78da9e041acfe01d3a085")
     version("1.6.1", sha256="fec30ac572d626d8f1a8bd0d03c41aac156e6911f9f822e5f7e5991aff91ba37")
     version("1.5.1", sha256="50834bf5d8cb4bde92df9028f799aeba411a0a16e55ca33da10a329b5d7f55ea")
     version("1.4.1", sha256="7d49316150e59afabd853df0066b457a268731633898ab51f6f244569679c84a")


### PR DESCRIPTION
Just some minor tweaks to these packages:
- New etrans feature for ecTrans@1.6.0:
- Added new Fiat version, 1.6.2

@climbfuji we at ECMWF are hoping to get a bit more involved with maintenance of Spack recipes for our libraries (at least, ecTrans and Fiat) ! Hope this looks okay.