### PR TITLE
PyTorch: add v2.10.0

### DIFF
--- a/repos/spack_repo/builtin/packages/cpuinfo/package.py
+++ b/repos/spack_repo/builtin/packages/cpuinfo/package.py
@@ -20,7 +20,8 @@ class Cpuinfo(CMakePackage):
     license("BSD-2-Clause")
 
     version("main", branch="main")
-    version("2025-03-21", commit="5e3d2445e6a84d9599bee2bf78edbb4d80865e1d")  # py-torch@2.8:
+    version("2025-11-14", commit="f858c30bcb16f8effd5ff46996f0514539e17abc")  # py-torch@2.10:
+    version("2025-03-21", commit="5e3d2445e6a84d9599bee2bf78edbb4d80865e1d")  # py-torch@2.8:2.9
     version("2024-09-26", commit="1e83a2fdd3102f65c6f1fb602c1b320486218a99")  # py-torch@2.6:2.7
     version("2024-09-06", commit="094fc30b9256f54dad5ad23bcbfb5de74781422f")  # py-torch@2.5.1
     version("2024-08-30", commit="fa1c679da8d19e1d87f20175ae1ec10995cd3dd3")  # py-torch@2.5.0
@@ -35,11 +36,13 @@ class Cpuinfo(CMakePackage):
     version("2018-05-13", commit="1e6c8c99d27f2b5eb9d2e6231055c6a4115b85e5")  # py-torch@0.4.1
     version("2018-04-04", commit="831dc28341b5f20d13e840caf87eaba644d82643")  # py-torch@:0.4.0
 
-    depends_on("c", type="build")
-    depends_on("cxx", type="build")
-
     generator("ninja")
-    depends_on("cmake@3.5:", type="build")
+
+    with default_args(type="build"):
+        depends_on("c")
+        depends_on("cxx")
+        depends_on("cmake@3.18:", when="@2025-09-06:")
+        depends_on("cmake@3.5:")
 
     def cmake_args(self):
         # cpuinfo cannot produce a shared build with MSVC because it does not export

--- a/repos/spack_repo/builtin/packages/nvtx/package.py
+++ b/repos/spack_repo/builtin/packages/nvtx/package.py
@@ -19,6 +19,7 @@ class Nvtx(Package, PythonExtension):
     license("Apache-2.0")
 
     version("develop", branch="dev")
+    version("3.3.0", sha256="67d0cda2f9d19a89684592dab40c0bf2c2b13d5d588e51392076c0890a64b6c0")
     version("3.2.1", sha256="737c3035f0e43a2252e7cd94c3f26e11e169f624236efe31794f044ce44a70af")
     version("3.1.0", sha256="dc4e4a227d04d3da46ad920dfee5f7599ac8d6b2ee1809c9067110fb1cc71ced")
 

--- a/repos/spack_repo/builtin/packages/py_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_torch/package.py
@@ -29,6 +29,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     tags = ["e4s"]
 
     version("main", branch="main")
+    version("2.10.0", tag="v2.10.0", commit="449b1768410104d3ed79d3bcfe4ba1d65c7f22c0")
     version("2.9.1", tag="v2.9.1", commit="d38164a545b4a4e4e0cf73ce67173f70574890b6")
     version("2.9.0", tag="v2.9.0", commit="0fabc3ba44823f257e70ce397d989c8de5e362c1")
     version("2.8.0", tag="v2.8.0", commit="ba56102387ef21a3b04b357e5b183d48f0afefc7")
@@ -185,9 +186,10 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
         depends_on("py-fsspec", when="@2.1:")
 
         # pyproject.toml
+        depends_on("py-setuptools@70.1:", when="@2.10:")
         depends_on("py-setuptools@70.1:79", when="@2.9:")
         depends_on("py-setuptools@62.3:79", when="@2.8")
-        depends_on("py-setuptools")
+        depends_on("py-setuptools@:79", when="@:2.7")
         depends_on("py-numpy")
         # https://github.com/pytorch/pytorch/issues/107302
         depends_on("py-numpy@:1", when="@:2.2")
@@ -204,7 +206,8 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     # third_party
     depends_on("fp16@2020-05-14")
     depends_on("fxdiv@2020-04-17")
-    depends_on("nvtx@3.2.1", when="@2.8:")
+    depends_on("nvtx@3.3.0", when="@2.10:")
+    depends_on("nvtx@3.2.1", when="@2.8:2.9")
     depends_on("nvtx@3.1.0", when="@2.6:2.7")
     # https://github.com/pytorch/pytorch/issues/60332
     # depends_on("xnnpack@2024-12-03", when="@2.7:+xnnpack")
@@ -216,7 +219,8 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     # depends_on("xnnpack@2021-02-22", when="@1.8:1.9+xnnpack")
     # depends_on("xnnpack@2020-03-23", when="@1.6:1.7+xnnpack")
     depends_on("benchmark", when="@1.6:+test")
-    depends_on("cpuinfo@2025-03-21", when="@2.8:")
+    depends_on("cpuinfo@2025-11-14", when="@2.10:")
+    depends_on("cpuinfo@2025-03-21", when="@2.8:2.9")
     depends_on("cpuinfo@2024-09-26", when="@2.6:2.7")
     depends_on("cpuinfo@2024-09-06", when="@2.5.1")
     depends_on("cpuinfo@2024-08-30", when="@2.5.0")

--- a/repos/spack_repo/builtin/packages/py_torchaudio/package.py
+++ b/repos/spack_repo/builtin/packages/py_torchaudio/package.py
@@ -19,6 +19,7 @@ class PyTorchaudio(PythonPackage):
     maintainers("adamjstewart")
 
     version("main", branch="main")
+    version("2.10.0", tag="v2.10.0", commit="27b7ebdebd2d2e4d34a2f5c05b0fb26efbd1da63")
     version("2.9.1", tag="v2.9.1", commit="a224ab24a7f4797f6707051257265e223e12576f")
     version("2.9.0", tag="v2.9.0", commit="eaa9e4e4dd413dca1084116581dc84fad403db3b")
     version("2.8.0", tag="v2.8.0", commit="6e1c7fe9ff6d82b8665d0a46d859d3357d2ebaaa")
@@ -59,7 +60,8 @@ class PyTorchaudio(PythonPackage):
 
     with default_args(type=("build", "link", "run")):
         # Based on PyPI wheel availability
-        depends_on("python@3.10:3.14", when="@2.9:")
+        depends_on("python@3.10:", when="@2.10:")
+        depends_on("python@3.10:3.14", when="@2.9")
         depends_on("python@3.9:3.13", when="@2.6:2.8")
         depends_on("python@3.9:3.12", when="@2.5")
         depends_on("python@3.8:3.12", when="@2.2:2.4")
@@ -68,6 +70,7 @@ class PyTorchaudio(PythonPackage):
         depends_on("python@:3.9", when="@0.7.2:0.11")
 
         depends_on("py-torch@main", when="@main")
+        depends_on("py-torch@2.10:", when="@2.10.0")
         depends_on("py-torch@2.9.1", when="@2.9.1")
         depends_on("py-torch@2.9.0", when="@2.9.0")
         depends_on("py-torch@2.8.0", when="@2.8.0")

--- a/repos/spack_repo/builtin/packages/py_torchvision/package.py
+++ b/repos/spack_repo/builtin/packages/py_torchvision/package.py
@@ -20,6 +20,7 @@ class PyTorchvision(PythonPackage):
     license("BSD-3-Clause")
 
     version("main", branch="main")
+    version("0.25.0", sha256="a7ac1b3ab489d71f6e27edfad1e27616e4b8a9b1517e60fce4a950600d3510e8")
     version("0.24.1", sha256="071da2078600bfec4886efab77358c9329abfedcf1488b05879b556cb9b84ba7")
     version("0.24.0", sha256="f799cdd1d67a3edbcdc6af8fb416fe1b019b512fb426c0314302cd81518a0095")
     version("0.23.0", sha256="db5a91569e5eb4a3b02e9eaad6080335f5ae3824890a697f5618541999f04027")
@@ -82,6 +83,7 @@ class PyTorchvision(PythonPackage):
 
         # https://github.com/pytorch/vision#installation
         depends_on("py-torch@main", when="@main")
+        depends_on("py-torch@2.10.0", when="@0.25.0")
         depends_on("py-torch@2.9.1", when="@0.24.1")
         depends_on("py-torch@2.9.0", when="@0.24.0")
         depends_on("py-torch@2.8.0", when="@0.23.0")
@@ -147,6 +149,8 @@ class PyTorchvision(PythonPackage):
     depends_on("py-six", when="@:0.5", type=("build", "run"))
     depends_on("py-typing-extensions", when="@0.12:0.14", type=("build", "run"))
 
+    # https://github.com/pytorch/vision/issues/9307
+    conflicts("^python@3.14.1")
     # https://github.com/pytorch/vision/pull/5898
     conflicts("^pil@10:", when="@:0.12")
     # https://github.com/pytorch/vision/issues/4146


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
* https://github.com/pytorch/pytorch/releases/tag/v2.10.0
* https://github.com/pytorch/audio/releases/tag/v2.10.0
* https://github.com/pytorch/vision/releases/tag/v0.25.0

This is the final torchaudio release. Therefore, I've removed upper bounds to try to allow support for newer versions of Python/PyTorch. We can add them on an as-needed basis.