### PR TITLE
CMake: conflict older CMake with newer curl

### DIFF
--- a/repos/spack_repo/builtin/packages/cmake/package.py
+++ b/repos/spack_repo/builtin/packages/cmake/package.py
@@ -175,7 +175,7 @@ class Cmake(Package):
     depends_on("curl")
 
     # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/11134
-    conflicts("curl@8.17:", when="@:3.30")
+    conflicts("curl@8.16:", when="@:3.30")
 
     # When using curl, cmake defaults to using system zlib too, probably because
     # curl already depends on zlib. Therefore, also unconditionaly depend on zlib.

--- a/repos/spack_repo/builtin/packages/cmake/package.py
+++ b/repos/spack_repo/builtin/packages/cmake/package.py
@@ -174,6 +174,9 @@ class Cmake(Package):
     depends_on("curl@:8.15", when="@:3.25")
     depends_on("curl")
 
+    # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/11134
+    conflicts("curl@8.17:", when="@:3.30")
+
     # When using curl, cmake defaults to using system zlib too, probably because
     # curl already depends on zlib. Therefore, also unconditionaly depend on zlib.
     depends_on("zlib-api")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
