### PR TITLE
kokkos: add atomics_bypass variant for serial backend-only

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -124,6 +124,11 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
 
     options_variants = {
         "aggressive_vectorization": [False, None, "Aggressively vectorize loops"],
+        "atomics_bypass": [
+            False,
+            "@4.6: +serial~threads~cuda~rocm~hpx~openmp~sycl~openmptarget",
+            "Make atomics non-atomic for non-threaded MPI-only use cases",
+        ],
         "compiler_warnings": [False, "@:4", "Print all compiler warnings"],
         "complex_align": [True, None, "Align complex numbers"],
         "cuda_constexpr": [False, "+cuda", "Activate experimental constexpr features"],


### PR DESCRIPTION
Only available is `+serial` and all other backends are OFF. Default is OFF to not break existing behavior.
