### PR TITLE
Corrects overly restrictive chapel range in arkouda package dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/arkouda/package.py
+++ b/repos/spack_repo/builtin/packages/arkouda/package.py
@@ -69,7 +69,7 @@ class Arkouda(MakefilePackage):
     )
 
     depends_on(
-        "chapel@2.1: +hdf5 +zmq", when="@:2025.01.13", type=("build", "link", "run", "test")
+        "chapel@2.1:2.2 +hdf5 +zmq", when="@:2025.01.13", type=("build", "link", "run", "test")
     )
     depends_on(
         "chapel@2.0:2.4 +hdf5 +zmq",

--- a/repos/spack_repo/builtin/packages/arkouda/package.py
+++ b/repos/spack_repo/builtin/packages/arkouda/package.py
@@ -80,7 +80,7 @@ class Arkouda(MakefilePackage):
         "chapel@2.0:2.5 +hdf5 +zmq", when="@2025.09.30", type=("build", "link", "run", "test")
     )
     depends_on(
-        "chapel@2.3:2.6 +hdf5 +zmq", when="@2025.12.16:", type=("build", "link", "run", "test")
+        "chapel@2.4:2.6 +hdf5 +zmq", when="@2025.12.16:", type=("build", "link", "run", "test")
     )
 
     depends_on("cmake@3.13.4:", type="build")

--- a/repos/spack_repo/builtin/packages/arkouda/package.py
+++ b/repos/spack_repo/builtin/packages/arkouda/package.py
@@ -69,15 +69,18 @@ class Arkouda(MakefilePackage):
     )
 
     depends_on(
+        "chapel@2.1: +hdf5 +zmq", when="@:2025.01.13", type=("build", "link", "run", "test")
+    )
+    depends_on(
         "chapel@2.0:2.4 +hdf5 +zmq",
         when="@2025.07.03:2025.08.20",
         type=("build", "link", "run", "test"),
     )
     depends_on(
-        "chapel@2.0:2.5 +hdf5 +zmq", when="@2025.09.30:", type=("build", "link", "run", "test")
+        "chapel@2.0:2.5 +hdf5 +zmq", when="@2025.09.30", type=("build", "link", "run", "test")
     )
     depends_on(
-        "chapel@2.1: +hdf5 +zmq", when="@:2025.01.13", type=("build", "link", "run", "test")
+        "chapel@2.3:2.6 +hdf5 +zmq", when="@2025.12.16:", type=("build", "link", "run", "test")
     )
 
     depends_on("cmake@3.13.4:", type="build")


### PR DESCRIPTION
Adjusts Chapel version constraints for the Arkouda Spack package to better align supported Chapel ranges with Arkouda release timelines.

Introduces a new Chapel version range for Arkouda @2025.12.16: and later.  Reorders and adjust the Chapel version ranges for the other Arkouda versions.

Arkouda @2025.12.16 supports Chapel: 2.4.0, 2.5.0, 2.6.0, as seen in the release notes: https://github.com/Bears-R-Us/arkouda/releases/tag/v2025.12.16

