### PR TITLE
WRF: Fix build with aocc-5.1

### DIFF
--- a/repos/spack_repo/builtin/packages/wrf/package.py
+++ b/repos/spack_repo/builtin/packages/wrf/package.py
@@ -355,6 +355,9 @@ class Wrf(Package):
 
         zen_conf = (Path(__file__).parent / "aocc_config.inc").read_text().format(**param)
 
+        if self.spec.satisfies("%aocc@5.1:"):
+            zen_conf = zen_conf.replace("-finline-aggressive ", "")  # removed flag in AOCC 5.1+
+
         if self.spec.satisfies("@4.0:"):
             filter_file("#insert new stanza here", zen_conf, "arch/configure.defaults")
         else:


### PR DESCRIPTION
Due to a recent change in the AOCC compiler, a previously supported flag has been removed. 
This PR removes the affected flag from the application's build system to prevent build failures at compile time.
