### PR TITLE
openmpi: adjust to change in gpfs header for v4.1.x

### DIFF
--- a/repos/spack_repo/builtin/packages/openmpi/fix_fs_gpfs_file_set_info.patch
+++ b/repos/spack_repo/builtin/packages/openmpi/fix_fs_gpfs_file_set_info.patch
@@ -1,0 +1,17 @@
+--- openmpi-4.1.8.orig/ompi/mca/fs/gpfs/fs_gpfs_file_set_info.c	2025-02-04 18:12:40.670052103 +0100
++++ openmpi-4.1.8.bugfix/ompi/mca/fs/gpfs/fs_gpfs_file_set_info.c	2026-01-20 18:12:44.331378461 +0100
+@@ -305,7 +305,13 @@
+         gpfs_hint_SetReplication.gpfsSetReplication.maxMetadataReplicas = atoi(token);
+         gpfs_hint_SetReplication.gpfsSetReplication.dataReplicas = atoi(token);
+         gpfs_hint_SetReplication.gpfsSetReplication.maxDataReplicas = atoi(token);
+-        gpfs_hint_SetReplication.gpfsSetReplication.reserved = 0;
++        /* see issue #13313 on https://github.com/open-mpi/ompi
++         * and commit https://github.com/open-mpi/ompi/commit/556014c */
++        #ifdef GPFS_FCNTL_SET_REPLICATIONX
++            gpfs_hint_SetReplication.gpfsSetReplication.perfReplicas = 0;
++        #else
++            gpfs_hint_SetReplication.gpfsSetReplication.reserved = 0;
++        #endif
+ 
+         rc = gpfs_fcntl(gpfs_file_handle, &gpfs_hint_SetReplication);
+         if (rc != 0) {

--- a/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -455,6 +455,9 @@ class Openmpi(AutotoolsPackage, CudaPackage, ROCmPackage):
     patch("configure.patch", when="@1.10.1")
     patch("fix_multidef_pmi_class.patch", when="@2.0.0:2.0.1")
     patch("fix-ucx-1.7.0-api-instability.patch", when="@4.0.0:4.0.2")
+    # see issue with gpfs #13313 on https://github.com/open-mpi/ompi and
+    # commit https://github.com/open-mpi/ompi/commit/556014c
+    patch("fix_fs_gpfs_file_set_info.patch", when="@4.1 +gpfs")
 
     # Vader Bug: https://github.com/open-mpi/ompi/issues/5375
     # Haven't release fix for 2.1.x


### PR DESCRIPTION
Due to changes in the header files of "recent" GPFS header files, openmpi 4.1.x fails to compile when the _--with-gpfs_ option is enabled.
This issue has been fixed in OpenMPI 5.x, but, at the moment of writing, not in openmpi 4.1.x.
See issue #13313 on https://github.com/open-mpi/ompi and and commit https://github.com/open-mpi/ompi/commit/556014c
The PR is just a patch with a backport for the 4.1.x series (the patched header file never changed in the openmpi 4.1.x branch since the commit in which it was added: https://github.com/open-mpi/ompi/commits/v4.1.x/ompi/mca/fs/gpfs/fs_gpfs_file_set_info.c).

