### PR TITLE
ascent: fix fortran support 

### DIFF
--- a/repos/spack_repo/builtin/packages/ascent/package.py
+++ b/repos/spack_repo/builtin/packages/ascent/package.py
@@ -218,7 +218,7 @@ class Ascent(CMakePackage, CudaPackage, ROCmPackage):
     # MPI
     #######################
     depends_on("mpi", when="+mpi")
-    depends_on("py-mpi4py", when="+mpi+python")
+    depends_on("py-mpi4py", when="+mpi+python", type=("build", "link", "run"))
 
     #############################
     # TPLs for Runtime Features

--- a/repos/spack_repo/builtin/packages/ascent/package.py
+++ b/repos/spack_repo/builtin/packages/ascent/package.py
@@ -192,6 +192,7 @@ class Ascent(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("conduit@0.9.1:0.9.3", when="@0.9.3")
     depends_on("conduit@0.9.4", when="@0.9.4")
     depends_on("conduit@0.9.5", when="@0.9.5")
+    depends_on("conduit+fortran", when="+fortran")
     depends_on("conduit+python", when="+python", type=("build", "link", "run"))
     depends_on("conduit+mpi", when="+mpi")
     depends_on("conduit~mpi", when="~mpi")


### PR DESCRIPTION
`ascent+fortran` requires `conduit+fortran`

https://github.com/Alpine-DAV/ascent/blob/efbdc206c7fd65408de8e2d68783688e95a09f64/src/cmake/thirdparty/SetupConduit.cmake#L33-L41