### PR TITLE
Update oneAPI packages to 2025.3.6

### DIFF
--- a/repos/spack_repo/builtin/packages/intel_oneapi_advisor/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_advisor/package.py
@@ -29,6 +29,12 @@ class IntelOneapiAdvisor(IntelOneApiLibraryPackageWithSdk):
     )
 
     version(
+        "2025.4.1",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/093b261b-0f17-4568-abce-ac68c3096192/intel-advisor-2025.4.1.9_offline.sh",
+        sha256="bdb9d53c37f4bbb17a64ca61037ce17c9848b515c2edc926d52e887e0d4f9af9",
+        expand=False,
+    )
+    version(
         "2025.3.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/142fde64-2178-4a36-b501-08c42c552495/intel-advisor-2025.3.0.112_offline.sh",
         sha256="f683401327d96b93f0ed486d0b9487d0d15ee0ad6cf7a7072cbd3cb47db54e79",

--- a/repos/spack_repo/builtin/packages/intel_oneapi_ccl/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_ccl/package.py
@@ -29,6 +29,12 @@ class IntelOneapiCcl(IntelOneApiLibraryPackage):
     depends_on("intel-oneapi-mpi")
 
     version(
+        "2021.17.2",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/c477188f-0ba1-4213-8945-22f16ebc8ecb/intel-oneccl-2021.17.2.6_offline.sh",
+        sha256="01d5f810634e6bfd92b0ce118d1b8dbb1844792d5ff5219df0facd9f8d67a203",
+        expand=False,
+    )
+    version(
         "2021.16.1",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/66ce2615-4f44-42d5-9b4b-69ca25df01fc/intel-oneccl-2021.16.1.10_offline.sh",
         sha256="e8a48c828d7f0d274ff8af7089a42fbe88664beef810b659be4aedc39830206e",

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
@@ -14,6 +14,17 @@ from spack.package import *
 
 versions = [
     {
+        "version": "2025.3.2",
+        "cpp": {
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/0d61d48a-4fe8-4cb2-bd9d-94d2c19c6227/intel-dpcpp-cpp-compiler-2025.3.2.26_offline.sh",
+            "sha256": "37d6c9c22f90fbb4d2072fd45d0284f2b6b1ffd030d699e1e7a669087d093396",
+        },
+        "ftn": {
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/3e53d136-2870-4836-adb1-892b558fa34a/intel-fortran-compiler-2025.3.2.25_offline.sh",
+            "sha256": "c64d20d70a277b1249d2ba9221be7245a843f3988df9076b4456619fe5929278",
+        },
+    },
+    {
         "version": "2025.2.1",
         "cpp": {
             "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/04c5fd98-57e6-4a4b-be4d-e84de3aea45a/intel-dpcpp-cpp-compiler-2025.2.1.7_offline.sh",

--- a/repos/spack_repo/builtin/packages/intel_oneapi_dal/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_dal/package.py
@@ -28,6 +28,12 @@ class IntelOneapiDal(IntelOneApiLibraryPackage):
     )
 
     version(
+        "2025.10.1",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19f5fbad-fc2e-48a7-b64c-0af30799f4e9/intel-onedal-2025.10.1.22_offline.sh",
+        sha256="3026f70ff3adef2cd37b18c6642ad97160a25fba7ffb7a8ab7b968dedf08740e",
+        expand=False,
+    )
+    version(
         "2025.6.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/c470125a-2268-496e-a54b-40e0e2961eb1/intel-onedal-2025.6.0.117_offline.sh",
         sha256="913ebfad57932bf28056229a5af4d8b50b796362273e655f4aac19122be20882",

--- a/repos/spack_repo/builtin/packages/intel_oneapi_dpct/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_dpct/package.py
@@ -21,6 +21,12 @@ class IntelOneapiDpct(IntelOneApiPackage):
     homepage = "https://www.intel.com/content/www/us/en/developer/tools/oneapi/dpc-compatibility-tool.html#gs.2p8km6"
 
     version(
+        "2025.3.1",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/08285d96-0fe2-47a0-ab0b-b4675a0541d8/intel-dpcpp-ct-2025.3.1.21_offline.sh",
+        sha256="08d671483622a463ad7e748d88bb90c5acc54815a2d59fec70f9ff85d11e6e27",
+        expand=False,
+    )
+    version(
         "2025.2.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/f2fe12fc-0458-42f0-8fd4-7f5d53cd327f/intel-dpcpp-ct-2025.2.0.518_offline.sh",
         sha256="34958d35093c6a2c81f255561bd9dd30f2a557409fa8761410b52e8e836f610d",

--- a/repos/spack_repo/builtin/packages/intel_oneapi_ipp/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_ipp/package.py
@@ -29,6 +29,12 @@ class IntelOneapiIpp(IntelOneApiLibraryPackage):
     )
 
     version(
+        "2022.3.1",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/f5ea6a8e-1b2d-4184-bf58-45c612fb2ee1/intel-ipp-2022.3.1.9_offline.sh",
+        sha256="0dacbe933d898c3a30086af90dfdca946d87a28530c2943dc98082a767e001ff",
+        expand=False,
+    )
+    version(
         "2022.2.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/d9649232-67ed-489e-8cd8-2c4c54b06135/intel-ipp-2022.2.0.583_offline.sh",
         sha256="624985c649f34b54004f7865a2df23389b9ca6d410f785e9f08ab0d56ddc84b9",

--- a/repos/spack_repo/builtin/packages/intel_oneapi_mkl/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_mkl/package.py
@@ -30,6 +30,12 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
     )
 
     version(
+        "2025.3.1",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/6a17080f-f0de-41b9-b587-52f92512c59a/intel-onemkl-2025.3.1.11_offline.sh",
+        sha256="89753ce0be82d31669172c08c6b6b863f2e25558d775496349473b3299240a01",
+        expand=False,
+    )
+    version(
         "2025.2.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/47c7d946-fca1-441a-b0df-b094e3f045ea/intel-onemkl-2025.2.0.629_offline.sh",
         sha256="7bfdde1379a9cd3c2784af4352931a0527a5c483c9da71e851a3f06e055af7c7",

--- a/repos/spack_repo/builtin/packages/intel_oneapi_mpi/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_mpi/package.py
@@ -23,6 +23,12 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
     homepage = "https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/mpi-library.html"
 
     version(
+        "2021.17.2",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/86923909-82e5-4c1a-9499-b4263e800a33/intel-mpi-2021.17.2.94_offline.sh",
+        sha256="4861c55fdfde1f08a293a7cfb715aaab498cb8fc700d5db8f0b67660e5948350",
+        expand=False,
+    )
+    version(
         "2021.16.1",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/203edae7-5269-4124-a1ed-09ad924f8b47/intel-mpi-2021.16.1.804_offline.sh",
         sha256="4165717608e90ae6123397ebf2a9b87a0b070842ce7d13378d1446a08966eb6e",

--- a/repos/spack_repo/builtin/packages/intel_oneapi_tbb/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_tbb/package.py
@@ -24,6 +24,12 @@ class IntelOneapiTbb(IntelOneApiLibraryPackage):
     )
 
     version(
+        "2022.3.1",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/233a8b7a-ec95-4e51-bc5f-9dcd4f0d1dc3/intel-onetbb-2022.3.1.402_offline.sh",
+        sha256="cbd986db85a6f8b2d924ef00bf9a8ac2f781690e64611cccdb60eb18bb658d3b",
+        expand=False,
+    )
+    version(
         "2022.2.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/7516db94-4877-4ffe-8dde-37e9a46e69a2/intel-onetbb-2022.2.0.508_offline.sh",
         sha256="b8da6678bf4fdd4bf780436c21d191fe13a5ec71db21c8af9e10e3c6209d258e",

--- a/repos/spack_repo/builtin/packages/intel_oneapi_vtune/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_vtune/package.py
@@ -30,6 +30,12 @@ class IntelOneapiVtune(IntelOneApiLibraryPackageWithSdk):
     homepage = "https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/vtune-profiler.html"
 
     version(
+        "2025.8.1",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/8ab935f9-98cd-46b2-8e3f-df29ef73af84/intel-vtune-2025.8.1.8_offline.sh",
+        sha256="bf47be3140f89b7e85eb09aad1314d032621e4a8c2fa4e0dab934a3c349e4a5e",
+        expand=False,
+    )
+    version(
         "2025.5.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2775669e-5be4-4982-96de-d0ca5444859a/intel-vtune-2025.5.0.40_offline.sh",
         sha256="dc75067a48dc04a58b15b5944f1d8e951f3340ef7e2652030cab082ff53c6a87",


### PR DESCRIPTION
This PR updates oneAPI packages to 2025.3.6.

@rscohn2