### PR TITLE
vasp: libbeef, libxc, wannier90, v6.4.2, v6.3.1

### DIFF
--- a/repos/spack_repo/builtin/packages/libbeef/package.py
+++ b/repos/spack_repo/builtin/packages/libbeef/package.py
@@ -1,0 +1,29 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+
+from spack.package import *
+
+
+class Libbeef(AutotoolsPackage):
+    """
+    Library for Bayesian error estimation functionals for use in density functional theory codes.
+    """
+
+    homepage = "https://github.com/vossjo/libbeef"
+    git = "https://github.com/vossjo/libbeef.git"
+
+    maintainers("nolta")
+
+    license("LGPL-3.0-or-later", checked_by="nolta")
+
+    version("0.1.3", commit="535ea67327baa8368ec5c502392a212375b16187")
+
+    depends_on("c", type="build")
+
+    @property
+    def libs(self):
+        libraries = ["libbeef"]
+        return find_libraries(libraries, root=self.prefix, recursive=True, shared=False)

--- a/repos/spack_repo/builtin/packages/vasp/package.py
+++ b/repos/spack_repo/builtin/packages/vasp/package.py
@@ -38,6 +38,7 @@ class Vasp(MakefilePackage, CudaPackage):
 
     variant("shmem", default=True, description="Enable use_shmem build flag")
     variant("hdf5", default=False, description="Enabled HDF5 support")
+    variant("wannier90", default=False, description="Enable wannier90 support")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
@@ -58,6 +59,7 @@ class Vasp(MakefilePackage, CudaPackage):
     depends_on("scalapack")
     depends_on("nccl", when="+cuda")
     depends_on("hdf5+fortran+mpi", when="+hdf5")
+    depends_on("wannier90", when="+wannier90")
     # at the very least the nvhpc mpi seems required
     requires("^nvhpc+mpi+lapack+blas", when="%nvhpc")
 
@@ -224,6 +226,10 @@ class Vasp(MakefilePackage, CudaPackage):
             cpp_options.append("-DVASP_HDF5")
             llibs.append(spec["hdf5:fortran"].libs.ld_flags)
             incs.append(spec["hdf5"].headers.include_flags)
+
+        if spec.satisfies("+wannier90"):
+            cpp_options.append("-DVASP2WANNIER90")
+            llibs.append(spec["wannier90"].libs.ld_flags)
 
         if spec.satisfies("%gcc@10:"):
             fflags.append("-fallow-argument-mismatch")

--- a/repos/spack_repo/builtin/packages/vasp/package.py
+++ b/repos/spack_repo/builtin/packages/vasp/package.py
@@ -38,6 +38,7 @@ class Vasp(MakefilePackage, CudaPackage):
 
     variant("shmem", default=True, description="Enable use_shmem build flag")
     variant("hdf5", default=False, description="Enabled HDF5 support")
+    variant("libbeef", default=False, description="Enable Libbeef support")
     variant("libxc", default=False, description="Enable Libxc support")
     variant("wannier90", default=False, description="Enable wannier90 support")
 
@@ -60,6 +61,7 @@ class Vasp(MakefilePackage, CudaPackage):
     depends_on("scalapack")
     depends_on("nccl", when="+cuda")
     depends_on("hdf5+fortran+mpi", when="+hdf5")
+    depends_on("libbeef", when="+libbeef")
     depends_on("libxc~fhc+fortran", when="+libxc")
     depends_on("wannier90", when="+wannier90")
     # at the very least the nvhpc mpi seems required
@@ -228,6 +230,10 @@ class Vasp(MakefilePackage, CudaPackage):
             cpp_options.append("-DVASP_HDF5")
             llibs.append(spec["hdf5:fortran"].libs.ld_flags)
             incs.append(spec["hdf5"].headers.include_flags)
+
+        if spec.satisfies("+libbeef"):
+            cpp_options.append("-Dlibbeef")
+            llibs.append(spec["libbeef"].libs.ld_flags)
 
         if spec.satisfies("+libxc"):
             cpp_options.append("-DUSELIBXC")

--- a/repos/spack_repo/builtin/packages/vasp/package.py
+++ b/repos/spack_repo/builtin/packages/vasp/package.py
@@ -26,7 +26,9 @@ class Vasp(MakefilePackage, CudaPackage):
     version("6.5.1", sha256="a53fd9dd2a66472a4aa30074dbda44634fc663ea2628377fc01d870e37136f61")
     version("6.5.0", sha256="7836f0fd2387a6768be578f1177e795dc625f36f19015e31cab0e81154a24196")
     version("6.4.3", sha256="fe30e773f2a3e909b5e0baa9654032dfbdeff7ec157bc348cee7681a7b6c24f4")
+    version("6.4.2", sha256="b704637f7384673f91adfbc803edc5cc7fe736d9623453461f7cdc29b123410e")
     version("6.3.2", sha256="f7595221b0f9236a324ea8afe170637a578cdd5a837cc7679e7f7812f6edf25a")
+    version("6.3.1", sha256="113db53c4346287c89982f52887a65d12d246e38de7ccd024e44499c4774dc66")
     version("6.3.0", sha256="adcf83bdfd98061016baae31616b54329563aa2739573f069dd9df19c2071ad3")
 
     variant("openmp", default=False, description="Enable openmp build")

--- a/repos/spack_repo/builtin/packages/vasp/package.py
+++ b/repos/spack_repo/builtin/packages/vasp/package.py
@@ -38,6 +38,7 @@ class Vasp(MakefilePackage, CudaPackage):
 
     variant("shmem", default=True, description="Enable use_shmem build flag")
     variant("hdf5", default=False, description="Enabled HDF5 support")
+    variant("libxc", default=False, description="Enable Libxc support")
     variant("wannier90", default=False, description="Enable wannier90 support")
 
     depends_on("c", type="build")
@@ -59,6 +60,7 @@ class Vasp(MakefilePackage, CudaPackage):
     depends_on("scalapack")
     depends_on("nccl", when="+cuda")
     depends_on("hdf5+fortran+mpi", when="+hdf5")
+    depends_on("libxc~fhc+fortran", when="+libxc")
     depends_on("wannier90", when="+wannier90")
     # at the very least the nvhpc mpi seems required
     requires("^nvhpc+mpi+lapack+blas", when="%nvhpc")
@@ -226,6 +228,11 @@ class Vasp(MakefilePackage, CudaPackage):
             cpp_options.append("-DVASP_HDF5")
             llibs.append(spec["hdf5:fortran"].libs.ld_flags)
             incs.append(spec["hdf5"].headers.include_flags)
+
+        if spec.satisfies("+libxc"):
+            cpp_options.append("-DUSELIBXC")
+            llibs.append(spec["libxc:fortran"].libs.ld_flags)
+            incs.append(spec["libxc"].headers.include_flags)
 
         if spec.satisfies("+wannier90"):
             cpp_options.append("-DVASP2WANNIER90")


### PR DESCRIPTION
This series of commits for vasp:

- adds versions 6.3.1 & 6.4.2;
- adds variants for `libbeef`, `libxc`, & `wannier90` support;
- adds a new `libbeef` package.
