### PR TITLE
singularity-eos: add v1.11.0

### DIFF
--- a/repos/spack_repo/builtin/packages/singularity_eos/package.py
+++ b/repos/spack_repo/builtin/packages/singularity_eos/package.py
@@ -32,6 +32,7 @@ class SingularityEos(CMakePackage, CudaPackage, ROCmPackage):
     license("BSD-3-Clause")
 
     version("main", branch="main")
+    version("1.11.0", sha256="8bee9a40a4c2337d4df2b811a7071f4f5b0e9a50714a30a02b2712db1038bdf7")
     version("1.10.0", sha256="f2b5986d2e7f11b61c4cc1ac3b264adac39e16047f95fac29c60a19a2853f35b")
     version("1.9.2", sha256="4a58782020ad7bff3ea1c0cf55838a3692205770dbe4be39a3df25ba6fae302d")
     version("1.9.1", sha256="148889e1b2d5bdc3d59c5fd6a6b5da25bb4f4f0f4343c57b3ccaf96691c93aff")
@@ -108,11 +109,16 @@ class SingularityEos(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("eigen@3.3.8:", when="~kokkos-kernels+closure")
     requires("+kokkos-kernels", when="+kokkos+closure")
 
+    # test_pte fails on AMD MI300 for versions of llvm < 19
+    # rocm 6.4 is the first version of rocm that depends on llvm >= 19
+    depends_on("hip@6.4:", when="+rocm")
+
     depends_on("eospac", when="+eospac")
 
     depends_on("ports-of-call@1.4.2,1.5.2:", when="@:1.7.0")
     depends_on("ports-of-call@1.5.2:", when="@1.7.1:")
     depends_on("ports-of-call@1.6.0:", when="@1.9.0:")
+    depends_on("ports-of-call@2.0.0:", when="@1.11.0:")
     depends_on("ports-of-call@main", when="@main")
 
     depends_on("spiner +kokkos", when="+kokkos+spiner")
@@ -123,14 +129,14 @@ class SingularityEos(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("spiner@1.6.3:", when="@1.9.1: +spiner")
     depends_on("spiner@main", when="@main +spiner")
 
-    depends_on("mpark-variant")
+    depends_on("mpark-variant", when="@:1.10")
     depends_on(
         "mpark-variant",
         patches=patch(
             "https://raw.githubusercontent.com/lanl/singularity-eos/b6ae9bac37fca51854c8da7a699577c9932188e8/utils/gpu_compatibility.patch",
             sha256="592e64ceccd2822ec1cc7eb01ac3fcad620551940beab793003afb6b5366dad8",
         ),
-        when="+cuda",
+        when="@:1.10 +cuda",
     )
     depends_on(
         "mpark-variant",
@@ -138,7 +144,7 @@ class SingularityEos(CMakePackage, CudaPackage, ROCmPackage):
             "https://raw.githubusercontent.com/lanl/singularity-eos/b6ae9bac37fca51854c8da7a699577c9932188e8/utils/gpu_compatibility.patch",
             sha256="592e64ceccd2822ec1cc7eb01ac3fcad620551940beab793003afb6b5366dad8",
         ),
-        when="+rocm",
+        when="@:1.10 +rocm",
     )
     depends_on("binutils@:2.39,2.42:+ld", when="build_type=Debug")
     depends_on("binutils@:2.39,2.42:+ld", when="build_type=RelWithDebInfo")
@@ -157,7 +163,6 @@ class SingularityEos(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("kokkos+pic", when="+kokkos-kernels")
     depends_on("kokkos+cuda_lambda", when="+cuda+kokkos")
 
-    # specfic specs when using GPU/cuda offloading
     for _flag in list(CudaPackage.cuda_arch_values):
         depends_on("kokkos cuda_arch=" + _flag, when="+cuda+kokkos cuda_arch=" + _flag)
         depends_on("kokkos-kernels cuda_arch=" + _flag, when="+cuda+kokkos cuda_arch=" + _flag)


### PR DESCRIPTION
removes mpark-variant dependency. variant is now provided by ports-of-call.

- Requires: #3111 
- Requires: #3110 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
