### PR TITLE
awscli-v2: relax dependencies to support newer docutils

### DIFF
--- a/repos/spack_repo/builtin/packages/awscli_v2/package.py
+++ b/repos/spack_repo/builtin/packages/awscli_v2/package.py
@@ -30,7 +30,8 @@ class AwscliV2(PythonPackage):
 
     with default_args(type=("build", "run")):
         depends_on("py-colorama@0.2.5:0.4.6")
-        depends_on("py-docutils@0.10:0.19")
+        # Upper bound relaxed for Sphinx compatibility
+        depends_on("py-docutils@0.10:")
         depends_on("py-cryptography@40:43.0.1", when="@2.22:")
         depends_on("py-cryptography@3.3.2:40.0.1", when="@:2.15")
         depends_on("py-ruamel-yaml@0.15:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
As usual, the dependencies are pinned to ancient versions but work fine with newer versions.