### PR TITLE
py-docstring-parser: add v0.17.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_docstring_parser/package.py
+++ b/repos/spack_repo/builtin/packages/py_docstring_parser/package.py
@@ -15,7 +15,12 @@ class PyDocstringParser(PythonPackage):
 
     license("MIT")
 
+    version("0.17.0", sha256="583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912")
     version("0.15", sha256="48ddc093e8b1865899956fcc03b03e66bb7240c310fac5af81814580c55bf682")
 
-    depends_on("python@3.6:3", type=("build", "run"))
-    depends_on("py-poetry-core@1:", type="build")
+    depends_on("py-hatchling", when="@0.17:", type="build")
+
+    # Historical dependencies
+    # https://github.com/rr-/docstring_parser/pull/91
+    depends_on("python@:3.13", when="@:0.16", type=("build", "run"))
+    depends_on("py-poetry-core@1:", when="@:0.16", type="build")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Previous version uses ast imports removed in Python 3.14.