### PR TITLE
py-jedi: relax Python requirements

### DIFF
--- a/repos/spack_repo/builtin/packages/py_jedi/package.py
+++ b/repos/spack_repo/builtin/packages/py_jedi/package.py
@@ -29,6 +29,9 @@ class PyJedi(PythonPackage):
         depends_on("python@:3.10", when="@:0.18.1")
         depends_on("python@:3.11", when="@:0.19.0")
         depends_on("python@:3.12", when="@:0.19.1")
+        # Although v0.19.2 does not explicitly support Python v3.14, it does work well enough 
+        # according to the project maintainer that we've chosen to drop the upperbound constraint
+        # https://github.com/ipython/ipython/issues/15117#issuecomment-3799451766
         # depends_on("python@:3.13", when="@0.19.2:")
 
         depends_on("py-setuptools")

--- a/repos/spack_repo/builtin/packages/py_jedi/package.py
+++ b/repos/spack_repo/builtin/packages/py_jedi/package.py
@@ -29,7 +29,7 @@ class PyJedi(PythonPackage):
         depends_on("python@:3.10", when="@:0.18.1")
         depends_on("python@:3.11", when="@:0.19.0")
         depends_on("python@:3.12", when="@:0.19.1")
-        depends_on("python@:3.13", when="@0.19.2:")
+        # depends_on("python@:3.13", when="@0.19.2:")
 
         depends_on("py-setuptools")
 

--- a/repos/spack_repo/builtin/packages/py_jedi/package.py
+++ b/repos/spack_repo/builtin/packages/py_jedi/package.py
@@ -29,7 +29,7 @@ class PyJedi(PythonPackage):
         depends_on("python@:3.10", when="@:0.18.1")
         depends_on("python@:3.11", when="@:0.19.0")
         depends_on("python@:3.12", when="@:0.19.1")
-        # Although v0.19.2 does not explicitly support Python v3.14, it does work well enough 
+        # Although v0.19.2 does not explicitly support Python v3.14, it does work well enough
         # according to the project maintainer that we've chosen to drop the upperbound constraint
         # https://github.com/ipython/ipython/issues/15117#issuecomment-3799451766
         # depends_on("python@:3.13", when="@0.19.2:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
I don't use jedi, but I want to be able to build ipython with Python 3.14. IPython seems to work fine with this jedi, so perhaps the requirements are too strict?