### PR TITLE
py-matplotlib: Python 3.14 requires newer versions

### DIFF
--- a/repos/spack_repo/builtin/packages/py_matplotlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_matplotlib/package.py
@@ -150,6 +150,8 @@ class PyMatplotlib(PythonPackage):
     depends_on("python@3.10:", when="@3.10:", type=("build", "link", "run"))
     depends_on("python@3.9:", when="@3.8:", type=("build", "link", "run"))
     depends_on("python@3.8:", when="@3.6:", type=("build", "link", "run"))
+    # Some kind of recursion error
+    depends_on("python@:3.13", when="@:3.10.3", type=("build", "link", "run"))
     # Python 3.12 removed SafeConfigParser, which was used up to matplotlib 3.5.0.
     depends_on("python@:3.11", when="@:3.4", type=("build", "link", "run"))
     depends_on("python", type=("build", "link", "run"))


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
I hit some kind of weird deepcopy recursion error in Python 3.14 with matplotlib 3.8. Not sure if there is a known issue for this. If we want to be more careful, we could only officially support Python versions for which wheels exist similar to numpy/scipy. It depends on how often changes are required in matplotlib to support newer Python versions.