### PR TITLE
py-tensorboard-data-server: relax rust constraints

### DIFF
--- a/repos/spack_repo/builtin/packages/py_tensorboard_data_server/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorboard_data_server/package.py
@@ -22,6 +22,7 @@ class PyTensorboardDataServer(PythonPackage):
 
     depends_on("py-setuptools", type="build")
     depends_on("rust+dev", type="build")
+    depends_on("rust@:1.89+dev", type="build", when="@:0.6")
 
     # https://github.com/tensorflow/tensorboard/issues/5713
     patch(

--- a/repos/spack_repo/builtin/packages/py_tensorboard_data_server/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorboard_data_server/package.py
@@ -22,7 +22,6 @@ class PyTensorboardDataServer(PythonPackage):
 
     depends_on("py-setuptools", type="build")
     depends_on("rust+dev", type="build")
-    depends_on("rust@:1.89+dev", type="build", when="@:0.8")
 
     # https://github.com/tensorflow/tensorboard/issues/5713
     patch(


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
I was able to build with rust 1.91.1 just fine.