### PR TITLE
mpas-model: add metis to dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/mpas_model/package.py
+++ b/repos/spack_repo/builtin/packages/mpas_model/package.py
@@ -64,6 +64,7 @@ class MpasModel(MakefilePackage):
     depends_on("fortran", type="build")  # generated
 
     depends_on("mpi")
+    depends_on("metis", type="run")
     depends_on("parallelio")
 
     conflicts(


### PR DESCRIPTION
Adding Metis to the dependencies of the mpas-model, as discussed here:
https://github.com/spack/spack-packages/issues/3016


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
