### PR TITLE
tree-sitter: add cli tool to the installation

### DIFF
--- a/repos/spack_repo/builtin/packages/tree_sitter/package.py
+++ b/repos/spack_repo/builtin/packages/tree_sitter/package.py
@@ -20,6 +20,7 @@ class TreeSitter(MakefilePackage):
 
     license("MIT")
 
+    version("0.26.3", sha256="7f4a7cf0a2cd217444063fe2a4d800bc9d21ed609badc2ac20c0841d67166550")
     version("0.26.2", sha256="3cda4166a049fc736326941d6f20783b698518b0f80d8735c7754a6b2d173d9a")
     version("0.25.3", sha256="862fac52653bc7bc9d2cd0630483e6bdf3d02bcd23da956ca32663c4798a93e3")
     version("0.25.2", sha256="26791f69182192fef179cd58501c3226011158823557a86fe42682cb4a138523")

--- a/repos/spack_repo/builtin/packages/tree_sitter/package.py
+++ b/repos/spack_repo/builtin/packages/tree_sitter/package.py
@@ -55,25 +55,34 @@ class TreeSitter(MakefilePackage):
 
     depends_on("node-js", type="run")
 
-    def edit(self, spec, prefix):
-        env["PREFIX"] = prefix
+    # https://github.com/tree-sitter/tree-sitter/pull/5226
+    patch(
+        "https://github.com/tree-sitter/tree-sitter/pull/5226.patch",
+        sha256="4fe83cf4fa00b3a54cd495d4b6a921ae70adc5bc8f49aeaf0c2218ec0e96f6b3",
+        when="@0.26:0.26.3",
+    )
 
-        # Starting from 0.25.0 endianness is taken into account using system headers
+    def setup_build_environment(self, env):
+        env.set("PREFIX", self.prefix)
+
+        # Starting from 0.25 endianness is taken into account using system headers
         #   https://github.com/tree-sitter/tree-sitter/pull/3740
         # but GLIBC provides them according to some defines that changed over time.
         #   https://www.sourceware.org/glibc/wiki/Release/2.20#Deprecation_of__BSD_SOURCE_and__SVID_SOURCE_feature_macros
-        if spec.satisfies("@0.25: ^glibc@:2.19"):
-            filter_file("-D_DEFAULT_SOURCE", "-D_BSD_SOURCE", "Makefile")
+        if self.spec.satisfies("@0.25 ^glibc@:2.19"):
+            env.append_flags("CFLAGS", "-D_BSD_SOURCE")
 
     def build(self, spec, prefix):
         super().build(spec, prefix)
 
+        # tree-sitter-cli
         cargo = Executable("cargo")
         cargo("build")
 
     def install(self, spec, prefix):
         super().install(spec, prefix)
 
+        # tree-sitter-cli
         cargo = Executable("cargo")
         if spec.satisfies("@0.26:"):
             crate_cli_path = "crates/cli"

--- a/repos/spack_repo/builtin/packages/tree_sitter/package.py
+++ b/repos/spack_repo/builtin/packages/tree_sitter/package.py
@@ -55,6 +55,10 @@ class TreeSitter(MakefilePackage):
 
     depends_on("node-js", type="run")
 
+    # rust-bindgen is a dependency for tree-sitter rust bindings (used by tree-sitter-cli)
+    # https://github.com/rust-lang/rust-bindgen/blob/main/book/src/requirements.md#clang
+    depends_on("llvm@9: +clang", type="build")
+
     patch(
         "https://github.com/tree-sitter/tree-sitter/pull/5226.patch?full_index=1",
         sha256="f690ba222c524f93f9dd1b679b46384ace53f184f9836d26e028ac6e4087fe8a",

--- a/repos/spack_repo/builtin/packages/tree_sitter/package.py
+++ b/repos/spack_repo/builtin/packages/tree_sitter/package.py
@@ -55,10 +55,9 @@ class TreeSitter(MakefilePackage):
 
     depends_on("node-js", type="run")
 
-    # https://github.com/tree-sitter/tree-sitter/pull/5226
     patch(
-        "https://github.com/tree-sitter/tree-sitter/pull/5226.patch",
-        sha256="4fe83cf4fa00b3a54cd495d4b6a921ae70adc5bc8f49aeaf0c2218ec0e96f6b3",
+        "https://github.com/tree-sitter/tree-sitter/pull/5226.patch?full_index=1",
+        sha256="f690ba222c524f93f9dd1b679b46384ace53f184f9836d26e028ac6e4087fe8a",
         when="@0.26:0.26.3",
     )
 

--- a/repos/spack_repo/builtin/packages/tree_sitter/package.py
+++ b/repos/spack_repo/builtin/packages/tree_sitter/package.py
@@ -49,13 +49,17 @@ class TreeSitter(MakefilePackage):
     version("0.20.2", sha256="2a0445f8172bbf83db005aedb4e893d394e2b7b33251badd3c94c2c5cc37c403")
     version("0.20.1", sha256="12a3f7206af3028dbe8a0de50d8ebd6d7010bf762db918acae76fc7585f1258d")
 
-    depends_on("c", type=["build", "run"])
-    depends_on("cxx", type=["build", "run"])
+    depends_on("c", type="build")
+
+    # tree-sitter-cli needs rust-bindings
     depends_on("rust", type="build")
 
+    # tree-sitter-cli needs a c compiler and a javascript runtime
+    # https://tree-sitter.github.io/tree-sitter/creating-parsers/1-getting-started.html#dependencies
+    depends_on("c", type="run")
     depends_on("node-js", type="run")
 
-    # rust-bindgen is a dependency for tree-sitter rust bindings (used by tree-sitter-cli)
+    # tree-sitter-cli depends on rust-bindgen, which needs libclang (transitive dependency)
     # https://github.com/rust-lang/rust-bindgen/blob/main/book/src/requirements.md#clang
     depends_on("llvm@9: +clang", type="build")
 

--- a/repos/spack_repo/builtin/packages/tree_sitter/package.py
+++ b/repos/spack_repo/builtin/packages/tree_sitter/package.py
@@ -68,15 +68,11 @@ class TreeSitter(MakefilePackage):
     def build(self, spec, prefix):
         super().build(spec, prefix)
 
-        from spack.package import Executable
-
         cargo = Executable("cargo")
         cargo("build")
 
     def install(self, spec, prefix):
         super().install(spec, prefix)
-
-        from spack.package import Executable
 
         cargo = Executable("cargo")
         if spec.satisfies("@0.26:"):

--- a/repos/spack_repo/builtin/packages/tree_sitter/package.py
+++ b/repos/spack_repo/builtin/packages/tree_sitter/package.py
@@ -48,8 +48,11 @@ class TreeSitter(MakefilePackage):
     version("0.20.2", sha256="2a0445f8172bbf83db005aedb4e893d394e2b7b33251badd3c94c2c5cc37c403")
     version("0.20.1", sha256="12a3f7206af3028dbe8a0de50d8ebd6d7010bf762db918acae76fc7585f1258d")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type=["build", "run"])
+    depends_on("cxx", type=["build", "run"])
+    depends_on("rust", type="build")
+
+    depends_on("node-js", type="run")
 
     def edit(self, spec, prefix):
         env["PREFIX"] = prefix
@@ -60,3 +63,24 @@ class TreeSitter(MakefilePackage):
         #   https://www.sourceware.org/glibc/wiki/Release/2.20#Deprecation_of__BSD_SOURCE_and__SVID_SOURCE_feature_macros
         if spec.satisfies("@0.25: ^glibc@:2.19"):
             filter_file("-D_DEFAULT_SOURCE", "-D_BSD_SOURCE", "Makefile")
+
+    def build(self, spec, prefix):
+        super().build(spec, prefix)
+
+        from spack.package import Executable
+
+        cargo = Executable("cargo")
+        cargo("build")
+
+    def install(self, spec, prefix):
+        super().install(spec, prefix)
+
+        from spack.package import Executable
+
+        cargo = Executable("cargo")
+        if spec.satisfies("@0.26:"):
+            crate_cli_path = "crates/cli"
+        else:
+            crate_cli_path = "cli"
+
+        cargo("install", "--root", prefix, "--path", crate_cli_path)

--- a/repos/spack_repo/builtin/packages/tree_sitter/package.py
+++ b/repos/spack_repo/builtin/packages/tree_sitter/package.py
@@ -49,19 +49,21 @@ class TreeSitter(MakefilePackage):
     version("0.20.2", sha256="2a0445f8172bbf83db005aedb4e893d394e2b7b33251badd3c94c2c5cc37c403")
     version("0.20.1", sha256="12a3f7206af3028dbe8a0de50d8ebd6d7010bf762db918acae76fc7585f1258d")
 
+    variant("cli", default=False, description="Build CLI tool")
+
     depends_on("c", type="build")
 
-    # tree-sitter-cli needs rust-bindings
-    depends_on("rust", type="build")
+    with when("+cli"):
+        depends_on("rust", type="build", when="+cli")
 
-    # tree-sitter-cli needs a c compiler and a javascript runtime
-    # https://tree-sitter.github.io/tree-sitter/creating-parsers/1-getting-started.html#dependencies
-    depends_on("c", type="run")
-    depends_on("node-js", type="run")
+        # tree-sitter-cli needs a c compiler and a javascript runtime
+        # https://tree-sitter.github.io/tree-sitter/creating-parsers/1-getting-started.html#dependencies
+        depends_on("c", type="run")
+        depends_on("node-js", type="run")
 
-    # tree-sitter-cli depends on rust-bindgen, which needs libclang (transitive dependency)
-    # https://github.com/rust-lang/rust-bindgen/blob/main/book/src/requirements.md#clang
-    depends_on("llvm@9: +clang", type="build")
+        # tree-sitter-cli depends on rust-bindgen, which needs libclang (transitive dependency)
+        # https://github.com/rust-lang/rust-bindgen/blob/main/book/src/requirements.md#clang
+        depends_on("llvm@9: +clang", type="build")
 
     patch(
         "https://github.com/tree-sitter/tree-sitter/pull/5226.patch?full_index=1",
@@ -82,18 +84,18 @@ class TreeSitter(MakefilePackage):
     def build(self, spec, prefix):
         super().build(spec, prefix)
 
-        # tree-sitter-cli
-        cargo = Executable("cargo")
-        cargo("build")
+        if spec.satisfies("+cli"):
+            cargo = Executable("cargo")
+            cargo("build")
 
     def install(self, spec, prefix):
         super().install(spec, prefix)
 
-        # tree-sitter-cli
-        cargo = Executable("cargo")
-        if spec.satisfies("@0.26:"):
-            crate_cli_path = "crates/cli"
-        else:
-            crate_cli_path = "cli"
+        if spec.satisfies("+cli"):
+            cargo = Executable("cargo")
+            if spec.satisfies("@0.26:"):
+                crate_cli_path = "crates/cli"
+            else:
+                crate_cli_path = "cli"
 
-        cargo("install", "--root", prefix, "--path", crate_cli_path)
+            cargo("install", "--root", prefix, "--path", crate_cli_path)


### PR DESCRIPTION
According to https://tree-sitter.github.io/tree-sitter/5-implementation.html#implementation

> Tree-sitter consists of two components: a C library (libtree-sitter), and a command-line tool (the tree-sitter CLI).

Before this PR just the library was built and the CLI tool wasn't.

Here the instruction on how to build it https://tree-sitter.github.io/tree-sitter/6-contributing.html#building, for which `rust` is required.

Given https://tree-sitter.github.io/tree-sitter/creating-parsers/1-getting-started.html#dependencies, I also updated the other dependencies, namely adding `node-js` and dropping the `# generated` comment for `c`/`cxx`.

About `cxx`, I'm not sure if it should be there, because AFAIK the library is written in `c`, so it might be not needed at all.

TODO
- [ ] how to deal with `+cli` and not-fully-supported systems with version 0.25 (https://github.com/spack/spack-packages/pull/3138#issuecomment-3806671487)