### PR TITLE
dd4hep: add v1.35

### DIFF
--- a/repos/spack_repo/builtin/packages/acts/package.py
+++ b/repos/spack_repo/builtin/packages/acts/package.py
@@ -434,6 +434,7 @@ class Acts(CMakePackage, CudaPackage):
     depends_on("edm4hep @0.4.1:", when="+edm4hep")
     depends_on("edm4hep @0.7:", when="@25: +edm4hep")
     depends_on("edm4hep @0.10.5:", when="@42: +edm4hep")
+    depends_on("edm4hep @:0", when="@:44 +edm4hep")
     depends_on("eigen @3.3.7:3", when="@15.1:")
     depends_on("eigen @3.3.7:3.3", when="@:15.0")
     depends_on("eigen @3.4:3", when="@36.1:")

--- a/repos/spack_repo/builtin/packages/dd4hep/package.py
+++ b/repos/spack_repo/builtin/packages/dd4hep/package.py
@@ -143,7 +143,6 @@ class Dd4hep(CMakePackage):
     with when("+ddg4"):
         depends_on("boost +iostreams")
         depends_on("geant4@10.2.2:")
-        for _std in _cxxstd_values:
         for _std, _when in _std_when(_cxxstd_values):
             depends_on(f"geant4 cxxstd={_std}", when=f"{_when} cxxstd={_std}")
 

--- a/repos/spack_repo/builtin/packages/dd4hep/package.py
+++ b/repos/spack_repo/builtin/packages/dd4hep/package.py
@@ -144,7 +144,8 @@ class Dd4hep(CMakePackage):
         depends_on("boost +iostreams")
         depends_on("geant4@10.2.2:")
         for _std in _cxxstd_values:
-            depends_on(f"geant4 cxxstd={_std}", when=f"cxxstd={_std}")
+        for _std, _when in _std_when(_cxxstd_values):
+            depends_on(f"geant4 cxxstd={_std}", when=f"{_when} cxxstd={_std}")
 
     depends_on("imagemagick", when="+doc")
     depends_on("xerces-c", when="+xercesc")

--- a/repos/spack_repo/builtin/packages/dd4hep/package.py
+++ b/repos/spack_repo/builtin/packages/dd4hep/package.py
@@ -27,6 +27,7 @@ class Dd4hep(CMakePackage):
     license("LGPL-3.0-or-later")
 
     version("master", branch="master")
+    version("1.35", sha256="d15c6fbc762e8863a7c5b222a661baae8e9e30263554a9e5c24c593c1effd00b")
     version("1.34", sha256="1c121f4b3eb14d104b7a7f734e7e52efc4b6e4e5bc74d21d5d2de1b91c8f9f75")
     version("1.33", sha256="23f78163e1371a5f092758cdc60a18906b1b19bbeacdd7c68557ebf71424fc23")
     version("1.32.1", sha256="f47fbede967b609e142c3116d23b4993f9d57fbae28a1739b5333503bc498883")
@@ -97,7 +98,7 @@ class Dd4hep(CMakePackage):
         " some places in addtion to the debug build type",
     )
 
-    _cxxstd_values = ("14", "17", "20")
+    _cxxstd_values = (conditional("14", when="@:1.34"), "17", "20")
     variant(
         "cxxstd",
         default="20",

--- a/repos/spack_repo/builtin/packages/dd4hep/package.py
+++ b/repos/spack_repo/builtin/packages/dd4hep/package.py
@@ -7,6 +7,15 @@ from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
 from spack.package import *
 
 
+def _std_when(values):
+    for v in values:
+        if isinstance(v, str):
+            yield v, ""
+            continue
+        for c in v:
+            yield c.value, c.when
+
+
 class Dd4hep(CMakePackage):
     """DD4hep is a software framework for providing a complete solution for
     full detector description (geometry, materials, visualization, readout,
@@ -113,9 +122,9 @@ class Dd4hep(CMakePackage):
     depends_on("cmake @3.12:", type="build")
     depends_on("cmake @3.14:", type="build", when="@1.26:")
 
-    for _std in _cxxstd_values:
+    for _std, _when in _std_when(_cxxstd_values):
         for _pkg in ["boost", "root"]:
-            depends_on(f"{_pkg} cxxstd={_std}", when=f"cxxstd={_std}")
+            depends_on(f"{_pkg} cxxstd={_std}", when=f"{_when} cxxstd={_std}")
 
     depends_on("boost @1.49:")
     depends_on("boost +system +filesystem", when="%gcc@:7")


### PR DESCRIPTION
This PR adds `dd4hep`, v1.35 ([diff](https://github.com/AIDASoft/DD4hep/compare/v01-34...v01-35)). Only relevant change is the now-required C++17 (this was effectively already required, but it would required archaeology to figure out what the actual version is when C++14 compatibility was lost).