### PR TITLE
arborx: update kokkos+cuda constraints for kokkos@5:

### DIFF
--- a/repos/spack_repo/builtin/packages/arborx/package.py
+++ b/repos/spack_repo/builtin/packages/arborx/package.py
@@ -82,7 +82,7 @@ class Arborx(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("kokkos@4.2.00:", when="@1.7")
     depends_on("kokkos@4.5.00:", when="@2.0:")
     for backend in kokkos_backends:
-        depends_on("kokkos+%s" % backend.lower(), when="~trilinos+%s" % backend.lower())
+        depends_on(f"kokkos+{backend.lower()}", when=f"~trilinos+{backend.lower()}")
 
     for arch in CudaPackage.cuda_arch_values:
         cuda_dep = f"+cuda cuda_arch={arch}"
@@ -96,7 +96,7 @@ class Arborx(CMakePackage, CudaPackage, ROCmPackage):
 
     conflicts("+cuda", when="cuda_arch=none")
     conflicts("^kokkos", when="+trilinos")
-    depends_on("kokkos+cuda_lambda", when="~trilinos+cuda ^kokkos@:4")
+    requires("^kokkos+cuda_lambda", when="~trilinos+cuda ^kokkos@:4")
 
     # Trilinos with internal Kokkos
     # Notes:

--- a/repos/spack_repo/builtin/packages/arborx/package.py
+++ b/repos/spack_repo/builtin/packages/arborx/package.py
@@ -61,7 +61,7 @@ class Arborx(CMakePackage, CudaPackage, ROCmPackage):
     variant("mpi", default=True, description="enable MPI")
     for backend in kokkos_backends:
         deflt, descr = kokkos_backends[backend]
-        variant(backend.lower(), default=deflt, description=descr)
+        variant(backend, default=deflt, description=descr)
     variant("trilinos", default=False, when="@:1.5", description="use Kokkos from Trilinos")
 
     depends_on("cxx", type="build")
@@ -82,7 +82,7 @@ class Arborx(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("kokkos@4.2.00:", when="@1.7")
     depends_on("kokkos@4.5.00:", when="@2.0:")
     for backend in kokkos_backends:
-        depends_on(f"kokkos+{backend.lower()}", when=f"~trilinos+{backend.lower()}")
+        depends_on(f"kokkos+{backend}", when=f"~trilinos+{backend}")
 
     for arch in CudaPackage.cuda_arch_values:
         cuda_dep = f"+cuda cuda_arch={arch}"

--- a/repos/spack_repo/builtin/packages/arborx/package.py
+++ b/repos/spack_repo/builtin/packages/arborx/package.py
@@ -96,7 +96,7 @@ class Arborx(CMakePackage, CudaPackage, ROCmPackage):
 
     conflicts("+cuda", when="cuda_arch=none")
     conflicts("^kokkos", when="+trilinos")
-    depends_on("kokkos+cuda_lambda", when="~trilinos+cuda")
+    depends_on("kokkos+cuda_lambda", when="~trilinos+cuda ^kokkos@:4")
 
     # Trilinos with internal Kokkos
     # Notes:

--- a/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
@@ -168,7 +168,7 @@ class KokkosKernels(CMakePackage, CudaPackage):
     depends_on("kokkos+cuda", when="+cuda")
     depends_on("kokkos+openmp", when="+openmp")
     depends_on("kokkos+threads", when="+threads")
-    depends_on("kokkos+cuda_lambda", when="@4.0.00:+cuda")
+    depends_on("kokkos+cuda_lambda", when="@4+cuda")
     depends_on("cmake@3.16:", type="build")
 
     tpls = {


### PR DESCRIPTION
Required for compatibility between `kokkos-kernels+cuda` or `arborx+cuda` with `kokkos@5:`.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
