### PR TITLE
New package rank-run

### DIFF
--- a/repos/spack_repo/builtin/packages/rank_run/package.py
+++ b/repos/spack_repo/builtin/packages/rank_run/package.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *

--- a/repos/spack_repo/builtin/packages/rank_run/package.py
+++ b/repos/spack_repo/builtin/packages/rank_run/package.py
@@ -1,0 +1,28 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class RankRun(CMakePackage):
+    """rank-run is an application that executes serial jobs in parallel where each rank
+    runs a given command or script."""
+
+    homepage = "https://github.com/RRFSx/rank_run"
+    git = "https://github.com/RRFSx/rank_run.git"
+    url = "https://github.com/RRFSx/rank_run/archive/refs/tags/v1.0.0.tar.gz"
+
+    maintainers("climbfuji")
+
+    license("GPL-3.0-only")
+
+    version("1.0.0", sha256="77cd9e8587566d414b2862d9022e44b3cdbcd5bd4b51915505cc4accdec9fe6b")
+
+    depends_on("c", type="build")
+
+    depends_on("mpi")


### PR DESCRIPTION
## Description

New package `rank-run`, requested by @guoqing-noaa in https://github.com/JCSDA/spack-stack/issues/1805.

I built and tested it with GCC and Intel oneAPI.