### PR TITLE
py-pyvips: add c dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pyvips/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyvips/package.py
@@ -18,5 +18,6 @@ class PyPyvips(PythonPackage):
     depends_on("py-setuptools@61:", type="build")
     depends_on("py-pkgconfig@1.5:", type="build")  # needed to enable API mode
     depends_on("py-cffi@1:", type=("build", "run"))
+    depends_on("c", type="build")
 
     depends_on("libvips +fftw +jpeg +tiff +png +poppler", type=("run", "build", "link"))


### PR DESCRIPTION
Their C sources were written as Python strings, but a C compiler is still needed.