### PR TITLE
py-hatch-fancy-pypi-readme: py-hatch lowerbound

### DIFF
--- a/repos/spack_repo/builtin/packages/py_hatch_fancy_pypi_readme/package.py
+++ b/repos/spack_repo/builtin/packages/py_hatch_fancy_pypi_readme/package.py
@@ -18,5 +18,6 @@ class PyHatchFancyPypiReadme(PythonPackage):
     version("22.7.0", sha256="dedf2ba0b81a2975abb1deee9310b2eb85d22380fda0d52869e760b5435aa596")
 
     depends_on("py-hatchling", type=("build", "run"))
+    depends_on("py-hatchling@1.26:", when="@25:", type=("build", "run"))
     depends_on("py-tomli", when="^python@:3.10", type=("build", "run"))
     depends_on("py-typing-extensions", when="^python@:3.7", type=("build", "run"))


### PR DESCRIPTION
Support for https://github.com/hynek/hatch-fancy-pypi-readme/commit/84bdb928146f6d2c01b7b58a6ab8a2877f74619e requires https://github.com/pypa/hatch/commit/28f233c535508247ffa9a40dab82c1d1cb2b700b

