### PR TITLE
pythia6: add build dependency on 'patch'.

### DIFF
--- a/repos/spack_repo/builtin/packages/pythia6/package.py
+++ b/repos/spack_repo/builtin/packages/pythia6/package.py
@@ -135,6 +135,7 @@ class Pythia6(CMakePackage):
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")
+    depends_on("patch", type="build")
 
     def patch(self):
         # Use our provided CMakeLists.txt. The Makefile provided with


### PR DESCRIPTION
Build fails when the `patch` command is not in `PATH`:
```
==> Error: CommandNotFoundError: spack requires 'patch'. Make sure it is in your path.
```

 This commit adds `patch` as a build-time dependency.

* repos/spack_repo/builtin/packages/pythia6/package.py: Add build-time dependency on 'patch' to fix the build.
