### PR TITLE
umpire + camp: add camp@2025.12.0 and add upper bound constraint for umpire and CUDA13

### DIFF
--- a/repos/spack_repo/builtin/packages/camp/package.py
+++ b/repos/spack_repo/builtin/packages/camp/package.py
@@ -25,6 +25,7 @@ class Camp(CMakePackage, CudaPackage, ROCmPackage):
     license("BSD-3-Clause")
 
     version("main", branch="main", submodules=False)
+    version("2025.12.0", sha256="e0e89649fc02beda44e28e2a750ecec1751e00f83498fec9762ebcf5ae66a8f7")
     version(
         "2025.09.2",
         tag="v2025.09.2",

--- a/repos/spack_repo/builtin/packages/camp/package.py
+++ b/repos/spack_repo/builtin/packages/camp/package.py
@@ -25,7 +25,12 @@ class Camp(CMakePackage, CudaPackage, ROCmPackage):
     license("BSD-3-Clause")
 
     version("main", branch="main", submodules=False)
-    version("2025.12.0", sha256="e0e89649fc02beda44e28e2a750ecec1751e00f83498fec9762ebcf5ae66a8f7")
+    version(
+        "2025.12.0",
+        tag="v2025.12.0",
+        commit="a8caefa9f4c811b1a114b4ed2c9b681d40f12325",
+        submodules=False,
+    )
     version(
         "2025.09.2",
         tag="v2025.09.2",

--- a/repos/spack_repo/builtin/packages/umpire/package.py
+++ b/repos/spack_repo/builtin/packages/umpire/package.py
@@ -341,7 +341,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     conflicts("+shared", when="+cuda +device_alloc")
 
     # https://github.com/LLNL/Umpire/pull/992
-    conflicts("^cuda@13:", when="+cuda")
+    conflicts("^cuda@13:", when="@:2025.09.0 +cuda")
 
     def _get_sys_type(self, spec):
         sys_type = spec.architecture


### PR DESCRIPTION
Changes:
- add missing version for camp
- add upper bound for CUDA13 constraint in umpire 