### PR TITLE
gawk: add v5.3.2

### DIFF
--- a/repos/spack_repo/builtin/packages/gawk/package.py
+++ b/repos/spack_repo/builtin/packages/gawk/package.py
@@ -1,6 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 import re
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
@@ -32,6 +33,7 @@ class Gawk(AutotoolsPackage, GNUMirrorPackage):
 
     license("GPL-3.0-or-later")
 
+    version("5.3.2", sha256="f8c3486509de705192138b00ef2c00bbbdd0e84c30d5c07d23fc73a9dc4cc9cc")
     version("5.3.1", sha256="694db764812a6236423d4ff40ceb7b6c4c441301b72ad502bb5c27e00cd56f78")
     version("5.3.0", sha256="ca9c16d3d11d0ff8c69d79dc0b47267e1329a69b39b799895604ed447d3ca90b")
     version("5.2.2", sha256="3c1fce1446b4cbee1cd273bd7ec64bc87d89f61537471cd3e05e33a965a250e9")
@@ -43,10 +45,9 @@ class Gawk(AutotoolsPackage, GNUMirrorPackage):
 
     variant("nls", default=False, description="Enable Native Language Support")
 
-    depends_on("c", type="build")  # generated
-
+    depends_on("c", type="build")
     depends_on("gettext", when="+nls")
-    depends_on("libsigsegv")
+    depends_on("libsigsegv", when="@:5.2.2")
     depends_on("readline")
     depends_on("mpfr")
     depends_on("gmp")

--- a/repos/spack_repo/builtin/packages/gawk/package.py
+++ b/repos/spack_repo/builtin/packages/gawk/package.py
@@ -47,7 +47,7 @@ class Gawk(AutotoolsPackage, GNUMirrorPackage):
 
     depends_on("c", type="build")
     depends_on("gettext", when="+nls")
-    depends_on("libsigsegv", when="@:5.2.2")
+    depends_on("libsigsegv", when="@:5.2")
     depends_on("readline")
     depends_on("mpfr")
     depends_on("gmp")


### PR DESCRIPTION
Adding gawk v5.3.2. The libsigsegv dependency is no longer needed starting with v5.3.0.