### PR TITLE
automake: add v1.18.1

### DIFF
--- a/repos/spack_repo/builtin/packages/automake/package.py
+++ b/repos/spack_repo/builtin/packages/automake/package.py
@@ -35,7 +35,7 @@ class Automake(AutotoolsPackage, GNUMirrorPackage):
 
     depends_on("c", type="build")
     depends_on("autoconf@2.65:", type="build", when="@1.13.4:")
-    depends_on("autoconf@2.62:", type="build", when="@1.11.6")
+    depends_on("autoconf@2.62:", type="build")
     depends_on("perl+threads", type=("build", "run"))
 
     build_directory = "spack-build"

--- a/repos/spack_repo/builtin/packages/automake/package.py
+++ b/repos/spack_repo/builtin/packages/automake/package.py
@@ -1,6 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 import re
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
@@ -15,8 +16,13 @@ class Automake(AutotoolsPackage, GNUMirrorPackage):
     homepage = "https://www.gnu.org/software/automake/"
     gnu_mirror_path = "automake/automake-1.15.tar.gz"
 
+    executables = ["^automake$"]
+
+    tags = ["build-tools"]
+
     license("GPL-2.0-or-later")
 
+    version("1.18.1", sha256="63e585246d0fc8772dffdee0724f2f988146d1a3f1c756a3dc5cfbefa3c01915")
     version("1.16.5", sha256="07bd24ad08a64bc17250ce09ec56e921d6343903943e99ccf63bbf0705e34605")
     version("1.16.3", sha256="ce010788b51f64511a1e9bb2a1ec626037c6d0e7ede32c1c103611b9d3cba65f")
     version("1.16.2", sha256="b2f361094b410b4acbf4efba7337bdb786335ca09eb2518635a09fb7319ca5c1")
@@ -27,16 +33,12 @@ class Automake(AutotoolsPackage, GNUMirrorPackage):
     version("1.13.4", sha256="4c93abc0bff54b296f41f92dd3aa1e73e554265a6f719df465574983ef6f878c")
     version("1.11.6", sha256="53dbf1945401c43f4ce19c1971baecdbf8bc32e0f37fa3f49fe7b6992d0d2030")
 
-    depends_on("c", type="build")  # generated
-
-    depends_on("autoconf", type="build")
+    depends_on("c", type="build")
+    depends_on("autoconf@2.65:", type="build", when="@1.13.4:")
+    depends_on("autoconf@2.62:", type="build", when="@1.11.6")
     depends_on("perl+threads", type=("build", "run"))
 
     build_directory = "spack-build"
-
-    tags = ["build-tools"]
-
-    executables = ["^automake$"]
 
     @classmethod
     def determine_version(cls, exe):


### PR DESCRIPTION
Adding Automake v1.18.1, including version constraints for dependency Autoconf, and making some minor style changes.