### PR TITLE
cusolvermp: add latest version + currently it is constrained to cuda@12

### DIFF
--- a/repos/spack_repo/builtin/packages/cusolvermp/package.py
+++ b/repos/spack_repo/builtin/packages/cusolvermp/package.py
@@ -19,7 +19,17 @@ _versions = {
             sha256="a0012c5be7ac742a26cf8894bed3c703edea84eddf0d5dca42d35582622ffb9b",
             url="https://developer.download.nvidia.com/compute/cusolvermp/redist/libcusolvermp/linux-sbsa/libcusolvermp-linux-sbsa-0.7.0.833_cuda12-archive.tar.xz",
         ),
-    }
+    },
+    "0.7.2.888": {
+        "Linux-x86_64": dict(
+            sha256="70243423e07861007ca5a95d35247af4ecdbcd0bf77aa09016a1abf3dcffb6a8",
+            url="https://developer.download.nvidia.com/compute/cusolvermp/redist/libcusolvermp/linux-x86_64/libcusolvermp-linux-x86_64-0.7.2.888_cuda12-archive.tar.xz",
+        ),
+        "Linux-aarch64": dict(
+            sha256="4c1a2688ec0072dec6d9d2303b489a48ad34a419e42ba05f51af68a43221fed6",
+            url="https://developer.download.nvidia.com/compute/cusolvermp/redist/libcusolvermp/linux-sbsa/libcusolvermp-linux-sbsa-0.7.2.888_cuda12-archive.tar.xz",
+        ),
+    },
 }
 
 

--- a/repos/spack_repo/builtin/packages/cusolvermp/package.py
+++ b/repos/spack_repo/builtin/packages/cusolvermp/package.py
@@ -45,6 +45,7 @@ class Cusolvermp(Package, CudaPackage):
     conflicts("~cuda", msg="cuSOLVERMp requires CUDA")
 
     depends_on("cuda@12:")
+    conflicts("cuda@13", msg="Not yet supported by the spack package.")
     depends_on("nccl@2.18.5:")
 
     for cuda_arch in CudaPackage.cuda_arch_values:


### PR DESCRIPTION
`cuSOLVERMp` binaries varies for CUDA versions. Currently, just CUDA12 is covered by the spack package, while for CUDA13 it would be needed a change in how the package manage versions (e.g. adding the `cuda` version it is built for in the version part of the spack package and add constraints for forcing the match).

For the moment I just took the chance to update the package and add the current limitation of the spack package as a constraint.