### PR TITLE
py-jaxlib: better default decisions

### DIFF
--- a/repos/spack_repo/builtin/packages/nmad/package.py
+++ b/repos/spack_repo/builtin/packages/nmad/package.py
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
-from spack.package import *
 from spack_repo.builtin.packages.puk.package import Puk
+
+from spack.package import *
 
 
 class Nmad(AutotoolsPackage):

--- a/repos/spack_repo/builtin/packages/padicotm/package.py
+++ b/repos/spack_repo/builtin/packages/padicotm/package.py
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
-from spack.package import *
 from spack_repo.builtin.packages.puk.package import Puk
+
+from spack.package import *
 
 
 class Padicotm(AutotoolsPackage):

--- a/repos/spack_repo/builtin/packages/pioman/package.py
+++ b/repos/spack_repo/builtin/packages/pioman/package.py
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
-from spack.package import *
 from spack_repo.builtin.packages.puk.package import Puk
+
+from spack.package import *
 
 
 class Pioman(AutotoolsPackage):

--- a/repos/spack_repo/builtin/packages/puk/package.py
+++ b/repos/spack_repo/builtin/packages/puk/package.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+
 from spack.package import *
 
 

--- a/repos/spack_repo/builtin/packages/pukabi/package.py
+++ b/repos/spack_repo/builtin/packages/pukabi/package.py
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
-from spack.package import *
 from spack_repo.builtin.packages.puk.package import Puk
+
+from spack.package import *
 
 
 class Pukabi(AutotoolsPackage):

--- a/repos/spack_repo/builtin/packages/py_jaxlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_jaxlib/package.py
@@ -209,7 +209,7 @@ class PyJaxlib(PythonPackage, CudaPackage, ROCmPackage):
             requires("%c,cxx=llvm", when="platform=linux")
             # Order here is important. Place the most common compiler first so that the
             # concretizer will not try to use v0.7.0 to avoid taking a penalty on requirements
-            requires("%c,cxx=apple-clang","%c,cxx=llvm", when="platform=darwin")
+            requires("%c,cxx=apple-clang", "%c,cxx=llvm", when="platform=darwin")
 
     conflicts(
         "cuda_arch=none",

--- a/repos/spack_repo/builtin/packages/py_jaxlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_jaxlib/package.py
@@ -204,12 +204,12 @@ class PyJaxlib(PythonPackage, CudaPackage, ROCmPackage):
     # backports https://github.com/abseil/abseil-cpp/pull/1732
     patch("jaxxlatsl.patch", when="@0.4.28:0.4.32 target=aarch64:")
 
-    requires(
-        "%c,cxx=llvm",
-        "%c,cxx=apple-clang",
-        when="@0.7.1:",
-        msg="Clang is the only acceptable compiler.",
-    )
+    with when("@0.7.1:"):
+        with default_args(msg="Clang is the only acceptable compiler."):
+            requires("%c,cxx=llvm", when="platform=linux")
+            # Order here is important. Place the most common compiler first so that the
+            # concretizer will not try to use v0.7.0 to avoid taking a penalty on requirements
+            requires("%c,cxx=apple-clang","%c,cxx=llvm", when="platform=darwin")
 
     conflicts(
         "cuda_arch=none",


### PR DESCRIPTION
This PR just reworks the `requires` directive so that an unconstrained concretization of `py-jaxlib` will not fall back to use v0.7.0 on `darwin` to avoid the penalty of using the second best required compiler.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
