### PR TITLE
Remove '-v' flag from vcheck mode determination

### DIFF
--- a/repos/spack_repo/builtin/packages/compiler_wrapper/cc.sh
+++ b/repos/spack_repo/builtin/packages/compiler_wrapper/cc.sh
@@ -357,7 +357,7 @@ esac
 if [ -z "$mode" ] || [ "$mode" = ld ]; then
     for arg in "$@"; do
         case $arg in
-            -v|-V|--version|-dumpversion)
+            -V|--version|-dumpversion)
                 mode=vcheck
                 break
                 ;;

--- a/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
+++ b/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
@@ -40,7 +40,7 @@ class CompilerWrapper(Package):
     if sys.platform != "win32":
         version(
             "1.0",
-            sha256="c7b816479554fd32f677db15ceec6627b91c86074a5d65498688afcbe2796188",
+            sha256="80538668346ae7efb046c6721c72fba598d61336725571d9ae7aa0ca93e99f4e",
             expand=False,
         )
     else:


### PR DESCRIPTION
In most compilers, the `-v` flag merely enables verbose output, which is different from `--version` or similar. However, the compiler wrapper switches into 'vcheck' mode if this flag is present, and does not apply any extra search paths or libraries as it should. Thus, if any package (e.g., in a Makefile) introduces a `-v` flag to the compilation or linking commands, it fails.

This PR simply removes the `-v` from the list of flags that are used to determine the 'vcheck' mode.