### PR TITLE
trilinos: allow %llvm (with fc=flang)

### DIFF
--- a/repos/spack_repo/builtin/packages/trilinos/package.py
+++ b/repos/spack_repo/builtin/packages/trilinos/package.py
@@ -592,7 +592,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
                 flags.append("-Wl,-undefined,dynamic_lookup")
 
             # Fortran lib (assumes clang is built with gfortran!)
-            if spec.satisfies("+fortran") and (
+            if spec.satisfies("+fortran %fortran=gcc") and (
                 spec.satisfies("%gcc")
                 or spec.satisfies("%clang")
                 or spec.satisfies("%apple-clang")

--- a/repos/spack_repo/builtin/packages/trilinos/package.py
+++ b/repos/spack_repo/builtin/packages/trilinos/package.py
@@ -592,11 +592,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
                 flags.append("-Wl,-undefined,dynamic_lookup")
 
             # Fortran lib (assumes clang is built with gfortran!)
-            if spec.satisfies("+fortran %fortran=gcc") and (
-                spec.satisfies("%gcc")
-                or spec.satisfies("%clang")
-                or spec.satisfies("%apple-clang")
-            ):
+            if spec.satisfies("+fortran %fortran=gcc"):
                 fc = Executable(self.compiler.fc)
                 libgfortran = fc(
                     "--print-file-name",


### PR DESCRIPTION
The current recipe for `trilinos` assumes that `%llvm` flavors will use `fc=gfortran`.  This small change allows compiles with `flang`.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
