### PR TITLE
intel-oneapi-mkl: try removing old preferred version

### DIFF
--- a/repos/spack_repo/builtin/packages/intel_oneapi_mkl/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_mkl/package.py
@@ -70,7 +70,6 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/89a381f6-f85d-4dda-ae62-30d51470f53c/l_onemkl_p_2024.2.2.17_offline.sh",
         sha256="6b64ab95567bee53d6cf7e78f9f7b15695902fb9da0d20c29e638ad001b6b348",
         expand=False,
-        preferred=True,
     )
     version(
         "2024.2.1",


### PR DESCRIPTION
From late 2024 in https://github.com/spack/spack-packages/commit/a567f3f4acf40f0bd6e6a3b4f24b3f8ef9aa8d86

> until e4s can upgrade to 2025 compiler and ginkgo compatibility issue can be resolved.

I don't know anything about this, just wondering if it has been solved in the meanwhile and the old pin can be dropped (otherwise I'm just going to close this, no need for it, just took the chance for housekeeping).