### PR TITLE
HDF5 - Inherit from CacheCMakePackage to fix MPI tests

### DIFF
--- a/repos/spack_repo/builtin/packages/hdf5/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5/package.py
@@ -7,11 +7,11 @@ import re
 import shutil
 import sys
 
-from spack_repo.builtin.build_systems.cached_cmake import CachedCMakePackage, cmake_cache_option
+from spack_repo.builtin.build_systems.cached_cmake import CachedCMakePackage
 
 from spack.package import *
 
-class Hdf5(CachedCMakePackage): 
+class Hdf5(CachedCMakePackage):
     """HDF5 is a data model, library, and file format for storing and managing
     data. It supports an unlimited variety of datatypes, and is designed for
     flexible and efficient I/O and for high volume and complex data.

--- a/repos/spack_repo/builtin/packages/hdf5/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5/package.py
@@ -7,9 +7,9 @@ import re
 import shutil
 import sys
 
+from spack.package import *
 from spack_repo.builtin.build_systems.cached_cmake import CachedCMakePackage
 
-from spack.package import *
 
 class Hdf5(CachedCMakePackage):
     """HDF5 is a data model, library, and file format for storing and managing

--- a/repos/spack_repo/builtin/packages/hdf5/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5/package.py
@@ -7,8 +7,9 @@ import re
 import shutil
 import sys
 
-from spack.package import *
 from spack_repo.builtin.build_systems.cached_cmake import CachedCMakePackage
+
+from spack.package import *
 
 
 class Hdf5(CachedCMakePackage):

--- a/repos/spack_repo/builtin/packages/hdf5/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5/package.py
@@ -7,10 +7,7 @@ import re
 import shutil
 import sys
 
-from spack_repo.builtin.build_systems.cached_cmake import (
-    CachedCMakePackage,
-    cmake_cache_option
-)
+from spack_repo.builtin.build_systems.cached_cmake import CachedCMakePackage, cmake_cache_option
 
 from spack.package import *
 

--- a/repos/spack_repo/builtin/packages/hdf5/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5/package.py
@@ -7,12 +7,14 @@ import re
 import shutil
 import sys
 
-from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems.cached_cmake import (
+    CachedCMakePackage,
+    cmake_cache_option
+)
 
 from spack.package import *
 
-
-class Hdf5(CMakePackage):
+class Hdf5(CachedCMakePackage): 
     """HDF5 is a data model, library, and file format for storing and managing
     data. It supports an unlimited variety of datatypes, and is designed for
     flexible and efficient I/O and for high volume and complex data.


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
MPI tests seg fault when trying to run mpirun on LC machines. Using CacheCMakePackage allows more options including srun which does run on LC machines.