### PR TITLE
py-rpy2: fix missing depends

### DIFF
--- a/repos/spack_repo/builtin/packages/py_rpy2/package.py
+++ b/repos/spack_repo/builtin/packages/py_rpy2/package.py
@@ -53,4 +53,6 @@ class PyRpy2(PythonPackage):
     depends_on("py-pandas", type=("build", "run"), when="+pandas ^python@:3.9")
     depends_on("py-pandas@1.3.5:", type=("build", "run"), when="+pandas ^python@3.10:")
 
+    # not explicitly listed but required
     depends_on("iconv")
+    depends_on("zstd")


### PR DESCRIPTION
Unsure how I missed this previously, but there is a hidden `zstd` depends on that I previously missed