### PR TITLE
GoPackage: disable CGO support by default for better portability

### DIFF
--- a/repos/spack_repo/builtin/build_systems/go.py
+++ b/repos/spack_repo/builtin/build_systems/go.py
@@ -69,15 +69,14 @@ class GoBuilder(BuilderWithDefaults):
         "check_args",
         "build_directory",
         "install_time_test_callbacks",
+        "cgo_enabled",
     )
 
     #: Callback names for install-time test
     install_time_test_callbacks = ["check"]
 
-    def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        env.set("GO111MODULE", "on")
-        env.set("GOTOOLCHAIN", "local")
-        env.set("GOPATH", join_path(self.pkg.stage.path, "go"))
+    # Enable or Disable CGO functionality in builds. (Disabled by default)
+    cgo_enabled = False
 
     @property
     def build_directory(self):
@@ -102,6 +101,12 @@ class GoBuilder(BuilderWithDefaults):
     def check_args(self):
         """Argument for ``go test`` during check phase"""
         return []
+
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        env.set("CGO_ENABLED", f"{'1' if self.cgo_enabled else '0'}")
+        env.set("GO111MODULE", "on")
+        env.set("GOTOOLCHAIN", "local")
+        env.set("GOPATH", join_path(self.pkg.stage.path, "go"))
 
     def build(self, pkg: GoPackage, spec: Spec, prefix: Prefix) -> None:
         """Runs ``go build`` in the source directory"""

--- a/repos/spack_repo/builtin/build_systems/go.py
+++ b/repos/spack_repo/builtin/build_systems/go.py
@@ -103,7 +103,7 @@ class GoBuilder(BuilderWithDefaults):
         return []
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        env.set("CGO_ENABLED", f"{'1' if self.cgo_enabled else '0'}")
+        env.set("CGO_ENABLED", "1" if self.cgo_enabled else "0")
         env.set("GO111MODULE", "on")
         env.set("GOTOOLCHAIN", "local")
         env.set("GOPATH", join_path(self.pkg.stage.path, "go"))

--- a/repos/spack_repo/builtin/packages/hugo/package.py
+++ b/repos/spack_repo/builtin/packages/hugo/package.py
@@ -61,6 +61,13 @@ class Hugo(GoPackage):
         return match.group(1) if match else None
 
     @property
+    def cgo_enabled(self):
+        if self.spec.satisfies("+extended"):
+            return True
+        else:
+            return False
+
+    @property
     def build_args(self):
         args = super().build_args
         if self.spec.satisfies("+extended"):


### PR DESCRIPTION
Fixes #3194.

Updates the `GoPackage` builder to disable CGO support by default to improve the portability of go programs by reducing C dependencies. Exposes a `cgo_enabled` property to packages to enable CGO functionality selectively.