### PR TITLE
HDF5: Remove Java directory from source builds if we're not using it

### DIFF
--- a/repos/spack_repo/builtin/packages/hdf5/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5/package.py
@@ -312,6 +312,12 @@ class Hdf5(CMakePackage):
                 "testpar/CMakeTests.cmake",
             )
 
+        # Remove the java subdirectory from source builds that aren't going to use it.
+        # The Java subdirectory unfortunately looks like a Java browser plugin to Tenable,
+        # and if it sits around it will cause users' machines to be erroneously flagged.
+        if not self.spec.satisfies("+java"):
+            shutil.rmtree("java")
+
     # The parallel compiler wrappers (i.e. h5pcc, h5pfc, etc.) reference MPI
     # compiler wrappers and do not need to be changed.
     # These do not exist on Windows.


### PR DESCRIPTION
Some sites use Tenable, and Tenable isn't very smart. It will unfortunately flag the `java` subdirectory in HDF5 source checkouts, as a path like this:

```
spack-stage-hdf5-1.14.6-ll3jck7sgauntx7ryvol5cz5it3hruge/spack-src/java
```

looks like an old version of the Java browser plugin to Tenable. This is not Spack's fault or HDF5's fault -- Tenable should be smarter.

Still, we can at least help Spack users while we wait for Tenable to get smarter. The HDF5 build doesn't use this directory when Java is not enabled, and I suspect that most users are not building the Java bindings. So we can just remove the directory, so that old builds don't get flagged by Tenable.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
