### PR TITLE
Add libsanitizer variant to GCC package

### DIFF
--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -202,9 +202,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     variant(
         "profiled", default=False, description="Use Profile Guided Optimization", when="+bootstrap"
     )
-    variant(
-        "libsanitizer", default=True, description="Use libsanitizer"
-    )
+    variant("libsanitizer", default=True, description="Use libsanitizer")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")

--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -202,6 +202,9 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     variant(
         "profiled", default=False, description="Use Profile Guided Optimization", when="+bootstrap"
     )
+    variant(
+        "libsanitizer", default=True, description="Use libsanitizer"
+    )
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
@@ -895,6 +898,12 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
             options.extend(["--enable-bootstrap"])
         else:
             options.extend(["--disable-bootstrap"])
+
+        # enable_libsanitizer
+        if spec.satisfies("+libsanitizer"):
+            options.extend(["--enable-libsanitizer"])
+        else:
+            options.extend(["--disable-libsanitizer"])
 
         # Configure include and lib directories explicitly for these
         # dependencies since the short GCC option assumes that libraries


### PR DESCRIPTION
Recent glibc releases (e.g. 2.42 on Arch Linux) expose build failures in older GCC versions due to libsanitizer incompatibilities. While multiple patches exist to address specific glibc changes, they are not always available or complete for all supported GCC releases.

This change introduces a +libsanitizer variant (enabled by default) to the GCC package, allowing users to explicitly disable libsanitizer when building older GCC versions on newer platforms. This provides a practical workaround for systems where libsanitizer currently prevents successful builds, without changing default behavior.

The variant maps directly to --enable-libsanitizer / --disable-libsanitizer at configure time and is intended to ease portability until upstream or Spack-side patches fully address these issues.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
