### PR TITLE
JAX: add v0.8.3

### DIFF
--- a/repos/spack_repo/builtin/packages/py_jax/package.py
+++ b/repos/spack_repo/builtin/packages/py_jax/package.py
@@ -24,6 +24,7 @@ class PyJax(PythonPackage):
     tags = ["e4s"]
 
     version("0.9.0", sha256="e5ce9d6991333aeaad37729dd8315d29c4b094ea9476a32fb49933b556c723fb")
+    version("0.8.3", sha256="cf0569abe750f08a7c06421134576ca292851ab763f16edba719b35269c0ff5e")
     version("0.8.2", sha256="1a685ded06a8223a7b52e45e668e406049dbbead02873f2b5a4d881ba7b421ae")
     version("0.8.1", sha256="e53f67b15315f5e154851a7fd77a192b59c6c75b3f7ac56e214296765391cca7")
     version("0.8.0", sha256="0ea5a7be7068c25934450dfd87d7d80a18a5d30e0a53454e7aade525b23accd5")
@@ -108,6 +109,7 @@ class PyJax(PythonPackage):
         # https://github.com/google/jax/commit/8be057de1f50756fe7522f7e98b2f30fad56f7e4
         for v in [
             "0.9.0",
+            "0.8.3",
             "0.8.2",
             "0.8.1",
             "0.8.0",

--- a/repos/spack_repo/builtin/packages/py_jaxlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_jaxlib/package.py
@@ -50,6 +50,7 @@ class PyJaxlib(PythonPackage, CudaPackage, ROCmPackage):
     maintainers("adamjstewart", "jonas-eschle")
 
     version("0.9.0", sha256="8525c72ac7ea01851297df5b25ca4622c65299c265c87dfe78420bb29e7b1bb3")
+    version("0.8.3", sha256="fad6506b91b761842263dc6a9691ecc4f584b313a214ed6c89b6e5d899a69a3d")
     version("0.8.2", sha256="f7e5080c97c1aaffb490a17d174cb59a83dd037800d9c41d309287bebd15b0b8")
     version("0.8.1", sha256="38882602112dadfd49a2c74868a0722574ae88e04646a96f32f8c36a7893c548")
     version("0.8.0", sha256="864aa46b5a4475c70195bd3728d32224f5b5ae1c7dd9c70646ef1387b4b0b04b")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
https://github.com/jax-ml/jax/releases/tag/jax-v0.8.3