### PR TITLE
geomodel: add v6.23.0

### DIFF
--- a/repos/spack_repo/builtin/packages/geomodel/package.py
+++ b/repos/spack_repo/builtin/packages/geomodel/package.py
@@ -109,6 +109,8 @@ class Geomodel(CMakePackage):
         depends_on("qmake")
         with when("^[virtuals=qmake] qt"):
             depends_on("qt +gui +opengl +sql")
+            # https://gitlab.cern.ch/GeoModelDev/GeoModel/-/merge_requests/567
+            conflicts("@6.23:")
         with when("^[virtuals=qmake] qt-base"):
             depends_on("qt-base +gui +opengl +sql +widgets")
             depends_on("qt-5compat", when="@6.22:")
@@ -116,8 +118,6 @@ class Geomodel(CMakePackage):
         depends_on("soqt")
         depends_on("gl")
         depends_on("egl", when="@6.11:")
-        # https://gitlab.cern.ch/GeoModelDev/GeoModel/-/merge_requests/567
-        conflicts("qt", when="@6.23:")
 
     depends_on("googletest", when="@6.11", type="build")
     depends_on("googletest", when="@6.12:", type="test")

--- a/repos/spack_repo/builtin/packages/geomodel/package.py
+++ b/repos/spack_repo/builtin/packages/geomodel/package.py
@@ -19,6 +19,7 @@ class Geomodel(CMakePackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    version("6.23.0", sha256="f39f2d1dc62693fd8358d0ca54716a5123bfa844458eb61f182a09dee292305a")
     version("6.22.0", sha256="6e23db099c3c7603d13c13dfac1152db484a69c0b9b962ec0ab495ae3299f2cd")
     version("6.21.0", sha256="44712cbe821eadfd74b187906686b52cf16d824c330d93a98d00f29c3e683314")
     version("6.20.0", sha256="e8ecb860658d94a6582be4b607111d9b81f3c38c9e46b8d6f4aae88573b5b878")
@@ -110,11 +111,13 @@ class Geomodel(CMakePackage):
             depends_on("qt +gui +opengl +sql")
         with when("^[virtuals=qmake] qt-base"):
             depends_on("qt-base +gui +opengl +sql +widgets")
-            depends_on("qt-5compat")
+            depends_on("qt-5compat", when="@6.22:")
         depends_on("coin3d")
         depends_on("soqt")
         depends_on("gl")
         depends_on("egl", when="@6.11:")
+        # https://gitlab.cern.ch/GeoModelDev/GeoModel/-/merge_requests/567
+        conflicts("qt", when="@6.23:")
 
     depends_on("googletest", when="@6.11", type="build")
     depends_on("googletest", when="@6.12:", type="test")


### PR DESCRIPTION
This commit adds version 6.23.0 of the GeoModel package.