### PR TITLE
py-numpy: fix amdblis detection logic

### DIFF
--- a/repos/spack_repo/builtin/packages/py_numpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_numpy/package.py
@@ -305,9 +305,9 @@ class PyNumpy(PythonPackage):
         # Handle AMD BLIS: use multithreaded pkg-config name for @5.1: when threading is enabled
         if spec["blas"].name == "amdblis":
             blas = "blis"
-            if spec["amdblis"].satisfies('@5.1:') and (
-                spec["amdblis"].satisfies('threads=openmp') or
-                spec["amdblis"].satisfies('threads=pthreads')
+            if spec["amdblis"].satisfies("@5.1:") and (
+                spec["amdblis"].satisfies("threads=openmp")
+                or spec["amdblis"].satisfies("threads=pthreads")
             ):
                 blas = "blis-mt"
 

--- a/repos/spack_repo/builtin/packages/py_numpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_numpy/package.py
@@ -302,10 +302,10 @@ class PyNumpy(PythonPackage):
         if spec["blas"].name == ["blis"]:
             blas = "blis"
 
-        # Handle AMD BLIS: use multithreaded pkg-config name when OpenMP is enabled
+        # Handle AMD BLIS: use multithreaded pkg-config name for @5.1: when OpenMP is enabled
         if spec["blas"].name == "amdblis":
             blas = "blis"
-            if spec["amdblis"].satisfies("threads=openmp"):
+            if spec["amdblis"].satisfies('@5.1: threads=openmp'):
                 blas = "blis-mt"
 
         if spec["blas"].name == "cray-libsci":

--- a/repos/spack_repo/builtin/packages/py_numpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_numpy/package.py
@@ -305,7 +305,7 @@ class PyNumpy(PythonPackage):
         # Handle AMD BLIS: use multithreaded pkg-config name for @5.1: when OpenMP is enabled
         if spec["blas"].name == "amdblis":
             blas = "blis"
-            if spec["amdblis"].satisfies('@5.1: threads=openmp'):
+            if spec["amdblis"].satisfies("@5.1: threads=openmp"):
                 blas = "blis-mt"
 
         if spec["blas"].name == "cray-libsci":

--- a/repos/spack_repo/builtin/packages/py_numpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_numpy/package.py
@@ -299,8 +299,14 @@ class PyNumpy(PythonPackage):
         if spec["lapack"].name in ["intel-mkl", "intel-parallel-studio", "intel-oneapi-mkl"]:
             lapack = self._blas_lapack_pkg_config_mkl(spec["lapack"])
 
-        if spec["blas"].name in ["blis", "amdblis"]:
+        if spec["blas"].name == ["blis"]:
             blas = "blis"
+
+        # Handle AMD BLIS: use multithreaded pkg-config name when OpenMP is enabled
+        if spec["blas"].name == "amdblis":
+            blas = "blis"
+            if spec["amdblis"].satisfies("threads=openmp"):
+                blas = "blis-mt"
 
         if spec["blas"].name == "cray-libsci":
             blas = "libsci"

--- a/repos/spack_repo/builtin/packages/py_numpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_numpy/package.py
@@ -299,7 +299,7 @@ class PyNumpy(PythonPackage):
         if spec["lapack"].name in ["intel-mkl", "intel-parallel-studio", "intel-oneapi-mkl"]:
             lapack = self._blas_lapack_pkg_config_mkl(spec["lapack"])
 
-        if spec["blas"].name == ["blis"]:
+        if spec["blas"].name == "blis":
             blas = "blis"
 
         # Handle AMD BLIS: use multithreaded pkg-config name for @5.1: when threading is enabled

--- a/repos/spack_repo/builtin/packages/py_numpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_numpy/package.py
@@ -302,10 +302,13 @@ class PyNumpy(PythonPackage):
         if spec["blas"].name == ["blis"]:
             blas = "blis"
 
-        # Handle AMD BLIS: use multithreaded pkg-config name for @5.1: when OpenMP is enabled
+        # Handle AMD BLIS: use multithreaded pkg-config name for @5.1: when threading is enabled
         if spec["blas"].name == "amdblis":
             blas = "blis"
-            if spec["amdblis"].satisfies("@5.1: threads=openmp"):
+            if spec["amdblis"].satisfies('@5.1:') and (
+                spec["amdblis"].satisfies('threads=openmp') or
+                spec["amdblis"].satisfies('threads=pthreads')
+            ):
                 blas = "blis-mt"
 
         if spec["blas"].name == "cray-libsci":


### PR DESCRIPTION
The py-numpy and py-scipy packages in Spack use the blas_lapack_pkg_config function defined in the numpy recipe for BLAS/LAPACK detection. This function returns the names of the BLAS and LAPACK libraries that pkg-config should search for.

As of version 5.1, the amdblis package, when built in multi-threaded mode, defines its pkg-config metadata in blis-mt.pc instead of blis.pc. Consequently, the library name mapping in the above function needs to be updated accordingly.

This PR adds the necessary logic to handle this change.