### PR TITLE
binutils: --enable-deterministic-archives

### DIFF
--- a/repos/spack_repo/builtin/packages/binutils/package.py
+++ b/repos/spack_repo/builtin/packages/binutils/package.py
@@ -235,6 +235,7 @@ class AutotoolsBuilder(autotools.AutotoolsBuilder):
             "--disable-dependency-tracking",
             "--disable-werror",
             "--enable-64-bit-bfd",
+            "--enable-deterministic-archives",
             "--enable-multilib",
             "--enable-pic",
             "--enable-targets={}".format(targets),


### PR DESCRIPTION
Zeros out UID, GID, and timestamp in `ar` etc.
