### PR TITLE
py-scipy: add lowerbound for meson version

### DIFF
--- a/repos/spack_repo/builtin/packages/py_meson_python/package.py
+++ b/repos/spack_repo/builtin/packages/py_meson_python/package.py
@@ -18,6 +18,7 @@ class PyMesonPython(PythonPackage):
 
     license("MIT")
 
+    version("0.19.0", sha256="9959d198aa69b57fcfd354a34518c6f795b781a73ed0656f4d01660160cc2553")
     version("0.18.0", sha256="c56a99ec9df669a40662fe46960321af6e4b14106c14db228709c1628e23848d")
     version("0.16.0", sha256="9068c17e36c89d6c7ff709fffb2a8a9925e8cd0b02629728e5ceaf2ec505cb5f")
     version("0.15.0", sha256="fddb73eecd49e89c1c41c87937cd89c2d0b65a1c63ba28238681d4bd9484d26f")

--- a/repos/spack_repo/builtin/packages/py_scipy/package.py
+++ b/repos/spack_repo/builtin/packages/py_scipy/package.py
@@ -69,6 +69,9 @@ class PyScipy(PythonPackage):
 
     # Build dependencies (do not include upper bound unless known issues)
     with default_args(type="build"):
+        depends_on("meson@1.5:", when="@1.15:")
+        depends_on("meson@1.1:", when="@1.11:")
+        depends_on("meson@0.64:")
         depends_on("py-meson-python@0.15:", when="@1.12:")
         depends_on("py-meson-python@0.12.1:", when="@1.11:")
         depends_on("py-meson-python@0.11:", when="@1.10:")

--- a/repos/spack_repo/builtin/packages/py_scipy/package.py
+++ b/repos/spack_repo/builtin/packages/py_scipy/package.py
@@ -69,9 +69,11 @@ class PyScipy(PythonPackage):
 
     # Build dependencies (do not include upper bound unless known issues)
     with default_args(type="build"):
+        # from meson.build
         depends_on("meson@1.5:", when="@1.15:")
         depends_on("meson@1.1:", when="@1.11:")
         depends_on("meson@0.64:")
+        # from pyproject.toml
         depends_on("py-meson-python@0.15:", when="@1.12:")
         depends_on("py-meson-python@0.12.1:", when="@1.11:")
         depends_on("py-meson-python@0.11:", when="@1.10:")


### PR DESCRIPTION
Meson is pulled in through `py-python-meson`, but without any version restrictions.

Just add it as a direct dep with the bounds from https://github.com/scipy/scipy/blob/main/meson.build.