### PR TITLE
nccl: fix cuda version requirements

### DIFF
--- a/repos/spack_repo/builtin/packages/nccl/package.py
+++ b/repos/spack_repo/builtin/packages/nccl/package.py
@@ -98,6 +98,12 @@ class Nccl(MakefilePackage, CudaPackage):
     # https://github.com/NVIDIA/nccl/issues/1743
     conflicts("%gcc@14:", msg="Compilation issue with gcc 14", when="@:2.27.5-1")
 
+    depends_on("cuda@12:13", when="@2.27:")
+    depends_on("cuda@12", when="@2.22:2.26")
+    depends_on("cuda@11:12", when="@2.16:2.21")
+    depends_on("cuda@10:11", when="@2.7:2.15")
+    depends_on("cuda@9:11", when="@:2.6")
+
     @classmethod
     def determine_version(cls, lib):
         match = re.search(r"lib\S*\.so\.(\d+\.\d+\.\d+)", lib)


### PR DESCRIPTION
Got some compilation errors with nccl 2.29 and cuda 11.8, which prompted me to go over all the release notes to add proper CUDA versioning.

Didn't do every single minor version (some versions claim they support CUDA 11.0, 11.4 and 12.0, but how about the rest?) but some others advertise it's all based on major version. This should tighten it down considerably though.