### PR TITLE
py-hatchling: fix two types of build issues

### DIFF
--- a/repos/spack_repo/builtin/packages/py_hatchling/package.py
+++ b/repos/spack_repo/builtin/packages/py_hatchling/package.py
@@ -28,6 +28,13 @@ class PyHatchling(PythonPackage):
     version("1.8.1", sha256="448b04b23faed669b2b565b998ac955af4feea66c5deed3a1212ac9399d2e1cd")
     version("1.4.1", sha256="13461b42876ade4f75ee5d2a2c656b288ca0aab7f048ef66657ef166996b2118")
 
+    def setup_dependent_build_environment(
+        self, env: EnvironmentModifications, dependent_spec: Spec
+    ) -> None:
+        # If trove-classifiers is older than the latest Python release, it pedantically errors
+        # over classifiers like "Programming Language :: Python :: 3.X". Disable that check.
+        env.set("HATCH_METADATA_CLASSIFIERS_NO_VERIFY", "1")
+
     with default_args(type=("build", "run")):
         depends_on("python@3.8:", when="@1.18:")
         depends_on("python@3.7:", when="@1.12:")

--- a/repos/spack_repo/builtin/packages/py_jupyter_core/package.py
+++ b/repos/spack_repo/builtin/packages/py_jupyter_core/package.py
@@ -41,6 +41,7 @@ class PyJupyterCore(PythonPackage):
 
     depends_on("python@3.8:", when="@5:", type=("build", "run"))
     depends_on("py-hatchling@1.4:", when="@4.11.1:", type="build")
+    depends_on("py-hatchling@1.26:", when="@5.8.1:", type="build")
 
     depends_on("py-platformdirs@2.5:", when="@5.1:", type=("build", "run"))
     depends_on("py-traitlets@5.3:", when="@5.1:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_referencing/package.py
+++ b/repos/spack_repo/builtin/packages/py_referencing/package.py
@@ -23,6 +23,7 @@ class PyReferencing(PythonPackage):
     depends_on("python@3.9:", type=("build", "run"), when="@0.36:")
     depends_on("python@3.8:", type=("build", "run"), when="@:0.35")
     depends_on("py-hatchling", type="build")
+    depends_on("py-hatchling@1.26:", when="@0.36:", type="build")
     depends_on("py-hatch-vcs", type="build")
 
     depends_on("py-attrs@22.2.0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_scikit_build_core/package.py
+++ b/repos/spack_repo/builtin/packages/py_scikit_build_core/package.py
@@ -41,7 +41,6 @@ class PyScikitBuildCore(PythonPackage):
 
     # Build system
     depends_on("py-hatchling", type="build")
-    depends_on("py-hatchling@1.26:", when="@0.11.3:", type="build")
     depends_on("py-hatch-vcs", type="build")
 
     # Dependencies

--- a/repos/spack_repo/builtin/packages/py_scikit_build_core/package.py
+++ b/repos/spack_repo/builtin/packages/py_scikit_build_core/package.py
@@ -41,6 +41,7 @@ class PyScikitBuildCore(PythonPackage):
 
     # Build system
     depends_on("py-hatchling", type="build")
+    depends_on("py-hatchling@1.26:", when="@0.11.3:", type="build")
     depends_on("py-hatch-vcs", type="build")
 
     # Dependencies

--- a/repos/spack_repo/builtin/packages/py_soupsieve/package.py
+++ b/repos/spack_repo/builtin/packages/py_soupsieve/package.py
@@ -31,6 +31,7 @@ class PySoupsieve(PythonPackage):
     depends_on("python@3.8:", when="@2.5:", type=("build", "run"))
     depends_on("python@3.7:", when="@2.4:", type=("build", "run"))
     depends_on("py-hatchling@0.21.1:", when="@2.3.2:", type="build")
+    depends_on("py-hatchling@1.26:", when="@2.8:", type="build")
 
     # Historical dependencies
     depends_on("py-setuptools@42:", when="@2.2", type="build")


### PR DESCRIPTION
Hatchling 1.26 is a strict requirement when `pyproject.toml` contains `license-files = [...]`.

Disable classifier validation since it causes unnecessary forward incompatibility, for example
when `py-trove-classifiers` is older than the latest Python supported by the package. It
pedantically errors out over `Programming Language :: Python :: 3.14` because it "doesn't
know" about Python 3.14 (even if the actual Python for the build is older).
