### PR TITLE
Precice: Added gcc@:9.2 conflict

### DIFF
--- a/repos/spack_repo/builtin/packages/precice/package.py
+++ b/repos/spack_repo/builtin/packages/precice/package.py
@@ -125,6 +125,7 @@ class Precice(CMakePackage):
     conflicts("%apple-clang@:5")
     conflicts("%clang@:3.7")
     conflicts("%intel@:16")
+    conflicts("%gcc@:9.2", when="@3.0.0:")
 
     # Fixes missing #include<array> in src/mesh/Edge.hpp
     patch(


### PR DESCRIPTION
Since version 3.0.0, gcc 9.3: has been a requirement.
https://github.com/precice/precice/blob/v3.0.0/cmake/CheckSTL.cmake#L5

Maintainers are @MakisH and @fsimonis. Let me know any comments/questions/concerns, though I'd imagine this would be a fairly easy fix...