### PR TITLE
ci: disable tutorial pipeline

### DIFF
--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -10,7 +10,7 @@ variables:
   PROTECTED_MIRROR_FETCH_DOMAIN: "s3://spack-binaries"
   PROTECTED_MIRROR_PUSH_DOMAIN: "s3://spack-binaries"
   SPACK_CI_DISABLE_STACKS:
-    value: /^.*(cray|darwin).*$/
+    value: /^.*(cray|darwin|tutorial).*$/
     expand: false
 
 default:


### PR DESCRIPTION
There are three issues with the pipeline:

* `x` and `x cflags=-O3` are unified, but the tutorial expects these to
  be concretized separately
* The concretization time is very long, and sometimes times out after 1h
* It no longer works with `spack@develop` due to changes to compiler
  mixing.

All these issues are caused by `unify: when_possible` in an attempt to
bootstrap GCC 12.

Soon enough there'll be a proper, faster way to do this in Spack. For
now, disable this stack so we can bump Spack.

