### PR TITLE
neovim: Fix utf8proc dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/neovim/package.py
+++ b/repos/spack_repo/builtin/packages/neovim/package.py
@@ -110,7 +110,7 @@ class Neovim(CMakePackage):
         depends_on("tree-sitter@0.20.9:0.25")
     with when("@0.11:"):
         depends_on("cmake@3.16:", type="build")
-        depends_on("utf8proc", type="link")
+        depends_on("utf8proc@2.10.0", type="link")
         depends_on("tree-sitter@0.25", type="link", when="@:0.11.5")
         depends_on("tree-sitter@0.25:", type="link")
 


### PR DESCRIPTION
Version 2.10.0 is needed for neovim 0.11+ to compile.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
