### PR TITLE
Update byobu and fix newt

### DIFF
--- a/repos/spack_repo/builtin/packages/byobu/package.py
+++ b/repos/spack_repo/builtin/packages/byobu/package.py
@@ -13,7 +13,7 @@ class Byobu(AutotoolsPackage):
 
     homepage = "https://www.byobu.org/"
 
-    maintainers("matthiasdiener")
+    maintainers("ebagrenrut")
 
     license("GPL-3.0-or-later")
 

--- a/repos/spack_repo/builtin/packages/byobu/package.py
+++ b/repos/spack_repo/builtin/packages/byobu/package.py
@@ -11,16 +11,53 @@ from spack.package import *
 class Byobu(AutotoolsPackage):
     """Byobu: Text-based window manager and terminal multiplexer."""
 
-    homepage = "https://www.byobu.co/"
-    url = "https://launchpad.net/byobu/trunk/5.123/+download/byobu_5.123.orig.tar.gz"
+    homepage = "https://www.byobu.org/"
 
     maintainers("matthiasdiener")
 
     license("GPL-3.0-or-later")
 
+    version("6.13", sha256="9690c629588e8f95d16b2461950d39934faaf8005dd2a283886d4e3bd6c86df6")
     version("5.131", sha256="77ac751ae79d8e3f0377ac64b64bc9738fa68d68466b8d2ff652b63b1d985e52")
     version("5.127", sha256="4bafc7cb69ff5b0ab6998816d58cd1ef7175e5de75abc1dd7ffd6d5288a4f63b")
     version("5.125", sha256="5022c82705a5d57f1d4e8dcb1819fd04628af2d4b4618b7d44fa27ebfcdda9db")
     version("5.123", sha256="2e5a5425368d2f74c0b8649ce88fc653420c248f6c7945b4b718f382adc5a67d")
 
-    depends_on("tmux", type=("build", "run"))
+    variant("python", default=True, description="Python support for byobu-config")
+
+    # byobu 6 source is not pre-autoconfigured
+    depends_on("autoconf", when="@6:", type="build")
+    depends_on("automake", when="@6:", type="build")
+    depends_on("libtool", when="@6:", type="build")
+
+    depends_on("coreutils", type=("build", "run"))
+    depends_on("findutils", type=("build", "run"))
+    depends_on("gawk", type=("build", "run"))
+    depends_on("grep", type=("build", "run"))
+    depends_on("sed", type=("build", "run"))
+
+    # The `-h` argument to byobu commands invokes man
+    depends_on("man-db", type="run")
+    depends_on("screen", type="run")
+    depends_on("tmux", type="run")
+
+    # newt and its snack Python module are needed for byobu-config. If the user
+    # does not want byobu@6 with a python in its spec, they can disable the
+    # python variant, but sacrifice the byobu-config functionality.
+    depends_on("newt+python", when="+python", type="run")
+    depends_on("python", when="+python", type="run")
+
+    def url_for_version(self, version):
+        # byobu 6+ are released on GitHub
+        if version < Version("6"):
+            return (
+                f"https://launchpad.net/byobu/trunk/{version}/+download/"
+                f"byobu_{version}.orig.tar.gz"
+            )
+
+        else:
+            return f"https://github.com/dustinkirkland/byobu/archive/refs/tags/{version}.tar.gz"
+
+    @when("+python")
+    def setup_run_environment(self, env: EnvironmentModifications) -> None:
+        env.set("BYOBU_PYTHON", f"{self.spec['python'].command}") 

--- a/repos/spack_repo/builtin/packages/byobu/package.py
+++ b/repos/spack_repo/builtin/packages/byobu/package.py
@@ -60,4 +60,4 @@ class Byobu(AutotoolsPackage):
 
     @when("+python")
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
-        env.set("BYOBU_PYTHON", f"{self.spec['python'].command}") 
+        env.set("BYOBU_PYTHON", f"{self.spec['python'].command}")

--- a/repos/spack_repo/builtin/packages/newt/0001-adjust-snack-installation.patch
+++ b/repos/spack_repo/builtin/packages/newt/0001-adjust-snack-installation.patch
@@ -1,0 +1,22 @@
+diff --git a/Makefile.in b/Makefile.in
+index f8fe290..12150a7 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -162,12 +162,11 @@ endif
+ install-py: _snack.$(SOEXT)
+ ifneq ($(PYTHONVERS),)
+ 	@for ver in $(PYTHONVERS); do \
+-		PLATLIB=`$$ver -c "import sysconfig; print(sysconfig.get_path('platlib'))"`; \
+-		[ -d $(instroot)/$$PLATLIB ] || install -m 755 -d $(instroot)/$$PLATLIB ;\
+-		echo install -m 755 $$ver/_snack.$(SOEXT) $(instroot)/$$PLATLIB;\
+-		install -m 755 $$ver/_snack.$(SOEXT) $(instroot)/$$PLATLIB;\
+-		echo install -m 644 snack.py $(instroot)/$$PLATLIB;\
+-		install -m 644 snack.py $(instroot)/$$PLATLIB;\
++		[ -d $(instroot)/$(libdir)/$$ver/site-packages ] || install -m 755 -d $(instroot)/$(libdir)/$$ver/site-packages;\
++		echo install -m 755 $$ver/_snack.$(SOEXT) $(instroot)/$(libdir)/$$ver/site-packages;\
++		install -m 755 $$ver/_snack.$(SOEXT) $(instroot)/$(libdir)/$$ver/site-packages;\
++		echo install -m 644 snack.py $(instroot)/$(libdir)/$$ver/site-packages;\
++		install -m 644 snack.py $(instroot)/$(libdir)/$$ver/site-packages;\
+ 	done
+ endif
+ 

--- a/repos/spack_repo/builtin/packages/newt/package.py
+++ b/repos/spack_repo/builtin/packages/newt/package.py
@@ -15,11 +15,53 @@ class Newt(AutotoolsPackage):
 
     license("LGPL-2.0-only")
 
+    version("0.52.25", sha256="ef0ca9ee27850d1a5c863bb7ff9aa08096c9ed312ece9087b30f3a426828de82")
     version("0.52.21", sha256="265eb46b55d7eaeb887fca7a1d51fe115658882dfe148164b6c49fccac5abb31")
     version("0.52.20", sha256="8d66ba6beffc3f786d4ccfee9d2b43d93484680ef8db9397a4fb70b5adbb6dbc")
     version("0.52.19", sha256="08c0db56c21996af6a7cbab99491b774c6c09cef91cd9b03903c84634bff2e80")
 
+    # newt prior to 0.51.21 did not allow one to specify where to find Python and would
+    # only look in /usr. Avoid using Python with earlier versions.
+    variant("python", when="@0.52.21:", default=False, description="Build the snack python module")
+
     depends_on("c", type="build")  # generated
 
-    depends_on("slang")
+    depends_on("gettext")
     depends_on("popt")
+    depends_on("slang")
+
+    depends_on("python", when="@0.52.21: +python")
+
+    # Beginning with newt 0.52.25, snack is installed into Python's site-packages, but
+    # we prefer the module to stay within newt's prefix
+    patch("0001-adjust-snack-installation.patch", when="@0.51.25: +python")
+
+    def configure_args(self):
+        args = []
+
+        # If --without-python is not specified, configure will try to find Python on
+        # PATH.
+        if self.spec.satisfies("~python") or self.version < Version("0.52.21"):
+            args.append("--without-python")
+
+        if self.spec.satisfies("+python"):
+            args.append(f"--with-python=python{self.spec['python'].version.up_to(2)}")
+
+        return args
+
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        super().setup_build_environment(env)
+        # Without these flags, newt does not link properly against libintl from
+        # spack-provided gettext
+        env.set("CPPFLAGS", f"-I{self.spec['gettext'].prefix.include}")
+        env.set("LDFLAGS", f"-L{self.spec['gettext'].prefix.lib}")
+        env.set("LIBS", "-lintl")
+
+    @when("+python")
+    def setup_dependent_run_environment(
+        self, env: EnvironmentModifications, dependent_spec: Spec
+    ) -> None:
+        env.prepend_path(
+            "PYTHONPATH",
+            f"{self.spec.prefix.lib}/python{self.spec['python'].version.up_to(2)}/site-packages",
+        )


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

- Update/fix `byobu`
    - Added the latest `byobu` release, 6.13
    - Enabled Python support for `byobu`, which allows the `byobu-config`
      command to work. If the user does not care about `byobu-config` and
      really does not want `byobu` to have a dependency on `python`, they
      can build with `~python`.
    - Added several missing build- and run-time dependencies. The `byobu`
      `configure` script and `Makefile` rely on a bunch of external
      utilities (`awk`, `find`, `grep`, several from `coreutils`, `man`, and
      `sed`). I suspect that these went unnoticed previously as builds were
      happening on systems/in environments with a bunch of things already
      installed, but in a container with a minimal image, I was unable to
      build and run `byobu`.
    - `url_for_version` is defined so that the source for `byobu` 6+ can be
      downloaded from GitHub. The source for 5.x is still only in LaunchPad.

- Update/fix `newt`
    - Add the latest `newt` release, 0.52.25
    - Add a `python` variant, default to `False`, that, when `True`, causes
      `newt`'s `snack` Python module to be built and installed. This module
      is needed by `byobu+python`. Having reviewed the `newt` source for
      past versions, it was clear that making it properly build `snack` for
      versions 0.52.20 and earlier was going to require a lot of
      hacking/patching of `newt`'s source as those versions look only in
      `/usr` for Python. This issue was fixed in `newt` 0.52.21, which added
      a `--with-python` configure option that can be used to provide the
      python command to be used.
    - Added a dependency on `gettext`. `newt` needs `libintl`, and if we do
      not provide it from Spack, the build will try to get it from the OS.
      If it doesn't find any provider of `libintl`, the `configure` fails. A
      `setup_build_environment` function is now defined to ensure that
      `configure` will find the Spack-provided `gettext`.
    - A `setup_dependent_run_environment` function is now defined that adds
      the directory containing the `snack` module to `PYTHONPATH`. This
      allows dependent packages that need `snack` to find it. This function
      is only called if `newt`'s `python` variant is `True`.
    - Include a patch for `newt` 0.52.25 (and possibly newer, should there be 
      another release), that forces the installation of `snack` into `newt`'s 
      `PREFIX` when the `python` variant is `True`. The build for 0.52.25 was 
      changed to find the `site-packages` directory of the provided Python 
      and install `snack` there. This is rather un-Spacky, so the patch reverts 
      this behavior.

@matthiasdiener Please let me know if you're still interested in maintaining the `byobu` Spack package.