### PR TITLE
Revert "ci: disable tutorial pipeline (#3249)"

### DIFF
--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -590,7 +590,7 @@ tools-sdk-build:
 
 tutorial-generate:
   extends: [ ".tutorial", ".generate-x86_64"]
-  image: ghcr.io/spack/tutorial-ubuntu-22.04:main
+  image: ghcr.io/spack/tutorial-ubuntu-22.04:v2023-10-30
 
 tutorial-build:
   extends: [ ".tutorial", ".build" ]

--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -10,7 +10,7 @@ variables:
   PROTECTED_MIRROR_FETCH_DOMAIN: "s3://spack-binaries"
   PROTECTED_MIRROR_PUSH_DOMAIN: "s3://spack-binaries"
   SPACK_CI_DISABLE_STACKS:
-    value: /^.*(cray|darwin|tutorial).*$/
+    value: /^.*(cray|darwin).*$/
     expand: false
 
 default:

--- a/.ci/gitlab/configs/linux/ci.yaml
+++ b/.ci/gitlab/configs/linux/ci.yaml
@@ -4,7 +4,7 @@ ci:
       before_script-:
       # Test package relocation on linux using a modified prefix
       # This is not well supported on MacOS (https://github.com/spack/spack/issues/37162)
-      - - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}/${SPACK_JOB_SPEC_DAG_HASH}:'morepadding/{architecture.platform}-{architecture.target}/{name}-{version}-{hash}'"
+      - - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture.platform}-{architecture.target}/{name}-{version}-{hash}'"
   - match_behavior: first
     submapping:
     - match:

--- a/.ci/gitlab/configs/win64/ci.yaml
+++ b/.ci/gitlab/configs/win64/ci.yaml
@@ -19,7 +19,7 @@ ci:
 
       script::
       - spack.ps1 env activate --without-view ${SPACK_CONCRETE_ENV_DIR}
-      - spack.ps1 config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}/${SPACK_JOB_SPEC_DAG_HASH}:'morepadding/{hash}'"
+      - spack.ps1 config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{hash}'"
       - mkdir ${SPACK_ARTIFACTS_ROOT}/user_data
       - spack.ps1 --backtrace ci rebuild | Tee-Object -FilePath "${env:SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt" 2>&1 | Tee-Object -FilePath "${env:SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt"
       image: "ghcr.io/johnwparent/windows-server21h2:sha-1c12b61"

--- a/stacks/tutorial/spack.yaml
+++ b/stacks/tutorial/spack.yaml
@@ -5,28 +5,21 @@ spack:
   - ../../.ci/gitlab/
   packages:
     all:
-      require:
-      - target=x86_64_v3
-      - spec: '%gcc-runtime@12'
-        when: '%gcc@12'
-      - spec: '%gcc-runtime@11'
-        when: '%gcc@11'
-      - spec: '%gcc-runtime@10'
-        when: '%gcc@10'
+      require: target=x86_64_v3
     tbb:
       require: intel-tbb
   definitions:
   - gcc_system_packages:
     - matrix:
-      - - zlib-ng@2.2.4
+      - - zlib-ng
         - zlib-ng@2.0.7
         - zlib-ng@2.0.7 cflags=-O3
-        - tcl ^zlib-ng@2.2.4
+        - tcl
         - tcl ^zlib-ng@2.0.7 cflags=-O3
-        - hdf5+mpi^openmpi
+        - hdf5
         - hdf5~mpi
         - hdf5+hl+mpi ^mpich
-        - trilinos ^openmpi
+        - trilinos
         - trilinos +hdf5 ^hdf5+hl+mpi ^mpich
         - gcc@12.3 ~binutils  # todo: enable ~binutils once unify: true is used
         - mpileaks
@@ -37,10 +30,10 @@ spack:
         - vim
       - ['%gcc@11']
   - gcc_old_packages:
-    - zlib-ng@2.2.4%gcc@10
+    - zlib-ng%gcc@10
   - clang_packages:
     - matrix:
-      - [zlib-ng@2.2.4, tcl ^zlib-ng@2.0.7]
+      - [zlib-ng, tcl ^zlib-ng@2.0.7]
       - ['%clang@14']
   - gcc_spack_built_packages:
     - matrix:
@@ -56,15 +49,12 @@ spack:
   - $gcc_old_packages
   - $clang_packages
   - $gcc_spack_built_packages
-  concretizer:
-    # Hacky way to allow bootstrapping the compiler
-    unify: when_possible
-    compiler_mixing: false
+
   ci:
     pipeline-gen:
     - build-job:
         image:
-          name: ghcr.io/spack/tutorial-ubuntu-22.04:main
+          name: ghcr.io/spack/tutorial-ubuntu-22.04:v2023-10-30
           entrypoint: ['']
   cdash:
     build-group: Spack Tutorial


### PR DESCRIPTION
This reverts commits c3ce4ac100fe65aa817a09e4fe000d427e1ce155 and 8d0701f2a54ac40f42a8f36335ddc00fb5d000bb.

~~We need the tutorial pipeline to keep running in CI. Yes, it elides the differences between two of the zlib-ng specs and that's not ideal. Yes, it will be better once we merge the concretization groups PR. But we still need to keep building it for now so that errors don't accumulate.~~

The tutorial stack as used in the tutorial is not currently buildable in CI, but the old version with an external gcc is buildable to ensure things don't break.
