### PR TITLE
cmake: fix a few constraints in dependents

### DIFF
--- a/repos/spack_repo/builtin/build_systems/cmake.py
+++ b/repos/spack_repo/builtin/build_systems/cmake.py
@@ -228,7 +228,9 @@ class CMakePackage(PackageBase):
         # must conflict.
         # this should be updated to reflect a oneapi fortran provider
         # once oneapi is usable with fortran on Windows
-        depends_on("cmake@4.1:", type="build", when="%cxx=msvc %fortran=msvc")
+        # NOTE: commented out for now because cmake@3 is used in Spack CI
+        # successfully with %fortran=msvc.
+        # depends_on("cmake@4.1:", type="build", when="%cxx=msvc %fortran=msvc")
 
     def flags_to_build_system_args(self, flags):
         """Return a list of all command line arguments to pass the specified

--- a/repos/spack_repo/builtin/build_systems/cmake.py
+++ b/repos/spack_repo/builtin/build_systems/cmake.py
@@ -228,7 +228,7 @@ class CMakePackage(PackageBase):
         # must conflict.
         # this should be updated to reflect a oneapi fortran provider
         # once oneapi is usable with fortran on Windows
-        conflicts("cmake@:4.0", when="%cxx=msvc %fortran=msvc")
+        depends_on("cmake@4.1:", type="build", when="%cxx=msvc %fortran=msvc")
 
     def flags_to_build_system_args(self, flags):
         """Return a list of all command line arguments to pass the specified

--- a/repos/spack_repo/builtin/build_systems/cmake.py
+++ b/repos/spack_repo/builtin/build_systems/cmake.py
@@ -218,6 +218,18 @@ class CMakePackage(PackageBase):
         depends_on("gmake", type="build", when="generator=make")
         depends_on("ninja", type="build", when="generator=ninja")
 
+        # CMake earlier than 4.1 improperly handles arguments provided to
+        # the linker when using msvc as a c/cxx compiler and oneapi as a
+        # fortran compiler https://gitlab.kitware.com/cmake/cmake/-/issues/26005
+        #
+        # Currently in Spack msvc is modeled as both the fortran/cxx compiler
+        # due to restrictions w/ oneapi on Windows, but in reality, when msvc
+        # is the fortran compiler, it is utilizing oneapi, and this
+        # must conflict.
+        # this should be updated to reflect a oneapi fortran provider
+        # once oneapi is usable with fortran on Windows
+        depends_on("cmake@4.1:", type="build", when="%cxx=msvc %fortran=msvc")
+
     def flags_to_build_system_args(self, flags):
         """Return a list of all command line arguments to pass the specified
         compiler flags to cmake. Note CMAKE does not have a cppflags option,

--- a/repos/spack_repo/builtin/build_systems/cmake.py
+++ b/repos/spack_repo/builtin/build_systems/cmake.py
@@ -218,18 +218,6 @@ class CMakePackage(PackageBase):
         depends_on("gmake", type="build", when="generator=make")
         depends_on("ninja", type="build", when="generator=ninja")
 
-        # CMake earlier than 4.1 improperly handles arguments provided to
-        # the linker when using msvc as a c/cxx compiler and oneapi as a
-        # fortran compiler https://gitlab.kitware.com/cmake/cmake/-/issues/26005
-        #
-        # Currently in Spack msvc is modeled as both the fortran/cxx compiler
-        # due to restrictions w/ oneapi on Windows, but in reality, when msvc
-        # is the fortran compiler, it is utilizing oneapi, and this
-        # must conflict.
-        # this should be updated to reflect a oneapi fortran provider
-        # once oneapi is usable with fortran on Windows
-        depends_on("cmake@4.1:", type="build", when="%cxx=msvc %fortran=msvc")
-
     def flags_to_build_system_args(self, flags):
         """Return a list of all command line arguments to pass the specified
         compiler flags to cmake. Note CMAKE does not have a cppflags option,

--- a/repos/spack_repo/builtin/packages/curl/package.py
+++ b/repos/spack_repo/builtin/packages/curl/package.py
@@ -91,7 +91,7 @@ class Curl(NMakePackage, AutotoolsPackage, CMakePackage):
 
     # CMake 4.0: is not compatible with CMake systems requiring
     # 3.0, which curl@7.63 requires
-    depends_on("cmake@:3", when="build_system=cmake @:7.63")
+    depends_on("cmake@:3", when="build_system=cmake @:7.63", type="build")
 
     depends_on("gnutls@3.6.5:", when="tls=gnutls @8.18:")
     depends_on("gnutls", when="tls=gnutls")

--- a/repos/spack_repo/builtin/packages/curl/package.py
+++ b/repos/spack_repo/builtin/packages/curl/package.py
@@ -91,7 +91,7 @@ class Curl(NMakePackage, AutotoolsPackage, CMakePackage):
 
     # CMake 4.0: is not compatible with CMake systems requiring
     # 3.0, which curl@7.63 requires
-    depends_on("cmake@:3", when="build_system=cmake @:7.63", type="build")
+    depends_on("cmake@:3", type="build", when="build_system=cmake @:7.63")
 
     depends_on("gnutls@3.6.5:", when="tls=gnutls @8.18:")
     depends_on("gnutls", when="tls=gnutls")

--- a/repos/spack_repo/builtin/packages/libuv/package.py
+++ b/repos/spack_repo/builtin/packages/libuv/package.py
@@ -101,7 +101,7 @@ class Libuv(CMakePackage, AutotoolsPackage):
     with when("build_system=cmake"):
         # explicitly require ownlibs to indicate we're short
         # circuiting the cmake<->libuv cyclic dependency here
-        depends_on("cmake+ownlibs")
+        depends_on("cmake+ownlibs", type="build")
 
     conflicts(
         "%gcc@:4.8",

--- a/repos/spack_repo/builtin/packages/scitokens_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/scitokens_cpp/package.py
@@ -43,7 +43,7 @@ class ScitokensCpp(CMakePackage):
     depends_on("cxx", type="build")  # generated
 
     depends_on("cmake@2.6:", type="build")
-    depends_on("cmake@3.10:", when="@0.7.1:", type="build")
+    depends_on("cmake@3.10:", type="build", when="@0.7.1:")
     depends_on("openssl")
     depends_on("sqlite")
     depends_on("curl")

--- a/repos/spack_repo/builtin/packages/scitokens_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/scitokens_cpp/package.py
@@ -42,8 +42,8 @@ class ScitokensCpp(CMakePackage):
 
     depends_on("cxx", type="build")  # generated
 
-    depends_on("cmake@2.6:")
-    depends_on("cmake@3.10:", when="@0.7.1:")
+    depends_on("cmake@2.6:", type="build")
+    depends_on("cmake@3.10:", when="@0.7.1:", type="build")
     depends_on("openssl")
     depends_on("sqlite")
     depends_on("curl")


### PR DESCRIPTION
Fixes a couple oversights that may or may not prevent unified concretization of
build dependencies in the Windows stack.

