### PR TITLE
gsibec: add v1.4.0

### DIFF
--- a/repos/spack_repo/builtin/packages/gsibec/package.py
+++ b/repos/spack_repo/builtin/packages/gsibec/package.py
@@ -12,15 +12,17 @@ class Gsibec(CMakePackage):
     capabilities from the Gridpoint Statistical Interpolation (GSI)
     atmospheric analysis system into a library of its own."""
 
-    homepage = "https://github.com/GEOS-ESM/gsibec"
-    git = "https://github.com/GEOS-ESM/gsibec.git"
-    url = "https://github.com/GEOS-ESM/gsibec/archive/refs/tags/1.0.2.tar.gz"
+    homepage = "https://github.com/GEOS-ESM/GSIbec"
+    git = "https://github.com/GEOS-ESM/GSIbec.git"
+    url = "https://github.com/GEOS-ESM/GSIbec/archive/refs/tags/v1.4.1.tar.gz"
+    list_url = "https://github.com/GEOS-ESM/GSIbec/tags"
 
     maintainers("mathomp4", "danholdaway")
 
     license("Apache-2.0")
 
     version("develop", branch="develop")
+    version("1.4.1", sha256="f624c1af36b5023fc35f5a5b0cec4b5649f6a7df933148da432a25b53e5b5c87")
     version("1.4.0", sha256="aa512995c32bd4a9998584a62707abed299fe34af4e9dbf5b44aebd335376e54")
     version("1.3.1", sha256="fe7dbe7d170b47dbacc3febc42fc9877c118860b1532d70246bc73934e548185")
     version("1.2.2", sha256="c15e6a2e75e6b4b0727490bff6a52c02c7309cc48a202e393009074ecf33b06a")
@@ -33,6 +35,17 @@ class Gsibec(CMakePackage):
     version("1.0.4", sha256="6460e221f2a45640adab016336c070fbe3e7c4b6fc55257945bf5cdb38d5d3e2")
     version("1.0.3", sha256="f104daf55705c5093a3d984073f082017bc9166f51ded36c7f7bb8adf233c916")
     version("1.0.2", sha256="7dc02f1f499e0d9f2843440f517d6c8e5d10ea084cbb2567ec198ba06816bc8b")
+
+    def url_for_version(self, version):
+        url_base = "https://github.com/GEOS-ESM/GSIbec/archive/refs/tags/"
+        # Version 1.4.1+ has a v...
+        if version >= Version("1.4.1"):
+            url = url_base + "v{0}.tar.gz"
+        # older do not
+        else:
+            url = url_base + "{0}.tar.gz"
+
+        return url.format(version)
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")

--- a/repos/spack_repo/builtin/packages/gsibec/package.py
+++ b/repos/spack_repo/builtin/packages/gsibec/package.py
@@ -47,8 +47,8 @@ class Gsibec(CMakePackage):
     depends_on("jedi-cmake", type="build")
 
     # sp is used in 1.3.x and earlier and ip in 1.4.x and later
-    depends_on("ip", when="@1.4:", type="build")
-    depends_on("sp", when="@:1.3", type="build")
+    depends_on("ip@5", when="@1.4:", type=("build", "run"))
+    depends_on("sp", when="@:1.3", type=("build", "run"))
 
     def cmake_args(self):
         return [

--- a/repos/spack_repo/builtin/packages/gsibec/package.py
+++ b/repos/spack_repo/builtin/packages/gsibec/package.py
@@ -21,6 +21,9 @@ class Gsibec(CMakePackage):
     license("Apache-2.0")
 
     version("develop", branch="develop")
+    version("1.4.0", sha256="aa512995c32bd4a9998584a62707abed299fe34af4e9dbf5b44aebd335376e54")
+    version("1.3.1", sha256="fe7dbe7d170b47dbacc3febc42fc9877c118860b1532d70246bc73934e548185")
+    version("1.2.2", sha256="c15e6a2e75e6b4b0727490bff6a52c02c7309cc48a202e393009074ecf33b06a")
     version("1.2.1", sha256="83bf12ad6603d66e2e48b50cfcb57b7acd64e0d428a597a842db978a3277baf6")
     version("1.1.3", sha256="9cac000562250487c16608e8245d97457cc1663b1793b3833be5a76ebccb4b47")
     version("1.1.2", sha256="8bdcdf1663e6071b6ad9e893a76307abc70a6de744fb75a13986e70242993ada")
@@ -31,7 +34,8 @@ class Gsibec(CMakePackage):
     version("1.0.3", sha256="f104daf55705c5093a3d984073f082017bc9166f51ded36c7f7bb8adf233c916")
     version("1.0.2", sha256="7dc02f1f499e0d9f2843440f517d6c8e5d10ea084cbb2567ec198ba06816bc8b")
 
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
 
     depends_on("mpi", type=("build", "run"))
     depends_on("netcdf-c +mpi", type=("build", "run"))
@@ -41,7 +45,10 @@ class Gsibec(CMakePackage):
 
     depends_on("ecbuild", type="build")
     depends_on("jedi-cmake", type="build")
-    depends_on("sp", type="build")
+
+    # sp is used in 1.3.x and earlier and ip in 1.4.x and later
+    depends_on("ip", when="@1.4:", type="build")
+    depends_on("sp", when="@:1.3", type="build")
 
     def cmake_args(self):
         return [


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This adds [`gsibec`](https://github.com/GEOS-ESM/GSIbec/) 1.4.0 which also now depends on `ip`

ETA: I also added v1.4.1 which is now a v-tag so I had to fiddle with the package.