### PR TITLE
vasp: fix compilation with intel-oneapi-mkl as fftw provider

### DIFF
--- a/repos/spack_repo/builtin/packages/vasp/package.py
+++ b/repos/spack_repo/builtin/packages/vasp/package.py
@@ -247,6 +247,10 @@ class Vasp(MakefilePackage, CudaPackage):
         if spec.satisfies("%gcc@10:"):
             fflags.append("-fallow-argument-mismatch")
 
+        if spec.satisfies("^[virtuals=fftw-api] intel-oneapi-mkl"):
+            mklroot = env["MKLROOT"]
+            incs.append(f" -I{join_path(mklroot, 'include/fftw')}")
+
         filter_file(r"^VASP_TARGET_CPU[ ]{0,}\?=.*", "", make_include)
 
         if spec.satisfies("+fftlib"):


### PR DESCRIPTION
Compilation failed with `Cannot open include file 'fftw3.f'` because the MKL FFTW headers are not in the default include path. Adds `$MKLROOT/include/fftw` to the list of include directories to resolve the issue.