### PR TITLE
hdf5-vol-log: add variant for hdf5 examples

### DIFF
--- a/repos/spack_repo/builtin/packages/hdf5_vol_log/hdf5_examples_option.patch
+++ b/repos/spack_repo/builtin/packages/hdf5_vol_log/hdf5_examples_option.patch
@@ -1,0 +1,39 @@
+diff --git a/configure.ac b/configure.ac
+index b73901f..1f53de6 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -695,6 +695,14 @@ if test "x${have_openpmd}" = xyes; then
+ fi
+ AM_CONDITIONAL(HAVE_OPENPMD, [test "x${have_openpmd}" = xyes])
+ 
++hdf5_examples=yes
++AC_ARG_ENABLE([hdf5-examples],
++   [AS_HELP_STRING([--disable-hdf5-examples],
++                   [Disable hdf5 examples. @<:@default: enabled@:>@])],
++   [hdf5_examples=${enableval}], [hdf5_examples=yes]
++)
++AM_CONDITIONAL(HDF5_EXAMPLES, [test "x${hdf5_examples}" = xyes])
++
+ dnl Configuration Date
+ dnl Note that command 'date' is not portable across Unix platforms
+ if test "x$SOURCE_DATE_EPOCH" != x ; then
+diff --git a/examples/Makefile.am b/examples/Makefile.am
+index b209b5e..eb34ad5 100644
+--- a/examples/Makefile.am
++++ b/examples/Makefile.am
+@@ -58,9 +58,13 @@ SH_LOG_COMPILER =
+ 
+ TESTS = $(TESTPROGRAMS)
+ 
+-C_SUBDIRS = hdf5_examples
++C_SUBDIRS =
+ 
+-DIST_SUBDIRS = $(C_SUBDIRS) 
++if HDF5_EXAMPLES
++    C_SUBDIRS += hdf5_examples
++endif
++
++DIST_SUBDIRS = hdf5_examples
+ 
+ SUBDIRS = . $(C_SUBDIRS)
+ 

--- a/repos/spack_repo/builtin/packages/hdf5_vol_log/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5_vol_log/package.py
@@ -22,6 +22,8 @@ class Hdf5VolLog(AutotoolsPackage):
 
     version("1.4.0", tag="logvol.1.4.0", commit="786d2cc4da8b4a0827ee00b1b0ab3968ef942f99")
 
+    variant("hdf5_examples", default=True, description="Enable HDF5 examples", when="@1.4.0")
+
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
@@ -32,12 +34,18 @@ class Hdf5VolLog(AutotoolsPackage):
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
 
+    # Adds an option to disable examples downloaded during build
+    # https://github.com/HDFGroup/vol-log-based/pull/79
+    patch("hdf5_examples_option.patch", when="@1.4.0")
+
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         env.prepend_path("HDF5_PLUGIN_PATH", self.spec.prefix.lib)
 
     def configure_args(self):
-        return [
+        args = [
             "--enable-shared",
             "--enable-zlib",
             "--with-mpi={}".format(self.spec["mpi"].prefix),
         ]
+        args.extend(self.enable_or_disable("hdf5-examples", variant="hdf5_examples"))
+        return args


### PR DESCRIPTION
Adds a patch and a variant to be able to disable the hdf5 examples. These examples are normally downloaded during build, which causes errors when building on compute nodes at facilities such as Frontier.