### PR TITLE
hdf5-vol-cache: fix gcc 14+ error

### DIFF
--- a/repos/spack_repo/builtin/packages/hdf5_vol_cache/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5_vol_cache/package.py
@@ -32,6 +32,8 @@ class Hdf5VolCache(CMakePackage):
         if name == "cflags":
             if self.spec.satisfies("%oneapi") or self.spec.satisfies("%cce"):
                 flags.append("-Wno-error=incompatible-function-pointer-types")
+            if self.spec.satisfies("%gcc@14:"):
+                flags.append("-Wno-error=incompatible-pointer-types")
         return (flags, None, None)
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:


### PR DESCRIPTION
Avoid incompatible pointer types errors when compiling with gcc 14 and above.