### PR TITLE
ucx: add 1.20.0 release

### DIFF
--- a/repos/spack_repo/builtin/packages/ucx/package.py
+++ b/repos/spack_repo/builtin/packages/ucx/package.py
@@ -24,9 +24,10 @@ class Ucx(AutotoolsPackage, CudaPackage):
     version("master", branch="master", submodules=True)
 
     # Current
-    version("1.19.1", sha256="dea5d821fce05b6ffe175a74e6e148386dd85791409fc71242f3d1369100fd8a")
+    version("1.20.0", sha256="7c8a6093cada179aa1d851b83625e3b25ed5658966e309de5118c27a038c7ef9")
 
     # Still supported
+    version("1.19.1", sha256="dea5d821fce05b6ffe175a74e6e148386dd85791409fc71242f3d1369100fd8a")
     version("1.19.0", sha256="9af07d55281059542f20c5b411db668643543174e51ac71f53f7ac839164f285")
     version("1.18.1", sha256="8018dd75f11b5e8d6e57dcdb5b798d2c1f000982c353efde1f3170025c6c3b4c")
     version("1.18.0", sha256="fa75070f5fa7442731b4ef5fc9549391e147ed3d859afeb1dad2d4513b39dc33")


### PR DESCRIPTION
The official release: https://github.com/openucx/ucx/releases/tag/v1.20.0

Local test:

```
$ spack install ucx@1.20.0 %gcc@15.2
[+] /usr (external glibc-2.28-vuczjrbyzfif5nzgt5gqbrdrzaioihy6)
[+] /usr (external glibc-2.28-iyhte7x7am7ap6asyuvzpe5hklifmvq5)
[+] /lustre/linsword_google_com/spack/opt/spack/linux-zen2/compiler-wrapper-1.0-exvkrrolajpukyx65olskfy44acsmsq4
[+] /lustre/linsword_google_com/spack/opt/spack/linux-x86_64/gmp-6.3.0-zz422fiujptps3p7taslblruuyx5hpb4
[+] /lustre/linsword_google_com/spack/opt/spack/linux-x86_64/zlib-ng-2.2.4-zo435prtmut3ydx3iimmw5ccptuaqhtv
[+] /lustre/linsword_google_com/spack/opt/spack/linux-x86_64/zstd-1.5.7-y3hthfcobgumwfj765e6jmtx2bf5u4o6
[+] /lustre/linsword_google_com/spack/opt/spack/linux-zen2/gmake-4.4.1-7uyxdtkya27qfmmc372zxqux52oaefgv
[+] /lustre/linsword_google_com/spack/opt/spack/linux-zen2/pkgconf-2.5.1-nvoke73vy7yztpod5kviqrvks7sbf4og
[+] /lustre/linsword_google_com/spack/opt/spack/linux-x86_64/mpfr-4.2.1-nssqhr47iau2dxqosunpa4eq7zburnxz
[+] /lustre/linsword_google_com/spack/opt/spack/linux-x86_64/binutils-2.44-7zbzp74aaz4j3vupiq4atj4woeeiadas
[+] /lustre/linsword_google_com/spack/opt/spack/linux-x86_64/mpc-1.3.1-agxmo6zzh3ivvpaeoprnjpyzty7nss7v
[+] /lustre/linsword_google_com/spack/opt/spack/linux-x86_64/gcc-15.2.0-kihne2eyjaxedyvo6hkm4uwdn55ixatw
==> No binary for gcc-runtime-15.2.0-vk5ekyazhegjfc4xb6vsfou5vzbyrx3s found: installing from source
==> Installing gcc-runtime-15.2.0-vk5ekyazhegjfc4xb6vsfou5vzbyrx3s [13/14]
==> No patches needed for gcc-runtime
==> gcc-runtime: Executing phase: 'install'
==> gcc-runtime: Successfully installed gcc-runtime-15.2.0-vk5ekyazhegjfc4xb6vsfou5vzbyrx3s
  Stage: 0.00s.  Install: 0.68s.  Post-install: 0.23s.  Total: 1.15s
[+] /lustre/linsword_google_com/spack/opt/spack/linux-zen2/gcc-runtime-15.2.0-vk5ekyazhegjfc4xb6vsfou5vzbyrx3s
==> No binary for ucx-1.20.0-i7drxeqpk2lfeuv23t7aon3mm7jenmar found: installing from source
==> Installing ucx-1.20.0-i7drxeqpk2lfeuv23t7aon3mm7jenmar [14/14]
    [100%]    3.50 MB @   46.8 MB/s
==> Ran patch() for ucx
==> ucx: Executing phase: 'autoreconf'
==> ucx: Executing phase: 'configure'
==> ucx: Executing phase: 'build'
==> ucx: Executing phase: 'install'
==> ucx: Successfully installed ucx-1.20.0-i7drxeqpk2lfeuv23t7aon3mm7jenmar
  Stage: 0.89s.  Autoreconf: 0.00s.  Configure: 26.89s.  Build: 1m 12.62s.  Install: 3.50s.  Post-install: 0.81s.  Total: 1m 44.99s
[+] /lustre/linsword_google_com/spack/opt/spack/linux-zen2/ucx-1.20.0-i7drxeqpk2lfeuv23t7aon3mm7jenmar
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
