### PR TITLE
py-orjson: fix rust dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/py_orjson/package.py
+++ b/repos/spack_repo/builtin/packages/py_orjson/package.py
@@ -36,3 +36,4 @@ class PyOrjson(PythonPackage):
             depends_on("rust@1.60:")
             depends_on("python@3.7:")
             depends_on("py-maturin@0.13:0.14")
+        depends_on("rust@:1.89", when="@:3.11.1")

--- a/repos/spack_repo/builtin/packages/py_orjson/package.py
+++ b/repos/spack_repo/builtin/packages/py_orjson/package.py
@@ -36,4 +36,4 @@ class PyOrjson(PythonPackage):
             depends_on("rust@1.60:")
             depends_on("python@3.7:")
             depends_on("py-maturin@0.13:0.14")
-        depends_on("rust@:1.89", when="@:3.11.1")
+        depends_on("rust@:1.88", when="@:3.11.1")


### PR DESCRIPTION
I'm getting this error when trying to build `py-orjson@3.11.1`:
```
 error[E0554]: `#![feature]` may not be used on the stable release channel
   --> src/lib.rs:3:33
    |
  3 | #![cfg_attr(feature = "avx512", feature(stdarch_x86_avx512, avx512_target_feature))] // MSRV 1.89
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: the feature `avx512_target_feature` has been stable since `1.89.0` and no longer requires an attribute to enable
```
The issue is resolved when using a pre 1.89.0 version of rust