### PR TITLE
qt: ensure a cxxstd=11 icu4c is used

### DIFF
--- a/repos/spack_repo/builtin/packages/qt/package.py
+++ b/repos/spack_repo/builtin/packages/qt/package.py
@@ -252,7 +252,7 @@ class Qt(Package):
     depends_on("python", when="@5.7.0:", type="build")
 
     # Dependencies, then variant- and version-specific dependencies
-    depends_on("icu4c")
+    depends_on("icu4c@:74") # @75: requires cxxstd 17 which is not modelled here
     depends_on("jpeg")
     depends_on("libtiff")
     depends_on("libxml2")

--- a/repos/spack_repo/builtin/packages/qt/package.py
+++ b/repos/spack_repo/builtin/packages/qt/package.py
@@ -252,7 +252,7 @@ class Qt(Package):
     depends_on("python", when="@5.7.0:", type="build")
 
     # Dependencies, then variant- and version-specific dependencies
-    depends_on("icu4c@:74") # @75: requires cxxstd 17 which is not modelled here
+    depends_on("icu4c@:74")  # @75: requires cxxstd 17 which is not modelled here
     depends_on("jpeg")
     depends_on("libtiff")
     depends_on("libxml2")


### PR DESCRIPTION
This works around https://github.com/spack/spack-packages/issues/3283 by ensuring a non-`cxxstd=17` `icu4c` is used