### PR TITLE
sundials: fix missing blas dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/sundials/package.py
+++ b/repos/spack_repo/builtin/packages/sundials/package.py
@@ -245,6 +245,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
             when="+kokkos +rocm amdgpu_target=%s" % rocm_arch,
         )
     depends_on("lapack", when="+lapack")
+    depends_on("blas", when="+lapack")
     depends_on("hypre+mpi~int64", when="@5.7.1: +hypre ~int64")
     depends_on("hypre+mpi+int64", when="@5.7.1: +hypre +int64")
     depends_on("hypre@:2.22.0+mpi~int64", when="@:5.7.0 +hypre ~int64")


### PR DESCRIPTION
Fixes error:

```
==> Error: KeyError: 'No spec with name blas in sundials@7.6.0/fbzst2z34w7qlvh7dnzd7tbaapxnha7s'

/home/ubuntu/.spack/package_repos/fncqgg4/repos/spack_repo/builtin/packages/sundials/package.py:459, in cmake_args:
        456
        457        # Building with LAPACK
        458        if "+lapack" in spec:
  >>    459            args.append(define("LAPACK_LIBRARIES", spec["lapack"].libs + spec["blas"].libs))
        460
        461        # Building with MAGMA
        462        if "+magma" in spec:
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
