### PR TITLE
Add a basic Devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://raw.githubusercontent.com/devcontainers/spec/refs/heads/main/schemas/devContainer.base.schema.json",
+  "image": "ghcr.io/spack/ubuntu-noble:develop",
+  "mounts": [
+    {
+      "type": "volume",
+      "source": "spack-installs",
+      "target": "/opt/spack/opt/spack"
+    }
+  ],
+  "onCreateCommand": {
+    "setup-spack": "echo '. /opt/spack/share/spack/setup-env.sh' >> /etc/profile",
+    "add-workspace-as-repo": "/opt/spack/bin/spack repo add --scope site ${containerWorkspaceFolder}/repos/spack_repo/builtin",
+    "compile-for-generic-arch": "/opt/spack/bin/spack config --scope site add \"concretizer:targets:granularity:generic\"",
+    "stage-in-var-tmp": "/opt/spack/bin/spack config --scope site add \"config:build_stage:/var/tmp/spack-stage\""
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,8 @@
     }
   ],
   "onCreateCommand": {
-    "setup-spack": "echo '. /opt/spack/share/spack/setup-env.sh' >> /etc/profile",
+    "setup-spack-bashrc": "echo '. /opt/spack/share/spack/setup-env.sh' >> /root/.bashrc",
+    "setup-spack-profile": "echo '. /opt/spack/share/spack/setup-env.sh' >> /etc/profile",
     "add-workspace-as-repo": "/opt/spack/bin/spack repo add --scope site ${containerWorkspaceFolder}/repos/spack_repo/builtin",
     "compile-for-generic-arch": "/opt/spack/bin/spack config --scope site add \"concretizer:targets:granularity:generic\"",
     "stage-in-var-tmp": "/opt/spack/bin/spack config --scope site add \"config:build_stage:/var/tmp/spack-stage\""


### PR DESCRIPTION
[Development containers](https://containers.dev/)  ("Devcontainers") are a way to describe a reproducible and automatically generated development environment, based off a Docker or Podman container. These allow new (and current) developers and contributors start writing and testing code faster and reduce the barrier for entry.

Devcontainers is still largely a VSCode feature, but is slowly gaining traction among IDEs ([IntelliJ](https://www.jetbrains.com/help/idea/connect-to-devcontainer.html), [Zed](https://zed.dev/)) and cloud-hosted development ([GitHub Codespaces](https://github.com/features/codespaces), [Ona](https://ona.com/)). In addition, Devcontainers is *the* development model supported by "atomic" Linux distros such [Project Bluefin](https://projectbluefin.io/) (part of [Universal Blue](https://universal-blue.org/)).

This PR adds a boilerplate devcontainer spec based on the [`spack/ubuntu-noble:develop`](https://github.com/spack/spack/pkgs/container/ubuntu-noble) container image. The container is configured with a persistent volume for Spack installs, staging area in the container's `/var/tmp` (to avoid size issues if `/tmp` is a tmpfs), and builds for the generic architecture by default.