### PR TITLE
eigen: Make dependence on fortran optional

### DIFF
--- a/repos/spack_repo/builtin/packages/eigen/package.py
+++ b/repos/spack_repo/builtin/packages/eigen/package.py
@@ -48,7 +48,9 @@ class Eigen(CMakePackage, ROCmPackage):
     version("3.2.5", sha256="8068bd528a2ff3885eb55225c27237cf5cda834355599f05c2c85345db8338b4")
 
     variant("blas", description="Build BLAS implementation", when="@3.4.1:", default=False)
-    variant("lapack", description="Build LAPACK implementation", when="@3.4.1: +blas", default=False)
+    variant(
+        "lapack", description="Build LAPACK implementation", when="@3.4.1: +blas", default=False
+    )
     variant("nightly", description="run Nightly test", default=False)
 
     # TODO: https://eigen.tuxfamily.org/dox/TopicUsingBlasLapack.html

--- a/repos/spack_repo/builtin/packages/eigen/package.py
+++ b/repos/spack_repo/builtin/packages/eigen/package.py
@@ -47,10 +47,9 @@ class Eigen(CMakePackage, ROCmPackage):
     version("3.2.6", sha256="e097b8dcc5ad30d40af4ad72d7052e3f78639469baf83cffaadc045459cda21f")
     version("3.2.5", sha256="8068bd528a2ff3885eb55225c27237cf5cda834355599f05c2c85345db8338b4")
 
-    variant("blas", description="Build BLAS implementation", when="@3.4.1:", default=False)
-    variant(
-        "lapack", description="Build LAPACK implementation", when="@3.4.1: +blas", default=False
-    )
+    variant("blas", description="Build eigen-based BLAS", when="@3.4.1:", default=False)
+    variant("lapack", description="Build eigen-based LAPACK", when="@3.4.1:", default=False)
+
     variant("nightly", description="run Nightly test", default=False)
 
     # TODO: https://eigen.tuxfamily.org/dox/TopicUsingBlasLapack.html
@@ -83,6 +82,9 @@ class Eigen(CMakePackage, ROCmPackage):
         sha256="5d4521e391a4e62e1ee7a98df5dbb20f67c4a1210863babfdbfec0466c8d2b13",
         when="@5.0.0 platform=windows",
     )
+
+    # Building eigen-based LAPACK implementation requires to also build BLAS
+    conflicts("~blas", when="+lapack")
 
     conflicts("platform=windows", when="@3.4.1")
 

--- a/repos/spack_repo/builtin/packages/eigen/package.py
+++ b/repos/spack_repo/builtin/packages/eigen/package.py
@@ -47,6 +47,8 @@ class Eigen(CMakePackage, ROCmPackage):
     version("3.2.6", sha256="e097b8dcc5ad30d40af4ad72d7052e3f78639469baf83cffaadc045459cda21f")
     version("3.2.5", sha256="8068bd528a2ff3885eb55225c27237cf5cda834355599f05c2c85345db8338b4")
 
+    variant("blas", description="Build BLAS implementation", when="@3.4.1:", default=False)
+    variant("lapack", description="Build LAPACK implementation", when="@3.4.1: +blas", default=False)
     variant("nightly", description="run Nightly test", default=False)
 
     # TODO: https://eigen.tuxfamily.org/dox/TopicUsingBlasLapack.html
@@ -88,7 +90,8 @@ class Eigen(CMakePackage, ROCmPackage):
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
-    depends_on("fortran", type="build", when="@3.4.1:")
+    depends_on("fortran", type="build", when="@3.4.1: +lapack")
+    depends_on("fortran", type="build", when="@3.4.1:3 +blas")
 
     depends_on("cmake@3.10:", when="@3.4.1:", type="build")
     depends_on("cmake@3.5:", when="@3.4.0", type="build")
@@ -105,6 +108,8 @@ class Eigen(CMakePackage, ROCmPackage):
         args = [
             self.define("EIGEN_BUILD_TESTING", self.run_tests),
             self.define("EIGEN_LEAVE_TEST_IN_ALL_TARGET", self.run_tests),
+            self.define_from_variant("EIGEN_BUILD_BLAS", "blas"),
+            self.define_from_variant("EIGEN_BUILD_LAPACK", "lapack"),
         ]
 
         if self.spec.satisfies("@:3.4"):


### PR DESCRIPTION
Eigen's dependence on Fortran is optional. In particular, Fortran is required to build eigen-based implementations for LAPACK and, when @:3, for BLAS as well.

When @:3.4.0, eigen detects if Fortran is present, and it automatically enables ot disables BLAS and LAPACK based on that.

When @3.41:, eigen exposes 2 CMake variables, EIGEN_BUILD_BLAS and EIGEN_BUILD_LAPACK, to let the user control whether to build BLAS and LAPACK. These variables are ON by default when eigen is the top level project.

So I added 2 variants, blas and lapack, that control the above CMake variables, and that are only available when @:3.4.1. I made thme *False* by default to make them mimick the behavior of eigen @3.4.0 under recent spack versions. My understanding is that when Fortran is not explicitly required, CMake does find it (or should not find it...) and thus BLAS and LAPACK are disabled. 

I also tried to make +lapack dependent on +blas.

Hopefully this PR offers a workaround for #2514.
