### PR TITLE
readline: fix dependency in pkgconfig file

### DIFF
--- a/repos/spack_repo/builtin/packages/readline/package.py
+++ b/repos/spack_repo/builtin/packages/readline/package.py
@@ -97,3 +97,10 @@ class Readline(AutotoolsPackage, GNUMirrorPackage):
             flags.append("-g")
             return (None, flags, None)
         return (flags, None, None)
+
+    def configure_args(self):
+        spec = self.spec
+
+        config_args = ["--with-curses"]
+
+        return config_args

--- a/repos/spack_repo/builtin/packages/readline/package.py
+++ b/repos/spack_repo/builtin/packages/readline/package.py
@@ -99,8 +99,6 @@ class Readline(AutotoolsPackage, GNUMirrorPackage):
         return (flags, None, None)
 
     def configure_args(self):
-        spec = self.spec
-
         config_args = ["--with-curses"]
 
         return config_args


### PR DESCRIPTION
Ensure correct dependency on ncurses (and not the ancient termcap) is listed in the generated pkgconfig for readline. This is important for programs linking to readline, who will look for a (probably non-existent) termcap library, when readline was in fact built against ncurses.