### PR TITLE
python: add variants for reducing package size

### DIFF
--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -150,6 +150,8 @@ class Python(Package):
     )
 
     variant("shared", default=True, description="Enable shared libraries")
+    variant("static", default=False, description="Enable static libraries")
+    variant("tests", default=False, description="Build and install tests")
     variant("pic", default=True, description="Produce position-independent code (for shared libs)")
     variant(
         "optimizations",
@@ -628,6 +630,12 @@ class Python(Package):
             config_args.append("--enable-shared")
         else:
             config_args.append("--disable-shared")
+
+        if "~static" in spec:
+            config_args.append("--without-static-libpython")
+
+        if "~tests" in spec:
+            config_args.append("--disable-test-modules")
 
         config_args.append("--without-ensurepip")
 


### PR DESCRIPTION
The python package is quite large, add two variants to significantly reduce its size:
1. Not building and installing tests reduces package size from 350 MB to 180 MB.
2. Not building static libpython reduces the size by a further 70 MB.

```
$ du -sh opt/spack/linux-skylake/python-3.14.2-*
112M    opt/spack/linux-skylake/python-3.14.2-2g344vsv4lsjs3txfucezltsdkqqcsmp
181M    opt/spack/linux-skylake/python-3.14.2-lsxjzkeekcfqotfntw4nbxk64l6hoipm
344M    opt/spack/linux-skylake/python-3.14.2-zddolhwp56z6hdnghovgcmebdyxamtle
```