### PR TITLE
rocksdb: add 10.10.1 and reduce package size

### DIFF
--- a/repos/spack_repo/builtin/packages/rocksdb/package.py
+++ b/repos/spack_repo/builtin/packages/rocksdb/package.py
@@ -17,6 +17,7 @@ class Rocksdb(MakefilePackage):
     license("Apache-2.0 OR GPL-2.0-only")
 
     version("master", git=git, branch="master", submodules=True)
+    version("10.10.1", sha256="df2ff348f3fac8578fd4b727eee7267aaf90cd403c99b55e898d1db63fa8cff5")
     version("10.4.2", sha256="afccfab496556904900afacf7d99887f1d50cb893e5d2288bd502db233adacac")
     version("9.4.0", sha256="1f829976aa24b8ba432e156f52c9e0f0bd89c46dc0cc5a9a628ea70571c1551c")
     version("9.2.1", sha256="bb20fd9a07624e0dc1849a8e65833e5421960184f9c469d508b58ed8f40a780f")
@@ -38,9 +39,10 @@ class Rocksdb(MakefilePackage):
     variant("lz4", default=True, description="Enable lz4 compression support")
     variant("shared", default=True, description="Build shared library")
     variant("snappy", default=False, description="Enable snappy compression support")
-    variant("static", default=True, description="Build static library")
+    variant("static", default=False, description="Build static library")
     variant("zlib", default=True, description="Enable zlib compression support")
     variant("zstd", default=False, description="Enable zstandard compression support")
+    variant("debug", default=False, description="Enable debug symbols")
     variant("tbb", default=False, description="Enable Intel TBB support")
     variant("werror", default=False, description="Build with -Werror")
     variant("rtti", default=False, description="Build with RTTI")
@@ -71,7 +73,13 @@ class Rocksdb(MakefilePackage):
     phases = ["install"]
 
     def patch(self):
-        filter_file("-march=native", "", join_path("build_tools", "build_detect_platform"))
+        filter_file(
+            "-march=native", "", join_path("build_tools", "build_detect_platform"), string=True
+        )
+
+        if "~debug" in self.spec:
+            filter_file("CFLAGS += -g", "CFLAGS += ", "Makefile", string=True)
+            filter_file("CXXFLAGS += -g", "CXXFLAGS += ", "Makefile", string=True)
 
     def install(self, spec, prefix):
         cflags = []


### PR DESCRIPTION
The rocksdb package is huge by default. Two changes reduce its size:
1. Do not build the static library by default. This decreases the size from 1.4 GB to 300 MB.
2. Introduce a strip variant that is on by default and strips the libraries. This decreases the sizes of the static+shared and shared builds to 50 MB and 20 MB, respectively.

```
$ du -sh opt/spack/linux-skylake/rocksdb-10.10.1-*
17M	opt/spack/linux-skylake/rocksdb-10.10.1-krej4blwryb5eixb6y6obza6xav7pqyu
48M	opt/spack/linux-skylake/rocksdb-10.10.1-ncospq5pojyhbwvo2jjqbmcth4r4bnlj
1.4G	opt/spack/linux-skylake/rocksdb-10.10.1-ru567lgykpxksilmc62q7f35d7kvwapl
322M	opt/spack/linux-skylake/rocksdb-10.10.1-vuy2e3hkrmbq2apwlzk7pv3a2fawwrq2
```