### PR TITLE
curl: 8.18

### DIFF
--- a/repos/spack_repo/builtin/packages/curl/package.py
+++ b/repos/spack_repo/builtin/packages/curl/package.py
@@ -31,17 +31,9 @@ class Curl(NMakePackage, AutotoolsPackage, CMakePackage):
     license("curl")
 
     version("8.18.0", sha256="ffd671a3dad424fb68e113a5b9894c5d1b5e13a88c6bdf0d4af6645123b31faf")
-
-    with default_args(deprecated=True):
-        version(
-            "8.17.0", sha256="230032528ce5f85594d4f3eace63364c4244ccc3c801b7f8db1982722f2761f4"
-        )
-        version(
-            "8.15.0", sha256="699a6d2192322792c88088576cff5fe188452e6ea71e82ca74409f07ecc62563"
-        )
-        version(
-            "8.14.1", sha256="5760ed3c1a6aac68793fc502114f35c3e088e8cd5c084c2d044abdf646ee48fb"
-        )
+    version("8.17.0", sha256="230032528ce5f85594d4f3eace63364c4244ccc3c801b7f8db1982722f2761f4")
+    version("8.15.0", sha256="699a6d2192322792c88088576cff5fe188452e6ea71e82ca74409f07ecc62563")
+    version("8.14.1", sha256="5760ed3c1a6aac68793fc502114f35c3e088e8cd5c084c2d044abdf646ee48fb")
 
     # TODO: add dependencies for other possible TLS backends
 

--- a/repos/spack_repo/builtin/packages/curl/package.py
+++ b/repos/spack_repo/builtin/packages/curl/package.py
@@ -30,9 +30,18 @@ class Curl(NMakePackage, AutotoolsPackage, CMakePackage):
 
     license("curl")
 
-    version("8.17.0", sha256="230032528ce5f85594d4f3eace63364c4244ccc3c801b7f8db1982722f2761f4")
-    version("8.15.0", sha256="699a6d2192322792c88088576cff5fe188452e6ea71e82ca74409f07ecc62563")
-    version("8.14.1", sha256="5760ed3c1a6aac68793fc502114f35c3e088e8cd5c084c2d044abdf646ee48fb")
+    version("8.18.0", sha256="ffd671a3dad424fb68e113a5b9894c5d1b5e13a88c6bdf0d4af6645123b31faf")
+
+    with default_args(deprecated=True):
+        version(
+            "8.17.0", sha256="230032528ce5f85594d4f3eace63364c4244ccc3c801b7f8db1982722f2761f4"
+        )
+        version(
+            "8.15.0", sha256="699a6d2192322792c88088576cff5fe188452e6ea71e82ca74409f07ecc62563"
+        )
+        version(
+            "8.14.1", sha256="5760ed3c1a6aac68793fc502114f35c3e088e8cd5c084c2d044abdf646ee48fb"
+        )
 
     # TODO: add dependencies for other possible TLS backends
 
@@ -92,9 +101,11 @@ class Curl(NMakePackage, AutotoolsPackage, CMakePackage):
     # 3.0, which curl@7.63 requires
     depends_on("cmake@:3", when="build_system=cmake @:7.63")
 
+    depends_on("gnutls@3.6.5:", when="tls=gnutls @8.18:")
     depends_on("gnutls", when="tls=gnutls")
     depends_on("mbedtls@3: +pic", when="tls=mbedtls @8.17:")
     depends_on("mbedtls@2: +pic", when="tls=mbedtls")
+    depends_on("openssl@3:", when="tls=openssl @8.18:")
     depends_on("openssl", when="tls=openssl")
 
     depends_on("libidn2", when="+libidn2")


### PR DESCRIPTION
See https://daniel.haxx.se/blog/2026/01/07/curl-8-18-0/

Not deprecating older versions because they're still needed by some.