### PR TITLE
clingo: support version 6 wip better

### DIFF
--- a/repos/spack_repo/builtin/packages/clingo/package.py
+++ b/repos/spack_repo/builtin/packages/clingo/package.py
@@ -68,8 +68,8 @@ class Clingo(CMakePackage):
         depends_on("bison@2.5:", type="build", when="platform=darwin")
         depends_on("bison@2.5:", type="build", when="platform=freebsd")
 
-    with when("@develop"):
-        depends_on("re2c@2:", type="build")
+    with when("@6:"):
+        depends_on("re2c@3:", type="build")
         depends_on("cmake@3.22.1:", type="build")
 
     with when("@spack"):
@@ -99,7 +99,7 @@ class Clingo(CMakePackage):
     def patch(self):
         # In bootstrap/prototypes/*.json we don't want to have specs that work for any python
         # version, so this conditional patch lives here instead of being its own directive.
-        if self.spec.satisfies("@spack,5.3:5.4 ^python@3.9:"):
+        if self.spec.satisfies("@spack,5.3:5.4 %python@3.9:"):
             filter_file(
                 "if (!PyEval_ThreadsInitialized()) { PyEval_InitThreads(); }",
                 "",
@@ -120,31 +120,46 @@ class Clingo(CMakePackage):
 
     def cmake_args(self):
         args = [
-            self.define_from_variant("CLINGO_BUILD_APPS", "apps"),
-            self.define("CLINGO_BUILD_WITH_LUA", False),
             self.define("CLASP_INSTALL_LIB", True),
-            self.define("CLASP_WITH_THREADS", True),
+            self.define("CLASP_BUILD_WITH_THREADS", True),
+            self.define("CLINGO_BUILD_TESTS", False),
+            self.define("CLINGO_BUILD_EXAMPLES", False),
         ]
-        if self.spec.satisfies("+python"):
-            suffix = python(
-                "-c", "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))", output=str
-            ).strip()
-            args += [
-                self.define("CLINGO_REQUIRE_PYTHON", True),
-                self.define("CLINGO_BUILD_WITH_PYTHON", True),
-                self.define("PYCLINGO_USER_INSTALL", False),
-                self.define("PYCLINGO_USE_INSTALL_PREFIX", True),
-                self.define("PYCLINGO_INSTALL_DIR", python_platlib),
-                self.define("PYCLINGO_SUFFIX", suffix),
-                self.define("CLINGO_BUILD_PY_SHARED", self.cmake_py_shared),
-            ]
-        else:
-            args += [self.define("CLINGO_BUILD_WITH_PYTHON", False)]
 
-        # Use LTO also for non-Intel compilers please. This can be removed when they
-        # bump cmake_minimum_required to VERSION 3.9.
-        if self.spec.satisfies("+ipo"):
-            args.append(self.define("CMAKE_POLICY_DEFAULT_CMP0069", "NEW"))
+        if self.spec.satisfies("@:5"):
+            # Use LTO also for non-Intel compilers please. This can be removed when they
+            # bump cmake_minimum_required to VERSION 3.9.
+            if self.spec.satisfies("+ipo"):
+                args.append(self.define("CMAKE_POLICY_DEFAULT_CMP0069", "NEW"))
+
+            args += [
+                self.define_from_variant("CLINGO_BUILD_APPS", "apps"),
+                self.define("CLINGO_BUILD_WITH_LUA", False),
+            ]
+
+            if self.spec.satisfies("+python"):
+                suffix = python(
+                    "-c",
+                    "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))",
+                    output=str,
+                ).strip()
+                args += [
+                    self.define("CLINGO_REQUIRE_PYTHON", True),
+                    self.define("CLINGO_BUILD_WITH_PYTHON", True),
+                    self.define("PYCLINGO_USER_INSTALL", False),
+                    self.define("PYCLINGO_USE_INSTALL_PREFIX", True),
+                    self.define("PYCLINGO_INSTALL_DIR", python_platlib),
+                    self.define("PYCLINGO_SUFFIX", suffix),
+                    self.define("CLINGO_BUILD_PY_SHARED", self.cmake_py_shared),
+                ]
+            else:
+                args.append(self.define("CLINGO_BUILD_WITH_PYTHON", False))
+
+        elif self.spec.satisfies("@6:"):
+            args += [
+                self.define_from_variant("CLINGO_BUILD_APP", "apps"),
+                self.define_from_variant("CLINGO_BUILD_PYTHON", "python"),
+            ]
 
         return args
 


### PR DESCRIPTION
Clingo 6 has various changes. Apart from those, two others:

* `CLASP_BUILD_WITH_THREADS` has always been correct, so fix for both v5 and v6.
* `re2c` version is something incorrectly specified in their CMake, submitted PR upstream: https://github.com/potassco/clingo/pull/600