### PR TITLE
py-urllib3: 2.6.3

### DIFF
--- a/repos/spack_repo/builtin/packages/brotli/package.py
+++ b/repos/spack_repo/builtin/packages/brotli/package.py
@@ -15,14 +15,17 @@ class Brotli(CMakePackage):
 
     license("MIT")
 
-    version("1.1.0", sha256="e720a6ca29428b803f4ad165371771f5398faba397edf6778837a18599ea13ff")
-    version("1.0.9", sha256="f9e8d81d0405ba66d181529af42a3354f838c939095ff99930da6aa9cdf6fe46")
-    version("1.0.7", sha256="4c61bfb0faca87219ea587326c467b95acb25555b53d1a421ffa3c8a9296ee2c")
+    version("1.2.0", sha256="816c96e8e8f193b40151dad7e8ff37b1221d019dbcb9c35cd3fadbfe6477dfec")
 
-    depends_on("c", type="build")  # generated
+    with default_args(deprecated=True):
+        version("1.1.0", sha256="e720a6ca29428b803f4ad165371771f5398faba397edf6778837a18599ea13ff")
+        version("1.0.9", sha256="f9e8d81d0405ba66d181529af42a3354f838c939095ff99930da6aa9cdf6fe46")
+        version("1.0.7", sha256="4c61bfb0faca87219ea587326c467b95acb25555b53d1a421ffa3c8a9296ee2c")
 
-    @run_after("install")
+    depends_on("c", type="build")
+
+    @run_after("install", when="@:1.0")
     def darwin_fix(self):
-        # The shared library is not installed correctly on Darwin; fix this
+        # cmake_minimum_required(VERSION 2.8.6) issue related to install name. Fixed in v1.1+
         if self.spec.satisfies("platform=darwin"):
             fix_darwin_install_name(self.prefix.lib)

--- a/repos/spack_repo/builtin/packages/py_brotli/package.py
+++ b/repos/spack_repo/builtin/packages/py_brotli/package.py
@@ -11,11 +11,24 @@ class PyBrotli(PythonPackage):
     """Python bindings for the Brotli compression library."""
 
     homepage = "https://github.com/google/brotli"
-    pypi = "Brotli/Brotli-1.1.0.tar.gz"
+    pypi = "brotli/brotli-1.2.0.tar.gz"
 
     license("MIT")
 
-    version("1.1.0", sha256="81de08ac11bcb85841e440c13611c00b67d3bf82698314928d0b676362546724")
+    version("1.2.0", sha256="e310f77e41941c13340a95976fe66a8a95b01e783d430eeaf7a2f87e0a57dd0a")
+    version(
+        "1.1.0",
+        sha256="81de08ac11bcb85841e440c13611c00b67d3bf82698314928d0b676362546724",
+        url="https://files.pythonhosted.org/packages/source/b/Brotli/Brotli-1.1.0.tar.gz",
+        deprecated=True,
+    )
+
+    def setup_build_environment(self, env):
+        env.set("USE_SYSTEM_BROTLI", "1")
+
+    with when("@1.2:"):
+        depends_on("brotli", type="link")
+        depends_on("py-pkgconfig", type="build")
 
     depends_on("python", type=("build", "link", "run"))
     depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/py_brotli/package.py
+++ b/repos/spack_repo/builtin/packages/py_brotli/package.py
@@ -27,7 +27,7 @@ class PyBrotli(PythonPackage):
         env.set("USE_SYSTEM_BROTLI", "1")
 
     with when("@1.2:"):
-        depends_on("brotli", type="link")
+        depends_on("brotli@1.2:", type="link")
         depends_on("py-pkgconfig", type="build")
 
     depends_on("python", type=("build", "link", "run"))

--- a/repos/spack_repo/builtin/packages/py_urllib3/package.py
+++ b/repos/spack_repo/builtin/packages/py_urllib3/package.py
@@ -17,6 +17,7 @@ class PyUrllib3(PythonPackage):
 
     license("MIT")
 
+    version("2.6.3", sha256="1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed")
     version("2.5.0", sha256="3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760")
     version("2.3.0", sha256="f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d")
     version("2.1.0", sha256="df7aa8afb0148fa78488e7899b2c59b5f4ffcfa82e6c54ccb9dd37c1d7b52d54")
@@ -41,7 +42,7 @@ class PyUrllib3(PythonPackage):
     variant("secure", default=False, when="@:2.0", description="Add SSL/TLS support")
 
     depends_on("python@3.9:", when="@2.3:", type=("build", "run"))
-    depends_on("python@3.8:", when="@2.1.0:2.2", type=("build", "run"))
+    depends_on("python@3.8:", when="@2.1:", type=("build", "run"))
 
     depends_on("py-hatchling@1.6:1", when="@2:", type="build")
     depends_on("py-hatch-vcs@0.4:0.5", when="@2.5:", type="build")
@@ -49,6 +50,7 @@ class PyUrllib3(PythonPackage):
     depends_on("py-setuptools-scm@8", when="@2.5:", type="build")
 
     with when("+brotli"):
+        depends_on("py-brotli@1.2:", when="@2.6:", type=("build", "run"))
         depends_on("py-brotli@1.0.9:", when="@1.26.9:", type=("build", "run"))
 
         # Historical dependencies


### PR DESCRIPTION
in a follow-up we should probably deprecate < 2.6.3 due to a CVE.

* add 2.6.3
* update brotli dep and make it use Spack installed brotli (from the same sources...)
