### PR TITLE
python ecosystem: trivial bump

### DIFF
--- a/repos/spack_repo/builtin/packages/py_advancedhtmlparser/package.py
+++ b/repos/spack_repo/builtin/packages/py_advancedhtmlparser/package.py
@@ -17,6 +17,7 @@ class PyAdvancedhtmlparser(PythonPackage):
 
     license("LGPL-3.0-or-later")
 
+    version("9.0.2", sha256="837d17dadaa8eef87bf5773f05b5ddaceb76183b3dc13671e5550adf177f5465")
     version("9.0.1", sha256="1b7f632ca4c61fca50ee896c84112b97915c07d5b25b9527aefe7cbad8458837")
     version("8.1.4", sha256="21a73137026c8ec3248c654a24cc40064196029256cdf71681149f6835e9ed39")
 

--- a/repos/spack_repo/builtin/packages/py_alpaca_eval/package.py
+++ b/repos/spack_repo/builtin/packages/py_alpaca_eval/package.py
@@ -19,6 +19,7 @@ class PyAlpacaEval(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.2.9", sha256="31196aa288b37ca8356cf95a1b760a6e7cc1fe4045ebf779044b5ffe0f704aa6")
     version("0.2.8", sha256="5b21b74d7362ee229481b6a6d826dd620b2ef6b82e4f5470645e0a4b696a31e6")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_amici/package.py
+++ b/repos/spack_repo/builtin/packages/py_amici/package.py
@@ -13,6 +13,7 @@ class PyAmici(PythonPackage):
     homepage = "https://github.com/AMICI-dev/AMICI"
     pypi = "amici/amici-0.11.28.tar.gz"
 
+    version("0.16.1", sha256="aec799184cc96fcbda075ab2a4599890ab42474145e064cc57da995e38a49b28")
     version("0.16.0", sha256="1a2d6633ec34241d8d8b496d18d4318482cffe125e9ddf3ca6cac5d36d235f38")
     version("0.11.28", sha256="a8ddda70d8ebdc40600b4ad2ea02eb26e765ca0e594b957f61866b8c84255d5b")
 

--- a/repos/spack_repo/builtin/packages/py_annoy/package.py
+++ b/repos/spack_repo/builtin/packages/py_annoy/package.py
@@ -18,6 +18,7 @@ class PyAnnoy(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.17.3", sha256="9cbfebefe0a5f843eba29c6be4c84d601f4f41ad4ded0486f1b88c3b07739c15")
     version("1.17.1", sha256="bf177dbeafb81f63b2ac1e1246b1f26a2acc82e73ba46638734d29d8258122da")
 
     depends_on("cxx", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_apeye_core/package.py
+++ b/repos/spack_repo/builtin/packages/py_apeye_core/package.py
@@ -16,6 +16,7 @@ class PyApeyeCore(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.1.5", sha256="5de72ed3d00cc9b20fea55e54b7ab8f5ef8500eb33a5368bc162a5585e238a55")
     version("1.1.4", sha256="72bb89fed3baa647cb81aa28e1d851787edcbf9573853b5d2b5f87c02f50eaf5")
 
     depends_on("py-hatch-requirements-txt", type="build")

--- a/repos/spack_repo/builtin/packages/py_appnope/package.py
+++ b/repos/spack_repo/builtin/packages/py_appnope/package.py
@@ -13,6 +13,7 @@ class PyAppnope(PythonPackage):
     homepage = "https://github.com/minrk/appnope"
     pypi = "appnope/appnope-0.1.0.tar.gz"
 
+    version("0.1.4", sha256="1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee")
     version("0.1.3", sha256="02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24")
     version("0.1.0", sha256="8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71")
 

--- a/repos/spack_repo/builtin/packages/py_argcomplete/package.py
+++ b/repos/spack_repo/builtin/packages/py_argcomplete/package.py
@@ -15,6 +15,7 @@ class PyArgcomplete(PythonPackage):
 
     license("Apache-2.0")
 
+    version("3.6.3", sha256="62e8ed4fd6a45864acc8235409461b72c9a28ee785a2011cc5eb78318786c89c")
     version("3.6.2", sha256="d0519b1bc867f5f4f4713c41ad0aba73a4a5f007449716b16f385f2166dc6adf")
     version("3.5.0", sha256="4349400469dccfb7950bb60334a680c58d88699bff6159df61251878dc6bf74b")
     version("3.1.6", sha256="3b1f07d133332547a53c79437527c00be48cca3807b1d4ca5cab1b26313386a6")

--- a/repos/spack_repo/builtin/packages/py_arpeggio/package.py
+++ b/repos/spack_repo/builtin/packages/py_arpeggio/package.py
@@ -15,6 +15,7 @@ class PyArpeggio(PythonPackage):
 
     license("MIT")
 
+    version("2.0.3", sha256="9e85ad35cfc6c938676817c7ae9a1000a7c72a34c71db0c687136c460d12b85e")
     version("2.0.2", sha256="c790b2b06e226d2dd468e4fbfb5b7f506cec66416031fde1441cf1de2a0ba700")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_asttokens/package.py
+++ b/repos/spack_repo/builtin/packages/py_asttokens/package.py
@@ -15,6 +15,7 @@ class PyAsttokens(PythonPackage):
 
     license("Apache-2.0")
 
+    version("3.0.1", sha256="71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7")
     version("3.0.0", sha256="0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7")
     version("2.4.0", sha256="2e0171b991b2c959acc6c49318049236844a5da1d65ba2672c4880c1c894834e")
     version("2.2.1", sha256="4622110b2a6f30b77e1473affaa97e711bc2f07d3f10848420ff1898edbe94f3")

--- a/repos/spack_repo/builtin/packages/py_atpublic/package.py
+++ b/repos/spack_repo/builtin/packages/py_atpublic/package.py
@@ -17,6 +17,7 @@ class PyAtpublic(PythonPackage):
 
     license("Apache-2.0")
 
+    version("2.1.3", sha256="e0b274759bfbcb6eeb7c7b44a7a46391990a43ac77aa55359b075765b54d9f5d")
     version("2.1.2", sha256="82a2f2c0343ac67913f67cdee8fa4da294a4d6b863111527a459c8e4d1a646c8")
     version("2.1.1", sha256="fa1d48bcb85bbed90f6ffee6936578f65ff0e93aa607397bd88eaeb408bd96d8")
 

--- a/repos/spack_repo/builtin/packages/py_audioread/package.py
+++ b/repos/spack_repo/builtin/packages/py_audioread/package.py
@@ -16,6 +16,7 @@ class PyAudioread(PythonPackage):
 
     license("MIT")
 
+    version("2.1.9", sha256="a3480e42056c8e80a8192a54f6729a280ef66d27782ee11cbd63e9d4d1523089")
     version("2.1.8", sha256="073904fabc842881e07bd3e4a5776623535562f70b1655b635d22886168dd168")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_authlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_authlib/package.py
@@ -15,6 +15,7 @@ class PyAuthlib(PythonPackage):
     pypi = "authlib/authlib-1.6.5.tar.gz"
 
     license("BSD-3-Clause")
+    version("1.6.7", sha256="dbf10100011d1e1b34048c9d120e83f13b35d69a826ae762b93d2fb5aafc337b")
     version("1.6.5", sha256="6aaf9c79b7cc96c900f0b284061691c5d4e61221640a948fe690b556a6d6d10b")
 
     depends_on("python@3.9:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_avro_json_serializer/package.py
+++ b/repos/spack_repo/builtin/packages/py_avro_json_serializer/package.py
@@ -15,6 +15,7 @@ class PyAvroJsonSerializer(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.4.1", sha256="53cf797f8d828831bb5a77b1e2e950aee0568a2c7271d865ff8d8af6bfc9d138")
     version("0.4", sha256="f9dac2dac92036c5dd5aba8c716545fc0a0630cc365a51ab15bc2ac47eac28f1")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_avro_python3/package.py
+++ b/repos/spack_repo/builtin/packages/py_avro_python3/package.py
@@ -17,6 +17,7 @@ class PyAvroPython3(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.10.2", sha256="3b63f24e6b04368c3e4a6f923f484be0230d821aad65ac36108edbff29e9aaab")
     version("1.10.0", sha256="a455c215540b1fceb1823e2a918e94959b54cb363307c97869aa46b5b55bde05")
     version("1.9.1", sha256="daab2cea71b942a1eb57d700d4a729e9d6cd93284d4dd4d65a378b9f958aa0d2")
 

--- a/repos/spack_repo/builtin/packages/py_azure_multiapi_storage/package.py
+++ b/repos/spack_repo/builtin/packages/py_azure_multiapi_storage/package.py
@@ -17,6 +17,7 @@ class PyAzureMultiapiStorage(PythonPackage):
 
     license("MIT")
 
+    version("0.3.7", sha256="de137ed313673014e8f740e99a9865ffccc5d2ad74e2f8c152428c73b4684411")
     version("0.3.5", sha256="71c238c785786a159b3ffd587a5e7fa1d9a517b66b592ae277fed73a9fbfa2b0")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_b2luigi/package.py
+++ b/repos/spack_repo/builtin/packages/py_b2luigi/package.py
@@ -24,6 +24,7 @@ class PyB2luigi(PythonPackage):
     # maintainers("github_user1", "github_user2")
 
     # We start at 1.2.6 as this was the change from retry2->tenacity dependency
+    version("1.2.7", sha256="9f2622bb5f8f8645a0ef2546c3125164e3d5ab167c1e2519b1593e930733df40")
     version("1.2.6", sha256="9f3be756f0961ca2241d36d9a9174ea5a23ebd7787cbfa78632047aae25f1202")
 
     depends_on("python@3.8:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_bcbio_gff/package.py
+++ b/repos/spack_repo/builtin/packages/py_bcbio_gff/package.py
@@ -13,6 +13,7 @@ class PyBcbioGff(PythonPackage):
 
     pypi = "bcbio-gff/bcbio-gff-0.6.2.tar.gz"
 
+    version("0.7.1", sha256="d1dc3294147b95baced6033f6386a0fed45c43767ef02d1223df5ef497e9cca6")
     version("0.7.0", sha256="f7b3922ee274106f8716703f41f05a1795aa9d73e903f4e481995ed8f5f65d2d")
     version("0.6.2", sha256="c682dc46a90e9fdb124ab5723797a5f71b2e3534542ceff9f6572b64b9814e68")
 

--- a/repos/spack_repo/builtin/packages/py_bdbag/package.py
+++ b/repos/spack_repo/builtin/packages/py_bdbag/package.py
@@ -18,6 +18,7 @@ class PyBdbag(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.6.4", sha256="bd6fb725bf32cf8dc82ec95dd4aaec57b5615452b611447aefbd325a9583228e")
     version("1.6.3", sha256="1ad2e4956045cb3d43a6276391ad919e42a90a2443727dbc5b1ac6eeb6d6e3c9")
 
     depends_on("python@2.7:2,3.5:3", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_beaker/package.py
+++ b/repos/spack_repo/builtin/packages/py_beaker/package.py
@@ -18,6 +18,7 @@ class PyBeaker(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.12.1", sha256="57770b40956e6c5cf1d8221dc59519029e470080ed8d3065c4e6ab36ce7e3c81")
     version("1.12.0", sha256="2d5f427e3b13259c98c934cab0e428fc1c18a4c4b94acbdae930df7e7f51d1ec")
     version("1.11.0", sha256="ad5d1c05027ee3be3a482ea39f8cb70339b41e5d6ace0cb861382754076d187e")
 

--- a/repos/spack_repo/builtin/packages/py_beartype/package.py
+++ b/repos/spack_repo/builtin/packages/py_beartype/package.py
@@ -15,6 +15,7 @@ class PyBeartype(PythonPackage):
 
     license("MIT")
 
+    version("0.16.4", sha256="1ada89cf2d6eb30eb6e156eed2eb5493357782937910d74380918e53c2eae0bf")
     version("0.16.2", sha256="47ec1c8c3be3f999f4f9f829e8913f65926aa7e85b180d9ffd305dc78d3e7d7b")
     version("0.15.0", sha256="2af6a8d8a7267ccf7d271e1a3bd908afbc025d2a09aa51123567d7d7b37438df")
 

--- a/repos/spack_repo/builtin/packages/py_beautifulsoup4/package.py
+++ b/repos/spack_repo/builtin/packages/py_beautifulsoup4/package.py
@@ -20,6 +20,7 @@ class PyBeautifulsoup4(PythonPackage):
     # Requires pytest
     skip_modules = ["bs4.tests"]
 
+    version("4.13.5", sha256="5e70131382930e7c3de33450a2f54a63d5e4b19386eab43a5b34d594268f3695")
     version("4.13.4", sha256="dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195")
     version("4.12.3", sha256="74e3d1928edc070d21748185c46e3fb33490f22f52a3addee9aee0f4f7781051")
     version("4.12.2", sha256="492bbc69dca35d12daac71c4db1bfff0c876c00ef4a2ffacce226d4638eb72da")

--- a/repos/spack_repo/builtin/packages/py_bids_validator_deno/package.py
+++ b/repos/spack_repo/builtin/packages/py_bids_validator_deno/package.py
@@ -15,7 +15,7 @@ class PyBidsValidatorDeno(PythonPackage):
 
     license("MIT")
 
-    version("2.0.9", sha256="8766e2cb0e53479453f05e4782a9e8cd41e9df18018d8639fff54dd6a3ad4a7b")
+    version("2.0.11", sha256="c6724949dae74f82964d0db4af6b3fe933a22717f6f32139ccd991acb6826e5b")
     version("2.0.7", sha256="55a46dc9e134c2996ecb077896aad65e5320f3c864b41c47e108011f8fd1e2d1")
 
     depends_on("py-pdm-backend", type="build")

--- a/repos/spack_repo/builtin/packages/py_bids_validator_deno/package.py
+++ b/repos/spack_repo/builtin/packages/py_bids_validator_deno/package.py
@@ -15,6 +15,7 @@ class PyBidsValidatorDeno(PythonPackage):
 
     license("MIT")
 
+    version("2.0.9", sha256="8766e2cb0e53479453f05e4782a9e8cd41e9df18018d8639fff54dd6a3ad4a7b")
     version("2.0.7", sha256="55a46dc9e134c2996ecb077896aad65e5320f3c864b41c47e108011f8fd1e2d1")
 
     depends_on("py-pdm-backend", type="build")

--- a/repos/spack_repo/builtin/packages/py_billiard/package.py
+++ b/repos/spack_repo/builtin/packages/py_billiard/package.py
@@ -14,6 +14,7 @@ class PyBilliard(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("4.2.4", sha256="55f542c371209e03cd5862299b74e52e4fbcba8250ba611ad94276b369b6a85f")
     version("4.2.0", sha256="9a3c3184cb275aa17a732f93f65b20c525d3d9f253722d26a82194803ade5a2c")
     version("3.6.4.0", sha256="299de5a8da28a783d51b197d496bef4f1595dd023a93a4f59dde1886ae905547")
     version("3.6.3.0", sha256="d91725ce6425f33a97dfa72fb6bfef0e47d4652acd98a032bd1a7fbf06d5fa6a")

--- a/repos/spack_repo/builtin/packages/py_biobb_io/package.py
+++ b/repos/spack_repo/builtin/packages/py_biobb_io/package.py
@@ -16,6 +16,7 @@ class PyBiobbIo(PythonPackage):
     maintainers("d-beltran")
 
     # Versions
+    version("4.1.1", sha256="2bccb966ab28bc6f63d1f09309c1a300392643fbfaf66ca690f8f7fad7abe516")
     version("4.1.0", sha256="074ea97a3682731e13d559b7f91b04e4a3f0f02ee798503089e4af79a730bf72")
 
     # Dependencies

--- a/repos/spack_repo/builtin/packages/py_biobb_structure_checking/package.py
+++ b/repos/spack_repo/builtin/packages/py_biobb_structure_checking/package.py
@@ -17,6 +17,7 @@ class PyBiobbStructureChecking(PythonPackage):
     maintainers("d-beltran")
 
     # Versions
+    version("3.13.5", sha256="4ba074da556a7aecac215f2020a04274c05f155413ed467177b9c9f31a53d4d0")
     version("3.13.4", sha256="d819819d13c7ad219411b70b043555dcd65d5535f696a1121db562646931f445")
 
     # Dependencies

--- a/repos/spack_repo/builtin/packages/py_bioblend/package.py
+++ b/repos/spack_repo/builtin/packages/py_bioblend/package.py
@@ -16,6 +16,7 @@ class PyBioblend(PythonPackage):
 
     license("MIT")
 
+    version("1.0.1", sha256="2b2213c2ed785edfe2a5673499cf24f85b2df0daf9fbdb498fa1f79d4e4367b5")
     version("1.0.0", sha256="3794288bbf891ae6edc1bcdd9618a3ae16b6ed4a04c946505f7e29f2f28898a5")
 
     depends_on("python@3.7:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_biopandas/package.py
+++ b/repos/spack_repo/builtin/packages/py_biopandas/package.py
@@ -20,6 +20,7 @@ class PyBiopandas(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.2.9", sha256="417e84bac4dddf6728a4c1960efef35f7bdb72da5688317e23c0bcd964645f83")
     version("0.2.5", branch="v0.2.5")
 
     depends_on("python@3.5:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_biosppy/package.py
+++ b/repos/spack_repo/builtin/packages/py_biosppy/package.py
@@ -15,6 +15,7 @@ class PyBiosppy(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("2.2.4", sha256="0b52eb27a410fe24c01bd15dd4a85149d20ac0026f73e03b9c61bf99577dcca5")
     version("2.2.3", sha256="2c4b84c98c71e3e84b43bf09a855414c31f534a8aed84e59fb05bbc3c36d9aa9")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_biotraj/package.py
+++ b/repos/spack_repo/builtin/packages/py_biotraj/package.py
@@ -15,6 +15,7 @@ class PyBiotraj(PythonPackage):
 
     license("LGPL-2.1")
 
+    version("1.2.2", sha256="4bcba92101ed50f369cc1487fb5dfcfe1d8402ad47adaa9232b080553271663a")
     version("1.2.1", sha256="4d7ad33ad940dbcfb3c2bd228a18f33f88e04657786a9562173b58dc2dd05349")
 
     depends_on("python@3.10:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_blessed/package.py
+++ b/repos/spack_repo/builtin/packages/py_blessed/package.py
@@ -17,6 +17,7 @@ class PyBlessed(PythonPackage):
 
     license("MIT")
 
+    version("1.19.1", sha256="9a0d099695bf621d4680dd6c73f6ad547f6a3442fbdbe80c4b1daa1edbc492fc")
     version("1.19.0", sha256="4db0f94e5761aea330b528e84a250027ffe996b5a94bf03e502600c9a5ad7a61")
     version("1.18.1", sha256="8b09936def6bc06583db99b65636b980075733e13550cb6af262ce724a55da23")
     version("1.18.0", sha256="1312879f971330a1b7f2c6341f2ae7e2cbac244bfc9d0ecfbbecd4b0293bc755")

--- a/repos/spack_repo/builtin/packages/py_blessings/package.py
+++ b/repos/spack_repo/builtin/packages/py_blessings/package.py
@@ -15,6 +15,7 @@ class PyBlessings(PythonPackage):
 
     license("MIT")
 
+    version("1.6.1", sha256="74919575885552e14bc24a68f8b539690bd1b5629180faa830b1a25b8c7fb6ea")
     version("1.6", sha256="edc5713061f10966048bf6b40d9a514b381e0ba849c64e034c4ef6c1847d3007")
 
     # Needs 2to3

--- a/repos/spack_repo/builtin/packages/py_bluepyefe/package.py
+++ b/repos/spack_repo/builtin/packages/py_bluepyefe/package.py
@@ -13,7 +13,6 @@ class PyBluepyefe(PythonPackage):
     pypi = "bluepyefe/bluepyefe-2.2.18.tar.gz"
     git = "https://github.com/BlueBrain/BluePyEfe.git"
 
-    version("2.3.9", sha256="6e30fe05e1b38184f61c2b163bcdae83960237fc927ed95ef22bc870b7430c21")
     version("2.3.6", sha256="e52117372c41bfa3796e7a340d04b9c4b14f9ebcaacb9d36e947f3d041eb7e35")
     version("2.2.18", sha256="bfb50c6482433ec2ffb4b65b072d2778bd89ae50d92dd6830969222aabb30275")
 

--- a/repos/spack_repo/builtin/packages/py_bluepyefe/package.py
+++ b/repos/spack_repo/builtin/packages/py_bluepyefe/package.py
@@ -13,6 +13,7 @@ class PyBluepyefe(PythonPackage):
     pypi = "bluepyefe/bluepyefe-2.2.18.tar.gz"
     git = "https://github.com/BlueBrain/BluePyEfe.git"
 
+    version("2.3.9", sha256="6e30fe05e1b38184f61c2b163bcdae83960237fc927ed95ef22bc870b7430c21")
     version("2.3.6", sha256="e52117372c41bfa3796e7a340d04b9c4b14f9ebcaacb9d36e947f3d041eb7e35")
     version("2.2.18", sha256="bfb50c6482433ec2ffb4b65b072d2778bd89ae50d92dd6830969222aabb30275")
 

--- a/repos/spack_repo/builtin/packages/py_bmtk/package.py
+++ b/repos/spack_repo/builtin/packages/py_bmtk/package.py
@@ -15,6 +15,7 @@ class PyBmtk(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.0.8", sha256="9609da6347e74b440a44590f22fc2de0b281fc2eed4c1ee259730c5a8b3c0535")
     version("1.0.7", sha256="11e85098cf3c940a3d64718645f4a24ee13c8a47438ef5d28e054cb27ee01702")
     version("1.0.5", sha256="e0cb47b334467a6d124cfb99bbc67cc88f39f0291f4c39929f50d153130642a4")
 

--- a/repos/spack_repo/builtin/packages/py_bokeh/package.py
+++ b/repos/spack_repo/builtin/packages/py_bokeh/package.py
@@ -15,6 +15,7 @@ class PyBokeh(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("3.7.3", sha256="70a89a9f797b103d5ee6ad15fb7944adda115cf0da996ed0b75cfba61cb12f2b")
     version("3.7.2", sha256="80c21885cec276431acd4db92f831c71eb999ea995470ce777e0c577b0cfc1d8")
     version("3.5.2", sha256="03a54a67db677b8881834271c620a781b383ae593af5c3ea2149164754440d07")
     version("3.3.1", sha256="2a7b3702d7e9f03ef4cd801b02b7380196c70cff2773859bcb84fa565218955c")

--- a/repos/spack_repo/builtin/packages/py_branca/package.py
+++ b/repos/spack_repo/builtin/packages/py_branca/package.py
@@ -15,6 +15,7 @@ class PyBranca(PythonPackage):
 
     license("MIT")
 
+    version("0.7.2", sha256="ca4c94643ef31b819987ca5bd19c6009ea17b440baa3aac04628545f7a4da023")
     version("0.7.1", sha256="e6b6f37a37bc0abffd960c68c045a7fe025d628eff87fedf6ab6ca814812110c")
 
     depends_on("python@3.7:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_brian/package.py
+++ b/repos/spack_repo/builtin/packages/py_brian/package.py
@@ -13,6 +13,7 @@ class PyBrian(PythonPackage):
     homepage = "https://www.briansimulator.org"
     pypi = "brian/brian-1.4.3.tar.gz"
 
+    version("1.4.4", sha256="72937607ac7207056f21b87bad3ca439e536ce4dbf8051f43f8681f99af97ce2")
     version("1.4.3", sha256="c881dcfcd1a21990f9cb3cca76cdd868111cfd9e227ef5c1b13bb372d2efeaa4")
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_bsddb3/package.py
+++ b/repos/spack_repo/builtin/packages/py_bsddb3/package.py
@@ -17,6 +17,7 @@ class PyBsddb3(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("6.2.9", sha256="70d05ec8dc568f42e70fc919a442e0daadc2a905a1cfb7ca77f549d49d6e7801")
     version("6.2.5", sha256="784bf40ad935258507594a89b32ea11f362cde120751c8b96de163955ced7db8")
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_cachetools/package.py
+++ b/repos/spack_repo/builtin/packages/py_cachetools/package.py
@@ -17,6 +17,7 @@ class PyCachetools(PythonPackage):
 
     license("MIT")
 
+    version("5.2.1", sha256="5991bc0e08a1319bb618d3195ca5b6bc76646a49c21d55962977197b301cc1fe")
     version("5.2.0", sha256="6a94c6402995a99c3970cc7e4884bb60b4a8639938157eeed436098bf9831757")
     version("4.2.4", sha256="89ea6f1b638d5a73a4f9226be57ac5e4f399d22770b92355f92dcb0f7f001693")
     version("4.2.2", sha256="61b5ed1e22a0924aed1d23b478f37e8d52549ff8a961de2909c69bf950020cff")

--- a/repos/spack_repo/builtin/packages/py_casadi/package.py
+++ b/repos/spack_repo/builtin/packages/py_casadi/package.py
@@ -15,6 +15,7 @@ class PyCasadi(PythonPackage):
 
     license("LGPL")
 
+    version("3.6.7", sha256="21cde87288afebb32a2a035bf6b6a91a025e24ee14aba7a0ae5515707b9887c1")
     version("3.6.4", sha256="affdca1a99c14580992cdf34d247754b7d851080b712c2922ad2e92442eeaa35")
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_cdo/package.py
+++ b/repos/spack_repo/builtin/packages/py_cdo/package.py
@@ -15,6 +15,7 @@ class PyCdo(PythonPackage):
 
     maintainers("Try2Code", "skosukhin")
 
+    version("1.5.7", sha256="898c2b0ff97ec494569e5d94302350538efa898d42998bfed76b4f52c6c16f3c")
     version("1.5.6", sha256="fec1a75382f01b3c9c368e8f143d98b12323e06975663f87d9b60c739ae1d335")
 
     depends_on("python@2.7:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_cheap_repr/package.py
+++ b/repos/spack_repo/builtin/packages/py_cheap_repr/package.py
@@ -15,6 +15,7 @@ class PyCheapRepr(PythonPackage):
 
     license("MIT", checked_by="jmlapre")
 
+    version("0.5.2", sha256="001a5cf8adb0305c7ad3152c5f776040ac2a559d97f85770cebcb28c6ca5a30f")
     version("0.5.1", sha256="31ec63b9d8394aa23d746c8376c8307f75f9fca0b983566b8bcf13cc661fe6dd")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_chemfiles/package.py
+++ b/repos/spack_repo/builtin/packages/py_chemfiles/package.py
@@ -17,6 +17,7 @@ class PyChemfiles(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.10.4", sha256="f9e5ece3fcc8b63fdc2708d4ecc2ba5862ae2ab6790447bffc10c1b34ef2f445")
     version("0.10.3", sha256="4bbb8b116492a57dbf6ddb4c84aad0133cd782e0cc0e53e4b957f2d93e6806ea")
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_cheroot/package.py
+++ b/repos/spack_repo/builtin/packages/py_cheroot/package.py
@@ -16,6 +16,7 @@ class PyCheroot(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("8.3.1", sha256="7076d5845f64d729e4155ec2650ad24ee70209340d11b9e619a82e9210a579b8")
     version("8.3.0", sha256="a0577e1f28661727d472671a7cc4e0c12ea0cbc5220265e70f00a8b8cb628931")
     version("6.5.5", sha256="f6a85e005adb5bc5f3a92b998ff0e48795d4d98a0fbb7edde47a7513d4100601")
 

--- a/repos/spack_repo/builtin/packages/py_cherrypy/package.py
+++ b/repos/spack_repo/builtin/packages/py_cherrypy/package.py
@@ -15,6 +15,7 @@ class PyCherrypy(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("18.1.2", sha256="48de31ba3db04c5354a0fcf8acf21a9c5190380013afca746d50237c9ebe70f0")
     version("18.1.1", sha256="6585c19b5e4faffa3613b5bf02c6a27dcc4c69a30d302aba819639a2af6fa48b")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_ci_sdr/package.py
+++ b/repos/spack_repo/builtin/packages/py_ci_sdr/package.py
@@ -18,6 +18,7 @@ class PyCiSdr(PythonPackage):
 
     license("MIT")
 
+    version("0.0.2", sha256="3f9d4c205b9b7c5c3239a90400b81f1f26ecb38484a46150d2677ff646a13465")
     version("0.0.0", sha256="a1387f39ccd55cce034e2c01000a0a337b3729d8a5010b42c5381d8c820fa4bb")
 
     depends_on("python@3.6:3", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_cinemasci/package.py
+++ b/repos/spack_repo/builtin/packages/py_cinemasci/package.py
@@ -18,6 +18,7 @@ class PyCinemasci(PythonPackage):
 
     maintainers("EthanS94")
 
+    version("1.7.9", sha256="ceab37e9d9f5c9b9bd94c12200ae05fb5a866c6f6a4ecae51db1858971998bfb")
     version("1.7.0", sha256="70e1fa494bcbefdbd9e8859cdf1b01163a94ecffcdfa3da1011e4ef2fcee6169")
     version("1.3", sha256="c024ca9791de9d78e5dad3fd11e8f87d8bc1afa5830f2697d7ec4116a5d23c20")
 

--- a/repos/spack_repo/builtin/packages/py_click/package.py
+++ b/repos/spack_repo/builtin/packages/py_click/package.py
@@ -16,6 +16,7 @@ class PyClick(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("8.2.2", sha256="068616e6ef9705a07b6db727cb9c248f4eb9dae437a30239f56fa94b18b852ef")
     version("8.2.1", sha256="27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202")
     version("8.1.8", sha256="ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a")
     version("8.1.7", sha256="ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de")

--- a/repos/spack_repo/builtin/packages/py_colorclass/package.py
+++ b/repos/spack_repo/builtin/packages/py_colorclass/package.py
@@ -15,6 +15,7 @@ class PyColorclass(PythonPackage):
 
     license("MIT")
 
+    version("2.2.2", sha256="6d4fe287766166a98ca7bc6f6312daf04a0481b1eda43e7173484051c0ab4366")
     version("2.2.0", sha256="b05c2a348dfc1aff2d502527d78a5b7b7e2f85da94a96c5081210d8e9ee8e18b")
 
     depends_on("python@3.3.0:")

--- a/repos/spack_repo/builtin/packages/py_colored/package.py
+++ b/repos/spack_repo/builtin/packages/py_colored/package.py
@@ -18,6 +18,7 @@ class PyColored(PythonPackage):
     homepage = "https://gitlab.com/dslackw/colored"
     pypi = "colored/colored-1.4.2.tar.gz"
 
+    version("2.2.5", sha256="60cc61ea656cd3e753380fbc19fc62b0f65b60b2a096ba01bc476d6738ace441")
     version("2.2.4", sha256="595e1dd7f3b472ea5f12af21d2fec8a2ea2cf8f9d93e67180197330b26df9b61")
     version("1.4.2", sha256="056fac09d9e39b34296e7618897ed1b8c274f98423770c2980d829fd670955ed")
 

--- a/repos/spack_repo/builtin/packages/py_colorful/package.py
+++ b/repos/spack_repo/builtin/packages/py_colorful/package.py
@@ -16,6 +16,7 @@ class PyColorful(PythonPackage):
 
     license("MIT")
 
+    version("0.5.8", sha256="bb16502b198be2f1c42ba3c52c703d5f651d826076817185f0294c1a549a7445")
     version("0.5.4", sha256="86848ad4e2eda60cd2519d8698945d22f6f6551e23e95f3f14dfbb60997807ea")
 
     depends_on("python@2.7:2.8,3.4:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_comm/package.py
+++ b/repos/spack_repo/builtin/packages/py_comm/package.py
@@ -15,6 +15,7 @@ class PyComm(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.2.3", sha256="2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971")
     version("0.2.2", sha256="3fd7a84065306e07bea1773df6eb8282de51ba82f77c72f9c85716ab11fe980e")
     version("0.1.4", sha256="354e40a59c9dd6db50c5cc6b4acc887d82e9603787f83b68c01a80a923984d15")
     version("0.1.3", sha256="a61efa9daffcfbe66fd643ba966f846a624e4e6d6767eda9cf6e993aadaab93e")

--- a/repos/spack_repo/builtin/packages/py_conda_inject/package.py
+++ b/repos/spack_repo/builtin/packages/py_conda_inject/package.py
@@ -15,6 +15,7 @@ class PyCondaInject(PythonPackage):
 
     license("MIT")
 
+    version("1.3.2", sha256="0b8cde8c47998c118d8ff285a04977a3abcf734caf579c520fca469df1cd0aac")
     version("1.3.1", sha256="9e8d902230261beba74083aae12c2c5a395e29b408469fefadc8aaf51ee441e5")
 
     depends_on("py-pyyaml@6", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_consolekit/package.py
+++ b/repos/spack_repo/builtin/packages/py_consolekit/package.py
@@ -16,6 +16,7 @@ class PyConsolekit(PythonPackage):
 
     license("MIT")
 
+    version("1.5.2", sha256="bc0cbcab4a40abbc3dbd8fa7058bc4c7fa4181d55a2adbfaa854d41f1a16db87")
     version("1.5.1", sha256="55ea43e226863e1d618ec9b860c9842d84249d895c3376c03b158d8f3a335626")
 
     depends_on("py-flit-core@3.2:3", type="build")

--- a/repos/spack_repo/builtin/packages/py_convokit/package.py
+++ b/repos/spack_repo/builtin/packages/py_convokit/package.py
@@ -15,6 +15,7 @@ class PyConvokit(PythonPackage):
     homepage = "https://convokit.cornell.edu/"
     pypi = "convokit/convokit-2.5.tar.gz"
 
+    version("2.5.3", sha256="f0995363d60fe4c6697ccd6884fae4844d3c54b45a20b4eca4dfa1f4b3d861ae")
     version("2.5", sha256="90de76c2a2df69eedeb20e0b89ff293a51180fb0152189f108c3331b7b7bb698")
 
     depends_on("python@3.6:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_corner/package.py
+++ b/repos/spack_repo/builtin/packages/py_corner/package.py
@@ -17,6 +17,7 @@ class PyCorner(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("2.2.3", sha256="471b7b63395d8f1dee176bb779348ade38d56abd23404a48802a593607745e1c")
     version("2.2.2", sha256="4bc79f3b6778c270103f0926e64ef2606c48c3b6f92daf5382fc4babf5d608d1")
 
     depends_on("python@3.9:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_cryptography/package.py
+++ b/repos/spack_repo/builtin/packages/py_cryptography/package.py
@@ -16,6 +16,7 @@ class PyCryptography(PythonPackage):
 
     license("Apache-2.0")
 
+    version("46.0.4", sha256="bfd019f60f8abc2ed1b9be4ddc21cfef059c841d86d710bb69909a688cbb8f59")
     version("46.0.3", sha256="a8b17438104fed022ce745b362294d9ce35b4c2e45c1d958ad4a4b019285f4a1")
     version("45.0.5", sha256="72e76caa004ab63accdf26023fccd1d087f6d90ec6048ff33ad0445abf7f605a")
     version("43.0.3", sha256="315b9001266a492a6ff443b61238f956b214dbec9910a081ba5b6646a055a805")

--- a/repos/spack_repo/builtin/packages/py_cuda_bindings/package.py
+++ b/repos/spack_repo/builtin/packages/py_cuda_bindings/package.py
@@ -16,7 +16,7 @@ class PyCudaBindings(PythonPackage):
     git = "https://github.com/NVIDIA/cuda-python"
     url = "https://github.com/NVIDIA/cuda-python/releases/download/v12.9.0/cuda-python-v12.9.0.tar.gz"
 
-    version("v12.9.5", sha256="5210b063a74741abb86eb82f2d40e075be4e85c755208f4c92dd7cb86647415f")
+    version("12.9.5", sha256="5210b063a74741abb86eb82f2d40e075be4e85c755208f4c92dd7cb86647415f")
     version("12.9.0", sha256="1fa57a9fad278256cbb3b6cf347d2b258a7f83bba2759257e54c9fabd0b07ce1")
     version("12.8.0", sha256="6cc8db1e65a1f995e289b64f9b9bff4362321d36ecf9b54eb192d0781475fbca")
     version("11.8.7", sha256="613ec6d0cde3db4d48074010ed6015ff60462f14c5fa7d8fe82fe7a7ecd5d1ac")

--- a/repos/spack_repo/builtin/packages/py_cuda_bindings/package.py
+++ b/repos/spack_repo/builtin/packages/py_cuda_bindings/package.py
@@ -16,6 +16,7 @@ class PyCudaBindings(PythonPackage):
     git = "https://github.com/NVIDIA/cuda-python"
     url = "https://github.com/NVIDIA/cuda-python/releases/download/v12.9.0/cuda-python-v12.9.0.tar.gz"
 
+    version("v12.9.5", sha256="5210b063a74741abb86eb82f2d40e075be4e85c755208f4c92dd7cb86647415f")
     version("12.9.0", sha256="1fa57a9fad278256cbb3b6cf347d2b258a7f83bba2759257e54c9fabd0b07ce1")
     version("12.8.0", sha256="6cc8db1e65a1f995e289b64f9b9bff4362321d36ecf9b54eb192d0781475fbca")
     version("11.8.7", sha256="613ec6d0cde3db4d48074010ed6015ff60462f14c5fa7d8fe82fe7a7ecd5d1ac")

--- a/repos/spack_repo/builtin/packages/py_cvxopt/package.py
+++ b/repos/spack_repo/builtin/packages/py_cvxopt/package.py
@@ -16,6 +16,7 @@ class PyCvxopt(PythonPackage):
 
     license("GPL-3.0-only")
 
+    version("1.2.7", sha256="3f9db1f4d4e820aaea81d6fc21054c89dc6327c84f935dd5a1eda1af11e1d504")
     version("1.2.5", sha256="94ec8c36bd6628a11de9014346692daeeef99b3b7bae28cef30c7490bbcb2d72")
 
     variant(

--- a/repos/spack_repo/builtin/packages/py_cylp/package.py
+++ b/repos/spack_repo/builtin/packages/py_cylp/package.py
@@ -20,6 +20,7 @@ class PyCylp(PythonPackage):
 
     license("EPL-2.0")
 
+    version("0.91.6", sha256="f026abc29c67a998264db8aa9653fc98c0c38661da68f80ef4b6a0edc117bec0")
     version("0.91.5", sha256="d68ab1dde125be60abf45c8fd9edd24ab880c8144ad881718ddfa01ff6674c77")
 
     depends_on("cxx", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_cymem/package.py
+++ b/repos/spack_repo/builtin/packages/py_cymem/package.py
@@ -16,6 +16,7 @@ class PyCymem(PythonPackage):
 
     license("MIT")
 
+    version("2.0.8", sha256="8fb09d222e21dcf1c7e907dc85cf74501d4cea6c4ed4ac6c9e016f98fb59cbbf")
     version("2.0.7", sha256="e6034badb5dd4e10344211c81f16505a55553a7164adc314c75bd80cf07e57a8")
     version("2.0.3", sha256="5083b2ab5fe13ced094a82e0df465e2dbbd9b1c013288888035e24fd6eb4ed01")
 

--- a/repos/spack_repo/builtin/packages/py_cymem/package.py
+++ b/repos/spack_repo/builtin/packages/py_cymem/package.py
@@ -16,7 +16,6 @@ class PyCymem(PythonPackage):
 
     license("MIT")
 
-    version("2.0.8", sha256="8fb09d222e21dcf1c7e907dc85cf74501d4cea6c4ed4ac6c9e016f98fb59cbbf")
     version("2.0.7", sha256="e6034badb5dd4e10344211c81f16505a55553a7164adc314c75bd80cf07e57a8")
     version("2.0.3", sha256="5083b2ab5fe13ced094a82e0df465e2dbbd9b1c013288888035e24fd6eb4ed01")
 

--- a/repos/spack_repo/builtin/packages/py_cython/package.py
+++ b/repos/spack_repo/builtin/packages/py_cython/package.py
@@ -16,6 +16,7 @@ class PyCython(PythonPackage):
 
     license("Apache-2.0")
 
+    version("3.2.4", sha256="84226ecd313b233da27dc2eb3601b4f222b8209c3a7216d8733b031da1dc64e6")
     version("3.2.3", sha256="f13832412d633376ffc08d751cc18ed0d7d00a398a4065e2871db505258748a6")
     version("3.2.2", sha256="c3add3d483acc73129a61d105389344d792c17e7c1cee24863f16416bd071634")
     version("3.2.1", sha256="2be1e4d0cbdf7f4cd4d9b8284a034e1989b59fd060f6bd4d24bf3729394d2ed8")

--- a/repos/spack_repo/builtin/packages/py_databricks_cli/package.py
+++ b/repos/spack_repo/builtin/packages/py_databricks_cli/package.py
@@ -13,6 +13,7 @@ class PyDatabricksCli(PythonPackage):
     homepage = "https://pypi.org/project/databricks-cli/"
     pypi = "databricks-cli/databricks-cli-0.17.4.tar.gz"
 
+    version("0.17.8", sha256="1d5ef6520ea3ed403d58f24538641bd8eeb163621f5054205fcf643578698579")
     version("0.17.4", sha256="bc0c4dd082f033cb6d7978cacaca5261698efe3a4c70f52f98762c38db925ce0")
     version("0.14.3", sha256="bdf89a3917a3f8f8b99163e38d40e66dc478c7408954747f145cd09816b05e2c")
 

--- a/repos/spack_repo/builtin/packages/py_datashader/package.py
+++ b/repos/spack_repo/builtin/packages/py_datashader/package.py
@@ -17,6 +17,7 @@ class PyDatashader(PythonPackage):
 
     license("BSD-3-Clause", checked_by="climbfuji")
 
+    version("0.18.2", sha256="53ef0bc35b9ba1034bdf290a2e28babf0fa2b075a3e5a822c79dcde12183d1ff")
     version("0.18.1", sha256="ad9390a9178eb03493fb67649f6570d59ccb371cf663533e0672a1826bb436b0")
     version("0.16.3", sha256="9d0040c7887f7a5a5edd374c297402fd208a62bf6845e87631b54f03b9ae479d")
 

--- a/repos/spack_repo/builtin/packages/py_datrie/package.py
+++ b/repos/spack_repo/builtin/packages/py_datrie/package.py
@@ -15,6 +15,7 @@ class PyDatrie(PythonPackage):
 
     license("LGPL-2.1-or-later")
 
+    version("0.8.3", sha256="ea021ad4c8a8bf14e08a71c7872a622aa399a510f981296825091c7ca0436e80")
     version("0.8.2", sha256="525b08f638d5cf6115df6ccd818e5a01298cd230b2dac91c8ff2e6499d18765d")
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_dbf/package.py
+++ b/repos/spack_repo/builtin/packages/py_dbf/package.py
@@ -13,6 +13,7 @@ class PyDbf(PythonPackage):
 
     pypi = "dbf/dbf-0.96.005.tar.gz"
 
+    version("0.99.9", sha256="305122d54d1136fadf0ed5781e9bcf80a4c289b021efacfb1a79a3df622e6d8c")
     version("0.99.3", sha256="940272a72ac27d16a1db69aafef820684012cc3553ffe9875d5cd2e3a9cb69dc")
     version("0.97.11", sha256="8aa5a73d8b140aa3c511a3b5b204a67d391962e90c66b380dd048fcae6ddbb68")
     version("0.96.005", sha256="d6e03f1dca40488c37cf38be9cb28b694c46cec747a064dcb0591987de58ed02")

--- a/repos/spack_repo/builtin/packages/py_dbf/package.py
+++ b/repos/spack_repo/builtin/packages/py_dbf/package.py
@@ -13,7 +13,7 @@ class PyDbf(PythonPackage):
 
     pypi = "dbf/dbf-0.96.005.tar.gz"
 
-    version("0.99.9", sha256="305122d54d1136fadf0ed5781e9bcf80a4c289b021efacfb1a79a3df622e6d8c")
+    version("0.99.11", sha256="2169c05252c0efbe897f346f0683326ec25854beab1d0c6430df6e903a57b315")
     version("0.99.3", sha256="940272a72ac27d16a1db69aafef820684012cc3553ffe9875d5cd2e3a9cb69dc")
     version("0.97.11", sha256="8aa5a73d8b140aa3c511a3b5b204a67d391962e90c66b380dd048fcae6ddbb68")
     version("0.96.005", sha256="d6e03f1dca40488c37cf38be9cb28b694c46cec747a064dcb0591987de58ed02")

--- a/repos/spack_repo/builtin/packages/py_deepspeed/package.py
+++ b/repos/spack_repo/builtin/packages/py_deepspeed/package.py
@@ -20,6 +20,7 @@ class PyDeepspeed(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.16.9", sha256="88dc08986cd321047c37c2d0f1edd6faac498a1b52eb486d559164362c6b9011")
     version("0.16.4", sha256="495febfb6dd20423f44b1c4a1bb6da2cadbcaf9b07962e17f87d52edfeec9bba")
     version("0.15.4", sha256="60e7c044b7fc386cdad1206212d22b6963ea551f656ed51f7cb34b299459bf2c")
     version("0.13.5", sha256="05404e083b5df36dcfe36884565dcb1d9fd1165e443a82c1c09370293943f6d1")

--- a/repos/spack_repo/builtin/packages/py_deprecation_alias/package.py
+++ b/repos/spack_repo/builtin/packages/py_deprecation_alias/package.py
@@ -16,6 +16,7 @@ class PyDeprecationAlias(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.3.3", sha256="e73266d4c866c040079d7a047f92ac2cd468b4608032486df1ffd7ef147e6515")
     version("0.3.2", sha256="1c9e1a5ddd0a276a1a18e7a4f9d56b53232217491c4549eaa45e51753013ce76")
 
     depends_on("py-wheel@0.34.2:", type="build")

--- a/repos/spack_repo/builtin/packages/py_dh_scikit_optimize/package.py
+++ b/repos/spack_repo/builtin/packages/py_dh_scikit_optimize/package.py
@@ -24,6 +24,7 @@ class PyDhScikitOptimize(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.9.6", sha256="53c2985ff1684e367fd4c14e199125cb34cbc0675f69769fc767ee22e4dceaf1")
     version("0.9.5", sha256="c2777839a536215ab40fc5db2242809ccffd5e5b23718e23d58ea76ff35a7543")
     version("0.9.4", sha256="9acfba4077fe45f3854a4af255763a3e8a396c05bd2a7c761a969171366b3840")
     version("0.9.3", sha256="0c922c61dc1f010c7bbd2f0930c766e8ae040c35b129e4de6d51b611fd72b7c9")

--- a/repos/spack_repo/builtin/packages/py_dist_meta/package.py
+++ b/repos/spack_repo/builtin/packages/py_dist_meta/package.py
@@ -16,6 +16,7 @@ class PyDistMeta(PythonPackage):
 
     license("MIT")
 
+    version("0.8.1", sha256="e73b873b08361835e25592d4d74129f0353bca4451dd12bfa10aaf14af4682e4")
     version("0.8.0", sha256="541d51f75b7f580c80d8d7b23112d0b4bf3edbc9442e425a7c4fcd75f4138551")
 
     depends_on("py-wheel@0.34.2:", type="build")

--- a/repos/spack_repo/builtin/packages/py_drep/package.py
+++ b/repos/spack_repo/builtin/packages/py_drep/package.py
@@ -21,6 +21,7 @@ class PyDrep(PythonPackage):
 
     license("MIT")
 
+    version("3.4.5", sha256="147ddbb775c8f81e8cf4c4d79dc0378039628bd375ea135b8052b8a1d07180c3")
     version("3.4.2", sha256="90d61e40b987cef85b52209720afe15c090d6af8095f5ac8d14354b374007fa7")
     version("3.4.0", sha256="a6533eb585122c1ee66ae622b1b97450a3e1e493a3c3c1d55e79a580d5c46d40")
 

--- a/repos/spack_repo/builtin/packages/py_dulwich/package.py
+++ b/repos/spack_repo/builtin/packages/py_dulwich/package.py
@@ -18,6 +18,7 @@ class PyDulwich(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.21.7", sha256="a9e9c66833cea580c3ac12927e4b9711985d76afca98da971405d414de60e968")
     version("0.21.6", sha256="30fbe87e8b51f3813c131e2841c86d007434d160bd16db586b40d47f31dd05b0")
     version("0.20.46", sha256="4f0e88ffff5db1523d93d92f1525fe5fa161318ffbaad502c1b9b3be7a067172")
     version("0.20.44", sha256="10e8d73763dd30c86a99a15ade8bfcf3ab8fe96532cdf497e8cb1d11832352b8")

--- a/repos/spack_repo/builtin/packages/py_dynaconf/package.py
+++ b/repos/spack_repo/builtin/packages/py_dynaconf/package.py
@@ -15,6 +15,7 @@ class PyDynaconf(PythonPackage):
 
     license("MIT")
 
+    version("3.2.9", sha256="a612a05c0307b826193b9f7e738f9497c537d5b2668aa2979da3538d7dcdd400")
     version("3.2.2", sha256="2f98ec85a2b8edb767b3ed0f82c6d605d30af116ce4622932a719ba70ff152fc")
 
     depends_on("python@3.8:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_dynaconf/package.py
+++ b/repos/spack_repo/builtin/packages/py_dynaconf/package.py
@@ -15,7 +15,7 @@ class PyDynaconf(PythonPackage):
 
     license("MIT")
 
-    version("3.2.9", sha256="a612a05c0307b826193b9f7e738f9497c537d5b2668aa2979da3538d7dcdd400")
+    version("3.2.12", sha256="29cea583b007d890e6031fa89c0ac489b631c73dbee83bcd5e6f97602c26354e")
     version("3.2.2", sha256="2f98ec85a2b8edb767b3ed0f82c6d605d30af116ce4622932a719ba70ff152fc")
 
     depends_on("python@3.8:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_easybuild_easyblocks/package.py
+++ b/repos/spack_repo/builtin/packages/py_easybuild_easyblocks/package.py
@@ -18,6 +18,7 @@ class PyEasybuildEasyblocks(PythonPackage):
 
     license("GPL-2.0-only")
 
+    version("4.7.2", sha256="6347aac95c56a5172688db98fd2cad3e348df206dd2a9c0389adab3208046699")
     version("4.7.0", sha256="c23e81cbaa3e4fa5ab1bb8b2db759332867d61110bf4ec34763ea170780f0655")
     version("4.0.0", sha256="a0fdef6c33c786e323bde1b28bab942fd8e535c26842877d705e692e85b31b07")
 

--- a/repos/spack_repo/builtin/packages/py_easybuild_easyconfigs/package.py
+++ b/repos/spack_repo/builtin/packages/py_easybuild_easyconfigs/package.py
@@ -18,6 +18,7 @@ class PyEasybuildEasyconfigs(PythonPackage):
 
     license("GPL-2.0-only")
 
+    version("4.7.2", sha256="d678c541bd1f0d3d2ccd2a203fb0eaa8f958d77c910138c3d2518f61047bc17e")
     version("4.7.0", sha256="c688f14a3b0dce45c6cc90d746f05127dbf7368bd9b5873ce50757992d8e6261")
     version("4.0.0", sha256="90d4e8f8abb11e7ae2265745bbd1241cd69d02570e9b4530175c4b2e2aba754e")
 

--- a/repos/spack_repo/builtin/packages/py_easybuild_framework/package.py
+++ b/repos/spack_repo/builtin/packages/py_easybuild_framework/package.py
@@ -18,6 +18,7 @@ class PyEasybuildFramework(PythonPackage):
 
     license("GPL-2.0-or-later")
 
+    version("4.7.2", sha256="508ed5ffbb450aa1212bd451b51b2555109b94964c6bbd2818a150eb47fb3662")
     version("4.7.0", sha256="ea51c3cb88fca27daadd2fb55ee31f5f51fc60c4e3519ee9d275954540312df8")
     version("4.0.0", sha256="f5c40345cc8b9b5750f53263ade6c9c3a8cd3dfab488d58f76ac61a8ca7c5a77")
 

--- a/repos/spack_repo/builtin/packages/py_eccodes/package.py
+++ b/repos/spack_repo/builtin/packages/py_eccodes/package.py
@@ -15,6 +15,7 @@ class PyEccodes(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.5.2", sha256="f7cce47fc9b1df3ed9eea21c4060fa572e07a4d0f014f6fd1f74683df9b45801")
     version("1.5.0", sha256="e70c8f159140c343c215fd608ddf533be652ff05ad2ff17243c7b66cf92127fa")
     version("1.4.2", sha256="63fa80a1d1b445904f486bc396a6a6605df029f4e215acc28ceb1a1ff5eb664f")
     version("1.3.2", sha256="f282adfdc1bc658356163c9cef1857d4b2bae99399660d3d4fcb145a52d3b2a6")

--- a/repos/spack_repo/builtin/packages/py_ecmwf_opendata/package.py
+++ b/repos/spack_repo/builtin/packages/py_ecmwf_opendata/package.py
@@ -15,6 +15,7 @@ class PyEcmwfOpendata(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.3.8", sha256="8a9c29ba369088477f9db2a2dabdb8f5282f02f6756e83d4288b38ed4d663c29")
     version("0.3.3", sha256="6f3181c7872b72e5529d2b4b7ec6ff08d37c37beee0a498f7f286410be178c6a")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_edfio/package.py
+++ b/repos/spack_repo/builtin/packages/py_edfio/package.py
@@ -16,6 +16,7 @@ class PyEdfio(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.4.9", sha256="c072c37f62ec994e277bfa60200805a9cec1e0f2f8bc15c40af692d3902f891c")
     version("0.4.3", sha256="9250e67af190379bb3432356b23c441a99682e97159ea58d4507b0827175b487")
 
     depends_on("python@3.9:3", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_edfio/package.py
+++ b/repos/spack_repo/builtin/packages/py_edfio/package.py
@@ -16,7 +16,7 @@ class PyEdfio(PythonPackage):
 
     license("Apache-2.0")
 
-    version("0.4.9", sha256="c072c37f62ec994e277bfa60200805a9cec1e0f2f8bc15c40af692d3902f891c")
+    version("0.4.12", sha256="8cdd5f7172fa9c3f094cf2924719690be00a68af28363c8f8c5b80f69d4ce78d")
     version("0.4.3", sha256="9250e67af190379bb3432356b23c441a99682e97159ea58d4507b0827175b487")
 
     depends_on("python@3.9:3", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_eerepr/package.py
+++ b/repos/spack_repo/builtin/packages/py_eerepr/package.py
@@ -15,6 +15,7 @@ class PyEerepr(PythonPackage):
 
     license("MIT")
 
+    version("0.1.2", sha256="304dc23c365d6fa7cc3b07bc09cf77b565c19af86733e5deed804fdce16fb51f")
     version("0.1.0", sha256="a3c6f4d94ee19374aea2ff7ae9f2471f06649be5e18f9cb1cced8a00c2c20857")
 
     depends_on("py-hatchling", type="build")

--- a/repos/spack_repo/builtin/packages/py_efel/package.py
+++ b/repos/spack_repo/builtin/packages/py_efel/package.py
@@ -21,6 +21,7 @@ class PyEfel(PythonPackage):
 
     license("LGPL-3.0-or-later")
 
+    version("5.2.9", sha256="1065a48eb83d8e99a98a11cf3dc935381468b2fc4831c62907124db3b39ebfcb")
     version("5.2.0", sha256="ed2c5efe22a4c703a4d9e47775b939009e1456713ac896898ebabf177c60b1dc")
 
     depends_on("cxx", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_efel/package.py
+++ b/repos/spack_repo/builtin/packages/py_efel/package.py
@@ -21,7 +21,7 @@ class PyEfel(PythonPackage):
 
     license("LGPL-3.0-or-later")
 
-    version("5.2.9", sha256="1065a48eb83d8e99a98a11cf3dc935381468b2fc4831c62907124db3b39ebfcb")
+    version("5.2.10", sha256="aca7e0edf245197b9acb9ac56dfe5b4c2801b632843cffe6b2013b899a6f12fe")
     version("5.2.0", sha256="ed2c5efe22a4c703a4d9e47775b939009e1456713ac896898ebabf177c60b1dc")
 
     depends_on("cxx", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_elastic_transport/package.py
+++ b/repos/spack_repo/builtin/packages/py_elastic_transport/package.py
@@ -13,6 +13,7 @@ class PyElasticTransport(PythonPackage):
     homepage = "https://github.com/elastic/elastic-transport-python"
     pypi = "elastic-transport/elastic-transport-8.4.0.tar.gz"
 
+    version("8.4.1", sha256="e5548997113c5d9566c9a1a51ed67bce50a4871bc0e44b692166461279e4167e")
     version("8.4.0", sha256="b9ad708ceb7fcdbc6b30a96f886609a109f042c0b9d9f2e44403b3133ba7ff10")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_elasticsearch_dsl/package.py
+++ b/repos/spack_repo/builtin/packages/py_elasticsearch_dsl/package.py
@@ -18,6 +18,7 @@ class PyElasticsearchDsl(PythonPackage):
 
     license("Apache-2.0")
 
+    version("7.4.1", sha256="07ee9c87dc28cc3cae2daa19401e1e18a172174ad9e5ca67938f752e3902a1d5")
     version("7.4.0", sha256="c4a7b93882918a413b63bed54018a1685d7410ffd8facbc860ee7fd57f214a6d")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_ema_pytorch/package.py
+++ b/repos/spack_repo/builtin/packages/py_ema_pytorch/package.py
@@ -17,6 +17,7 @@ class PyEmaPytorch(PythonPackage):
 
     license("MIT", checked_by="alex391")
 
+    version("0.7.9", sha256="a8ccdf2eeecce5489de02fc7c9776ef55400220afff92b8223f7516cb570b594")
     version("0.7.3", sha256="de640f1d1a054c79607aebfcfd4b8dfff1fba1110bf0c8f7d37517637450938a")
     version("0.5.1", sha256="e825212a44e8faae5d2cf2a1349961c4416cba0496ffa64d37718d8b06f206b2")
 

--- a/repos/spack_repo/builtin/packages/py_emcee/package.py
+++ b/repos/spack_repo/builtin/packages/py_emcee/package.py
@@ -16,6 +16,7 @@ class PyEmcee(PythonPackage):
 
     license("MIT")
 
+    version("3.1.6", sha256="11af4daf6ab8f9ca69681e3c29054665db7bbd87fd4eb8e437d2c3a1248c637d")
     version("3.1.1", sha256="48ffc6a7f5c51760b7a836056184c7286a9959ef81b45b977b02794f1210fb5c")
     version("3.0.2", sha256="035a44d7594fdd03efd10a522558cdfaa080e046ad75594d0bf2aec80ec35388")
     version("2.2.1", sha256="b83551e342b37311897906b3b8acf32979f4c5542e0a25786ada862d26241172")

--- a/repos/spack_repo/builtin/packages/py_equinox/package.py
+++ b/repos/spack_repo/builtin/packages/py_equinox/package.py
@@ -25,6 +25,7 @@ class PyEquinox(PythonPackage, CudaPackage):
     maintainers("abhishek1297")
     license("Apache-2.0", checked_by="abhishek1297")
 
+    version("0.13.4", sha256="d4eed5d7f981a5ddcb7bc70e601707769fb4da20f777703cc6e01a6248af9758")
     version("0.13.2", sha256="509ad744ff99b7c684d45230d6890f9e78eac1a556d7a06db1eff664a3cac74f")
     version("0.13.1", sha256="e90f11cfe66b2f73f5c172260a17c48851794a0f243dd2cbe4ea70f4c90cbd07")
     version("0.13.0", sha256="d59615be722373e9d66e0ba78462964e6357fb76a8b1b98c2c6027961b778a69")

--- a/repos/spack_repo/builtin/packages/py_exceptiongroup/package.py
+++ b/repos/spack_repo/builtin/packages/py_exceptiongroup/package.py
@@ -14,6 +14,7 @@ class PyExceptiongroup(PythonPackage):
     homepage = "https://github.com/agronholm/exceptiongroup"
     pypi = "exceptiongroup/exceptiongroup-1.0.4.tar.gz"
 
+    version("1.1.3", sha256="097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9")
     version("1.1.1", sha256="d484c3090ba2889ae2928419117447a14daf3c1231d5e30d0aae34f354f01785")
     version("1.0.4", sha256="bd14967b79cd9bdb54d97323216f8fdf533e278df937aa2a90089e7d6e06e5ec")
 

--- a/repos/spack_repo/builtin/packages/py_exodus_bundler/package.py
+++ b/repos/spack_repo/builtin/packages/py_exodus_bundler/package.py
@@ -16,6 +16,7 @@ class PyExodusBundler(PythonPackage):
 
     license("BSD-2-Clause-FreeBSD")
 
+    version("2.0.4", sha256="2aef54f16ce387a8a436249224469a20629901dcd84cfc10e99d69483ad3441b")
     version("2.0.2", sha256="4e896a2034b94cf7b4fb33d86a68e29a7d3b08e57541e444db34dddc6ac1ef68")
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_expandvars/package.py
+++ b/repos/spack_repo/builtin/packages/py_expandvars/package.py
@@ -15,6 +15,7 @@ class PyExpandvars(PythonPackage):
 
     license("MIT")
 
+    version("1.1.2", sha256="6c5822b7b756a99a356b915dd1267f52ab8a4efaa135963bd7f4bd5d368f71d7")
     version("1.1.1", sha256="98add8268b760dfee457bde1c17bf745795fdebc22b7ddab75fd3278653f1e05")
     version("0.12.0", sha256="7d1adfa55728cf4b5d812ece3d087703faea953e0c0a1a78415de9df5024d844")
 

--- a/repos/spack_repo/builtin/packages/py_f90nml/package.py
+++ b/repos/spack_repo/builtin/packages/py_f90nml/package.py
@@ -14,6 +14,7 @@ class PyF90nml(PythonPackage):
     homepage = "https://github.com/marshallward/f90nml"
     pypi = "f90nml/f90nml-1.4.3.tar.gz"
 
+    version("1.4.5", sha256="132ed8d72543e121de4f154fd7f0052f567401901ef9e8a0992f044b9d21c907")
     version("1.4.3", sha256="e2f3cd23d821ebcaef66ce406485b35aa08aae0df92c4bece76e227e5bd146e1")
     version("1.4.1", sha256="9df312aa13b9c21936f059cab9ab40afebc280f1ab54e6854c3873d0b7b7865c")
     version("1.3.1", sha256="145c1f2c55bad628d225af22fc9bf06347eb0d33e7bae8a05869a68274b8fb2d")

--- a/repos/spack_repo/builtin/packages/py_f90wrap/package.py
+++ b/repos/spack_repo/builtin/packages/py_f90wrap/package.py
@@ -17,6 +17,7 @@ class PyF90wrap(PythonPackage):
 
     license("LGPL-3.0-only")
 
+    version("0.2.9", sha256="030ad9aeac934b8fa2d07b1f2eef2b6875a44141866e9a16bccefc18cc8d88ca")
     version("0.2.6", sha256="e0748eb5e288be7f47829a272fc230373469fb40afccddf91e9973c56da43dd4")
     version("0.2.3", sha256="5577ea92934c5aad378df21fb0805b5fb433d6f2b8b9c1bf1a9ec1e3bf842cff")
 

--- a/repos/spack_repo/builtin/packages/py_f90wrap/package.py
+++ b/repos/spack_repo/builtin/packages/py_f90wrap/package.py
@@ -17,7 +17,6 @@ class PyF90wrap(PythonPackage):
 
     license("LGPL-3.0-only")
 
-    version("0.2.9", sha256="030ad9aeac934b8fa2d07b1f2eef2b6875a44141866e9a16bccefc18cc8d88ca")
     version("0.2.6", sha256="e0748eb5e288be7f47829a272fc230373469fb40afccddf91e9973c56da43dd4")
     version("0.2.3", sha256="5577ea92934c5aad378df21fb0805b5fb433d6f2b8b9c1bf1a9ec1e3bf842cff")
 

--- a/repos/spack_repo/builtin/packages/py_faker/package.py
+++ b/repos/spack_repo/builtin/packages/py_faker/package.py
@@ -19,6 +19,7 @@ class PyFaker(PythonPackage):
 
     license("MIT")
 
+    version("9.8.4", sha256="b0cee4dbe737fcb86f6b3f2aa2803c83264c7763e52185ccee9f85f638b43877")
     version("9.8.2", sha256="393bd1b5becf3ccbc04a4f0f13da7e437914b24cafd1a4d8b71b5fecff54fb34")
 
     depends_on("python@3.6:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_fastdownload/package.py
+++ b/repos/spack_repo/builtin/packages/py_fastdownload/package.py
@@ -18,6 +18,7 @@ class PyFastdownload(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.0.7", sha256="20507edb8e89406a1fbd7775e6e2a3d81a4dd633dd506b0e9cf0e1613e831d6a")
     version("0.0.5", sha256="64e67af30690fa98ae1c8a1b52495769842f723565239a5430208ad05585af18")
 
     depends_on("python@3.6:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_fastprogress/package.py
+++ b/repos/spack_repo/builtin/packages/py_fastprogress/package.py
@@ -14,6 +14,7 @@ class PyFastprogress(PythonPackage):
     homepage = "https://github.com/fastai/fastprogress"
     pypi = "fastprogress/fastprogress-1.0.0.tar.gz"
 
+    version("1.0.5", sha256="58ca16a981f0292804d905f2e0042ad608d788bf6cbe6ab96b71ec4b20453aef")
     version("1.0.0", sha256="89e28ac1d2a5412aab18ee3f3dfd1ee8b5c1f2f7a44d0add0d0d4f69f0191bfe")
 
     depends_on("python@3.6:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_ffmpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_ffmpy/package.py
@@ -15,6 +15,7 @@ class PyFfmpy(PythonPackage):
 
     license("MIT")
 
+    version("0.3.3", sha256="924cde7e0bb1b5eb58d21ada3b1622f95069c98769bbdf100ed381c7e750a55e")
     version("0.3.0", sha256="757591581eee25b4a50ac9ffb9b58035a2794533db47e0512f53fb2d7b6f9adc")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_findlibs/package.py
+++ b/repos/spack_repo/builtin/packages/py_findlibs/package.py
@@ -15,6 +15,7 @@ class PyFindlibs(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.0.5", sha256="7a801571e999d0ee83f9b92cbb598c21f861ee26ca9dba74cea8958ba4335e7e")
     version("0.0.2", sha256="6c7e038496f9a97783ab2cd5736bb68522d5bebd8b0eb17c976b6a4ae4032c8d")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_flake8_import_order/package.py
+++ b/repos/spack_repo/builtin/packages/py_flake8_import_order/package.py
@@ -15,6 +15,7 @@ class PyFlake8ImportOrder(PythonPackage):
 
     license("LGPL-3.0-only")
 
+    version("0.18.2", sha256="e23941f892da3e0c09d711babbb0c73bc735242e9b216b726616758a920d900e")
     version("0.18.1", sha256="a28dc39545ea4606c1ac3c24e9d05c849c6e5444a50fb7e9cdd430fc94de6e92")
 
     depends_on("py-pycodestyle", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_flexmock/package.py
+++ b/repos/spack_repo/builtin/packages/py_flexmock/package.py
@@ -23,7 +23,7 @@ class PyFlexmock(PythonPackage):
 
     license("BSD-2-Clause")
 
-    version("0.10.9", sha256="9c128b7cf31fac5340062c9c2cf1e0b12c601ee2d5c10ef39cc191036fb2e688")
+    version("0.10.10", sha256="8bb073f4b7b590672e8c312e73d6a14f88ae624a867b691462f9e8c24b9f19d1")
     version("0.10.4", sha256="5033ceb974d6452cf8716c2ff5059074b77e546df5c849fb44a53f98dfe0d82c")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_flexmock/package.py
+++ b/repos/spack_repo/builtin/packages/py_flexmock/package.py
@@ -23,6 +23,7 @@ class PyFlexmock(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("0.10.9", sha256="9c128b7cf31fac5340062c9c2cf1e0b12c601ee2d5c10ef39cc191036fb2e688")
     version("0.10.4", sha256="5033ceb974d6452cf8716c2ff5059074b77e546df5c849fb44a53f98dfe0d82c")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_flufl_lock/package.py
+++ b/repos/spack_repo/builtin/packages/py_flufl_lock/package.py
@@ -16,6 +16,7 @@ class PyFluflLock(PythonPackage):
 
     license("Apache-2.0")
 
+    version("5.0.5", sha256="ffbaa9f495b01d7990bc126e063c29184dc7f02261c0396c8fd5e494debccaae")
     version("5.0.4", sha256="09ffef831d57c4d182e398e97bb74ad8c8ffbd1710175a5a0b0f057095db12f1")
     version("5.0.3", sha256="94df161caa489d74afc26df8c0b640770923ecc0c6c5d331fbeabe7b91d306cb")
     version("3.2", sha256="a8d66accc9ab41f09961cd8f8db39f9c28e97e2769659a3567c63930a869ff5b")

--- a/repos/spack_repo/builtin/packages/py_fluiddyn/package.py
+++ b/repos/spack_repo/builtin/packages/py_fluiddyn/package.py
@@ -16,6 +16,7 @@ class PyFluiddyn(PythonPackage):
 
     license("CECILL-B", checked_by="paugier")
 
+    version("0.6.6", sha256="1b6aa7e8c79cb9cac302809333c38506629a32dca58e6ea9c13f7039611644b8")
     version("0.6.5", sha256="ad0df4c05855bd2ae702731983d310bfbb13802874ce83e2da6454bb7100b5df")
     version("0.6.4", sha256="576eb0fa50012552b3a68dd17e81ce4f08ddf1e276812b02316016bb1c3a1342")
     version("0.6.3", sha256="3c4c57ac8e48c55498aeafaf8b26daecefc03e6ac6e2c03a591e0f7fec13bb69")

--- a/repos/spack_repo/builtin/packages/py_fluidfft_builder/package.py
+++ b/repos/spack_repo/builtin/packages/py_fluidfft_builder/package.py
@@ -15,6 +15,7 @@ class PyFluidfftBuilder(PythonPackage):
     maintainers("paugier")
     license("MIT", checked_by="paugier")
 
+    version("0.0.3", sha256="7cd4bb179a17e9f636aabcdc36429a75a16d2122eb507df8c4873aa7a15e71a5")
     version("0.0.2", sha256="c0af9ceca27ae3a00ccf2f160703be9e394d8b886b8a02653b6c0a12a4f54a90")
 
     depends_on("python@3.9:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_folium/package.py
+++ b/repos/spack_repo/builtin/packages/py_folium/package.py
@@ -15,6 +15,7 @@ class PyFolium(PythonPackage):
 
     license("MIT")
 
+    version("0.19.7", sha256="cf256a1e38441e7a8e01977bceeba34f86fd68745d7d7e490ccbecc79dc0d388")
     version("0.19.4", sha256="431a655b52a9bf3efda336f2be022103f0106504a0599e7c349efbfd30bafda6")
     version("0.16.0", sha256="2585ee9253dc758d3a365534caa6fb5fa0c244646db4dc5819afc67bbd4daabb")
 

--- a/repos/spack_repo/builtin/packages/py_formulaic/package.py
+++ b/repos/spack_repo/builtin/packages/py_formulaic/package.py
@@ -14,6 +14,7 @@ class PyFormulaic(PythonPackage):
     homepage = "https://github.com/matthewwardrop/formulaic"
     pypi = "formulaic/formulaic-0.2.4.tar.gz"
 
+    version("1.2.1", sha256="dc79476baa2d811b35798893eb2f2c1e51edee8d7a9c1429b400e56f4e0beccc")
     version("1.2.0", sha256="ab5c43a5b107d1b1e87f55cf0a01245531cce793d3dcab433dae12053c3cb2d6")
     version("0.6.1", sha256="5b20b2130436dc8bf5ea604e69d88d44b3be4d8ea20bfea96d982fa1f6bb762b")
     version("0.5.2", sha256="25b1e1c8dff73f0b11c0028a6ab350222de6bbc47b316ccb770cec16189cef53")

--- a/repos/spack_repo/builtin/packages/py_fortls/package.py
+++ b/repos/spack_repo/builtin/packages/py_fortls/package.py
@@ -17,6 +17,7 @@ class PyFortls(PythonPackage):
 
     license("MIT")
 
+    version("3.1.2", sha256="93ea78598492ac699f7cefb624e89bf5012d44604d07fbe5ad4a31e32fc977bc")
     version("3.1.0", sha256="e38f9f6af548f78151d54bdbb9884166f8d717f8e147ab1e2dbf06b985df2c6d")
     version("2.13.0", sha256="23c5013e8dd8e1d65bf07be610d0827bc48aa7331a7a7ce13612d4c646d0db31")
 

--- a/repos/spack_repo/builtin/packages/py_frozendict/package.py
+++ b/repos/spack_repo/builtin/packages/py_frozendict/package.py
@@ -15,6 +15,7 @@ class PyFrozendict(PythonPackage):
 
     license("LGPL-3.0-only")
 
+    version("2.4.7", sha256="e478fb2a1391a56c8a6e10cc97c4a9002b410ecd1ac28c18d780661762e271bd")
     version("2.4.6", sha256="df7cd16470fbd26fc4969a208efadc46319334eb97def1ddf48919b351192b8e")
     version("2.3.10", sha256="aadc83510ce82751a0bb3575231f778bc37cbb373f5f05a52b888e26cbb92f79")
     version("2.3.4", sha256="15b4b18346259392b0d27598f240e9390fafbff882137a9c48a1e0104fb17f78")

--- a/repos/spack_repo/builtin/packages/py_gdown/package.py
+++ b/repos/spack_repo/builtin/packages/py_gdown/package.py
@@ -15,6 +15,7 @@ class PyGdown(PythonPackage):
 
     license("MIT")
 
+    version("5.2.1", sha256="247c2ad1f579db5b66b54c04e6a871995fc8fd7021708b950b8ba7b32cf90323")
     version("5.2.0", sha256="2145165062d85520a3cd98b356c9ed522c5e7984d408535409fd46f94defc787")
 
     with default_args(type="build"):

--- a/repos/spack_repo/builtin/packages/py_genshi/package.py
+++ b/repos/spack_repo/builtin/packages/py_genshi/package.py
@@ -14,6 +14,7 @@ class PyGenshi(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.7.9", sha256="c76170a8b2dc18944e0915103c284cb889dfcee34e0e140ba3363c80f7541ad2")
     version("0.7.7", sha256="c100520862cd69085d10ee1a87e91289e7f59f6b3d9bd622bf58b2804e6b9aab")
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_geocube/package.py
+++ b/repos/spack_repo/builtin/packages/py_geocube/package.py
@@ -16,6 +16,7 @@ class PyGeocube(PythonPackage):
     license("BSD-3-Clause")
     maintainers("adamjstewart")
 
+    version("0.7.1", sha256="5f0f4a2143b379434d81172ae8c9fb49c2c5ff2f9723864ed79d3947a68ea37f")
     version("0.7.0", sha256="986ff46e78d7dede09a1c93bff1642c24aaa5590acdc774049436f86f0989ca4")
     version("0.3.2", sha256="71ff0228f1ef44e3a649d29a045ff7e2a2094a5cfca30fadab8f88f4ec23a41d")
     version("0.3.1", sha256="5c97131010cd8d556a5fad2a3824452120640ac33a6a45b6ca9ee3c28f2e266f")

--- a/repos/spack_repo/builtin/packages/py_geoviews/package.py
+++ b/repos/spack_repo/builtin/packages/py_geoviews/package.py
@@ -16,6 +16,7 @@ class PyGeoviews(PythonPackage):
 
     license("BSD-3-Clause", checked_by="climbfuji")
 
+    version("1.14.1", sha256="7f07f997eb19aedb414d2afe780744321033154a36cb46788913097d9912fff9")
     version("1.14.0", sha256="3cca679a32b2c97215424a3a154e3fa343f61e2589d15e333e493bdf2f62fc6a")
     version("1.13.0", sha256="7554a1e9114995acd243546fac6c6c7f157fc28529fde6ab236a72a6e77fe0bf")
     # version("1.12.0", sha256="e2cbef0605e8fd1529bc643a31aeb61997f8f93c9b41a5aff8b2b355a76fa789")

--- a/repos/spack_repo/builtin/packages/py_google_auth_oauthlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_google_auth_oauthlib/package.py
@@ -16,6 +16,7 @@ class PyGoogleAuthOauthlib(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.5.3", sha256="307d21918d61a0741882ad1fd001c67e68ad81206451d05fc4d26f79de56fc90")
     version("0.5.2", sha256="d5e98a71203330699f92a26bc08847a92e8c3b1b8d82a021f1af34164db143ae")
     version("0.4.6", sha256="a90a072f6993f2c327067bf65270046384cda5a8ecb20b94ea9a687f1f233a7a")
     version("0.4.1", sha256="88d2cd115e3391eb85e1243ac6902e76e77c5fe438b7276b297fbe68015458dd")

--- a/repos/spack_repo/builtin/packages/py_gpustat/package.py
+++ b/repos/spack_repo/builtin/packages/py_gpustat/package.py
@@ -16,6 +16,7 @@ class PyGpustat(PythonPackage):
 
     license("MIT")
 
+    version("1.0.0", sha256="581e8ff858c32c95a322bb8f03f1d9dc3d177b4ecb33ddcbed2c373c67f4e3f1")
     version("1.0.0b1", sha256="a25c460c5751180265814f457249ba5100baf7a055b23ad762a4e3ab3f6496dd")
     version(
         "0.6.0",

--- a/repos/spack_repo/builtin/packages/py_graphql_core/package.py
+++ b/repos/spack_repo/builtin/packages/py_graphql_core/package.py
@@ -18,6 +18,7 @@ class PyGraphqlCore(PythonPackage):
 
     license("MIT")
 
+    version("3.1.7", sha256="62ec192150ccecd9a18cfb79e3e72eb7d1fd68fb594ef19c40099b6deec8ef0c")
     version("3.1.2", sha256="c056424cbdaa0ff67446e4379772f43746bad50a44ec23d643b9bdcd052f5b3a")
     version("3.0.5", sha256="51f7dab06b5035515b23984f6fcb677ed909b56c672152699cca32e03624992e")
     version("2.3.2", sha256="aac46a9ac524c9855910c14c48fc5d60474def7f99fd10245e76608eba7af746")

--- a/repos/spack_repo/builtin/packages/py_greenlet/package.py
+++ b/repos/spack_repo/builtin/packages/py_greenlet/package.py
@@ -18,6 +18,7 @@ class PyGreenlet(PythonPackage):
 
     license("MIT AND PSF-2.0", checked_by="tgamblin")
 
+    version("3.2.4", sha256="0dca0d95ff849f9a364385f36ab49f50065d76964944638be9691e1832e9f86d")
     version("3.2.2", sha256="ad053d34421a2debba45aa3cc39acf454acbcd025b3fc1a9f8a0dee237abd485")
     version("3.1.1", sha256="4ce3ac6cdb6adf7946475d7ef31777c26d94bccc377e070a7986bd2d5c515467")
     version("3.0.3", sha256="43374442353259554ce33599da8b692d5aa96f8976d567d4badf263371fbe491")

--- a/repos/spack_repo/builtin/packages/py_griffe/package.py
+++ b/repos/spack_repo/builtin/packages/py_griffe/package.py
@@ -18,6 +18,7 @@ class PyGriffe(PythonPackage):
 
     license("ISC")
 
+    version("0.22.2", sha256="1408e336a4155392bbd81eed9f2f44bf144e71b9c664e905630affe83bbc088e")
     version("0.22.0", sha256="a3c25a2b7bf729ecee7cd455b4eff548f01c620b8f58a8097a800caad221f12e")
 
     depends_on("python@3.7:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_grpcio/package.py
+++ b/repos/spack_repo/builtin/packages/py_grpcio/package.py
@@ -15,6 +15,7 @@ class PyGrpcio(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.75.1", sha256="3e81d89ece99b9ace23a6916880baca613c03a799925afb2857887efa8b1b3d2")
     version("1.75.0", sha256="b989e8b09489478c2d19fecc744a298930f40d8b27c3638afbfe84d22f36ce4e")
     version("1.71.0", sha256="2b85f7820475ad3edec209d3d89a7909ada16caab05d3f2e08a7e8ae3200a55c")
     version("1.64.0", sha256="257baf07f53a571c215eebe9679c3058a313fd1d1f7c4eede5a8660108c52d9c")

--- a/repos/spack_repo/builtin/packages/py_grpcio_tools/package.py
+++ b/repos/spack_repo/builtin/packages/py_grpcio_tools/package.py
@@ -13,6 +13,7 @@ class PyGrpcioTools(PythonPackage):
     homepage = "https://grpc.io/"
     pypi = "grpcio-tools/grpcio-tools-1.42.0.tar.gz"
 
+    version("1.62.3", sha256="7c7136015c3d62c3eef493efabaf9e3380e3e66d24ee8e94c01cb71377f57833")
     version("1.62.2", sha256="5fd5e1582b678e6b941ee5f5809340be5e0724691df5299aae8226640f94e18f")
     version("1.56.2", sha256="82af2f4040084141a732f0ef1ecf3f14fdf629923d74d850415e4d09a077e77a")
     version("1.48.2", sha256="8902a035708555cddbd61b5467cea127484362decc52de03f061a1a520fe90cd")

--- a/repos/spack_repo/builtin/packages/py_h5netcdf/package.py
+++ b/repos/spack_repo/builtin/packages/py_h5netcdf/package.py
@@ -17,6 +17,7 @@ class PyH5netcdf(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.6.4", sha256="83db7e5eb9b822bed2c79050d6cf8f36ecbd1039f4252bd90fab200edcaaf67d")
     version("1.6.1", sha256="7ef4ecd811374d94d29ac5e7f7db71ff59b55ef8eeefbe4ccc2c316853d31894")
     version("1.3.0", sha256="a171c027daeb34b24c24a3b6304195b8eabbb6f10c748256ed3cfe19806383cf")
     version("0.10.0", sha256="fc1cfec33bb9f730c412f87fcbc259167fd7620635679ccfc6e31971730dbd60")

--- a/repos/spack_repo/builtin/packages/py_hatch/package.py
+++ b/repos/spack_repo/builtin/packages/py_hatch/package.py
@@ -15,6 +15,7 @@ class PyHatch(PythonPackage):
 
     license("MIT")
 
+    version("1.14.2", sha256="b522c7463198c6e24bd9d9c83252327502e3cc3509844141de0aad7b0aa1967d")
     version("1.14.1", sha256="ca1aff788f8596b0dd1f8f8dfe776443d2724a86b1976fabaf087406ba3d0713")
     version("1.13.0", sha256="5e1a75770cfe8f3ebae3abfded3a976238b0acefd19cdabc5245597525b8066f")
     version("1.12.0", sha256="ae80478d10312df2b44d659c93bc2ed4d33aecddce4b76378231bdf81c8bf6ad")

--- a/repos/spack_repo/builtin/packages/py_hep_ml/package.py
+++ b/repos/spack_repo/builtin/packages/py_hep_ml/package.py
@@ -15,6 +15,7 @@ class PyHepMl(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.7.3", sha256="606bb1d7724a71dbecc67998ea46cb304f93a17e1b777c199abb3f7f481ebc6b")
     version("0.7.1", sha256="f13635dac09ffc32ae276af9c58ebf93c593dae3da25c4e456e10e965708320b")
     version("0.7.0", sha256="0402037064d78f5723106b385ad5f20df8f67cb312c57cb4ce3839c5616f328e")
 

--- a/repos/spack_repo/builtin/packages/py_hepdata_validator/package.py
+++ b/repos/spack_repo/builtin/packages/py_hepdata_validator/package.py
@@ -15,6 +15,7 @@ class PyHepdataValidator(PythonPackage):
 
     tags = ["hep"]
 
+    version("0.3.6", sha256="e57b97f83509c81d579ccbbd4cdd515043ba32aa1d8543bf31a36a19dcf08fbb")
     version("0.3.3", sha256="dccdf2ba58bac78e879145a2ff31d299e7b20bd7f28b575ab9d07b950ab723ae")
     version("0.3.0", sha256="d603ddf908ce3838bac09bf7334184db4b35f03e2b215572c67b5e1fabbf0d9b")
     version("0.2.3", sha256="314e75eae7d4a134bfc8291440259839d82aabefdd720f237c0bf8ea5c9be4dc")

--- a/repos/spack_repo/builtin/packages/py_hf_xet/package.py
+++ b/repos/spack_repo/builtin/packages/py_hf_xet/package.py
@@ -14,7 +14,7 @@ class PyHfXet(PythonPackage):
 
     license("Apache-2.0")
 
-    version("1.1.9", sha256="c99073ce404462e909f1d5839b2d14a3827b8fe75ed8aed551ba6609c026c803")
+    version("1.1.10", sha256="408aef343800a2102374a883f283ff29068055c111f003ff840733d3b715bb97")
     version("1.1.5", sha256="69ebbcfd9ec44fdc2af73441619eeb06b94ee34511bbcf57cd423820090f5694")
 
     depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/py_hf_xet/package.py
+++ b/repos/spack_repo/builtin/packages/py_hf_xet/package.py
@@ -14,6 +14,7 @@ class PyHfXet(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.1.9", sha256="c99073ce404462e909f1d5839b2d14a3827b8fe75ed8aed551ba6609c026c803")
     version("1.1.5", sha256="69ebbcfd9ec44fdc2af73441619eeb06b94ee34511bbcf57cd423820090f5694")
 
     depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/py_huggingface_hub/package.py
+++ b/repos/spack_repo/builtin/packages/py_huggingface_hub/package.py
@@ -17,6 +17,7 @@ class PyHuggingfaceHub(PythonPackage):
     license("Apache-2.0")
     maintainers("adamjstewart")
 
+    version("0.34.6", sha256="d0824eb012e37594357bb1790dfbe26c8f45eed7e701c1cdae02539e0c06f3f8")
     version("0.34.3", sha256="d58130fd5aa7408480681475491c0abd7e835442082fbc3ef4d45b6c39f83853")
     version("0.33.1", sha256="589b634f979da3ea4b8bdb3d79f97f547840dc83715918daf0b64209c0844c7b")
     version("0.26.2", sha256="b100d853465d965733964d123939ba287da60a547087783ddff8a323f340332b")

--- a/repos/spack_repo/builtin/packages/py_hyperframe/package.py
+++ b/repos/spack_repo/builtin/packages/py_hyperframe/package.py
@@ -15,6 +15,7 @@ class PyHyperframe(PythonPackage):
 
     license("MIT")
 
+    version("6.0.1", sha256="ae510046231dc8e9ecb1a6586f63d2347bf4c8905914aa84ba585ae85f28a914")
     version("6.0.0", sha256="742d2a4bc3152a340a49d59f32e33ec420aa8e7054c1444ef5c7efff255842f1")
     version("5.2.0", sha256="a9f5c17f2cc3c719b917c4f33ed1c61bd1f8dfac4b1bd23b7c80b3400971b41f")
 

--- a/repos/spack_repo/builtin/packages/py_hypothesis/package.py
+++ b/repos/spack_repo/builtin/packages/py_hypothesis/package.py
@@ -15,6 +15,7 @@ class PyHypothesis(PythonPackage):
 
     license("MPL-2.0")
 
+    version("6.96.4", sha256="3b0d080bfd3b303e91388507ac7edebd7039ffcc96ac2cfcdc3c45806352c09f")
     version("6.96.2", sha256="524a0ac22c8dfff640f21f496b85ee193a470e8570ab7707b8e3bfccd7da34a6")
     version("6.23.1", sha256="23a1b0488aec5719e2f9e399342e10f30d497cbb9fd39470ef0975c1b502ae35")
     version("5.3.0", sha256="c9fdb53fe3bf1f8e7dcca1a7dd6e430862502f088aca2903d141511212e79429")

--- a/repos/spack_repo/builtin/packages/py_ibm_cloud_sdk_core/package.py
+++ b/repos/spack_repo/builtin/packages/py_ibm_cloud_sdk_core/package.py
@@ -17,6 +17,7 @@ class PyIbmCloudSdkCore(PythonPackage):
 
     license("Apache-2.0")
 
+    version("3.10.1", sha256="f807853ce3b861b428e60b3c3dad96818342b155f5fb41e8d2e8fd356e8257cc")
     version("3.10.0", sha256="ab9520be99066ec41a24e31ac653c28953adc8fc349f0fa53a598e1802a79cd6")
     version("3.9.0", sha256="51403f33003254d83d5028d8cebd7617f5cca82af85b6e9c4ad553eccd079dbf")
 

--- a/repos/spack_repo/builtin/packages/py_imagehash/package.py
+++ b/repos/spack_repo/builtin/packages/py_imagehash/package.py
@@ -17,6 +17,7 @@ class PyImagehash(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("4.3.2", sha256="e54a79805afb82a34acde4746a16540503a9636fd1ffb31d8e099b29bbbf8156")
     version("4.3.1", sha256="7038d1b7f9e0585beb3dd8c0a956f02b95a346c0b5f24a9e8cc03ebadaf0aa70")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_imageio/package.py
+++ b/repos/spack_repo/builtin/packages/py_imageio/package.py
@@ -20,6 +20,7 @@ class PyImageio(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("2.37.2", sha256="0212ef2727ac9caa5ca4b2c75ae89454312f440a756fcfc8ef1993e718f50f8a")
     version("2.37.0", sha256="71b57b3669666272c818497aebba2b4c5f20d5b37c81720e5e1a56d59c492996")
     version("2.35.1", sha256="4952dfeef3c3947957f6d5dedb1f4ca31c6e509a476891062396834048aeed2a")
     version("2.34.0", sha256="ae9732e10acf807a22c389aef193f42215718e16bd06eed0c5bb57e1034a4d53")

--- a/repos/spack_repo/builtin/packages/py_imageio_ffmpeg/package.py
+++ b/repos/spack_repo/builtin/packages/py_imageio_ffmpeg/package.py
@@ -21,6 +21,7 @@ class PyImageioFfmpeg(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("0.4.9", sha256="39bcd1660118ef360fa4047456501071364661aa9d9021d3d26c58f1ee2081f5")
     version("0.4.5", sha256="f2ea4245a2adad25dedf98d343159579167e549ac8c4691cef5eff980e20c139")
     version("0.4.3", sha256="f826260a3207b872f1a4ba87ec0c8e02c00afba4fd03348a59049bdd8215841e")
 

--- a/repos/spack_repo/builtin/packages/py_iminuit/package.py
+++ b/repos/spack_repo/builtin/packages/py_iminuit/package.py
@@ -17,6 +17,7 @@ class PyIminuit(PythonPackage):
 
     license("MIT AND LGPL-2.0-only", checked_by="wdconinc")
 
+    version("2.31.3", sha256="ffb3aeb2de26c400d0aff7e2b7457f64cd609a494c45ee579effee81b1bc5d78")
     version("2.31.1", sha256="d5e004f1ffd83d2a076409fbf4a79691e7a17c9d73950bb63465af32e104de18")
     version("2.30.1", sha256="2815bfdeb8e7f78185f316b75e2d4b19d0f6993bdc5ff03352ed37b70a796360")
     version("2.29.1", sha256="474d10eb2f924b9320f6f7093e4c149d0a38c124d0419c12a07a3eca942de025")

--- a/repos/spack_repo/builtin/packages/py_importlib_metadata/package.py
+++ b/repos/spack_repo/builtin/packages/py_importlib_metadata/package.py
@@ -16,6 +16,7 @@ class PyImportlibMetadata(PythonPackage):
 
     license("Apache-2.0")
 
+    version("8.7.1", sha256="49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb")
     version("8.7.0", sha256="d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000")
     version("7.0.1", sha256="f238736bb06590ae52ac1fab06a3a9ef1d8dce2b7a35b5ab329371d6c8f5d2cc")
     version("6.6.0", sha256="92501cdf9cc66ebd3e612f1b4f0c0765dfa42f0fa38ffb319b6bd84dd675d705")

--- a/repos/spack_repo/builtin/packages/py_inquirer/package.py
+++ b/repos/spack_repo/builtin/packages/py_inquirer/package.py
@@ -15,6 +15,7 @@ class PyInquirer(PythonPackage):
 
     license("MIT")
 
+    version("3.1.4", sha256="958dbd5978f173630756a6ed6243acf931e750416eb7a6ed3a0ff13af0fdfcb5")
     version("3.1.3", sha256="aac309406f5b49d4b8ab7c6872117f43bf082a552dc256aa16bc95e16bb58bec")
 
     depends_on("python@3.8:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_intbitset/package.py
+++ b/repos/spack_repo/builtin/packages/py_intbitset/package.py
@@ -19,6 +19,7 @@ class PyIntbitset(PythonPackage):
 
     license("LGPL-3.0-or-later")
 
+    version("3.0.2", sha256="a300b2d5a4989857ff1d0c3971624766a89a751e315aa080c07865031ae637a7")
     version("3.0.1", sha256="f1e6d03c6729922a223c51849df65b9e916e625aefb911784e7f9acd4c207d53")
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_invoke/package.py
+++ b/repos/spack_repo/builtin/packages/py_invoke/package.py
@@ -15,6 +15,7 @@ class PyInvoke(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("2.2.1", sha256="515bf49b4a48932b79b024590348da22f39c4942dff991ad1fb8b8baea1be707")
     version("2.2.0", sha256="ee6cbb101af1a859c7fe84f2a264c059020b0cb7fe3535f9424300ab568f6bd5")
     version("1.4.1", sha256="de3f23bfe669e3db1085789fd859eb8ca8e0c5d9c20811e2407fa042e8a5e15d")
     version("1.2.0", sha256="dc492f8f17a0746e92081aec3f86ae0b4750bf41607ea2ad87e5a7b5705121b7")

--- a/repos/spack_repo/builtin/packages/py_ipycanvas/package.py
+++ b/repos/spack_repo/builtin/packages/py_ipycanvas/package.py
@@ -15,6 +15,7 @@ class PyIpycanvas(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.14.3", sha256="c6a53a22eebf4d611b168b8f4434145883f27a7575509bd99a4bfc48c5385a39")
     version("0.14.1", sha256="921f1482258b5929b599317b5c129931d80e16be35fa38300a32e7aa4cfe9f89")
     version("0.10.2", sha256="a02c494834cb3c60509801172e7429beae837b3cb6c61d3becf8b586c5a66004")
     version("0.9.0", sha256="f29e56b93fe765ceace0676c3e75d44e02a3ff6c806f3b7e5b869279f470cc43")

--- a/repos/spack_repo/builtin/packages/py_ipyvue/package.py
+++ b/repos/spack_repo/builtin/packages/py_ipyvue/package.py
@@ -19,6 +19,7 @@ class PyIpyvue(PythonPackage):
 
     maintainers("jeremyfix")
 
+    version("1.10.2", sha256="a9973586fa2e296510d9a24b935a22a2450acca057b5de9f0bab66ecb1c33ab4")
     version("1.10.1", sha256="20615ce86ba516cf0b7aad84cc607e4e2c9104232e954cd0eccbf33530a5e1d4")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_ipyvuetify/package.py
+++ b/repos/spack_repo/builtin/packages/py_ipyvuetify/package.py
@@ -20,6 +20,7 @@ class PyIpyvuetify(PythonPackage):
 
     maintainers("jeremyfix")
 
+    version("1.9.4", sha256="c29c1f37af30a63dbe94b6f8c347ab01961aeceadb56135f18cbf4eb7e68895b")
     version("1.9.0", sha256="9c537e218299de32194b1da949d6b96bffe6c00f36bb6035409f2485feb881e7")
 
     depends_on("python@3.6:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_jaconv/package.py
+++ b/repos/spack_repo/builtin/packages/py_jaconv/package.py
@@ -17,6 +17,7 @@ class PyJaconv(PythonPackage):
 
     license("MIT")
 
+    version("0.3.4", sha256="9e7c55f3f0b0e2dbad62f6c9fa0c30fc6fffdbb78297955509d90856b3a31d6d")
     version("0.3", sha256="cc70c796c19a6765598c03eac59d1399a555a9a8839cc70e540ec26f0ec3e66e")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_jaxlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_jaxlib/package.py
@@ -49,6 +49,7 @@ class PyJaxlib(PythonPackage, CudaPackage, ROCmPackage):
     license("Apache-2.0")
     maintainers("adamjstewart", "jonas-eschle")
 
+    version("0.9.0.1", sha256="5da025820419009fe0e40f5ffb503015b4fff12d212afc6252ebcd37bf6f611e")
     version("0.9.0", sha256="8525c72ac7ea01851297df5b25ca4622c65299c265c87dfe78420bb29e7b1bb3")
     version("0.8.3", sha256="fad6506b91b761842263dc6a9691ecc4f584b313a214ed6c89b6e5d899a69a3d")
     version("0.8.2", sha256="f7e5080c97c1aaffb490a17d174cb59a83dd037800d9c41d309287bebd15b0b8")

--- a/repos/spack_repo/builtin/packages/py_jdatetime/package.py
+++ b/repos/spack_repo/builtin/packages/py_jdatetime/package.py
@@ -13,6 +13,7 @@ class PyJdatetime(PythonPackage):
     homepage = "https://github.com/slashmili/python-jalali"
     pypi = "jdatetime/jdatetime-3.6.2.tar.gz"
 
+    version("3.6.4", sha256="39d0be41076b3a3850c3bfa90817e7ed459edc0e9cadce37dc7229b11f121c7e")
     version("3.6.2", sha256="a589e35f0dab89283c1a3de9d70ed6cf657932aaed8e8ce1b0e5801aaab1da67")
 
     # pip silently replaces distutils with setuptools

--- a/repos/spack_repo/builtin/packages/py_joblib/package.py
+++ b/repos/spack_repo/builtin/packages/py_joblib/package.py
@@ -20,6 +20,7 @@ class PyJoblib(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.5.3", sha256="8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3")
     version("1.5.2", sha256="3faa5c39054b2f03ca547da9b2f52fde67c06240c31853f306aea97f13647b55")
     version("1.4.2", sha256="2382c5816b2636fbd20a09e0f4e9dad4736765fdfb7dca582943b9c1366b3f0e")
     version("1.2.0", sha256="e1cee4a79e4af22881164f218d4311f60074197fb707e082e803b61f6d137018")

--- a/repos/spack_repo/builtin/packages/py_jproperties/package.py
+++ b/repos/spack_repo/builtin/packages/py_jproperties/package.py
@@ -18,6 +18,7 @@ class PyJproperties(PythonPackage):
 
     license("BSD", checked_by="teaguesterling")
 
+    version("2.1.2", sha256="036fcd52c10a8a1c21e6fa2a1c292c93892e759b76490acc4809213a36ddc329")
     version("2.1.1", sha256="40b71124e8d257e8954899a91cd2d5c0f72e0f67f1b72048a5ba264567604f29")
     version("2.1.0", sha256="504d7b8d3b2f5f0f52c22c1f72bd50576dca17b01b4cd00d4359c6b0607a59ce")
     version("2.0.0", sha256="b6709652f5c602e5271f519cf14cb9bf5d5a101df06e6c1d300123477a239588")

--- a/repos/spack_repo/builtin/packages/py_jsonpath_ng/package.py
+++ b/repos/spack_repo/builtin/packages/py_jsonpath_ng/package.py
@@ -18,6 +18,7 @@ class PyJsonpathNg(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.6.1", sha256="086c37ba4917304850bd837aeab806670224d3f038fe2833ff593a672ef0a5fa")
     version("1.6.0", sha256="5483f8e9d74c39c9abfab554c070ae783c1c8cbadf5df60d561bc705ac68a07e")
     version("1.5.3", sha256="a273b182a82c1256daab86a313b937059261b5c5f8c4fa3fc38b882b344dd567")
     version("1.5.2", sha256="144d91379be14d9019f51973bd647719c877bfc07dc6f3f5068895765950c69d")

--- a/repos/spack_repo/builtin/packages/py_jupyter_server_terminals/package.py
+++ b/repos/spack_repo/builtin/packages/py_jupyter_server_terminals/package.py
@@ -13,6 +13,7 @@ class PyJupyterServerTerminals(PythonPackage):
     homepage = "https://github.com/jupyter-server/jupyter_server_terminals"
     pypi = "jupyter_server_terminals/jupyter_server_terminals-0.4.4.tar.gz"
 
+    version("0.5.4", sha256="bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5")
     version("0.5.3", sha256="5ae0295167220e9ace0edcfdb212afd2b01ee8d179fe6f23c899590e9b8a5269")
     version("0.4.4", sha256="57ab779797c25a7ba68e97bcfb5d7740f2b5e8a83b5e8102b10438041a7eac5d")
 

--- a/repos/spack_repo/builtin/packages/py_jupyterhub/package.py
+++ b/repos/spack_repo/builtin/packages/py_jupyterhub/package.py
@@ -14,6 +14,7 @@ class PyJupyterhub(PythonPackage):
 
     tags = ["e4s"]
 
+    version("1.4.2", sha256="d72908b3063fed1d35a3aa793c4a7ded2c8c4016b38e0135b33af0be49a8fc21")
     version("1.4.1", sha256="ee1b0718a4db8e0b339796e3e50b704ca6822ab22a7435289dbb5932f65b5199")
     version("1.0.0", sha256="33541a515a041b9a518ca057c1c4ab4215a7450fdddc206401713ee8137fa67f")
     version("0.9.4", sha256="7848bbb299536641a59eb1977ec3c7c95d931bace4a2803d7e9b28b9256714da")

--- a/repos/spack_repo/builtin/packages/py_keyring/package.py
+++ b/repos/spack_repo/builtin/packages/py_keyring/package.py
@@ -17,6 +17,7 @@ class PyKeyring(PythonPackage):
 
     license("MIT")
 
+    version("24.3.1", sha256="c3327b6ffafc0e8befbdb597cacdb4928ffe5c1212f7645f186e6d9957a898db")
     version("24.3.0", sha256="e730ecffd309658a08ee82535a3b5ec4b4c8669a9be11efb66249d8e0aeb9a25")
     version("23.13.1", sha256="ba2e15a9b35e21908d0aaf4e0a47acc52d6ae33444df0da2b49d41a46ef6d678")
     version("23.9.1", sha256="39e4f6572238d2615a82fcaa485e608b84b503cf080dc924c43bbbacb11c1c18")

--- a/repos/spack_repo/builtin/packages/py_kiwisolver/package.py
+++ b/repos/spack_repo/builtin/packages/py_kiwisolver/package.py
@@ -13,6 +13,7 @@ class PyKiwisolver(PythonPackage):
     homepage = "https://github.com/nucleic/kiwi"
     pypi = "kiwisolver/kiwisolver-1.1.0.tar.gz"
 
+    version("1.4.9", sha256="c3b22c26c6fd6811b0ae8363b95ca8ce4ea3c202d3d0975b2914310ceb1bcc4d")
     version("1.4.8", sha256="23d5f023bdc8c7e54eb65f03ca5d5bb25b601eac4d7f1a042888a1f45237987e")
     version("1.4.7", sha256="9893ff81bd7107f7b685d3017cc6583daadb4fc26e4a888350df530e41980a60")
     version("1.4.6", sha256="3cda29d601445e6aa11f80d90a9b8c2ae501650c55d7ad29829bd44499c9e7e0")

--- a/repos/spack_repo/builtin/packages/py_kmodes/package.py
+++ b/repos/spack_repo/builtin/packages/py_kmodes/package.py
@@ -16,6 +16,7 @@ class PyKmodes(PythonPackage):
 
     license("MIT")
 
+    version("0.10.2", sha256="2ae2e8dbc7b317f81354b951811df911ba2875d31a45bda4c6275e5eb35b84f2")
     version("0.10.1", sha256="3222c2f672a6356be353955c02d1e38472d9f6074744b4ffb0c058e8c2235ea1")
 
     depends_on("python@3.4:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_knack/package.py
+++ b/repos/spack_repo/builtin/packages/py_knack/package.py
@@ -16,6 +16,7 @@ class PyKnack(PythonPackage):
 
     license("MIT")
 
+    version("0.7.2", sha256="dfc6aef6760ea9a9620577e01540617678d78cab3111a0f03e8b9f987d0f08ca")
     version("0.7.1", sha256="fcef6040164ebe7d69629e4e089b398c9b980791446496301befcf8381dba0fc")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_kneaddata/package.py
+++ b/repos/spack_repo/builtin/packages/py_kneaddata/package.py
@@ -16,6 +16,7 @@ class PyKneaddata(PythonPackage):
     homepage = "https://github.com/biobakery/kneaddata"
     pypi = "kneaddata/kneaddata-0.12.0.tar.gz"
 
+    version("0.12.4", sha256="f95811aeb7c4a74250ce3f62879676f4e3c970f20dad2d5f9628250a9c45a6c3")
     version("0.12.0", sha256="b211bf973ea50cc89dd5935761ca3b101d422cfb62b215aae08f5ed92a624a58")
 
     maintainers("Pandapip1")

--- a/repos/spack_repo/builtin/packages/py_krb5/package.py
+++ b/repos/spack_repo/builtin/packages/py_krb5/package.py
@@ -17,6 +17,7 @@ class PyKrb5(PythonPackage):
 
     license("MIT", checked_by="wdconinc")
 
+    version("0.7.1", sha256="ed5f13d5031489b10d8655c0ada28a81c2391b3ecb8a08c6d739e1e5835bc450")
     version("0.7.0", sha256="6a308f2e17d151c395b24e6aec7bdff6a56fe3627a32042fc86d412398a92ddd")
     version("0.6.0", sha256="712ba092fbe3a28ec18820bb1b1ed2cc1037b75c5c7033f970c6a8c97bbd1209")
 

--- a/repos/spack_repo/builtin/packages/py_kt_legacy/package.py
+++ b/repos/spack_repo/builtin/packages/py_kt_legacy/package.py
@@ -17,6 +17,7 @@ class PyKtLegacy(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.0.5", sha256="dbbade58f12c6a6da6062f4b045a6395a8d4195815e3e064bc3e609b69c8a26c")
     version("1.0.4", sha256="a94112e42a50e7cc3aad31f3287aa384c23555ea1432c55b5823852e09e706cf")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_lfpykit/package.py
+++ b/repos/spack_repo/builtin/packages/py_lfpykit/package.py
@@ -16,6 +16,7 @@ class PyLfpykit(PythonPackage):
 
     license("GPL-3.0-only")
 
+    version("0.5.1", sha256="a962029460c8173c4fec3923204e04d64c370b05740b64c2d07efbe29cbe63a6")
     version("0.5", sha256="9a7ae80ad905bb8dd0eeab8517b43c3d5b4fff2b8766c9d5a36320a7a67bd545")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_lightning_fabric/package.py
+++ b/repos/spack_repo/builtin/packages/py_lightning_fabric/package.py
@@ -15,6 +15,9 @@ class PyLightningFabric(PythonPackage):
 
     license("Apache-2.0")
 
+    version(
+        "2.0.9.post0", sha256="542b28fc73119c6d54114e666157efed8f9f808bca5c72b4408e6911575bfcd0"
+    )
     version("2.0.0", sha256="56ecf23e2857f76cc1ca4528cc314b884fed1541182d4e8b130e3c2efd39c896")
 
     # src/lightning_fabric/__setup__.py

--- a/repos/spack_repo/builtin/packages/py_line_profiler/package.py
+++ b/repos/spack_repo/builtin/packages/py_line_profiler/package.py
@@ -17,6 +17,7 @@ class PyLineProfiler(PythonPackage):
 
     license("PSF-2.0")
 
+    version("4.1.3", sha256="e5f1123c3672c3218ba063c23bd64a51159e44649fed6780b993c781fb5ed318")
     version("4.1.2", sha256="aa56578b0ff5a756fe180b3fda7bd67c27bbd478b3d0124612d8cf00e4a21df2")
     version("3.5.1", sha256="77400208bfbd5d4341938a9a3a4fb5194f5af7fc23b2d496c913755f8310e8b8")
     version("2.1.2", sha256="efa66e9e3045aa7cb1dd4bf0106e07dec9f80bc781a993fbaf8162a36c20af5c")

--- a/repos/spack_repo/builtin/packages/py_lineenhancer/package.py
+++ b/repos/spack_repo/builtin/packages/py_lineenhancer/package.py
@@ -17,6 +17,7 @@ class PyLineenhancer(PythonPackage):
 
     license("MIT")
 
+    version("1.0.9", sha256="170698c7947c3257d19234668ad6743df163d26fe607dcab8d84a1995442f7b6")
     version("1.0.8", sha256="a1c7f2556110135d7298b0002674b669b8bbf23f94d63e3e3db8f17f2fd3efbe")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_linkify_it_py/package.py
+++ b/repos/spack_repo/builtin/packages/py_linkify_it_py/package.py
@@ -15,6 +15,7 @@ class PyLinkifyItPy(PythonPackage):
 
     license("MIT")
 
+    version("2.0.3", sha256="68cda27e162e9215c17d786649d1da0021a451bdc436ef9e0fa0ba5234b9b048")
     version("2.0.2", sha256="19f3060727842c254c808e99d465c80c49d2c7306788140987a1a7a29b0d6ad2")
     version("1.0.3", sha256="2b3f168d5ce75e3a425e34b341a6b73e116b5d9ed8dbbbf5dc7456843b7ce2ee")
 

--- a/repos/spack_repo/builtin/packages/py_lmfit/package.py
+++ b/repos/spack_repo/builtin/packages/py_lmfit/package.py
@@ -15,6 +15,7 @@ class PyLmfit(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.0.3", sha256="d067c3ea501f035af5d3c079e6e6e35dc3cc1ac7d439429a425b0aeb5a7858a2")
     version("1.0.2", sha256="67090ce56685cf7f92bd7358a1e7d4ad862b3758988109ec440e9825e5184b45")
     version("1.0.1", sha256="d249eb756899360f4d2a544c9458f47fc8f765ac22c09e099530585fd64e286e")
     version("0.9.15", sha256="cd7bdf47c09a3d49f30dff9a1c7f778973d15d1e1b5dc642f14c22f6630eaf2f")

--- a/repos/spack_repo/builtin/packages/py_logilab_common/package.py
+++ b/repos/spack_repo/builtin/packages/py_logilab_common/package.py
@@ -15,6 +15,7 @@ class PyLogilabCommon(PythonPackage):
 
     license("LGPL-2.1-or-later")
 
+    version("1.4.4", sha256="8c1bf26431a3b487940cd4a7c0eefde328f5ff7098222ee695805752dae94aa6")
     version("1.4.2", sha256="cdda9ed0deca7c68f87f7a404ad742e47aaa1ca5956d12988236a5ec3bda13a0")
     version("1.2.0", sha256="d4e5cec3be3a89f06ff05e359a221e69bd1da33cb7096cad648ddcccea8465b7")
 

--- a/repos/spack_repo/builtin/packages/py_loky/package.py
+++ b/repos/spack_repo/builtin/packages/py_loky/package.py
@@ -15,6 +15,7 @@ class PyLoky(PythonPackage):
 
     license("BSD-3-Clause", checked_by="RobertMaaskant")
 
+    version("3.5.6", sha256="d96935ed689aa53eeb7b329769544950fa10a52706968f5d0af3d9c33a761e77")
     version("3.5.1", sha256="bcd1d718f005d06b099da856305cb337be36f552d49794f0b86df628a885eefe")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_lru_dict/package.py
+++ b/repos/spack_repo/builtin/packages/py_lru_dict/package.py
@@ -16,6 +16,7 @@ class PyLruDict(PythonPackage):
 
     license("MIT")
 
+    version("1.1.8", sha256="878bc8ef4073e5cfb953dfc1cf4585db41e8b814c0106abde34d00ee0d0b3115")
     version("1.1.6", sha256="365457660e3d05b76f1aba3e0f7fedbfcd6528e97c5115a351ddd0db488354cc")
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_luigi/package.py
+++ b/repos/spack_repo/builtin/packages/py_luigi/package.py
@@ -15,6 +15,7 @@ class PyLuigi(PythonPackage):
 
     license("Apache-2.0")
 
+    version("3.2.1", sha256="54a2932d0682c15d93695473ba115157a40f503f54e5c5714997e4b68a5e625c")
     version("3.2.0", sha256="5ef267ebfbbd5747576821b6835e08e956e24055841dee0ef7b1319b4e9d4740")
     version("3.1.1", sha256="29961582db2704d8df4ec01f6b8f7f0d529cc8f27cff67733ccd809299771218")
     version("3.1.0", sha256="1ae7d76e6f8889e9ed40c699891f990eb6697c974eeaf8ab010f0dfc3766adf1")

--- a/repos/spack_repo/builtin/packages/py_lws/package.py
+++ b/repos/spack_repo/builtin/packages/py_lws/package.py
@@ -16,6 +16,7 @@ class PyLws(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.2.8", sha256="aaaf86c4f040bc33f81981333fb37c280cd82ec338b8a421a5f74ba3c6f64d06")
     version("1.2.6", sha256="ac94834832aadfcd53fcf4a77e1d95155063b39adbce14c733f8345bdac76e87")
 
     depends_on("cxx", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_lxml/package.py
+++ b/repos/spack_repo/builtin/packages/py_lxml/package.py
@@ -17,6 +17,7 @@ class PyLxml(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("6.0.2", sha256="cd79f3367bd74b317dda655dc8fcfa304d9eb6e4fb06b7168c5cf27f96e0cd62")
     version("6.0.1", sha256="2b3a882ebf27dd026df3801a87cf49ff791336e0f94b0fad195db77e01240690")
     version("5.3.0", sha256="4e109ca30d1edec1ac60cdbe341905dc3b8f55b16855e03a54aaf59e51ec8c6f")
     version("5.2.2", sha256="bb2dc4898180bea79863d5487e5f9c7c34297414bad54bcd0f0852aee9cfdb87")

--- a/repos/spack_repo/builtin/packages/py_mailchecker/package.py
+++ b/repos/spack_repo/builtin/packages/py_mailchecker/package.py
@@ -17,6 +17,7 @@ class PyMailchecker(PythonPackage):
 
     license("MIT")
 
+    version("4.0.9", sha256="ea94bfcd06d100fef5dc126f51b27269c7285e6939ab49281f21896cfa2160e7")
     version("4.0.3", sha256="00dbe9739c754366233eb3887c5deef987672482a26e814314c3e749fc7b1d1f")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_mailchecker/package.py
+++ b/repos/spack_repo/builtin/packages/py_mailchecker/package.py
@@ -17,7 +17,7 @@ class PyMailchecker(PythonPackage):
 
     license("MIT")
 
-    version("4.0.9", sha256="ea94bfcd06d100fef5dc126f51b27269c7285e6939ab49281f21896cfa2160e7")
+    version("4.0.16", sha256="801b914134c9da4b81b17bf58ea7e276090fc1c5a04347259f3d9b71b67daeed")
     version("4.0.3", sha256="00dbe9739c754366233eb3887c5deef987672482a26e814314c3e749fc7b1d1f")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_mapclassify/package.py
+++ b/repos/spack_repo/builtin/packages/py_mapclassify/package.py
@@ -17,6 +17,7 @@ class PyMapclassify(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("2.4.3", sha256="51b81e1f1ee7f64a4ca1e9f61f01216c364a3f086a48b1be38eb057199cb19bf")
     version("2.4.2", sha256="bc20954aa433466f5fbc572e3f23b05f9606b59209f40b0ded93ac1ca983d24e")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_markdown/package.py
+++ b/repos/spack_repo/builtin/packages/py_markdown/package.py
@@ -20,6 +20,7 @@ class PyMarkdown(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("3.4.4", sha256="225c6123522495d4119a90b3a3ba31a1e87a70369e03f14799ea9c0d7183a3d6")
     version("3.4.1", sha256="3b809086bb6efad416156e00a0da66fe47618a5d6918dd688f53f40c8e4cfeff")
     version("3.3.4", sha256="31b5b491868dcc87d6c24b7e3d19a0d730d59d3e46f4eea6430a321bed387a49")
     version("3.1.1", sha256="2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a")

--- a/repos/spack_repo/builtin/packages/py_markupsafe/package.py
+++ b/repos/spack_repo/builtin/packages/py_markupsafe/package.py
@@ -19,6 +19,7 @@ class PyMarkupsafe(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("3.0.3", sha256="722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698")
     version("3.0.2", sha256="ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0")
     version("2.1.5", sha256="d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b")
     version("2.1.3", sha256="af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad")

--- a/repos/spack_repo/builtin/packages/py_matplotlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_matplotlib/package.py
@@ -27,6 +27,7 @@ class PyMatplotlib(PythonPackage):
     license("Apache-2.0")
     maintainers("adamjstewart", "rgommers")
 
+    version("3.10.8", sha256="2299372c19d56bcd35cf05a2738308758d32b9eaed2371898d8f5bd33f084aa3")
     version("3.10.7", sha256="a06ba7e2a2ef9131c79c49e63dad355d2d878413a0376c1727c8b9335ff731c7")
     version("3.10.6", sha256="ec01b645840dd1996df21ee37f208cd8ba57644779fa20464010638013d3203c")
     version("3.10.5", sha256="352ed6ccfb7998a00881692f38b4ca083c691d3e275b4145423704c34c909076")

--- a/repos/spack_repo/builtin/packages/py_mayavi/package.py
+++ b/repos/spack_repo/builtin/packages/py_mayavi/package.py
@@ -16,6 +16,7 @@ class PyMayavi(PythonPackage):
 
     license("EPL-1.0")
 
+    version("4.7.4", sha256="ec50e7ec6afb0f9224ad1863d104a0d1ded6c8deb13e720652007aaca2303332")
     version("4.7.3", sha256="670d0023b9cd2d2346c451db9ba2f61da23a5df5033b25aea89cb6d81b9464f0")
     version(
         "4.7.1",

--- a/repos/spack_repo/builtin/packages/py_mdocfile/package.py
+++ b/repos/spack_repo/builtin/packages/py_mdocfile/package.py
@@ -16,6 +16,7 @@ class PyMdocfile(PythonPackage):
 
     license("BSD-3-Clause", checked_by="Markus92")
 
+    version("0.2.3", sha256="7cb9a4e14719fe76524a064209b0acc7ca9272781ae04ed03dceac7b23151c64")
     version("0.2.2", sha256="74d2dbe55ffda288f61cfac82aaf0052e1365a65c5acc1ed93e3c86e1457e5b0")
     version("0.0.8", sha256="61e352b569128fdeaff9f639e6aa3d46c8f8c3b8fe36627461ba0153f46f103d")
 

--- a/repos/spack_repo/builtin/packages/py_meshio/package.py
+++ b/repos/spack_repo/builtin/packages/py_meshio/package.py
@@ -15,6 +15,7 @@ class PyMeshio(PythonPackage):
 
     license("MIT")
 
+    version("5.0.6", sha256="2a47b09e27425f8c87e916c46385bc6525eaa1139a616a021eaf68cba5a9e5a1")
     version("5.0.1", sha256="e283f40b5fb68fc5c232829c33c086789661438960762b22dc2823571a089a8b")
     version("5.0.0", sha256="f6327c06d6171d30e0991d3dcb048751035f9cfac1f19e2444971275fd971188")
     version("4.4.6", sha256="be352a0924c9eff99768a6f402b7558dbb280bbf1e7bf43f18cef92db418684f")

--- a/repos/spack_repo/builtin/packages/py_metaphlan/package.py
+++ b/repos/spack_repo/builtin/packages/py_metaphlan/package.py
@@ -16,6 +16,7 @@ class PyMetaphlan(PythonPackage):
     homepage = "https://github.com/biobakery/MetaPhlAn/"
     pypi = "MetaPhlAn/MetaPhlAn-4.0.2.tar.gz"
 
+    version("4.0.6", sha256="e810d6b894ec6d0029255407f03a7dea1753ff65bde333ab34b40544cfb5553e")
     version("4.0.2", sha256="2549fdf2de97a0024551a7bb8d639613b8a7b612054506c88cdb719353f466ff")
     version("3.1.0", sha256="4e7a7a36d07ed6f4f945afc4216db7f691d44a22b059c2404c917a160a687a6b")
 

--- a/repos/spack_repo/builtin/packages/py_metpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_metpy/package.py
@@ -21,6 +21,7 @@ class PyMetpy(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.7.1", sha256="cdfd8fdab58bc092a1974c016f2ea3a7715ffdf6a4660b28b0de7049328bce75")
     version("1.7.0", sha256="aad7e03dc735cf8bfd870d16aca24920a707152de6caa24dbaf4da695c6f6ae4")
     version("1.6.2", sha256="eb065bac0d7818587fa38fa6c96dfe720d9d15b59af4e4866541894e267476bb")
     version("1.0.1", sha256="16fa9806facc24f31f454b898741ec5639a72ba9d4ff8a19ad0e94629d93cb95")

--- a/repos/spack_repo/builtin/packages/py_minio/package.py
+++ b/repos/spack_repo/builtin/packages/py_minio/package.py
@@ -17,6 +17,7 @@ class PyMinio(PythonPackage):
 
     license("Apache-2.0")
 
+    version("7.1.9", sha256="a711f3e6961ef083c161cee79f42a01d73369fc9111ccf76a74fb8d58b41d00a")
     version("7.1.2", sha256="40d0cdb4dba5d5610d6599ea740cf827102db5bfa71279fc220c3cf7305bedc1")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_minio/package.py
+++ b/repos/spack_repo/builtin/packages/py_minio/package.py
@@ -17,7 +17,7 @@ class PyMinio(PythonPackage):
 
     license("Apache-2.0")
 
-    version("7.1.9", sha256="a711f3e6961ef083c161cee79f42a01d73369fc9111ccf76a74fb8d58b41d00a")
+    version("7.1.17", sha256="b0b687c1ec9be422a1f8b04c65fb8e43a1c090f9508178db57c434a17341c404")
     version("7.1.2", sha256="40d0cdb4dba5d5610d6599ea740cf827102db5bfa71279fc220c3cf7305bedc1")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_mkdocs_material/package.py
+++ b/repos/spack_repo/builtin/packages/py_mkdocs_material/package.py
@@ -17,6 +17,7 @@ class PyMkdocsMaterial(PythonPackage):
 
     license("MIT")
 
+    version("8.4.4", sha256="877cdaff642a224ea50e8f0f0a024c6e4a883c731c2efe4a6aaa4b958f3fd693")
     version("8.4.0", sha256="6c0a6e6cda8b43956e0c562374588160af8110584a1444f422b1cfd91930f9c7")
     version("8.3.6", sha256="be8f95c0dfb927339b55b2cc066423dc0b381be9828ff74a5b02df979a859b66")
 

--- a/repos/spack_repo/builtin/packages/py_mkdocstrings/package.py
+++ b/repos/spack_repo/builtin/packages/py_mkdocstrings/package.py
@@ -16,6 +16,7 @@ class PyMkdocstrings(PythonPackage):
 
     license("ISC")
 
+    version("0.19.1", sha256="d1037cacb4b522c1e8c164ed5d00d724a82e49dcee0af80db8fb67b384faeef9")
     version("0.19.0", sha256="efa34a67bad11229d532d89f6836a8a215937548623b64f3698a1df62e01cc3e")
 
     depends_on("python@3.7:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_ml_dtypes/package.py
+++ b/repos/spack_repo/builtin/packages/py_ml_dtypes/package.py
@@ -18,6 +18,7 @@ class PyMlDtypes(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.5.4", sha256="8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453")
     version("0.5.1", tag="v0.5.1", commit="560866cfbb44990c9c68b82e878bf8ee7972a595")
     version("0.4.0", tag="v0.4.0", commit="9fc7e6773acb66fa496ed8d476a008a489a4da49")
     version("0.3.1", tag="v0.3.1", commit="bbeedd470ecac727c42e97648c0f27bfc312af30")

--- a/repos/spack_repo/builtin/packages/py_modules_gui/package.py
+++ b/repos/spack_repo/builtin/packages/py_modules_gui/package.py
@@ -18,6 +18,7 @@ class PyModulesGui(PythonPackage):
 
     license("GPL-2.0")
 
+    version("0.2.2", sha256="9b0b1a5aecff5db30e214d0e193cb2db6f35f89c672adf0267d00f9967512cc1")
     version("0.2", sha256="d58a3943f4631756afa4f84c13b70fae67a72365ab3cad28014f972b8d023aec")
 
     depends_on("py-setuptools@61:", type=("build"))

--- a/repos/spack_repo/builtin/packages/py_motmetrics/package.py
+++ b/repos/spack_repo/builtin/packages/py_motmetrics/package.py
@@ -17,6 +17,7 @@ class PyMotmetrics(PythonPackage):
 
     license("MIT")
 
+    version("1.2.5", sha256="3a777d5ab611cee008ae2c1acc39c7048d2b0b2eafed0f0f1ae473f35ebe34b9")
     version("1.2.0", sha256="7328d8468c948400b38fcc212f3e448bc1f2fdfc727e170d85a029e49f1cdbc6")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_mpld3/package.py
+++ b/repos/spack_repo/builtin/packages/py_mpld3/package.py
@@ -16,6 +16,7 @@ class PyMpld3(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.5.9", sha256="d8d228b2911132fd0154e2a49543b7f97247f9851cfe468c6b616f452c676158")
     version("0.5.8", sha256="1a167dbef836dd7c66d8aa71c06a32d50bffa18725f304d93cb74fdb3545043b")
     version("0.5.5", sha256="b080f3535238a71024c0158280ab4f6091717c45347c41c907012f8dd6da1bd5")
     version("0.3", sha256="4d455884a211bf99b37ecc760759435c7bb6a5955de47d8daf4967e301878ab7")

--- a/repos/spack_repo/builtin/packages/py_mpld3/package.py
+++ b/repos/spack_repo/builtin/packages/py_mpld3/package.py
@@ -16,7 +16,7 @@ class PyMpld3(PythonPackage):
 
     license("BSD-3-Clause")
 
-    version("0.5.9", sha256="d8d228b2911132fd0154e2a49543b7f97247f9851cfe468c6b616f452c676158")
+    version("0.5.12", sha256="1333e2bca012ea9af3c27801ba36f65bc26540b6fad4c56a903afb19477f2c37")
     version("0.5.8", sha256="1a167dbef836dd7c66d8aa71c06a32d50bffa18725f304d93cb74fdb3545043b")
     version("0.5.5", sha256="b080f3535238a71024c0158280ab4f6091717c45347c41c907012f8dd6da1bd5")
     version("0.3", sha256="4d455884a211bf99b37ecc760759435c7bb6a5955de47d8daf4967e301878ab7")

--- a/repos/spack_repo/builtin/packages/py_msgpack_numpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_msgpack_numpy/package.py
@@ -19,6 +19,7 @@ class PyMsgpackNumpy(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.4.8", sha256="c667d3180513422f9c7545be5eec5d296dcbb357e06f72ed39cc683797556e69")
     version("0.4.7.1", sha256="7eaf51acf82d7c467d21aa71df94e1c051b2055e54b755442051b474fa7cf5e1")
     version("0.4.7", sha256="8e975dd7dd9eb13cbf5e8cd90af1f12af98706bbeb7acfcbd8d558fd005a85d7")
     version("0.4.6", sha256="ef3c5fe3d6cbab5c9db97de7062681c18f82d32a37177aaaf58b483d0336f135")

--- a/repos/spack_repo/builtin/packages/py_multidict/package.py
+++ b/repos/spack_repo/builtin/packages/py_multidict/package.py
@@ -16,6 +16,7 @@ class PyMultidict(PythonPackage):
 
     license("Apache-2.0")
 
+    version("6.7.1", sha256="ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d")
     version("6.7.0", sha256="c6e99d9a65ca282e578dfea819cfa9c0a62b2499d8677392e09feaf305e9e6f5")
     version("6.6.4", sha256="d2d4e4787672911b48350df02ed3fa3fffdc2f2e8ca06dd6afdf34189b76a9dd")
     version("6.1.0", sha256="22ae2ebf9b0c69d206c003e2f6a914ea33f0a932d4aa16f236afc049d9958f4a")

--- a/repos/spack_repo/builtin/packages/py_mypy/package.py
+++ b/repos/spack_repo/builtin/packages/py_mypy/package.py
@@ -18,6 +18,7 @@ class PyMypy(PythonPackage):
 
     license("MIT AND PSF-2.0", checked_by="tgamblin")
 
+    version("1.19.1", sha256="19d88bb05303fe63f71dd2c6270daca27cb9401c4ca8255fe50d1d920e0eb9ba")
     version("1.19.0", sha256="f6b874ca77f733222641e5c46e4711648c4037ea13646fd0cdc814c2eaec2528")
     version("1.16.0", sha256="84b94283f817e2aa6350a14b4a8fb2a35a53c286f97c9d30f53b63620e7af8ab")
     version("1.15.0", sha256="404534629d51d3efea5c800ee7c42b72a6554d6c400e6a79eafe15d11341fd43")

--- a/repos/spack_repo/builtin/packages/py_mysqlclient/package.py
+++ b/repos/spack_repo/builtin/packages/py_mysqlclient/package.py
@@ -18,6 +18,7 @@ class PyMysqlclient(PythonPackage):
 
     license("GPL-2.0-or-later")
 
+    version("2.2.7", sha256="24ae22b59416d5fcce7e99c9d37548350b4565baac82f95e149cac6ce4163845")
     version("2.2.4", sha256="33bc9fb3464e7d7c10b1eaf7336c5ff8f2a3d3b88bab432116ad2490beb3bf41")
     version("1.4.6", sha256="f3fdaa9a38752a3b214a6fe79d7cae3653731a53e577821f9187e67cbecb2e16")
     version("1.4.5", sha256="e80109b0ae8d952b900b31b623181532e5e89376d707dcbeb63f99e69cefe559")

--- a/repos/spack_repo/builtin/packages/py_namex/package.py
+++ b/repos/spack_repo/builtin/packages/py_namex/package.py
@@ -15,6 +15,7 @@ class PyNamex(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.0.9", sha256="8adfea9da5cea5be8f4e632349b4669e30172c7859e1fd97459fdf3b17469253")
     version("0.0.8", sha256="32a50f6c565c0bb10aa76298c959507abdc0e850efe085dc38f3440fcb3aa90b")
     version("0.0.7", sha256="84ba65bc4d22bd909e3d26bf2ffb4b9529b608cb3f9a4336f776b04204ced69b")
 

--- a/repos/spack_repo/builtin/packages/py_napari_plugin_manager/package.py
+++ b/repos/spack_repo/builtin/packages/py_napari_plugin_manager/package.py
@@ -17,6 +17,7 @@ class PyNapariPluginManager(PythonPackage):
 
     license("BSD-3-Clause", checked_by="Markus92")
 
+    version("0.1.9", sha256="d1d599e32b8dbf665e33e59cee58bce138a163f58252e32db255ec72a3141df1")
     version("0.1.7", sha256="858adeacfc65bb8ed92e875659999a51c06188a6c813ebef54f5248e27dd5a74")
 
     depends_on("python@3.10:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_napari_plugin_manager/package.py
+++ b/repos/spack_repo/builtin/packages/py_napari_plugin_manager/package.py
@@ -17,7 +17,7 @@ class PyNapariPluginManager(PythonPackage):
 
     license("BSD-3-Clause", checked_by="Markus92")
 
-    version("0.1.9", sha256="d1d599e32b8dbf665e33e59cee58bce138a163f58252e32db255ec72a3141df1")
+    version("0.1.10", sha256="8e6ddbe642f44b79a0b3ffb8e4ebf8fc0962cecef4998a483a97b8b1196202cb")
     version("0.1.7", sha256="858adeacfc65bb8ed92e875659999a51c06188a6c813ebef54f5248e27dd5a74")
 
     depends_on("python@3.10:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_nara_wpe/package.py
+++ b/repos/spack_repo/builtin/packages/py_nara_wpe/package.py
@@ -20,6 +20,7 @@ class PyNaraWpe(PythonPackage):
 
     license("MIT")
 
+    version("0.0.9", sha256="407d340fdfc27b35f9c933f086e0e23be7b3d139b541c66acbfa31c2e7511b32")
     version("0.0.7", sha256="7aa2edd5261e5d953e584e69a9233d60fc588fc8a4b7886c3ce43cc8ac8cd99b")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_nara_wpe/package.py
+++ b/repos/spack_repo/builtin/packages/py_nara_wpe/package.py
@@ -20,7 +20,7 @@ class PyNaraWpe(PythonPackage):
 
     license("MIT")
 
-    version("0.0.9", sha256="407d340fdfc27b35f9c933f086e0e23be7b3d139b541c66acbfa31c2e7511b32")
+    version("0.0.11", sha256="e0321457319e01bc4967da8df1223056b0de5c467a212d4e1802f4abf1153a10")
     version("0.0.7", sha256="7aa2edd5261e5d953e584e69a9233d60fc588fc8a4b7886c3ce43cc8ac8cd99b")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_nbclassic/package.py
+++ b/repos/spack_repo/builtin/packages/py_nbclassic/package.py
@@ -15,6 +15,7 @@ class PyNbclassic(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.3.3", sha256="434228763f8cee754318cd6dfa42370db191af630dabab8e30bafc8c1aa3eee6")
     version("1.3.1", sha256="4c52da8fc88f9f73ef512cc305091d5ce726bdca19f44ed697cb5ba12dcaad3c")
     version("1.1.0", sha256="77b77ba85f9e988f9bad85df345b514e9e64c7f0e822992ab1df4a78ac64fc1e")
     version("1.0.0", sha256="0ae11eb2319455d805596bf320336cda9554b41d99ab9a3c31bf8180bffa30e3")

--- a/repos/spack_repo/builtin/packages/py_nbqa/package.py
+++ b/repos/spack_repo/builtin/packages/py_nbqa/package.py
@@ -15,6 +15,7 @@ class PyNbqa(PythonPackage):
 
     license("MIT")
 
+    version("1.6.4", sha256="1fbcbe37ef530495bd7f08e53bb838a869b074a0fbef5785ed270d370a613eb0")
     version("1.6.3", sha256="5394a29fc6d27b9a950c0a36d2d9de25de980be9acfe2a3f3aea0d27b5f7fec1")
 
     depends_on("python@3.8:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_nbstripout/package.py
+++ b/repos/spack_repo/builtin/packages/py_nbstripout/package.py
@@ -15,6 +15,7 @@ class PyNbstripout(PythonPackage):
 
     license("MIT")
 
+    version("0.8.2", sha256="2876530eb684bf93a5b48fe6d92b2163f78d040721c76b37d5b9e1514d38fc69")
     version("0.8.1", sha256="eaac8b6b4e729e8dfe1e5df2c0f8ba44abc5a17a65448f0480141f80be230bb1")
     version("0.6.1", sha256="9065bcdd1488b386e4f3c081ffc1d48f4513a2f8d8bf4d0d9a28208c5dafe9d3")
 

--- a/repos/spack_repo/builtin/packages/py_ncbi_genome_download/package.py
+++ b/repos/spack_repo/builtin/packages/py_ncbi_genome_download/package.py
@@ -16,6 +16,7 @@ class PyNcbiGenomeDownload(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.3.3", sha256="fb949f087f2cde1408414758678e714fb1a1f1b9196b3e8cac6bd3e8e395c996")
     version("0.3.1", sha256="74675e94f184b8d80429641b27ed6d46ed81028d95156337de6d09f8dd739c6e")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_neptune_client/package.py
+++ b/repos/spack_repo/builtin/packages/py_neptune_client/package.py
@@ -16,6 +16,7 @@ class PyNeptuneClient(PythonPackage):
     homepage = "https://neptune.ai/"
     pypi = "neptune-client/neptune-client-0.16.7.tar.gz"
 
+    version("0.16.9", sha256="d893af6280f3a7f07d64ff2eb7080cf3c7f3fdbab98217cbe53e081b4be2aee2")
     version("0.16.7", sha256="9b8bf2f59cb6b7ed6d96ea221b68ea20d9d481a1a4672d8173648ef998134454")
     version("0.16.1", sha256="821238f510486feacd87c745f4646916259a416545ab678b47195729c071f249")
 

--- a/repos/spack_repo/builtin/packages/py_nexusforge/package.py
+++ b/repos/spack_repo/builtin/packages/py_nexusforge/package.py
@@ -18,6 +18,7 @@ class PyNexusforge(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.8.2", sha256="a4511b4abed9a6968945ef5f73d1a329ac24994700c1805468a42fa1e2a11aa9")
     version("0.8.1", sha256="eb2909cbec185e7a73191c1be1e62902a0d8534f0d93454ef3e4e3b18b5129cf")
     version("0.8.0", sha256="4358505ead26e41c2a0c4e6113cf3a486c9661e2a3899394497a2b5a94b70424")
     version("0.7.0", sha256="a8d2951d9ad18df9f2f4db31a4c18fcdd27bfcec929b03a3c91f133ea439413c")

--- a/repos/spack_repo/builtin/packages/py_nh3/package.py
+++ b/repos/spack_repo/builtin/packages/py_nh3/package.py
@@ -15,6 +15,7 @@ class PyNh3(PythonPackage):
 
     license("MIT")
 
+    version("0.3.2", sha256="f394759a06df8b685a4ebfb1874fb67a9cbfd58c64fc5ed587a663c0e63ec376")
     version("0.3.0", sha256="d8ba24cb31525492ea71b6aac11a4adac91d828aadeff7c4586541bf5dc34d2f")
 
     depends_on("python@3.8:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_nibabel/package.py
+++ b/repos/spack_repo/builtin/packages/py_nibabel/package.py
@@ -19,6 +19,7 @@ class PyNibabel(PythonPackage):
     # As detailed: https://nipy.org/nibabel/legal.html
     license("MIT AND BSD-3-Clause AND PSF-2.0 AND PDDL-1.0")
 
+    version("5.3.3", sha256="8d2006b70d727fd0a798a88ae5fd64339741f436fcfc83d6ea3256cdbc51c5b7")
     version("5.3.2", sha256="0bdca6503b1c784b446c745a4542367de7756cfba0d72143b91f9ffb78be569b")
     version("5.2.1", sha256="b6c80b2e728e4bc2b65f1142d9b8d2287a9102a8bf8477e115ef0d8334559975")
     version("5.1.0", sha256="ce73ca5e957209e7219a223cb71f77235c9df2acf4d3f27f861ba38e9481ac53")

--- a/repos/spack_repo/builtin/packages/py_niworkflows/package.py
+++ b/repos/spack_repo/builtin/packages/py_niworkflows/package.py
@@ -15,7 +15,6 @@ class PyNiworkflows(PythonPackage):
 
     license("Apache-2.0")
 
-    version("1.4.9", sha256="981e6dea3b32a94b99e19174a8e0324f6d5dbef73cefccfbf1de82922e0e4d20")
     version("1.4.0", sha256="d4e59070fde0290e0bfeece120ff1d2ff1f9573e3f2e6a719fe463c913af25ec")
     version("1.3.5", sha256="92e24f3462fb3ad4d8ee724506fba05da2b3ca0626850dd2e637a553e17d69b8")
     version("1.0.4", sha256="34bfa5561e6f872dbd85bb30a1b44c5e1be525167abe3932aee8ac06d15f6ed9")

--- a/repos/spack_repo/builtin/packages/py_niworkflows/package.py
+++ b/repos/spack_repo/builtin/packages/py_niworkflows/package.py
@@ -15,6 +15,7 @@ class PyNiworkflows(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.4.9", sha256="981e6dea3b32a94b99e19174a8e0324f6d5dbef73cefccfbf1de82922e0e4d20")
     version("1.4.0", sha256="d4e59070fde0290e0bfeece120ff1d2ff1f9573e3f2e6a719fe463c913af25ec")
     version("1.3.5", sha256="92e24f3462fb3ad4d8ee724506fba05da2b3ca0626850dd2e637a553e17d69b8")
     version("1.0.4", sha256="34bfa5561e6f872dbd85bb30a1b44c5e1be525167abe3932aee8ac06d15f6ed9")

--- a/repos/spack_repo/builtin/packages/py_nose2/package.py
+++ b/repos/spack_repo/builtin/packages/py_nose2/package.py
@@ -15,6 +15,7 @@ class PyNose2(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("0.9.2", sha256="8762f77925bbafcdf38331e0e2ee718756fb75ff74b1f9097cd08731ad59ab5e")
     version("0.9.1", sha256="0ede156fd7974fa40893edeca0b709f402c0ccacd7b81b22e76f73c116d1b999")
     version("0.6.0", sha256="daa633e92a52e0db60ade7e105a2ba5cad7ac819f3608740dcfc6140b9fd0a94")
 

--- a/repos/spack_repo/builtin/packages/py_nuitka/package.py
+++ b/repos/spack_repo/builtin/packages/py_nuitka/package.py
@@ -19,6 +19,7 @@ class PyNuitka(PythonPackage):
 
     license("Apache-2.0")
 
+    version("2.2.3", sha256="aa78f838c2b5d165e2c071e9a9e705b2ac77506d24e91121321fa4b9740bba88")
     version("2.2.1", sha256="7bf67e80f94c93017fbaacfe1e277b92422d234a3c849a1555e43848f5fb27a1")
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_numba/package.py
+++ b/repos/spack_repo/builtin/packages/py_numba/package.py
@@ -22,6 +22,7 @@ class PyNumba(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("0.63.1", sha256="b320aa675d0e3b17b40364935ea52a7b1c670c9037c39cf92c49502a75902f4b")
     version("0.63.0", sha256="27e525ce6f9f727c4f61e89b9d453d4a7d0aabbbf110278988334f43cbd70fdc")
     version("0.62.1", sha256="7b774242aa890e34c21200a1fc62e5b5757d5286267e71103257f4e2af0d5161")
     version(

--- a/repos/spack_repo/builtin/packages/py_numpy_groupies/package.py
+++ b/repos/spack_repo/builtin/packages/py_numpy_groupies/package.py
@@ -25,6 +25,7 @@ class PyNumpyGroupies(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("0.11.3", sha256="aed4afdad55e856b9e737fe4b4673c77e47c2f887c3663a18baaa200407c23e0")
     version("0.11.2", sha256="2fda978c4d28d2f1633a63972f425d0a7f2f12a75505d215b41b6de712e2ec4b")
     version("0.9.20", sha256="923a382d6bc6876384b58a9c0503b05b9d36a660f329695c2d33e4f93fcbbe3d")
 

--- a/repos/spack_repo/builtin/packages/py_numpy_stl/package.py
+++ b/repos/spack_repo/builtin/packages/py_numpy_stl/package.py
@@ -15,6 +15,7 @@ class PyNumpyStl(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("3.0.1", sha256="dd4da1a379d2632f168518be8dcd9cddd7edc6c3238094fd8d21476b3586a0bc")
     version("3.0.0", sha256="578b78eacb0529ac9aba2f17dcc363d58c7c3c5708710c18f8c1e9965f2e81ac")
     version("2.10.1", sha256="f6b529b8a8112dfe456d4f7697c7aee0aca62be5a873879306afe4b26fca963c")
 

--- a/repos/spack_repo/builtin/packages/py_obspy/package.py
+++ b/repos/spack_repo/builtin/packages/py_obspy/package.py
@@ -18,6 +18,7 @@ class PyObspy(PythonPackage):
 
     license("LGPL-3.0-only", checked_by="snehring")
 
+    version("1.4.2", sha256="dd93a17cda32be057937b551f096df07def6aa61ccf26558ce9cd1866a70397c")
     version("1.4.1", sha256="9cf37b0ce03de43d80398703c006bfddbd709f32e8460a9404b27df998d3f747")
     version("1.4.0", sha256="336a6e1d9a485732b08173cb5dc1dd720a8e53f3b54c180a62bb8ceaa5fe5c06")
 

--- a/repos/spack_repo/builtin/packages/py_onnx_opcounter/package.py
+++ b/repos/spack_repo/builtin/packages/py_onnx_opcounter/package.py
@@ -15,6 +15,7 @@ class PyOnnxOpcounter(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.0.4", sha256="b12ace32c4f953dd2232ebf901131af55eb8a4ebf6abf877a5af38cc1cc845f2")
     version("0.0.3", sha256="c75e76d066eb777e4855c486beb402b1fef83783a6634237b8ca20eb75cce8c9")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_openai/package.py
+++ b/repos/spack_repo/builtin/packages/py_openai/package.py
@@ -21,7 +21,7 @@ class PyOpenai(PythonPackage):
 
     license("MIT")
 
-    version("0.27.9", sha256="b687761c82f5ebb6f61efc791b2083d2d068277b94802d4d1369efe39851813d")
+    version("0.27.10", sha256="60e09edf7100080283688748c6803b7b3b52d5a55d21890f3815292a0552d83b")
     version("0.27.8", sha256="2483095c7db1eee274cebac79e315a986c4e55207bb4fa7b82d185b3a2ed9536")
 
     variant("datalib", default=False, description="facilities for data loading")

--- a/repos/spack_repo/builtin/packages/py_openai/package.py
+++ b/repos/spack_repo/builtin/packages/py_openai/package.py
@@ -21,6 +21,7 @@ class PyOpenai(PythonPackage):
 
     license("MIT")
 
+    version("0.27.9", sha256="b687761c82f5ebb6f61efc791b2083d2d068277b94802d4d1369efe39851813d")
     version("0.27.8", sha256="2483095c7db1eee274cebac79e315a986c4e55207bb4fa7b82d185b3a2ed9536")
 
     variant("datalib", default=False, description="facilities for data loading")

--- a/repos/spack_repo/builtin/packages/py_openpmd_validator/package.py
+++ b/repos/spack_repo/builtin/packages/py_openpmd_validator/package.py
@@ -20,6 +20,7 @@ class PyOpenpmdValidator(PythonPackage):
 
     license("ISC")
 
+    version("1.1.0.6", sha256="6ac3c744b2e0f5cdb6d89ee265b8c5d33bc2bf0fcbbd71a75dfd1d82f5d292ca")
     version("1.1.0.3", sha256="b2e57123c1dc09cdc121011d007e30fab82b3d21732d02e4f1ba919b24345810")
     version("1.1.0.2", sha256="6ac6e2860351d9940821ca6f3b44ab63629e0bd06f6984225c55830c3e58b83c")
     version("1.1.0.1", sha256="7585abbd32523ae6b8065772e1cc27a45e232c526a9fc0bd8ce85182d1b4b325")

--- a/repos/spack_repo/builtin/packages/py_ops/package.py
+++ b/repos/spack_repo/builtin/packages/py_ops/package.py
@@ -15,6 +15,7 @@ class PyOps(PythonPackage):
 
     license("Apache-2.0", checked_by="qwertos")
 
+    version("2.16.1", sha256="64315cd114cd5f445ce0f382ecebe431dd05620a7917f76eb2d77632fdea8cbb")
     version("2.16.0", sha256="c4405185744c82589fca4752a76cd7eabd667cf2d3f07d2700b82777186b8de9")
     version("1.4.0", sha256="6bb7c8d8cd3eb1da99469564e37a04f9677205c4c07ef97167e0b93a17ccb59a")
 

--- a/repos/spack_repo/builtin/packages/py_orbax_checkpoint/package.py
+++ b/repos/spack_repo/builtin/packages/py_orbax_checkpoint/package.py
@@ -19,7 +19,6 @@ class PyOrbaxCheckpoint(PythonPackage):
 
     license("Apache-2.0")
 
-    version("0.5.9", sha256="1fde8891433723157bf6e75d341094d1dabed1dbcfc7cfcfb381de088b468b60")
     version("0.5.3", sha256="1572904cbbfe8513927e0d80f80b730e0ef2f680332d3c2810d8443532938b45")
 
     depends_on("py-flit-core@3.5:3", type="build")

--- a/repos/spack_repo/builtin/packages/py_orbax_checkpoint/package.py
+++ b/repos/spack_repo/builtin/packages/py_orbax_checkpoint/package.py
@@ -19,6 +19,7 @@ class PyOrbaxCheckpoint(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.5.9", sha256="1fde8891433723157bf6e75d341094d1dabed1dbcfc7cfcfb381de088b468b60")
     version("0.5.3", sha256="1572904cbbfe8513927e0d80f80b730e0ef2f680332d3c2810d8443532938b45")
 
     depends_on("py-flit-core@3.5:3", type="build")

--- a/repos/spack_repo/builtin/packages/py_oslo_serialization/package.py
+++ b/repos/spack_repo/builtin/packages/py_oslo_serialization/package.py
@@ -18,6 +18,7 @@ class PyOsloSerialization(PythonPackage):
 
     maintainers("haampie")
 
+    version("4.1.1", sha256="05995169131f5e82ce9af8bbef99ada5ca457c9a60f979590bbe5f1a414368cd")
     version("4.1.0", sha256="cecc7794df806c85cb70dbd6c2b3af19bc68047ad29e3c6442be90a0a4de5379")
 
     depends_on("python@3.6:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_paralleltask/package.py
+++ b/repos/spack_repo/builtin/packages/py_paralleltask/package.py
@@ -17,6 +17,7 @@ class PyParalleltask(PythonPackage):
 
     license("GPL-3.0-only")
 
+    version("0.2.3", sha256="8015a8311d5021bc44edbfbf45ff2557a529999e235d25190bac62993fdf7b66")
     version("0.2.2", sha256="f00945e2bd5b6aff9cdc48fbd92aa7b48d23bb530d7f6643ac966fea11a7a9d5")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_parameterized/package.py
+++ b/repos/spack_repo/builtin/packages/py_parameterized/package.py
@@ -13,6 +13,7 @@ class PyParameterized(PythonPackage):
     homepage = "https://github.com/wolever/parameterized"
     pypi = "parameterized/parameterized-0.7.1.tar.gz"
 
+    version("0.7.5", sha256="b5e6af67b9e49485e30125b1c8f031ffa81a265ca08bfa73f31551bf03cf68c4")
     version("0.7.1", sha256="6a94dbea30c6abde99fd4c2f2042c1bf7f980e48908bf92ead62394f93cf57ed")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_parasail/package.py
+++ b/repos/spack_repo/builtin/packages/py_parasail/package.py
@@ -19,6 +19,7 @@ class PyParasail(PythonPackage):
 
     license("LiLiQ-R-1.1")
 
+    version("1.3.4", sha256="d6a7035dfae3ef5aafdd7e6915711214c22b572ea059fa69d9d7ecbfb9b61b0f")
     version("1.3.3", sha256="06f05066d9cf624c0b043f51a1e9d2964154e1edd0f9843e0838f32073e576f8")
 
     depends_on("perl", type="build")

--- a/repos/spack_repo/builtin/packages/py_parmed/package.py
+++ b/repos/spack_repo/builtin/packages/py_parmed/package.py
@@ -18,6 +18,7 @@ class PyParmed(PythonPackage):
 
     license("MIT")
 
+    version("3.4.4", sha256="96dd9e4d7de413d83b18a85c971dd1ea957077d435e4b9041f3b160a666f8647")
     version("3.4.3", sha256="90afb155e3ffe69230a002922b28968464126d4450059f0bd97ceca679c6627c")
 
     depends_on("cxx", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_paste/package.py
+++ b/repos/spack_repo/builtin/packages/py_paste/package.py
@@ -16,6 +16,7 @@ class PyPaste(PythonPackage):
 
     license("MIT")
 
+    version("3.5.3", sha256="fa093f46a4d1ea3898a849c8ce1d2a425c2bed5fc06b36384fe3ffaa652c081b")
     version("3.5.2", sha256="d5a7340c30bcdf3023dd0106c8a5c430dd8fe84aeb8113bc7b93f8dd729f4af6")
 
     depends_on("python@3:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_path_py/package.py
+++ b/repos/spack_repo/builtin/packages/py_path_py/package.py
@@ -15,6 +15,7 @@ class PyPathPy(PythonPackage):
 
     license("MIT")
 
+    version("12.0.2", sha256="45556ae7d59268a7d41ce5c43d53dc0fc7aab3f1028895003a8831d151a96f19")
     version("12.0.1", sha256="9f2169633403aa0423f6ec000e8701dd1819526c62465f5043952f92527fea0f")
     version("5.2", sha256="9916ae9aa603ce7e131e4ac76c25bcdbf6208f8fe5cc565a5022b85dc9d7022c")
 

--- a/repos/spack_repo/builtin/packages/py_pathml/package.py
+++ b/repos/spack_repo/builtin/packages/py_pathml/package.py
@@ -15,6 +15,7 @@ class PyPathml(PythonPackage):
 
     license("GPL-2.0-or-later")
 
+    version("2.1.1", sha256="151534376179334ca59e17a7e9a324471d1b081bdb28aa3b76eb18e3478c77ba")
     version("2.1.0", sha256="462bb2f16452dddad310c30f62678a1336ce492263355fd6722c07ee4840ea6a")
 
     depends_on("py-setuptools@42:", type="build")

--- a/repos/spack_repo/builtin/packages/py_pathy/package.py
+++ b/repos/spack_repo/builtin/packages/py_pathy/package.py
@@ -15,6 +15,7 @@ class PyPathy(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.10.3", sha256="b45185d06f9b18c6d3346d3aab881ab96874553f661ee88ccd2e60246e103c22")
     version("0.10.1", sha256="4cd6e71b4cd5ff875cfbb949ad9fa5519d8d1dbe69d5fc1d1b23aa3cb049618b")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_patsy/package.py
+++ b/repos/spack_repo/builtin/packages/py_patsy/package.py
@@ -19,6 +19,7 @@ class PyPatsy(PythonPackage):
 
     license("PSF-2.0")
 
+    version("1.0.2", sha256="cdc995455f6233e90e22de72c37fcadb344e7586fb83f06696f54d92f8ce74c0")
     version("1.0.1", sha256="e786a9391eec818c054e359b737bbce692f051aee4c661f4141cc88fb459c0c4")
     version("0.5.4", sha256="7dabc527597308de0e8f188faa20af7e06a89bdaa306756dfc7783693ea16af4")
     version("0.5.3", sha256="bdc18001875e319bc91c812c1eb6a10be4bb13cb81eb763f466179dca3b67277")

--- a/repos/spack_repo/builtin/packages/py_pdm_backend/package.py
+++ b/repos/spack_repo/builtin/packages/py_pdm_backend/package.py
@@ -15,6 +15,7 @@ class PyPdmBackend(PythonPackage):
 
     license("MIT", checked_by="matz-e")
 
+    version("2.4.7", sha256="a509d083850378ce919d41e7a2faddfc57a1764d376913c66731125d6b14110f")
     version("2.4.5", sha256="56c019c440308adad5d057c08cbb777e65f43b991a3b0920749781258972fe5b")
     version("2.4.3", sha256="dbd9047a7ac10d11a5227e97163b617ad5d665050476ff63867d971758200728")
     version("2.3.0", sha256="e39ed2da206d90d4a6e9eb62f6dce54ed4fa65ddf172a7d5700960d0f8a09e09")

--- a/repos/spack_repo/builtin/packages/py_pdm_pep517/package.py
+++ b/repos/spack_repo/builtin/packages/py_pdm_pep517/package.py
@@ -16,6 +16,7 @@ class PyPdmPep517(PythonPackage):
 
     license("MIT")
 
+    version("1.0.6", sha256="a4407703d50fa4d671383a354868b05a13060c1bf38264cbb5ddc9a73e4a1dc5")
     version("1.0.4", sha256="392f8c2b47c6ec20550cb8e19e24b9dbd27373413f067b56ecd75f9767f93015")
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_pebble/package.py
+++ b/repos/spack_repo/builtin/packages/py_pebble/package.py
@@ -16,6 +16,7 @@ class PyPebble(PythonPackage):
 
     license("LGPL-3.0-only")
 
+    version("5.0.7", sha256="2784c147766f06388cea784084b14bec93fdbaa793830f1983155aa330a2a6e4")
     version("5.0.3", sha256="bdcfd9ea7e0aedb895b204177c19e6d6543d9962f4e3402ebab2175004863da8")
 
     depends_on("python@3.6:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_periodictable/package.py
+++ b/repos/spack_repo/builtin/packages/py_periodictable/package.py
@@ -13,6 +13,7 @@ class PyPeriodictable(PythonPackage):
 
     pypi = "periodictable/periodictable-1.4.1.tar.gz"
 
+    version("1.5.3", sha256="1d09c359468e2de74b43fc3a7dcb0d3d71e0ff53adb85995215d8d7796451af6")
     version("1.5.0", sha256="b020c04c6765d21903e4604a76ca33cda98677003fe6eb48ed3690cfb03253b2")
     version("1.4.1", sha256="f42e66f6efca33caec4f27dad8d6a6d4e59da147ecf5adfce152cb84e7bd160b")
 

--- a/repos/spack_repo/builtin/packages/py_phanotate/package.py
+++ b/repos/spack_repo/builtin/packages/py_phanotate/package.py
@@ -20,6 +20,7 @@ class PyPhanotate(PythonPackage):
 
     license("GPL-3.0-or-later")
 
+    version("1.5.1", sha256="1c3b241d59b801f9023946ef3ba1090e4fc32a4ff5bd06ba0144320ae9693de6")
     version("1.5.0", sha256="589e441d2369e5550aef98b8d99fd079d130363bf881a70ac862fc7a8e0d2c88")
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_pipdeptree/package.py
+++ b/repos/spack_repo/builtin/packages/py_pipdeptree/package.py
@@ -16,6 +16,7 @@ class PyPipdeptree(PythonPackage):
 
     license("MIT")
 
+    version("2.13.2", sha256="1237791977ef61602dc967b287167c1a6b058501afbc145a04e835c622355e6f")
     version("2.13.0", sha256="ff71a48abd0b1ab810c23734b47de6ebd93270857d6665e21ed5ef6136fcba6e")
 
     depends_on("python@3.8:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_plac/package.py
+++ b/repos/spack_repo/builtin/packages/py_plac/package.py
@@ -19,6 +19,7 @@ class PyPlac(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("1.4.5", sha256="5f05bf85235c017fcd76c73c8101d4ff8e96beb3dc58b9a37de49cac7de82d14")
     version("1.4.3", sha256="d4cb3387b2113a28aebd509433d0264a4e5d9bb7c1a86db4fbd0a8f11af74eb3")
     version("1.3.5", sha256="38bdd864d0450fb748193aa817b9c458a8f5319fbf97b2261151cfc0a5812090")
     version("1.3.3", sha256="51e332dabc2aed2cd1f038be637d557d116175101535f53eaa7ae854a00f2a74")

--- a/repos/spack_repo/builtin/packages/py_planet/package.py
+++ b/repos/spack_repo/builtin/packages/py_planet/package.py
@@ -15,6 +15,7 @@ class PyPlanet(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.4.9", sha256="c779bb923fa3ddbfb271de40d925b2370663588575e6f829ab1a63119817fa7b")
     version("1.4.6", sha256="43ff6a765f465302f500aaf65b81a46ac6aad7bb42899e4a7543bdc293d4ca0d")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_planet/package.py
+++ b/repos/spack_repo/builtin/packages/py_planet/package.py
@@ -15,7 +15,6 @@ class PyPlanet(PythonPackage):
 
     license("Apache-2.0")
 
-    version("1.4.9", sha256="c779bb923fa3ddbfb271de40d925b2370663588575e6f829ab1a63119817fa7b")
     version("1.4.6", sha256="43ff6a765f465302f500aaf65b81a46ac6aad7bb42899e4a7543bdc293d4ca0d")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_plotly/package.py
+++ b/repos/spack_repo/builtin/packages/py_plotly/package.py
@@ -18,6 +18,7 @@ class PyPlotly(PythonPackage):
 
     license("MIT")
 
+    version("6.3.1", sha256="dd896e3d940e653a7ce0470087e82c2bd903969a55e30d1b01bb389319461bb0")
     version("6.3.0", sha256="8840a184d18ccae0f9189c2b9a2943923fd5cae7717b723f36eef78f444e5a73")
     version("5.20.0", sha256="bf901c805d22032cfa534b2ff7c5aa6b0659e037f19ec1e0cca7f585918b5c89")
     version("5.19.0", sha256="5ea91a56571292ade3e3bc9bf712eba0b95a1fb0a941375d978cc79432e055f4")

--- a/repos/spack_repo/builtin/packages/py_poetry_core/package.py
+++ b/repos/spack_repo/builtin/packages/py_poetry_core/package.py
@@ -15,6 +15,7 @@ class PyPoetryCore(PythonPackage):
 
     license("MIT")
 
+    version("2.2.1", sha256="97e50d8593c8729d3f49364b428583e044087ee3def1e010c6496db76bd65ac5")
     version("2.2.0", sha256="b4033b71b99717a942030e074fec7e3082e5fde7a8ed10f02cd2413bdf940b1f")
     version("2.1.2", sha256="f9dbbbd0ebf9755476a1d57f04b30e9aecf71ca9dc2fcd4b17aba92c0002aa04")
     version("1.8.1", sha256="67a76c671da2a70e55047cddda83566035b701f7e463b32a2abfeac6e2a16376")

--- a/repos/spack_repo/builtin/packages/py_pomegranate/package.py
+++ b/repos/spack_repo/builtin/packages/py_pomegranate/package.py
@@ -15,6 +15,7 @@ class PyPomegranate(PythonPackage):
 
     license("MIT")
 
+    version("0.12.2", sha256="942a7bd3b3d5a540a00edc7a12166b37384a068cc4b2f1fdb10f3afeeb6e9eeb")
     version("0.12.0", sha256="8b00c88f7cf9cad8d38ea00ea5274821376fefb217a1128afe6b1fcac54c975a")
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_preshed/package.py
+++ b/repos/spack_repo/builtin/packages/py_preshed/package.py
@@ -16,7 +16,6 @@ class PyPreshed(PythonPackage):
 
     license("MIT")
 
-    version("3.0.9", sha256="721863c5244ffcd2651ad0928951a2c7c77b102f4e11a251ad85d37ee7621660")
     version("3.0.8", sha256="6c74c70078809bfddda17be96483c41d06d717934b07cab7921011d81758b357")
     version("3.0.2", sha256="61d73468c97c1d6d5a048de0b01d5a6fd052123358aca4823cdb277e436436cb")
 

--- a/repos/spack_repo/builtin/packages/py_preshed/package.py
+++ b/repos/spack_repo/builtin/packages/py_preshed/package.py
@@ -16,6 +16,7 @@ class PyPreshed(PythonPackage):
 
     license("MIT")
 
+    version("3.0.9", sha256="721863c5244ffcd2651ad0928951a2c7c77b102f4e11a251ad85d37ee7621660")
     version("3.0.8", sha256="6c74c70078809bfddda17be96483c41d06d717934b07cab7921011d81758b357")
     version("3.0.2", sha256="61d73468c97c1d6d5a048de0b01d5a6fd052123358aca4823cdb277e436436cb")
 

--- a/repos/spack_repo/builtin/packages/py_pudb/package.py
+++ b/repos/spack_repo/builtin/packages/py_pudb/package.py
@@ -16,6 +16,7 @@ class PyPudb(PythonPackage):
 
     license("MIT")
 
+    version("2017.1.4", sha256="aac8cb5008402e0189055f0288d9379c855c8506ab70f4c47cc7459925fa348a")
     version("2017.1.1", sha256="87117640902c5f602c8517d0167eb5c953a5bdede97975ba29ff17e3d570442c")
     version("2016.2", sha256="e958d7f7b1771cf297714e95054075df3b2a47455d7a740be4abbbd41289505a")
 

--- a/repos/spack_repo/builtin/packages/py_py2bit/package.py
+++ b/repos/spack_repo/builtin/packages/py_py2bit/package.py
@@ -14,6 +14,7 @@ class PyPy2bit(PythonPackage):
 
     license("MIT")
 
+    version("0.2.2", sha256="8bf068f250b18144cf31984f7325424abc315082c1d18bf526ae424966a56249")
     version("0.2.1", sha256="34f7ac22be0eb4b5493063826bcc2016a78eb216bb7130890b50f3572926aeb1")
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_py4j/package.py
+++ b/repos/spack_repo/builtin/packages/py_py4j/package.py
@@ -18,6 +18,7 @@ class PyPy4j(PythonPackage):
 
     maintainers("teaguesterling")
 
+    version("0.10.9.9", sha256="f694cad19efa5bd1dee4f3e5270eb406613c974394035e5bfc4ec1aba870b879")
     version("0.10.9.7", sha256="0b6e5315bb3ada5cf62ac651d107bb2ebc02def3dee9d9548e3baac644ea8dbb")
     version("0.10.9.5", sha256="276a4a3c5a2154df1860ef3303a927460e02e97b047dc0a47c1c3fb8cce34db6")
     version("0.10.9.3", sha256="0d92844da4cb747155b9563c44fc322c9a1562b3ef0979ae692dbde732d784dd")

--- a/repos/spack_repo/builtin/packages/py_py6s/package.py
+++ b/repos/spack_repo/builtin/packages/py_py6s/package.py
@@ -17,6 +17,7 @@ class PyPy6s(PythonPackage):
     homepage = "https://py6s.rtwilson.com/"
     pypi = "py6s/Py6S-1.8.0.tar.gz"
 
+    version("1.8.2", sha256="296b09db5e56ef82aced031aa06219c2901ef598f67c0e47d07c566bfb4b87db")
     version("1.8.0", sha256="256162d2f1f558e601d4f79022c037a0051838ba307b9f4d1f5fcf0b46a0c277")
 
     depends_on("python@3:", type=("build", "run"), when="@1.8.0")

--- a/repos/spack_repo/builtin/packages/py_pyaml_env/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyaml_env/package.py
@@ -15,6 +15,7 @@ class PyPyamlEnv(PythonPackage):
 
     license("MIT", checked_by="A_N_Other")
 
+    version("1.2.2", sha256="f83502516b6f1561ba7c2db9ced939a7a9933a66702d8071e98ad07da49a4bb4")
     version("1.2.1", sha256="6d5dc98c8c82df743a132c196e79963050c9feb05b0a6f25f3ad77771d3d95b0")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_pyani/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyani/package.py
@@ -19,7 +19,7 @@ class PyPyani(PythonPackage):
 
     license("MIT")
 
-    version("0.2.9", sha256="0b87870a03cf5ccd8fbab7572778903212a051990f00cf8e4ef5887b36b9ec91")
+    version("0.2.12", sha256="4f56b217656f53416b333b69495a4ba8cde782e64e475e1481cb2213ce6b9388")
     version("0.2.7", sha256="dbc6c71c46fbbfeced3f8237b84474221268b51170caf044bec8559987a7deb9")
     version("0.2.6", sha256="e9d899bccfefaabe7bfa17d48eef9c713d321d2d15465f7328c8984807c3dd8d")
 

--- a/repos/spack_repo/builtin/packages/py_pyani/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyani/package.py
@@ -19,6 +19,7 @@ class PyPyani(PythonPackage):
 
     license("MIT")
 
+    version("0.2.9", sha256="0b87870a03cf5ccd8fbab7572778903212a051990f00cf8e4ef5887b36b9ec91")
     version("0.2.7", sha256="dbc6c71c46fbbfeced3f8237b84474221268b51170caf044bec8559987a7deb9")
     version("0.2.6", sha256="e9d899bccfefaabe7bfa17d48eef9c713d321d2d15465f7328c8984807c3dd8d")
 

--- a/repos/spack_repo/builtin/packages/py_pycbc/package.py
+++ b/repos/spack_repo/builtin/packages/py_pycbc/package.py
@@ -20,6 +20,7 @@ class PyPycbc(PythonPackage):
 
     license("GPL-3.0-or-later")
 
+    version("1.14.4", sha256="99741c702982b7b782c926055a418a27df3c27357c460551751b111084687a45")
     version("1.14.1", sha256="4b0a309cb6209837aaebbd691413a286dd7200ccf4b977ffed1462a65ac35dc0")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_pycortex/package.py
+++ b/repos/spack_repo/builtin/packages/py_pycortex/package.py
@@ -19,6 +19,7 @@ class PyPycortex(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("1.2.9", sha256="1b290a292ceb47208a578c5fad0e46bd4373024953067248b0d1c8e43d0ac58b")
     version("1.2.2", sha256="ac46ed6a1dc727c3126c2b5d7916fc0ac21a6510c32a5edcd3b8cfb7b2128414")
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_pycortex/package.py
+++ b/repos/spack_repo/builtin/packages/py_pycortex/package.py
@@ -19,7 +19,6 @@ class PyPycortex(PythonPackage):
 
     license("BSD-2-Clause")
 
-    version("1.2.9", sha256="1b290a292ceb47208a578c5fad0e46bd4373024953067248b0d1c8e43d0ac58b")
     version("1.2.2", sha256="ac46ed6a1dc727c3126c2b5d7916fc0ac21a6510c32a5edcd3b8cfb7b2128414")
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_pycurl/package.py
+++ b/repos/spack_repo/builtin/packages/py_pycurl/package.py
@@ -16,6 +16,7 @@ class PyPycurl(PythonPackage):
 
     license("curl")
 
+    version("7.45.7", sha256="9d43013002eab2fd6d0dcc671cd1e9149e2fc1c56d5e796fad94d076d6cb69ef")
     version("7.45.1", sha256="a863ad18ff478f5545924057887cdae422e1b2746e41674615f687498ea5b88a")
     version("7.44.1", sha256="5bcef4d988b74b99653602101e17d8401338d596b9234d263c728a0c3df003e8")
     version("7.43.0", sha256="aa975c19b79b6aa6c0518c0cc2ae33528900478f0b500531dbcdbf05beec584c")

--- a/repos/spack_repo/builtin/packages/py_pydantic/package.py
+++ b/repos/spack_repo/builtin/packages/py_pydantic/package.py
@@ -15,6 +15,7 @@ class PyPydantic(PythonPackage):
 
     license("MIT")
 
+    version("2.12.5", sha256="4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49")
     version("2.12.4", sha256="0f8cb9555000a4b5b617f66bfd2566264c4984b27589d3b845685983e8ea85ac")
     version("2.10.1", sha256="a4daca2dc0aa429555e0656d6bf94873a7dc5f54ee42b1f5873d666fb3f35560")
     version("2.9.0", sha256="c7a8a9fdf7d100afa49647eae340e2d23efa382466a8d177efcd1381e9be5598")

--- a/repos/spack_repo/builtin/packages/py_pydantic_extra_types/package.py
+++ b/repos/spack_repo/builtin/packages/py_pydantic_extra_types/package.py
@@ -16,6 +16,7 @@ class PyPydanticExtraTypes(PythonPackage):
 
     license("MIT", checked_by="wdconinc")
 
+    version("2.10.6", sha256="c63d70bf684366e6bbe1f4ee3957952ebe6973d41e7802aea0b770d06b116aeb")
     version("2.10.0", sha256="552c47dd18fe1d00cfed75d9981162a2f3203cf7e77e55a3d3e70936f59587b9")
 
     depends_on("python@3.8:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_pydap/package.py
+++ b/repos/spack_repo/builtin/packages/py_pydap/package.py
@@ -14,6 +14,7 @@ class PyPydap(PythonPackage):
     pypi = "pydap/pydap-3.5.5.tar.gz"
     license("MIT")
 
+    version("3.5.8", sha256="0dc3c7f28fd456e17ed1c789ccfd119938a2bd1d73828cdf5319c69a213df560")
     version("3.5.5", sha256="0f8ca9b4e244c4d345d0b5269c4ebc886fcd0778b828e5ae1415b7ea5341eabd")
     version("3.2.2", sha256="86326642e24f421595a74b0f9986da76d7932b277768f501fe214d72592bdc40")
 

--- a/repos/spack_repo/builtin/packages/py_pydeprecate/package.py
+++ b/repos/spack_repo/builtin/packages/py_pydeprecate/package.py
@@ -16,6 +16,7 @@ class PyPydeprecate(PythonPackage):
 
     license("MIT")
 
+    version("0.3.2", sha256="d481116cc5d7f6c473e7c4be820efdd9b90a16b594b350276e9e66a6cb5bdd29")
     version("0.3.1", sha256="fa26870924d3475621c344045c2c01a16ba034113a902600c78e75b3fac5f72c")
     version("0.3.0", sha256="335742ec53b9d22a0a9ff4f3470300c94935f6e169c74b08aee14d871ca40e00")
 

--- a/repos/spack_repo/builtin/packages/py_pydeps/package.py
+++ b/repos/spack_repo/builtin/packages/py_pydeps/package.py
@@ -13,6 +13,7 @@ class PyPydeps(PythonPackage):
 
     pypi = "pydeps/pydeps-1.7.1.tar.gz"
 
+    version("1.9.9", sha256="dceb972167db9cba4ee626f68783f3c25d13e903aef0eaa0ee278c856efb61cd")
     version("1.9.0", sha256="ba9b8c7d72cb4dfd3f4dd6b8a250c240d15824850a415fd428f2660ed371361f")
     version("1.7.1", sha256="7eeb8d0ec2713befe81dd0d15eac540e843b1daae13613df1c572528552d6340")
 

--- a/repos/spack_repo/builtin/packages/py_pydeps/package.py
+++ b/repos/spack_repo/builtin/packages/py_pydeps/package.py
@@ -13,7 +13,7 @@ class PyPydeps(PythonPackage):
 
     pypi = "pydeps/pydeps-1.7.1.tar.gz"
 
-    version("1.9.9", sha256="dceb972167db9cba4ee626f68783f3c25d13e903aef0eaa0ee278c856efb61cd")
+    version("1.9.15", sha256="5158bb915b27bfd49aa25982f354b558c4599e16bf13cf058d1633686245e474")
     version("1.9.0", sha256="ba9b8c7d72cb4dfd3f4dd6b8a250c240d15824850a415fd428f2660ed371361f")
     version("1.7.1", sha256="7eeb8d0ec2713befe81dd0d15eac540e843b1daae13613df1c572528552d6340")
 

--- a/repos/spack_repo/builtin/packages/py_pydispatcher/package.py
+++ b/repos/spack_repo/builtin/packages/py_pydispatcher/package.py
@@ -13,6 +13,7 @@ class PyPydispatcher(PythonPackage):
     homepage = "https://pydispatcher.sourceforge.net/"
     pypi = "PyDispatcher/PyDispatcher-2.0.5.tar.gz"
 
+    version("2.0.7", sha256="b777c6ad080dc1bad74a4c29d6a46914fa6701ac70f94b0d66fbcfde62f5be31")
     version("2.0.5", sha256="5570069e1b1769af1fe481de6dd1d3a388492acddd2cdad7a3bde145615d5caf")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_pydocstyle/package.py
+++ b/repos/spack_repo/builtin/packages/py_pydocstyle/package.py
@@ -17,6 +17,7 @@ class PyPydocstyle(PythonPackage):
 
     license("MIT")
 
+    version("6.2.3", sha256="d867acad25e48471f2ad8a40ef9813125e954ad675202245ca836cb6e28b2297")
     version("6.2.1", sha256="5ddccabe3c9555d4afaabdba909ca2de4fa24ac31e2eede4ab3d528a4bcadd52")
     version("6.2.0", sha256="b2d280501a4c0d9feeb96e9171dc3f6f7d0064c55270f4c7b1baa18452019fd9")
     version("6.1.1", sha256="1d41b7c459ba0ee6c345f2eb9ae827cab14a7533a88c5c6f7e94923f72df92dc")

--- a/repos/spack_repo/builtin/packages/py_pygdal/package.py
+++ b/repos/spack_repo/builtin/packages/py_pygdal/package.py
@@ -23,6 +23,7 @@ class PyPygdal(PythonPackage):
 
     license("MIT")
 
+    version("3.3.3.10", sha256="9ede4ff757defb7c28b298e1a619961b32accb841db6c10bf0af7324137d7a02")
     version("3.3.2.10", sha256="7fb9eec8aeb36b94389ff9f2b40cdceffefc8c290d813f4908b4acd208ca3a84")
     version("3.3.0.10", sha256="ea0c20bee67fac94fe0b1cb604a4fd0dc600aa8aa15cf9a7b6dc76adeb48670e")
     version("3.0.4.6", sha256="8e39b58cd9465bb5f41786a7cf6a62df93334c104db05a5bfb8181a0be276b86")

--- a/repos/spack_repo/builtin/packages/py_pygelf/package.py
+++ b/repos/spack_repo/builtin/packages/py_pygelf/package.py
@@ -19,6 +19,7 @@ class PyPygelf(PythonPackage):
 
     license("MIT")
 
+    version("0.4.3", sha256="8ed972563be3c8f168483f01dbf522b6bc697959c97a3f4881324b3f79638911")
     version("0.4.0", sha256="3693da38794561d42b0556a78af7dcb22d92ea450125577e58089ab89a890ee5")
     version("0.3.6", sha256="3e5bc59e3b5a754556a76ff2c69fcf2003218ad7b5ff8417482fa1f6a7eba5f9")
 

--- a/repos/spack_repo/builtin/packages/py_pygit2/package.py
+++ b/repos/spack_repo/builtin/packages/py_pygit2/package.py
@@ -15,8 +15,8 @@ class PyPygit2(PythonPackage):
     homepage = "https://www.pygit2.org/"
     pypi = "pygit2/pygit2-1.12.2.tar.gz"
 
-    version("1.12.2", sha256="8218922abedc88a65d5092308d533ca4c4ed634aec86a3493d3bdf1a25aeeff3")
-    version("1.12.1", sha256="56e85d0e66de957d599d1efb2409d39afeefd8f01009bfda0796b42a4b678358")
+    version("1.12.2", sha256="56e85d0e66de957d599d1efb2409d39afeefd8f01009bfda0796b42a4b678358")
+    version("1.12.1", sha256="8218922abedc88a65d5092308d533ca4c4ed634aec86a3493d3bdf1a25aeeff3")
     version("1.11.1", sha256="793f583fd33620f0ac38376db0f57768ef2922b89b459e75b1ac440377eb64ec")
     version("1.6.0", sha256="7aacea4e57011777f4774421228e5d0ddb9a6ddb87ac4b542346d17ab12a4d62")
     version("1.4.0", sha256="cbeb38ab1df9b5d8896548a11e63aae8a064763ab5f1eabe4475e6b8a78ee1c8")

--- a/repos/spack_repo/builtin/packages/py_pygit2/package.py
+++ b/repos/spack_repo/builtin/packages/py_pygit2/package.py
@@ -15,6 +15,7 @@ class PyPygit2(PythonPackage):
     homepage = "https://www.pygit2.org/"
     pypi = "pygit2/pygit2-1.12.2.tar.gz"
 
+    version("1.12.2", sha256="8218922abedc88a65d5092308d533ca4c4ed634aec86a3493d3bdf1a25aeeff3")
     version("1.12.1", sha256="56e85d0e66de957d599d1efb2409d39afeefd8f01009bfda0796b42a4b678358")
     version("1.11.1", sha256="793f583fd33620f0ac38376db0f57768ef2922b89b459e75b1ac440377eb64ec")
     version("1.6.0", sha256="7aacea4e57011777f4774421228e5d0ddb9a6ddb87ac4b542346d17ab12a4d62")

--- a/repos/spack_repo/builtin/packages/py_pygobject/package.py
+++ b/repos/spack_repo/builtin/packages/py_pygobject/package.py
@@ -15,6 +15,7 @@ class PyPygobject(MesonPackage, PythonPackage):
 
     license("LGPL-2.1-or-later")
 
+    version("3.54.5", sha256="b6656f6348f5245606cf15ea48c384c7f05156c75ead206c1b246c80a22fb585")
     version("3.54.3", sha256="a8da09134a0f7d56491cf2412145e35aa74e91d760e8f337096a1cda0b92bae7")
     version(
         "3.46.0",

--- a/repos/spack_repo/builtin/packages/py_pyinstrument/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyinstrument/package.py
@@ -15,6 +15,7 @@ class PyPyinstrument(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("5.1.2", sha256="af149d672da9493fa37334a1cc68f7b80c3e6cb9fd99b9e426c447db5c650bf0")
     version("5.1.1", sha256="bc401cda990b3c1cfe8e0e0473cbd605df3c63b73478a89ac4ab108f2184baa8")
     version("4.4.0", sha256="be34a2e8118c14a616a64538e02430d9099d5d67d8a370f2888e4ac71e52bbb7")
     version("4.0.3", sha256="08caf41d21ae8f24afe79c664a34af1ed1e17aa5d4441cd9b1dc15f87bbbac95")

--- a/repos/spack_repo/builtin/packages/py_pyinstrument_cext/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyinstrument_cext/package.py
@@ -15,6 +15,7 @@ class PyPyinstrumentCext(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.2.4", sha256="79b29797209eebd441a8596accfa8b617445d9252fbf7ce75d3a4a0eb46cb877")
     version("0.2.2", sha256="f29e25f71d74c0415ca9310e5567fff0f5d29f4240a09a885abf8b0eed71cc5b")
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_pylatex/package.py
+++ b/repos/spack_repo/builtin/packages/py_pylatex/package.py
@@ -15,6 +15,7 @@ class PyPylatex(PythonPackage):
 
     license("MIT")
 
+    version("1.4.2", sha256="bb7b21bec57ecdba3f6f44c856ebebdf6549fd6e80661bd44fd5094236729242")
     version("1.4.1", sha256="d3c12efb8b260771260443dce78d1e9089c09f9d0b92e6273dfca0bf5e7302fb")
 
     variant("docs", default=False, description="Build with Sphinx support for documentation")

--- a/repos/spack_repo/builtin/packages/py_pylikwid/package.py
+++ b/repos/spack_repo/builtin/packages/py_pylikwid/package.py
@@ -21,6 +21,7 @@ class PyPylikwid(PythonPackage):
 
     license("GPL-2.0-only")
 
+    version("0.4.2", sha256="6b275d1adb58586749e26675c9181866b885eb88a70c033e7b82475325e70cb4")
     version("0.4.0", sha256="f7894a6d7ebcea7da133ef639599a314f850f55cd6c5ffdd630bb879bd2aa0b8")
 
     variant("cuda", default=False, description="with Nvidia GPU profiling support")

--- a/repos/spack_repo/builtin/packages/py_pylint/package.py
+++ b/repos/spack_repo/builtin/packages/py_pylint/package.py
@@ -28,6 +28,7 @@ class PyPylint(PythonPackage):
 
     license("GPL-2.0-or-later")
 
+    version("3.3.9", sha256="d312737d7b25ccf6b01cc4ac629b5dcd14a0fcf3ec392735ac70f137a9d5f83a")
     version("3.3.7", sha256="2b11de8bde49f9c5059452e0c310c079c746a0a8eeaa789e5aa966ecc23e4559")
     version("2.16.2", sha256="13b2c805a404a9bf57d002cd5f054ca4d40b0b87542bdaba5e05321ae8262c84")
     version("2.15.0", sha256="4f3f7e869646b0bd63b3dfb79f3c0f28fc3d2d923ea220d52620fd625aed92b0")

--- a/repos/spack_repo/builtin/packages/py_pymysql/package.py
+++ b/repos/spack_repo/builtin/packages/py_pymysql/package.py
@@ -15,6 +15,7 @@ class PyPymysql(PythonPackage):
 
     license("MIT")
 
+    version("0.9.3", sha256="d8c059dcd81dedb85a9f034d5e22dcb4442c0b201908bede99e306d65ea7c8e7")
     version("0.9.2", sha256="9ec760cbb251c158c19d6c88c17ca00a8632bac713890e465b2be01fdc30713f")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_pynn/package.py
+++ b/repos/spack_repo/builtin/packages/py_pynn/package.py
@@ -18,6 +18,7 @@ class PyPynn(PythonPackage):
 
     license("CECILL-2.0")
 
+    version("0.10.1", sha256="03fbafeddd64ae7163e2b557b2760380b6eceb52469f1b3f4cc203bbb80f0cde")
     version("0.10.0", sha256="04120fe0e03260d664b337e0ac29d985c3fb3684ef35b1add93a66739891c98f")
     version("0.9.1", sha256="bbc60fea3235427191feb2daa0e2fa07eb1c3946104c068ac8a2a0501263b0b1")
     version("0.8.3", sha256="9d59e6cffa4714f0c892ec6b32d1f5f8f75ba3a20d8635bac50c047aa6f2537e")

--- a/repos/spack_repo/builtin/packages/py_pynndescent/package.py
+++ b/repos/spack_repo/builtin/packages/py_pynndescent/package.py
@@ -16,7 +16,6 @@ class PyPynndescent(PythonPackage):
 
     license("BSD-2-Clause")
 
-    version("0.5.9", sha256="bacf78d914f44724528adcfea9681ddd6c873d14f4b0526c0ff6b9f243338042")
     version("0.5.7", sha256="ecb395255fa36a748b5870b4ba0300ea0f7da8b1964864b8edd62577a84dfd7d")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_pynndescent/package.py
+++ b/repos/spack_repo/builtin/packages/py_pynndescent/package.py
@@ -16,6 +16,7 @@ class PyPynndescent(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("0.5.9", sha256="bacf78d914f44724528adcfea9681ddd6c873d14f4b0526c0ff6b9f243338042")
     version("0.5.7", sha256="ecb395255fa36a748b5870b4ba0300ea0f7da8b1964864b8edd62577a84dfd7d")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_pyprof2html/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyprof2html/package.py
@@ -14,6 +14,7 @@ class PyPyprof2html(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.3.2", sha256="ca0bc88f8a98f523f97f63293144922d7c4f5bd7ca92cd39c009d2feb8f2ee93")
     version("0.3.1", sha256="db2d37e21d8c76f2fd25fb1ba9273c9b3ff4a98a327e37d943fed1ea225a6720")
 
     patch("version_0.3.1.patch", when="@0.3.1")

--- a/repos/spack_repo/builtin/packages/py_pyqt6/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyqt6/package.py
@@ -16,6 +16,7 @@ class PyPyqt6(SIPPackage):
 
     license("GPL-3.0-or-later")
 
+    version("6.10.2", sha256="6c0db5d8cbb9a3e7e2b5b51d0ff3f283121fa27b864db6d2f35b663c9be5cc83")
     version("6.10.0", sha256="710ecfd720d9a03b2c684881ae37f528e11d17e8f1bf96431d00a6a73f308e36")
     version("6.9.1", sha256="50642be03fb40f1c2111a09a1f5a0f79813e039c15e78267e6faaf8a96c1c3a6")
     version("6.7.0", sha256="3d31b2c59dc378ee26e16586d9469842483588142fc377280aad22aaf2fa6235")

--- a/repos/spack_repo/builtin/packages/py_pyqt_builder/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyqt_builder/package.py
@@ -15,6 +15,7 @@ class PyPyqtBuilder(PythonPackage):
 
     license("GPL-2.0-or-later")
 
+    version("1.19.1", sha256="6af6646ba29668751b039bfdced51642cb510e300796b58a4d68b7f956a024d8")
     version("1.19.0", sha256="79540e001c476bc050180db00fffcb1e9fa74544d95c148e48ad6117e49d6ea2")
     version("1.18.2", sha256="56dfea461484a87a8f0c8b0229190defc436d7ec5de71102e20b35e5639180bc")
     version("1.15.1", sha256="a2bd3cfbf952e959141dfe55b44b451aa945ca8916d1b773850bb2f9c0fa2985")

--- a/repos/spack_repo/builtin/packages/py_pyquaternion/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyquaternion/package.py
@@ -16,6 +16,7 @@ class PyPyquaternion(PythonPackage):
 
     license("MIT")
 
+    version("0.9.9", sha256="b1f61af219cb2fe966b5fb79a192124f2e63a3f7a777ac3cadf2957b1a81bea8")
     version("0.9.5", sha256="2d89d19259d62a8fbd25219eee7dacc1f6bb570becb70e1e883f622597c7d81d")
 
     depends_on("py-setuptools", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_pyro_ppl/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyro_ppl/package.py
@@ -17,6 +17,7 @@ class PyPyroPpl(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.8.6", sha256="00d2f4dda8a53e66d955124dc6e49e92dcf570cd3bd706825091db764d93cd07")
     version("1.8.4", sha256="766fad61e52df48885de96d41213da1f8e8c1b79ecf308ad53189fcd15c1cb41")
     version("1.8.1", sha256="d7c049eb2e7485a612b4dd99c24c309cc860c7cbc6b1973387034f5436d1c8d6")
     version("1.8.0", sha256="68e4ea30f219227dd88e55de2550d3f8c20a20adbdb67ad1e13b50868bb2ac0c")

--- a/repos/spack_repo/builtin/packages/py_pysmartdl/package.py
+++ b/repos/spack_repo/builtin/packages/py_pysmartdl/package.py
@@ -14,6 +14,7 @@ class PyPysmartdl(PythonPackage):
 
     license("Unlicense")
 
+    version("1.3.4", sha256="35275d1694f3474d33bdca93b27d3608265ffd42f5aeb28e56f38b906c0c35f4")
     version("1.3.2", sha256="9a96deb3ee4f4ab2279b22eb908d506f57215e1fbad290d540adcebff187a52c")
     version("1.2.5", sha256="d3968ce59412f99d8e17ca532a1d949d2aa770a914e3f5eb2c0385579dc2b6b8")
 

--- a/repos/spack_repo/builtin/packages/py_pyspark/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyspark/package.py
@@ -15,6 +15,7 @@ class PyPyspark(PythonPackage):
 
     maintainers("teaguesterling")
 
+    version("3.5.8", sha256="54cca0767b21b40e3953ad1d30f8601c53abf9cbda763653289cdcfcac52313c")
     version("3.5.1", sha256="dd6569e547365eadc4f887bf57f153e4d582a68c4b490de475d55b9981664910")
     version("3.4.3", sha256="8d7025fa274830cb6c3bd592228be3d9345cb3b8b1e324018c2aa6e75f48a208")
     version("3.3.4", sha256="1f866be47130a522355240949ed50d9812a8f327bd7619f043ffe07fbcf7f7b6")

--- a/repos/spack_repo/builtin/packages/py_pyspellchecker/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyspellchecker/package.py
@@ -15,6 +15,7 @@ class PyPyspellchecker(PythonPackage):
 
     license("MIT")
 
+    version("0.6.3", sha256="764dfe1bcbd4d860b74205402167d55a02910870c07b83678e7d6b5a4d471909")
     version("0.6.2", sha256="af6a1d0393a175499475a873f31e52135f1efd5fc912c979101b795b3c2ee77f")
 
     depends_on("python@3.0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_pyspnego/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyspnego/package.py
@@ -17,6 +17,7 @@ class PyPyspnego(PythonPackage):
 
     license("MIT", checked_by="wdconinc")
 
+    version("0.11.2", sha256="994388d308fb06e4498365ce78d222bf4f3570b6df4ec95738431f61510c971b")
     version("0.11.1", sha256="e92ed8b0a62765b9d6abbb86a48cf871228ddb97678598dc01c9c39a626823f6")
 
     variant("kerberos", default=False, description="Enable Kerberos authentication on Linux")

--- a/repos/spack_repo/builtin/packages/py_pysqlite3/package.py
+++ b/repos/spack_repo/builtin/packages/py_pysqlite3/package.py
@@ -15,6 +15,7 @@ class PyPysqlite3(PythonPackage):
 
     license("Zlib")
 
+    version("0.4.8", sha256="0276f8b2b66a91867d4c805aaeb534403f29b9165133ce7b0b56ef65a230cd00")
     version("0.4.7", sha256="0352864898aa406beb762f4a620594c950a9a4430caab679bce574065698c8ac")
     version("0.4.6", sha256="7ec4d4c477fa96609c1517afbc33bf02747588e528e79c695de95907cea7bf30")
 

--- a/repos/spack_repo/builtin/packages/py_pystac_client/package.py
+++ b/repos/spack_repo/builtin/packages/py_pystac_client/package.py
@@ -15,6 +15,7 @@ class PyPystacClient(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.8.6", sha256="83d4f4420c14b8dbb3e39ab0da00e72639903912942075d42e06737d61ab3e7d")
     version("0.8.5", sha256="7fba8d4f3c641ff7e840084fc3a53c96443a227f8a5889ae500fc38183ccd994")
 
     with default_args(type="build"):

--- a/repos/spack_repo/builtin/packages/py_pytest/package.py
+++ b/repos/spack_repo/builtin/packages/py_pytest/package.py
@@ -17,6 +17,7 @@ class PyPytest(PythonPackage):
     license("MIT")
     maintainers("adamjstewart")
 
+    version("9.0.2", sha256="75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11")
     version("9.0.0", sha256="8f44522eafe4137b0f35c9ce3072931a788a21ee40a2ed279e817d3cc16ed21e")
     version("8.4.2", sha256="86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01")
     version("8.4.1", sha256="7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c")

--- a/repos/spack_repo/builtin/packages/py_pytest_flakes/package.py
+++ b/repos/spack_repo/builtin/packages/py_pytest_flakes/package.py
@@ -16,6 +16,7 @@ class PyPytestFlakes(PythonPackage):
 
     license("MIT")
 
+    version("4.0.5", sha256="953134e97215ae31f6879fbd7368c18d43f709dc2fab5b7777db2bb2bac3a924")
     version("4.0.3", sha256="bf070c5485dad82d5b5f5d0eb08d269737e378492d9a68f5223b0a90924c7754")
     version("4.0.2", sha256="6733db47937d9689032876359e5ee0ee6926e3638546c09220e2f86b3581d4c1")
 

--- a/repos/spack_repo/builtin/packages/py_pytest_remotedata/package.py
+++ b/repos/spack_repo/builtin/packages/py_pytest_remotedata/package.py
@@ -15,6 +15,7 @@ class PyPytestRemotedata(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.4.1", sha256="05c08bf638cdd1ed66eb01738a1647c3c714737c3ec3abe009d2c1f793b4bb59")
     version("0.4.0", sha256="be21c558e34d7c11b0f6aeb50956c09520bffcd02b7fce9c6f8e8531a401a1c8")
 
     depends_on("py-setuptools@30.3:", type="build")

--- a/repos/spack_repo/builtin/packages/py_pytest_xdist/package.py
+++ b/repos/spack_repo/builtin/packages/py_pytest_xdist/package.py
@@ -15,6 +15,7 @@ class PyPytestXdist(PythonPackage):
 
     license("MIT")
 
+    version("3.2.1", sha256="1849bd98d8b242b948e472db7478e090bf3361912a8fed87992ed94085f54727")
     version("3.2.0", sha256="fa10f95a2564cd91652f2d132725183c3b590d9fdcdec09d3677386ecf4c1ce9")
     version("1.30.0", sha256="5d1b1d4461518a6023d56dab62fb63670d6f7537f23e2708459a557329accf48")
     version("1.29.0", sha256="3489d91516d7847db5eaecff7a2e623dba68984835dbe6cedb05ae126c4fb17f")

--- a/repos/spack_repo/builtin/packages/py_python_crfsuite/package.py
+++ b/repos/spack_repo/builtin/packages/py_python_crfsuite/package.py
@@ -15,6 +15,7 @@ class PyPythonCrfsuite(PythonPackage):
 
     license("MIT")
 
+    version("0.9.9", sha256="caa6261d6955466756f986b7fcfbd4fd50622963e3bdb5cc180c129c62b3a76d")
     version("0.9.7", sha256="3b4538d2ce5007e4e42005818247bf43ade89ef08a66d158462e2f7c5d63cee7")
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_python_daemon/package.py
+++ b/repos/spack_repo/builtin/packages/py_python_daemon/package.py
@@ -24,6 +24,7 @@ class PyPythonDaemon(PythonPackage):
 
     license("GPL-3.0-or-later")
 
+    version("2.3.2", sha256="3deeb808e72b6b89f98611889e11cc33754f5b2c1517ecfa1aaf25f402051fb5")
     version("2.3.1", sha256="15c2c5e2cef563e0a5f98d542b77ba59337380b472975d2b2fd6b8c4d5cf46ca")
     version("2.3.0", sha256="bda993f1623b1197699716d68d983bb580043cf2b8a66a01274d9b8297b0aeaf")
     version("2.0.5", sha256="afde4fa433d94d007206ee31a0941d55b5eb232a5422b670aad628547b46bf68")

--- a/repos/spack_repo/builtin/packages/py_python_levenshtein/package.py
+++ b/repos/spack_repo/builtin/packages/py_python_levenshtein/package.py
@@ -16,6 +16,7 @@ class PyPythonLevenshtein(PythonPackage):
 
     license("GPL-2.0-or-later")
 
+    version("0.12.2", sha256="dc2395fbd148a1ab31090dd113c366695934b9e85fe5a4b2a032745efd0346f6")
     version("0.12.0", sha256="033a11de5e3d19ea25c9302d11224e1a1898fe5abd23c61c7c360c25195e3eb1")
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_python_logstash/package.py
+++ b/repos/spack_repo/builtin/packages/py_python_logstash/package.py
@@ -15,6 +15,7 @@ class PyPythonLogstash(PythonPackage):
 
     license("MIT")
 
+    version("0.4.8", sha256="d04e1ce11ecc107e4a4f3b807fc57d96811e964a554081b3bbb44732f74ef5f9")
     version("0.4.6", sha256="10943e5df83f592b4d61b63ad1afff855ccc8c9467f78718f0a59809ba1fe68c")
 
     # pip silently replaces distutils with setuptools

--- a/repos/spack_repo/builtin/packages/py_python_slugify/package.py
+++ b/repos/spack_repo/builtin/packages/py_python_slugify/package.py
@@ -15,6 +15,7 @@ class PyPythonSlugify(PythonPackage):
 
     license("MIT")
 
+    version("4.0.1", sha256="69a517766e00c1268e5bbfc0d010a0a8508de0b18d30ad5a1ff357f8ae724270")
     version("4.0.0", sha256="a8fc3433821140e8f409a9831d13ae5deccd0b033d4744d94b31fea141bdd84c")
 
     depends_on("python@2.7:2.8,3.5:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_python_xmp_toolkit/package.py
+++ b/repos/spack_repo/builtin/packages/py_python_xmp_toolkit/package.py
@@ -15,6 +15,7 @@ class PyPythonXmpToolkit(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("2.0.2", sha256="3a88431bb8222e9723da688b3ead50506f3ed3002749362845745dd995a7a68b")
     version("2.0.1", sha256="f8d912946ff9fd46ed5c7c355aa5d4ea193328b3f200909ef32d9a28a1419a38")
 
     depends_on("python@2.6:2.7,3.3:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_pyupgrade/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyupgrade/package.py
@@ -15,6 +15,7 @@ class PyPyupgrade(PythonPackage):
 
     license("MIT")
 
+    version("3.3.2", sha256="bcfed63d38811809f179fd269dec246680b0aaa5bbe662b535826e5fa2275219")
     version("3.3.1", sha256="f88bce38b0ba92c2a9a5063c8629e456e8d919b67d2d42c7ecab82ff196f9813")
     version("2.31.1", sha256="22e0ad6dd39c4381805cb059f1e691b6315c62c0ebcec98a5f29d22cd186a72a")
 

--- a/repos/spack_repo/builtin/packages/py_pyuwsgi/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyuwsgi/package.py
@@ -16,6 +16,7 @@ class PyPyuwsgi(PythonPackage):
 
     license("GPL-2.0-or-later")
 
+    version("2.0.30", sha256="1c9f226a9278f8a2ecc08d4445a7eb776bda53f44721c565c499131ebe5ff0ce")
     version("2.0.21", sha256="211e8877f5191e347ba905232d04ab30e05ce31ba7a6dac4bfcb48de9845bb52")
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_pyvista/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyvista/package.py
@@ -20,6 +20,7 @@ class PyPyvista(PythonPackage):
 
     license("MIT")
 
+    version("0.46.5", sha256="b637bfa32136b95e5e5a6d972871606a68e3c625fc652ff5d9f00390294e99c0")
     version("0.46.3", sha256="1f8e6e39516d24d93bc227f278841a0d72ec3722959f612cf4616d2720a8afe1")
     version("0.45.3", sha256="bca39f5ea17e45f40070ab45423dfd2c4fc81c33e0fb565bafded81c024fd04f")
     version("0.44.1", sha256="63976f5d57d151b3f7e1616dde40dcf56a66d1f37f6db067087fa9cc9667f512")

--- a/repos/spack_repo/builtin/packages/py_pyviz_comms/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyviz_comms/package.py
@@ -15,6 +15,7 @@ class PyPyvizComms(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("3.0.6", sha256="73d66b620390d97959b2c4d8a2c0778d41fe20581be4717f01e46b8fae8c5695")
     version("3.0.4", sha256="d70e17555f7262c4884a6b7bc9ca19cb816507a032a334d9cb411b4546caff4c")
     version("2.2.1", sha256="a26145b8ce43d2d934b3c6826d77b913ce105c528eb2e494c890b3e3525ddf33")
 

--- a/repos/spack_repo/builtin/packages/py_qiskit_aer/package.py
+++ b/repos/spack_repo/builtin/packages/py_qiskit_aer/package.py
@@ -18,6 +18,7 @@ class PyQiskitAer(PythonPackage, CudaPackage):
 
     license("Apache-2.0")
 
+    version("0.11.2", sha256="1bc1d3b46f7fc8976084a900cb9a2a80e8b25df6e59a88fd11136f24e1297fc1")
     version("0.11.1", sha256="ff136a086d0473346e5f5309ae34cc78b103dcd8a898344c6e5f86de91af41a1")
     version("0.9.1", sha256="3bf5f615aaae7cc5f816c39a4e9108aabaed0cc894fb6f841e48ffd56574e7eb")
 

--- a/repos/spack_repo/builtin/packages/py_qtawesome/package.py
+++ b/repos/spack_repo/builtin/packages/py_qtawesome/package.py
@@ -15,6 +15,7 @@ class PyQtawesome(PythonPackage):
 
     license("MIT")
 
+    version("0.4.4", sha256="50f9c1d9ce34e57f5b13ef76d5c87e06de9804b8dfe1c34c4ba73197200f878a")
     version("0.4.1", sha256="9ea91efeb83e8b73f814aeca898c29cade0c087acec58e91b4f384595aeb4cfd")
     version("0.3.3", sha256="c3c98ee4df0133ae42d202fea20253f8746266b4541c5df4269ca4131792ce0f")
 

--- a/repos/spack_repo/builtin/packages/py_qtconsole/package.py
+++ b/repos/spack_repo/builtin/packages/py_qtconsole/package.py
@@ -15,6 +15,7 @@ class PyQtconsole(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("5.2.2", sha256="8f9db97b27782184efd0a0f2d57ea3bd852d053747a2e442a9011329c082976d")
     version("5.2.0", sha256="6bb4df839609f240194213407872076f871e3a3884cf8e785068e8c7f39344c6")
     version("4.5.1", sha256="4af84facdd6f00a6b9b2927255f717bb23ae4b7a20ba1d9ef0a5a5a8dbe01ae2")
     version("4.2.1", sha256="25ec7d345528b3e8f3c91be349dd3c699755f206dc4b6ec668e2e5dd60ea18ef")

--- a/repos/spack_repo/builtin/packages/py_quart/package.py
+++ b/repos/spack_repo/builtin/packages/py_quart/package.py
@@ -16,6 +16,7 @@ class PyQuart(PythonPackage):
 
     license("MIT")
 
+    version("0.19.9", sha256="30a61a0d7bae1ee13e6e99dc14c929b3c945e372b9445d92d21db053e91e95a5")
     version("0.19.8", sha256="ef567d0be7677c99890d5c6ff30e679699fe7e5fca1a90fa3b6974edd8421794")
     version("0.16.3", sha256="16521d8cf062461b158433d820fff509f98fb997ae6c28740eda061d9cba7d5e")
 

--- a/repos/spack_repo/builtin/packages/py_rapidfuzz/package.py
+++ b/repos/spack_repo/builtin/packages/py_rapidfuzz/package.py
@@ -15,6 +15,7 @@ class PyRapidfuzz(PythonPackage):
 
     license("MIT")
 
+    version("3.14.3", sha256="2491937177868bc4b1e469087601d53f925e8d270ccc21e07404b4b5814b7b5f")
     version("3.14.1", sha256="b02850e7f7152bd1edff27e9d584505b84968cacedee7a734ec4050c655a803c")
     version("3.3.1", sha256="6783b3852f15ed7567688e2e358757a7b4f38683a915ba5edc6c64f1a3f0b450")
     version("2.2.0", sha256="acb8839aac452ec61a419fdc8799e8a6e6cd21bed53d04678cdda6fba1247e2f")

--- a/repos/spack_repo/builtin/packages/py_rbtools/package.py
+++ b/repos/spack_repo/builtin/packages/py_rbtools/package.py
@@ -16,6 +16,7 @@ class PyRbtools(PythonPackage):
 
     license("MIT")
 
+    version("1.0.3", sha256="4d1ed5dc58ab7b12f3511e03753005cf228460e91e12acdd66d13033656a6b9d")
     version("1.0.2", sha256="dd7aa95691be91f394d085120e44bcec3dc440b01a8f7e2742e09a8d756c831c")
     version("1.0.1", sha256="bc5e3c511a2273ec61c43a82f56b4cef0b23beae81e277cecbb37ce6761edf29")
     version("1.0", sha256="dbab2cc89d798462c7e74952d43ba1ff1c97eb9c8f92876e600c6520f72454c9")

--- a/repos/spack_repo/builtin/packages/py_reacton/package.py
+++ b/repos/spack_repo/builtin/packages/py_reacton/package.py
@@ -21,6 +21,7 @@ class PyReacton(PythonPackage):
 
     maintainers("jeremyfix")
 
+    version("1.8.3", sha256="db0b42242746c902a31220a52efcb8964ba4e1e0cff2c5145b75569547811bff")
     version("1.8.2", sha256="eaa4eeeffd11688d2b60a49a9895fd299f2ecbe8614f1ad61d144c56edaf7304")
 
     depends_on("py-hatchling", type="build")

--- a/repos/spack_repo/builtin/packages/py_reportlab/package.py
+++ b/repos/spack_repo/builtin/packages/py_reportlab/package.py
@@ -16,6 +16,7 @@ class PyReportlab(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("4.4.9", sha256="7cf487764294ee791a4781f5a157bebce262a666ae4bbb87786760a9676c9378")
     version("4.4.4", sha256="cb2f658b7f4a15be2cc68f7203aa67faef67213edd4f2d4bdd3eb20dab75a80d")
     version("4.0.4", sha256="7f70b3b56aff5f11cb4136c51a0f5a56fe6e4c8fbbac7b903076db99a8ef31c1")
     version("3.6.12", sha256="b13cebf4e397bba14542bcd023338b6ff2c151a3a12aabca89eecbf972cb361a")

--- a/repos/spack_repo/builtin/packages/py_requests_cache/package.py
+++ b/repos/spack_repo/builtin/packages/py_requests_cache/package.py
@@ -18,6 +18,7 @@ class PyRequestsCache(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("0.9.8", sha256="eaed4eb5fd5c392ba5e7cfa000d4ab96b1d32c1a1620f37aa558c43741ac362b")
     version("0.9.7", sha256="b7c26ea98143bac7058fad6e773d56c3442eabc0da9ea7480af5edfc134ff515")
 
     depends_on("python@3.7:3", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_responses/package.py
+++ b/repos/spack_repo/builtin/packages/py_responses/package.py
@@ -17,6 +17,7 @@ class PyResponses(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.13.4", sha256="9476775d856d3c24ae660bbebe29fb6d789d4ad16acd723efbfb6ee20990b899")
     version("0.13.3", sha256="18a5b88eb24143adbf2b4100f328a2f5bfa72fbdacf12d97d41f07c26c45553d")
 
     depends_on("python@2.7:2.8,3.5:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_retrying/package.py
+++ b/repos/spack_repo/builtin/packages/py_retrying/package.py
@@ -17,6 +17,7 @@ class PyRetrying(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.3.7", sha256="7aab7324db8ad92029eef1073bf7257315cc7d9f861243a66b916c164a2c3c20")
     version("1.3.3", sha256="08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_rich_click/package.py
+++ b/repos/spack_repo/builtin/packages/py_rich_click/package.py
@@ -17,6 +17,7 @@ class PyRichClick(PythonPackage):
 
     license("MIT")
 
+    version("1.8.9", sha256="fd98c0ab9ddc1cf9c0b7463f68daf28b4d0033a74214ceb02f761b3ff2af3136")
     version("1.8.5", sha256="a3eebe81da1c9da3c32f3810017c79bd687ff1b3fa35bfc9d8a3338797f1d1a1")
     version("1.7.4", sha256="7ce5de8e4dc0333aec946113529b3eeb349f2e5d2fafee96b9edf8ee36a01395")
     version("1.6.1", sha256="f8ff96693ec6e261d1544e9f7d9a5811c5ef5d74c8adb4978430fc0dac16777e")

--- a/repos/spack_repo/builtin/packages/py_rsa/package.py
+++ b/repos/spack_repo/builtin/packages/py_rsa/package.py
@@ -15,6 +15,7 @@ class PyRsa(PythonPackage):
 
     license("Apache-2.0")
 
+    version("4.9.1", sha256="e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75")
     version("4.9", sha256="e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21")
     version("4.7.2", sha256="9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9")
     version("4.0", sha256="1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487")

--- a/repos/spack_repo/builtin/packages/py_schema/package.py
+++ b/repos/spack_repo/builtin/packages/py_schema/package.py
@@ -15,6 +15,7 @@ class PySchema(PythonPackage):
 
     license("MIT")
 
+    version("0.7.8", sha256="e86cc08edd6fe6e2522648f4e47e3a31920a76e82cce8937535422e310862ab5")
     version("0.7.7", sha256="7da553abd2958a19dc2547c388cde53398b39196175a9be59ea1caf5ab0a1807")
     version("0.7.5", sha256="f06717112c61895cabc4707752b88716e8420a8819d71404501e114f91043197")
 

--- a/repos/spack_repo/builtin/packages/py_scikit_build_core/package.py
+++ b/repos/spack_repo/builtin/packages/py_scikit_build_core/package.py
@@ -20,6 +20,7 @@ class PyScikitBuildCore(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.11.6", sha256="5982ccd839735be99cfd3b92a8847c6c196692f476c215da84b79d2ad12f9f1b")
     version("0.11.5", sha256="8f0a1edb86cb087876f3c699d2a2682012efd8867b390ed37355f13949d0628e")
     version("0.11.1", sha256="4e5988df5cd33f0bdb9967b72663ca99f50383c9bc21d8b24fa40c0661ae72b7")
     version("0.10.7", sha256="04cbb59fe795202a7eeede1849112ee9dcbf3469feebd9b8b36aa541336ac4f8")

--- a/repos/spack_repo/builtin/packages/py_scinum/package.py
+++ b/repos/spack_repo/builtin/packages/py_scinum/package.py
@@ -16,6 +16,7 @@ class PyScinum(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.4.7", sha256="3e1c60fa7cd316278bba76cb34c6ea43d0b85d40b36046c42f7ed03d8c1e0869")
     version("1.4.3", sha256="c8144b6a2ed5cb58b2c26a8151752b6f5f5ea460678a9e092015b91da926c443")
     version("1.2.0", sha256="31802d9b580f3a89c0876f34432851bc4def9cb2844d6f3c8e044480f2dd2f91")
 

--- a/repos/spack_repo/builtin/packages/py_scooby/package.py
+++ b/repos/spack_repo/builtin/packages/py_scooby/package.py
@@ -15,6 +15,7 @@ class PyScooby(PythonPackage):
 
     license("MIT")
 
+    version("0.10.2", sha256="974e115877f3dde8f2bbfd68734d761c629f1b27f54cc29aaede1c8303e85379")
     version("0.10.0", sha256="7ea33c262c0cc6a33c6eeeb5648df787be4f22660e53c114e5fff1b811a8854f")
     version("0.5.7", sha256="ae2c2b6f5f5d10adf7aaab32409028f1e28d3ce833664bdd1e8c2072e8da169a")
 

--- a/repos/spack_repo/builtin/packages/py_scoop/package.py
+++ b/repos/spack_repo/builtin/packages/py_scoop/package.py
@@ -18,6 +18,7 @@ class PyScoop(PythonPackage):
 
     license("LGPL-3.0-only")
 
+    version("0.7.2.0", sha256="7658faf751627f5507b6f636794721d89db1771234a36e1378ee6796dd7ee761")
     version("0.7.1.1", sha256="d8b6444c7bac901171e3327a97e241dde63f060354e162a65551fd8083ca62b4")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_semver/package.py
+++ b/repos/spack_repo/builtin/packages/py_semver/package.py
@@ -16,6 +16,7 @@ class PySemver(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("3.0.4", sha256="afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602")
     version("3.0.1", sha256="9ec78c5447883c67b97f98c3b6212796708191d22e4ad30f4570f840171cbce1")
     version("2.8.1", sha256="5b09010a66d9a3837211bb7ae5a20d10ba88f8cb49e92cb139a69ef90d5060d8")
 

--- a/repos/spack_repo/builtin/packages/py_setproctitle/package.py
+++ b/repos/spack_repo/builtin/packages/py_setproctitle/package.py
@@ -16,6 +16,7 @@ class PySetproctitle(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.3.7", sha256="bc2bc917691c1537d5b9bca1468437176809c7e11e5694ca79a9ca12345dcb9e")
     version("1.3.6", sha256="c9f32b96c700bb384f33f7cf07954bb609d35dd82752cef57fb2ee0968409169")
     version("1.2.2", sha256="7dfb472c8852403d34007e01d6e3c68c57eb66433fb8a5c77b13b89a160d97df")
     version("1.1.10", sha256="6283b7a58477dd8478fbb9e76defb37968ee4ba47b05ec1c053cb39638bd7398")

--- a/repos/spack_repo/builtin/packages/py_setupmeta/package.py
+++ b/repos/spack_repo/builtin/packages/py_setupmeta/package.py
@@ -15,6 +15,7 @@ class PySetupmeta(PythonPackage):
 
     license("MIT")
 
+    version("3.4.1", sha256="f0818ae2bd0adbc36d34141d6afb5542e68f49aee0c89bb0c77b1faae2109c33")
     version("3.4.0", sha256="f986a1d9c5b595a840d71d888950c7cc6bbb586b4145d04e7992501e280e07c3")
     version("3.3.2", sha256="221463a64d2528ba558f14b087410e05a7ef0dab17d19004f124a262d6e007f5")
     version("3.3.0", sha256="32914af4eeffb8bf1bd45057254d9dff4d16cb7ae857141e07698f7ac19dc960")

--- a/repos/spack_repo/builtin/packages/py_setuptools_git_versioning/package.py
+++ b/repos/spack_repo/builtin/packages/py_setuptools_git_versioning/package.py
@@ -17,6 +17,7 @@ class PySetuptoolsGitVersioning(PythonPackage):
 
     license("MIT")
 
+    version("1.13.6", sha256="75e3e8c4528fa21ca2417a1f222fdaaa4d2ca7d8536c44affad827c6ec9ba0d4")
     version("1.13.3", sha256="9dfc59a31dcadcae04bcddc50534ccfc07a25a3180ab5cc1b1e3730217971c63")
 
     depends_on("py-setuptools", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_shtab/package.py
+++ b/repos/spack_repo/builtin/packages/py_shtab/package.py
@@ -15,6 +15,7 @@ class PyShtab(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.3.9", sha256="3d99abe5398c73c94644d4cbefb4bf44a145d0b8440e902b0d9dc02bff653543")
     version("1.3.4", sha256="353f2a3a5178cd2df8eb746e7ab26a5039a9989e4386de8fd239d8c1653a8887")
     version("1.3.3", sha256="1f7f263631acdf0a9e685bbf7126a0fa711c2d663db12441670b1cea3fa431d4")
 

--- a/repos/spack_repo/builtin/packages/py_shtab/package.py
+++ b/repos/spack_repo/builtin/packages/py_shtab/package.py
@@ -15,7 +15,7 @@ class PyShtab(PythonPackage):
 
     license("Apache-2.0")
 
-    version("1.3.9", sha256="3d99abe5398c73c94644d4cbefb4bf44a145d0b8440e902b0d9dc02bff653543")
+    version("1.3.10", sha256="2740cb128bfd78382ddf300639a1378ef7e4658a562b268b1b52b5c73607c798")
     version("1.3.4", sha256="353f2a3a5178cd2df8eb746e7ab26a5039a9989e4386de8fd239d8c1653a8887")
     version("1.3.3", sha256="1f7f263631acdf0a9e685bbf7126a0fa711c2d663db12441670b1cea3fa431d4")
 

--- a/repos/spack_repo/builtin/packages/py_simplejson/package.py
+++ b/repos/spack_repo/builtin/packages/py_simplejson/package.py
@@ -16,6 +16,7 @@ class PySimplejson(PythonPackage):
 
     license("MIT")
 
+    version("3.20.2", sha256="5fe7a6ce14d1c300d80d08695b7f7e633de6cd72c80644021874d985b3393649")
     version("3.20.1", sha256="e64139b4ec4f1f24c142ff7dcafe55a22b811a74d86d66560c8815687143037d")
     version("3.19.1", sha256="6277f60848a7d8319d27d2be767a7546bc965535b28070e310b3a9af90604a4c")
     version("3.18.0", sha256="58a429d2c2fa80834115b923ff689622de8f214cf0dc4afa9f59e824b444ab31")

--- a/repos/spack_repo/builtin/packages/py_simsimd/package.py
+++ b/repos/spack_repo/builtin/packages/py_simsimd/package.py
@@ -15,7 +15,7 @@ class PySimsimd(PythonPackage):
 
     license("Apache-2.0")
 
-    version("6.5.8", sha256="0c78cedddf85e9ffa7bc4fdb2e57ebae89ed55367f05acb2c7e1b9c3db6e2ff7")
+    version("6.5.12", sha256="c9b8720c9bc9dcfc36f570c2f96bfd74d1c9e1d0ebeecafc7a130ad3f0affe41")
     version("6.5.3", sha256="5ff341e84fe1c46e7268ee9e31f885936b29c38ce59f423433aef5f4bb5bfd18")
 
     depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/py_simsimd/package.py
+++ b/repos/spack_repo/builtin/packages/py_simsimd/package.py
@@ -15,6 +15,7 @@ class PySimsimd(PythonPackage):
 
     license("Apache-2.0")
 
+    version("6.5.8", sha256="0c78cedddf85e9ffa7bc4fdb2e57ebae89ed55367f05acb2c7e1b9c3db6e2ff7")
     version("6.5.3", sha256="5ff341e84fe1c46e7268ee9e31f885936b29c38ce59f423433aef5f4bb5bfd18")
 
     depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/py_slicer/package.py
+++ b/repos/spack_repo/builtin/packages/py_slicer/package.py
@@ -13,6 +13,7 @@ class PySlicer(PythonPackage):
     homepage = "https://github.com/interpretml/slicer"
     pypi = "slicer/slicer-0.0.7.tar.gz"
 
+    version("0.0.8", sha256="2e7553af73f0c0c2d355f4afcc3ecf97c6f2156fcf4593955c3f56cf6c4d6eb7")
     version("0.0.7", sha256="f5d5f7b45f98d155b9c0ba6554fa9770c6b26d5793a3e77a1030fb56910ebeec")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_slurm_pipeline/package.py
+++ b/repos/spack_repo/builtin/packages/py_slurm_pipeline/package.py
@@ -15,7 +15,6 @@ class PySlurmPipeline(PythonPackage):
 
     license("MIT")
 
-    version("4.0.9", sha256="fba9298f779ca1c226f67182a796eba08416b6774efc3c5cafc48b10b6331d0a")
     version("4.0.4", sha256="5496e46edb890ef745231b4d05b8dfd194374b3fe2c6b33da43cda9685f145c8")
     version("3.0.2", sha256="28e07eb93e846b395a16e6778fd3fc8344a82d115a6a8420276ec68f67f7131c")
     version("2.0.9", sha256="2360e43965ecfa3701f287b7d597c99b4accd4dc8faf9d55cfdcc2228c4054cc")

--- a/repos/spack_repo/builtin/packages/py_slurm_pipeline/package.py
+++ b/repos/spack_repo/builtin/packages/py_slurm_pipeline/package.py
@@ -15,6 +15,7 @@ class PySlurmPipeline(PythonPackage):
 
     license("MIT")
 
+    version("4.0.9", sha256="fba9298f779ca1c226f67182a796eba08416b6774efc3c5cafc48b10b6331d0a")
     version("4.0.4", sha256="5496e46edb890ef745231b4d05b8dfd194374b3fe2c6b33da43cda9685f145c8")
     version("3.0.2", sha256="28e07eb93e846b395a16e6778fd3fc8344a82d115a6a8420276ec68f67f7131c")
     version("2.0.9", sha256="2360e43965ecfa3701f287b7d597c99b4accd4dc8faf9d55cfdcc2228c4054cc")

--- a/repos/spack_repo/builtin/packages/py_smartredis/package.py
+++ b/repos/spack_repo/builtin/packages/py_smartredis/package.py
@@ -18,6 +18,7 @@ class PySmartredis(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("0.4.2", sha256="332e734d41558c2115be615ee327b4df1f6ecf01b114000771868b9f618c72f4")
     version("0.4.1", sha256="fff16ed1eb09648ac3c3f845373beb37f3ffe7414d8745ae36af9daf585f8c5b")
     version("0.4.0", sha256="d12779aa8bb038e837c25eac41b178aab9e16b729d50ee360b5af8f813d9f1dd")
 

--- a/repos/spack_repo/builtin/packages/py_smartsim/package.py
+++ b/repos/spack_repo/builtin/packages/py_smartsim/package.py
@@ -20,6 +20,7 @@ class PySmartsim(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("0.5.1", sha256="e35be4e6006594ce5c3499104889c87f185603ad25e272114392c688822d635e")
     version("0.5.0", sha256="35b36243dc84af62261a7f772bae92f0b3502faf01401423899cb2a48339858c")
 
     variant("torch", default=True, description="Build with the pytorch backend")

--- a/repos/spack_repo/builtin/packages/py_snakemake_executor_plugin_cluster_sync/package.py
+++ b/repos/spack_repo/builtin/packages/py_snakemake_executor_plugin_cluster_sync/package.py
@@ -19,6 +19,7 @@ class PySnakemakeExecutorPluginClusterSync(PythonPackage):
 
     license("MIT")
 
+    version("0.1.5", sha256="f34b8cbc282d926ecfc7443257cb1845fc7965b92ef303c4ae7c342a4c99c5d7")
     version("0.1.4", sha256="6a6dcb2110d4c2ee74f9a48ea68e0fd7ddd2800672ebef00a01faa4affa835ad")
     version("0.1.3", sha256="c30fca6ccb98a3f7ca52ca8a95414c71360a3d4a835bd4a097a13445d6fce2ac")
 

--- a/repos/spack_repo/builtin/packages/py_snakemake_interface_report_plugins/package.py
+++ b/repos/spack_repo/builtin/packages/py_snakemake_interface_report_plugins/package.py
@@ -16,6 +16,7 @@ class PySnakemakeInterfaceReportPlugins(PythonPackage):
 
     license("MIT")
 
+    version("1.1.2", sha256="3d1218c5897345632f138a3f02794dfef7e59e407100c2a87313307a2da63c5b")
     version("1.1.0", sha256="b1ee444b2fca51225cf8a102f8e56633791d01433cd00cf07a1d9713a12313a5")
     version("1.0.0", sha256="02311cdc4bebab2a1c28469b5e6d5c6ac6e9c66998ad4e4b3229f1472127490f")
 

--- a/repos/spack_repo/builtin/packages/py_sortedcollections/package.py
+++ b/repos/spack_repo/builtin/packages/py_sortedcollections/package.py
@@ -16,6 +16,7 @@ class PySortedcollections(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.2.3", sha256="34934caf3142268cd6792bd5af9c269e5b1dfdd27f815965b973c6473edf2c45")
     version("1.2.1", sha256="58c31f35e3d052ada6a1fbfc235a408e9ec5e2cfc64a02731cf97cac4afd306a")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_soupsieve/package.py
+++ b/repos/spack_repo/builtin/packages/py_soupsieve/package.py
@@ -18,6 +18,7 @@ class PySoupsieve(PythonPackage):
     # Circular dependency on beautifulsoup4
     skip_modules = ["soupsieve"]
 
+    version("2.8.3", sha256="3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349")
     version("2.8", sha256="e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f")
     version("2.4.1", sha256="89d12b2d5dfcd2c9e8c22326da9d9aa9cb3dfab0a83a024f05704076ee8d35ea")
     version(

--- a/repos/spack_repo/builtin/packages/py_spacy/package.py
+++ b/repos/spack_repo/builtin/packages/py_spacy/package.py
@@ -17,6 +17,7 @@ class PySpacy(PythonPackage):
 
     license("MIT")
 
+    version("2.3.9", sha256="403620847f32030da4d9489c11232f6b6e2eca55d65be5c8468c52d5cf629c7f")
     version("2.3.7", sha256="c0f2315fea23497662e28212f89af3a03667f97c867c597b599c37ab84092e22")
     version("2.3.2", sha256="818de26e0e383f64ccbe3db185574920de05923d8deac8bbb12113b9e33cee1f")
     version("2.2.4", sha256="f0f3a67c5841e6e35d62c98f40ebb3d132587d3aba4f4dccac5056c4e90ff5b9")

--- a/repos/spack_repo/builtin/packages/py_spacy_loggers/package.py
+++ b/repos/spack_repo/builtin/packages/py_spacy_loggers/package.py
@@ -15,6 +15,7 @@ class PySpacyLoggers(PythonPackage):
 
     license("MIT")
 
+    version("1.0.5", sha256="d60b0bdbf915a60e516cc2e653baeff946f0cfc461b452d11a4d5458c6fe5f24")
     version("1.0.4", sha256="e6f983bf71230091d5bb7b11bf64bd54415eca839108d5f83d9155d0ba93bf28")
 
     depends_on("python@3.6:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_sphericart/package.py
+++ b/repos/spack_repo/builtin/packages/py_sphericart/package.py
@@ -17,6 +17,7 @@ class PySphericart(PythonPackage):
 
     maintainers("RMeli", "luthaf", "HaoZeke", "rubber-duck-debug")
 
+    version("1.0.6", sha256="faebf5bd9ab83fd0a511b17c8a2461bb1ee892f0c8ce14866f81a9c66dddb5a4")
     version("1.0.5", sha256="b1e424d85f2460bf1884f0e42355af7c846e23c4a8789a0aca545e8117edbc6e")
 
     depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/py_sphericart_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_sphericart_torch/package.py
@@ -16,6 +16,7 @@ class PySphericartTorch(PythonPackage, CudaPackage):
 
     maintainers("RMeli", "luthaf", "HaoZeke", "rubber-duck-debug")
 
+    version("1.0.6", sha256="e601371962f5f97afd3a39e5eefa6daf06d4653e6b0104d37932954223960ccf")
     version("1.0.5", sha256="d58c372395236b339837ee35b19933fca0c9803dcecabb213bedc51178e764a3")
 
     depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/py_sphinx_argparse/package.py
+++ b/repos/spack_repo/builtin/packages/py_sphinx_argparse/package.py
@@ -17,6 +17,7 @@ class PySphinxArgparse(PythonPackage):
 
     license("MIT")
 
+    version("0.3.2", sha256="e54ad6c8f895ac6bb9d0dd9fa07e47e137a2a42ae18a714515262e86b4cc4bab")
     version("0.3.1", sha256="82151cbd43ccec94a1530155f4ad34f251aaca6a0ffd5516d7fadf952d32dc1e")
 
     depends_on("python@2.7.0:2.7,3.5:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_sphinx_removed_in/package.py
+++ b/repos/spack_repo/builtin/packages/py_sphinx_removed_in/package.py
@@ -15,6 +15,7 @@ class PySphinxRemovedIn(PythonPackage):
 
     maintainers("LydDeb")
 
+    version("0.2.3", sha256="a62dfeaa7962c5b6760b55de65ef3ed2ea83afa1a7c3416ac0bb7d3dec8fd2a6")
     version("0.2.1", sha256="0588239cb534cd97b1d3900d0444311c119e45296a9f73f1ea81ea81a2cd3db1")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_sphinx_rtd_theme/package.py
+++ b/repos/spack_repo/builtin/packages/py_sphinx_rtd_theme/package.py
@@ -15,6 +15,7 @@ class PySphinxRtdTheme(PythonPackage):
 
     license("MIT")
 
+    version("3.0.2", sha256="b7457bc25dda723b20b086a670b9953c859eab60a2a03ee8eb2bb23e176e5f85")
     version("3.0.0", sha256="905d67de03217fd3d76fbbdd992034ac8e77044ef8063a544dda1af74d409e08")
     version("2.0.0", sha256="bd5d7b80622406762073a04ef8fadc5f9151261563d47027de09910ce03afe6b")
     version("1.2.2", sha256="01c5c5a72e2d025bd23d1f06c59a4831b06e6ce6c01fdd5ebfe9986c0a880fc7")

--- a/repos/spack_repo/builtin/packages/py_spython/package.py
+++ b/repos/spack_repo/builtin/packages/py_spython/package.py
@@ -16,6 +16,7 @@ class PySpython(PythonPackage):
 
     license("MPL-2.0")
 
+    version("0.3.14", sha256="8ad53ef034395cfa2d8a710cc1c3638e4475e5bbc6a2842d317db8013c2e4188")
     version("0.3.1", sha256="143557849d636697ddd80e0ba95920efe4668351f5becce6bdc73a7651aa128d")
     version("0.2.14", sha256="49e22fbbdebe456b27ca17d30061489db8e0f95e62be3623267a23b85e3ce0f0")
 

--- a/repos/spack_repo/builtin/packages/py_starlette/package.py
+++ b/repos/spack_repo/builtin/packages/py_starlette/package.py
@@ -16,6 +16,7 @@ class PyStarlette(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.41.3", sha256="0e4ab3d16522a255be6b28260b938eae2482f98ce5cc934cb08dce8dc3ba5835")
     version("0.41.2", sha256="9834fd799d1a87fd346deb76158668cfa0b0d56f85caefe8268e2d97c3468b62")
     version("0.37.2", sha256="9af890290133b79fc3db55474ade20f6220a364a0402e0b556e7cd5e1e093823")
     version("0.36.3", sha256="90a671733cfb35771d8cc605e0b679d23b992f8dcfad48cc60b38cb29aeb7080")

--- a/repos/spack_repo/builtin/packages/py_starsessions/package.py
+++ b/repos/spack_repo/builtin/packages/py_starsessions/package.py
@@ -15,6 +15,7 @@ class PyStarsessions(PythonPackage):
 
     license("MIT")
 
+    version("2.1.3", sha256="d20c5f277b64a86c16819f65ac50814ccdbd146776159e08c88b378b6612297d")
     version("2.1.1", sha256="cb250de84ebc6159ad187cab69e6fe60eab11684b40349457e74dcfb7656c805")
     version("1.3.0", sha256="8d3b509d4e6d235655f7dd495fcf0afc1bd86da84de3a8d434e6f82137ebcde8")
 

--- a/repos/spack_repo/builtin/packages/py_statsmodels/package.py
+++ b/repos/spack_repo/builtin/packages/py_statsmodels/package.py
@@ -21,6 +21,7 @@ class PyStatsmodels(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.14.6", sha256="4d17873d3e607d398b85126cd4ed7aad89e4e9d89fc744cdab1af3189a996c2a")
     version("0.14.5", sha256="de260e58cccfd2ceddf835b55a357233d6ca853a1aa4f90f7553a52cc71c6ddf")
     version("0.14.1", sha256="2260efdc1ef89f39c670a0bd8151b1d0843567781bcafec6cda0534eb47a94f6")
 

--- a/repos/spack_repo/builtin/packages/py_stevedore/package.py
+++ b/repos/spack_repo/builtin/packages/py_stevedore/package.py
@@ -15,6 +15,7 @@ class PyStevedore(PythonPackage):
 
     license("Apache-2.0")
 
+    version("5.4.1", sha256="3135b5ae50fe12816ef291baff420acb727fcd356106e3e9cbfa9e5985cd6f4b")
     version("5.4.0", sha256="79e92235ecb828fe952b6b8b0c6c87863248631922c8e8e0fa5b17b232c4514d")
     version("5.3.0", sha256="9a64265f4060312828151c204efbe9b7a9852a0d9228756344dbc7e4023e375a")
     version("5.2.0", sha256="46b93ca40e1114cea93d738a6c1e365396981bb6bb78c27045b7587c9473544d")

--- a/repos/spack_repo/builtin/packages/py_stomp_py/package.py
+++ b/repos/spack_repo/builtin/packages/py_stomp_py/package.py
@@ -19,6 +19,7 @@ class PyStompPy(PythonPackage):
 
     license("Apache-2.0")
 
+    version("8.0.1", sha256="d2bc55b4596604feb51d56895d93431ff8ee159b31b28d9038a2310777bbd3fa")
     version("8.0.0", sha256="7085935293bfcc4a112a9830513275b2e0f3b040c5aad5ff8907e78f285b8b57")
 
     depends_on("python@3.6.3:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_stratify/package.py
+++ b/repos/spack_repo/builtin/packages/py_stratify/package.py
@@ -18,6 +18,7 @@ class PyStratify(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.1.1", sha256="29f5afc9a94719ccce277032b9db5b778f605d914917b43f031f752070e91e78")
     version("0.1", sha256="5426f3b66e45e1010952d426e5a7be42cd45fe65f1cd73a98fee1eb7c110c6ee")
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_stringzilla/package.py
+++ b/repos/spack_repo/builtin/packages/py_stringzilla/package.py
@@ -15,6 +15,7 @@ class PyStringzilla(PythonPackage):
 
     license("Apache-2.0")
 
+    version("4.2.3", sha256="7557b395729228c4c8f13bca01a4958dc7adaf1f5ea2a812b78d265ec9c0ab14")
     version("4.2.1", sha256="fd15835ab3b78b09dba678c66b36715bcf7f9e550994ea09abcc8eb7a5e1c9f7")
 
     depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/py_submitit/package.py
+++ b/repos/spack_repo/builtin/packages/py_submitit/package.py
@@ -15,6 +15,7 @@ class PySubmitit(PythonPackage):
 
     license("MIT")
 
+    version("1.4.6", sha256="6f27037e8beacf744e372efa3998dada9f937f375f23e98a24a1207559a665a7")
     version("1.4.5", sha256="d12cbbfc98a8c1777c4f6e87f73f063dafdba15653bca2984223b038d41f8223")
     version("1.3.3", sha256="efaa77b2df9ea9ee02545478cbfc377853ddf8016bff59df6988bebcf51ffa7e")
 

--- a/repos/spack_repo/builtin/packages/py_superqt/package.py
+++ b/repos/spack_repo/builtin/packages/py_superqt/package.py
@@ -15,6 +15,7 @@ class PySuperqt(PythonPackage):
 
     license("BSD-3-Clause", checked_by="A-N-Other")
 
+    version("0.7.8", sha256="799c76d780ad9ca289a6a87d481686e28d85e47e2383d1579f57a02b572392a8")
     version("0.7.6", sha256="822fdba71dc391929c9d3db839f78ca2a861e2f2876926f969a288dfb2a9787e")
     version("0.6.1", sha256="f1a9e0499c4bbcef34b6f895eb57cd41301b3799242cd030029238124184dade")
 

--- a/repos/spack_repo/builtin/packages/py_supervisor/package.py
+++ b/repos/spack_repo/builtin/packages/py_supervisor/package.py
@@ -14,6 +14,7 @@ class PySupervisor(PythonPackage):
     homepage = "http://supervisord.org"
     pypi = "supervisor/supervisor-4.2.4.tar.gz"
 
+    version("4.2.5", sha256="34761bae1a23c58192281a5115fb07fbf22c9b0133c08166beffc70fed3ebc12")
     version("4.2.4", sha256="40dc582ce1eec631c3df79420b187a6da276bbd68a4ec0a8f1f123ea616b97a2")
 
     depends_on("python@3.4:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_symfit/package.py
+++ b/repos/spack_repo/builtin/packages/py_symfit/package.py
@@ -15,6 +15,7 @@ class PySymfit(PythonPackage):
 
     license("MIT")
 
+    version("0.3.7", sha256="f16bffcf6171ba9b3883426ceed72fb2ccef915c324856aa3fc1de4ccc786ece")
     version("0.3.5", sha256="24c66305895c590249da7e61f62f128ee1c0c43c0a8c8e33b8abd3e0931f0881")
 
     depends_on("py-setuptools@17.1:", type="build")

--- a/repos/spack_repo/builtin/packages/py_templateflow/package.py
+++ b/repos/spack_repo/builtin/packages/py_templateflow/package.py
@@ -15,6 +15,7 @@ class PyTemplateflow(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.7.2", sha256="f5cf0a796afa17e8ac384de10635ea63a6049c7741fc8111fd7b7807ea244482")
     version("0.7.1", sha256="c6e8282d1ffbb5dca7bd704a12e02bd00021860b71a043c35716861910c7187f")
     version("0.4.2", sha256="5585f3e7ccaa756f811aafb526ed6b2c79aabfd012477129af9c6038d7686f84")
 

--- a/repos/spack_repo/builtin/packages/py_terminaltables/package.py
+++ b/repos/spack_repo/builtin/packages/py_terminaltables/package.py
@@ -17,6 +17,7 @@ class PyTerminaltables(PythonPackage):
 
     license("MIT")
 
+    version("3.1.9", sha256="df28eedd73431283c59c44ebdfaefa6c4905e3d1704a4c2eaf692046efcb6774")
     version("3.1.0", sha256="f3eb0eb92e3833972ac36796293ca0906e998dc3be91fbe1f8615b331b853b81")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_terminaltables/package.py
+++ b/repos/spack_repo/builtin/packages/py_terminaltables/package.py
@@ -17,7 +17,7 @@ class PyTerminaltables(PythonPackage):
 
     license("MIT")
 
-    version("3.1.9", sha256="df28eedd73431283c59c44ebdfaefa6c4905e3d1704a4c2eaf692046efcb6774")
+    version("3.1.10", sha256="ba6eca5cb5ba02bba4c9f4f985af80c54ec3dccf94cfcd190154386255e47543")
     version("3.1.0", sha256="f3eb0eb92e3833972ac36796293ca0906e998dc3be91fbe1f8615b331b853b81")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_thinc/package.py
+++ b/repos/spack_repo/builtin/packages/py_thinc/package.py
@@ -16,6 +16,7 @@ class PyThinc(PythonPackage):
 
     license("MIT")
 
+    version("7.4.6", sha256="6e592a21382287114b5ba412a2d2b8c20d73989fec78edea82e7151d03e4f627")
     version("7.4.1", sha256="0139fa84dc9b8d88af15e648fc4ae13d899b8b5e49cb26a8f4a0604ee9ad8a9e")
     version("7.4.0", sha256="523e9be1bfaa3ed1d03d406ce451b6b4793a9719d5b83d2ea6b3398b96bc58b8")
 

--- a/repos/spack_repo/builtin/packages/py_tinyarray/package.py
+++ b/repos/spack_repo/builtin/packages/py_tinyarray/package.py
@@ -25,6 +25,7 @@ class PyTinyarray(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("1.2.5", sha256="5d47b3d475a30478ee72d6afe238c3d3683b3a3f9d425bb2f6384270b2c8799b")
     version("1.2.4", sha256="ecd3428fd8a48b61fc5f0a413ede03e27db3a1dd53fcd49e24a36d11a8a29aba")
     version("1.2.3", sha256="47a06f801ed4b3d438f4f7098e244cd0c6d7db09428b1bc5ee813e52234dee9f")
     version("1.2.2", sha256="660d6d8532e1db5efbebae2861e5733a7082486fbdeb47d57d84b8f477d697e4")

--- a/repos/spack_repo/builtin/packages/py_tokenizers/package.py
+++ b/repos/spack_repo/builtin/packages/py_tokenizers/package.py
@@ -14,6 +14,7 @@ class PyTokenizers(PythonPackage):
     homepage = "https://github.com/huggingface/tokenizers"
     pypi = "tokenizers/tokenizers-0.6.0.tar.gz"
 
+    version("0.22.2", sha256="473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917")
     version("0.22.1", sha256="61de6522785310a309b3407bac22d99c4db5dba349935e99e4d15ea2226af2d9")
     version("0.21.0", sha256="ee0894bf311b75b0c03079f33859ae4b2334d675d4e93f5a4132e1eae2834fe4")
     version("0.20.4", sha256="db50ac15e92981227f499268541306824f49e97dbeec05d118ebdc7c2d22322c")

--- a/repos/spack_repo/builtin/packages/py_tornado/package.py
+++ b/repos/spack_repo/builtin/packages/py_tornado/package.py
@@ -16,6 +16,7 @@ class PyTornado(PythonPackage):
 
     license("Apache-2.0")
 
+    version("6.5.4", sha256="a22fa9047405d03260b483980635f0b041989d8bcc9a313f8fe18b411d84b1d7")
     version("6.5.2", sha256="ab53c8f9a0fa351e2c0741284e06c7a45da86afb544133201c5cc8578eb076a0")
     version("6.3.3", sha256="e7d8db41c0181c80d76c982aacc442c0783a2c54d6400fe028954201a2e032fe")
     version("6.2", sha256="9b630419bde84ec666bfd7ea0a4cb2a8a651c2d5cccdbdd1972a0c859dfc3c13")

--- a/repos/spack_repo/builtin/packages/py_toytree/package.py
+++ b/repos/spack_repo/builtin/packages/py_toytree/package.py
@@ -19,6 +19,7 @@ class PyToytree(PythonPackage):
 
     maintainers("snehring")
 
+    version("2.0.5", sha256="7be04ca310067e0e9737449700d6ab1b68b4379b64e2d22f2f7697a70030ceb0")
     version("2.0.1", sha256="4f1452a76441857a13f72c99bf7d9f0a394cd8eae7fc02ee5349d946f2507101")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_traittypes/package.py
+++ b/repos/spack_repo/builtin/packages/py_traittypes/package.py
@@ -15,6 +15,7 @@ class PyTraittypes(PythonPackage):
 
     license("BSD")
 
+    version("0.2.3", sha256="212feed38d566d772648768b78d3347c148ef23915b91c02078188e631316c86")
     version("0.2.1", sha256="be6fa26294733e7489822ded4ae25da5b4824a8a7a0e0c2dccfde596e3489bd6")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_transformers/package.py
+++ b/repos/spack_repo/builtin/packages/py_transformers/package.py
@@ -19,6 +19,7 @@ class PyTransformers(PythonPackage):
 
     license("Apache-2.0")
 
+    version("4.57.6", sha256="55e44126ece9dc0a291521b7e5492b572e6ef2766338a610b9ab5afbb70689d3")
     version("4.57.0", sha256="d045753f3d93f9216e693cdb168698dfd2e9d3aad1bb72579a5d60ebf1545a8b")
     version("4.48.3", sha256="a5e8f1e9a6430aa78215836be70cecd3f872d99eeda300f41ad6cc841724afdb")
     version("4.46.3", sha256="8ee4b3ae943fe33e82afff8e837f4b052058b07ca9be3cb5b729ed31295f72cc")

--- a/repos/spack_repo/builtin/packages/py_tree_math/package.py
+++ b/repos/spack_repo/builtin/packages/py_tree_math/package.py
@@ -15,6 +15,7 @@ class PyTreeMath(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.2.1", sha256="77613c2360e067b16c0738b32e7d64aa5e1167e609ca1a32b6fa05dcb0d330bb")
     version("0.2.0", sha256="fced2b436fa265b4e24ab46b5768d7b03a4a8d0b75de8a5ab110abaeac3b5772")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_treelib/package.py
+++ b/repos/spack_repo/builtin/packages/py_treelib/package.py
@@ -15,6 +15,7 @@ class PyTreelib(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.7.1", sha256="a2b57ba38290f7da6af97b41de8ff7be98e7a8c00815f95d0782241f77503952")
     version("1.7.0", sha256="9bff1af416b9e642a6cd0e0431d15edf26a24b8d0c8ae68afbd3801b5e30fb61")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_typed_ast/package.py
+++ b/repos/spack_repo/builtin/packages/py_typed_ast/package.py
@@ -15,6 +15,7 @@ class PyTypedAst(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.5.5", sha256="94282f7a354f36ef5dbce0ef3467ebf6a258e370ab33d5b40c249fa996e590dd")
     version("1.5.4", sha256="39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2")
     version("1.4.3", sha256="fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65")
     version("1.4.2", sha256="9fc0b3cb5d1720e7141d103cf4819aea239f7d136acf9ee4a69b047b7986175a")

--- a/repos/spack_repo/builtin/packages/py_ubiquerg/package.py
+++ b/repos/spack_repo/builtin/packages/py_ubiquerg/package.py
@@ -16,6 +16,7 @@ class PyUbiquerg(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("0.6.3", sha256="025509c4ec77a5cde8e8be66dabfef2ca6e3cd99da3cb15066c66a6f2bc3b9b5")
     version("0.6.2", sha256="a9b1388799d4c366f956e0c912819099ad8f6cd0e5d890923cdde197f80d14cf")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_uc_micro_py/package.py
+++ b/repos/spack_repo/builtin/packages/py_uc_micro_py/package.py
@@ -15,6 +15,7 @@ class PyUcMicroPy(PythonPackage):
 
     license("MIT")
 
+    version("1.0.3", sha256="d321b92cff673ec58027c04015fcaa8bb1e005478643ff4a500882eaab88c48a")
     version("1.0.2", sha256="30ae2ac9c49f39ac6dce743bd187fcd2b574b16ca095fa74cd9396795c954c54")
 
     depends_on("python@3.7:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_ultralytics/package.py
+++ b/repos/spack_repo/builtin/packages/py_ultralytics/package.py
@@ -19,6 +19,7 @@ class PyUltralytics(PythonPackage):
 
     license("AGPL-3.0")
 
+    version("8.0.99", sha256="b648c423410373a5db8339f9482ef1f10559e7964c90ccc498f46f0d9576702c")
     version("8.0.50", sha256="fdcb22300b63b72aa52da1713c33c01741aca031a61f15327eb6f02615bb4b97")
 
     depends_on("py-setuptools", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_ultralytics/package.py
+++ b/repos/spack_repo/builtin/packages/py_ultralytics/package.py
@@ -19,7 +19,6 @@ class PyUltralytics(PythonPackage):
 
     license("AGPL-3.0")
 
-    version("8.0.99", sha256="b648c423410373a5db8339f9482ef1f10559e7964c90ccc498f46f0d9576702c")
     version("8.0.50", sha256="fdcb22300b63b72aa52da1713c33c01741aca031a61f15327eb6f02615bb4b97")
 
     depends_on("py-setuptools", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_unidecode/package.py
+++ b/repos/spack_repo/builtin/packages/py_unidecode/package.py
@@ -14,6 +14,7 @@ class PyUnidecode(PythonPackage):
 
     license("GPL-2.0-or-later")
 
+    version("1.1.2", sha256="a039f89014245e0cad8858976293e23501accc9ff5a7bdbc739a14a2b7b85cdc")
     version("1.1.1", sha256="2b6aab710c2a1647e928e36d69c21e76b453cd455f4e2621000e54b2a9b8cce8")
     version("0.04.21", sha256="280a6ab88e1f2eb5af79edff450021a0d3f0448952847cd79677e55e58bad051")
 

--- a/repos/spack_repo/builtin/packages/py_userpath/package.py
+++ b/repos/spack_repo/builtin/packages/py_userpath/package.py
@@ -14,6 +14,7 @@ class PyUserpath(PythonPackage):
     pypi = "userpath/userpath-1.8.0.tar.gz"
 
     license("MIT")
+    version("1.9.2", sha256="6c52288dab069257cc831846d15d48133522455d4677ee69a9781f11dbefd815")
     version("1.9.0", sha256="85e3274543174477c62d5701ed43a3ef1051824a9dd776968adc411e58640dd1")
     version("1.8.0", sha256="04233d2fcfe5cff911c1e4fb7189755640e1524ff87a4b82ab9d6b875fee5787")
     version("1.7.0", sha256="dcd66c5fa9b1a3c12362f309bbb5bc7992bac8af86d17b4e6b1a4b166a11c43f")

--- a/repos/spack_repo/builtin/packages/py_usgs/package.py
+++ b/repos/spack_repo/builtin/packages/py_usgs/package.py
@@ -17,6 +17,7 @@ class PyUsgs(PythonPackage):
 
     license("MIT")
 
+    version("0.2.8", sha256="69c837666b9403cf482a657849263a9104a93e0750ac7318163670ce39db4044")
     version("0.2.7", sha256="484e569ea1baf9574e11ccf15219957364690dcf06ee3d09afef030df944e79b")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_virtualenv/package.py
+++ b/repos/spack_repo/builtin/packages/py_virtualenv/package.py
@@ -16,6 +16,7 @@ class PyVirtualenv(PythonPackage):
 
     license("MIT")
 
+    version("20.35.4", sha256="643d3914d73d3eeb0c552cbb12d7e82adf0e504dbf86a3182f8771a153a1971c")
     version("20.35.3", sha256="4f1a845d131133bdff10590489610c98c168ff99dc75d6c96853801f7f67af44")
     version("20.26.6", sha256="280aede09a2a5c317e409a00102e7077c6432c5a38f0ef938e643805a7ad2c48")
     version("20.26.5", sha256="ce489cac131aa58f4b25e321d6d186171f78e6cb13fafbf32a840cee67733ff4")

--- a/repos/spack_repo/builtin/packages/py_wadler_lindig/package.py
+++ b/repos/spack_repo/builtin/packages/py_wadler_lindig/package.py
@@ -13,6 +13,7 @@ class PyWadlerLindig(PythonPackage):
     homepage = "https://docs.kidger.site/wadler_lindig"
     pypi = "wadler_lindig/wadler_lindig-0.1.3.tar.gz"
 
+    version("0.1.7", sha256="81d14d3fe77d441acf3ebd7f4aefac20c74128bf460e84b512806dccf7b2cd55")
     version("0.1.3", sha256="476fb7015135f714cef8f8eac7c44b164c8b993345e651a9b6f25b7b112440c9")
 
     license("Apache-2.0", checked_by="viperML")

--- a/repos/spack_repo/builtin/packages/py_waitress/package.py
+++ b/repos/spack_repo/builtin/packages/py_waitress/package.py
@@ -15,6 +15,7 @@ class PyWaitress(PythonPackage):
 
     license("ZPL-2.1")
 
+    version("3.0.2", sha256="682aaaf2af0c44ada4abfb70ded36393f0e307f4ab9456a215ce0020baefc31f")
     version("3.0.1", sha256="ef0c1f020d9f12a515c4ec65c07920a702613afcad1dbfdc3bcec256b6c072b3")
 
     depends_on("py-setuptools@41:", type="build")

--- a/repos/spack_repo/builtin/packages/py_watchdog/package.py
+++ b/repos/spack_repo/builtin/packages/py_watchdog/package.py
@@ -15,6 +15,7 @@ class PyWatchdog(PythonPackage):
 
     license("Apache-2.0")
 
+    version("2.1.9", sha256="43ce20ebb36a51f21fa376f76d1d4692452b2527ccd601950d69ed36b9e21609")
     version("2.1.6", sha256="a36e75df6c767cbf46f61a91c70b3ba71811dfa0aca4a324d9407a06a8b7a2e7")
     version("0.10.3", sha256="4214e1379d128b0588021880ccaf40317ee156d4603ac388b9adcf29165e0c04")
     version("0.10.2", sha256="c560efb643faed5ef28784b2245cf8874f939569717a4a12826a173ac644456b")

--- a/repos/spack_repo/builtin/packages/py_werkzeug/package.py
+++ b/repos/spack_repo/builtin/packages/py_werkzeug/package.py
@@ -16,6 +16,7 @@ class PyWerkzeug(PythonPackage):
 
     license("BSD-3-Clause", checked_by="wdconinc")
 
+    version("3.1.5", sha256="6a548b0e88955dd07ccb25539d7d0cc97417ee9e179677d22c7041c8f078ce67")
     version("3.1.3", sha256="60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746")
     version("3.0.4", sha256="34f2371506b250df4d4f84bfe7b0921e4762525762bbd936614909fe25cd7306")
     version("3.0.0", sha256="3ffff4dcc32db52ef3cc94dff3000a3c2846890f3a5a51800a27b909c5e770f0")

--- a/repos/spack_repo/builtin/packages/py_widgetsnbextension/package.py
+++ b/repos/spack_repo/builtin/packages/py_widgetsnbextension/package.py
@@ -14,6 +14,7 @@ class PyWidgetsnbextension(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("4.0.9", sha256="3c1f5e46dc1166dfd40a42d685e6a51396fd34ff878742a3e47c6f0cc4a2a385")
     version("4.0.3", sha256="34824864c062b0b3030ad78210db5ae6a3960dfb61d5b27562d6631774de0286")
     version("3.6.0", sha256="e84a7a9fcb9baf3d57106e184a7389a8f8eb935bf741a5eb9d60aa18cc029a80")
     version("3.5.1", sha256="079f87d87270bce047512400efd70238820751a11d2d8cb137a5a5bdbaf255c7")

--- a/repos/spack_repo/builtin/packages/py_widgetsnbextension/package.py
+++ b/repos/spack_repo/builtin/packages/py_widgetsnbextension/package.py
@@ -14,7 +14,7 @@ class PyWidgetsnbextension(PythonPackage):
 
     license("BSD-3-Clause")
 
-    version("4.0.9", sha256="3c1f5e46dc1166dfd40a42d685e6a51396fd34ff878742a3e47c6f0cc4a2a385")
+    version("4.0.15", sha256="de8610639996f1567952d763a5a41af8af37f2575a41f9852a38f947eb82a3b9")
     version("4.0.3", sha256="34824864c062b0b3030ad78210db5ae6a3960dfb61d5b27562d6631774de0286")
     version("3.6.0", sha256="e84a7a9fcb9baf3d57106e184a7389a8f8eb935bf741a5eb9d60aa18cc029a80")
     version("3.5.1", sha256="079f87d87270bce047512400efd70238820751a11d2d8cb137a5a5bdbaf255c7")

--- a/repos/spack_repo/builtin/packages/py_wordcloud/package.py
+++ b/repos/spack_repo/builtin/packages/py_wordcloud/package.py
@@ -15,6 +15,7 @@ class PyWordcloud(PythonPackage):
 
     license("MIT")
 
+    version("1.8.2.2", sha256="523db887e47e840eb5c2e60428243bb1d7439fdc60f89626b17bafa1be64459c")
     version("1.8.1", sha256="e6ef771aac17c1cf8558c8d5ef025796184066d7b78f8118aefe011fb0d22952")
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_wurlitzer/package.py
+++ b/repos/spack_repo/builtin/packages/py_wurlitzer/package.py
@@ -16,6 +16,7 @@ class PyWurlitzer(PythonPackage):
 
     license("MIT")
 
+    version("3.0.3", sha256="224f5fe70618be3872c05dfddc8c457191ec1870654596279fcc1edadebe3e5b")
     version("3.0.2", sha256="36051ac530ddb461a86b6227c4b09d95f30a1d1043de2b4a592e97ae8a84fcdf")
 
     depends_on("python+ctypes@3.5:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_xarray_regrid/package.py
+++ b/repos/spack_repo/builtin/packages/py_xarray_regrid/package.py
@@ -17,6 +17,7 @@ class PyXarrayRegrid(PythonPackage):
 
     license("Apache-2.0", checked_by="Chrismarsh")
 
+    version("0.4.2", sha256="96525d39b0290efa59e0255cebd35be028052f1b347bfb10fd259b4380289673")
     version("0.4.1", sha256="2c8a7baa321c2451aa42b387fef3b22ecd7bdf693e7ee5c52ebe5168482a1e2a")
     version("0.4.0", sha256="f0bef6a346e247c657ed293752b5685f3b559b32de546889ca9e9fca14b81f3a")
 

--- a/repos/spack_repo/builtin/packages/py_xarray_tensorstore/package.py
+++ b/repos/spack_repo/builtin/packages/py_xarray_tensorstore/package.py
@@ -17,6 +17,7 @@ class PyXarrayTensorstore(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.1.5", sha256="a8e17c08df6b32875e50f7b9278a64bbd9156b660d2245153abba4b2a9b30e9c")
     version("0.1.1", sha256="2ee6f164c9f1bc43328245b8d06c21863204fcd4e6159ddd6d8867c313c1d9b4")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_xesmf/package.py
+++ b/repos/spack_repo/builtin/packages/py_xesmf/package.py
@@ -15,7 +15,7 @@ class PyXesmf(PythonPackage):
 
     license("MIT")
 
-    version("0.8.9", sha256="5ecb5276f94137eba8d5ce532c3757a07df4e19d2fdf974289d4651c173c914e")
+    version("0.8.10", sha256="6f924cfd16e40e9adaad80af26fd1f26e509e66b177ea80ae45c3ef1ed56f5fd")
     version("0.8.8", sha256="8588f83007ce7011379991f516be3691df6fb30486741f0e1c33aa962056ea33")
     version("0.8.4", sha256="c5a2c4b3e8dbbc9fccd5772a940f9067d68e824215ef87ba222b06718c4eeb56")
 

--- a/repos/spack_repo/builtin/packages/py_xesmf/package.py
+++ b/repos/spack_repo/builtin/packages/py_xesmf/package.py
@@ -15,6 +15,7 @@ class PyXesmf(PythonPackage):
 
     license("MIT")
 
+    version("0.8.9", sha256="5ecb5276f94137eba8d5ce532c3757a07df4e19d2fdf974289d4651c173c914e")
     version("0.8.8", sha256="8588f83007ce7011379991f516be3691df6fb30486741f0e1c33aa962056ea33")
     version("0.8.4", sha256="c5a2c4b3e8dbbc9fccd5772a940f9067d68e824215ef87ba222b06718c4eeb56")
 

--- a/repos/spack_repo/builtin/packages/py_xgboost/package.py
+++ b/repos/spack_repo/builtin/packages/py_xgboost/package.py
@@ -20,6 +20,7 @@ class PyXgboost(PythonPackage):
     license("Apache-2.0")
     maintainers("adamjstewart")
 
+    version("2.1.4", sha256="ab84c4bbedd7fae1a26f61e9dd7897421d5b08454b51c6eb072abc1d346d08d7")
     version("2.1.1", sha256="4b1729837f9f1ba88a32ef1be3f8efb860fee6454a68719b196dc88032c23d97")
     version("2.1.0", sha256="7144980923e76ce741c7b03a14d3bd7514db6de5c7cabe96ba95b229d274f5ca")
     version("1.7.6", sha256="1c527554a400445e0c38186039ba1a00425dcdb4e40b37eed0e74cb39a159c47")

--- a/repos/spack_repo/builtin/packages/py_xlrd/package.py
+++ b/repos/spack_repo/builtin/packages/py_xlrd/package.py
@@ -14,6 +14,7 @@ class PyXlrd(PythonPackage):
     homepage = "http://www.python-excel.org/"
     pypi = "xlrd/xlrd-0.9.4.tar.gz"
 
+    version("2.0.2", sha256="08b5e25de58f21ce71dc7db3b3b8106c1fa776f3024c54e45b45b374e89234c9")
     version("2.0.1", sha256="f72f148f54442c6b056bf931dbc34f986fd0c3b0b6b5a58d013c9aef274d0c88")
     version("0.9.4", sha256="8e8d3359f39541a6ff937f4030db54864836a06e42988c452db5b6b86d29ea72")
 

--- a/repos/spack_repo/builtin/packages/py_yt_dlp_ejs/package.py
+++ b/repos/spack_repo/builtin/packages/py_yt_dlp_ejs/package.py
@@ -15,6 +15,7 @@ class PyYtDlpEjs(PythonPackage):
 
     license("Unlicense AND MIT AND ISC")
 
+    version("0.3.2", sha256="31a41292799992bdc913e03c9fac2a8c90c82a5cbbc792b2e3373b01da841e3e")
     version("0.3.1", sha256="7f2119eb02864800f651fa33825ddfe13d152a1f730fa103d9864f091df24227")
 
     with default_args(type="build"):


### PR DESCRIPTION
Automatic bump of patch version numbers (the `Z` in `x.y.Z`) among ~pure
Python packages.

* Only bumps packages without changes in deps (including python)
* Spack's computed URLs were used
* Archives were fetched and checksummed (and validated in gha)

Before, Spack's pure Python packages were outdated like this:

```
major version updates: 291
minor version updates: 607
patch version updates: 272
total: 1170
```

now it's

```
major version updates: 291
minor version updates: 607
patch version updates: 163
total: 1061
```

so, still pretty bad, but better.


