### PR TITLE
python ecosystem: bulk update

### DIFF
--- a/repos/spack_repo/builtin/packages/py_addict/package.py
+++ b/repos/spack_repo/builtin/packages/py_addict/package.py
@@ -17,6 +17,7 @@ class PyAddict(PythonPackage):
 
     license("MIT")
 
+    version("2.4.0", sha256="8eb5674667e39549e7e5534b98d7c942ec4a4195b76bdb748739eac5d3861bc1")
     version("2.2.1", sha256="398bba9e7fa25e2ce144c5c4b8ec6208e89b9445869403dfa88ab66ec110fa12")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_advancedhtmlparser/package.py
+++ b/repos/spack_repo/builtin/packages/py_advancedhtmlparser/package.py
@@ -17,6 +17,7 @@ class PyAdvancedhtmlparser(PythonPackage):
 
     license("LGPL-3.0-or-later")
 
+    version("9.0.2", sha256="837d17dadaa8eef87bf5773f05b5ddaceb76183b3dc13671e5550adf177f5465")
     version("9.0.1", sha256="1b7f632ca4c61fca50ee896c84112b97915c07d5b25b9527aefe7cbad8458837")
     version("8.1.4", sha256="21a73137026c8ec3248c654a24cc40064196029256cdf71681149f6835e9ed39")
 

--- a/repos/spack_repo/builtin/packages/py_aenum/package.py
+++ b/repos/spack_repo/builtin/packages/py_aenum/package.py
@@ -14,6 +14,7 @@ class PyAenum(PythonPackage):
     homepage = "https://github.com/ethanfurman/aenum"
     pypi = "aenum/aenum-2.1.2.tar.gz"
 
+    version("3.1.16", sha256="bfaf9589bdb418ee3a986d85750c7318d9d2839c1b1a1d6fe8fc53ec201cf140")
     version("3.1.12", sha256="3e531c91860a81f885f7e6e97d219ae9772cb899580084788935dad7d9742ef0")
     version("2.1.2", sha256="a3208e4b28db3a7b232ff69b934aef2ea1bf27286d9978e1e597d46f490e4687")
 

--- a/repos/spack_repo/builtin/packages/py_altgraph/package.py
+++ b/repos/spack_repo/builtin/packages/py_altgraph/package.py
@@ -18,6 +18,7 @@ class PyAltgraph(PythonPackage):
 
     license("MIT")
 
+    version("0.17.5", sha256="c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7")
     version("0.16.1", sha256="ddf5320017147ba7b810198e0b6619bd7b5563aa034da388cea8546b877f9b0c")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_ampltools/package.py
+++ b/repos/spack_repo/builtin/packages/py_ampltools/package.py
@@ -16,6 +16,7 @@ class PyAmpltools(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.7.5", sha256="df43fffd2d263a24fc95297bc56a62a6ab18248f86496b46eba2998fd1431af3")
     version("0.4.6", sha256="d54b399c1d78d02e3f4023aa2335b57832deb7d31cdefe4e219e4f2a2bb19a83")
 
     depends_on("py-requests", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_antimeridian/package.py
+++ b/repos/spack_repo/builtin/packages/py_antimeridian/package.py
@@ -16,6 +16,7 @@ class PyAntimeridian(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.4.5", sha256="088f8daec4109ce5d85d52e9b4382bffcbd1a5b47c78644898f9c6d8562d1207")
     version("0.3.11", sha256="fde0134e6799676ec68765d3e588f5f32cabd4041b1f969b923758d0a6cd0c7f")
 
     depends_on("python@3.10:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_anybadge/package.py
+++ b/repos/spack_repo/builtin/packages/py_anybadge/package.py
@@ -14,6 +14,7 @@ class PyAnybadge(PythonPackage):
     homepage = "https://github.com/jongracecox/anybadge"
     pypi = "anybadge/anybadge-1.14.0.tar.gz"
 
+    version("1.16.0", sha256="f4e95eca834482f9932f9020ac2fe04a5ca863728b446324a8d35b1e67faab71")
     version("1.14.0", sha256="47f06e0a6320d3e5eac55c712dc0bab71b9ed85353c591d448653c5a0740783f")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_anywidget/package.py
+++ b/repos/spack_repo/builtin/packages/py_anywidget/package.py
@@ -15,6 +15,7 @@ class PyAnywidget(PythonPackage):
 
     license("MIT")
 
+    version("0.9.21", sha256="b8d0172029ac426573053c416c6a587838661612208bb390fa0607862e594b27")
     version("0.9.18", sha256="262cf459b517a7d044d6fbc84b953e9c83f026790b2dd3ce90f21a7f8eded00f")
 
     depends_on("py-hatchling", type="build")

--- a/repos/spack_repo/builtin/packages/py_apeye_core/package.py
+++ b/repos/spack_repo/builtin/packages/py_apeye_core/package.py
@@ -16,6 +16,7 @@ class PyApeyeCore(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.1.5", sha256="5de72ed3d00cc9b20fea55e54b7ab8f5ef8500eb33a5368bc162a5585e238a55")
     version("1.1.4", sha256="72bb89fed3baa647cb81aa28e1d851787edcbf9573853b5d2b5f87c02f50eaf5")
 
     depends_on("py-hatch-requirements-txt", type="build")

--- a/repos/spack_repo/builtin/packages/py_applicationinsights/package.py
+++ b/repos/spack_repo/builtin/packages/py_applicationinsights/package.py
@@ -29,6 +29,7 @@ class PyApplicationinsights(PythonPackage):
 
     license("MIT")
 
+    version("0.11.10", sha256="0b761f3ef0680acf4731906dfc1807faa6f2a57168ae74592db0084a6099f7b3")
     version("0.11.9", sha256="30a11aafacea34f8b160fbdc35254c9029c7e325267874e3c68f6bdbcd6ed2c3")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_argcomplete/package.py
+++ b/repos/spack_repo/builtin/packages/py_argcomplete/package.py
@@ -15,6 +15,7 @@ class PyArgcomplete(PythonPackage):
 
     license("Apache-2.0")
 
+    version("3.6.3", sha256="62e8ed4fd6a45864acc8235409461b72c9a28ee785a2011cc5eb78318786c89c")
     version("3.6.2", sha256="d0519b1bc867f5f4f4713c41ad0aba73a4a5f007449716b16f385f2166dc6adf")
     version("3.5.0", sha256="4349400469dccfb7950bb60334a680c58d88699bff6159df61251878dc6bf74b")
     version("3.1.6", sha256="3b1f07d133332547a53c79437527c00be48cca3807b1d4ca5cab1b26313386a6")

--- a/repos/spack_repo/builtin/packages/py_authlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_authlib/package.py
@@ -15,6 +15,7 @@ class PyAuthlib(PythonPackage):
     pypi = "authlib/authlib-1.6.5.tar.gz"
 
     license("BSD-3-Clause")
+    version("1.6.7", sha256="dbf10100011d1e1b34048c9d120e83f13b35d69a826ae762b93d2fb5aafc337b")
     version("1.6.5", sha256="6aaf9c79b7cc96c900f0b284061691c5d4e61221640a948fe690b556a6d6d10b")
 
     depends_on("python@3.9:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_autograd_gamma/package.py
+++ b/repos/spack_repo/builtin/packages/py_autograd_gamma/package.py
@@ -17,6 +17,7 @@ class PyAutogradGamma(PythonPackage):
 
     license("MIT")
 
+    version("0.5.0", sha256="f27abb7b8bb9cffc8badcbf59f3fe44a9db39e124ecacf1992b6d952934ac9c4")
     version("0.4.3", sha256="2cb570cbb8da61ede937ccc004d87d3924108f754b351a86cdd2ad31ace6cdf6")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_avro_json_serializer/package.py
+++ b/repos/spack_repo/builtin/packages/py_avro_json_serializer/package.py
@@ -15,6 +15,7 @@ class PyAvroJsonSerializer(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.0.4", sha256="7453a3239b9aa8277321c668b27e49895b4c532a6c2f7b2884e10cdda7b9d381")
     version("0.4", sha256="f9dac2dac92036c5dd5aba8c716545fc0a0630cc365a51ab15bc2ac47eac28f1")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_avro_python3/package.py
+++ b/repos/spack_repo/builtin/packages/py_avro_python3/package.py
@@ -17,6 +17,7 @@ class PyAvroPython3(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.10.2", sha256="3b63f24e6b04368c3e4a6f923f484be0230d821aad65ac36108edbff29e9aaab")
     version("1.10.0", sha256="a455c215540b1fceb1823e2a918e94959b54cb363307c97869aa46b5b55bde05")
     version("1.9.1", sha256="daab2cea71b942a1eb57d700d4a729e9d6cd93284d4dd4d65a378b9f958aa0d2")
 

--- a/repos/spack_repo/builtin/packages/py_azure_common/package.py
+++ b/repos/spack_repo/builtin/packages/py_azure_common/package.py
@@ -14,6 +14,7 @@ class PyAzureCommon(PythonPackage):
     homepage = "https://github.com/Azure/azure-sdk-for-python"
     pypi = "azure-common/azure-common-1.1.25.zip"
 
+    version("1.1.28", sha256="4ac0cd3214e36b6a1b6a442686722a5d8cc449603aa833f3f0f40bda836704a3")
     version("1.1.25", sha256="ce0f1013e6d0e9faebaf3188cc069f4892fc60a6ec552e3f817c1a2f92835054")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_b2luigi/package.py
+++ b/repos/spack_repo/builtin/packages/py_b2luigi/package.py
@@ -24,6 +24,7 @@ class PyB2luigi(PythonPackage):
     # maintainers("github_user1", "github_user2")
 
     # We start at 1.2.6 as this was the change from retry2->tenacity dependency
+    version("1.2.7", sha256="9f2622bb5f8f8645a0ef2546c3125164e3d5ab167c1e2519b1593e930733df40")
     version("1.2.6", sha256="9f3be756f0961ca2241d36d9a9174ea5a23ebd7787cbfa78632047aae25f1202")
 
     depends_on("python@3.8:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_babel/package.py
+++ b/repos/spack_repo/builtin/packages/py_babel/package.py
@@ -18,6 +18,7 @@ class PyBabel(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("2.18.0", sha256="b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d")
     version("2.17.0", sha256="0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d")
     version("2.15.0", sha256="8daf0e265d05768bc6c7a314cf1321e9a123afc328cc635c18622a2f30a04413")
     version("2.12.1", sha256="cc2d99999cd01d44420ae725a21c9e3711b3aadc7976d6147f622d8581963455")

--- a/repos/spack_repo/builtin/packages/py_backports_ssl_match_hostname/package.py
+++ b/repos/spack_repo/builtin/packages/py_backports_ssl_match_hostname/package.py
@@ -12,6 +12,7 @@ class PyBackportsSslMatchHostname(PythonPackage):
 
     pypi = "backports.ssl_match_hostname/backports.ssl_match_hostname-3.5.0.1.tar.gz"
 
+    version("3.7.0.1", sha256="bb82e60f9fbf4c080eabd957c39f0641f0fc247d9a16e31e26d594d8f42b9fd2")
     version("3.5.0.1", sha256="502ad98707319f4a51fa2ca1c677bd659008d27ded9f6380c79e8932e38dcdf2")
 
     # pip silently replaces distutils with setuptools

--- a/repos/spack_repo/builtin/packages/py_bagit/package.py
+++ b/repos/spack_repo/builtin/packages/py_bagit/package.py
@@ -18,6 +18,7 @@ class PyBagit(PythonPackage):
 
     license("CC0-1.0")
 
+    version("1.9.0", sha256="9455006c2d1df88be95ec1fccabc5ea623389589ea4c85b3d85bd256f29d7656")
     version("1.8.1", sha256="37df1330d2e8640c8dee8ab6d0073ac701f0614d25f5252f9e05263409cee60c")
 
     depends_on("python@2.7:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_bcbio_gff/package.py
+++ b/repos/spack_repo/builtin/packages/py_bcbio_gff/package.py
@@ -13,6 +13,7 @@ class PyBcbioGff(PythonPackage):
 
     pypi = "bcbio-gff/bcbio-gff-0.6.2.tar.gz"
 
+    version("0.7.1", sha256="d1dc3294147b95baced6033f6386a0fed45c43767ef02d1223df5ef497e9cca6")
     version("0.7.0", sha256="f7b3922ee274106f8716703f41f05a1795aa9d73e903f4e481995ed8f5f65d2d")
     version("0.6.2", sha256="c682dc46a90e9fdb124ab5723797a5f71b2e3534542ceff9f6572b64b9814e68")
 

--- a/repos/spack_repo/builtin/packages/py_beaker/package.py
+++ b/repos/spack_repo/builtin/packages/py_beaker/package.py
@@ -18,6 +18,7 @@ class PyBeaker(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.13.0", sha256="e956cd8a35ad5de1b5212c7bff8fc01e2b3d34ab92466d24684c666abb8c9c30")
     version("1.12.0", sha256="2d5f427e3b13259c98c934cab0e428fc1c18a4c4b94acbdae930df7e7f51d1ec")
     version("1.11.0", sha256="ad5d1c05027ee3be3a482ea39f8cb70339b41e5d6ace0cb861382754076d187e")
 

--- a/repos/spack_repo/builtin/packages/py_bids_validator_deno/package.py
+++ b/repos/spack_repo/builtin/packages/py_bids_validator_deno/package.py
@@ -15,6 +15,7 @@ class PyBidsValidatorDeno(PythonPackage):
 
     license("MIT")
 
+    version("2.4.0", sha256="78cd6bc4d43aa6b17555185181c74b22e2ccaea8c3494175b6524807b467aa94")
     version("2.0.7", sha256="55a46dc9e134c2996ecb077896aad65e5320f3c864b41c47e108011f8fd1e2d1")
 
     depends_on("py-pdm-backend", type="build")

--- a/repos/spack_repo/builtin/packages/py_biosppy/package.py
+++ b/repos/spack_repo/builtin/packages/py_biosppy/package.py
@@ -15,6 +15,7 @@ class PyBiosppy(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("2.2.4", sha256="0b52eb27a410fe24c01bd15dd4a85149d20ac0026f73e03b9c61bf99577dcca5")
     version("2.2.3", sha256="2c4b84c98c71e3e84b43bf09a855414c31f534a8aed84e59fb05bbc3c36d9aa9")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_biotraj/package.py
+++ b/repos/spack_repo/builtin/packages/py_biotraj/package.py
@@ -15,6 +15,7 @@ class PyBiotraj(PythonPackage):
 
     license("LGPL-2.1")
 
+    version("1.2.2", sha256="4bcba92101ed50f369cc1487fb5dfcfe1d8402ad47adaa9232b080553271663a")
     version("1.2.1", sha256="4d7ad33ad940dbcfb3c2bd228a18f33f88e04657786a9562173b58dc2dd05349")
 
     depends_on("python@3.10:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_bokeh/package.py
+++ b/repos/spack_repo/builtin/packages/py_bokeh/package.py
@@ -15,6 +15,7 @@ class PyBokeh(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("3.8.2", sha256="8e7dcacc21d53905581b54328ad2705954f72f2997f99fc332c1de8da53aa3cc")
     version("3.7.2", sha256="80c21885cec276431acd4db92f831c71eb999ea995470ce777e0c577b0cfc1d8")
     version("3.5.2", sha256="03a54a67db677b8881834271c620a781b383ae593af5c3ea2149164754440d07")
     version("3.3.1", sha256="2a7b3702d7e9f03ef4cd801b02b7380196c70cff2773859bcb84fa565218955c")

--- a/repos/spack_repo/builtin/packages/py_bottle/package.py
+++ b/repos/spack_repo/builtin/packages/py_bottle/package.py
@@ -16,6 +16,7 @@ class PyBottle(PythonPackage):
 
     license("MIT")
 
+    version("0.13.4", sha256="807c789c3184d7070010dbdf1339ee46ff9fb9b6694d7caa3047f975f8a7df60")
     version("0.12.23", sha256="f38c26395736ae4653cbeb94087d3bd1d2e1ad0c29b1d3e5384f5db20b63bc98")
     version("0.12.19", sha256="b97277f8e87d452a0aa5fbcd16cd604a189e2cc17fdb2d4eaf6baa732f8d111b")
     version("0.12.18", sha256="176721f1e26082c66fd4df76f31800933e4bb36de6814b0fda3851cb409a95e6")

--- a/repos/spack_repo/builtin/packages/py_bqplot/package.py
+++ b/repos/spack_repo/builtin/packages/py_bqplot/package.py
@@ -16,6 +16,7 @@ class PyBqplot(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.12.45", sha256="cf2e046adb401670902ab53a18d9f63540091279bc45c4ef281bfdadf6e7e92c")
     version("0.12.44", sha256="cad65bf5c4ce7ea7b03e1c674340f9274c0975941e63057831b29f7c2c37f144")
 
     with default_args(type=("build", "run")):

--- a/repos/spack_repo/builtin/packages/py_brain_indexer/package.py
+++ b/repos/spack_repo/builtin/packages/py_brain_indexer/package.py
@@ -16,6 +16,7 @@ class PyBrainIndexer(PythonPackage):
 
     maintainers("matz-e")
 
+    version("3.1.1", sha256="114d7ce2d916051a495dd36e81221ee950d0f0cfa4381024a047c69eba43e364")
     version("3.0.0", sha256="23947519df5f87c65781d1776f02e8e17798c40c617399b02e6ecae8e09a0a72")
 
     variant("mpi", default=True, description="Enable MPI parallelism")

--- a/repos/spack_repo/builtin/packages/py_calver/package.py
+++ b/repos/spack_repo/builtin/packages/py_calver/package.py
@@ -16,6 +16,9 @@ class PyCalver(PythonPackage):
 
     license("Apache-2.0")
 
+    version(
+        "2025.10.20", sha256="c98b376c2424642224d456b2f70c51402343e008c63d204634665e1a2a2835f5"
+    )
     version("2025.4.17", sha256="460702737d620f5c3d4175450485180a1b7f7a422c5db0e6af3e655c7395ec7e")
     version("2022.6.26", sha256="e05493a3b17517ef1748fbe610da11f10485faa7c416b9d33fd4a52d74894f8b")
 

--- a/repos/spack_repo/builtin/packages/py_certifi/package.py
+++ b/repos/spack_repo/builtin/packages/py_certifi/package.py
@@ -17,6 +17,7 @@ class PyCertifi(PythonPackage):
 
     license("MPL-2.0")
 
+    version("2026.1.4", sha256="ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120")
     version("2025.7.14", sha256="8ea99dbdfaaf2ba2f9bac77b9249ef62ec5218e7c2b2e903378ed5fccf765995")
     version("2025.4.26", sha256="0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6")
 

--- a/repos/spack_repo/builtin/packages/py_ci_sdr/package.py
+++ b/repos/spack_repo/builtin/packages/py_ci_sdr/package.py
@@ -18,6 +18,7 @@ class PyCiSdr(PythonPackage):
 
     license("MIT")
 
+    version("0.0.2", sha256="3f9d4c205b9b7c5c3239a90400b81f1f26ecb38484a46150d2677ff646a13465")
     version("0.0.0", sha256="a1387f39ccd55cce034e2c01000a0a337b3729d8a5010b42c5381d8c820fa4bb")
 
     depends_on("python@3.6:3", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_cinemasci/package.py
+++ b/repos/spack_repo/builtin/packages/py_cinemasci/package.py
@@ -18,6 +18,7 @@ class PyCinemasci(PythonPackage):
 
     maintainers("EthanS94")
 
+    version("1.7.9", sha256="ceab37e9d9f5c9b9bd94c12200ae05fb5a866c6f6a4ecae51db1858971998bfb")
     version("1.7.0", sha256="70e1fa494bcbefdbd9e8859cdf1b01163a94ecffcdfa3da1011e4ef2fcee6169")
     version("1.3", sha256="c024ca9791de9d78e5dad3fd11e8f87d8bc1afa5830f2697d7ec4116a5d23c20")
 

--- a/repos/spack_repo/builtin/packages/py_click/package.py
+++ b/repos/spack_repo/builtin/packages/py_click/package.py
@@ -16,6 +16,7 @@ class PyClick(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("8.3.1", sha256="12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a")
     version("8.2.1", sha256="27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202")
     version("8.1.8", sha256="ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a")
     version("8.1.7", sha256="ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de")

--- a/repos/spack_repo/builtin/packages/py_cloudpickle/package.py
+++ b/repos/spack_repo/builtin/packages/py_cloudpickle/package.py
@@ -15,6 +15,7 @@ class PyCloudpickle(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("3.1.2", sha256="7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414")
     version("3.0.0", sha256="996d9a482c6fb4f33c1a35335cf8afd065d2a56e973270364840712d9131a882")
     version("2.2.1", sha256="d89684b8de9e34a2a43b3460fbca07d09d6e25ce858df4d5a44240403b6178f5")
     version("2.2.0", sha256="3f4219469c55453cfe4737e564b67c2a149109dabf7f242478948b895f61106f")

--- a/repos/spack_repo/builtin/packages/py_clustershell/package.py
+++ b/repos/spack_repo/builtin/packages/py_clustershell/package.py
@@ -17,6 +17,7 @@ class PyClustershell(PythonPackage):
 
     license("LGPL-2.1-or-later")
 
+    version("1.9.3", sha256="94c97e8de4d701ceb953772a4cfd88b60323dd5b50bfd9ad765e92fe543303f3")
     version("1.8.4", sha256="763793f729bd1c275361717c540e01ad5fe536119eca92f14077c0995739b9d7")
     version("1.8.3", sha256="86b0d524e5e50c0a15faec01d8642f0ff12ba78d50b7e7b660261be5d53fed9c")
     version("1.8.2", sha256="abf5ed23b6adfc802ee65aa0208c697f617e5fb8fd0d8cb0100ee337e2721796")

--- a/repos/spack_repo/builtin/packages/py_coapthon3/package.py
+++ b/repos/spack_repo/builtin/packages/py_coapthon3/package.py
@@ -17,6 +17,7 @@ class PyCoapthon3(PythonPackage):
 
     license("MIT")
 
+    version("1.0.2", sha256="07a2c8699eeda2fa819cde30b40a408e7ee6e803f7746bb8702bf52143fb3481")
     version("1.0.1", sha256="331150a581708d47b208cee3b067ced80a00f0cc1278e913ec546e6c6b28bffd")
     version("1.0", sha256="63eb083269c2a286aedd206d3df17ab67fa978dc43caf34eaab9498da15c497a")
 

--- a/repos/spack_repo/builtin/packages/py_codespell/package.py
+++ b/repos/spack_repo/builtin/packages/py_codespell/package.py
@@ -16,6 +16,7 @@ class PyCodespell(PythonPackage):
 
     license("GPL-2.0", checked_by="cmelone")
 
+    version("2.4.1", sha256="299fcdcb09d23e81e35a671bbe746d5ad7e8385972e65dbb833a2eaac33c01e5")
     version("2.3.0", sha256="360c7d10f75e65f67bad720af7007e1060a5d395670ec11a7ed1fed9dd17471f")
     version("2.2.6", sha256="a8c65d8eb3faa03deabab6b3bbe798bea72e1799c7e9e955d57eca4096abcff9")
 

--- a/repos/spack_repo/builtin/packages/py_colored/package.py
+++ b/repos/spack_repo/builtin/packages/py_colored/package.py
@@ -18,6 +18,7 @@ class PyColored(PythonPackage):
     homepage = "https://gitlab.com/dslackw/colored"
     pypi = "colored/colored-1.4.2.tar.gz"
 
+    version("2.3.1", sha256="fe6e888e12dc16643daa0b108f785df6d0b48420084b5d0a567de27bb09a14d8")
     version("2.2.4", sha256="595e1dd7f3b472ea5f12af21d2fec8a2ea2cf8f9d93e67180197330b26df9b61")
     version("1.4.2", sha256="056fac09d9e39b34296e7618897ed1b8c274f98423770c2980d829fd670955ed")
 

--- a/repos/spack_repo/builtin/packages/py_cryolobm/package.py
+++ b/repos/spack_repo/builtin/packages/py_cryolobm/package.py
@@ -16,6 +16,7 @@ class PyCryolobm(PythonPackage):
 
     license("MIT")
 
+    version("1.6.1", sha256="6beb622861d9cc4eb841758993944242e73e46c6cb22851404a7a7c144352913")
     version("1.3.7", sha256="e3505c95cddac3a344d1c6eddf1a9ff576a1384f9194b580287c76367912bedc")
 
     depends_on("python@3.4.0:")

--- a/repos/spack_repo/builtin/packages/py_css_parser/package.py
+++ b/repos/spack_repo/builtin/packages/py_css_parser/package.py
@@ -17,6 +17,7 @@ class PyCssParser(PythonPackage):
 
     license("LGPL-3.0-or-later")
 
+    version("1.0.10", sha256="bf1e972ad33344e93206964fb4cd908d9ddef9fcd0c01fa93e0d734675394363")
     version("1.0.9", sha256="196db822cef22745af6a58d180cf8206949ced58b48f5f3ee98f1de1627495bb")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_dask_awkward/package.py
+++ b/repos/spack_repo/builtin/packages/py_dask_awkward/package.py
@@ -17,6 +17,7 @@ class PyDaskAwkward(PythonPackage):
 
     license("BSD-3-Clause", checked_by="wdconinc")
 
+    version("2025.9.0", sha256="46712213abc0546bfd1941c4137ded185ade669a96ec6d0b6a2061219e802269")
     version("2025.5.0", sha256="2e6e71562055b9b7eadaab5e66b23a78d23274487ebf38669bfd82e7346f3659")
     version("2024.12.2", sha256="13c5ef32c5489e9e32e9f9163eb13e045f722ed6ed0f17ce1e07f892fc77a547")
 

--- a/repos/spack_repo/builtin/packages/py_datashader/package.py
+++ b/repos/spack_repo/builtin/packages/py_datashader/package.py
@@ -17,6 +17,7 @@ class PyDatashader(PythonPackage):
 
     license("BSD-3-Clause", checked_by="climbfuji")
 
+    version("0.18.2", sha256="53ef0bc35b9ba1034bdf290a2e28babf0fa2b075a3e5a822c79dcde12183d1ff")
     version("0.18.1", sha256="ad9390a9178eb03493fb67649f6570d59ccb371cf663533e0672a1826bb436b0")
     version("0.16.3", sha256="9d0040c7887f7a5a5edd374c297402fd208a62bf6845e87631b54f03b9ae479d")
 

--- a/repos/spack_repo/builtin/packages/py_dbf/package.py
+++ b/repos/spack_repo/builtin/packages/py_dbf/package.py
@@ -13,6 +13,7 @@ class PyDbf(PythonPackage):
 
     pypi = "dbf/dbf-0.96.005.tar.gz"
 
+    version("0.99.11", sha256="2169c05252c0efbe897f346f0683326ec25854beab1d0c6430df6e903a57b315")
     version("0.99.3", sha256="940272a72ac27d16a1db69aafef820684012cc3553ffe9875d5cd2e3a9cb69dc")
     version("0.97.11", sha256="8aa5a73d8b140aa3c511a3b5b204a67d391962e90c66b380dd048fcae6ddbb68")
     version("0.96.005", sha256="d6e03f1dca40488c37cf38be9cb28b694c46cec747a064dcb0591987de58ed02")

--- a/repos/spack_repo/builtin/packages/py_dh_scikit_optimize/package.py
+++ b/repos/spack_repo/builtin/packages/py_dh_scikit_optimize/package.py
@@ -24,6 +24,7 @@ class PyDhScikitOptimize(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.9.6", sha256="53c2985ff1684e367fd4c14e199125cb34cbc0675f69769fc767ee22e4dceaf1")
     version("0.9.5", sha256="c2777839a536215ab40fc5db2242809ccffd5e5b23718e23d58ea76ff35a7543")
     version("0.9.4", sha256="9acfba4077fe45f3854a4af255763a3e8a396c05bd2a7c761a969171366b3840")
     version("0.9.3", sha256="0c922c61dc1f010c7bbd2f0930c766e8ae040c35b129e4de6d51b611fd72b7c9")

--- a/repos/spack_repo/builtin/packages/py_docutils/package.py
+++ b/repos/spack_repo/builtin/packages/py_docutils/package.py
@@ -21,6 +21,7 @@ class PyDocutils(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.22.4", sha256="4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968")
     version("0.21.2", sha256="3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f")
     version("0.20.1", sha256="f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b")
     version("0.19", sha256="33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6")

--- a/repos/spack_repo/builtin/packages/py_dpath/package.py
+++ b/repos/spack_repo/builtin/packages/py_dpath/package.py
@@ -16,6 +16,7 @@ class PyDpath(PythonPackage):
 
     license("MIT")
 
+    version("2.2.0", sha256="34f7e630dc55ea3f219e555726f5da4b4b25f2200319c8e6902c394258dd6a3e")
     version("2.1.6", sha256="f1e07c72e8605c6a9e80b64bc8f42714de08a789c7de417e49c3f87a19692e47")
     version("2.0.1", sha256="bea06b5f4ff620a28dfc9848cf4d6b2bfeed34238edeb8ebe815c433b54eb1fa")
 

--- a/repos/spack_repo/builtin/packages/py_eerepr/package.py
+++ b/repos/spack_repo/builtin/packages/py_eerepr/package.py
@@ -15,6 +15,7 @@ class PyEerepr(PythonPackage):
 
     license("MIT")
 
+    version("0.1.2", sha256="304dc23c365d6fa7cc3b07bc09cf77b565c19af86733e5deed804fdce16fb51f")
     version("0.1.0", sha256="a3c6f4d94ee19374aea2ff7ae9f2471f06649be5e18f9cb1cced8a00c2c20857")
 
     depends_on("py-hatchling", type="build")

--- a/repos/spack_repo/builtin/packages/py_eg/package.py
+++ b/repos/spack_repo/builtin/packages/py_eg/package.py
@@ -15,6 +15,7 @@ class PyEg(PythonPackage):
 
     license("MIT")
 
+    version("1.2.3", sha256="936d9ef89f62053df7f9a0b97cc13577bf5ae876b02c6c1dd499873a926d9504")
     version("1.2.0", sha256="dfeff9f8c16afec1b621c9484c8cdb670dbc69ab40590d16a9becb740ea289f3")
     version("1.1.1", sha256="99020af6ff24742b3eb93a15a289f36156fdb93abdbec50b614b982b1ba9c399")
     version("1.1.0", sha256="41316c79e8f7a999e82057ac54c6d57c58a50cd37dc91e172b634998f61b1b86")

--- a/repos/spack_repo/builtin/packages/py_ema_pytorch/package.py
+++ b/repos/spack_repo/builtin/packages/py_ema_pytorch/package.py
@@ -17,6 +17,7 @@ class PyEmaPytorch(PythonPackage):
 
     license("MIT", checked_by="alex391")
 
+    version("0.7.9", sha256="a8ccdf2eeecce5489de02fc7c9776ef55400220afff92b8223f7516cb570b594")
     version("0.7.3", sha256="de640f1d1a054c79607aebfcfd4b8dfff1fba1110bf0c8f7d37517637450938a")
     version("0.5.1", sha256="e825212a44e8faae5d2cf2a1349961c4416cba0496ffa64d37718d8b06f206b2")
 

--- a/repos/spack_repo/builtin/packages/py_email_validator/package.py
+++ b/repos/spack_repo/builtin/packages/py_email_validator/package.py
@@ -16,6 +16,7 @@ class PyEmailValidator(PythonPackage):
     license("Unlicense", when="@2.1.1:", checked_by="wdconinc")
     license("CC0-1.0", when="@:2.1.0", checked_by="wdconinc")
 
+    version("2.3.0", sha256="9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426")
     version("2.2.0", sha256="cb690f344c617a714f22e66ae771445a1ceb46821152df8e165c5f9a364582b7")
     version("1.3.1", sha256="d178c5c6fa6c6824e9b04f199cf23e79ac15756786573c190d2ad13089411ad2")
 

--- a/repos/spack_repo/builtin/packages/py_equinox/package.py
+++ b/repos/spack_repo/builtin/packages/py_equinox/package.py
@@ -25,6 +25,7 @@ class PyEquinox(PythonPackage, CudaPackage):
     maintainers("abhishek1297")
     license("Apache-2.0", checked_by="abhishek1297")
 
+    version("0.13.4", sha256="d4eed5d7f981a5ddcb7bc70e601707769fb4da20f777703cc6e01a6248af9758")
     version("0.13.2", sha256="509ad744ff99b7c684d45230d6890f9e78eac1a556d7a06db1eff664a3cac74f")
     version("0.13.1", sha256="e90f11cfe66b2f73f5c172260a17c48851794a0f243dd2cbe4ea70f4c90cbd07")
     version("0.13.0", sha256="d59615be722373e9d66e0ba78462964e6357fb76a8b1b98c2c6027961b778a69")

--- a/repos/spack_repo/builtin/packages/py_expandvars/package.py
+++ b/repos/spack_repo/builtin/packages/py_expandvars/package.py
@@ -15,6 +15,7 @@ class PyExpandvars(PythonPackage):
 
     license("MIT")
 
+    version("1.1.2", sha256="6c5822b7b756a99a356b915dd1267f52ab8a4efaa135963bd7f4bd5d368f71d7")
     version("1.1.1", sha256="98add8268b760dfee457bde1c17bf745795fdebc22b7ddab75fd3278653f1e05")
     version("0.12.0", sha256="7d1adfa55728cf4b5d812ece3d087703faea953e0c0a1a78415de9df5024d844")
 

--- a/repos/spack_repo/builtin/packages/py_fastcov/package.py
+++ b/repos/spack_repo/builtin/packages/py_fastcov/package.py
@@ -20,6 +20,7 @@ class PyFastcov(PythonPackage):
 
     license("MIT")
 
+    version("1.16", sha256="a54bd43b5c86f00a5df369e45b1821292cea17ef85054b78bd829d0f1180f669")
     version("1.13", sha256="ec8a5271f90a2f8b894cb999e262c33e225ed6072d9a6ca38f636f88cc0543e8")
 
     # Depends on gcov too, but that's installed with the compiler

--- a/repos/spack_repo/builtin/packages/py_fastdownload/package.py
+++ b/repos/spack_repo/builtin/packages/py_fastdownload/package.py
@@ -18,6 +18,7 @@ class PyFastdownload(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.0.7", sha256="20507edb8e89406a1fbd7775e6e2a3d81a4dd633dd506b0e9cf0e1613e831d6a")
     version("0.0.5", sha256="64e67af30690fa98ae1c8a1b52495769842f723565239a5430208ad05585af18")
 
     depends_on("python@3.6:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_fisher/package.py
+++ b/repos/spack_repo/builtin/packages/py_fisher/package.py
@@ -17,6 +17,7 @@ class PyFisher(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.1.14", sha256="3594e247f28be0e7716e7ff7e420583ddb2eab9e5732dc86514b1ff78c3000b9")
     version("0.1.10", sha256="0ec89019e814cf102f33be5674a6205af433711ecb742a7ed5b48896af243523")
     version("0.1.9", sha256="d378b3f7e488e2a679c6d0e5ea1bce17bc931c2bfe8ec8424ee47a74f251968d")
 

--- a/repos/spack_repo/builtin/packages/py_flask_paginate/package.py
+++ b/repos/spack_repo/builtin/packages/py_flask_paginate/package.py
@@ -18,6 +18,7 @@ class PyFlaskPaginate(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("2024.4.12", sha256="2de04606b061736f0fc8fbe73d9d4d6fc03664638eca70a57728b03b3e2c9577")
     version("2022.1.8", sha256="a32996ec07ca004c45b768b0d50829728ab8f3986c0650ef538e42852c7aeba2")
 
     # From setup.py:

--- a/repos/spack_repo/builtin/packages/py_fluidfft_builder/package.py
+++ b/repos/spack_repo/builtin/packages/py_fluidfft_builder/package.py
@@ -15,6 +15,7 @@ class PyFluidfftBuilder(PythonPackage):
     maintainers("paugier")
     license("MIT", checked_by="paugier")
 
+    version("0.0.3", sha256="7cd4bb179a17e9f636aabcdc36429a75a16d2122eb507df8c4873aa7a15e71a5")
     version("0.0.2", sha256="c0af9ceca27ae3a00ccf2f160703be9e394d8b886b8a02653b6c0a12a4f54a90")
 
     depends_on("python@3.9:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_folium/package.py
+++ b/repos/spack_repo/builtin/packages/py_folium/package.py
@@ -15,6 +15,7 @@ class PyFolium(PythonPackage):
 
     license("MIT")
 
+    version("0.20.0", sha256="a0d78b9d5a36ba7589ca9aedbd433e84e9fcab79cd6ac213adbcff922e454cb9")
     version("0.19.4", sha256="431a655b52a9bf3efda336f2be022103f0106504a0599e7c349efbfd30bafda6")
     version("0.16.0", sha256="2585ee9253dc758d3a365534caa6fb5fa0c244646db4dc5819afc67bbd4daabb")
 

--- a/repos/spack_repo/builtin/packages/py_formulaic/package.py
+++ b/repos/spack_repo/builtin/packages/py_formulaic/package.py
@@ -14,6 +14,7 @@ class PyFormulaic(PythonPackage):
     homepage = "https://github.com/matthewwardrop/formulaic"
     pypi = "formulaic/formulaic-0.2.4.tar.gz"
 
+    version("1.2.1", sha256="dc79476baa2d811b35798893eb2f2c1e51edee8d7a9c1429b400e56f4e0beccc")
     version("1.2.0", sha256="ab5c43a5b107d1b1e87f55cf0a01245531cce793d3dcab433dae12053c3cb2d6")
     version("0.6.1", sha256="5b20b2130436dc8bf5ea604e69d88d44b3be4d8ea20bfea96d982fa1f6bb762b")
     version("0.5.2", sha256="25b1e1c8dff73f0b11c0028a6ab350222de6bbc47b316ccb770cec16189cef53")

--- a/repos/spack_repo/builtin/packages/py_funcy/package.py
+++ b/repos/spack_repo/builtin/packages/py_funcy/package.py
@@ -15,6 +15,7 @@ class PyFuncy(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("2.0", sha256="3963315d59d41c6f30c04bc910e10ab50a3ac4a225868bfa96feed133df075cb")
     version("1.15", sha256="65b746fed572b392d886810a98d56939c6e0d545abb750527a717c21ced21008")
     version("1.14", sha256="75ee84c3b446f92e68a857c2267b15a1b49c631c9d5a87a5f063cd2d6761a5c4")
 

--- a/repos/spack_repo/builtin/packages/py_fypp/package.py
+++ b/repos/spack_repo/builtin/packages/py_fypp/package.py
@@ -15,6 +15,7 @@ class PyFypp(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("3.2", sha256="42a551fa82df5ea752f0c0dd5c008d5f544e1aa90c1abd054b0afd8170878dba")
     version("3.1", sha256="bac9d02be308b6bff7fd17da835f01fb9ce9b2dddaaad1ccd22ac7628b2dc53c")
     version("2.1.1", sha256="3744ad17045e91466bbb75a33ce0cab0f65bc2c377127067a932cdf15655e049")
 

--- a/repos/spack_repo/builtin/packages/py_gast/package.py
+++ b/repos/spack_repo/builtin/packages/py_gast/package.py
@@ -15,6 +15,7 @@ class PyGast(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.7.0", sha256="0bb14cd1b806722e91ddbab6fb86bba148c22b40e7ff11e248974e04c8adfdae")
     version("0.6.0", sha256="88fc5300d32c7ac6ca7b515310862f71e6fdf2c029bbec7c66c0f5dd47b6b1fb")
     version("0.5.4", sha256="9c270fe5f4b130969b54174de7db4e764b09b4f7f67ccfc32480e29f78348d97")
     version("0.5.3", sha256="cfbea25820e653af9c7d1807f659ce0a0a9c64f2439421a7bba4f0983f532dea")

--- a/repos/spack_repo/builtin/packages/py_gdown/package.py
+++ b/repos/spack_repo/builtin/packages/py_gdown/package.py
@@ -15,6 +15,7 @@ class PyGdown(PythonPackage):
 
     license("MIT")
 
+    version("5.2.1", sha256="247c2ad1f579db5b66b54c04e6a871995fc8fd7021708b950b8ba7b32cf90323")
     version("5.2.0", sha256="2145165062d85520a3cd98b356c9ed522c5e7984d408535409fd46f94defc787")
 
     with default_args(type="build"):

--- a/repos/spack_repo/builtin/packages/py_grandalf/package.py
+++ b/repos/spack_repo/builtin/packages/py_grandalf/package.py
@@ -16,6 +16,7 @@ class PyGrandalf(PythonPackage):
 
     license("EPL-1.0")
 
+    version("0.8", sha256="82d80072e5a1928bc46d94a54d2d92a38f73da0af052efc84ce34b5f4601dfa2")
     version("0.7", sha256="b3112299fe0a9123c088a16bf2f1b541d0d91199b77170a9739b569bd16a828e")
     version("0.6", sha256="928db4b90f7aff01e252a833951086b20d5958c00083411193c794de7bf59df2")
 

--- a/repos/spack_repo/builtin/packages/py_graphlib_backport/package.py
+++ b/repos/spack_repo/builtin/packages/py_graphlib_backport/package.py
@@ -13,6 +13,7 @@ class PyGraphlibBackport(PythonPackage):
     homepage = "https://github.com/mariushelf/graphlib_backport"
     pypi = "graphlib_backport/graphlib_backport-1.0.3.tar.gz"
 
+    version("1.1.0", sha256="00a7888b21e5393064a133209cb5d3b3ef0a2096cf023914c9d778dff5644125")
     version("1.0.3", sha256="7bb8fc7757b8ae4e6d8000a26cd49e9232aaa9a3aa57edb478474b8424bfaae2")
 
     depends_on("python@3.6:3", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_grequests/package.py
+++ b/repos/spack_repo/builtin/packages/py_grequests/package.py
@@ -17,6 +17,7 @@ class PyGrequests(PythonPackage):
     homepage = "https://github.com/spyoungtech/grequests"
     pypi = "grequests/grequests-0.4.0.tar.gz"
 
+    version("0.7.0", sha256="5c33f14268df5b8fa1107d8537815be6febbad6ec560524d6a404b7778cf6ba6")
     version("0.4.0", sha256="8aeccc15e60ec65c7e67ee32e9c596ab2196979815497f85cf863465a1626490")
     version("0.3.0", sha256="0f41c4eee83bab39f5543af49665c08681637a0562a5704a3f7b2e4a996531c9")
 

--- a/repos/spack_repo/builtin/packages/py_gym/package.py
+++ b/repos/spack_repo/builtin/packages/py_gym/package.py
@@ -19,6 +19,7 @@ class PyGym(PythonPackage):
 
     license("MIT")
 
+    version("0.26.2", sha256="e0d882f4b54f0c65f203104c24ab8a38b039f1289986803c7d02cdbe214fbcc4")
     version("0.19.0", sha256="940069b983806e1ccc400fa6d47b4e34e462accf6a4fb0acb0a5e509ad0f502d")
     version("0.18.0", sha256="a0dcd25c1373f3938f4cb4565f74f434fba6faefb73a42d09c9dddd0c08af53e")
 

--- a/repos/spack_repo/builtin/packages/py_hdfs/package.py
+++ b/repos/spack_repo/builtin/packages/py_hdfs/package.py
@@ -15,6 +15,7 @@ class PyHdfs(PythonPackage):
 
     license("MIT")
 
+    version("2.7.3", sha256="752a21e43f82197dce43697c73f454ba490838108c73a57a9247efb66d1c0479")
     version("2.1.0", sha256="a40fe99ccb03b5c3247b33a4110eb21b57405dd7c3f1b775e362e66c19b44bc6")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_hpccm/package.py
+++ b/repos/spack_repo/builtin/packages/py_hpccm/package.py
@@ -16,6 +16,7 @@ class PyHpccm(PythonPackage):
 
     license("Apache-2.0")
 
+    version("26.1.0", sha256="f0757993c18df8619d9722c082ffa6edfec07a99d46b4be38f7ee10dfd26fc8b")
     version("19.2.0", sha256="c60eec914a802b0a76596cfd5fdf7122d3f8665fcef06ef928323f5dfb5219a6")
 
     depends_on("py-setuptools", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_hstspreload/package.py
+++ b/repos/spack_repo/builtin/packages/py_hstspreload/package.py
@@ -15,6 +15,7 @@ class PyHstspreload(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("2025.1.1", sha256="346552a807b3a1762376de8ecce097544e7fcd64fb64231b4652da52f86fa6f1")
     version("2020.9.23", sha256="35822733ba67cfb4efc6cd7d1230b509f0bd42c90eeb329faf2fe679f801e40f")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_igv_notebook/package.py
+++ b/repos/spack_repo/builtin/packages/py_igv_notebook/package.py
@@ -16,6 +16,7 @@ class PyIgvNotebook(PythonPackage):
 
     license("MIT license", checked_by="ashim-mahara")
 
+    version("0.6.2", sha256="24c3990872851701bf17e7479180b02b63ab988e35b59859b294acae36eccc21")
     version("0.5.2", sha256="8b47a1a6c41f11359a07264815401cc4000c99722c77cbb749182bf6b66cf69c")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_imagehash/package.py
+++ b/repos/spack_repo/builtin/packages/py_imagehash/package.py
@@ -17,6 +17,7 @@ class PyImagehash(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("4.3.2", sha256="e54a79805afb82a34acde4746a16540503a9636fd1ffb31d8e099b29bbbf8156")
     version("4.3.1", sha256="7038d1b7f9e0585beb3dd8c0a956f02b95a346c0b5f24a9e8cc03ebadaf0aa70")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_invoke/package.py
+++ b/repos/spack_repo/builtin/packages/py_invoke/package.py
@@ -15,6 +15,7 @@ class PyInvoke(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("2.2.1", sha256="515bf49b4a48932b79b024590348da22f39c4942dff991ad1fb8b8baea1be707")
     version("2.2.0", sha256="ee6cbb101af1a859c7fe84f2a264c059020b0cb7fe3535f9424300ab568f6bd5")
     version("1.4.1", sha256="de3f23bfe669e3db1085789fd859eb8ca8e0c5d9c20811e2407fa042e8a5e15d")
     version("1.2.0", sha256="dc492f8f17a0746e92081aec3f86ae0b4750bf41607ea2ad87e5a7b5705121b7")

--- a/repos/spack_repo/builtin/packages/py_ipdb/package.py
+++ b/repos/spack_repo/builtin/packages/py_ipdb/package.py
@@ -15,6 +15,7 @@ class PyIpdb(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.13.13", sha256="e3ac6018ef05126d442af680aad863006ec19d02290561ac88b8b1c0b0cfc726")
     version("0.13.11", sha256="c23b6736f01fd4586cc2ecbebdf79a5eb454796853e1cd8f2ed3b7b91d4a3e93")
     version("0.13.10", sha256="6950715f491d59df6c27b49cb372f22c2f1763478a5e9ed03fb0507e2d85f460")
     version("0.13.9", sha256="951bd9a64731c444fd907a5ce268543020086a697f6be08f7cc2c9a752a278c5")

--- a/repos/spack_repo/builtin/packages/py_ipycanvas/package.py
+++ b/repos/spack_repo/builtin/packages/py_ipycanvas/package.py
@@ -15,6 +15,7 @@ class PyIpycanvas(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.14.3", sha256="c6a53a22eebf4d611b168b8f4434145883f27a7575509bd99a4bfc48c5385a39")
     version("0.14.1", sha256="921f1482258b5929b599317b5c129931d80e16be35fa38300a32e7aa4cfe9f89")
     version("0.10.2", sha256="a02c494834cb3c60509801172e7429beae837b3cb6c61d3becf8b586c5a66004")
     version("0.9.0", sha256="f29e56b93fe765ceace0676c3e75d44e02a3ff6c806f3b7e5b869279f470cc43")

--- a/repos/spack_repo/builtin/packages/py_jaconv/package.py
+++ b/repos/spack_repo/builtin/packages/py_jaconv/package.py
@@ -17,6 +17,7 @@ class PyJaconv(PythonPackage):
 
     license("MIT")
 
+    version("0.5.0", sha256="53f6f968276846716f0f37100a6d5c7308cfa1e0c714eb41287d5bb09345c40f")
     version("0.3", sha256="cc70c796c19a6765598c03eac59d1399a555a9a8839cc70e540ec26f0ec3e66e")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_jdcal/package.py
+++ b/repos/spack_repo/builtin/packages/py_jdcal/package.py
@@ -15,6 +15,7 @@ class PyJdcal(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("1.4.1", sha256="472872e096eb8df219c23f2689fc336668bdb43d194094b5cc1707e1640acfc8")
     version("1.3", sha256="b760160f8dc8cc51d17875c6b663fafe64be699e10ce34b6a95184b5aa0fdc9e")
     version("1.2", sha256="5ebedb58b95ebabd30f56abef65139c6f69ec1687cf1d2f3a7c503f9a2cdfa4d")
 

--- a/repos/spack_repo/builtin/packages/py_joblib/package.py
+++ b/repos/spack_repo/builtin/packages/py_joblib/package.py
@@ -20,6 +20,7 @@ class PyJoblib(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.5.3", sha256="8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3")
     version("1.5.2", sha256="3faa5c39054b2f03ca547da9b2f52fde67c06240c31853f306aea97f13647b55")
     version("1.4.2", sha256="2382c5816b2636fbd20a09e0f4e9dad4736765fdfb7dca582943b9c1366b3f0e")
     version("1.2.0", sha256="e1cee4a79e4af22881164f218d4311f60074197fb707e082e803b61f6d137018")

--- a/repos/spack_repo/builtin/packages/py_jsonpath_ng/package.py
+++ b/repos/spack_repo/builtin/packages/py_jsonpath_ng/package.py
@@ -18,6 +18,7 @@ class PyJsonpathNg(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.7.0", sha256="f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c")
     version("1.6.0", sha256="5483f8e9d74c39c9abfab554c070ae783c1c8cbadf5df60d561bc705ac68a07e")
     version("1.5.3", sha256="a273b182a82c1256daab86a313b937059261b5c5f8c4fa3fc38b882b344dd567")
     version("1.5.2", sha256="144d91379be14d9019f51973bd647719c877bfc07dc6f3f5068895765950c69d")

--- a/repos/spack_repo/builtin/packages/py_jupyterlab_server/package.py
+++ b/repos/spack_repo/builtin/packages/py_jupyterlab_server/package.py
@@ -19,6 +19,7 @@ class PyJupyterlabServer(PythonPackage):
 
     tags = ["build-tools"]
 
+    version("2.28.0", sha256="35baa81898b15f93573e2deca50d11ac0ae407ebb688299d3a5213265033712c")
     version("2.27.3", sha256="eb36caca59e74471988f0ae25c77945610b887f777255aa21f8065def9e51ed4")
     version("2.27.2", sha256="15cbb349dc45e954e09bacf81b9f9bcb10815ff660fb2034ecd7417db3a7ea27")
     version("2.27.1", sha256="097b5ac709b676c7284ac9c5e373f11930a561f52cd5a86e4fc7e5a9c8a8631d")

--- a/repos/spack_repo/builtin/packages/py_jupyterlab_widgets/package.py
+++ b/repos/spack_repo/builtin/packages/py_jupyterlab_widgets/package.py
@@ -17,6 +17,7 @@ class PyJupyterlabWidgets(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("3.0.16", sha256="45fa36d9c6422cf2559198e4db481aa243c7a32d9926b500781c830c80f7ecf8")
     version("3.0.3", sha256="6aa1bc0045470d54d76b9c0b7609a8f8f0087573bae25700a370c11f82cb38c8")
     version("1.1.0", sha256="c2a9bd3789f120f64d73268c066ed3b000c56bc1dda217be5cdc43e7b4ebad3f")
     version("1.0.2", sha256="f5d9efface8ec62941173ba1cffb2edd0ecddc801c11ae2931e30b50492eb8f7")

--- a/repos/spack_repo/builtin/packages/py_kneaddata/package.py
+++ b/repos/spack_repo/builtin/packages/py_kneaddata/package.py
@@ -16,6 +16,7 @@ class PyKneaddata(PythonPackage):
     homepage = "https://github.com/biobakery/kneaddata"
     pypi = "kneaddata/kneaddata-0.12.0.tar.gz"
 
+    version("0.12.4", sha256="f95811aeb7c4a74250ce3f62879676f4e3c970f20dad2d5f9628250a9c45a6c3")
     version("0.12.0", sha256="b211bf973ea50cc89dd5935761ca3b101d422cfb62b215aae08f5ed92a624a58")
 
     maintainers("Pandapip1")

--- a/repos/spack_repo/builtin/packages/py_kt_legacy/package.py
+++ b/repos/spack_repo/builtin/packages/py_kt_legacy/package.py
@@ -17,6 +17,7 @@ class PyKtLegacy(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.0.5", sha256="dbbade58f12c6a6da6062f4b045a6395a8d4195815e3e064bc3e609b69c8a26c")
     version("1.0.4", sha256="a94112e42a50e7cc3aad31f3287aa384c23555ea1432c55b5823852e09e706cf")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_lerc/package.py
+++ b/repos/spack_repo/builtin/packages/py_lerc/package.py
@@ -13,6 +13,7 @@ class PyLerc(PythonPackage):
     homepage = "https://github.com/Esri/lerc"
     pypi = "lerc/lerc-0.1.0.tar.gz"
 
+    version("4.0.1", sha256="dc4c243db0cd1d5c9df612f69bd75b880679aa0b575b347c491f1ec5bc891e41")
     version("0.1.0", sha256="46cac3f5a0194518f49a52e3ae073093fc85b0d79396383b64b1f9dba4aeacc1")
 
     depends_on("python@3.6:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_lfpykit/package.py
+++ b/repos/spack_repo/builtin/packages/py_lfpykit/package.py
@@ -16,6 +16,7 @@ class PyLfpykit(PythonPackage):
 
     license("GPL-3.0-only")
 
+    version("0.5.1", sha256="a962029460c8173c4fec3923204e04d64c370b05740b64c2d07efbe29cbe63a6")
     version("0.5", sha256="9a7ae80ad905bb8dd0eeab8517b43c3d5b4fff2b8766c9d5a36320a7a67bd545")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_lineenhancer/package.py
+++ b/repos/spack_repo/builtin/packages/py_lineenhancer/package.py
@@ -17,6 +17,7 @@ class PyLineenhancer(PythonPackage):
 
     license("MIT")
 
+    version("1.0.9", sha256="170698c7947c3257d19234668ad6743df163d26fe607dcab8d84a1995442f7b6")
     version("1.0.8", sha256="a1c7f2556110135d7298b0002674b669b8bbf23f94d63e3e3db8f17f2fd3efbe")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_linkchecker/package.py
+++ b/repos/spack_repo/builtin/packages/py_linkchecker/package.py
@@ -17,6 +17,7 @@ class PyLinkchecker(PythonPackage):
 
     license("GPL-2.0")
 
+    version("10.6.0", sha256="fb7e8facda7749c2fa5fa5dc241c0adc302da3d31d588964a2570db501aa49e5")
     version("10.5.0", sha256="978b42b803e58b7a8f6ffae1ff88fa7fd1e87b944403b5dc82380dd59f516bb9")
 
     depends_on("python@3.9:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_linkify_it_py/package.py
+++ b/repos/spack_repo/builtin/packages/py_linkify_it_py/package.py
@@ -15,6 +15,7 @@ class PyLinkifyItPy(PythonPackage):
 
     license("MIT")
 
+    version("2.0.3", sha256="68cda27e162e9215c17d786649d1da0021a451bdc436ef9e0fa0ba5234b9b048")
     version("2.0.2", sha256="19f3060727842c254c808e99d465c80c49d2c7306788140987a1a7a29b0d6ad2")
     version("1.0.3", sha256="2b3f168d5ce75e3a425e34b341a6b73e116b5d9ed8dbbbf5dc7456843b7ce2ee")
 

--- a/repos/spack_repo/builtin/packages/py_localcider/package.py
+++ b/repos/spack_repo/builtin/packages/py_localcider/package.py
@@ -15,6 +15,7 @@ class PyLocalcider(PythonPackage):
 
     license("GPL-2.0-or-later")
 
+    version("0.1.21", sha256="58acf94264c08675c6fc2edc7e0e6e4e3b046594bbe25f238993483c75250393")
     version("0.1.14", sha256="54ff29e8a011947cca5df79e96f3c69a76c49c4db41dcf1608663992be3e3f5f")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_logistro/package.py
+++ b/repos/spack_repo/builtin/packages/py_logistro/package.py
@@ -15,6 +15,7 @@ class PyLogistro(PythonPackage):
 
     license("MIT")
 
+    version("2.0.1", sha256="8446affc82bab2577eb02bfcbcae196ae03129287557287b6a070f70c1985047")
     version("1.1.0", sha256="ad51f0efa2bc705bea7c266e8a759cf539457cf7108202a5eec77bdf6300d774")
 
     depends_on("python@3.8:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_m2r/package.py
+++ b/repos/spack_repo/builtin/packages/py_m2r/package.py
@@ -16,6 +16,7 @@ class PyM2r(PythonPackage):
 
     license("MIT")
 
+    version("0.3.1", sha256="db99105d3b43121ca31d543f561a2078c00d0b9d9d6a7062b64ca5d084a74288")
     version("0.2.1", sha256="9286c1a5d7548f34b0a12017444e4c441781bef4b71f321f723e314b76b6c498")
     version("0.2.0", sha256="e9b7476203c4a5e3b822eb0ef110011d7b427d2c0dbdc4030f9cbcd239fbd4d6")
     version("0.1.15", sha256="4ca4c73385512f6e54db8e152ba157fc3eea84f9e942fe60a12ace5078ff83df")

--- a/repos/spack_repo/builtin/packages/py_mdocfile/package.py
+++ b/repos/spack_repo/builtin/packages/py_mdocfile/package.py
@@ -16,6 +16,7 @@ class PyMdocfile(PythonPackage):
 
     license("BSD-3-Clause", checked_by="Markus92")
 
+    version("0.2.3", sha256="7cb9a4e14719fe76524a064209b0acc7ca9272781ae04ed03dceac7b23151c64")
     version("0.2.2", sha256="74d2dbe55ffda288f61cfac82aaf0052e1365a65c5acc1ed93e3c86e1457e5b0")
     version("0.0.8", sha256="61e352b569128fdeaff9f639e6aa3d46c8f8c3b8fe36627461ba0153f46f103d")
 

--- a/repos/spack_repo/builtin/packages/py_metpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_metpy/package.py
@@ -21,6 +21,7 @@ class PyMetpy(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.7.1", sha256="cdfd8fdab58bc092a1974c016f2ea3a7715ffdf6a4660b28b0de7049328bce75")
     version("1.7.0", sha256="aad7e03dc735cf8bfd870d16aca24920a707152de6caa24dbaf4da695c6f6ae4")
     version("1.6.2", sha256="eb065bac0d7818587fa38fa6c96dfe720d9d15b59af4e4866541894e267476bb")
     version("1.0.1", sha256="16fa9806facc24f31f454b898741ec5639a72ba9d4ff8a19ad0e94629d93cb95")

--- a/repos/spack_repo/builtin/packages/py_microsoft_aurora/package.py
+++ b/repos/spack_repo/builtin/packages/py_microsoft_aurora/package.py
@@ -17,6 +17,7 @@ class PyMicrosoftAurora(PythonPackage):
 
     license("MIT")
 
+    version("1.8.0", sha256="2557523e880b9754ced6a535e8861ad6bc0b29c26c5c7f62ce4e625b3d1f7d16")
     version("1.7.0", sha256="1c285f5b39e7f5f47f7dc11c5c4f16edb63998179141a4ee27e66ce4b764d0ba")
 
     with default_args(type="build"):

--- a/repos/spack_repo/builtin/packages/py_mistletoe/package.py
+++ b/repos/spack_repo/builtin/packages/py_mistletoe/package.py
@@ -16,6 +16,7 @@ class PyMistletoe(PythonPackage):
 
     license("MIT")
 
+    version("1.5.1", sha256="c5571ce6ca9cfdc7ce9151c3ae79acb418e067812000907616427197648030a3")
     version("1.2.1", sha256="7d0c1ab3747047d169f9fc4b925d1cba3f5c13eaf0b90c365b72e47e59d00a02")
 
     depends_on("python@3.5:3", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_mistune/package.py
+++ b/repos/spack_repo/builtin/packages/py_mistune/package.py
@@ -15,6 +15,7 @@ class PyMistune(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("3.2.0", sha256="708487c8a8cdd99c9d90eb3ed4c3ed961246ff78ac82f03418f5183ab70e398a")
     version("3.1.4", sha256="b5a7f801d389f724ec702840c11d8fc48f2b33519102fc7ee739e8177b672164")
     version("2.0.5", sha256="0246113cb2492db875c6be56974a7c893333bf26cd92891c85f63151cee09d34")
     version("2.0.4", sha256="9ee0a66053e2267aba772c71e06891fa8f1af6d4b01d5e84e267b4570d4d9808")

--- a/repos/spack_repo/builtin/packages/py_modules_gui/package.py
+++ b/repos/spack_repo/builtin/packages/py_modules_gui/package.py
@@ -18,6 +18,7 @@ class PyModulesGui(PythonPackage):
 
     license("GPL-2.0")
 
+    version("0.2.2", sha256="9b0b1a5aecff5db30e214d0e193cb2db6f35f89c672adf0267d00f9967512cc1")
     version("0.2", sha256="d58a3943f4631756afa4f84c13b70fae67a72365ab3cad28014f972b8d023aec")
 
     depends_on("py-setuptools@61:", type=("build"))

--- a/repos/spack_repo/builtin/packages/py_mpld3/package.py
+++ b/repos/spack_repo/builtin/packages/py_mpld3/package.py
@@ -16,6 +16,7 @@ class PyMpld3(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.5.12", sha256="1333e2bca012ea9af3c27801ba36f65bc26540b6fad4c56a903afb19477f2c37")
     version("0.5.8", sha256="1a167dbef836dd7c66d8aa71c06a32d50bffa18725f304d93cb74fdb3545043b")
     version("0.5.5", sha256="b080f3535238a71024c0158280ab4f6091717c45347c41c907012f8dd6da1bd5")
     version("0.3", sha256="4d455884a211bf99b37ecc760759435c7bb6a5955de47d8daf4967e301878ab7")

--- a/repos/spack_repo/builtin/packages/py_msgpack_numpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_msgpack_numpy/package.py
@@ -19,6 +19,7 @@ class PyMsgpackNumpy(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.4.8", sha256="c667d3180513422f9c7545be5eec5d296dcbb357e06f72ed39cc683797556e69")
     version("0.4.7.1", sha256="7eaf51acf82d7c467d21aa71df94e1c051b2055e54b755442051b474fa7cf5e1")
     version("0.4.7", sha256="8e975dd7dd9eb13cbf5e8cd90af1f12af98706bbeb7acfcbd8d558fd005a85d7")
     version("0.4.6", sha256="ef3c5fe3d6cbab5c9db97de7062681c18f82d32a37177aaaf58b483d0336f135")

--- a/repos/spack_repo/builtin/packages/py_multiurl/package.py
+++ b/repos/spack_repo/builtin/packages/py_multiurl/package.py
@@ -15,6 +15,7 @@ class PyMultiurl(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.3.7", sha256="4201563fc8989baca7b525fdc69d4cd5a6c0cef4f303559710b9890021aab6d9")
     version("0.2.3.2", sha256="b625892ef3a5b8d4bd323f1dcd4750b6ea7e4e2e2e4574b6e88cdf92e10579e9")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_nbclassic/package.py
+++ b/repos/spack_repo/builtin/packages/py_nbclassic/package.py
@@ -15,6 +15,7 @@ class PyNbclassic(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.3.3", sha256="434228763f8cee754318cd6dfa42370db191af630dabab8e30bafc8c1aa3eee6")
     version("1.3.1", sha256="4c52da8fc88f9f73ef512cc305091d5ce726bdca19f44ed697cb5ba12dcaad3c")
     version("1.1.0", sha256="77b77ba85f9e988f9bad85df345b514e9e64c7f0e822992ab1df4a78ac64fc1e")
     version("1.0.0", sha256="0ae11eb2319455d805596bf320336cda9554b41d99ab9a3c31bf8180bffa30e3")

--- a/repos/spack_repo/builtin/packages/py_ncbi_genome_download/package.py
+++ b/repos/spack_repo/builtin/packages/py_ncbi_genome_download/package.py
@@ -16,6 +16,7 @@ class PyNcbiGenomeDownload(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.3.3", sha256="fb949f087f2cde1408414758678e714fb1a1f1b9196b3e8cac6bd3e8e395c996")
     version("0.3.1", sha256="74675e94f184b8d80429641b27ed6d46ed81028d95156337de6d09f8dd739c6e")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_nexusforge/package.py
+++ b/repos/spack_repo/builtin/packages/py_nexusforge/package.py
@@ -18,6 +18,7 @@ class PyNexusforge(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.8.2", sha256="a4511b4abed9a6968945ef5f73d1a329ac24994700c1805468a42fa1e2a11aa9")
     version("0.8.1", sha256="eb2909cbec185e7a73191c1be1e62902a0d8534f0d93454ef3e4e3b18b5129cf")
     version("0.8.0", sha256="4358505ead26e41c2a0c4e6113cf3a486c9661e2a3899394497a2b5a94b70424")
     version("0.7.0", sha256="a8d2951d9ad18df9f2f4db31a4c18fcdd27bfcec929b03a3c91f133ea439413c")

--- a/repos/spack_repo/builtin/packages/py_nh3/package.py
+++ b/repos/spack_repo/builtin/packages/py_nh3/package.py
@@ -15,6 +15,7 @@ class PyNh3(PythonPackage):
 
     license("MIT")
 
+    version("0.3.2", sha256="f394759a06df8b685a4ebfb1874fb67a9cbfd58c64fc5ed587a663c0e63ec376")
     version("0.3.0", sha256="d8ba24cb31525492ea71b6aac11a4adac91d828aadeff7c4586541bf5dc34d2f")
 
     depends_on("python@3.8:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_nibabel/package.py
+++ b/repos/spack_repo/builtin/packages/py_nibabel/package.py
@@ -19,6 +19,7 @@ class PyNibabel(PythonPackage):
     # As detailed: https://nipy.org/nibabel/legal.html
     license("MIT AND BSD-3-Clause AND PSF-2.0 AND PDDL-1.0")
 
+    version("5.3.3", sha256="8d2006b70d727fd0a798a88ae5fd64339741f436fcfc83d6ea3256cdbc51c5b7")
     version("5.3.2", sha256="0bdca6503b1c784b446c745a4542367de7756cfba0d72143b91f9ffb78be569b")
     version("5.2.1", sha256="b6c80b2e728e4bc2b65f1142d9b8d2287a9102a8bf8477e115ef0d8334559975")
     version("5.1.0", sha256="ce73ca5e957209e7219a223cb71f77235c9df2acf4d3f27f861ba38e9481ac53")

--- a/repos/spack_repo/builtin/packages/py_node_semver/package.py
+++ b/repos/spack_repo/builtin/packages/py_node_semver/package.py
@@ -15,6 +15,7 @@ class PyNodeSemver(PythonPackage):
 
     license("MIT")
 
+    version("0.9.0", sha256="04aa0b0016dbc06748d6378c42d8cf82a343415bd9fca6284f488041d08b33bb")
     version("0.8.1", sha256="281600d009606f4f63ddcbe148992e235b39a69937b9c20359e2f4a2adbb1e00")
     version("0.6.1", sha256="4016f7c1071b0493f18db69ea02d3763e98a633606d7c7beca811e53b5ac66b7")
 

--- a/repos/spack_repo/builtin/packages/py_nodeenv/package.py
+++ b/repos/spack_repo/builtin/packages/py_nodeenv/package.py
@@ -13,6 +13,7 @@ class PyNodeenv(PythonPackage):
     homepage = "https://github.com/ekalinin/nodeenv"
     pypi = "nodeenv/nodeenv-1.3.3.tar.gz"
 
+    version("1.10.0", sha256="996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb")
     version("1.9.1", sha256="6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f")
     version("1.8.0", sha256="d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2")
     version("1.7.0", sha256="e0e7f7dfb85fc5394c6fe1e8fa98131a2473e04311a45afb6508f7cf1836fa2b")

--- a/repos/spack_repo/builtin/packages/py_nptyping/package.py
+++ b/repos/spack_repo/builtin/packages/py_nptyping/package.py
@@ -16,6 +16,7 @@ class PyNptyping(PythonPackage):
 
     license("MIT")
 
+    version("2.5.0", sha256="7f061750bcbda8ce3926fc22c22c372c9cebfdb9b889376c71cb5d911173660d")
     version("2.4.1", sha256="1c1b2b08220d271f3e52dbf2bd9190e4dd15b3c04abfcf7a04ec533d3cc9fdab")
     version("1.4.1", sha256="bbcedb967f8be1302dffdd999eb531b99712c6914078294b4411758d5899b3b6")
     version("1.0.1", sha256="a00e672bfdaddc99aa6b25dd1ae89d7d58d2b76e8ad099bd69577bac2598589f")

--- a/repos/spack_repo/builtin/packages/py_nvidia_ml_py/package.py
+++ b/repos/spack_repo/builtin/packages/py_nvidia_ml_py/package.py
@@ -16,6 +16,7 @@ class PyNvidiaMlPy(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("13.590.48", sha256="8184d1be52914ac7f0991cd1c0d946c65dc88a840c754cd12c274b77b88760dd")
     version("12.575.51", sha256="6490e93fea99eb4e966327ae18c6eec6256194c921f23459c8767aee28c54581")
     version("12.570.86", sha256="0508d4a0c7b6d015cf574530b95a62ed4fc89da3b8b47e1aefe6777db170ec8b")
     version("12.560.30", sha256="f0254dc7400647680a072ee02509bfd46102b60bdfeca321576d4d4817e7fe97")

--- a/repos/spack_repo/builtin/packages/py_onnx_opcounter/package.py
+++ b/repos/spack_repo/builtin/packages/py_onnx_opcounter/package.py
@@ -15,6 +15,7 @@ class PyOnnxOpcounter(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.0.4", sha256="b12ace32c4f953dd2232ebf901131af55eb8a4ebf6abf877a5af38cc1cc845f2")
     version("0.0.3", sha256="c75e76d066eb777e4855c486beb402b1fef83783a6634237b8ca20eb75cce8c9")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_opencensus_context/package.py
+++ b/repos/spack_repo/builtin/packages/py_opencensus_context/package.py
@@ -16,4 +16,5 @@ class PyOpencensusContext(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.1.3", sha256="073bb0590007af276853009fac7e4bab1d523c3f03baf4cb4511ca38967c6039")
     version("0.1.1", sha256="1a3fdf6bec537031efcc93d51b04f1edee5201f8c9a0c85681d63308b76f5702")

--- a/repos/spack_repo/builtin/packages/py_packaging/package.py
+++ b/repos/spack_repo/builtin/packages/py_packaging/package.py
@@ -15,6 +15,7 @@ class PyPackaging(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("26.0", sha256="00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4")
     version("25.0", sha256="d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f")
     version("24.2", sha256="c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f")
     version("24.1", sha256="026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002")

--- a/repos/spack_repo/builtin/packages/py_pamela/package.py
+++ b/repos/spack_repo/builtin/packages/py_pamela/package.py
@@ -14,6 +14,7 @@ class PyPamela(PythonPackage):
 
     license("MIT")
 
+    version("1.2.0", sha256="0ea6e2a99dded8c7783a4a06f2d31f5bdcad894d79101e8f09322e387a34aacf")
     version("1.0.0", sha256="65c9389bef7d1bb0b168813b6be21964df32016923aac7515bdf05366acbab6c")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_paralleltask/package.py
+++ b/repos/spack_repo/builtin/packages/py_paralleltask/package.py
@@ -17,6 +17,7 @@ class PyParalleltask(PythonPackage):
 
     license("GPL-3.0-only")
 
+    version("0.2.3", sha256="8015a8311d5021bc44edbfbf45ff2557a529999e235d25190bac62993fdf7b66")
     version("0.2.2", sha256="f00945e2bd5b6aff9cdc48fbd92aa7b48d23bb530d7f6643ac966fea11a7a9d5")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_parasail/package.py
+++ b/repos/spack_repo/builtin/packages/py_parasail/package.py
@@ -19,6 +19,7 @@ class PyParasail(PythonPackage):
 
     license("LiLiQ-R-1.1")
 
+    version("1.3.4", sha256="d6a7035dfae3ef5aafdd7e6915711214c22b572ea059fa69d9d7ecbfb9b61b0f")
     version("1.3.3", sha256="06f05066d9cf624c0b043f51a1e9d2964154e1edd0f9843e0838f32073e576f8")
 
     depends_on("perl", type="build")

--- a/repos/spack_repo/builtin/packages/py_parse/package.py
+++ b/repos/spack_repo/builtin/packages/py_parse/package.py
@@ -14,6 +14,7 @@ class PyParse(PythonPackage):
 
     license("MIT")
 
+    version("1.21.0", sha256="937725d51330ffec9c7a26fdb5623baa135d8ba8ed78817ea9523538844e3ce4")
     version("1.20.2", sha256="b41d604d16503c79d81af5165155c0b20f6c8d6c559efa66b4b695c3e5a0a0ce")
     version("1.19.1", sha256="cc3a47236ff05da377617ddefa867b7ba983819c664e1afe46249e5b469be464")
     version("1.18.0", sha256="91666032d6723dc5905248417ef0dc9e4c51df9526aaeef271eacad6491f06a4")

--- a/repos/spack_repo/builtin/packages/py_parsedatetime/package.py
+++ b/repos/spack_repo/builtin/packages/py_parsedatetime/package.py
@@ -13,6 +13,7 @@ class PyParsedatetime(PythonPackage):
     homepage = "https://github.com/bear/parsedatetime"
     pypi = "parsedatetime/parsedatetime-2.5.tar.gz"
 
+    version("2.6", sha256="4cb368fbb18a0b7231f4d76119165451c8d2e35951455dfee97c62a87b04d455")
     version("2.5", sha256="d2e9ddb1e463de871d32088a3f3cea3dc8282b1b2800e081bd0ef86900451667")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_patsy/package.py
+++ b/repos/spack_repo/builtin/packages/py_patsy/package.py
@@ -19,6 +19,7 @@ class PyPatsy(PythonPackage):
 
     license("PSF-2.0")
 
+    version("1.0.2", sha256="cdc995455f6233e90e22de72c37fcadb344e7586fb83f06696f54d92f8ce74c0")
     version("1.0.1", sha256="e786a9391eec818c054e359b737bbce692f051aee4c661f4141cc88fb459c0c4")
     version("0.5.4", sha256="7dabc527597308de0e8f188faa20af7e06a89bdaa306756dfc7783693ea16af4")
     version("0.5.3", sha256="bdc18001875e319bc91c812c1eb6a10be4bb13cb81eb763f466179dca3b67277")

--- a/repos/spack_repo/builtin/packages/py_pdf2image/package.py
+++ b/repos/spack_repo/builtin/packages/py_pdf2image/package.py
@@ -15,6 +15,7 @@ class PyPdf2image(PythonPackage):
 
     license("MIT")
 
+    version("1.17.0", sha256="eaa959bc116b420dd7ec415fcae49b98100dda3dd18cd2fdfa86d09f112f6d57")
     version("1.16.3", sha256="74208810c2cef4d9e347769b8e62a52303982ddb4f2dfd744c7ab4b940ae287e")
     version("1.12.1", sha256="a0d9906f5507192210a8d5d7ead63145e9dec4bccc4564b1fb644e923913c31c")
 

--- a/repos/spack_repo/builtin/packages/py_pdm_backend/package.py
+++ b/repos/spack_repo/builtin/packages/py_pdm_backend/package.py
@@ -15,6 +15,7 @@ class PyPdmBackend(PythonPackage):
 
     license("MIT", checked_by="matz-e")
 
+    version("2.4.7", sha256="a509d083850378ce919d41e7a2faddfc57a1764d376913c66731125d6b14110f")
     version("2.4.5", sha256="56c019c440308adad5d057c08cbb777e65f43b991a3b0920749781258972fe5b")
     version("2.4.3", sha256="dbd9047a7ac10d11a5227e97163b617ad5d665050476ff63867d971758200728")
     version("2.3.0", sha256="e39ed2da206d90d4a6e9eb62f6dce54ed4fa65ddf172a7d5700960d0f8a09e09")

--- a/repos/spack_repo/builtin/packages/py_phylophlan/package.py
+++ b/repos/spack_repo/builtin/packages/py_phylophlan/package.py
@@ -17,6 +17,7 @@ class PyPhylophlan(PythonPackage):
 
     license("MIT")
 
+    version("3.1.1", sha256="67df67b60b5a361ee9354db031608213d3ecfa2f9ec78104cb3e81903a8cc07a")
     version("3.0.3", sha256="d8d0082c95d58d7b11a60c1e2214b35c1a23a65675005f1393e7647d76c6a054")
     version("3.0.2", sha256="c342116662bbfbb49f0665291fc7c0be5a0d04a02a7be2da81de0322eb2256b4")
 

--- a/repos/spack_repo/builtin/packages/py_pid/package.py
+++ b/repos/spack_repo/builtin/packages/py_pid/package.py
@@ -16,6 +16,7 @@ class PyPid(PythonPackage):
 
     license("Apache-2.0")
 
+    version("3.0.4", sha256="6dc99da0991c7b4ec1a65381947c814e968c2a74b7acdb77665245ff71251ac7")
     version("3.0.3", sha256="082281e2f6b99b4aaa02a24ae4796c604ac17f19cdd0327b8c1ba9c2e73aadc8")
     version("3.0.2", sha256="0be7dc260e35788163b3171a5f0e1a8b9888bc2b77232c053c042a65496b8396")
     version("3.0.1", sha256="2f51b61210f8e1f009b09a2034717003ca22dcd86995537ecb857863bddca89a")

--- a/repos/spack_repo/builtin/packages/py_pip/package.py
+++ b/repos/spack_repo/builtin/packages/py_pip/package.py
@@ -26,6 +26,7 @@ class PyPip(Package, PythonExtension):
 
     license("MIT")
 
+    version("26.0.1", sha256="bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b")
     version("25.1.1", sha256="2913a38a2abf4ea6b64ab507bd9e967f3b53dc1ede74b01b0931e1ce548751af")
     version("25.1", sha256="13b4aa0aaad055020a11bec8a1c2a70a2b2d080e12d89b962266029fff0a16ba")
     version("25.0.1", sha256="c46efd13b6aa8279f33f2864459c8ce587ea6a1a59ee20de055868d8f7688f7f")

--- a/repos/spack_repo/builtin/packages/py_pip/package.py
+++ b/repos/spack_repo/builtin/packages/py_pip/package.py
@@ -26,7 +26,6 @@ class PyPip(Package, PythonExtension):
 
     license("MIT")
 
-    version("26.0.1", sha256="bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b")
     version("25.1.1", sha256="2913a38a2abf4ea6b64ab507bd9e967f3b53dc1ede74b01b0931e1ce548751af")
     version("25.1", sha256="13b4aa0aaad055020a11bec8a1c2a70a2b2d080e12d89b962266029fff0a16ba")
     version("25.0.1", sha256="c46efd13b6aa8279f33f2864459c8ce587ea6a1a59ee20de055868d8f7688f7f")

--- a/repos/spack_repo/builtin/packages/py_plac/package.py
+++ b/repos/spack_repo/builtin/packages/py_plac/package.py
@@ -19,6 +19,7 @@ class PyPlac(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("1.4.5", sha256="5f05bf85235c017fcd76c73c8101d4ff8e96beb3dc58b9a37de49cac7de82d14")
     version("1.4.3", sha256="d4cb3387b2113a28aebd509433d0264a4e5d9bb7c1a86db4fbd0a8f11af74eb3")
     version("1.3.5", sha256="38bdd864d0450fb748193aa817b9c458a8f5319fbf97b2261151cfc0a5812090")
     version("1.3.3", sha256="51e332dabc2aed2cd1f038be637d557d116175101535f53eaa7ae854a00f2a74")

--- a/repos/spack_repo/builtin/packages/py_pmtiles/package.py
+++ b/repos/spack_repo/builtin/packages/py_pmtiles/package.py
@@ -16,6 +16,7 @@ class PyPmtiles(PythonPackage):
 
     license("BSD-3-Clause", checked_by="Chrismarsh")
 
+    version("3.7.0", sha256="ed8b04d550d104c81a759c9cc07bfc5743750f62e751f840425f4b9f4bb903df")
     version("3.5.0", sha256="2b849ede4e006aa0ba9d508a4d77400dd5117d5da74346e057dc9e28bad8e9f0")
 
     # https://github.com/protomaps/PMTiles/blob/main/python/pmtiles/setup.py

--- a/repos/spack_repo/builtin/packages/py_pmw/package.py
+++ b/repos/spack_repo/builtin/packages/py_pmw/package.py
@@ -13,6 +13,7 @@ class PyPmw(PythonPackage):
 
     pypi = "Pmw/Pmw-2.0.0.tar.gz"
 
+    version("2.1.1", sha256="948412457cfccf0c775dd08e0913fb00f90896a33c79737d571c7312aeaf55c6")
     version("2.0.1", sha256="0b9d28f52755a7a081b44591c3dd912054f896e56c9a627db4dd228306ad1120")
     version("2.0.0", sha256="2babb2855feaabeea1003c6908b61c9d39cff606d418685f0559952714c680bb")
 

--- a/repos/spack_repo/builtin/packages/py_portpicker/package.py
+++ b/repos/spack_repo/builtin/packages/py_portpicker/package.py
@@ -15,6 +15,7 @@ class PyPortpicker(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.6.0", sha256="bd507fd6f96f65ee02781f2e674e9dc6c99bbfa6e3c39992e3916204c9d431fa")
     version("1.5.2", sha256="c55683ad725f5c00a41bc7db0225223e8be024b1fa564d039ed3390e4fd48fb3")
 
     depends_on("py-setuptools@40.9:", type="build")

--- a/repos/spack_repo/builtin/packages/py_poxy/package.py
+++ b/repos/spack_repo/builtin/packages/py_poxy/package.py
@@ -15,6 +15,7 @@ class PyPoxy(PythonPackage):
 
     license("MIT", checked_by="pranav-sivaraman")
 
+    version("0.20.1", sha256="3d4f3b6b924e28fa0a47e63fb68636c1183f1852db52313651f89fa96580d4fe")
     version("0.18.0", sha256="f5da8ff04ec08859bfd1c8ec6ef61b70e3af630915a4cce6a3e377eec3bcd3d4")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_pre_commit/package.py
+++ b/repos/spack_repo/builtin/packages/py_pre_commit/package.py
@@ -17,6 +17,7 @@ class PyPreCommit(PythonPackage):
 
     license("MIT")
 
+    version("4.5.1", sha256="eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61")
     version("4.4.0", sha256="f0233ebab440e9f17cabbb558706eb173d19ace965c68cdce2c081042b4fab15")
     version("4.3.0", sha256="499fe450cc9d42e9d58e606262795ecb64dd05438943c62b66f6a8673da30b16")
     version("4.2.0", sha256="601283b9757afd87d40c4c4a9b2b5de9637a8ea02eaff7adc2d0fb4e04841146")

--- a/repos/spack_repo/builtin/packages/py_preshed/package.py
+++ b/repos/spack_repo/builtin/packages/py_preshed/package.py
@@ -16,6 +16,7 @@ class PyPreshed(PythonPackage):
 
     license("MIT")
 
+    version("4.0.0", sha256="5e2b0b2a07dd1a8deeaad6612019845c602ee24907f6936eaaf17aabd56e544c")
     version("3.0.8", sha256="6c74c70078809bfddda17be96483c41d06d717934b07cab7921011d81758b357")
     version("3.0.2", sha256="61d73468c97c1d6d5a048de0b01d5a6fd052123358aca4823cdb277e436436cb")
 

--- a/repos/spack_repo/builtin/packages/py_propcache/package.py
+++ b/repos/spack_repo/builtin/packages/py_propcache/package.py
@@ -15,6 +15,7 @@ class PyPropcache(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.4.1", sha256="f48107a8c637e80362555f37ecf49abe20370e557cc4ab374f04ec4423c97c3d")
     version("0.3.2", sha256="20d7d62e4e7ef05f221e0db2856b979540686342e7dd9973b815599c7057e168")
     version("0.3.1", sha256="40d980c33765359098837527e18eddefc9a24cea5b45e078a7f3bb5b032c6ecf")
 

--- a/repos/spack_repo/builtin/packages/py_py4j/package.py
+++ b/repos/spack_repo/builtin/packages/py_py4j/package.py
@@ -18,6 +18,7 @@ class PyPy4j(PythonPackage):
 
     maintainers("teaguesterling")
 
+    version("0.10.9.9", sha256="f694cad19efa5bd1dee4f3e5270eb406613c974394035e5bfc4ec1aba870b879")
     version("0.10.9.7", sha256="0b6e5315bb3ada5cf62ac651d107bb2ebc02def3dee9d9548e3baac644ea8dbb")
     version("0.10.9.5", sha256="276a4a3c5a2154df1860ef3303a927460e02e97b047dc0a47c1c3fb8cce34db6")
     version("0.10.9.3", sha256="0d92844da4cb747155b9563c44fc322c9a1562b3ef0979ae692dbde732d784dd")

--- a/repos/spack_repo/builtin/packages/py_py6s/package.py
+++ b/repos/spack_repo/builtin/packages/py_py6s/package.py
@@ -17,6 +17,7 @@ class PyPy6s(PythonPackage):
     homepage = "https://py6s.rtwilson.com/"
     pypi = "py6s/Py6S-1.8.0.tar.gz"
 
+    version("1.9.2", sha256="2378ef027bbd3ead67cec47e9a14cf799b3bd851bc7833fbd44e2440666c0ff3")
     version("1.8.0", sha256="256162d2f1f558e601d4f79022c037a0051838ba307b9f4d1f5fcf0b46a0c277")
 
     depends_on("python@3:", type=("build", "run"), when="@1.8.0")

--- a/repos/spack_repo/builtin/packages/py_pyani/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyani/package.py
@@ -19,6 +19,7 @@ class PyPyani(PythonPackage):
 
     license("MIT")
 
+    version("0.2.12", sha256="4f56b217656f53416b333b69495a4ba8cde782e64e475e1481cb2213ce6b9388")
     version("0.2.7", sha256="dbc6c71c46fbbfeced3f8237b84474221268b51170caf044bec8559987a7deb9")
     version("0.2.6", sha256="e9d899bccfefaabe7bfa17d48eef9c713d321d2d15465f7328c8984807c3dd8d")
 

--- a/repos/spack_repo/builtin/packages/py_pyassimp/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyassimp/package.py
@@ -15,6 +15,7 @@ class PyPyassimp(PythonPackage):
 
     license("ISC")
 
+    version("5.2.5", sha256="107d93780e4300d70698c4291c54dd32ff78e8cf0dafd56ac1801cd0260c36f3")
     version("4.1.4", sha256="266bd4be170d46065b8c2ad0f5396dad10938a6bbf9a566c4e4d56456e33aa6a")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_pyautogui/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyautogui/package.py
@@ -17,6 +17,7 @@ class PyPyautogui(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.9.54", sha256="dd1d29e8fd118941cb193f74df57e5c6ff8e9253b99c7b04f39cfc69f3ae04b2")
     version("0.9.53", sha256="d31de8f712218d90be7fc98091fce1a12a3e9196e0c814eb9afd73bb2ec97035")
     version("0.9.52", sha256="a486cb6b818bcbcdf98b48d010c7cee964134fa394b756e8ce6e50d43b58ecc8")
 

--- a/repos/spack_repo/builtin/packages/py_pydantic/package.py
+++ b/repos/spack_repo/builtin/packages/py_pydantic/package.py
@@ -15,6 +15,7 @@ class PyPydantic(PythonPackage):
 
     license("MIT")
 
+    version("2.12.5", sha256="4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49")
     version("2.12.4", sha256="0f8cb9555000a4b5b617f66bfd2566264c4984b27589d3b845685983e8ea85ac")
     version("2.10.1", sha256="a4daca2dc0aa429555e0656d6bf94873a7dc5f54ee42b1f5873d666fb3f35560")
     version("2.9.0", sha256="c7a8a9fdf7d100afa49647eae340e2d23efa382466a8d177efcd1381e9be5598")

--- a/repos/spack_repo/builtin/packages/py_pydap/package.py
+++ b/repos/spack_repo/builtin/packages/py_pydap/package.py
@@ -14,6 +14,7 @@ class PyPydap(PythonPackage):
     pypi = "pydap/pydap-3.5.5.tar.gz"
     license("MIT")
 
+    version("3.5.8", sha256="0dc3c7f28fd456e17ed1c789ccfd119938a2bd1d73828cdf5319c69a213df560")
     version("3.5.5", sha256="0f8ca9b4e244c4d345d0b5269c4ebc886fcd0778b828e5ae1415b7ea5341eabd")
     version("3.2.2", sha256="86326642e24f421595a74b0f9986da76d7932b277768f501fe214d72592bdc40")
 

--- a/repos/spack_repo/builtin/packages/py_pydocstyle/package.py
+++ b/repos/spack_repo/builtin/packages/py_pydocstyle/package.py
@@ -17,6 +17,7 @@ class PyPydocstyle(PythonPackage):
 
     license("MIT")
 
+    version("6.3.0", sha256="7ce43f0c0ac87b07494eb9c0b462c0b73e6ff276807f204d6b53edc72b7e44e1")
     version("6.2.1", sha256="5ddccabe3c9555d4afaabdba909ca2de4fa24ac31e2eede4ab3d528a4bcadd52")
     version("6.2.0", sha256="b2d280501a4c0d9feeb96e9171dc3f6f7d0064c55270f4c7b1baa18452019fd9")
     version("6.1.1", sha256="1d41b7c459ba0ee6c345f2eb9ae827cab14a7533a88c5c6f7e94923f72df92dc")

--- a/repos/spack_repo/builtin/packages/py_pygame/package.py
+++ b/repos/spack_repo/builtin/packages/py_pygame/package.py
@@ -14,11 +14,11 @@ class PyPygame(PythonPackage):
     the most common functions, making writing these programs a more intuitive task."""
 
     homepage = "https://www.pygame.org/"
-    url = "https://pypi.org/project/pygame/2.5.2/"
+    pypi = "pygame/pygame-2.5.2.tar.gz"
 
     license("LGPL-2.1-only")
 
-    version("2.6.1", sha256="9c640260c0817e72f2a8da236a2f8c506a839294fcd4cadbe471ca5259f488ea")
+    version("2.6.1", sha256="56fb02ead529cee00d415c3e007f75e0780c655909aaa8e8bf616ee09c9feb1f")
     version("2.5.2", sha256="c1b89eb5d539e7ac5cf75513125fb5f2f0a2d918b1fd6e981f23bf0ac1b1c24a")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_pygame/package.py
+++ b/repos/spack_repo/builtin/packages/py_pygame/package.py
@@ -18,6 +18,7 @@ class PyPygame(PythonPackage):
 
     license("LGPL-2.1-only")
 
+    version("2.6.1", sha256="9c640260c0817e72f2a8da236a2f8c506a839294fcd4cadbe471ca5259f488ea")
     version("2.5.2", sha256="c1b89eb5d539e7ac5cf75513125fb5f2f0a2d918b1fd6e981f23bf0ac1b1c24a")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_pygdbmi/package.py
+++ b/repos/spack_repo/builtin/packages/py_pygdbmi/package.py
@@ -15,6 +15,7 @@ class PyPygdbmi(PythonPackage):
 
     license("MIT")
 
+    version("0.11.0.0", sha256="7a286be2fcf25650d9f66e11adc46e972cf078a466864a700cd44739ad261fb0")
     version("0.9.0.3", sha256="5bdf2f072e8f2f6471f19f8dcd87d6425c5d8069d47c0a5ffe8d0eff48cb171e")
 
     depends_on("python@3.5:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_pygelf/package.py
+++ b/repos/spack_repo/builtin/packages/py_pygelf/package.py
@@ -19,6 +19,7 @@ class PyPygelf(PythonPackage):
 
     license("MIT")
 
+    version("0.4.3", sha256="8ed972563be3c8f168483f01dbf522b6bc697959c97a3f4881324b3f79638911")
     version("0.4.0", sha256="3693da38794561d42b0556a78af7dcb22d92ea450125577e58089ab89a890ee5")
     version("0.3.6", sha256="3e5bc59e3b5a754556a76ff2c69fcf2003218ad7b5ff8417482fa1f6a7eba5f9")
 

--- a/repos/spack_repo/builtin/packages/py_pylatex/package.py
+++ b/repos/spack_repo/builtin/packages/py_pylatex/package.py
@@ -15,6 +15,7 @@ class PyPylatex(PythonPackage):
 
     license("MIT")
 
+    version("1.4.2", sha256="bb7b21bec57ecdba3f6f44c856ebebdf6549fd6e80661bd44fd5094236729242")
     version("1.4.1", sha256="d3c12efb8b260771260443dce78d1e9089c09f9d0b92e6273dfca0bf5e7302fb")
 
     variant("docs", default=False, description="Build with Sphinx support for documentation")

--- a/repos/spack_repo/builtin/packages/py_pymeeus/package.py
+++ b/repos/spack_repo/builtin/packages/py_pymeeus/package.py
@@ -15,6 +15,7 @@ class PyPymeeus(PythonPackage):
 
     license("LGPL-3.0-only")
 
+    version("0.5.12", sha256="548f7186bd8b96cbc069cf649a8e8e377dce49ac74486709849fe63a99cad684")
     version("0.3.6", sha256="1f1ba0682e1b5c6b0cd6432c966e8bc8acc31737ea6f0ae79917a2189a98bb87")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_pyparsing/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyparsing/package.py
@@ -15,6 +15,7 @@ class PyPyparsing(PythonPackage):
 
     license("MIT")
 
+    version("3.3.2", sha256="c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc")
     version("3.2.5", sha256="2df8d5b7b2802ef88e8d016a2eb9c7aeaa923529cd251ed0fe4608275d4105b6")
     version("3.1.2", sha256="a1bac0ce561155ecc3ed78ca94d3c9378656ad4c94c1270de543f621420f94ad")
     version("3.1.1", sha256="ede28a1a32462f5a9705e07aea48001a08f7cf81a021585011deba701581a0db")

--- a/repos/spack_repo/builtin/packages/py_pyperclip/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyperclip/package.py
@@ -15,6 +15,7 @@ class PyPyperclip(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.11.0", sha256="244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6")
     version("1.10.0", sha256="180c8346b1186921c75dfd14d9048a6b5d46bfc499778811952c6dd6eb1ca6be")
     version("1.8.2", sha256="105254a8b04934f0bc84e9c24eb360a591aaf6535c9def5f29d92af107a9bf57")
     version("1.7.0", sha256="979325468ccf682104d5dcaf753f869868100631301d3e72f47babdea5700d1c")

--- a/repos/spack_repo/builtin/packages/py_pyprof2html/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyprof2html/package.py
@@ -14,6 +14,7 @@ class PyPyprof2html(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.3.2", sha256="ca0bc88f8a98f523f97f63293144922d7c4f5bd7ca92cd39c009d2feb8f2ee93")
     version("0.3.1", sha256="db2d37e21d8c76f2fd25fb1ba9273c9b3ff4a98a327e37d943fed1ea225a6720")
 
     patch("version_0.3.1.patch", when="@0.3.1")

--- a/repos/spack_repo/builtin/packages/py_pyproject_metadata/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyproject_metadata/package.py
@@ -15,6 +15,7 @@ class PyPyprojectMetadata(PythonPackage):
 
     license("MIT")
 
+    version("0.11.0", sha256="c72fa49418bb7c5a10f25e050c418009898d1c051721d19f98a6fb6da59a66cf")
     version("0.10.0", sha256="7f5bd0ef398b60169556cb17ea261d715caf7f8561238151f51b2305084ba8d4")
     version("0.9.1", sha256="b8b2253dd1b7062b78cf949a115f02ba7fa4114aabe63fa10528e9e1a954a816")
     version("0.7.1", sha256="0a94f18b108b9b21f3a26a3d541f056c34edcb17dc872a144a15618fed7aef67")

--- a/repos/spack_repo/builtin/packages/py_pyqt_builder/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyqt_builder/package.py
@@ -15,6 +15,7 @@ class PyPyqtBuilder(PythonPackage):
 
     license("GPL-2.0-or-later")
 
+    version("1.19.1", sha256="6af6646ba29668751b039bfdced51642cb510e300796b58a4d68b7f956a024d8")
     version("1.19.0", sha256="79540e001c476bc050180db00fffcb1e9fa74544d95c148e48ad6117e49d6ea2")
     version("1.18.2", sha256="56dfea461484a87a8f0c8b0229190defc436d7ec5de71102e20b35e5639180bc")
     version("1.15.1", sha256="a2bd3cfbf952e959141dfe55b44b451aa945ca8916d1b773850bb2f9c0fa2985")

--- a/repos/spack_repo/builtin/packages/py_pyrect/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyrect/package.py
@@ -14,6 +14,7 @@ class PyPyrect(PythonPackage):
     homepage = "https://github.com/asweigart/pyrect"
     pypi = "PyRect/PyRect-0.1.4.tar.gz"
 
+    version("0.2.0", sha256="f65155f6df9b929b67caffbd57c0947c5ae5449d3b580d178074bffb47a09b78")
     version("0.1.4", sha256="3b2fa7353ce32a11aa6b0a15495968d2a763423c8947ae248b92c037def4e202")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_pyro4/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyro4/package.py
@@ -20,6 +20,7 @@ class PyPyro4(PythonPackage):
 
     license("MIT")
 
+    version("4.82", sha256="511f5b0804e92dd77dc33adf9c947787e3f9e9c5a96b12162f0557a7c4ce21fb")
     version("4.81", sha256="e130da06478b813173b959f7013d134865e07fbf58cc5f1a2598f99479cdac5f")
     version("4.80", sha256="46847ca703de3f483fbd0b2d22622f36eff03e6ef7ec7704d4ecaa3964cb2220")
     version("4.79", sha256="b1eb34c9a1e63f731ca480f3e2c48169341a25a7504397badbaaab07e0f3241e")

--- a/repos/spack_repo/builtin/packages/py_pysmartdl/package.py
+++ b/repos/spack_repo/builtin/packages/py_pysmartdl/package.py
@@ -14,6 +14,7 @@ class PyPysmartdl(PythonPackage):
 
     license("Unlicense")
 
+    version("1.3.4", sha256="35275d1694f3474d33bdca93b27d3608265ffd42f5aeb28e56f38b906c0c35f4")
     version("1.3.2", sha256="9a96deb3ee4f4ab2279b22eb908d506f57215e1fbad290d540adcebff187a52c")
     version("1.2.5", sha256="d3968ce59412f99d8e17ca532a1d949d2aa770a914e3f5eb2c0385579dc2b6b8")
 

--- a/repos/spack_repo/builtin/packages/py_pytest/package.py
+++ b/repos/spack_repo/builtin/packages/py_pytest/package.py
@@ -17,6 +17,7 @@ class PyPytest(PythonPackage):
     license("MIT")
     maintainers("adamjstewart")
 
+    version("9.0.2", sha256="75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11")
     version("9.0.0", sha256="8f44522eafe4137b0f35c9ce3072931a788a21ee40a2ed279e817d3cc16ed21e")
     version("8.4.2", sha256="86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01")
     version("8.4.1", sha256="7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c")

--- a/repos/spack_repo/builtin/packages/py_pytest_flakes/package.py
+++ b/repos/spack_repo/builtin/packages/py_pytest_flakes/package.py
@@ -16,6 +16,7 @@ class PyPytestFlakes(PythonPackage):
 
     license("MIT")
 
+    version("4.0.5", sha256="953134e97215ae31f6879fbd7368c18d43f709dc2fab5b7777db2bb2bac3a924")
     version("4.0.3", sha256="bf070c5485dad82d5b5f5d0eb08d269737e378492d9a68f5223b0a90924c7754")
     version("4.0.2", sha256="6733db47937d9689032876359e5ee0ee6926e3638546c09220e2f86b3581d4c1")
 

--- a/repos/spack_repo/builtin/packages/py_python_json_logger/package.py
+++ b/repos/spack_repo/builtin/packages/py_python_json_logger/package.py
@@ -15,6 +15,7 @@ class PyPythonJsonLogger(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("4.0.0", sha256="f58e68eb46e1faed27e0f574a55a0455eecd7b8a5b88b85a784519ba3cff047f")
     version("3.3.0", sha256="12b7e74b17775e7d565129296105bbe3910842d9d0eb083fc83a6a617aa8df84")
     version("2.0.7", sha256="23e7ec02d34237c5aa1e29a070193a4ea87583bb4e7f8fd06d3de8264c4b2e1c")
     version("2.0.2", sha256="202a4f29901a4b8002a6d1b958407eeb2dd1d83c18b18b816f5b64476dde9096")

--- a/repos/spack_repo/builtin/packages/py_python_logstash/package.py
+++ b/repos/spack_repo/builtin/packages/py_python_logstash/package.py
@@ -15,6 +15,7 @@ class PyPythonLogstash(PythonPackage):
 
     license("MIT")
 
+    version("0.4.8", sha256="d04e1ce11ecc107e4a4f3b807fc57d96811e964a554081b3bbb44732f74ef5f9")
     version("0.4.6", sha256="10943e5df83f592b4d61b63ad1afff855ccc8c9467f78718f0a59809ba1fe68c")
 
     # pip silently replaces distutils with setuptools

--- a/repos/spack_repo/builtin/packages/py_python_louvain/package.py
+++ b/repos/spack_repo/builtin/packages/py_python_louvain/package.py
@@ -20,6 +20,7 @@ class PyPythonLouvain(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.16", sha256="b7ba2df5002fd28d3ee789a49532baad11fe648e4f2117cf0798e7520a1da56b")
     version("0.15", sha256="2a856edfbe29952a60a5538a84bb78cca18f6884a88b9325e85a11c8dd4917eb")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_python_xlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_python_xlib/package.py
@@ -19,6 +19,7 @@ class PyPythonXlib(PythonPackage):
 
     license("LGPL-2.1-or-later")
 
+    version("0.33", sha256="55af7906a2c75ce6cb280a584776080602444f75815a7aff4d287bb2d7018b32")
     version("0.30", sha256="74131418faf9e7b83178c71d9d80297fbbd678abe99ae9258f5a20cd027acb5f")
 
     depends_on("python@2.7,3.3:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_pyviz_comms/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyviz_comms/package.py
@@ -15,6 +15,7 @@ class PyPyvizComms(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("3.0.6", sha256="73d66b620390d97959b2c4d8a2c0778d41fe20581be4717f01e46b8fae8c5695")
     version("3.0.4", sha256="d70e17555f7262c4884a6b7bc9ca19cb816507a032a334d9cb411b4546caff4c")
     version("2.2.1", sha256="a26145b8ce43d2d934b3c6826d77b913ce105c528eb2e494c890b3e3525ddf33")
 

--- a/repos/spack_repo/builtin/packages/py_qpth/package.py
+++ b/repos/spack_repo/builtin/packages/py_qpth/package.py
@@ -15,6 +15,7 @@ class PyQpth(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.0.18", sha256="ade478c6bf5ab60b7f86435c8893812c2c5938083fe8bccd775bb23d613fa3c5")
     version("0.0.15", sha256="99d8ec5a35877c18543875a7d5b7fc9af1fa9a4d4b0888011c1ecf42ad9d521c")
 
     depends_on("python", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_quantiphy/package.py
+++ b/repos/spack_repo/builtin/packages/py_quantiphy/package.py
@@ -17,6 +17,7 @@ class PyQuantiphy(PythonPackage):
 
     license("MIT", checked_by="ax3l")
 
+    version("2.21", sha256="bf8d06ffa7150f69a5c7e3fb4a7a0a535109df85e7c0ab0f39fb317c5c9cafe0")
     version("2.20", sha256="ba5375ac55c3b90077a793588dd5a88aaf81b2c3b0fc9c9359513ac39f6ed84d")
 
     depends_on("python@3.6:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_recommonmark/package.py
+++ b/repos/spack_repo/builtin/packages/py_recommonmark/package.py
@@ -20,6 +20,7 @@ class PyRecommonmark(PythonPackage):
 
     license("MIT")
 
+    version("0.7.1", sha256="bdb4db649f2222dcd8d2d844f0006b958d627f732415d399791ee436a3686d67")
     version("0.6.0", sha256="29cd4faeb6c5268c633634f2d69aef9431e0f4d347f90659fd0aab20e541efeb")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_reportlab/package.py
+++ b/repos/spack_repo/builtin/packages/py_reportlab/package.py
@@ -16,6 +16,7 @@ class PyReportlab(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("4.4.9", sha256="7cf487764294ee791a4781f5a157bebce262a666ae4bbb87786760a9676c9378")
     version("4.4.4", sha256="cb2f658b7f4a15be2cc68f7203aa67faef67213edd4f2d4bdd3eb20dab75a80d")
     version("4.0.4", sha256="7f70b3b56aff5f11cb4136c51a0f5a56fe6e4c8fbbac7b903076db99a8ef31c1")
     version("3.6.12", sha256="b13cebf4e397bba14542bcd023338b6ff2c151a3a12aabca89eecbf972cb361a")

--- a/repos/spack_repo/builtin/packages/py_resultsfile/package.py
+++ b/repos/spack_repo/builtin/packages/py_resultsfile/package.py
@@ -18,6 +18,7 @@ class PyResultsfile(PythonPackage):
 
     license("GPL-2.0-only")
 
+    version("2.4", sha256="7917c5462e12e8299c8c369434eab68df2ed6b72a8a0ba4aeaad6657d9a428e6")
     version("2.0", sha256="2a34208254e4bea155695690437f6a59bf5f7b0ddb421d6c1a2d377510f018f7")
 
     depends_on("python@3:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_rich/package.py
+++ b/repos/spack_repo/builtin/packages/py_rich/package.py
@@ -17,6 +17,7 @@ class PyRich(PythonPackage):
 
     license("MIT")
 
+    version("14.3.2", sha256="e712f11c1a562a11843306f5ed999475f09ac31ffb64281f73ab29ffdda8b3b8")
     version("14.1.0", sha256="e497a48b844b0320d45007cdebfeaeed8db2a4f4bcf49f15e455cfc4af11eaa8")
     version("13.9.4", sha256="439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098")
     version("13.7.1", sha256="9be308cb1fe2f1f57d67ce99e95af38a1e2bc71ad9813b0e247cf7ffbcc3a432")

--- a/repos/spack_repo/builtin/packages/py_rio_pmtiles/package.py
+++ b/repos/spack_repo/builtin/packages/py_rio_pmtiles/package.py
@@ -17,6 +17,7 @@ class PyRioPmtiles(PythonPackage):
 
     license("BSD-3-Clause", checked_by="Chrismarsh")
 
+    version("1.2.0", sha256="b1ca2264afab0b37d62631976b25ef1cc611d62502ef1b8e3d2b584007763f83")
     version("1.0.3", sha256="bd4c1bc94c292cdc6d06f0d50837ce18fa2e6e49f4811fa0f58588735bd65f26")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_robotframework/package.py
+++ b/repos/spack_repo/builtin/packages/py_robotframework/package.py
@@ -15,6 +15,7 @@ class PyRobotframework(PythonPackage):
 
     license("Apache-2.0")
 
+    version("7.4.1", sha256="6fa65c2708f0d48dd7a05bea2dc96943d0e39fdac9b3eb7290e780200b2cec57")
     version("7.3.2", sha256="82e8bc68dea843a82e710c9b864535811e62bf6e03d3258d8cbb8c78eac30711")
     version("7.2.2", sha256="4581c3a0da0c655b629aa1b56e6ff69256abdfa7ab26ae49e52c264c61f175b0")
     version("7.1.1", sha256="8abeb82324d6e476297ed7d43d7d89518399c2404a26702cf9cac23548bf8a86")

--- a/repos/spack_repo/builtin/packages/py_s3cmd/package.py
+++ b/repos/spack_repo/builtin/packages/py_s3cmd/package.py
@@ -19,6 +19,7 @@ class PyS3cmd(PythonPackage):
     homepage = "https://github.com/s3tools/s3cmd"
     url = "https://github.com/s3tools/s3cmd/releases/download/v2.0.2/s3cmd-2.0.2.tar.gz"
 
+    version("2.4.0", sha256="6b567521be1c151323f2059c8feec85ded96b6f184ff80535837fea33798b40b")
     version("2.3.0", sha256="15330776e7ff993d8ae0ac213bf896f210719e9b91445f5f7626a8fa7e74e30b")
     version("2.2.0", sha256="2a7d2afe09ce5aa9f2ce925b68c6e0c1903dd8d4e4a591cd7047da8e983a99c3")
     version("2.1.0", sha256="966b0a494a916fc3b4324de38f089c86c70ee90e8e1cae6d59102103a4c0cc03")

--- a/repos/spack_repo/builtin/packages/py_s3transfer/package.py
+++ b/repos/spack_repo/builtin/packages/py_s3transfer/package.py
@@ -15,6 +15,7 @@ class PyS3transfer(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.16.0", sha256="8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920")
     version("0.14.0", sha256="eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125")
     version("0.10.0", sha256="d0c8bbf672d5eebbe4e57945e23b972d963f07d82f661cabf678a5c88831595b")
     version("0.9.0", sha256="9e1b186ec8bb5907a1e82b51237091889a9973a2bb799a924bcd9f301ff79d3d")

--- a/repos/spack_repo/builtin/packages/py_schema/package.py
+++ b/repos/spack_repo/builtin/packages/py_schema/package.py
@@ -15,6 +15,7 @@ class PySchema(PythonPackage):
 
     license("MIT")
 
+    version("0.7.8", sha256="e86cc08edd6fe6e2522648f4e47e3a31920a76e82cce8937535422e310862ab5")
     version("0.7.7", sha256="7da553abd2958a19dc2547c388cde53398b39196175a9be59ea1caf5ab0a1807")
     version("0.7.5", sha256="f06717112c61895cabc4707752b88716e8420a8819d71404501e114f91043197")
 

--- a/repos/spack_repo/builtin/packages/py_scooby/package.py
+++ b/repos/spack_repo/builtin/packages/py_scooby/package.py
@@ -15,6 +15,7 @@ class PyScooby(PythonPackage):
 
     license("MIT")
 
+    version("0.11.0", sha256="3dfacc6becf2d6558efa4b625bae3b844ced5d256f3143ebf774e005367e712a")
     version("0.10.0", sha256="7ea33c262c0cc6a33c6eeeb5648df787be4f22660e53c114e5fff1b811a8854f")
     version("0.5.7", sha256="ae2c2b6f5f5d10adf7aaab32409028f1e28d3ce833664bdd1e8c2072e8da169a")
 

--- a/repos/spack_repo/builtin/packages/py_scoop/package.py
+++ b/repos/spack_repo/builtin/packages/py_scoop/package.py
@@ -18,6 +18,7 @@ class PyScoop(PythonPackage):
 
     license("LGPL-3.0-only")
 
+    version("0.7.2.0", sha256="7658faf751627f5507b6f636794721d89db1771234a36e1378ee6796dd7ee761")
     version("0.7.1.1", sha256="d8b6444c7bac901171e3327a97e241dde63f060354e162a65551fd8083ca62b4")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_semver/package.py
+++ b/repos/spack_repo/builtin/packages/py_semver/package.py
@@ -16,6 +16,7 @@ class PySemver(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("3.0.4", sha256="afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602")
     version("3.0.1", sha256="9ec78c5447883c67b97f98c3b6212796708191d22e4ad30f4570f840171cbce1")
     version("2.8.1", sha256="5b09010a66d9a3837211bb7ae5a20d10ba88f8cb49e92cb139a69ef90d5060d8")
 

--- a/repos/spack_repo/builtin/packages/py_serpent/package.py
+++ b/repos/spack_repo/builtin/packages/py_serpent/package.py
@@ -20,6 +20,7 @@ class PySerpent(PythonPackage):
 
     license("MIT")
 
+    version("1.42", sha256="8ea082b01f8ba07ecd74e34a9118ac4521bc4594938d912b808c89f1da425506")
     version("1.40", sha256="10b34e7f8e3207ee6fb70dcdc9bce473851ee3daf0b47c58aec1b48032ac11ce")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_sgp4/package.py
+++ b/repos/spack_repo/builtin/packages/py_sgp4/package.py
@@ -15,6 +15,7 @@ class PySgp4(PythonPackage):
 
     license("MIT")
 
+    version("2.25", sha256="e19edc6dcc25d69fb8fde0a267b8f0c44d7e915c7bcbeacf5d3a8b595baf0674")
     version("1.4", sha256="1fb3cdbc11981a9ff34a032169f83c1f4a2877d1b6c295aed044e1d890b73892")
 
     depends_on("python@2.6:2.8,3.3:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_slicer/package.py
+++ b/repos/spack_repo/builtin/packages/py_slicer/package.py
@@ -13,6 +13,7 @@ class PySlicer(PythonPackage):
     homepage = "https://github.com/interpretml/slicer"
     pypi = "slicer/slicer-0.0.7.tar.gz"
 
+    version("0.0.8", sha256="2e7553af73f0c0c2d355f4afcc3ecf97c6f2156fcf4593955c3f56cf6c4d6eb7")
     version("0.0.7", sha256="f5d5f7b45f98d155b9c0ba6554fa9770c6b26d5793a3e77a1030fb56910ebeec")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_snakemake_interface_report_plugins/package.py
+++ b/repos/spack_repo/builtin/packages/py_snakemake_interface_report_plugins/package.py
@@ -16,6 +16,7 @@ class PySnakemakeInterfaceReportPlugins(PythonPackage):
 
     license("MIT")
 
+    version("1.3.0", sha256="fc9495298bec4e69721ab8afe6d6d88a86966fda2eeb003db56b9a88b86d5934")
     version("1.1.0", sha256="b1ee444b2fca51225cf8a102f8e56633791d01433cd00cf07a1d9713a12313a5")
     version("1.0.0", sha256="02311cdc4bebab2a1c28469b5e6d5c6ac6e9c66998ad4e4b3229f1472127490f")
 

--- a/repos/spack_repo/builtin/packages/py_sortedcollections/package.py
+++ b/repos/spack_repo/builtin/packages/py_sortedcollections/package.py
@@ -16,6 +16,7 @@ class PySortedcollections(PythonPackage):
 
     license("Apache-2.0")
 
+    version("2.1.0", sha256="d8e9609d6c580a16a1224a3dc8965789e03ebc4c3e5ffd05ada54a2fed5dcacd")
     version("1.2.1", sha256="58c31f35e3d052ada6a1fbfc235a408e9ec5e2cfc64a02731cf97cac4afd306a")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_soupsieve/package.py
+++ b/repos/spack_repo/builtin/packages/py_soupsieve/package.py
@@ -18,6 +18,7 @@ class PySoupsieve(PythonPackage):
     # Circular dependency on beautifulsoup4
     skip_modules = ["soupsieve"]
 
+    version("2.8.3", sha256="3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349")
     version("2.8", sha256="e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f")
     version("2.4.1", sha256="89d12b2d5dfcd2c9e8c22326da9d9aa9cb3dfab0a83a024f05704076ee8d35ea")
     version(

--- a/repos/spack_repo/builtin/packages/py_spacy_loggers/package.py
+++ b/repos/spack_repo/builtin/packages/py_spacy_loggers/package.py
@@ -15,6 +15,7 @@ class PySpacyLoggers(PythonPackage):
 
     license("MIT")
 
+    version("1.0.5", sha256="d60b0bdbf915a60e516cc2e653baeff946f0cfc461b452d11a4d5458c6fe5f24")
     version("1.0.4", sha256="e6f983bf71230091d5bb7b11bf64bd54415eca839108d5f83d9155d0ba93bf28")
 
     depends_on("python@3.6:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_spectral/package.py
+++ b/repos/spack_repo/builtin/packages/py_spectral/package.py
@@ -19,6 +19,7 @@ class PySpectral(PythonPackage):
 
     license("MIT")
 
+    version("0.24", sha256="d10fbdd39715e0b91f1e816f59b0f80423c60c77b87727451721df86d4b28911")
     version("0.22.4", sha256="b208ffd1042e32fd2276a35e098e3df26a5f6ff1310b829e97d222c66645a9af")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_sphinx_bootstrap_theme/package.py
+++ b/repos/spack_repo/builtin/packages/py_sphinx_bootstrap_theme/package.py
@@ -14,6 +14,7 @@ class PySphinxBootstrapTheme(PythonPackage):
 
     license("MIT")
 
+    version("0.8.1", sha256="683e3b735448dadd0149f76edecf95ff4bd9157787e9e77e0d048ca6f1d680df")
     version("0.4.13", sha256="47f7719e56304026f285455bbb115525d227a6e23341d4b7f6f0b48b2eface82")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_sphinx_removed_in/package.py
+++ b/repos/spack_repo/builtin/packages/py_sphinx_removed_in/package.py
@@ -15,6 +15,7 @@ class PySphinxRemovedIn(PythonPackage):
 
     maintainers("LydDeb")
 
+    version("0.2.3", sha256="a62dfeaa7962c5b6760b55de65ef3ed2ea83afa1a7c3416ac0bb7d3dec8fd2a6")
     version("0.2.1", sha256="0588239cb534cd97b1d3900d0444311c119e45296a9f73f1ea81ea81a2cd3db1")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_spython/package.py
+++ b/repos/spack_repo/builtin/packages/py_spython/package.py
@@ -16,6 +16,7 @@ class PySpython(PythonPackage):
 
     license("MPL-2.0")
 
+    version("0.3.14", sha256="8ad53ef034395cfa2d8a710cc1c3638e4475e5bbc6a2842d317db8013c2e4188")
     version("0.3.1", sha256="143557849d636697ddd80e0ba95920efe4668351f5becce6bdc73a7651aa128d")
     version("0.2.14", sha256="49e22fbbdebe456b27ca17d30061489db8e0f95e62be3623267a23b85e3ce0f0")
 

--- a/repos/spack_repo/builtin/packages/py_superqt/package.py
+++ b/repos/spack_repo/builtin/packages/py_superqt/package.py
@@ -15,6 +15,7 @@ class PySuperqt(PythonPackage):
 
     license("BSD-3-Clause", checked_by="A-N-Other")
 
+    version("0.7.8", sha256="799c76d780ad9ca289a6a87d481686e28d85e47e2383d1579f57a02b572392a8")
     version("0.7.6", sha256="822fdba71dc391929c9d3db839f78ca2a861e2f2876926f969a288dfb2a9787e")
     version("0.6.1", sha256="f1a9e0499c4bbcef34b6f895eb57cd41301b3799242cd030029238124184dade")
 

--- a/repos/spack_repo/builtin/packages/py_tensorflow_estimator/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow_estimator/package.py
@@ -22,6 +22,7 @@ class PyTensorflowEstimator(Package):
 
     license("Apache-2.0")
 
+    version("2.15.0", sha256="2d7e100b1878084da34b5e23b49a0cbb5ee8a7add74b7dd189a82ada1cf85530")
     version("2.14.0", sha256="622797bf5311f239c2b123364fa360868ae97d16b678413e5e0633241f7d7d5c")
     version("2.13.0", sha256="4175e9276a1eb8b5e4e876d228e4605871832e7bd8517965d6a47f1481af2c3e")
     version("2.12.0", sha256="86c75e830c6ba762d0e3cf04c160096930fb12a992e69b3f24674b9f58902063")

--- a/repos/spack_repo/builtin/packages/py_tensorly/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorly/package.py
@@ -19,6 +19,7 @@ class PyTensorly(PythonPackage):
 
     maintainers("meyersbs")
 
+    version("0.9.0", sha256="9b970dde47e2267a17b66a1444113e879c0bb77fb22f497a4207eb2b548ff792")
     version("0.8.1", sha256="cf78e4ffe612feca3510214002845c6831b267b1f2c1181154d41430310b237d")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_texttable/package.py
+++ b/repos/spack_repo/builtin/packages/py_texttable/package.py
@@ -16,6 +16,7 @@ class PyTexttable(PythonPackage):
 
     license("MIT")
 
+    version("1.7.0", sha256="2d2068fb55115807d3ac77a4ca68fa48803e84ebb0ee2340f858107a36522638")
     version("1.6.7", sha256="290348fb67f7746931bcdfd55ac7584ecd4e5b0846ab164333f0794b121760f2")
     version("1.6.6", sha256="e106b1204b788663283784fd6e5dfc23f1574b84e518e5d286c1a1e66dabd42c")
     version("1.6.5", sha256="fc3f763a89796ae03789a02343bd4e8fed9735935123b1bfb9537a5935852315")

--- a/repos/spack_repo/builtin/packages/py_tiktoken/package.py
+++ b/repos/spack_repo/builtin/packages/py_tiktoken/package.py
@@ -18,6 +18,7 @@ class PyTiktoken(PythonPackage):
 
     license("MIT")
 
+    version("0.12.0", sha256="b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931")
     version("0.9.0", sha256="d02a5ca6a938e0490e1ff957bc48c8b078c88cb83977be1625b1fd8aac792c5d")
     version("0.4.0", sha256="59b20a819969735b48161ced9b92f05dc4519c17be4015cfb73b65270a243620")
     version("0.3.1", sha256="8295912429374f5f3c6c6bf053a091ce1de8c1792a62e3b30d4ad36f47fa8b52")

--- a/repos/spack_repo/builtin/packages/py_timm/package.py
+++ b/repos/spack_repo/builtin/packages/py_timm/package.py
@@ -16,6 +16,7 @@ class PyTimm(PythonPackage):
     license("Apache-2.0")
     maintainers("adamjstewart")
 
+    version("1.0.24", sha256="c7b909f43fe2ef8fe62c505e270cd4f1af230dfbc37f2ee93e3608492b9d9a40")
     version("1.0.16", sha256="a3b8130dd2cb8dc3b9f5e3d09ab6d677a6315a8695fd5264eb6d52a4a46c1044")
     version("1.0.15", sha256="756a3bc30c96565f056e608a9b559daed904617eaadb6be536f96874879b1055")
     version("1.0.14", sha256="00a7f2cc04ce3ed8f80476bbb7eea27eac8cf6f2d59b5e9aa9cdd375dd6550db")

--- a/repos/spack_repo/builtin/packages/py_tuswsgi/package.py
+++ b/repos/spack_repo/builtin/packages/py_tuswsgi/package.py
@@ -16,6 +16,7 @@ class PyTuswsgi(PythonPackage):
 
     license("MIT")
 
+    version("0.5.5", sha256="10dddb1ae8ee5faa65069a9d6f178c08551fad45cf17c158df6c7d1e19f964c4")
     version("0.5.4", sha256="f681a386254a161a97301a67c01ee7da77419c007d9bc43dbd48d5a987491a5e")
 
     depends_on("python@3.6:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_typing_inspect/package.py
+++ b/repos/spack_repo/builtin/packages/py_typing_inspect/package.py
@@ -15,6 +15,7 @@ class PyTypingInspect(PythonPackage):
 
     license("MIT")
 
+    version("0.9.0", sha256="b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78")
     version("0.8.0", sha256="8b1ff0c400943b6145df8119c41c244ca8207f1f10c9c057aeed1560e4806e3d")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_tzdata/package.py
+++ b/repos/spack_repo/builtin/packages/py_tzdata/package.py
@@ -15,6 +15,7 @@ class PyTzdata(PythonPackage):
 
     license("Apache-2.0")
 
+    version("2025.3", sha256="de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7")
     version("2025.2", sha256="b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9")
     version("2023.3", sha256="11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a")
 

--- a/repos/spack_repo/builtin/packages/py_uc_micro_py/package.py
+++ b/repos/spack_repo/builtin/packages/py_uc_micro_py/package.py
@@ -15,6 +15,7 @@ class PyUcMicroPy(PythonPackage):
 
     license("MIT")
 
+    version("1.0.3", sha256="d321b92cff673ec58027c04015fcaa8bb1e005478643ff4a500882eaab88c48a")
     version("1.0.2", sha256="30ae2ac9c49f39ac6dce743bd187fcd2b574b16ca095fa74cd9396795c954c54")
 
     depends_on("python@3.7:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_userpath/package.py
+++ b/repos/spack_repo/builtin/packages/py_userpath/package.py
@@ -14,6 +14,7 @@ class PyUserpath(PythonPackage):
     pypi = "userpath/userpath-1.8.0.tar.gz"
 
     license("MIT")
+    version("1.9.2", sha256="6c52288dab069257cc831846d15d48133522455d4677ee69a9781f11dbefd815")
     version("1.9.0", sha256="85e3274543174477c62d5701ed43a3ef1051824a9dd776968adc411e58640dd1")
     version("1.8.0", sha256="04233d2fcfe5cff911c1e4fb7189755640e1524ff87a4b82ab9d6b875fee5787")
     version("1.7.0", sha256="dcd66c5fa9b1a3c12362f309bbb5bc7992bac8af86d17b4e6b1a4b166a11c43f")

--- a/repos/spack_repo/builtin/packages/py_uxarray/package.py
+++ b/repos/spack_repo/builtin/packages/py_uxarray/package.py
@@ -19,6 +19,7 @@ class PyUxarray(PythonPackage):
 
     maintainers("Chrismarsh")
 
+    version("2025.12.0", sha256="0be5ad31f916253d6a3167dd42b0f6ccea754443aace90ddf0e36cc16407a6d5")
     version("2025.11.0", sha256="a1976851451d3729f86e9fe9a8a899c4bf338b84af8dc265298f5a16a6400bb9")
     version("2025.10.0", sha256="b25b8e13c7f041cb4c094ad7de0addd49acd0baae18da2a75a278c3c411ca20d")
     version("2025.9.0", sha256="cdbeef657bb75518a9c4a1880ac2e2d446b1c2bdaacf15e6ce45654a2ed47f34")

--- a/repos/spack_repo/builtin/packages/py_vcstool/package.py
+++ b/repos/spack_repo/builtin/packages/py_vcstool/package.py
@@ -16,6 +16,7 @@ class PyVcstool(PythonPackage):
     homepage = "https://github.com/dirk-thomas/vcstool"
     pypi = "vcstool/vcstool-0.2.15.tar.gz"
 
+    version("0.3.0", sha256="04b3a963e15386660f139e5b95d293e43e3cb414e3b13e14ee36f5223032ee2c")
     version("0.2.15", sha256="b1fce6fcef7b117b245a72dc8658a128635749d01dc7e9d1316490f89f9c2fde")
 
     depends_on("py-pyyaml", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_vine/package.py
+++ b/repos/spack_repo/builtin/packages/py_vine/package.py
@@ -14,6 +14,7 @@ class PyVine(PythonPackage):
 
     license("CC-BY-SA-4.0")
 
+    version("5.1.0", sha256="8b62e981d35c41049211cf62a0a1242d8c1ee9bd15bb196ce38aefd6799e61e0")
     version("5.0.0", sha256="7d3b1624a953da82ef63462013bbd271d3eb75751489f9807598e8f340bd637e")
     version("1.3.0", sha256="133ee6d7a9016f177ddeaf191c1f58421a1dcc6ee9a42c58b34bed40e1d2cd87")
     version("1.2.0", sha256="ee4813e915d0e1a54e5c1963fde0855337f82655678540a6bc5996bca4165f76")

--- a/repos/spack_repo/builtin/packages/py_visdom/package.py
+++ b/repos/spack_repo/builtin/packages/py_visdom/package.py
@@ -17,6 +17,7 @@ class PyVisdom(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.2.4", sha256="84a911d3c8814a056d54812b381bd938cb44bcfc503a85fe0f701502bb720574")
     version("0.1.8.9", sha256="c73ad23723c24a48156899f78dd76bd4538eba3edf9120b6c65a9528fa677126")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_vispy/package.py
+++ b/repos/spack_repo/builtin/packages/py_vispy/package.py
@@ -19,6 +19,7 @@ class PyVispy(PythonPackage):
 
     license("BSD-3-Clause", checked_by="Markus92")
 
+    version("0.16.1", sha256="b93c32c85d08c06ae8f5e3177f9cfd6c495e1745f2120b777830adee5d9c3648")
     version("0.15.2", sha256="d52d10c0697f48990555cea2a2bad3f9f5a772391856fda364ea4bbc69fd075c")
     version("0.12.2", sha256="141c2ddccc1158555bc89f09010c4b1d754487e816357333f31e795a7146a024")
 

--- a/repos/spack_repo/builtin/packages/py_vl_convert_python/package.py
+++ b/repos/spack_repo/builtin/packages/py_vl_convert_python/package.py
@@ -13,6 +13,7 @@ class PyVlConvertPython(PythonPackage):
     homepage = "https://github.com/vega/vl-convert"
     pypi = "vl_convert_python/vl_convert_python-1.4.0.tar.gz"
 
+    version("1.9.0", sha256="bbf4eb9ac9aa9f32f6fdb689391c914dff311846365658ac70bc5b30f30d57cd")
     version("1.4.0", sha256="264d6f2338c7d3474e60c6907cca016b880b0c1c9be302bb84abc6690188a7e9")
 
     # TODO: This package currently requires internet access to install.

--- a/repos/spack_repo/builtin/packages/py_vsc_base/package.py
+++ b/repos/spack_repo/builtin/packages/py_vsc_base/package.py
@@ -15,6 +15,7 @@ class PyVscBase(PythonPackage):
 
     license("LGPL-2.0-only")
 
+    version("3.6.1", sha256="8e6a14431d3ebd19c4746a77398510fa8bdd985db5d192cc50785995b72e656e")
     version("2.5.8", sha256="7fcd300f842edf4baade7d0b7a3b462ca7dfb2a411a7532694a90127c6646ee2")
 
     depends_on("py-setuptools", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_watchfiles/package.py
+++ b/repos/spack_repo/builtin/packages/py_watchfiles/package.py
@@ -15,6 +15,7 @@ class PyWatchfiles(PythonPackage):
 
     license("MIT")
 
+    version("1.1.1", sha256="a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2")
     version("1.0.5", sha256="b7529b5dcc114679d43827d8c35a07c493ad6f083633d573d81c660abc5979e9")
     version("0.18.1", sha256="4ec0134a5e31797eb3c6c624dbe9354f2a8ee9c720e0b46fc5b7bab472b7c6d4")
 

--- a/repos/spack_repo/builtin/packages/py_wcsaxes/package.py
+++ b/repos/spack_repo/builtin/packages/py_wcsaxes/package.py
@@ -16,6 +16,7 @@ class PyWcsaxes(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.9", sha256="be1a90457c93d18e24da1983c9cd8905260153b1abf0f7a38c0ce3c5fe8905ef")
     version("0.8", sha256="9c6addc1ec04cc99617850354b2c03dbd4099d2e43b45a81f8bc3069de9c8e83")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_whichcraft/package.py
+++ b/repos/spack_repo/builtin/packages/py_whichcraft/package.py
@@ -15,6 +15,7 @@ class PyWhichcraft(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.6.1", sha256="bfa077578261e8bce72ebd44025a2ac196f943123e551589bd5f1c25af9f0085")
     version("0.4.1", sha256="66875022b3b9da8ddf7ab236c15670a782094550d07daeb51ceba4bc61b6b4aa")
 
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_widgetsnbextension/package.py
+++ b/repos/spack_repo/builtin/packages/py_widgetsnbextension/package.py
@@ -14,6 +14,7 @@ class PyWidgetsnbextension(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("4.0.15", sha256="de8610639996f1567952d763a5a41af8af37f2575a41f9852a38f947eb82a3b9")
     version("4.0.3", sha256="34824864c062b0b3030ad78210db5ae6a3960dfb61d5b27562d6631774de0286")
     version("3.6.0", sha256="e84a7a9fcb9baf3d57106e184a7389a8f8eb935bf741a5eb9d60aa18cc029a80")
     version("3.5.1", sha256="079f87d87270bce047512400efd70238820751a11d2d8cb137a5a5bdbaf255c7")

--- a/repos/spack_repo/builtin/packages/py_wurlitzer/package.py
+++ b/repos/spack_repo/builtin/packages/py_wurlitzer/package.py
@@ -16,6 +16,7 @@ class PyWurlitzer(PythonPackage):
 
     license("MIT")
 
+    version("3.1.1", sha256="bfb9144ab9f02487d802b9ff89dbd3fa382d08f73e12db8adc4c2fb00cd39bd9")
     version("3.0.2", sha256="36051ac530ddb461a86b6227c4b09d95f30a1d1043de2b4a592e97ae8a84fcdf")
 
     depends_on("python+ctypes@3.5:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_xarray_regrid/package.py
+++ b/repos/spack_repo/builtin/packages/py_xarray_regrid/package.py
@@ -17,6 +17,7 @@ class PyXarrayRegrid(PythonPackage):
 
     license("Apache-2.0", checked_by="Chrismarsh")
 
+    version("0.4.2", sha256="96525d39b0290efa59e0255cebd35be028052f1b347bfb10fd259b4380289673")
     version("0.4.1", sha256="2c8a7baa321c2451aa42b387fef3b22ecd7bdf693e7ee5c52ebe5168482a1e2a")
     version("0.4.0", sha256="f0bef6a346e247c657ed293752b5685f3b559b32de546889ca9e9fca14b81f3a")
 

--- a/repos/spack_repo/builtin/packages/py_xyzservices/package.py
+++ b/repos/spack_repo/builtin/packages/py_xyzservices/package.py
@@ -16,6 +16,7 @@ class PyXyzservices(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("2025.11.0", sha256="2fc72b49502b25023fd71e8f532fb4beddbbf0aa124d90ea25dba44f545e17ce")
     version("2023.10.1", sha256="091229269043bc8258042edbedad4fcb44684b0473ede027b5672ad40dc9fa02")
 
     depends_on("python@3.8:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_yt_dlp_ejs/package.py
+++ b/repos/spack_repo/builtin/packages/py_yt_dlp_ejs/package.py
@@ -15,6 +15,7 @@ class PyYtDlpEjs(PythonPackage):
 
     license("Unlicense AND MIT AND ISC")
 
+    version("0.4.0", sha256="3c67e0beb6f9f3603fbcb56f425eabaa37c52243d90d20ccbcce1dd941cfbd07")
     version("0.3.1", sha256="7f2119eb02864800f651fa33825ddfe13d152a1f730fa103d9864f091df24227")
 
     with default_args(type="build"):

--- a/repos/spack_repo/builtin/packages/py_zxcvbn/package.py
+++ b/repos/spack_repo/builtin/packages/py_zxcvbn/package.py
@@ -18,6 +18,7 @@ class PyZxcvbn(PythonPackage):
 
     license("MIT")
 
+    version("4.5.0", sha256="5e4efc8c9ef2a50220fb627066e4b698482643070ab2a51e020bd85957595271")
     version("4.4.28", sha256="b7275765acdf8028c21aa502d742e56de2252bac604c04ba5e336c39f88d5576")
     version("4.4.27", sha256="9b84927fff7b4cc557b63a49adbd74f7a92026e25edd9e1b2867c1610d15fa5d")
     version("4.4.26", sha256="ee498e9257742972950f33540f0e36112db14c636417ce5b53d99a492dad8aba")


### PR DESCRIPTION
Generated with [https://github.com/spack/pypi-to-spack-package](https://github.com/spack/pypi-to-spack-package)'s `pypi-to-spack-bump`

* Updates `py-*` packages only
* Only packages without changes to Requires-Dist
* Only packages without changes to Requires-Python
* Only packages without deps on `c`, `cxx`, `fortran` and `rust`
* No prereleases, dev versions, etc.