### PR TITLE
eigen: loosen Windows conflict

### DIFF
--- a/repos/spack_repo/builtin/packages/eigen/package.py
+++ b/repos/spack_repo/builtin/packages/eigen/package.py
@@ -86,7 +86,7 @@ class Eigen(CMakePackage, ROCmPackage):
     # Building eigen-based LAPACK implementation requires to also build BLAS
     conflicts("~blas", when="+lapack")
 
-    conflicts("platform=windows", when="@3.4.1")
+    conflicts("platform=windows", when="@3.4.1 +blas")
 
     # there is a bug in 3.3.4 that provokes a compile error with the xl compiler
     # See https://gitlab.com/libeigen/eigen/-/issues/1555

--- a/repos/spack_repo/builtin/packages/eigen/package.py
+++ b/repos/spack_repo/builtin/packages/eigen/package.py
@@ -18,7 +18,7 @@ class Eigen(CMakePackage, ROCmPackage):
     git = "https://gitlab.com/libeigen/eigen.git"
     url = "https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz"
 
-    maintainers("HaoZeke")
+    maintainers("HaoZeke", "jcortial-safran")
 
     license("MPL-2.0")
 

--- a/repos/spack_repo/builtin/packages/eigen/package.py
+++ b/repos/spack_repo/builtin/packages/eigen/package.py
@@ -14,7 +14,7 @@ class Eigen(CMakePackage, ROCmPackage):
     vectors, numerical solvers, and related algorithms.
     """
 
-    homepage = "https://eigen.tuxfamily.org/"
+    homepage = "https://libeigen.gitlab.io/"
     git = "https://gitlab.com/libeigen/eigen.git"
     url = "https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz"
 


### PR DESCRIPTION
Following merged PRs https://github.com/spack/spack-packages/pull/3293 and https://github.com/spack/spack-packages/pull/1807, I think we can loosen the conflict on Windows platform for @3.4.1.

The Windows build failure is ontly relevant if we compile Fortran libraries, so unless +blas is specified (+lapack implies +blas), @3.4.1 sould be ok on Windows.
