### PR TITLE
py_uv: add 0.10.1

### DIFF
--- a/repos/spack_repo/builtin/packages/py_uv/package.py
+++ b/repos/spack_repo/builtin/packages/py_uv/package.py
@@ -11,11 +11,11 @@ class PyUv(PythonPackage):
     """An extremely fast Python package and project manager, written in Rust."""
 
     homepage = "https://github.com/astral-sh/uv"
-    pypi = "uv/uv-0.10.0.tar.gz"
+    pypi = "uv/uv-0.10.1.tar.gz"
 
     license("APACHE 2.0 or MIT")
 
-    version("0.10.0", sha256="ad01dd614a4bb8eb732da31ade41447026427397c5ad171cc98bd59579ef57ea")
+    version("0.10.1", sha256="c89e7fd708fb3474332d6fc54beb2ea48313ebdc82c6931df92a884fcb636d9d")
     version("0.7.22", sha256="f5cf159907d594e33433f14737d1ee843dc8799edfcf57b5b8c0f282d1117051")
     version("0.7.15", sha256="c608cd2d89db7482ab40fc6e7de27afc87b20595e145ed81a2a8702e9a0d7e2d")
     version("0.7.5", sha256="ae2192283eb645ccab189b1dfd8b13d3264eae631469a903c0e0f2dffce65e3b")

--- a/repos/spack_repo/builtin/packages/py_uv/package.py
+++ b/repos/spack_repo/builtin/packages/py_uv/package.py
@@ -11,10 +11,11 @@ class PyUv(PythonPackage):
     """An extremely fast Python package and project manager, written in Rust."""
 
     homepage = "https://github.com/astral-sh/uv"
-    pypi = "uv/uv-0.4.15.tar.gz"
+    pypi = "uv/uv-0.10.0.tar.gz"
 
     license("APACHE 2.0 or MIT")
 
+    version("0.10.0", sha256="ad01dd614a4bb8eb732da31ade41447026427397c5ad171cc98bd59579ef57ea")
     version("0.7.22", sha256="f5cf159907d594e33433f14737d1ee843dc8799edfcf57b5b8c0f282d1117051")
     version("0.7.15", sha256="c608cd2d89db7482ab40fc6e7de27afc87b20595e145ed81a2a8702e9a0d7e2d")
     version("0.7.5", sha256="ae2192283eb645ccab189b1dfd8b13d3264eae631469a903c0e0f2dffce65e3b")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Hi, this is a new attempt of bumping `uv`, after #481 was unsuccessful.
Using rust 1.92 I got this working on a test machine. Package can be built and `uv` and `uvx` commands are working.

Refs:
- https://github.com/astral-sh/uv/releases/tag/0.10.0
- https://pypi.org/project/uv/0.10.0/