### PR TITLE
task: add v3.4.2, modify URL to point at GitHub

### DIFF
--- a/repos/spack_repo/builtin/packages/task/package.py
+++ b/repos/spack_repo/builtin/packages/task/package.py
@@ -11,15 +11,17 @@ class Task(CMakePackage):
     """Feature-rich console based todo list manager"""
 
     homepage = "https://www.taskwarrior.org"
-    url = "https://taskwarrior.org/download/task-2.4.4.tar.gz"
+    url = "https://github.com/GothenburgBitFactory/taskwarrior/releases/download/v2.5.2/task-2.5.2.tar.gz"
 
     license("MIT")
 
+    version("3.4.2", sha256="d302761fcd1268e4a5a545613a2b68c61abd50c0bcaade3b3e68d728dd02e716")
     version("3.0.0", sha256="30f397081044f5dc2e5a0ba51609223011a23281cd9947ea718df98d149fcc83")
     version("2.6.2", sha256="b1d3a7f000cd0fd60640670064e0e001613c9e1cb2242b9b3a9066c78862cfec")
-    version("2.5.1", sha256="d87bcee58106eb8a79b850e9abc153d98b79e00d50eade0d63917154984f2a15")
-    version("2.4.4", sha256="7ff406414e0be480f91981831507ac255297aab33d8246f98dbfd2b1b2df8e3b")
+    version("2.5.1", sha256="d87bcee58106eb8a79b850e9abc153d98b79e00d50eade0d63917154984f2a15", url="https://taskwarrior.org/download/task-2.5.1.tar.gz")
+    version("2.4.4", sha256="7ff406414e0be480f91981831507ac255297aab33d8246f98dbfd2b1b2df8e3b", url="https://taskwarrior.org/download/task-2.4.4.tar.gz")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     depends_on("cmake@2.8:", type="build")

--- a/repos/spack_repo/builtin/packages/task/package.py
+++ b/repos/spack_repo/builtin/packages/task/package.py
@@ -18,8 +18,16 @@ class Task(CMakePackage):
     version("3.4.2", sha256="d302761fcd1268e4a5a545613a2b68c61abd50c0bcaade3b3e68d728dd02e716")
     version("3.0.0", sha256="30f397081044f5dc2e5a0ba51609223011a23281cd9947ea718df98d149fcc83")
     version("2.6.2", sha256="b1d3a7f000cd0fd60640670064e0e001613c9e1cb2242b9b3a9066c78862cfec")
-    version("2.5.1", sha256="d87bcee58106eb8a79b850e9abc153d98b79e00d50eade0d63917154984f2a15", url="https://taskwarrior.org/download/task-2.5.1.tar.gz")
-    version("2.4.4", sha256="7ff406414e0be480f91981831507ac255297aab33d8246f98dbfd2b1b2df8e3b", url="https://taskwarrior.org/download/task-2.4.4.tar.gz")
+    version(
+        "2.5.1",
+        sha256="d87bcee58106eb8a79b850e9abc153d98b79e00d50eade0d63917154984f2a15",
+        url="https://taskwarrior.org/download/task-2.5.1.tar.gz",
+    )
+    version(
+        "2.4.4",
+        sha256="7ff406414e0be480f91981831507ac255297aab33d8246f98dbfd2b1b2df8e3b",
+        url="https://taskwarrior.org/download/task-2.4.4.tar.gz",
+    )
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated


### PR DESCRIPTION
This introduces three changes to the `task` package:

1. Add a new checksum for the latest version, Taskwarrior 3.4.0
2. Add `depends_on("c")` -- Taskwarrior is written in C++ and Rust, but without this set, the `cmake` phase fails with an error complaining that the `SPACK_CC` environment variable is unset.
3. Update the download URL 

Prior versions of Taskwarrior were released as source tarballs on `taskwarrior.org`, which was the original download URL in the package. Starting with release 2.5.2 the developers began publishing it in parallel through GitHub releases, but continued to redirect appropriately from taskwarrior.org. Starting with `task@3.3.0`, however, they seem to have stopped adding redirects for new versions -- GitHub now appears to be the only place to get new releases. With this in mind, I've updated the `url` property on the package to point to the GitHub release (thankfully, the checksums for old versions of the packages are the same for both). For the two versions which predate the earliest GitHub release, I've set the `url=` property separately on those versions.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
