### PR TITLE
timew: add v1.9.1 and c language dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/timew/package.py
+++ b/repos/spack_repo/builtin/packages/timew/package.py
@@ -18,6 +18,8 @@ class Timew(CMakePackage):
 
     license("MIT", checked_by="taliaferro")
 
+    version("1.9.1", sha256="7ad34f95c0d61d356df55149f9479f8d9aaec417e5f57f2a1cc76ae2f8a3171b")
     version("1.7.1", sha256="5e0817fbf092beff12598537c894ec1f34b0a21019f5a3001fe4e6d15c11bd94")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated


### PR DESCRIPTION
This adds a checksum for `timew@1.9.1`, released last August. In the process of getting it to build, I also noticed that (much like Taskwarrior) it would no longer build with new versions of Spack because it was missing `depends("c")`. (the `cmake` phase would fail, complaining that the `SPACK_CC` environment variable was unset.)

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
