### PR TITLE
xrootd: add missing libxcrypt dep

### DIFF
--- a/repos/spack_repo/builtin/packages/xrootd/package.py
+++ b/repos/spack_repo/builtin/packages/xrootd/package.py
@@ -114,6 +114,7 @@ class Xrootd(CMakePackage):
     depends_on("krb5", when="+krb5")
     depends_on("json-c")
     depends_on("scitokens-cpp", when="+scitokens-cpp")
+    depends_on("libxcrypt", type="link")
 
     extends("python", when="+python")
 


### PR DESCRIPTION
Fixes:

```
==> Warning: lib/libXrdSecpwd-5.so
        libXrdCrypto.so.2 => /opt/linux-x86_64_v3/xrootd-5.9.1-2lzc4e42btjopyqyqiebhv2epoq2shtz/lib/libXrdCrypto.so.2
        libXrdUtils.so.3 => /opt/linux-x86_64_v3/xrootd-5.9.1-2lzc4e42btjopyqyqiebhv2epoq2shtz/lib/libXrdUtils.so.3
        libcrypt.so.1 => not found
```

