### PR TITLE
py-pillow: add v12.1.1

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pillow/package.py
+++ b/repos/spack_repo/builtin/packages/py_pillow/package.py
@@ -157,6 +157,7 @@ class PyPillow(PyPillowBase):
     license("MIT-CMU", when="@11:")
     license("HPND", when="@:10")
 
+    version("12.1.1", sha256="9ad8fa5937ab05218e2b6a4cff30295ad35afd2f83ac592e68c0d871bb0fdbc4")
     version("12.1.0", sha256="5c5ae0a06e9ea030ab786b0251b32c7e4ce10e58d983c0d5c56029455180b5b9")
     version("12.0.0", sha256="87d4f8125c9988bfbed67af47dd7a953e2fc7b0cc1e7800ec6d2080d490bb353")
     version("11.3.0", sha256="3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523")
@@ -183,6 +184,7 @@ class PyPillow(PyPillowBase):
     depends_on("c", type="build")
 
     for ver in [
+        "12.1.1",
         "12.1.0",
         "12.0.0",
         "11.3.0",


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
https://pillow.readthedocs.io/en/stable/releasenotes/12.1.1.html

Not sure if we should deprecate older versions? Also wondering if we should deprecate py-pillow-simd, which now has multiple CVEs piling up...