### PR TITLE
fenics-ufcx: correct license

### DIFF
--- a/repos/spack_repo/builtin/packages/fenics_ufcx/package.py
+++ b/repos/spack_repo/builtin/packages/fenics_ufcx/package.py
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import *
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
 
 
 class FenicsUfcx(CMakePackage):

--- a/repos/spack_repo/builtin/packages/fenics_ufcx/package.py
+++ b/repos/spack_repo/builtin/packages/fenics_ufcx/package.py
@@ -19,27 +19,12 @@ class FenicsUfcx(CMakePackage):
     license("Unlicense")
 
     version("main", branch="main", no_cache=True)
-    version(
-        "0.10.0",
-        sha256="fa27e2dc68988cbf9aca537eb5a58483f75cc719c1a383713b7f8cca49844ff9",
-    )
-    version(
-        "0.9.0",
-        sha256="afa517272a3d2249f513cb711c50b77cf8368dd0b8f5ea4b759142229204a448",
-    )
-    version(
-        "0.8.0",
-        sha256="8a854782dbd119ec1c23c4522a2134d5281e7f1bd2f37d64489f75da055282e3",
-    )
+    version("0.10.0", sha256="fa27e2dc68988cbf9aca537eb5a58483f75cc719c1a383713b7f8cca49844ff9")
+    version("0.9.0", sha256="afa517272a3d2249f513cb711c50b77cf8368dd0b8f5ea4b759142229204a448")
+    version("0.8.0", sha256="8a854782dbd119ec1c23c4522a2134d5281e7f1bd2f37d64489f75da055282e3")
     with default_args(deprecated=True):
-        version(
-            "0.7.0",
-            sha256="7f3c3ca91d63ce7831d37799cc19d0551bdcd275bdfa4c099711679533dd1c71",
-        )
-        version(
-            "0.6.0",
-            sha256="076fad61d406afffd41019ae1abf6da3f76406c035c772abad2156127667980e",
-        )
+        version("0.7.0", sha256="7f3c3ca91d63ce7831d37799cc19d0551bdcd275bdfa4c099711679533dd1c71")
+        version("0.6.0", sha256="076fad61d406afffd41019ae1abf6da3f76406c035c772abad2156127667980e")
 
     depends_on("cmake@3.19:", type="build")
     depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/fenics_ufcx/package.py
+++ b/repos/spack_repo/builtin/packages/fenics_ufcx/package.py
@@ -2,9 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack_repo.builtin.build_systems.cmake import CMakePackage
-
 from spack.package import *
+from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 
 class FenicsUfcx(CMakePackage):
@@ -17,15 +16,30 @@ class FenicsUfcx(CMakePackage):
     url = "https://github.com/FEniCS/ffcx/archive/v0.4.2.tar.gz"
     maintainers("ma595", "jhale", "garth-wells", "chrisrichardson")
 
-    license("LGPL-3.0-or-later")
+    license("Unlicense")
 
     version("main", branch="main", no_cache=True)
-    version("0.10.0", sha256="fa27e2dc68988cbf9aca537eb5a58483f75cc719c1a383713b7f8cca49844ff9")
-    version("0.9.0", sha256="afa517272a3d2249f513cb711c50b77cf8368dd0b8f5ea4b759142229204a448")
-    version("0.8.0", sha256="8a854782dbd119ec1c23c4522a2134d5281e7f1bd2f37d64489f75da055282e3")
+    version(
+        "0.10.0",
+        sha256="fa27e2dc68988cbf9aca537eb5a58483f75cc719c1a383713b7f8cca49844ff9",
+    )
+    version(
+        "0.9.0",
+        sha256="afa517272a3d2249f513cb711c50b77cf8368dd0b8f5ea4b759142229204a448",
+    )
+    version(
+        "0.8.0",
+        sha256="8a854782dbd119ec1c23c4522a2134d5281e7f1bd2f37d64489f75da055282e3",
+    )
     with default_args(deprecated=True):
-        version("0.7.0", sha256="7f3c3ca91d63ce7831d37799cc19d0551bdcd275bdfa4c099711679533dd1c71")
-        version("0.6.0", sha256="076fad61d406afffd41019ae1abf6da3f76406c035c772abad2156127667980e")
+        version(
+            "0.7.0",
+            sha256="7f3c3ca91d63ce7831d37799cc19d0551bdcd275bdfa4c099711679533dd1c71",
+        )
+        version(
+            "0.6.0",
+            sha256="076fad61d406afffd41019ae1abf6da3f76406c035c772abad2156127667980e",
+        )
 
     depends_on("cmake@3.19:", type="build")
     depends_on("c", type="build")


### PR DESCRIPTION
Corrects the license - UFCx, which is a single header file within FFCx (LGPLv3+) is Unlicense.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
