### PR TITLE
py-torchmetrics: does not support setuptools 82+

### DIFF
--- a/repos/spack_repo/builtin/packages/py_torchmetrics/package.py
+++ b/repos/spack_repo/builtin/packages/py_torchmetrics/package.py
@@ -63,7 +63,8 @@ class PyTorchmetrics(PythonPackage):
     variant("image", default=False, description="image support", when="@0.11.2:")
 
     # setup.py
-    depends_on("py-setuptools", type="build")
+    # https://github.com/Lightning-AI/torchmetrics/pull/3324
+    depends_on("py-setuptools@:81", type="build")
 
     # requirements/base.txt (upper bound is removed during processing)
     with default_args(type=("build", "run")):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Another package that will break with setuptools 82.