### PR TITLE
Use more padding only for the spec being built

### DIFF
--- a/.ci/gitlab/configs/linux/ci.yaml
+++ b/.ci/gitlab/configs/linux/ci.yaml
@@ -4,7 +4,7 @@ ci:
       before_script-:
       # Test package relocation on linux using a modified prefix
       # This is not well supported on MacOS (https://github.com/spack/spack/issues/37162)
-      - - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture.platform}-{architecture.target}/{name}-{version}-{hash}'"
+      - - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}/${SPACK_JOB_SPEC_DAG_HASH}:'morepadding/{architecture.platform}-{architecture.target}/{name}-{version}-{hash}'"
   - match_behavior: first
     submapping:
     - match:

--- a/.ci/gitlab/configs/win64/ci.yaml
+++ b/.ci/gitlab/configs/win64/ci.yaml
@@ -19,7 +19,7 @@ ci:
 
       script::
       - spack.ps1 env activate --without-view ${SPACK_CONCRETE_ENV_DIR}
-      - spack.ps1 config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{hash}'"
+      - spack.ps1 config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}/${SPACK_JOB_SPEC_DAG_HASH}:'morepadding/{hash}'"
       - mkdir ${SPACK_ARTIFACTS_ROOT}/user_data
       - spack.ps1 --backtrace ci rebuild | Tee-Object -FilePath "${env:SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt" 2>&1 | Tee-Object -FilePath "${env:SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt"
       image: "ghcr.io/johnwparent/windows-server21h2:sha-1c12b61"


### PR DESCRIPTION
In some DAGs there could be more instances of the same package. We want to use "morepadding" only for the path of the spec being built, not for the other dependencies.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
