### PR TITLE
ci: sprinkle `target=`

### DIFF
--- a/stacks/e4s-neoverse-v2/spack.yaml
+++ b/stacks/e4s-neoverse-v2/spack.yaml
@@ -45,7 +45,7 @@ spack:
     paraview:
       require: "+examples target=neoverse_v2 %gcc"
     boost:
-      require: "cxxstd=17"
+      require: "cxxstd=17 target=neoverse_v2 %gcc"
 
   specs:
   # CPU

--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -12,7 +12,6 @@ spack:
   packages:
     all:
       require:
-      - "%gcc"
       - target=x86_64_v3
       variants: +mpi
     c:
@@ -32,14 +31,6 @@ spack:
       - openblas
     binutils:
       variants: +ld +gold +headers +libiberty ~nls
-    cmake:
-      require:
-      - "~qtgui"
-      - 'target=x86_64_v3 %gcc'
-    gmake:
-      require:
-      - "~guile"
-      - 'target=x86_64_v3 %gcc'
     hdf5:
       variants: +fortran +hl +shared
     libfabric:
@@ -58,26 +49,28 @@ spack:
     mpich:
       require:
       - '~wrapperrpath ~hwloc'
-      - 'target=x86_64_v3 %gcc'
+      - target=x86_64_v3 %gcc
     tbb:
       require:
       - intel-tbb
     vtk-m:
       require:
-      - "+examples"
-      - 'target=x86_64_v3 %gcc'
+      - +examples
+      - target=x86_64_v3 %gcc
     visit:
       require:
-      - "~gui target=x86_64_v3"
+      - "~gui"
+      - target=x86_64_v3 %gcc
     paraview:
       # Don't build GUI support or GLX rendering for HPC/container deployments
       require:
-      - "+examples"
+      - +examples
       - "~qt ^[virtuals=gl] osmesa" # Headless
-      - "target=x86_64_v3 %gcc"
+      - target=x86_64_v3 %gcc
     boost:
       require:
       - cxxstd=17
+      - target=x86_64_v3 %gcc
 
   specs:
   # CPU

--- a/stacks/ml-linux-aarch64-cpu/spack.yaml
+++ b/stacks/ml-linux-aarch64-cpu/spack.yaml
@@ -14,14 +14,15 @@ spack:
     mpi:
       require: openmpi
     python:
-      require: "@3.13:"
+      require: "@3.13: target=aarch64"
     py-jaxlib:
-      require: "%c,cxx=clang"
+      require: "target=aarch64 %c,cxx=clang"
     py-tensorflow:
       require:
         - any_of: ["@:2.18 %c,cxx=gcc", "@2.19: %c,cxx=clang"]
+        - target=aarch64
     py-torch:
-      require: "%c,cxx=gcc"
+      require: "target=aarch64 %c,cxx=gcc"
 
   specs:
     # Hugging Face

--- a/stacks/ml-linux-aarch64-cuda/spack.yaml
+++ b/stacks/ml-linux-aarch64-cuda/spack.yaml
@@ -19,12 +19,13 @@ spack:
     mpi:
       require: openmpi
     python:
-      require: "@3.13:"
+      require: "@3.13: target=aarch64"
     py-jaxlib:
-      require: "%c,cxx=clang"
+      require: "target=aarch64 %c,cxx=clang"
     py-tensorflow:
       require:
         - any_of: ["@:2.18 %c,cxx=gcc", "@2.19: %c,cxx=clang"]
+        - target=aarch64
     py-torch:
       require:
       - target=aarch64

--- a/stacks/ml-linux-x86_64-cpu/spack.yaml
+++ b/stacks/ml-linux-x86_64-cpu/spack.yaml
@@ -13,13 +13,13 @@ spack:
     mpi:
       require: openmpi
     python:
-      require: "@3.13:"
+      require: "@3.13: target=x86_64_v3"
     py-jaxlib:
-      require: "%c,cxx=clang"
+      require: "target=x86_64_v3 %c,cxx=clang"
     py-tensorflow:
-      require: "%c,cxx=clang"
+      require: "target=x86_64_v3 %c,cxx=clang"
     py-torch:
-      require: "%c,cxx=gcc"
+      require: "target=x86_64_v3 %c,cxx=gcc"
 
   specs:
     # Hugging Face

--- a/stacks/ml-linux-x86_64-cuda/spack.yaml
+++ b/stacks/ml-linux-x86_64-cuda/spack.yaml
@@ -19,11 +19,11 @@ spack:
     mpi:
       require: openmpi
     python:
-      require: "@3.13:"
+      require: "@3.13: target=x86_64_v3"
     py-jaxlib:
-      require: "%c,cxx=clang"
+      require: "target=x86_64_v3 %c,cxx=clang"
     py-tensorflow:
-      require: "%c,cxx=clang"
+      require: "target=x86_64_v3 %c,cxx=clang"
     py-torch:
       require:
       - target=x86_64_v3

--- a/stacks/ml-linux-x86_64-rocm/spack.yaml
+++ b/stacks/ml-linux-x86_64-rocm/spack.yaml
@@ -12,17 +12,17 @@ spack:
       - +rocm
       - amdgpu_target=gfx90a
     eigen:
-      require: ~rocm
+      require: ~rocm target=x86_64_v3
     gl:
       require: "osmesa"
     mpi:
       require: openmpi
     python:
-      require: "@3.13:"
+      require: "@3.13: target=x86_64_v3"
     py-jaxlib:
-      require: "%c,cxx=clang"
+      require: "target=x86_64_v3 %c,cxx=clang"
     py-tensorflow:
-      require: "%c,cxx=clang"
+      require: "target=x86_64_v3 %c,cxx=clang"
     py-torch:
       require:
       - target=x86_64_v3


### PR DESCRIPTION
package specific requirements override `all`, leading to other arch
choises among some packages

