### PR TITLE
More memory for RCCL build

### DIFF
--- a/.ci/gitlab/configs/linux/ci.yaml
+++ b/.ci/gitlab/configs/linux/ci.yaml
@@ -32,6 +32,7 @@ ci:
 
     - match:
       - py-tensorflow
+      - rccl
       build-job:
         tags: [ "spack", "huge" ]
         variables:


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Up the allocation for RCCL 

ref. https://github.com/ROCm/rocm-systems/issues/3086