### PR TITLE
fix(hdf5): remove LD_LIBRARY_PATH setup in run environment

### DIFF
--- a/repos/spack_repo/builtin/packages/hdf5/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5/package.py
@@ -512,10 +512,7 @@ class Hdf5(CMakePackage):
         env.set("SZIP_INSTALL", self.spec["szip"].prefix)
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
-        # According to related github posts and problems running test_install
-        # as a stand-alone test, it appears the lib path must be added to
-        # LD_LIBRARY_PATH.
-        env.append_path("LD_LIBRARY_PATH", self.prefix.lib)
+        pass
 
     def cmake_args(self):
         spec = self.spec

--- a/repos/spack_repo/builtin/packages/hdf5/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5/package.py
@@ -511,9 +511,6 @@ class Hdf5(CMakePackage):
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         env.set("SZIP_INSTALL", self.spec["szip"].prefix)
 
-    def setup_run_environment(self, env: EnvironmentModifications) -> None:
-        pass
-
     def cmake_args(self):
         spec = self.spec
 


### PR DESCRIPTION
Removed unnecessary LD_LIBRARY_PATH setup in run environment.

close #3380

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
