### PR TITLE
rccl: add patch to limit max memory usage, reduce number of targets

### DIFF
--- a/repos/spack_repo/builtin/packages/rccl/memory-3231.patch
+++ b/repos/spack_repo/builtin/packages/rccl/memory-3231.patch
@@ -1,0 +1,45 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cb5d34e1caf..86b97a29c93 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1364,24 +1364,35 @@ execute_process(
+   COMMAND bash "-c" "cat /sys/fs/cgroup/memory.max"
+   OUTPUT_VARIABLE memory_max_string)
+ if (${memory_max_string} MATCHES "^[0-9]+")
+-  math(EXPR memory_in_gb "${memory_max_string} / (1024 * 1024 * 1024)")
++  math(EXPR detected_memory_gb "${memory_max_string} / (1024 * 1024 * 1024)")
+ else()
+   execute_process(
+     COMMAND bash "-c" "free | grep -o '[[:digit:]]*' | head -1"
+     OUTPUT_VARIABLE memory_max_string)
+   ## memory_max_string holds the free memory in KB
+   if (${memory_max_string} MATCHES "^[0-9]+")
+-    math(EXPR memory_in_gb "${memory_max_string} / (1024 * 1024)") ## KB to GB conversion
++    math(EXPR detected_memory_gb "${memory_max_string} / (1024 * 1024)") ## KB to GB conversion
+   else()
+     cmake_host_system_information(RESULT memory_max_string QUERY AVAILABLE_PHYSICAL_MEMORY )
+-    math(EXPR memory_in_gb "${memory_max_string} / 1024")
++    math(EXPR detected_memory_gb "${memory_max_string} / 1024")
+   endif()
+ endif()
+-## Reserve 16GB for each linker job. Limit max number of linker jobs to 16
++set(RCCL_MAX_MEMORY ${detected_memory_gb} CACHE STRING "Maximum memory (in GB) during linking")
++set(RCCL_MEMORY_PER_LINK_JOB 32 CACHE STRING "Memory (in GB) reserved for each linker job")
++
++# Use the minimum of detected memory and user-specified memory
++if (RCCL_MAX_MEMORY LESS detected_memory_gb)
++  set(memory_in_gb ${RCCL_MAX_MEMORY})
++else()
++  set(memory_in_gb ${detected_memory_gb})
++endif()
++
+ if (HAVE_PARALLEL_JOBS)
+-  math(EXPR num_linker_jobs "(${memory_in_gb} + 15) / 16")
++  math(EXPR num_linker_jobs "(${memory_in_gb} + ${RCCL_MEMORY_PER_LINK_JOB} - 1) / ${RCCL_MEMORY_PER_LINK_JOB}")
+   if (${num_linker_jobs} GREATER_EQUAL "16")
+     set(num_linker_jobs "16")
++  elseif (${num_linker_jobs} LESS_EQUAL "0")
++    set(num_linker_jobs "1")
+   endif()
+   message(STATUS "Use ${num_linker_jobs} jobs for linking")
+   target_link_options(rccl PRIVATE -parallel-jobs=${num_linker_jobs})       # Use multiple threads to link

--- a/repos/spack_repo/builtin/packages/rccl/package.py
+++ b/repos/spack_repo/builtin/packages/rccl/package.py
@@ -179,7 +179,10 @@ class Rccl(CMakePackage):
             self.define("BUILD_TESTS", self.run_tests),
             self.define("ENABLE_MSCCLPP", False),
             self.define("ENABLE_MSCCL_KERNEL", False),
-            self.define("RCCL_MAX_MEMORY", "128"),
+            # Anecdotally, memory usage is about ~8GB per job per GPU arch. The value could be
+            # computed from amd_gpu_targets, except in the case of auto. Leave constant for now.
+            self.define("RCCL_MAX_MEMORY", "32"),
+            self.define("RCCL_MEMORY_PER_LINK_JOB", "8"),
         ]
         if "auto" not in self.spec.variants["amdgpu_target"]:
             if self.spec.satisfies("@7.1:"):

--- a/repos/spack_repo/builtin/packages/rccl/package.py
+++ b/repos/spack_repo/builtin/packages/rccl/package.py
@@ -105,8 +105,11 @@ class Rccl(CMakePackage):
         sha256="a747b2f76acf938860b4319cafb90426506d5b931ca776d094fd0eb9580ef785",
         when="@7.1",
     )
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    # See https://github.com/ROCm/rocm-systems/pull/3231
+    patch("memory-3231.patch", when="@7.1:")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("cmake@3.5:", type="build")
     depends_on("numactl@2:")
@@ -176,6 +179,7 @@ class Rccl(CMakePackage):
             self.define("BUILD_TESTS", self.run_tests),
             self.define("ENABLE_MSCCLPP", False),
             self.define("ENABLE_MSCCL_KERNEL", False),
+            self.define("RCCL_MAX_MEMORY", "32"),
         ]
         if "auto" not in self.spec.variants["amdgpu_target"]:
             if self.spec.satisfies("@7.1:"):

--- a/repos/spack_repo/builtin/packages/rccl/package.py
+++ b/repos/spack_repo/builtin/packages/rccl/package.py
@@ -179,7 +179,7 @@ class Rccl(CMakePackage):
             self.define("BUILD_TESTS", self.run_tests),
             self.define("ENABLE_MSCCLPP", False),
             self.define("ENABLE_MSCCL_KERNEL", False),
-            self.define("RCCL_MAX_MEMORY", "32"),
+            self.define("RCCL_MAX_MEMORY", "128"),
         ]
         if "auto" not in self.spec.variants["amdgpu_target"]:
             if self.spec.satisfies("@7.1:"):


### PR DESCRIPTION
ref https://github.com/ROCm/rocm-systems/pull/3231

Cause we don't use cgroups v2, the computation of "available memory" doesn't
work, and we end up with up to 16 jobs, with user reports claiming 32GB per job
is needed.

Edit: in practice it's less and depends on number of GPU architectures selected.
After #3418, 8GB per link job seems reasonable.

This patch allows us to set a maximum on the amount of memory used, provided
an accurate estimate for memory per job is given. Currently they are hard-coded
at 32GB and 8GB respectively, so we link with at most 4 jobs (or fewer if less
memory is available on the system)