### PR TITLE
py-thinc: added versions 8.1.10 and 8.3.10; and increased readability of complex dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/py_thinc/package.py
+++ b/repos/spack_repo/builtin/packages/py_thinc/package.py
@@ -70,5 +70,5 @@ class PyThinc(PythonPackage):
         depends_on("py-contextvars@2.4:2", when="@8.1.10:^python@3.6")
 
         # Historical
-        depends_on("py-plac@0.9.6:1.1")
-        depends_on("py-tqdm@4.10:4")
+        depends_on("py-plac@0.9.6:1.1", when="@:7.4.1")
+        depends_on("py-tqdm@4.10:4", when="@:7.4.1")

--- a/repos/spack_repo/builtin/packages/py_thinc/package.py
+++ b/repos/spack_repo/builtin/packages/py_thinc/package.py
@@ -16,6 +16,7 @@ class PyThinc(PythonPackage):
 
     license("MIT")
 
+    version("8.3.10", sha256="5a75109f4ee1c968fc055ce651a17cb44b23b000d9e95f04a4d047ab3cb3e34e")
     version("8.1.10", sha256="6c4a48d7da07e044e84a68cbb9b22f32f8490995a2bab0bfc60e412d14afb991")
     version("7.4.1", sha256="0139fa84dc9b8d88af15e648fc4ae13d899b8b5e49cb26a8f4a0604ee9ad8a9e")
     version("7.4.0", sha256="523e9be1bfaa3ed1d03d406ce451b6b4793a9719d5b83d2ea6b3398b96bc58b8")
@@ -23,13 +24,18 @@ class PyThinc(PythonPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    depends_on("python@3.6:", type=("build", "run"), when="@8.1.10:")
+    depends_on("python@3.6:", type=("build", "run"), when="@8.1.10")
+    depends_on("python@3.10:3.14", type=("build", "run"), when="@8.3.10:")
+
     depends_on("py-setuptools", type="build")
-    depends_on("py-cython@0.25:2", type="build", when="@8.1.10:")
+
+    depends_on("py-cython@0.25:2", type="build", when="@8.1.10")
+    depends_on("py-cython@3", type="build", when="@8.3.10:")
 
     with default_args(type=("build", "run")):
         depends_on("py-blis@0.4.0:0.4", when="@:7.4.1")
-        depends_on("py-blis@0.7.8:0.7", when="@8.1.10:")
+        depends_on("py-blis@0.7.8:0.7", when="@8.1.10")
+        depends_on("py-blis@1.3", when="@8.3.10:")
 
         depends_on("py-murmurhash@0.28:1.0", when="@:7.4.1")
         depends_on("py-murmurhash@1.0.2:1.0", when="@8.1.10:")
@@ -52,8 +58,11 @@ class PyThinc(PythonPackage):
 
         depends_on("py-numpy@1.7:", when="@:7.4.1")
         depends_on("py-numpy@1.15:", when="@8.1.10:")
+        depends_on("py-numpy@2:", when="@8.1.10:")
 
-        depends_on("py-pydantic@1.7.4:1.7,1.9:1.10", when="@8.1.10:")
+        depends_on("py-pydantic@1.7.4:1.7,1.9:1.10", when="@8.1.10")
+        depends_on("py-pydantic@2", when="@8.3.10:")
+
         depends_on("py-packaging@20:", when="@8.1.10:")
 
         depends_on("py-dataclasses@0.6:0", when="@8.1.10:^python@:3.6")

--- a/repos/spack_repo/builtin/packages/py_thinc/package.py
+++ b/repos/spack_repo/builtin/packages/py_thinc/package.py
@@ -16,20 +16,50 @@ class PyThinc(PythonPackage):
 
     license("MIT")
 
+    version("8.1.10", sha256="6c4a48d7da07e044e84a68cbb9b22f32f8490995a2bab0bfc60e412d14afb991")
     version("7.4.1", sha256="0139fa84dc9b8d88af15e648fc4ae13d899b8b5e49cb26a8f4a0604ee9ad8a9e")
     version("7.4.0", sha256="523e9be1bfaa3ed1d03d406ce451b6b4793a9719d5b83d2ea6b3398b96bc58b8")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
+    depends_on("python@3.6:", type=("build", "run"), when="@8.1.10:")
     depends_on("py-setuptools", type="build")
-    depends_on("py-murmurhash@0.28:1.0", type=("build", "run"))
-    depends_on("py-cymem@2.0.2:2.0", type=("build", "run"))
-    depends_on("py-preshed@1.0.1:3.0", type=("build", "run"))
-    depends_on("py-blis@0.4.0:0.4", type=("build", "run"))
-    depends_on("py-wasabi@0.0.9:1.0", type=("build", "run"))
-    depends_on("py-srsly@0.0.6:1.0", type=("build", "run"))
-    depends_on("py-catalogue@0.0.7:1.0", type=("build", "run"))
-    depends_on("py-numpy@1.7:", type=("build", "run"))
-    depends_on("py-plac@0.9.6:1.1", type=("build", "run"))
-    depends_on("py-tqdm@4.10:4", type=("build", "run"))
+    depends_on("py-cython@0.25:2", type="build", when="@8.1.10:")
+
+    with default_args(type=("build", "run")):
+        depends_on("py-blis@0.4.0:0.4", when="@:7.4.1")
+        depends_on("py-blis@0.7.8:0.7", when="@8.1.10:")
+
+        depends_on("py-murmurhash@0.28:1.0", when="@:7.4.1")
+        depends_on("py-murmurhash@1.0.2:1.0", when="@8.1.10:")
+
+        depends_on("py-cymem@2.0.2:2.0")
+
+        depends_on("py-preshed@1.0.1:3.0", when="@:7.4.1")
+        depends_on("py-preshed@3.0.2:3.0", when="@8.1.10:")
+
+        depends_on("py-wasabi@0.0.9:1.0", when="@:7.4.1")
+        depends_on("py-wasabi@0.8.1:1.1", when="@8.1.10:")
+
+        depends_on("py-srsly@0.0.6:1.0", when="@:7.4.1")
+        depends_on("py-srsly@2.4:2", when="@8.1.10:")
+
+        depends_on("py-catalogue@0.0.7:1.0", when="@:7.4.1")
+        depends_on("py-catalogue@2.0.4:2.0", when="@8.1.10:")
+
+        depends_on("py-confection@0.0.1:0", when="@8.1.10:")
+
+        depends_on("py-numpy@1.7:", when="@:7.4.1")
+        depends_on("py-numpy@1.15:", when="@8.1.10:")
+
+        depends_on("py-pydantic@1.7.4:1.7,1.9:1.10", when="@8.1.10:")
+        depends_on("py-packaging@20:", when="@8.1.10:")
+
+        depends_on("py-dataclasses@0.6:0", when="@8.1.10:^python@:3.6")
+        depends_on("py-typing-extensions@3.7.4.1:4.4", when="@8.1.10:^python@:3.7")
+        depends_on("py-contextvars@2.4:2", when="@8.1.10:^python@3.6")
+
+        # Historical
+        depends_on("py-plac@0.9.6:1.1")
+        depends_on("py-tqdm@4.10:4")

--- a/repos/spack_repo/builtin/packages/py_thinc/package.py
+++ b/repos/spack_repo/builtin/packages/py_thinc/package.py
@@ -24,7 +24,9 @@ class PyThinc(PythonPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    depends_on("python@3.6:", type=("build", "run"), when="@8.1.10")
+    # @8.1.10 minimum python version is 3.6. Set minimum version to 3.7 due to spack missing
+    # py-contextvars and 3.6 being deprecated in spack.
+    depends_on("python@3.7:", type=("build", "run"), when="@8.1.10")
     depends_on("python@3.10:3.14", type=("build", "run"), when="@8.3.10:")
 
     depends_on("py-setuptools", type="build")
@@ -65,9 +67,9 @@ class PyThinc(PythonPackage):
 
         depends_on("py-packaging@20:", when="@8.1.10:")
 
-        depends_on("py-dataclasses@0.6:0", when="@8.1.10:^python@:3.6")
+        # depends_on("py-dataclasses@0.6:0", when="@8.1.10:^python@:3.6")
         depends_on("py-typing-extensions@3.7.4.1:4.4", when="@8.1.10:^python@:3.7")
-        depends_on("py-contextvars@2.4:2", when="@8.1.10:^python@3.6")
+        # depends_on("py-contextvars@2.4:2", when="@8.1.10:^python@3.6")
 
         # Historical
         depends_on("py-plac@0.9.6:1.1", when="@:7.4.1")

--- a/repos/spack_repo/builtin/packages/py_thinc/package.py
+++ b/repos/spack_repo/builtin/packages/py_thinc/package.py
@@ -59,8 +59,8 @@ class PyThinc(PythonPackage):
         depends_on("py-confection@0.0.1:0", when="@8.1.10:")
 
         depends_on("py-numpy@1.7:", when="@:7.4.1")
-        depends_on("py-numpy@1.15:", when="@8.1.10:")
-        depends_on("py-numpy@2:", when="@8.1.10:")
+        depends_on("py-numpy@1.15:", when="@8.1.10")
+        depends_on("py-numpy@2:", when="@8.3.10:")
 
         depends_on("py-pydantic@1.7.4:1.7,1.9:1.10", when="@8.1.10")
         depends_on("py-pydantic@2", when="@8.3.10:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
