### PR TITLE
cudnn: add rpath to helper libraries for cudnn 8

### DIFF
--- a/repos/spack_repo/builtin/packages/cudnn/package.py
+++ b/repos/spack_repo/builtin/packages/cudnn/package.py
@@ -454,13 +454,12 @@ class Cudnn(Package):
     # and also not an issue in cudnn@9 comes with RPATH set to $ORIGIN
     # in all those helper libraries.
     # Note that libcudnn.so does come with the RPATH set.
-    @run_after("install")
+    @run_after("install", when="@8")
     def ensure_rpaths(self):
-        if self.spec.satisfies("@8"):
-            patchelf = which("patchelf")
-            for path in Path(self.prefix).rglob("*.so.*"):
-                if not path.is_symlink() and not path.name.startswith("libcudnn.so"):
-                    patchelf("--set-rpath", "$ORIGIN", str(path))
+        patchelf = which("patchelf")
+        for path in Path(self.prefix.lib).rglob("lib*.so.*"):
+            if not path.is_symlink() and not path.name.startswith("libcudnn.so"):
+                patchelf("--set-rpath", "$ORIGIN", str(path))
 
     # contains precompiled binaries without rpaths
     unresolved_libraries = ["*"]

--- a/repos/spack_repo/builtin/packages/cudnn/package.py
+++ b/repos/spack_repo/builtin/packages/cudnn/package.py
@@ -4,6 +4,7 @@
 
 import os
 import platform
+from pathlib import Path
 
 from spack_repo.builtin.build_systems.generic import Package
 
@@ -369,6 +370,8 @@ class Cudnn(Package):
                 cuda_ver = cuda_ver.up_to(1)
             depends_on(f"cuda@{cuda_ver}", when=f"@{long_ver}")
 
+    depends_on("patchelf", type="build", when="@8")
+
     def url_for_version(self, version):
         # Get the system and machine arch for building the file path
         sys = "{0}-{1}".format(platform.system(), platform.machine())
@@ -444,6 +447,20 @@ class Cudnn(Package):
             target_include = os.path.join(prefix, "targets", "ppc64le-linux", "include")
             if os.path.isdir(target_include) and not os.path.isdir(prefix.include):
                 symlink(target_include, prefix.include)
+
+    # CuDNN 8 does not have rpaths set in the helper libraries, which can cause
+    # issues if the LD_LIBRARY_PATH is not set at runtime.
+    # This is not an issue in cudnn@:7 as those only have one libcudnn.so file,
+    # and also not an issue in cudnn@9 comes with RPATH set to $ORIGIN
+    # in all those helper libraries.
+    # Note that libcudnn.so does come with the RPATH set.
+    @run_after("install")
+    def ensure_rpaths(self):
+        if self.spec.satisfies("@8"):
+            patchelf = which("patchelf")
+            for path in Path(self.prefix).rglob("*.so.*"):
+                if not path.is_symlink() and not path.name.startswith("libcudnn.so"):
+                    patchelf("--set-rpath", "$ORIGIN", str(path))
 
     # contains precompiled binaries without rpaths
     unresolved_libraries = ["*"]


### PR DESCRIPTION
CuDNN versions prior to 7 shipped with one library: `libcudnn.so`. This made linking easy as there is only one thing to link to.

CuDNN 8 changed this: the CuDNN library was split into 6 libraries and a shim `libcudnn.so`. To make sure `libcudnn.so` can find it's helper libraries, it has its rpath set to `$ORIGIN`. As all libs come into the same folder, this works fine for the most part. However, the individual split libraries do not have an rpath set, so they cannot see each other. When using pytorch this can lead to library not found errors during runtime, as the libraries do link to each other: e.g. `libcudnn_adv_infer.so` links to `libcudnn_ops_infer.so.8`

CuDNN 9 has the rpath set to `$ORIGIN` in all helper libraries off-the-shelf, so is not affected by this behavior. This PR adds that behavior to CuDNN 8.