### PR TITLE
munge: fix CVE-2026-25506

### DIFF
--- a/repos/spack_repo/builtin/packages/munge/package.py
+++ b/repos/spack_repo/builtin/packages/munge/package.py
@@ -18,6 +18,7 @@ class Munge(AutotoolsPackage):
 
     license("LGPL-3.0-only")
 
+    version("0.5.18", sha256="39c3ec6ef5604bfa206e8aa10fc05d5119040f6de4a554bc0fb98ca1aed838dc")
     version("0.5.15", sha256="3f979df117a34c74db8fe2835521044bdeb08e3b7d0f168ca97c3547f51da9ba")
     version("0.5.14", sha256="6606a218f18090fa1f702e3f6fb608073eb6aafed534cf7dd81b67b2e0d30640")
     version("0.5.13", sha256="99753dfd06a4f063c36f3fb0eb1964f394feb649937d94c4734d85b7964144da")
@@ -35,11 +36,25 @@ class Munge(AutotoolsPackage):
         description="Set local state path (possibly to /var)",
     )
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     depends_on("openssl")
     depends_on("libgcrypt")
     depends_on("bzip2")
+
+    # Below two patches fix CVE-2026-25506 in older versions of Munge
+    # Fix out-of-bounds read in credential decoding
+    patch(
+        "https://github.com/dun/munge/commit/5bd6d4db92dabdbed3aaf01ebd5f0d98944326bb.patch?full_index=1",
+        sha256="3145b60b1bf94fcca9b361d59140ea12b1a8b3e09d88181d7d73335580ca7a6f",
+        when="@:0.5.17",
+    )
+    # Fix buffer overflow allowing key leakage and credential forgery
+    patch(
+        "https://github.com/dun/munge/commit/bf40cc27c4ce8451d4b062c9de0b67ec40894812.patch?full_index=1",
+        sha256="05b4d63ea71d27db27eb7201fb907abf50dd2384b729be0f0a78c381ac4f6ccc",
+        when="@:0.5.17",
+    )
 
     def configure_args(self):
         args = []


### PR DESCRIPTION
Munge recently had [CVE-2026-25506](https://nvd.nist.gov/vuln/detail/CVE-2026-25506) reported. The CVE is no longer under embargo and is fixed in Munge `0.5.18`.

This adds Munge `0.5.18` along with patches for prior versions that fix the CVE.