### PR TITLE
py-pip: 26.0.1

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pip/package.py
+++ b/repos/spack_repo/builtin/packages/py_pip/package.py
@@ -26,6 +26,7 @@ class PyPip(Package, PythonExtension):
 
     license("MIT")
 
+    version("26.0.1", sha256="bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b")
     version("25.1.1", sha256="2913a38a2abf4ea6b64ab507bd9e967f3b53dc1ede74b01b0931e1ce548751af")
     version("25.1", sha256="13b4aa0aaad055020a11bec8a1c2a70a2b2d080e12d89b962266029fff0a16ba")
     version("25.0.1", sha256="c46efd13b6aa8279f33f2864459c8ce587ea6a1a59ee20de055868d8f7688f7f")


### PR DESCRIPTION
Extracted from mass bump PR because of build failures, let's see...

Edit: cause we have a handful `--global-option`s that need to be migrated.

