### PR TITLE
julia: needs readelf

### DIFF
--- a/repos/spack_repo/builtin/packages/julia/package.py
+++ b/repos/spack_repo/builtin/packages/julia/package.py
@@ -223,6 +223,7 @@ class Julia(MakefilePackage):
     depends_on("libwhich", type="build")
     depends_on("which", type="build")  # for detecting 7z, lld, dsymutil
     depends_on("python", type="build")
+    depends_on("binutils", type="build")  # for readelf
 
     depends_on("blas")  # note: for now openblas is fixed...
     depends_on("curl tls=mbedtls +nghttp2 +libssh2")


### PR DESCRIPTION
Closes #3258

~On some RHEL systems `readelf` is reportedly broken/unusable.~

Edit: RHEL doesn't deserve blame here, it's that `binutils` has an
enormous set of dependencies nowadays, and we set the env variable
`LD_LIBRARY_PATH` to tell Julia about certain link dependencies, which
in turn breaks system binutils. So, a second fix is in #3413.

In any case, it doesn't hurt to make binutils a build dep. In the past we
tried not to add compiler runtime dependencies to packages, but it's
fine now.

