### PR TITLE
qmcpack: add v4.2.0

### DIFF
--- a/repos/spack_repo/builtin/packages/qmcpack/package.py
+++ b/repos/spack_repo/builtin/packages/qmcpack/package.py
@@ -26,6 +26,7 @@ class Qmcpack(CMakePackage, CudaPackage):
     # can occasionally change.
     # NOTE: 12/19/2017 QMCPACK 3.0.0 does not build properly with Spack.
     version("develop")
+    version("4.2.0", tag="v4.2.0", commit="44a7f7e99a5770ea368b8ea35b181329606bc343")
     version("4.1.0", tag="v4.1.0", commit="c32123a5233186b177d75b800b86f1ad3b1a1413")
     version("4.0.0", tag="v4.0.0", commit="0199944fb644b4798446fdfc0549c81666a4a943")
     version("3.17.1", tag="v3.17.1", commit="9d0d968139fc33f71dbf9159f526dd7b47f10a3b")


### PR DESCRIPTION
Add latest release from https://github.com/QMCPACK/qmcpack/tags
