### PR TITLE
magma: add -Xfatbin -compress-all flags when compiling with cuda

### DIFF
--- a/repos/spack_repo/builtin/packages/magma/package.py
+++ b/repos/spack_repo/builtin/packages/magma/package.py
@@ -159,6 +159,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
             options.append(define("GPU_TARGET", capabilities))
             archs = ";".join("%s" % i for i in cuda_arch)
             options.append(define("CMAKE_CUDA_ARCHITECTURES", archs))
+            options.append(define("CMAKE_CUDA_FLAGS", " -Xfatbin -compress-all"))
 
         if "@2.5.0" in spec:
             options.append(define("MAGMA_SPARSE", False))


### PR DESCRIPTION
When compiling magma with a lot of cuda architectures (we got 6 in our heterogenous cluster!) the library can get over 2GB of code causing linker errors:

```
lib/libmagma.so: PC-relative offset overflow in PLT entry for `_Z24herk_template_batched_tnI6float2Li8ELi12ELi24ELi24ELi8ELi1ELi8ELi12ELi8ELi12ELi1ELi0EEv12magma_uplo_tiiPKPKT_iiiS6_iiiPPS2_iiiS2_S2_iP11magma_queue'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/magma.dir/build.make:23918: lib/libmagma.so] Error 1
make[2]: Leaving directory '/tmp/spackadmin/spack-stage/spack-stage-magma-2.9.0
```

The people over at Nix had the same [issue](https://github.com/NixOS/nixpkgs/pull/220402
) and looked at how PyTorch [solved it](https://github.com/pytorch/pytorch/blob/fe05266fda4f908130dea7cbac37e9264c0429a2/CMakeLists.txt#L548), as PyTorch ships with a dozen architectures for their conda builds.

This PR adds these flags for the CUDA builds and this fixed my linker issues.