### PR TITLE
mozjs: add 140.7.0 and fix build

### DIFF
--- a/repos/spack_repo/builtin/packages/mozjs/package.py
+++ b/repos/spack_repo/builtin/packages/mozjs/package.py
@@ -19,6 +19,7 @@ class Mozjs(AutotoolsPackage):
 
     license("MPL-2.0")
 
+    version("140.7.0", sha256="608a739071726f30236f7100ec5e30e1b8ec342d4e91e715948c287909cb1529")
     version("140.3.1", sha256="0b43b3a1c4f40765d96eb2094d38838f5d01b7280ad8b9b0a17612bed9c36735")
     version("128.1.0", sha256="ccdab622a395622abc6d80040a11715ad81a614f601db6672c05b98ac91fd9b5")
     version("115.28.0", sha256="91b52505f91ec8bc1ba93afc50c59a845a5f6a57fac4967df04d54906a14181a")
@@ -29,7 +30,8 @@ class Mozjs(AutotoolsPackage):
     depends_on("cxx", type="build")
 
     depends_on("curl", type="build")
-    depends_on("python", type="build")
+    depends_on("llvm", type="build")
+    depends_on("python@:3.13", type="build")
     depends_on("py-pip", type="build")
     depends_on("rust", type="build")
     depends_on("cbindgen@0.27:", type="build", when="@140:")


### PR DESCRIPTION
llvm is required to fix:
```
checking for llvm-objdump... not found
DEBUG: llvm_objdump: Looking for llvm-objdump
ERROR: Cannot find llvm-objdump
```

python@3.14 does not work due to:
```
AttributeError: module 'ast' has no attribute 'Str'
```