### PR TITLE
vim: 9.2

### DIFF
--- a/repos/spack_repo/builtin/packages/vim/package.py
+++ b/repos/spack_repo/builtin/packages/vim/package.py
@@ -25,6 +25,7 @@ class Vim(AutotoolsPackage):
     license("Vim")
 
     version("master", branch="master")
+    version("9.2.0000", sha256="875875fb5988af3db0726bef9b048a559a9563aa0ecca8240e82057e8e5941c3")
     version("9.1.2103", sha256="b0fb638adc1ee6e28c53ce734dc5a73bbdda044658df1257be790c50d6ff2749")
     version("9.1.1194", sha256="4575b9ae81cca6a304f165d16ea3c65f4864390001ed5d7bf000e55417153f30")
     version("9.1.0437", sha256="7024fbf8d0e8eec2eae21d279d487b60c58dc4ba3d42146388dc3743506d1fe6")
@@ -77,12 +78,17 @@ class Vim(AutotoolsPackage):
 
     def configure_args(self):
         spec = self.spec
-        args = ["--enable-fail-if-missing"]
+        args = [
+            "--enable-fail-if-missing",
+            "--without-wayland",
+            "--disable-canberra",
+            "--disable-libsodium",
+        ]
 
         def yes_or_no(variant):
             return "yes" if spec.variants[variant].value else "no"
 
-        if "+termlib" in spec["ncurses"]:
+        if spec.satisfies("%ncurses +termlib"):
             args.append("--with-tlib=tinfow")
         else:
             args.append("--with-tlib=ncursesw")
@@ -90,12 +96,8 @@ class Vim(AutotoolsPackage):
         args.append("--with-features=" + spec.variants["features"].value)
 
         if "+python" in spec:
-            if spec["python"].version >= Version("3"):
-                args.append("--enable-python3interp=dynamic")
-                args.append("--enable-pythoninterp=no")
-            else:
-                args.append("--enable-python3interp=no")
-                args.append("--enable-pythoninterp=dynamic")
+            args.append("--enable-python3interp=dynamic")
+            args.append("--enable-pythoninterp=no")
         else:
             args.append("--enable-python3interp=no")
 


### PR DESCRIPTION
Remove Python 2 support, make a few flags explicit.

