### PR TITLE
bats: add 1.13.0

### DIFF
--- a/repos/spack_repo/builtin/packages/bats/package.py
+++ b/repos/spack_repo/builtin/packages/bats/package.py
@@ -11,10 +11,11 @@ class Bats(Package):
     """Bats is a TAP-compliant testing framework for Bash."""
 
     homepage = "https://github.com/bats-core/bats-core"
-    url = "https://github.com/bats-core/bats-core/archive/refs/tags/v1.10.0.tar.gz"
+    url = "https://github.com/bats-core/bats-core/archive/refs/tags/v1.13.0.tar.gz"
 
     license("MIT")
 
+    version("1.13.0", sha256="a85e12b8828271a152b338ca8109aa23493b57950987c8e6dff97ba492772ff3")
     version("1.10.0", sha256="a1a9f7875aa4b6a9480ca384d5865f1ccf1b0b1faead6b47aa47d79709a5c5fd")
     version(
         "0.4.0",


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR adds version 1.13.0 of bats-core.

Ref: https://github.com/bats-core/bats-core/releases/tag/v1.13.0

Built tested locally, worked fine.