### PR TITLE
melissa & py-melissa: version 2.4.1, deprecating older versions

### DIFF
--- a/repos/spack_repo/builtin/packages/melissa/package.py
+++ b/repos/spack_repo/builtin/packages/melissa/package.py
@@ -18,13 +18,18 @@ class Melissa(CMakePackage):
     # attention: Git**Hub**.com accounts
     maintainers("abhishek1297", "raffino")
 
-    version("develop", branch="develop", preferred=True)
-    version("2.3.0", sha256="f356e05082e4bb26a210cd11ccfa78a783ebe07be2bd75d5e51ed10da3b58997")
-    version("2.2.0", sha256="e805c9ac08de5aa666768d5d92bfc680f064bd9108415a911dfd08ad7b0a3cf3")
-    version("2.1.1", sha256="6b92852429f13b144860edc37c7914723addabb0ec0bd108929ff567334d3f71")
-    version("2.1.0", sha256="cf0f105ed5b1da260cc7476aec23df084470b50a61df997c0e457c38948bed93")
-    version("2.0.1", sha256="a7ff4df75ea09af435b0c28c3fa3cab9335c1c76e1c48757facce36786b4962c")
-    version("2.0.0", sha256="75957d1933cd9c228a6e8643bc855587162c31f3b0ca94c3f5e0e380d01775dd")
+    version(
+        "2.4.0",
+        sha256="932d09a94c1794911683b027b817370c84a122cfa04765ab082488704b689962",
+        preferred=True,
+    )
+    with default_args(deprecated=True):
+        version("2.3.0", sha256="f356e05082e4bb26a210cd11ccfa78a783ebe07be2bd75d5e51ed10da3b58997")
+        version("2.2.0", sha256="e805c9ac08de5aa666768d5d92bfc680f064bd9108415a911dfd08ad7b0a3cf3")
+        version("2.1.1", sha256="6b92852429f13b144860edc37c7914723addabb0ec0bd108929ff567334d3f71")
+        version("2.1.0", sha256="cf0f105ed5b1da260cc7476aec23df084470b50a61df997c0e457c38948bed93")
+        version("2.0.1", sha256="a7ff4df75ea09af435b0c28c3fa3cab9335c1c76e1c48757facce36786b4962c")
+        version("2.0.0", sha256="75957d1933cd9c228a6e8643bc855587162c31f3b0ca94c3f5e0e380d01775dd")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")
@@ -43,10 +48,6 @@ class Melissa(CMakePackage):
         depends_on("libzmq@4.2:4")
         depends_on("mpi")
 
-    def setup_build_environment(self, env):
-        zmq_pkgconfig_path = self.spec["libzmq"].prefix.lib.pkgconfig
-        env.prepend_path("PKG_CONFIG_PATH", zmq_pkgconfig_path)
-
     def cmake_args(self):
         args = []
 
@@ -57,7 +58,6 @@ class Melissa(CMakePackage):
 
             args.append(f"-DCMAKE_INSTALL_RPATH={joined_rpaths}")
             args.append("-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON")
-
         return args
 
     def setup_run_environment(self, env):

--- a/repos/spack_repo/builtin/packages/melissa/package.py
+++ b/repos/spack_repo/builtin/packages/melissa/package.py
@@ -19,8 +19,8 @@ class Melissa(CMakePackage):
     maintainers("abhishek1297", "raffino")
 
     version(
-        "2.4.0",
-        sha256="932d09a94c1794911683b027b817370c84a122cfa04765ab082488704b689962",
+        "2.4.1",
+        sha256="92a8c7f823ef79c8a5eb05b67120e130c9b03bf7fecd635b4ae9501eb32b2fd7",
         preferred=True,
     )
     with default_args(deprecated=True):

--- a/repos/spack_repo/builtin/packages/py_melissa_core/package.py
+++ b/repos/spack_repo/builtin/packages/py_melissa_core/package.py
@@ -22,13 +22,18 @@ class PyMelissaCore(PythonPackage, CudaPackage):
 
     license("BSD-3-Clause")
 
-    version("develop", branch="develop", preferred=True)
-    version("2.3.0", sha256="f356e05082e4bb26a210cd11ccfa78a783ebe07be2bd75d5e51ed10da3b58997")
-    version("2.2.0", sha256="e805c9ac08de5aa666768d5d92bfc680f064bd9108415a911dfd08ad7b0a3cf3")
-    version("2.1.1", sha256="6b92852429f13b144860edc37c7914723addabb0ec0bd108929ff567334d3f71")
-    version("2.1.0", sha256="cf0f105ed5b1da260cc7476aec23df084470b50a61df997c0e457c38948bed93")
-    version("2.0.1", sha256="a7ff4df75ea09af435b0c28c3fa3cab9335c1c76e1c48757facce36786b4962c")
-    version("2.0.0", sha256="75957d1933cd9c228a6e8643bc855587162c31f3b0ca94c3f5e0e380d01775dd")
+    version(
+        "2.4.0",
+        sha256="932d09a94c1794911683b027b817370c84a122cfa04765ab082488704b689962",
+        preferred=True,
+    )
+    with default_args(deprecated=True):
+        version("2.3.0", sha256="f356e05082e4bb26a210cd11ccfa78a783ebe07be2bd75d5e51ed10da3b58997")
+        version("2.2.0", sha256="e805c9ac08de5aa666768d5d92bfc680f064bd9108415a911dfd08ad7b0a3cf3")
+        version("2.1.1", sha256="6b92852429f13b144860edc37c7914723addabb0ec0bd108929ff567334d3f71")
+        version("2.1.0", sha256="cf0f105ed5b1da260cc7476aec23df084470b50a61df997c0e457c38948bed93")
+        version("2.0.1", sha256="a7ff4df75ea09af435b0c28c3fa3cab9335c1c76e1c48757facce36786b4962c")
+        version("2.0.0", sha256="75957d1933cd9c228a6e8643bc855587162c31f3b0ca94c3f5e0e380d01775dd")
 
     # define variants for the deep learning server (torch, tf)
     variant(
@@ -56,7 +61,7 @@ class PyMelissaCore(PythonPackage, CudaPackage):
 
     with default_args(type="run"):
         depends_on("py-pyzmq@22.3.0:")
-        depends_on("py-mpi4py@3.1.3:3")
+        depends_on("py-mpi4py@3.1.3:")
         depends_on("py-numpy@1.21:1")
         depends_on("py-jsonschema@4.5:")
         depends_on("py-python-rapidjson@1.8:")

--- a/repos/spack_repo/builtin/packages/py_melissa_core/package.py
+++ b/repos/spack_repo/builtin/packages/py_melissa_core/package.py
@@ -61,7 +61,8 @@ class PyMelissaCore(PythonPackage, CudaPackage):
 
     with default_args(type="run"):
         depends_on("py-pyzmq@22.3.0:")
-        depends_on("py-mpi4py@3.1.3:")
+        depends_on("py-mpi4py@3.1.3:3", when="@:2.3.0")
+        depends_on("py-mpi4py@3.1.3:", when="@2.4.0")
         depends_on("py-numpy@1.21:1")
         depends_on("py-jsonschema@4.5:")
         depends_on("py-python-rapidjson@1.8:")

--- a/repos/spack_repo/builtin/packages/py_melissa_core/package.py
+++ b/repos/spack_repo/builtin/packages/py_melissa_core/package.py
@@ -23,8 +23,8 @@ class PyMelissaCore(PythonPackage, CudaPackage):
     license("BSD-3-Clause")
 
     version(
-        "2.4.0",
-        sha256="932d09a94c1794911683b027b817370c84a122cfa04765ab082488704b689962",
+        "2.4.1",
+        sha256="92a8c7f823ef79c8a5eb05b67120e130c9b03bf7fecd635b4ae9501eb32b2fd7",
         preferred=True,
     )
     with default_args(deprecated=True):
@@ -62,7 +62,7 @@ class PyMelissaCore(PythonPackage, CudaPackage):
     with default_args(type="run"):
         depends_on("py-pyzmq@22.3.0:")
         depends_on("py-mpi4py@3.1.3:3", when="@:2.3.0")
-        depends_on("py-mpi4py@3.1.3:", when="@2.4.0")
+        depends_on("py-mpi4py@3.1.3:", when="@2.4:")
         depends_on("py-numpy@1.21:1")
         depends_on("py-jsonschema@4.5:")
         depends_on("py-python-rapidjson@1.8:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->


### Updates:
- Added `v2.4.1` (keeping as preferred)
- Removed `develop` as it will no longer support separate installation (`melissa` & `py-melissa-core`)
- Deprecated older versions
- Removed upper bound for `mpi4py` `@2.4.1`
- Removed `setup_build_environment` (sanity additions related to `PKG_CONFIG_PATH`)