### PR TITLE
zlib: fix indentation in determine_version method

### DIFF
--- a/repos/spack_repo/builtin/packages/zlib/package.py
+++ b/repos/spack_repo/builtin/packages/zlib/package.py
@@ -56,9 +56,9 @@ class Zlib(MakefilePackage, Package):
                     pattern = re.compile(rf"{library}\.(\d+\.\d+\.\d+)\.{ext}")
                 else:
                     pattern = re.compile(rf"{library}\.{ext}\.(\d+\.\d+\.\d+)")
-                    match = re.search(pattern, lib)
-                    if match:
-                        return match.group(1)
+                match = re.search(pattern, lib)
+                if match:
+                    return match.group(1)
 
     @property
     def libs(self):


### PR DESCRIPTION
The pattern matching logic in the determine_version method had incorrect indentation, causing the search and match check to only run in the 'else' branch of the if statement. This fix ensures the pattern matching happens for both dylib and other file extensions.

Discovered and implemented by claude-code while experimenting with what claude can do. I asked claude to look at the packaging guide docs and asked what we should change about the zlib package. This is what it came up with. I believe it is correct.
