### PR TITLE
emacs: improve platform conditionals

### DIFF
--- a/repos/spack_repo/builtin/packages/emacs/package.py
+++ b/repos/spack_repo/builtin/packages/emacs/package.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import sys
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack_repo.builtin.build_systems.gnu import GNUMirrorPackage
@@ -119,7 +118,7 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
     patch("disable-posix-spawn-macos.patch", when="@28:30.2 platform=darwin os=sequoia")
     patch("disable-posix-spawn-macos.patch", when="@28:30.2 platform=darwin os=sonoma")
 
-    def configure_args(self):
+    def configure_args(self) -> list:
         args = []
 
         gui = self.spec.variants["gui"].value
@@ -131,7 +130,7 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
             args.append("--disable-ns-self-contained")
         else:
             args.append("--without-x")
-            if sys.platform == "darwin":
+            if self.spec.satisfies("platform=darwin"):
                 args.append("--without-ns")
 
         args.extend(self.with_or_without("native-compilation", variant="native"))

--- a/repos/spack_repo/builtin/packages/emacs/package.py
+++ b/repos/spack_repo/builtin/packages/emacs/package.py
@@ -118,7 +118,7 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
     patch("disable-posix-spawn-macos.patch", when="@28:30.2 platform=darwin os=sequoia")
     patch("disable-posix-spawn-macos.patch", when="@28:30.2 platform=darwin os=sonoma")
 
-    def configure_args(self) -> list:
+    def configure_args(self):
         args = []
 
         gui = self.spec.variants["gui"].value


### PR DESCRIPTION
Removed a dependency on `sys` by swapping to `self.spec.satisfies()` as is currently recommended in the docs.