### PR TITLE
openmpi: swap to spec.satisfies(), %direct-dependencies, and f-strings

### DIFF
--- a/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -1199,13 +1199,13 @@ with '-Wl,-commons,use_dylibs' and without
 
         # Package dependencies
         for dep in ["lustre", "valgrind"]:
-            if spec.satisfies(f"^{dep}"):
+            if spec.satisfies(f"%{dep}"):
                 config_args.append(f"--with-{dep}={spec[dep].prefix}")
 
         # libevent support
         if spec.satisfies("+internal-libevent"):
             config_args.append("--with-libevent=internal")
-        elif spec.satisfies("^libevent"):
+        elif spec.satisfies("%libevent"):
             config_args.append(f"--with-libevent={spec['libevent'].prefix}")
 
         # PMIx/PRRTE support
@@ -1213,18 +1213,18 @@ with '-Wl,-commons,use_dylibs' and without
             config_args.append("--with-pmix=internal")
             config_args.append("--with-prrte=internal")
         else:
-            if spec.satisfies("^pmix"):
+            if spec.satisfies("%pmix"):
                 config_args.append(f"--with-pmix={spec['pmix'].prefix}")
-            if spec.satisfies("^prrte"):
+            if spec.satisfies("%prrte"):
                 config_args.append(f"--with-prrte={spec['prrte'].prefix}")
 
-        if spec.satisfies("^zlib-api"):
+        if spec.satisfies("%zlib-api"):
             config_args.append(f"--with-zlib={spec['zlib-api'].prefix}")
 
         # Hwloc support
         if spec.satisfies("+internal-hwloc"):
             config_args.append("--with-hwloc=internal")
-        elif spec.satisfies("^hwloc"):
+        elif spec.satisfies("%hwloc"):
             config_args.append(f"--with-hwloc={spec['hwloc'].prefix}")
 
         # Java support

--- a/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -1150,7 +1150,7 @@ with '-Wl,-commons,use_dylibs' and without
         config_args.extend(self.enable_or_disable("builtin-atomics", variant="atomics"))
 
         if spec.satisfies("+pmi"):
-            config_args.append("--with-pmi={0}".format(spec["slurm"].prefix))
+            config_args.append(f"--with-pmi={spec['slurm'].prefix}")
         else:
             config_args.extend(self.with_or_without("pmi"))
 
@@ -1191,7 +1191,7 @@ with '-Wl,-commons,use_dylibs' and without
             config_args.extend(self.with_or_without("schedulers"))
 
         if spec.satisfies("schedulers=lsf"):
-            config_args.append("--with-lsf-libdir={0}".format(spec["lsf"].libs.directories[0]))
+            config_args.append(f"--with-lsf-libdir={spec['lsf'].libs.directories[0]}")
 
         config_args.extend(self.enable_or_disable("memchecker"))
         if spec.satisfies("+memchecker"):
@@ -1199,44 +1199,44 @@ with '-Wl,-commons,use_dylibs' and without
 
         # Package dependencies
         for dep in ["lustre", "valgrind"]:
-            if "^" + dep in spec:
-                config_args.append("--with-{0}={1}".format(dep, spec[dep].prefix))
+            if spec.satisfies(f"^{dep}"):
+                config_args.append(f"--with-{dep}={spec[dep].prefix}")
 
         # libevent support
         if spec.satisfies("+internal-libevent"):
             config_args.append("--with-libevent=internal")
-        elif "^libevent" in spec:
-            config_args.append("--with-libevent={0}".format(spec["libevent"].prefix))
+        elif spec.satisfies("^libevent"):
+            config_args.append(f"--with-libevent={spec['libevent'].prefix}")
 
         # PMIx/PRRTE support
         if spec.satisfies("+internal-pmix"):
             config_args.append("--with-pmix=internal")
             config_args.append("--with-prrte=internal")
         else:
-            if "^pmix" in spec:
-                config_args.append("--with-pmix={0}".format(spec["pmix"].prefix))
-            if "^prrte" in spec:
-                config_args.append("--with-prrte={0}".format(spec["prrte"].prefix))
+            if spec.satisfies("^pmix"):
+                config_args.append(f"--with-pmix={spec['pmix'].prefix}")
+            if spec.satisfies("^prrte"):
+                config_args.append(f"--with-prrte={spec['prrte'].prefix}")
 
-        if "^zlib-api" in spec:
-            config_args.append("--with-zlib={0}".format(spec["zlib-api"].prefix))
+        if spec.satisfies("^zlib-api"):
+            config_args.append(f"--with-zlib={spec['zlib-api'].prefix}")
 
         # Hwloc support
         if spec.satisfies("+internal-hwloc"):
             config_args.append("--with-hwloc=internal")
-        elif "^hwloc" in spec:
-            config_args.append("--with-hwloc=" + spec["hwloc"].prefix)
+        elif spec.satisfies("^hwloc"):
+            config_args.append(f"--with-hwloc={spec['hwloc'].prefix}")
 
         # Java support
-        if "+java" in spec:
+        if spec.satisfies("+java"):
             config_args.extend(
-                ["--enable-java", "--enable-mpi-java", "--with-jdk-dir=" + spec["java"].home]
+                ["--enable-java", "--enable-mpi-java", f"--with-jdk-dir={spec['java'].home}"]
             )
         elif spec.satisfies("@1.7.4:"):
             config_args.extend(["--disable-java", "--disable-mpi-java"])
 
         # Romio
-        if "~romio" in spec:
+        if spec.satisfies("~romio"):
             config_args.append("--disable-io-romio")
 
         if not spec.satisfies("romio-filesystem=none"):


### PR DESCRIPTION
Package maintenance to bring `openmpi` up to date with modern packaging recommendations in the packaging guide.