### PR TITLE
acts: add v45.1.0 and v45.1.1

### DIFF
--- a/repos/spack_repo/builtin/packages/acts/package.py
+++ b/repos/spack_repo/builtin/packages/acts/package.py
@@ -50,6 +50,8 @@ class Acts(CMakePackage, CudaPackage):
 
     # Supported Acts versions
     version("main", branch="main")
+    version("45.1.1", commit="da50efc7b15cad8fdc5e194719c72d7d8b706823")
+    version("45.1.0", commit="061a9d87b0fc07b554ec0b3849e875cf964f8323")
     version("45.0.0", commit="92ab57740f8e875555ea28f542844ac1eb5db65b")
     version("44.4.0", commit="a05c35a14b39a461925d11de12ccd2da5e38b3d1")
     version("44.3.0", commit="d4c630145d5050dd2edc58f1de0c872caff23dd8")


### PR DESCRIPTION
This commit adds two new versions of the ACTS package: v45.1.0 and v45.1.1.
