### PR TITLE
llvm: fewer targets by default

### DIFF
--- a/repos/spack_repo/builtin/packages/llvm/package.py
+++ b/repos/spack_repo/builtin/packages/llvm/package.py
@@ -211,7 +211,7 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
     )
     variant(
         "targets",
-        default="all",
+        default="aarch64,amdgpu,nvptx,x86",
         description=(
             "What targets to build. Spack's target family is always added "
             "(e.g. X86 is automatically enabled when targeting znver2)."


### PR DESCRIPTION
This is about 1000 fewer source files to build and a reasonable default IMO: x86/aarch64 for the CPU, amdgpu/nvptx for the GPU.

On the fence about webassembly / bpf, but I think it's fine like this.

