### PR TITLE
acts: improve variant dependency handling

### DIFF
--- a/repos/spack_repo/builtin/packages/acts/package.py
+++ b/repos/spack_repo/builtin/packages/acts/package.py
@@ -237,24 +237,12 @@ class Acts(CMakePackage, CudaPackage):
     }
     variant("cxxstd", default="17", when="@:35", **_cxxstd_common)
     variant("cxxstd", default="20", when="@36:", **_cxxstd_common)
-    variant(
-        "examples",
-        default=False,
-        description="Build the examples",
-        when="@0.23:16 +digitization +fatras +identification +json +root",
-    )
-    variant(
-        "examples",
-        default=False,
-        description="Build the examples",
-        when="@17:34 +fatras +identification +json +root",
-    )
-    variant(
-        "examples",
-        default=False,
-        description="Build the examples",
-        when="@35: +fatras +json +root",
-    )
+    variant("examples", default=False, description="Build the examples", when="@0.23:")
+    requires("+digitization", when="@:16 +examples")
+    requires("+identification", when="@:34 +examples")
+    requires("+root", when="+examples")
+    requires("+fatras", when="+examples")
+    requires("+json", when="+examples")
     variant("integration_tests", default=False, description="Build the integration tests")
     variant("unit_tests", default=False, description="Build the unit tests")
     variant(
@@ -308,8 +296,9 @@ class Acts(CMakePackage, CudaPackage):
         "torch",
         default=False,
         description="Build the torch based parts of the GNN plugin",
-        when="@44: +gnn",
+        when="@44:",
     )
+    requires("+gnn", when="+torch")
     variant("odd", default=False, description="Build the Open Data Detector", when="@19.1:")
     variant("podio", default=False, description="Build Podio plugin", when="@30.3:")
     variant(
@@ -333,14 +322,10 @@ class Acts(CMakePackage, CudaPackage):
     # and we use ROOT instead. We then "deprecate" the TGeo naming by
     # eliminating it in ACTS release 45. Finally, we retain the TGeo naming
     # until version 44 of ACTS is removed due to deprecation.
-    variant(
-        "tgeo", default=False, description="Build the TGeo plugin", when="@:34 +identification"
-    )
-    variant("tgeo", default=False, description="Build the TGeo plugin", when="@35:44")
-    variant(
-        "root", default=False, description="Build the ROOT plugin", when="@:34 +identification"
-    )
-    variant("root", default=False, description="Build the ROOT plugin", when="@35:")
+    variant("tgeo", default=False, description="Build the TGeo plugin", when="@:44")
+    requires("+identification", when="@:34 +tgeo")
+    variant("root", default=False, description="Build the ROOT plugin")
+    requires("+identification", when="@:34 +root")
     # Establish a mutual implication between the tgeo and root variants; if
     # one is enabled, so must be the other.
     with when("@:44"):
@@ -348,6 +333,8 @@ class Acts(CMakePackage, CudaPackage):
         conflicts("+root", when="~tgeo")
 
     variant("traccc", default=False, description="Build the Traccc plugin", when="@35.1:")
+    requires("+svg", when="+traccc")
+    requires("+json", when="+traccc")
 
     # Variants that only affect Acts examples for now
     variant(
@@ -512,10 +499,6 @@ class Acts(CMakePackage, CudaPackage):
     with when("+traccc"):
         for _scalar in _scalar_values:
             depends_on(f"detray scalar={_scalar}", when=f"scalar={_scalar}")
-
-    # ACTS enables certain options anyway based on other options
-    conflicts("~svg", when="+traccc")
-    conflicts("~json", when="+traccc")
 
     # ACTS has been using C++17 for a while, which precludes use of old GCC
     conflicts("%gcc@:7", when="@0.23:")

--- a/repos/spack_repo/builtin/packages/acts/package.py
+++ b/repos/spack_repo/builtin/packages/acts/package.py
@@ -238,11 +238,12 @@ class Acts(CMakePackage, CudaPackage):
     variant("cxxstd", default="17", when="@:35", **_cxxstd_common)
     variant("cxxstd", default="20", when="@36:", **_cxxstd_common)
     variant("examples", default=False, description="Build the examples", when="@0.23:")
-    requires("+digitization", when="@:16 +examples")
-    requires("+identification", when="@:34 +examples")
-    requires("+root", when="+examples")
-    requires("+fatras", when="+examples")
-    requires("+json", when="+examples")
+    with when("+examples"):
+        requires("+digitization", when="@:16")
+        requires("+identification", when="@:34")
+        requires("+root")
+        requires("+fatras")
+        requires("+json")
     variant("integration_tests", default=False, description="Build the integration tests")
     variant("unit_tests", default=False, description="Build the unit tests")
     variant(


### PR DESCRIPTION
The ACTS package currently defines a lot of variants with `when` clauses based on other variants. This makes it difficult to add and remove requirements in a granular way as new versions get added: it requires the re-declaration of the variant multiple times. In order to streamline this process, I migrated the dependencies between variants to using `requires` statements instead.