### PR TITLE
py-setuptools: add v82.0.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_gevent/package.py
+++ b/repos/spack_repo/builtin/packages/py_gevent/package.py
@@ -53,6 +53,9 @@ class PyGevent(PythonPackage):
     depends_on("py-zope-event", when="@20.5.1:", type=("build", "run"))
     depends_on("py-zope-interface", when="@20.5.1:", type=("build", "run"))
 
+    # https://github.com/pypa/distutils/pull/335
+    depends_on("py-setuptools@:80", type=("build", "run"))
+
     # https://github.com/gevent/gevent/issues/2076
     conflicts("^py-cython@3.1:", when="@:24.10.3")
     # https://github.com/gevent/gevent/issues/1599

--- a/repos/spack_repo/builtin/packages/py_llvmlite/package.py
+++ b/repos/spack_repo/builtin/packages/py_llvmlite/package.py
@@ -43,6 +43,9 @@ class PyLlvmlite(PythonPackage):
         depends_on("binutils", when="platform=linux")
         depends_on("py-setuptools")
 
+        # https://github.com/numba/llvmlite/pull/1400
+        depends_on("py-setuptools@:80", when="@:0.46")
+
     # Based on PyPI wheel availability
     with default_args(type=("build", "run")):
         depends_on("python@3.10:3.14", when="@0.46:")

--- a/repos/spack_repo/builtin/packages/py_petsc4py/package.py
+++ b/repos/spack_repo/builtin/packages/py_petsc4py/package.py
@@ -109,6 +109,9 @@ class PyPetsc4py(PythonPackage):
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-mpi4py", when="+mpi", type=("build", "run"))
 
+    # https://github.com/pypa/distutils/pull/335
+    depends_on("py-setuptools@:80", type="build")
+
     depends_on("petsc+mpi", when="+mpi")
     depends_on("petsc~mpi", when="~mpi")
     depends_on("petsc@main", when="@main")

--- a/repos/spack_repo/builtin/packages/py_petsc4py/package.py
+++ b/repos/spack_repo/builtin/packages/py_petsc4py/package.py
@@ -109,8 +109,8 @@ class PyPetsc4py(PythonPackage):
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-mpi4py", when="+mpi", type=("build", "run"))
 
-    # https://github.com/pypa/distutils/pull/335
-    depends_on("py-setuptools@:80", type="build")
+    # https://gitlab.com/petsc/petsc/-/merge_requests/9016
+    depends_on("py-setuptools@:80", when="@:3.24.4", type="build")
 
     depends_on("petsc+mpi", when="+mpi")
     depends_on("petsc~mpi", when="~mpi")

--- a/repos/spack_repo/builtin/packages/py_protobuf/package.py
+++ b/repos/spack_repo/builtin/packages/py_protobuf/package.py
@@ -75,6 +75,9 @@ class PyProtobuf(PythonPackage):
     depends_on("py-setuptools", type=("build", "run"))
     depends_on("py-six@1.9:", when="@3.0:3.17", type=("build", "run"))
 
+    # https://github.com/protocolbuffers/protobuf/pull/22447
+    depends_on("py-setuptools@:81", when="@:6.31", type=("build", "run"))
+
     # https://protobuf.dev/support/version-support/#python
     for ver in range(30, 33):
         depends_on(f"protobuf@{ver}", when=f"@6.{ver}")

--- a/repos/spack_repo/builtin/packages/py_setuptools/package.py
+++ b/repos/spack_repo/builtin/packages/py_setuptools/package.py
@@ -24,6 +24,7 @@ class PySetuptools(Package, PythonExtension):
     # Requires railroad
     skip_modules = ["setuptools._vendor", "pkg_resources._vendor"]
 
+    version("82.0.0", sha256="70b18734b607bd1da571d097d236cfcfacaf01de45717d59e6e04b96877532e0")
     version("80.9.0", sha256="062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922")
     version("79.0.1", sha256="e147c0549f27767ba362f9da434eab9c5dc0045d5304feb602a0af001089fc51")
     version("78.1.1", sha256="c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561")


### PR DESCRIPTION
Honestly just want to see how many packages break due to the removal of `pkg_resources`. I've already fixed a couple, but I know there are a lot more.

FYI @haampie @alalazo 