### PR TITLE
ncbi-vdb, sra-tools: Updated

### DIFF
--- a/repos/spack_repo/builtin/packages/ncbi_vdb/package.py
+++ b/repos/spack_repo/builtin/packages/ncbi_vdb/package.py
@@ -15,6 +15,7 @@ class NcbiVdb(CMakePackage):
     homepage = "https://github.com/ncbi/ncbi-vdb"
     git = "https://github.com/ncbi/ncbi-vdb.git"
 
+    version("3.3.0", tag="3.3.0", commit="41a6b24fa8128253912fc1f0b44f06a314a59f9c")
     version("3.0.2", tag="3.0.2", commit="c4aa19632714c2f04af07505721fb16c71bba3d5")
     version("3.0.0", tag="3.0.0", commit="2222d7727122d0cbad93344dd6a9044abff34280")
 

--- a/repos/spack_repo/builtin/packages/sra_tools/package.py
+++ b/repos/spack_repo/builtin/packages/sra_tools/package.py
@@ -14,6 +14,7 @@ class SraTools(CMakePackage):
     homepage = "https://github.com/ncbi/sra-tools"
     git = "https://github.com/ncbi/sra-tools.git"
 
+    version("3.3.0", tag="3.3.0", commit="a7fff20b1a8c1dcf1586dd1a32460b9d2dfb9392")
     version("3.0.3", tag="3.0.3", commit="01f0aa21bb20b84c68ea34404d43da680811e27a")
     version("3.0.0", tag="3.0.0", commit="bd2053a1049e64207e75f4395fd1be7f1572a5aa")
 
@@ -25,15 +26,26 @@ class SraTools(CMakePackage):
     depends_on("libxml2")
     depends_on("ncbi-vdb")
     depends_on("ncbi-vdb@3.0.2:", when="@3.0.3:")
+    depends_on("ncbi-vdb@3.3.0:", when="@3.3.0:")
+
+    variant("internal", default=False, description="Build internal tools", when="@3.0.1:")
+    variant("loaders", default=False, description="Build loaders", when="@3.0.1:")
+    variant("test", default=False, description="Build test tools", when="@3.0.1:")
 
     # The CMakeLists.txt  file set the path to ${TARGDIR}/obj but the code
     # actually uses ${TARGDIR}.
-    patch("ngs-java.patch")
+    patch("ngs-java.patch", when="@:3.0.3")
+
+    # Escape CMAKE_PREFIX_PATH, allow compilation w/o ncbi-vdb being in same directory
+    patch("path.patch", when="@3.1.1:")
 
     def cmake_args(self):
         args = [
             self.define("VDB_INCDIR", format(self.spec["ncbi-vdb"].prefix) + "/include"),
             self.define("VDB_LIBDIR", format(self.spec["ncbi-vdb"].prefix) + "/lib64"),
             self.define("VDB_BINDIR", format(self.spec["ncbi-vdb"].prefix)),
+            self.define_from_variant("BUILD_TOOLS_INTERNAL", "internal"),
+            self.define_from_variant("BUILD_TOOLS_LOADERS", "loaders"),
+            self.define_from_variant("BUILD_TOOLS_TEST_TOOLS", "test"),
         ]
         return args

--- a/repos/spack_repo/builtin/packages/sra_tools/path.patch
+++ b/repos/spack_repo/builtin/packages/sra_tools/path.patch
@@ -1,0 +1,30 @@
+diff --git a/tools/external/driver-tool/CMakeLists.txt b/tools/external/driver-tool/CMakeLists.txt
+index 1baf97e7..75d0c912 100644
+--- a/tools/external/driver-tool/CMakeLists.txt
++++ b/tools/external/driver-tool/CMakeLists.txt
+@@ -109,7 +109,11 @@ if( WIN32 )
+         Ws2_32 Crypt32 ShLwApi PathCch
+     )
+ else()
+-    list(APPEND compile_defs PREFIX_PATH="${CMAKE_PREFIX_PATH}" BUILD_PATH="${BINDIR}")
++    string(REPLACE ";" ":" ESCAPED_PREFIX_PATH "${CMAKE_PREFIX_PATH}")
++    list(APPEND compile_defs
++      PREFIX_PATH="${ESCAPED_PREFIX_PATH}"
++      BUILD_PATH="${BINDIR}"
++    )
+ endif()
+ 
+ GenerateExecutableWithDefs(sratools "${sources}" "${compile_defs}" "" "${link_libs}")
+diff --git a/tools/loaders/sharq/version.h b/tools/loaders/sharq/version.h
+index 145ccac3..de685271 100644
+--- a/tools/loaders/sharq/version.h
++++ b/tools/loaders/sharq/version.h
+@@ -18,6 +18,7 @@
+ #define SHARQ_VERSION ( to_string(TOOLKIT_VERS >> 24) + "." + to_string((TOOLKIT_VERS >> 16) & 0x00ff) + "." + to_string(TOOLKIT_VERS & 0xffff) )
+ 
+ #include <klib/sra-release-version.h>
+-#include <../libs/kapp/version-hash.h> //TODO: relocate to sra-tools/kapp
++#define HASH_NCBI_VDB ""
++#define HASH_SRA_TOOLS ""
+ 
+ #endif


### PR DESCRIPTION
This PR brings ncbi-vdb and sra-tools up to the latest version 3.3.0.

Combining these in one PR as sra-tools appears to be version-dependent on ncbi-vdb being the same version as it is.

An additional patch is created that fixes a problem I encountered when the "CMAKE_PREFIX_PATH" variable has more than 1 path, as well as allows sra-tools to compile w/o ncbi-vdb being in the same directory (which would be required with the `#include <../libs/kapp/version-hash.h>` statement.)

There are no maintainers to mention.