### PR TITLE
openPMD-api: Fix pybind11 3.0.2

### DIFF
--- a/repos/spack_repo/builtin/packages/openpmd_api/package.py
+++ b/repos/spack_repo/builtin/packages/openpmd_api/package.py
@@ -124,6 +124,13 @@ class OpenpmdApi(CMakePackage):
         when="@0.16.0",
     )
 
+    # Python property lifetime fix & pybind11 3.0.2 support
+    patch(
+        "https://github.com/openPMD/openPMD-api/pull/1849.patch?full_index=1",
+        sha256="0fda91f9f1227832766dadacf12bfb5119cd179e60a73ccff15ac8c77b86b7ec",
+        when="@0.17.0 +python",
+    )
+
     extends("python", when="+python")
 
     def cmake_args(self):


### PR DESCRIPTION
Hotfix: Python property lifetime fix & pybind11 3.0.2 support

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
