### PR TITLE
ci: use target=m1

### DIFF
--- a/stacks/ml-darwin-aarch64-mps/spack.yaml
+++ b/stacks/ml-darwin-aarch64-mps/spack.yaml
@@ -10,13 +10,19 @@ spack:
       - +mps
       - ~cuda
       - ~rocm
+      - target=m1
     mpi:
-      require: mpich
+      require:
+      - mpich
+      - target=m1
     openblas:
       require:
       - ~fortran
+      - target=m1
     python:
-      require: "@3.13:"
+      require:
+      - "@3.13:"
+      - target=m1
 
   specs:
   # Hugging Face

--- a/stacks/ml-darwin-aarch64-mps/spack.yaml
+++ b/stacks/ml-darwin-aarch64-mps/spack.yaml
@@ -14,7 +14,6 @@ spack:
     mpi:
       require:
       - mpich
-      - target=m1
     openblas:
       require:
       - ~fortran


### PR DESCRIPTION
Set a fixed target; currently it picks host arch (m2 or m4) causing unnecessary rebuilds.