### PR TITLE
mochi-margo: added version 0.22.1 and 0.23.0

### DIFF
--- a/repos/spack_repo/builtin/packages/mochi_margo/package.py
+++ b/repos/spack_repo/builtin/packages/mochi_margo/package.py
@@ -25,6 +25,8 @@ class MochiMargo(cmake.CMakePackage, autotools.AutotoolsPackage):
     )
 
     version("main", branch="main")
+    version("0.23.0", sha256="7c39df5e09da67745ad4df8de81c30c1d95  62d8a5ce7f35278bc9c38f2e7dc03")
+    version("0.22.1", sha256="4f619e48ec64e5250c45e79095e2687cd5d  04008731b0fb3d90264b892bfd017")
     version("0.22.0", sha256="65d9170e517779beea7ce6f251271602bbee98cc434312336d0dcc8496ffed58")
     version("0.21.0", sha256="d0a527cd0dcbeb9a8f04d090140cdedb66d9a90c6794a046d48d6bc2d11fc278")
     version("0.20.0", sha256="ed19f65c3c0dda42b285904f64508d1997f4b0fcef81cddb011aa9c42381eb2a")

--- a/repos/spack_repo/builtin/packages/mochi_margo/package.py
+++ b/repos/spack_repo/builtin/packages/mochi_margo/package.py
@@ -25,8 +25,8 @@ class MochiMargo(cmake.CMakePackage, autotools.AutotoolsPackage):
     )
 
     version("main", branch="main")
-    version("0.23.0", sha256="7c39df5e09da67745ad4df8de81c30c1d95  62d8a5ce7f35278bc9c38f2e7dc03")
-    version("0.22.1", sha256="4f619e48ec64e5250c45e79095e2687cd5d  04008731b0fb3d90264b892bfd017")
+    version("0.23.0", sha256="7c39df5e09da67745ad4df8de81c30c1d9562d8a5ce7f35278bc9c38f2e7dc03")
+    version("0.22.1", sha256="4f619e48ec64e5250c45e79095e2687cd5d04008731b0fb3d90264b892bfd017")
     version("0.22.0", sha256="65d9170e517779beea7ce6f251271602bbee98cc434312336d0dcc8496ffed58")
     version("0.21.0", sha256="d0a527cd0dcbeb9a8f04d090140cdedb66d9a90c6794a046d48d6bc2d11fc278")
     version("0.20.0", sha256="ed19f65c3c0dda42b285904f64508d1997f4b0fcef81cddb011aa9c42381eb2a")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Add version 0.22.1 and 0.23.0 of mochi-margo.