### PR TITLE
%py-meson-python: respect jobserver

### DIFF
--- a/repos/spack_repo/builtin/build_systems/python.py
+++ b/repos/spack_repo/builtin/build_systems/python.py
@@ -19,10 +19,12 @@ from spack.package import (
     build_system,
     classproperty,
     depends_on,
+    determine_number_of_jobs,
     execute_install_time_tests,
     extends,
     filter_file,
     find,
+    get_effective_jobs,
     has_shebang,
     join_path,
     path_contains_subdirectory,
@@ -313,7 +315,7 @@ class PythonPipBuilder(BuilderWithDefaults):
         """
         return self.pkg.stage.source_path
 
-    def config_settings(self, spec: Spec, prefix: Prefix) -> Mapping[str, object]:
+    def config_settings(self, spec: Spec, prefix: Prefix) -> Dict[str, object]:
         """Configuration settings to be passed to the PEP 517 build backend.
 
         Requires pip 22.1 or newer for keys that appear only a single time,
@@ -363,8 +365,18 @@ class PythonPipBuilder(BuilderWithDefaults):
         pip.add_default_arg("-m", "pip")
 
         args = PythonPipBuilder.std_args(pkg) + [f"--prefix={prefix}"]
+        config_settings = self.config_settings(spec, prefix)
 
-        for setting in _flatten_dict(self.config_settings(spec, prefix)):
+        # Pass -jN for compile-args if supported and needed
+        if spec.satisfies("%py-pip@22.1: %py-meson-python@0.11:"):
+            # get_effective_jobs returns None when a jobserver is active, then we don't pass -j.
+            jobs = get_effective_jobs(
+                jobs=determine_number_of_jobs(parallel=pkg.parallel), supports_jobserver=True
+            )
+            if jobs is not None:
+                config_settings["compile-args"] = f"-j{jobs}"
+
+        for setting in _flatten_dict(config_settings):
             args.append(f"--config-settings={setting}")
         for option in self.install_options(spec, prefix):
             args.append(f"--install-option={option}")

--- a/repos/spack_repo/builtin/packages/py_matplotlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_matplotlib/package.py
@@ -300,7 +300,6 @@ class PyMatplotlib(PythonPackage):
     def config_settings(self, spec, prefix):
         return {
             "builddir": "build",
-            "compile-args": f"-j{make_jobs}",
             "setup-args": {
                 "-Dsystem-freetype": True,
                 "-Dsystem-qhull": True,

--- a/repos/spack_repo/builtin/packages/py_matplotlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_matplotlib/package.py
@@ -298,8 +298,9 @@ class PyMatplotlib(PythonPackage):
 
     @when("@3.9:")
     def config_settings(self, spec, prefix):
-        settings = {
+        return {
             "builddir": "build",
+            "compile-args": f"-j{make_jobs}",
             "setup-args": {
                 "-Dsystem-freetype": True,
                 "-Dsystem-qhull": True,
@@ -308,11 +309,6 @@ class PyMatplotlib(PythonPackage):
                 "-Db_lto": not (self.spec.satisfies("%clang") or self.spec.satisfies("%oneapi")),
             },
         }
-        # Do not pass -jN if we're running under a jobserver
-        jobs = get_effective_jobs(make_jobs, supports_jobserver=True)
-        if jobs is not None:
-            settings["compile-args"] = f"-j{jobs}"
-        return settings
 
     @run_after("install")
     @on_package_attributes(run_tests=True)

--- a/repos/spack_repo/builtin/packages/py_matplotlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_matplotlib/package.py
@@ -298,9 +298,8 @@ class PyMatplotlib(PythonPackage):
 
     @when("@3.9:")
     def config_settings(self, spec, prefix):
-        return {
+        settings = {
             "builddir": "build",
-            "compile-args": f"-j{make_jobs}",
             "setup-args": {
                 "-Dsystem-freetype": True,
                 "-Dsystem-qhull": True,
@@ -309,6 +308,11 @@ class PyMatplotlib(PythonPackage):
                 "-Db_lto": not (self.spec.satisfies("%clang") or self.spec.satisfies("%oneapi")),
             },
         }
+        # Do not pass -jN if we're running under a jobserver
+        jobs = get_effective_jobs(make_jobs, supports_jobserver=True)
+        if jobs is not None:
+            settings["compile-args"] = f"-j{jobs}"
+        return settings
 
     @run_after("install")
     @on_package_attributes(run_tests=True)

--- a/repos/spack_repo/builtin/packages/py_numpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_numpy/package.py
@@ -337,7 +337,6 @@ class PyNumpy(PythonPackage):
 
         settings = {
             "builddir": "build",
-            "compile-args": f"-j{make_jobs}",
             "setup-args": {
                 # https://scipy.github.io/devdocs/building/blas_lapack.html
                 "-Dblas": blas,

--- a/repos/spack_repo/builtin/packages/py_numpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_numpy/package.py
@@ -337,7 +337,6 @@ class PyNumpy(PythonPackage):
 
         settings = {
             "builddir": "build",
-            "compile-args": f"-j{make_jobs}",
             "setup-args": {
                 # https://scipy.github.io/devdocs/building/blas_lapack.html
                 "-Dblas": blas,
@@ -349,6 +348,11 @@ class PyNumpy(PythonPackage):
                 # "-Dcpu-dispatch": "none",
             },
         }
+
+        # Do not pass -jN if we're running under a jobserver
+        jobs = get_effective_jobs(make_jobs, supports_jobserver=True)
+        if jobs is not None:
+            settings["compile-args"] = f"-j{jobs}"
 
         # Disable AVX512 features for Intel Classic compilers
         # https://numpy.org/doc/stable/reference/simd/build-options.html

--- a/repos/spack_repo/builtin/packages/py_numpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_numpy/package.py
@@ -337,6 +337,7 @@ class PyNumpy(PythonPackage):
 
         settings = {
             "builddir": "build",
+            "compile-args": f"-j{make_jobs}",
             "setup-args": {
                 # https://scipy.github.io/devdocs/building/blas_lapack.html
                 "-Dblas": blas,
@@ -348,11 +349,6 @@ class PyNumpy(PythonPackage):
                 # "-Dcpu-dispatch": "none",
             },
         }
-
-        # Do not pass -jN if we're running under a jobserver
-        jobs = get_effective_jobs(make_jobs, supports_jobserver=True)
-        if jobs is not None:
-            settings["compile-args"] = f"-j{jobs}"
 
         # Disable AVX512 features for Intel Classic compilers
         # https://numpy.org/doc/stable/reference/simd/build-options.html

--- a/repos/spack_repo/builtin/packages/py_scikit_learn/package.py
+++ b/repos/spack_repo/builtin/packages/py_scikit_learn/package.py
@@ -119,8 +119,9 @@ class PyScikitLearn(PythonPackage):
         return url.format(name, version)
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        # Enable parallel builds of the sklearn backend
-        env.append_flags("SKLEARN_BUILD_PARALLEL", str(make_jobs))
+        if self.spec.satisfies("@:1.4"):
+            # Enable parallel builds for the pre py-meson-python build system
+            env.append_flags("SKLEARN_BUILD_PARALLEL", str(make_jobs))
 
         # https://scikit-learn.org/stable/developers/advanced_installation.html#macos
         if self.spec.satisfies("%apple-clang"):

--- a/repos/spack_repo/builtin/packages/py_scipy/package.py
+++ b/repos/spack_repo/builtin/packages/py_scipy/package.py
@@ -227,7 +227,6 @@ class PyScipy(PythonPackage):
 
         return {
             "builddir": "build",
-            "compile-args": f"-j{make_jobs}",
             "setup-args": {
                 # http://scipy.github.io/devdocs/building/blas_lapack.html
                 "-Dfortran_std": fortran_std,

--- a/repos/spack_repo/builtin/packages/py_scipy/package.py
+++ b/repos/spack_repo/builtin/packages/py_scipy/package.py
@@ -225,9 +225,8 @@ class PyScipy(PythonPackage):
         else:
             fortran_std = "legacy"
 
-        return {
+        settings = {
             "builddir": "build",
-            "compile-args": f"-j{make_jobs}",
             "setup-args": {
                 # http://scipy.github.io/devdocs/building/blas_lapack.html
                 "-Dfortran_std": fortran_std,
@@ -235,6 +234,13 @@ class PyScipy(PythonPackage):
                 "-Dlapack": lapack,
             },
         }
+
+        # Do not pass -jN if we're running under a jobserver
+        jobs = get_effective_jobs(make_jobs, supports_jobserver=True)
+        if jobs is not None:
+            settings["compile-args"] = f"-j{jobs}"
+
+        return settings
 
     @run_before("install", when="@:1.8")
     def set_blas_lapack(self):

--- a/repos/spack_repo/builtin/packages/py_scipy/package.py
+++ b/repos/spack_repo/builtin/packages/py_scipy/package.py
@@ -225,8 +225,9 @@ class PyScipy(PythonPackage):
         else:
             fortran_std = "legacy"
 
-        settings = {
+        return {
             "builddir": "build",
+            "compile-args": f"-j{make_jobs}",
             "setup-args": {
                 # http://scipy.github.io/devdocs/building/blas_lapack.html
                 "-Dfortran_std": fortran_std,
@@ -234,13 +235,6 @@ class PyScipy(PythonPackage):
                 "-Dlapack": lapack,
             },
         }
-
-        # Do not pass -jN if we're running under a jobserver
-        jobs = get_effective_jobs(make_jobs, supports_jobserver=True)
-        if jobs is not None:
-            settings["compile-args"] = f"-j{jobs}"
-
-        return settings
 
     @run_before("install", when="@:1.8")
     def set_blas_lapack(self):


### PR DESCRIPTION
If Spack is running under a jobserver, packages should not pass `-jN` to ninja.

Spack's new installer creates a jobserver server by default, and ninja is a
client. If you pass it `-jN`, it ignores Spack's jobserver and spawns `N`
subprocesses, leading to oversubscription.

Without `-jN`, you get composable parallelism across multiple concurrent
package builds :rainbow: :unicorn: `get_effective_jobs` runs `None` in case
of a jobserver.

@adamjstewart we could probably have better API for this. Is `compile-args`
standard? (Bit weird that it's a string, but well...)