### PR TITLE
dyninst: patch missing cstdint includes

### DIFF
--- a/repos/spack_repo/builtin/packages/dyninst/include_cstdint.patch
+++ b/repos/spack_repo/builtin/packages/dyninst/include_cstdint.patch
@@ -1,0 +1,36 @@
+diff --git a/common/src/arch-x86.h b/common/src/arch-x86.h
+index ecdc3dc13..7745306d3 100644
+--- a/common/src/arch-x86.h
++++ b/common/src/arch-x86.h
+@@ -40,6 +40,7 @@
+ #include <set>
+ #include <map>
+ #include <vector>
++#include <cstdint>
+ #include "entryIDs.h"
+ #include "registers/MachRegister.h"
+ #include "common/src/ia32_locations.h"
+diff --git a/common/src/sha1.C b/common/src/sha1.C
+index 08dd9f6bb..489e6314a 100644
+--- a/common/src/sha1.C
++++ b/common/src/sha1.C
+@@ -102,6 +102,7 @@ A million repetitions of "a"
+ 
+ #include <stdio.h>
+ #include <string.h>
++#include <cstdint>
+ 
+ #include "dyntypes.h"
+ #include "common/src/sha1.h"
+diff --git a/instructionAPI/h/ArchSpecificFormatters.h b/instructionAPI/h/ArchSpecificFormatters.h
+index b32d4cc14..145c604f9 100644
+--- a/instructionAPI/h/ArchSpecificFormatters.h
++++ b/instructionAPI/h/ArchSpecificFormatters.h
+@@ -34,6 +34,7 @@
+ #include <map>
+ #include <vector>
+ #include <string>
++#include <cstdint>
+ #include "Architecture.h"
+ #include "registers/MachRegister.h"
+ 

--- a/repos/spack_repo/builtin/packages/dyninst/package.py
+++ b/repos/spack_repo/builtin/packages/dyninst/package.py
@@ -83,6 +83,11 @@ class Dyninst(CMakePackage):
         when="@10.0.0:12.2.0",
         sha256="0064d8d51bd01bd0035e1ebc49276f627ce6366d4524c92cf47d3c09b0031f96",
     )
+    # missing <cstdint> include
+    patch(
+        "include_cstdint.patch",
+        when="@13.0.0"
+    )
 
     requires("%gcc", when="@:12", msg="dyninst builds only with GCC")
 

--- a/repos/spack_repo/builtin/packages/dyninst/package.py
+++ b/repos/spack_repo/builtin/packages/dyninst/package.py
@@ -84,10 +84,7 @@ class Dyninst(CMakePackage):
         sha256="0064d8d51bd01bd0035e1ebc49276f627ce6366d4524c92cf47d3c09b0031f96",
     )
     # missing <cstdint> include
-    patch(
-        "include_cstdint.patch",
-        when="@13.0.0"
-    )
+    patch("include_cstdint.patch", when="@13.0.0")
 
     requires("%gcc", when="@:12", msg="dyninst builds only with GCC")
 


### PR DESCRIPTION
Building DynInst with GCC 15 currently fails as `cstdint` [is no longer included by default](https://gcc.gnu.org/gcc-15/porting_to.html#header-dep-changes). With this PR, I propose to add a patch to pulls in a commit from `master` that adds the missing include.