### PR TITLE
abyss: use spec.satisfies() for direct MPI dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/abyss/package.py
+++ b/repos/spack_repo/builtin/packages/abyss/package.py
@@ -73,8 +73,11 @@ class Abyss(AutotoolsPackage):
             f"--with-sqlite={self.spec['sqlite'].prefix}",
             f"--with-mpi={self.spec['mpi'].prefix}",
         ]
+
         if maxk:
             args.append(f"--enable-maxk={maxk}")
-        if self.spec["mpi"].name == "mpich":
+
+        if self.spec.satisfies("%mpich"):
             args.append("--enable-mpich")
+
         return args

--- a/repos/spack_repo/builtin/packages/abyss/package.py
+++ b/repos/spack_repo/builtin/packages/abyss/package.py
@@ -77,7 +77,7 @@ class Abyss(AutotoolsPackage):
         if maxk:
             args.append(f"--enable-maxk={maxk}")
 
-        if self.spec.satisfies("%mpich"):
+        if self.spec.satisfies("%mpi=mpich"):
             args.append("--enable-mpich")
 
         return args


### PR DESCRIPTION
Update Abyss to use `spec.satisfies()` to standardize on querying direct dependency.