### PR TITLE
AOCC: Removed preferred from a previous version

### DIFF
--- a/repos/spack_repo/builtin/packages/aocc/package.py
+++ b/repos/spack_repo/builtin/packages/aocc/package.py
@@ -44,7 +44,6 @@ class Aocc(Package, LlvmDetection, CompilerPackage):
         ver="5.0.0",
         sha256="966fac2d2c759e9de6e969c10ada7a7b306c113f7f1e07ea376829ec86380daa",
         url="https://download.amd.com/developer/eula/aocc/aocc-5-0/aocc-compiler-5.0.0.tar",
-        preferred=True,
     )
     version(
         ver="4.2.0",


### PR DESCRIPTION
This pull request makes a small change to the `aocc` package definition by removing the `preferred=True` flag from the `5.0.0` version. This is required to ensure picking the latest version while installing without specifying version