### PR TITLE
hdf-eos2: add flags for gcc@14

### DIFF
--- a/repos/spack_repo/builtin/packages/hdf_eos2/package.py
+++ b/repos/spack_repo/builtin/packages/hdf_eos2/package.py
@@ -131,6 +131,9 @@ class HdfEos2(AutotoolsPackage):
                 flags.append("-Wno-error=implicit-function-declaration")
                 flags.append("-Wno-error=implicit-int")
 
+            # Testing shows we need one extra flag for gcc@14
+            if self.spec.satisfies("%gcc@14:"):
+                flags.append("-Wno-error=incompatible-pointer-types")
         return flags, None, None
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

In test builds of spack-stack with `gcc@14` (see https://github.com/JCSDA/spack-stack/pull/1908) it was found this package needed an extra flag to build. It needed the first two flags already here, but I needed an extra. Not sure why I'm different...