### PR TITLE
py-pyhdf: add flags for gcc@14

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pyhdf/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyhdf/package.py
@@ -37,6 +37,13 @@ class PyPyhdf(PythonPackage):
     depends_on("py-numpy@:1.24", when="@0.10.4", type=("build", "run"))
     depends_on("jpeg", type=("build", "run"))
 
+    def flag_handler(self, name, flags):
+        if name == "cflags":
+            if self.spec.satisfies("%gcc@14:"):
+                flags.append("-Wno-error=incompatible-pointer-types")
+                flags.append("-Wno-error=discarded-qualifiers")
+        return (flags, None, None)
+
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         inc_dirs = []
         lib_dirs = []


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

In test builds of spack-stack with `gcc@14` (see https://github.com/JCSDA/spack-stack/pull/1908) it was found this package needed extra flags to build. 

I based this code on code I found in `py-h5py` for oneapi.