### PR TITLE
py-h5py: add flags for gcc@14

### DIFF
--- a/repos/spack_repo/builtin/packages/py_h5py/package.py
+++ b/repos/spack_repo/builtin/packages/py_h5py/package.py
@@ -97,6 +97,9 @@ class PyH5py(PythonPackage):
             if self.spec.satisfies("%oneapi@2023.0.0:"):
                 flags.append("-Wno-error=incompatible-function-pointer-types")
                 flags.append("-Wno-error=incompatible-pointer-types-discards-qualifiers")
+            elif self.spec.satisfies("%gcc@14:"):
+                flags.append("-Wno-error=incompatible-pointer-types")
+                flags.append("-Wno-error=discarded-qualifiers")
         return (flags, None, None)
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

In test builds of spack-stack with `gcc@14` (see https://github.com/JCSDA/spack-stack/pull/1908) it was found this package needed extra flags to build. 