### PR TITLE
cups,cargo_c,ffmpeg,fltk,gettext,ghostscript,wxwidgets,qt: Fixes for libraries pulling in unintended external dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/cargo_c/package.py
+++ b/repos/spack_repo/builtin/packages/cargo_c/package.py
@@ -21,3 +21,4 @@ class CargoC(CargoPackage):
 
     depends_on("rust@1.89:", type="build", when="@0.10.17:")
     depends_on("rust@1.88:", type="build", when="@0.10.16:")
+    depends_on("openssl")

--- a/repos/spack_repo/builtin/packages/cups/package.py
+++ b/repos/spack_repo/builtin/packages/cups/package.py
@@ -29,7 +29,8 @@ class Cups(AutotoolsPackage):
     depends_on("pkgconfig", type="build")
 
     depends_on("gnutls")
+    depends_on("libxcrypt")
 
     def configure_args(self):
-        args = ["--enable-gnutls", "--with-components=core"]
+        args = ["--with-tls=gnutls", "--with-components=core"]
         return args

--- a/repos/spack_repo/builtin/packages/ffmpeg/package.py
+++ b/repos/spack_repo/builtin/packages/ffmpeg/package.py
@@ -92,6 +92,7 @@ class Ffmpeg(AutotoolsPackage):
     variant("sdl2", default=False, when="@3.2:", description="sdl2 support")
     variant("shared", default=True, description="build shared libraries")
     variant("libx264", default=False, description="H.264 encoding")
+    variant("libdrm", default=False, description="Build with libdrm")
 
     conflicts("@1", when="platform=darwin target=aarch64:", msg="requires gas-preprocessor")
 
@@ -130,8 +131,11 @@ class Ffmpeg(AutotoolsPackage):
     depends_on("x264", when="+libx264")
     depends_on("texinfo", when="+doc")
     depends_on("texinfo@:6", when="+doc @:4")
+    depends_on("libdrm", when="+libdrm")
 
     conflicts("%nvhpc")
+    conflicts("+libdrm", when="platform=darwin", msg="drm is linux only")
+    conflicts("+libdrm", when="platform=windows", msg="drm is linux only")
 
     # Solve build failure against vulkan headers 1.3.279
     patch(
@@ -241,6 +245,7 @@ class Ffmpeg(AutotoolsPackage):
             "libsnappy",
             "sdl2",
             "libaom",
+            "libdrm",
         ]
 
         if spec.satisfies("@4:"):

--- a/repos/spack_repo/builtin/packages/fltk/package.py
+++ b/repos/spack_repo/builtin/packages/fltk/package.py
@@ -2,12 +2,12 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack_repo.builtin.build_systems.generic import Package
+from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 
 from spack.package import *
 
 
-class Fltk(Package):
+class Fltk(AutotoolsPackage):
     """FLTK (pronounced "fulltick") is a cross-platform C++ GUI toolkit for
     UNIX/Linux (X11), Microsoft Windows, and MacOS X. FLTK provides
     modern GUI functionality without the bloat and supports 3D
@@ -56,13 +56,14 @@ class Fltk(Package):
     variant("gl", default=True, description="Enables opengl support")
 
     variant("xft", default=False, description="Enables Anti-Aliased Fonts")
-    variant("xcursor", default=True, description="Enables custom cursor shapes")
-    variant("xfixes", default=True, description="Enables clipboard management")
-    variant("xinerama", default=True, description="Enables multi-monitor support")
-    variant("xrender", default=True, description="Enables advanced image scaling")
+    variant("xcursor", default=False, description="Enables custom cursor shapes")
+    variant("xfixes", default=False, description="Enables clipboard management")
+    variant("xinerama", default=False, description="Enables multi-monitor support")
+    variant("xrender", default=False, description="Enables advanced image scaling")
 
     # variant dependencies
     depends_on("gl", when="+gl")
+    depends_on("glu", when="+gl")
 
     depends_on("libxft", when="+xft")
     depends_on("libxcursor", when="+xcursor")
@@ -70,38 +71,30 @@ class Fltk(Package):
     depends_on("libxinerama", when="+xinerama")
     depends_on("libxrender", when="+xrender")
 
-    def install(self, spec, prefix):
+    @run_before("autoreconf")
+    def autogen(self):
+        autogen = Executable("./autogen.sh")
+        autogen()
+
+    def configure_args(self):
         options = [
-            "--prefix=%s" % prefix,
             "--enable-localjpeg",
             "--enable-localpng",
             "--enable-localzlib",
         ]
 
-        if spec.satisfies("+shared"):
+        if self.spec.satisfies("+shared"):
             options.append("--enable-shared")
 
-        if spec.satisfies("+xft"):
+        if self.spec.satisfies("+xft"):
             # https://www.fltk.org/articles.php?L374+I0+TFAQ+P1+Q
             options.append("--enable-xft")
         else:
             options.append("--disable-xft")
+        for x in ["xcursor", "xfixes", "xinerama", "xrender", "gl"]:
+            options.extend(self.enable_or_disable(x))
 
-        for option in ["xcursor", "xfixes", "xinerama", "xrender"]:
-            if spec.satisfies(f"+{option}"):
-                options.append(f"--enable-{option}")
-            else:
-                options.append(f"--disable-{option}")
-
-        if spec.satisfies("~gl"):
-            options.append("--disable-gl")
-
-        # FLTK needs to be built in-source
-        autogen = Executable("./autogen.sh")
-        autogen()
-        configure(*options)
-        make()
-        make("install")
+        return options
 
     def patch(self):
         # Remove flags not recognized by the NVIDIA compiler

--- a/repos/spack_repo/builtin/packages/fltk/package.py
+++ b/repos/spack_repo/builtin/packages/fltk/package.py
@@ -77,11 +77,7 @@ class Fltk(AutotoolsPackage):
         autogen()
 
     def configure_args(self):
-        options = [
-            "--enable-localjpeg",
-            "--enable-localpng",
-            "--enable-localzlib",
-        ]
+        options = ["--enable-localjpeg", "--enable-localpng", "--enable-localzlib"]
 
         if self.spec.satisfies("+shared"):
             options.append("--enable-shared")

--- a/repos/spack_repo/builtin/packages/fltk/package.py
+++ b/repos/spack_repo/builtin/packages/fltk/package.py
@@ -56,11 +56,19 @@ class Fltk(Package):
     variant("gl", default=True, description="Enables opengl support")
 
     variant("xft", default=False, description="Enables Anti-Aliased Fonts")
+    variant("xcursor", default=True, description="Enables custom cursor shapes")
+    variant("xfixes", default=True, description="Enables clipboard management")
+    variant("xinerama", default=True, description="Enables multi-monitor support")
+    variant("xrender", default=True, description="Enables advanced image scaling")
 
     # variant dependencies
     depends_on("gl", when="+gl")
 
     depends_on("libxft", when="+xft")
+    depends_on("libxcursor", when="+xcursor")
+    depends_on("libxfixes", when="+xfixes")
+    depends_on("libxinerama", when="+xinerama")
+    depends_on("libxrender", when="+xrender")
 
     def install(self, spec, prefix):
         options = [
@@ -78,6 +86,12 @@ class Fltk(Package):
             options.append("--enable-xft")
         else:
             options.append("--disable-xft")
+
+        for option in ["xcursor", "xfixes", "xinerama", "xrender"]:
+            if spec.satisfies(f"+{option}"):
+                options.append(f"--enable-{option}")
+            else:
+                options.append(f"--disable-{option}")
 
         if spec.satisfies("~gl"):
             options.append("--disable-gl")

--- a/repos/spack_repo/builtin/packages/gettext/package.py
+++ b/repos/spack_repo/builtin/packages/gettext/package.py
@@ -69,6 +69,9 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
     depends_on("libunistring", when="+libunistring")
     # depends_on('cvs')
 
+    depends_on("curl", when="@1:")
+    depends_on("json-c", when="@1:")
+
     conflicts("+shared~pic")
     # https://savannah.gnu.org/bugs/?65811
     conflicts("%gcc@:5", when="@0.22:")

--- a/repos/spack_repo/builtin/packages/ghostscript/package.py
+++ b/repos/spack_repo/builtin/packages/ghostscript/package.py
@@ -34,11 +34,13 @@ class Ghostscript(AutotoolsPackage):
     variant("krb5", default=True, description="Enable Kerberos 5 support")
     variant("x11", default=True, description="Enable X11 support")
     variant("dbus", default=True, description="Enable D-Bus support")
+    variant("cups", default=True, description="Enable CUPS support")
 
     depends_on("c", type="build")
 
     depends_on("pkgconfig", type="build")
     depends_on("krb5", type="link", when="+krb5")
+    depends_on("cups", when="+cups")
 
     depends_on("freetype@2.4.2:")
     depends_on("fontconfig", type="link")
@@ -103,6 +105,9 @@ class Ghostscript(AutotoolsPackage):
             args.append("--disable-hidden-visibility")
         else:
             args.append("--disable-dynamic")
+
+        if "+cups" not in self.spec:
+            args.append("--disable-cups")
 
         args.extend(self.enable_or_disable("gtk"))
         args.append("--with-libiconv=gnu")

--- a/repos/spack_repo/builtin/packages/pbzip2/package.py
+++ b/repos/spack_repo/builtin/packages/pbzip2/package.py
@@ -24,7 +24,7 @@ class Pbzip2(MakefilePackage):
     version("1.1.13", sha256="8fd13eaaa266f7ee91f85c1ea97c86d9c9cc985969db9059cdebcb1e1b7bdbe6")
 
     depends_on("cxx", type="build")
-    depends_on("bzip2 +shared", type=("build", "run"))
+    depends_on("bzip2")
 
     def edit(self, spec, prefix):
         makefile = FileFilter("Makefile")

--- a/repos/spack_repo/builtin/packages/qt/package.py
+++ b/repos/spack_repo/builtin/packages/qt/package.py
@@ -68,6 +68,9 @@ class Qt(Package):
     )
     variant("gtk", default=False, description="Build with gtkplus.")
     variant("gui", default=True, description="Build the Qt GUI module and dependencies")
+    variant("cups", default=True, description="Build with printer support")
+    variant("gssapi", default=False, description="Build with Kerberos support")
+
     # Desktop only on Windows
     variant("opengl", default=False, description="Build with OpenGL support")
     for plat in ["linux", "darwin", "freebsd"]:
@@ -276,6 +279,8 @@ class Qt(Package):
     depends_on("pcre2+multibyte", when="@5.9:")
     depends_on("llvm", when="@5.11: +doc")
     depends_on("zstd@1.3:", when="@5.13:")
+    depends_on("cups", when="+cups")
+    depends_on("krb5", when="+gssapi")
 
     with when("+webkit"):
         patch(
@@ -700,6 +705,14 @@ class Qt(Package):
             use_spack_dep("libpng")
             use_spack_dep("jpeg", "libjpeg")
             use_spack_dep("zlib-api", "zlib")
+
+        if "+cups" in spec:
+            config_args.append("-cups")
+        else:
+            config_args.append('QMAKE_LIBS_CUPS=""')
+
+        if "+gssapi" not in spec:
+            config_args.append("-no-feature-gssapi")
 
         if "@:5.5" in spec:
             config_args.extend(

--- a/repos/spack_repo/builtin/packages/wxwidgets/package.py
+++ b/repos/spack_repo/builtin/packages/wxwidgets/package.py
@@ -36,7 +36,8 @@ class Wxwidgets(AutotoolsPackage):
 
     variant("opengl", default=False, description="Enable OpenGL support")
     variant("gui", default=True, description="Enable GUI support.")
-    variant("tiff", default=True, description="Enable TIFF support.")
+    variant("libtiff", default=True, description="Enable TIFF support.")
+    variant("zlib", default=True, description="Enable zlib support.")
 
     patch("math_include.patch", when="@3.0.1:3.0.2")
 
@@ -46,7 +47,8 @@ class Wxwidgets(AutotoolsPackage):
     depends_on("pkgconfig", type="build")
     depends_on("gtkplus", when="+gui")
     depends_on("mesa-glu", when="+opengl")
-    depends_on("libtiff", when="+tiff")
+    depends_on("libtiff", when="+libtiff")
+    depends_on("zlib-api", when="+zlib")
 
     @when("@:3.0.2")
     def build(self, spec, prefix):
@@ -67,5 +69,8 @@ class Wxwidgets(AutotoolsPackage):
         # see https://trac.wxwidgets.org/ticket/17639
         if spec.satisfies("@:3.1.0") and sys.platform == "darwin":
             options.extend(["--disable-qtkit", "--disable-mediactrl"])
+
+        options.extend(self.with_or_without("zlib"))
+        options.extend(self.with_or_without("libtiff"))
 
         return options

--- a/repos/spack_repo/builtin/packages/wxwidgets/package.py
+++ b/repos/spack_repo/builtin/packages/wxwidgets/package.py
@@ -36,6 +36,7 @@ class Wxwidgets(AutotoolsPackage):
 
     variant("opengl", default=False, description="Enable OpenGL support")
     variant("gui", default=True, description="Enable GUI support.")
+    variant("tiff", default=True, description="Enable TIFF support.")
 
     patch("math_include.patch", when="@3.0.1:3.0.2")
 
@@ -45,6 +46,7 @@ class Wxwidgets(AutotoolsPackage):
     depends_on("pkgconfig", type="build")
     depends_on("gtkplus", when="+gui")
     depends_on("mesa-glu", when="+opengl")
+    depends_on("libtiff", when="+tiff")
 
     @when("@:3.0.2")
     def build(self, spec, prefix):
@@ -58,6 +60,9 @@ class Wxwidgets(AutotoolsPackage):
             options.append("--with-opengl")
         if not self.spec.satisfies("+gui"):
             options.append("--disable-gui")
+
+        if self.spec.satisfies("+tiff"):
+            options.append("--with-libtiff")
 
         # see https://trac.wxwidgets.org/ticket/17639
         if spec.satisfies("@:3.1.0") and sys.platform == "darwin":


### PR DESCRIPTION
I've started building some of my environments with `missing-libs: error` and this exposed a few issues. Our build server runs a full Gnome desktop environment (don't ask why) so there's a lot of cruft that can get pulled in accidentally.

Some packages make it extremely difficult to disable automatic detection (looking at you, `fltk` and `wxwidgets`) as they don't always honor the disable option. They might need some patches, but those are beyond the scope of this PR for now. Setting the default variants to True at least makes it so the right stuff gets pulled in. If your build environment doesn't include 1900 RPMs this will probably work a lot better.