### PR TITLE
fix: libseccomp+python build

### DIFF
--- a/repos/spack_repo/builtin/packages/libseccomp/fix-pyx-copy.patch
+++ b/repos/spack_repo/builtin/packages/libseccomp/fix-pyx-copy.patch
@@ -1,0 +1,11 @@
+--- a/src/python/Makefile.in	2026-02-19
++++ b/src/python/Makefile.in	2026-02-19
+@@ -36,7 +36,7 @@
+ all-local: build
+ 
+ build: ../libseccomp.la libseccomp.pxd seccomp.pyx setup.py
+-	[ ${srcdir} = ${builddir} ] || cp ${srcdir}/seccomp.pyx ${builddir}
++	test -f ${builddir}/seccomp.pyx || cp ${srcdir}/seccomp.pyx ${builddir}
+ 	${PY_BUILD} && touch build
+ 
+ install-exec-local: build

--- a/repos/spack_repo/builtin/packages/libseccomp/package.py
+++ b/repos/spack_repo/builtin/packages/libseccomp/package.py
@@ -35,6 +35,7 @@ class Libseccomp(AutotoolsPackage, PythonExtension):
         # https://github.com/seccomp/libseccomp/commit/afbde6ddaec7c58c3b281d43b0b287269ffca9bd
         depends_on("python@:3.11", type=("run", "link", "build"), when="@:2.5")
         depends_on("py-setuptools", type="build", when="@2.6:")
+        # upstream PR: https://github.com/seccomp/libseccomp/pull/482
         patch("fix-pyx-copy.patch", when="@2.6")
 
     def configure_args(self):

--- a/repos/spack_repo/builtin/packages/libseccomp/package.py
+++ b/repos/spack_repo/builtin/packages/libseccomp/package.py
@@ -35,6 +35,7 @@ class Libseccomp(AutotoolsPackage, PythonExtension):
         # https://github.com/seccomp/libseccomp/commit/afbde6ddaec7c58c3b281d43b0b287269ffca9bd
         depends_on("python@:3.11", type=("run", "link", "build"), when="@:2.5")
         depends_on("py-setuptools", type="build", when="@2.6:")
+        patch("fix-pyx-copy.patch", when="@2.6")
 
     def configure_args(self):
         return self.enable_or_disable("python", variant="python")


### PR DESCRIPTION
libseccomp's python extension Makefile does a check for out of source builds, but fails when srcdir and builddir are different strings but point to the same underlying directory (ie `/dir` and `.`).

```
[ /var/tmp/melone1/spack-stage/spack-stage-libseccomp-2.6.0-w24sgwofjl4355bnza4sfvikvesxqawt/spack-src/src/python = . ] || cp /var/tmp/melone1/spack-stage/spack-stage-libseccomp-2.6.0-w24sgwofjl4355bnza4sfvikvesxqawt/spack-src/src/python/seccomp.pyx .
cp: '/var/tmp/melone1/spack-stage/spack-stage-libseccomp-2.6.0-w24sgwofjl4355bnza4sfvikvesxqawt/spack-src/src/python/seccomp.pyx' and './seccomp.pyx' are the same file
```

This adds a patch that checks if the file to be copied already exists in the builddir before attempting to copy it over.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
