### PR TITLE
metkit: add dependency for C compiler

### DIFF
--- a/repos/spack_repo/builtin/packages/metkit/package.py
+++ b/repos/spack_repo/builtin/packages/metkit/package.py
@@ -30,6 +30,7 @@ class Metkit(CMakePackage):
     variant("odb", default=False, description="Enable support for ODB data")
 
     depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
 
     depends_on("cmake@3.12:", type="build")
     depends_on("ecbuild@3.4:", type="build")


### PR DESCRIPTION
Metkit needs a C compiler, otherwise the build fails with ```[spack cc]: Error: SPACK_CC_* variables not set: this usually means a missing `depends_on("c", type="build")` in package.py.```