### PR TITLE
mesa: don't build llvmpipe when ~llvm

### DIFF
--- a/repos/spack_repo/builtin/packages/mesa/package.py
+++ b/repos/spack_repo/builtin/packages/mesa/package.py
@@ -221,8 +221,13 @@ class MesonBuilder(meson.MesonBuilder):
             args.append("-Dgallium-omx=disabled")
 
         args_platforms = []
-        args_gallium_drivers = ["swrast"]
         args_dri_drivers = []
+
+        # swrast includes softpipe and llvmpipe
+        if spec.satisfied("+llvm"):
+            args_gallium_drivers = ["swrast"]
+        else:
+            args_gallium_drivers = ["softpipe"]
 
         opt_enable = lambda c, o: "-D%s=%sabled" % (o, "en" if c else "dis")
         opt_bool = lambda c, o: "-D%s=%s" % (o, str(c).lower())

--- a/repos/spack_repo/builtin/packages/mesa/package.py
+++ b/repos/spack_repo/builtin/packages/mesa/package.py
@@ -224,7 +224,7 @@ class MesonBuilder(meson.MesonBuilder):
         args_dri_drivers = []
 
         # swrast includes softpipe and llvmpipe
-        if spec.satisfied("+llvm"):
+        if spec.satisfies("+llvm"):
             args_gallium_drivers = ["swrast"]
         else:
             args_gallium_drivers = ["softpipe"]


### PR DESCRIPTION
This PR modifies `mesa` to reflect https://gitlab.freedesktop.org/mesa/mesa/-/commit/010b2f9497a. `swrast` was (removed since then) an alias for `softpipe` and `llvmpipe`. When `~llvm`, the configuration with `llvmpipe` fails (see e.g. https://github.com/spack/spack-packages/issues/824#issuecomment-3126380585).

Note: There may be other ways to support this (e.g. instead of adding `swrast` by default, we could add both `llvmpipe` and `softpipe` explicitly), but I'm trying to apply a minimal fix to the issue at hand.