### PR TITLE
sentencepiece: add 2.1.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_sentencepiece/package.py
+++ b/repos/spack_repo/builtin/packages/py_sentencepiece/package.py
@@ -32,5 +32,6 @@ class PySentencepiece(PythonPackage):
     depends_on("sentencepiece@0.2.1", when="@0.2.1")
     depends_on("pkgconfig", type="build")
     depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@61:", when="@0.2.1:", type="build")
 
     build_directory = "python"

--- a/repos/spack_repo/builtin/packages/py_sentencepiece/package.py
+++ b/repos/spack_repo/builtin/packages/py_sentencepiece/package.py
@@ -31,7 +31,7 @@ class PySentencepiece(PythonPackage):
     depends_on("sentencepiece@0.1.91", when="@0.1.91")
     depends_on("sentencepiece@0.2.1", when="@0.2.1")
     depends_on("pkgconfig", type="build")
-    depends_on("py-setuptools", type="build")
     depends_on("py-setuptools@61:", when="@0.2.1:", type="build")
+    depends_on("py-setuptools", type="build")
 
     build_directory = "python"

--- a/repos/spack_repo/builtin/packages/py_sentencepiece/package.py
+++ b/repos/spack_repo/builtin/packages/py_sentencepiece/package.py
@@ -20,6 +20,7 @@ class PySentencepiece(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.2.1", sha256="c1a59e9259c9653ad0ade653dadff074cd31f0a6ff2a11316f67bee4189a8f1b")
     version("0.1.91", sha256="acbc7ea12713cd2a8d64892f8d2033c7fd2bb4faecab39452496120ace9a4b1b")
     version("0.1.85", sha256="dd4956287a1b6af3cbdbbd499b7227a859a4e3f41c9882de5e6bdd929e219ae6")
 
@@ -28,6 +29,7 @@ class PySentencepiece(PythonPackage):
     depends_on("sentencepiece")
     depends_on("sentencepiece@0.1.85", when="@0.1.85")
     depends_on("sentencepiece@0.1.91", when="@0.1.91")
+    depends_on("sentencepiece@0.2.1", when="@0.2.1")
     depends_on("pkgconfig", type="build")
     depends_on("py-setuptools", type="build")
 

--- a/repos/spack_repo/builtin/packages/sentencepiece/package.py
+++ b/repos/spack_repo/builtin/packages/sentencepiece/package.py
@@ -27,5 +27,6 @@ class Sentencepiece(CMakePackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
-    depends_on("cmake@3.10:", type="build")
+    depends_on("cmake@3.10:", when="@0.2.1:", type="build")
+    depends_on("cmake@3.1:", type="build")
     depends_on("gperftools")  # optional, 10-40% performance improvement

--- a/repos/spack_repo/builtin/packages/sentencepiece/package.py
+++ b/repos/spack_repo/builtin/packages/sentencepiece/package.py
@@ -20,11 +20,12 @@ class Sentencepiece(CMakePackage):
 
     license("Apache-2.0")
 
+    version("0.2.1", sha256="c1a59e9259c9653ad0ade653dadff074cd31f0a6ff2a11316f67bee4189a8f1b")
     version("0.1.91", sha256="acbc7ea12713cd2a8d64892f8d2033c7fd2bb4faecab39452496120ace9a4b1b")
     version("0.1.85", sha256="dd4956287a1b6af3cbdbbd499b7227a859a4e3f41c9882de5e6bdd929e219ae6")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
-    depends_on("cmake@3.1:", type="build")
+    depends_on("cmake@3.10:", type="build")
     depends_on("gperftools")  # optional, 10-40% performance improvement


### PR DESCRIPTION
### Description

This PR updates both the `sentencepiece` C++ tokenizer and its Python bindings (`py-sentencepiece`) to the latest version `0.2.1`. 

* **sentencepiece:** Added version 0.2.1.
* **py-sentencepiece:** Added version 0.2.1 and mapped the dependency to the updated C++ package.

### Maintainers

@adamjstewart 

### General Checks

- [x] I have run `spack style` and it passes.
- [x] I have run `spack audit packages` and it passes.
- [x] I have built the packages locally on my system (e.g., macOS ARM64).