### PR TITLE
py-joblib: latest version requires newer setuptools.

### DIFF
--- a/repos/spack_repo/builtin/packages/py_joblib/package.py
+++ b/repos/spack_repo/builtin/packages/py_joblib/package.py
@@ -48,5 +48,6 @@ class PyJoblib(PythonPackage):
         depends_on("python@:3.11", when="@:1.2")
 
     with default_args(type="build"):
+        depends_on("py-setuptools@77.0.3:", when="@1.5.3:")
         depends_on("py-setuptools@61.2:", when="@1.4:")
         depends_on("py-setuptools")


### PR DESCRIPTION
add py-setuptools version constraint for latest version. or else build fails due to multiple license statements in pyproject.toml.

https://github.com/joblib/joblib/blame/1.5.3/pyproject.toml

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
