### PR TITLE
VTK: model scnlib dependency required for building 9.5 and newer

### DIFF
--- a/repos/spack_repo/builtin/packages/scnlib/package.py
+++ b/repos/spack_repo/builtin/packages/scnlib/package.py
@@ -47,7 +47,7 @@ class Scnlib(CMakePackage):
     depends_on("python@3:", type="test")
 
     patch(
-        url="https://github.com/eliaskosunen/scnlib/commit/39276cc436adcfc2544faf1de3991c2784c86ce3.patch?full_index=1",
+        "https://github.com/eliaskosunen/scnlib/commit/39276cc436adcfc2544faf1de3991c2784c86ce3.patch?full_index=1",
         sha256="013a8a9466fadb3396af187da08057f4e79b1c26bf340da99b19fd47dd049795",
         when="@4",
     )

--- a/repos/spack_repo/builtin/packages/scnlib/package.py
+++ b/repos/spack_repo/builtin/packages/scnlib/package.py
@@ -48,12 +48,6 @@ class Scnlib(CMakePackage):
 
     conflicts("+shared", when="platform=windows")
 
-    patch(
-        "https://github.com/eliaskosunen/scnlib/commit/39276cc436adcfc2544faf1de3991c2784c86ce3.patch?full_index=1",
-        sha256="013a8a9466fadb3396af187da08057f4e79b1c26bf340da99b19fd47dd049795",
-        when="@4",
-    )
-
     def cmake_args(self):
         args = [
             self.define("SCN_TESTS", self.run_tests),

--- a/repos/spack_repo/builtin/packages/scnlib/package.py
+++ b/repos/spack_repo/builtin/packages/scnlib/package.py
@@ -46,6 +46,8 @@ class Scnlib(CMakePackage):
     depends_on("googletest cxxstd=17", type="test")
     depends_on("python@3:", type="test")
 
+    conflicts("+shared", when="platform=windows")
+
     patch(
         "https://github.com/eliaskosunen/scnlib/commit/39276cc436adcfc2544faf1de3991c2784c86ce3.patch?full_index=1",
         sha256="013a8a9466fadb3396af187da08057f4e79b1c26bf340da99b19fd47dd049795",

--- a/repos/spack_repo/builtin/packages/scnlib/package.py
+++ b/repos/spack_repo/builtin/packages/scnlib/package.py
@@ -46,6 +46,12 @@ class Scnlib(CMakePackage):
     depends_on("googletest cxxstd=17", type="test")
     depends_on("python@3:", type="test")
 
+    patch(
+        url="https://github.com/eliaskosunen/scnlib/commit/39276cc436adcfc2544faf1de3991c2784c86ce3.patch?full_index=1",
+        sha256="013a8a9466fadb3396af187da08057f4e79b1c26bf340da99b19fd47dd049795",
+        when="@4",
+    )
+
     def cmake_args(self):
         args = [
             self.define("SCN_TESTS", self.run_tests),

--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -251,6 +251,7 @@ class Vtk(CMakePackage):
         depends_on("seacas@2024-06-27", when="@9.4:")
 
     depends_on("nlohmann-json", when="@9.2:")
+    depends_on("scnlib", when="@9.5:")
 
     # For finding Fujitsu-MPI wrapper commands
     patch("find_fujitsu_mpi.patch", when="@:8.2.0%fj")
@@ -403,7 +404,10 @@ class Vtk(CMakePackage):
             if spec.satisfies("@9.2:"):
                 cmake_args.append("-DVTK_MODULE_USE_EXTERNAL_VTK_verdict:BOOL=OFF")
             if spec.satisfies("@9.5:"):
-                cmake_args.append("-DVTK_MODULE_USE_EXTERNAL_VTK_vtkviskores:BOOL=OFF")
+                cmake_args.extend([
+                    "-DVTK_MODULE_USE_EXTERNAL_VTK_vtkviskores:BOOL=OFF",
+                    "-DVTK_MODULE_USE_EXTERNAL_VTK_scn:BOOL=ON",
+                ])
 
         # Some variable names have changed
         if spec.satisfies("@8.2.0"):

--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -404,10 +404,12 @@ class Vtk(CMakePackage):
             if spec.satisfies("@9.2:"):
                 cmake_args.append("-DVTK_MODULE_USE_EXTERNAL_VTK_verdict:BOOL=OFF")
             if spec.satisfies("@9.5:"):
-                cmake_args.extend([
-                    "-DVTK_MODULE_USE_EXTERNAL_VTK_vtkviskores:BOOL=OFF",
-                    "-DVTK_MODULE_USE_EXTERNAL_VTK_scn:BOOL=ON",
-                ])
+                cmake_args.extend(
+                    [
+                        "-DVTK_MODULE_USE_EXTERNAL_VTK_vtkviskores:BOOL=OFF",
+                        "-DVTK_MODULE_USE_EXTERNAL_VTK_scn:BOOL=ON",
+                    ]
+                )
 
         # Some variable names have changed
         if spec.satisfies("@8.2.0"):

--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -223,6 +223,7 @@ class Vtk(CMakePackage):
         depends_on("seacas@2024-06-27", when="@9.4:")
 
     depends_on("nlohmann-json+multiple_headers", when="@9.2:")
+    depends_on("scnlib", when="@9.5:")
 
     # Freetype@2.10.3 no longer exports FT_CALLBACK_DEF, this
     # patch replaces FT_CALLBACK_DEF with simple extern "C"
@@ -400,7 +401,12 @@ class Vtk(CMakePackage):
         if spec.satisfies("@9.2:"):
             cmake_args.append("-DVTK_MODULE_USE_EXTERNAL_VTK_verdict:BOOL=OFF")
         if spec.satisfies("@9.5:"):
-            cmake_args.append("-DVTK_MODULE_USE_EXTERNAL_VTK_vtkviskores:BOOL=OFF")
+            cmake_args.extend(
+                [
+                    "-DVTK_MODULE_USE_EXTERNAL_VTK_vtkviskores:BOOL=OFF",
+                    "-DVTK_MODULE_USE_EXTERNAL_VTK_scn:BOOL=ON",
+                ]
+            )
 
         if spec.satisfies("io=ffmpeg"):
             if spec.satisfies("@:8"):


### PR DESCRIPTION
Additionally enforce use of external scn
cc @Chrismarsh 

Blocks:
- #3981
  - #5513