### PR TITLE
geant3,vmc: don't require non-existent root variant

### DIFF
--- a/repos/spack_repo/builtin/packages/geant3/package.py
+++ b/repos/spack_repo/builtin/packages/geant3/package.py
@@ -22,12 +22,11 @@ class Geant3(CMakePackage):
     version("3-5", sha256="5bec0b442bbb3456d5cd1751ac9f90f1da48df0fcb7f6bf0a86c566bfc408261")
     version("3-4", sha256="c7b487ab4fb4e6479c652b9b11dcafb686edf35e2f2048045c501e4f5597d62c")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
 
     depends_on("root")
-    requires("^root~vmc", when="^root@:6.25")
     depends_on("vmc")
 
     variant(

--- a/repos/spack_repo/builtin/packages/vmc/package.py
+++ b/repos/spack_repo/builtin/packages/vmc/package.py
@@ -28,13 +28,12 @@ class Vmc(CMakePackage):
     patch("dict_fixes_101.patch", when="@1-0-p1")
 
     depends_on("c", type="build")
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
 
     depends_on("cmake@3.3:", type="build")
     depends_on("cmake@3.16:", type="build", when="@2-1:")
 
-    depends_on("root@6.18.04:")
-    requires("^root~vmc", when="^root@:6.25")
+    depends_on("root")
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("platform=darwin"):


### PR DESCRIPTION
This PR fixes an issue in `geant3` and `vmc` where the `requires("^root~vmc")` directive became invalid with the removal of the `vmc` variant in `root` with commit 0844bd024352520e9cec3a3fd23b3419754c16d7. That resulted in:
```
$ spack spec vmc
==> Error: cannot emit requirements for the solver: No such variant 'vmc' in package root
$ spack spec geant3
==> Error: cannot emit requirements for the solver: No such variant 'vmc' in package root
```