### PR TITLE
Remove spurious Fortran build dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/fontconfig/package.py
+++ b/repos/spack_repo/builtin/packages/fontconfig/package.py
@@ -25,7 +25,6 @@ class Fontconfig(AutotoolsPackage):
     version("2.11.1", sha256="b6b066c7dce3f436fdc0dfbae9d36122b38094f4f53bd8dffd45e195b0540d8d")
 
     depends_on("c", type="build")  # generated
-    depends_on("fortran", type="build")
 
     # freetype2 21.0.15+ provided by freetype 2.8.1+
     depends_on("freetype@2.8.1:", when="@2.13:")
@@ -71,7 +70,8 @@ class Fontconfig(AutotoolsPackage):
 
         if self.spec.satisfies("+pic"):
             args.append(f"CFLAGS={self.compiler.cc_pic_flag}")
-            args.append(f"FFLAGS={self.compiler.f77_pic_flag}")
+            # fontconfig is C-only; use cc_pic_flag (f77_pic_flag required fortran dep)
+            # args.append(f"FFLAGS={self.compiler.cc_pic_flag}")
 
         return args
 

--- a/repos/spack_repo/builtin/packages/fontconfig/package.py
+++ b/repos/spack_repo/builtin/packages/fontconfig/package.py
@@ -70,8 +70,6 @@ class Fontconfig(AutotoolsPackage):
 
         if self.spec.satisfies("+pic"):
             args.append(f"CFLAGS={self.compiler.cc_pic_flag}")
-            # fontconfig is C-only; use cc_pic_flag (f77_pic_flag required fortran dep)
-            # args.append(f"FFLAGS={self.compiler.cc_pic_flag}")
 
         return args
 


### PR DESCRIPTION
Fontconfig is a C-only library: configure.ac has no AC_PROG_FC/AC_PROG_F77, and the source tree contains only .c/.h files. The Fortran dependency and FFLAGS usage were added by mistake.

History:
- fd0baca222 (#44884): Added +pic variant with CFLAGS and FFLAGS using f77_pic_flag (likely copied from a mixed C/Fortran package pattern)
- a3f4fd68d6 (#49920): Bulk "add missing compiler dependencies" added depends_on("fortran") by detecting f77_pic_flag usage without checking whether the package actually compiles Fortran code

This caused concretization failures ("Only external, or concrete, compilers are allowed for the fortran language") when building fontconfig dependents (e.g. xnedit) on systems without an external Fortran compiler.

Fix:
- Remove depends_on("fortran", type="build")
- Remove FFLAGS from +pic variant (never used; fontconfig build ignores it)
- CFLAGS with cc_pic_flag is sufficient for the +pic variant
