### PR TITLE
Add dependencies to CUDA package

### DIFF
--- a/repos/spack_repo/builtin/packages/cuda/package.py
+++ b/repos/spack_repo/builtin/packages/cuda/package.py
@@ -785,11 +785,15 @@ class Cuda(Package):
         description="Allow unsupported host compiler and CUDA version combinations",
     )
 
-    depends_on("libxml2", when="@10.1.243:")
+    # depends on libxml2.so.2
+    depends_on("libxml2@:2.13", type=("build", "run"), when="@10.1.243:")
     # cuda-gdb needed libncurses.so.5 before 11.4.0
     # see https://docs.nvidia.com/cuda/archive/11.3.1/cuda-gdb/index.html#common-issues-oss
     # see https://docs.nvidia.com/cuda/archive/11.4.0/cuda-gdb/index.html#release-notes
     depends_on("ncurses abi=5", type="run", when="@:11.3.99+dev")
+
+    depends_on("gzip", type="build")
+    depends_on("coreutils", type="build")
 
     provides("opencl@:1.2", when="@7:")
     provides("opencl@:1.1", when="@:6")

--- a/repos/spack_repo/builtin/packages/cuda/package.py
+++ b/repos/spack_repo/builtin/packages/cuda/package.py
@@ -786,7 +786,7 @@ class Cuda(Package):
     )
 
     # depends on libxml2.so.2
-    depends_on("libxml2@:2.13", type=("build", "run"), when="@10.1.243:")
+    depends_on("libxml2@:2.13", when="@10.1.243:")
     # cuda-gdb needed libncurses.so.5 before 11.4.0
     # see https://docs.nvidia.com/cuda/archive/11.3.1/cuda-gdb/index.html#common-issues-oss
     # see https://docs.nvidia.com/cuda/archive/11.4.0/cuda-gdb/index.html#release-notes


### PR DESCRIPTION
This PR adds some assumed dependencies to the CUDA package and a pin to `libxml2` so that it can be built on Ubuntu 25.10.