### PR TITLE
gfe: Update GFE packages for 2025-Feb-23

### DIFF
--- a/repos/spack_repo/builtin/packages/fargparse/package.py
+++ b/repos/spack_repo/builtin/packages/fargparse/package.py
@@ -21,6 +21,7 @@ class Fargparse(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("1.11.0", sha256="867854b0d312ef22ba3938f5398727973942a31d75f4e1abd3cd9d35f0159691")
     version("1.10.0", sha256="c2f2b2c2f0dc263e484f7f5f6918d93f40c5b96b8970b5f19426f0a89e14a8f9")
     version("1.9.0", sha256="c83c13fa90b6b45adf8d84fe00571174acfa118d2a0d1e8c467f74bbd7dec49d")
     version("1.8.0", sha256="37108bd3c65d892d8c24611ce4d8e5451767e4afe81445fde67eab652178dd01")

--- a/repos/spack_repo/builtin/packages/gftl/package.py
+++ b/repos/spack_repo/builtin/packages/gftl/package.py
@@ -40,6 +40,7 @@ class Gftl(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("1.17.0", sha256="2a86047d329297c1c6147b1619d1412259a21d9c2188e229ebf6c4e73ec51546")
     version("1.16.0", sha256="c72061a955e79a2d2fd58ddacedb5dfdf3a4a36881c53fad167830d320dbf1a6")
     version("1.15.2", sha256="1d3b7057da7057995c13055ba1149ed53e80937423b74d0ab5f40e6b85b7e6aa")
     version("1.15.1", sha256="13b9e17b7ec5e9ba19d0ee3ad1957bfa2015055b654891c6bb0bbe68b7a040d7")

--- a/repos/spack_repo/builtin/packages/gftl_shared/package.py
+++ b/repos/spack_repo/builtin/packages/gftl_shared/package.py
@@ -26,6 +26,7 @@ class GftlShared(CMakePackage):
 
     version("main", branch="main")
 
+    version("1.12.0", sha256="38f0353c4d53d474db9d6b301223c2848ac19e5e8c83b136d4c03605ac4bd768")
     version("1.11.0", sha256="785f3ccae7a28a3060c2155d67754379991e60cde19b1b238f77ef68dc2ad022")
     version("1.10.0", sha256="42158fe75fa6bee336516c7531b4c6c4e7252dee2fed541eec740209a07ceafe")
     version("1.9.0", sha256="a3291ce61b512fe88628cc074b02363c2ba3081e7b453371089121988482dd6f")

--- a/repos/spack_repo/builtin/packages/pfunit/package.py
+++ b/repos/spack_repo/builtin/packages/pfunit/package.py
@@ -20,6 +20,7 @@ class Pfunit(CMakePackage):
 
     maintainers("mathomp4", "tclune")
 
+    version("4.16.0", sha256="314381ff08dc99e87a4da5862501053d112babaf73244b1c04b77065d3fd3091")
     version("4.15.0", sha256="8c9cb7f7275802c5169b16dd511209b15ccde3a0e2fb3ed9007a0ab9acf4abb1")
     version("4.14.0", sha256="3f5fcc79cf5f12ed08eb8e49aff23e0826243b14d4b2b2efee91ce823ac1749d")
     version("4.13.0", sha256="f4f894faea5cc591f05e071a2bb16ddf613c3c22f88a6dc3b8149f5c4f159548")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR updates four of the GFE packages. Two of them had actual updates

* [gftl v1.17.0](https://github.com/Goddard-Fortran-Ecosystem/gFTL/releases/tag/v1.17.0)
  * Fixed macro redefinition warnings during template instantiation (https://github.com/Goddard-Fortran-Ecosystem/gFTL/issues/268)
* [pfunit v4.16.0](https://github.com/Goddard-Fortran-Ecosystem/pFUnit/releases/tag/v4.16.0)
  * Advanced test filtering with regex and glob patterns (issue https://github.com/Goddard-Fortran-Ecosystem/pFUnit/issues/523)

The other two are updated because of submodule updates due to dependencies (gftl → gftl-shared → fargparse)