### PR TITLE
Bump repo package api version to 2.4

### DIFF
--- a/repos/spack_repo/builtin/repo.yaml
+++ b/repos/spack_repo/builtin/repo.yaml
@@ -1,3 +1,3 @@
 repo:
   namespace: builtin
-  api: v2.2
+  api: v2.4


### PR DESCRIPTION
Since there is no mechanism to restrict usage of features from a newer API version it is not possible to enforce older API versions on develop.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
