### PR TITLE
llvm-amdgpu: remove fortran build dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
+++ b/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
@@ -96,9 +96,8 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
     provides("libllvm@20", when="@7.0:7.1")
     provides("libllvm@22", when="@7.2")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("cmake@3.13.4:", type="build")
     depends_on("python", type="build")


### PR DESCRIPTION
Correct me if I'm wrong, but I don't see a Fortran dependency in LLVM either. So this seems like a misdetection.
