### PR TITLE
alps: add v2.3.4, modify maintainers & license

### DIFF
--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -5,7 +5,7 @@
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
-
+import os
 
 class Alps(CMakePackage):
     """
@@ -15,15 +15,14 @@ class Alps(CMakePackage):
     """
 
     homepage = "https://github.com/ALPSim/ALPS"
-    url = "https://github.com/ALPSim/ALPS/archive/refs/tags/v2.3.3-beta.5.tar.gz"
+    url = "https://github.com/ALPSim/ALPS/archive/refs/tags/v2.3.4.tar.gz"
 
-    maintainers("Sinan81")
+    maintainers("Ooolab","egull")
 
-    license("BSL-1.0", checked_by="Sinan81")
+    license("MIT", checked_by="Ooolab")
 
-    version(
-        "2.3.3-beta.6", sha256="eb0c8115b034dd7a9dd585d277c4f86904ba374cdbdd130545aca1c432583b68"
-    )
+    version("2.3.4", sha256="bc65453bb88cc42de77c2963a44966fb3c92e80ff8e8e29e80fb87694fba41d7")
+    version("2.3.3-beta.6", sha256="eb0c8115b034dd7a9dd585d277c4f86904ba374cdbdd130545aca1c432583b68")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
@@ -31,10 +30,7 @@ class Alps(CMakePackage):
 
     # update version constraint on every boost release after providing version & checksum info
     # in resources dictionary below
-    depends_on(
-        "boost@:1.87 +chrono +date_time +filesystem +iostreams +mpi +numpy"
-        "+program_options +python +regex +serialization +system +test +thread +timer"
-    )
+    depends_on("boost@1.80:")  # Just for headers. Note that the checksums are listed below
     depends_on("fftw")
     depends_on("hdf5 ~mpi+hl")
     depends_on("lapack")
@@ -42,18 +38,21 @@ class Alps(CMakePackage):
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-scipy", type=("build", "run"))
     depends_on("py-matplotlib", type=("build", "run"))
-
+    depends_on("mpi")
+    
     extends("python")
 
     # https://github.com/ALPSim/ALPS/issues/9
-    conflicts(
-        "%gcc@14", when="@:2.3.3-beta.6", msg="use gcc older than version 14 or else build fails"
-    )
+    #conflicts(
+    #    "%gcc@14", when="@:2.3.3-beta.6", msg="use gcc older than version 14 or else build fails"
+    #)
 
     # See https://github.com/ALPSim/ALPS/issues/6#issuecomment-2604912169
     # for why this is needed
     for boost_version, boost_checksum in (
         # boost version, shasum
+        ("1.89.0", "85a33fa22621b4f314f8e85e1a5e2a9363d22e4f4992925d4bb3bc631b5a0c7a"),
+        ("1.88.0", "46d9d2c06637b219270877c9e16155cbd015b6dc84349af064c088e9b5b12f7b"),
         ("1.87.0", "af57be25cb4c4f4b413ed692fe378affb4352ea50fbe294a11ef548f4d527d89"),
         ("1.86.0", "1bed88e40401b2cb7a1f76d4bab499e352fa4d0c5f31c0dbae64e24d34d7513b"),
         ("1.85.0", "7009fe1faa1697476bdc7027703a2badb84e849b7b0baad5086b087b971f8617"),
@@ -73,21 +72,141 @@ class Alps(CMakePackage):
             destination="",
             placement="boost_source_files",
         )
+        
+    # Patch for >=Boost 1.88.0 compatibility
+    def patch(self):
+        # Only apply patch for Boost versions greater than 1.87
+        # Check if boost dependency is specified and get its version
+        if 'boost' in self.spec:
+            boost_spec = self.spec['boost']
+            # Compare versions: only apply patch if boost version > 1.87
+            if boost_spec.version > Version('1.87'):
+                # Fix boost::is_same and boost::add_const for >=Boost 1.88.0 compatibility
+                # These type traits were moved to std:: in >=Boost 1.88.0
+                
+                # First, let's add necessary includes
+                filter_file(
+                    '#include <boost/type_traits.hpp>',
+                    '#include <boost/type_traits.hpp>\n#include <type_traits>',
+                    'src/alps/numeric/matrix/strided_iterator.hpp'
+                )
+                
+                filter_file(
+                    '#include <boost/type_traits.hpp>',
+                    '#include <boost/type_traits.hpp>\n#include <type_traits>',
+                    'src/alps/numeric/matrix/matrix_element_iterator.hpp'
+                )
+                
+                # Now replace boost::is_same with std::is_same
+                filter_file(
+                    'boost::is_same',
+                    'std::is_same',
+                    'src/alps/numeric/matrix/strided_iterator.hpp'
+                )
+                
+                filter_file(
+                    'boost::is_same',
+                    'std::is_same',
+                    'src/alps/numeric/matrix/matrix_element_iterator.hpp'
+                )
+                
+                # Replace boost::add_const with std::add_const
+                filter_file(
+                    'boost::add_const',
+                    'std::add_const',
+                    'src/alps/numeric/matrix/strided_iterator.hpp'
+                )
+                
+                filter_file(
+                    'boost::add_const',
+                    'std::add_const',
+                    'src/alps/numeric/matrix/matrix_element_iterator.hpp'
+                )
 
     def cmake_args(self):
         args = []
-        # Boost_ROOT_DIR option is replaced by Boost_SRC_DIR as of 2.3.3-beta.6
+        #this will ensure availability of the cstddef header on darwin (mac)
+        cstdlibstr=""
+        if self.spec.satisfies("platform=darwin"):
+          cstdlibstr=" -stdlib=libc++"
+
         args.append(
             "-DCMAKE_CXX_FLAGS={0}".format(
                 self.compiler.cxx14_flag
                 + " -fpermissive -DBOOST_NO_AUTO_PTR -DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF"
                 + " -DBOOST_TIMER_ENABLE_DEPRECATED"
+                + cstdlibstr
             )
         )
+        
+        # Point to boost source files that need to be compiled
+        boost_src_dir = os.path.join(self.stage.source_path, "boost_source_files")
         args.append(
-            "-DBoost_SRC_DIR={0}".format(join_path(self.stage.source_path, "boost_source_files"))
+            "-DBoost_SRC_DIR={0}".format(boost_src_dir)
         )
+        
+        # Tell CMake to compile boost from source
+        args.append(
+            "-DBoost_USE_STATIC_LIBS=ON"
+        )
+        
+        args.append(
+            "-DBoost_USE_STATIC_RUNTIME=OFF"
+        )
+        
+        # Add MPI support - just specify compilers (minimal change)
+        args.append(
+            "-DMPI_CXX_COMPILER={0}".format(self.spec['mpi'].mpicxx)
+        )
+        
+        args.append(
+            "-DMPI_C_COMPILER={0}".format(self.spec['mpi'].mpicc)
+        )
+        
+        # Add Python support
+        args.append(
+            "-DPYTHON_EXECUTABLE={0}".format(self.spec['python'].command.path)
+        )
+        
+        args.append(
+            "-DPYTHON_INCLUDE_DIR={0}".format(self.spec['python'].headers.directories[0])
+        )
+        
+        args.append(
+            "-DPYTHON_LIBRARY={0}".format(self.spec['python'].libs[0])
+        )
+        
         return args
+        
+        
+    def setup_build_environment(self, env):
+        # Set up environment for boost source compilation
+        boost_src_dir = os.path.join(self.stage.source_path, 'boost_source_files')
+        env.set('BOOST_ROOT', boost_src_dir)
+        env.set('Boost_SRC_DIR', boost_src_dir)
+        
+        # Include paths for compilation
+        env.append_path('CPLUS_INCLUDE_PATH', self.spec['python'].headers.directories[0])
+        
+        # For MPI - set compiler wrappers
+        env.set('MPI_CXX', self.spec['mpi'].mpicxx)
+        env.set('MPI_CC', self.spec['mpi'].mpicc)
+        env.set('MPICXX', self.spec['mpi'].mpicxx)
+        
+        # Add MPI include path if available
+        if hasattr(self.spec['mpi'], 'headers'):
+            env.append_path('CPLUS_INCLUDE_PATH', self.spec['mpi'].headers.directories[0])
+        
+        # For Python
+        env.set('PYTHON', self.spec['python'].command.path)
+        
+        # Compiler flags
+        env.append_flags('CXXFLAGS', '-fpermissive')
+        env.append_flags('CXXFLAGS', '-DBOOST_NO_AUTO_PTR')
+        env.append_flags('CXXFLAGS', '-DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF')
+        env.append_flags('CXXFLAGS', '-DBOOST_TIMER_ENABLE_DEPRECATED')
+        env.append_flags('CXXFLAGS', self.compiler.cxx14_flag)
+
 
     @run_after("install")
     def relocate_python_stuff(self):

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -3,8 +3,11 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+
 from spack.package import *
+
 
 class Alps(CMakePackage):
     """
@@ -43,7 +46,8 @@ class Alps(CMakePackage):
     depends_on("py-matplotlib", type=("build", "run"))
     depends_on("mpi")
     depends_on("zlib")
-    
+
+
     extends("python")
 
     # See https://github.com/ALPSim/ALPS/issues/6#issuecomment-2604912169
@@ -71,7 +75,8 @@ class Alps(CMakePackage):
             destination="",
             placement="boost_source_files",
         )
-        
+
+
     # Patch for >=Boost 1.88.0 compatibility
     def patch(self):
         # Only apply patch for Boost versions greater than 1.87

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -47,7 +47,6 @@ class Alps(CMakePackage):
     depends_on("mpi")
     depends_on("zlib")
 
-
     extends("python")
 
     # See https://github.com/ALPSim/ALPS/issues/6#issuecomment-2604912169
@@ -75,7 +74,6 @@ class Alps(CMakePackage):
             destination="",
             placement="boost_source_files",
         )
-
 
     # Patch for >=Boost 1.88.0 compatibility
     def patch(self):

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -17,34 +17,36 @@ class Alps(CMakePackage):
     """
 
     homepage = "https://github.com/ALPSim/ALPS"
+    url = "https://github.com/ALPSim/ALPS/archive/refs/tags/v2.3.4-beta.2.tar.gz"
 
-    maintainers("Ooolab", "egull")
+    maintainers("Ooolab", "egull", "Sinan81")
 
     license("MIT", checked_by="Ooolab")
 
     version(
         "2.3.4-beta.2",
-        sha256="ca2e1307630e6fccac279ab7711036f7c6dee43c386fd6f24cfc77c86a3c7f1c",
-        url="https://github.com/ALPSim/ALPS/archive/refs/tags/v2.3.4-beta.2.tar.gz",
+        sha256="ca2e1307630e6fccac279ab7711036f7c6dee43c386fd6f24cfc77c86a3c7f1c"
     )
     version(
         "2.3.3",
-        sha256="73d8c9038d00c7f768f65474b2a657d5c49daf105ddfcaef7d16737500b5d02f",
-        url="https://github.com/ALPSim/ALPS/archive/refs/tags/v2.3.3.tar.gz",
+        sha256="73d8c9038d00c7f768f65474b2a657d5c49daf105ddfcaef7d16737500b5d02f"
     )
+
+    variant("mpi", default=True,  description="Build with MPI support")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
     depends_on("boost@1.80:")  # Just for headers. Note that the checksums are listed below
     depends_on("fftw")
-    depends_on("hdf5 ~mpi+hl")
     depends_on("lapack")
     depends_on("python", type=("build", "link", "run"))
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-scipy", type=("build", "run"))
     depends_on("py-matplotlib", type=("build", "run"))
-    depends_on("mpi")
+    depends_on("mpi", when="+mpi")
+    depends_on("hdf5+mpi+hl", when="+mpi")
+    depends_on("hdf5~mpi+hl", when="~mpi")
     depends_on("zlib")
 
     extends("python")
@@ -151,9 +153,11 @@ class Alps(CMakePackage):
         args.append("-DBoost_USE_STATIC_RUNTIME=OFF")
 
         # Add MPI support - just specify compilers (minimal change)
-        args.append("-DMPI_CXX_COMPILER={0}".format(self.spec["mpi"].mpicxx))
-
-        args.append("-DMPI_C_COMPILER={0}".format(self.spec["mpi"].mpicc))
+        if "+mpi" in self.spec:
+            args.append("-DMPI_CXX_COMPILER={0}".format(self.spec["mpi"].mpicxx))
+            args.append("-DMPI_C_COMPILER={0}".format(self.spec["mpi"].mpicc))
+        else:
+            args.append("-DENABLE_MPI=OFF")
 
         # Preserve link paths as RPATH in the installed binary
         args.append("-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON")
@@ -181,9 +185,10 @@ class Alps(CMakePackage):
         env.append_path("CPLUS_INCLUDE_PATH", self.spec["python"].headers.directories[0])
 
         # For MPI - set compiler wrappers
-        env.set("MPI_CXX", self.spec["mpi"].mpicxx)
-        env.set("MPI_CC", self.spec["mpi"].mpicc)
-        env.set("MPICXX", self.spec["mpi"].mpicxx)
+        if "+mpi" in self.spec:
+            env.set("MPI_CXX", self.spec["mpi"].mpicxx)
+            env.set("MPI_CC", self.spec["mpi"].mpicc)
+            env.set("MPICXX", self.spec["mpi"].mpicxx)
 
         # Add MPI include path if available
         if hasattr(self.spec["mpi"], "headers"):

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -24,7 +24,8 @@ class Alps(CMakePackage):
     license("MIT", checked_by="Ooolab")
 
     version(
-        "2.3.4-beta.2", sha256="ca2e1307630e6fccac279ab7711036f7c6dee43c386fd6f24cfc77c86a3c7f1c", preferred=True
+        "2.3.4-beta.2", sha256="ca2e1307630e6fccac279ab7711036f7c6dee43c386fd6f24cfc77c86a3c7f1c", 
+        preferred=True,
     )
     version("2.3.3", sha256="73d8c9038d00c7f768f65474b2a657d5c49daf105ddfcaef7d16737500b5d02f")
 
@@ -33,7 +34,9 @@ class Alps(CMakePackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
-    depends_on("boost@1.80:", type="build")  # Just for headers. Note that the checksums are listed below
+    depends_on(
+        "boost@1.80:", type="build"
+    )  # Just for headers. Note that the checksums are listed below
     depends_on("fftw")
     depends_on("lapack")
     depends_on("python", type=("build", "link", "run"))
@@ -101,9 +104,7 @@ class Alps(CMakePackage):
 
             # Now replace boost::is_same with std::is_same
             filter_file(
-                "boost::is_same",
-                "std::is_same",
-                "src/alps/numeric/matrix/strided_iterator.hpp",
+                "boost::is_same", "std::is_same", "src/alps/numeric/matrix/strided_iterator.hpp"
             )
 
             filter_file(
@@ -141,29 +142,31 @@ class Alps(CMakePackage):
             + cstdlibstr
         )
 
-        args.append(self.define('CMAKE_CXX_FLAGS', cxx_flags))
+        args.append(self.define("CMAKE_CXX_FLAGS", cxx_flags))
 
         # Boost source directory
         boost_src_dir = os.path.join(self.stage.source_path, "boost_source_files")
-        args.append(self.define('Boost_SRC_DIR', boost_src_dir))
+        args.append(self.define("Boost_SRC_DIR", boost_src_dir))
 
         # Boost linking options
-        args.append(self.define('Boost_USE_STATIC_LIBS', True))        # → -DBoost_USE_STATIC_LIBS=ON
-        args.append(self.define('Boost_USE_STATIC_RUNTIME', False))    # → -DBoost_USE_STATIC_RUNTIME=OFF
+        args.append(self.define("Boost_USE_STATIC_LIBS", True))        # → -DBoost_USE_STATIC_LIBS=ON
+        args.append(self.define(
+            "Boost_USE_STATIC_RUNTIME", False)
+        )    # → -DBoost_USE_STATIC_RUNTIME=OFF
 
         # MPI support
         if self.spec.satisfies("+mpi"):
-            args.append(self.define('MPI_CXX_COMPILER', self.spec["mpi"].mpicxx))
-            args.append(self.define('MPI_C_COMPILER', self.spec["mpi"].mpicc))
+            args.append(self.define("MPI_CXX_COMPILER", self.spec["mpi"].mpicxx))
+            args.append(self.define("MPI_C_COMPILER", self.spec["mpi"].mpicc))
         else:
-            args.append(self.define('ENABLE_MPI', False))
+            args.append(self.define("ENABLE_MPI", False))
 
         # RPATH settings
-        args.append(self.define('CMAKE_INSTALL_RPATH_USE_LINK_PATH', True))
-        args.append(self.define('CMAKE_BUILD_WITH_INSTALL_RPATH', True))
+        args.append(self.define("CMAKE_INSTALL_RPATH_USE_LINK_PATH", True))
+        args.append(self.define("CMAKE_BUILD_WITH_INSTALL_RPATH", True))
 
         # Point to Spack's HDF5
-        args.append(self.define('HDF5_DIR', self.spec["hdf5"].prefix))
+        args.append(self.define("HDF5_DIR", self.spec["hdf5"].prefix))
 
         return args
 

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -24,8 +24,8 @@ class Alps(CMakePackage):
     license("MIT", checked_by="Ooolab")
 
     version(
-        "2.3.4-beta.2", 
-        sha256="ca2e1307630e6fccac279ab7711036f7c6dee43c386fd6f24cfc77c86a3c7f1c", 
+        "2.3.4-beta.2",
+        sha256="ca2e1307630e6fccac279ab7711036f7c6dee43c386fd6f24cfc77c86a3c7f1c",
         preferred=True,
     )
     version("2.3.3", sha256="73d8c9038d00c7f768f65474b2a657d5c49daf105ddfcaef7d16737500b5d02f")
@@ -150,10 +150,10 @@ class Alps(CMakePackage):
         args.append(self.define("Boost_SRC_DIR", boost_src_dir))
 
         # Boost linking options
-        args.append(self.define("Boost_USE_STATIC_LIBS", True)) # → -DBoost_USE_STATIC_LIBS=ON
+        args.append(self.define("Boost_USE_STATIC_LIBS", True))  # → -DBoost_USE_STATIC_LIBS=ON
         args.append(
             self.define("Boost_USE_STATIC_RUNTIME", False)
-        ) # → -DBoost_USE_STATIC_RUNTIME=OFF
+        )  # → -DBoost_USE_STATIC_RUNTIME=OFF
 
         # MPI support
         if self.spec.satisfies("+mpi"):

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -15,21 +15,21 @@ class Alps(CMakePackage):
     """
 
     homepage = "https://github.com/ALPSim/ALPS"
-    url = "https://github.com/ALPSim/ALPS/archive/refs/tags/v2.3.4.tar.gz"
 
     maintainers("Ooolab","egull")
 
     license("MIT", checked_by="Ooolab")
 
-    version("2.3.4", sha256="bc65453bb88cc42de77c2963a44966fb3c92e80ff8e8e29e80fb87694fba41d7")
-    version("2.3.3-beta.6", sha256="eb0c8115b034dd7a9dd585d277c4f86904ba374cdbdd130545aca1c432583b68")
+    version(
+        "2.3.4-beta.2", sha256="ca2e1307630e6fccac279ab7711036f7c6dee43c386fd6f24cfc77c86a3c7f1c", url = "https://github.com/ALPSim/ALPS/archive/refs/tags/v2.3.4-beta.2.tar.gz"
+    )
+    version(
+        "2.3.3", sha256="73d8c9038d00c7f768f65474b2a657d5c49daf105ddfcaef7d16737500b5d02f", url = "https://github.com/ALPSim/ALPS/archive/refs/tags/v2.3.3.tar.gz"
+    )
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
-
-    # update version constraint on every boost release after providing version & checksum info
-    # in resources dictionary below
     depends_on("boost@1.80:")  # Just for headers. Note that the checksums are listed below
     depends_on("fftw")
     depends_on("hdf5 ~mpi+hl")
@@ -39,13 +39,9 @@ class Alps(CMakePackage):
     depends_on("py-scipy", type=("build", "run"))
     depends_on("py-matplotlib", type=("build", "run"))
     depends_on("mpi")
+    depends_on("zlib")
     
     extends("python")
-
-    # https://github.com/ALPSim/ALPS/issues/9
-    #conflicts(
-    #    "%gcc@14", when="@:2.3.3-beta.6", msg="use gcc older than version 14 or else build fails"
-    #)
 
     # See https://github.com/ALPSim/ALPS/issues/6#issuecomment-2604912169
     # for why this is needed
@@ -122,6 +118,7 @@ class Alps(CMakePackage):
                     'std::add_const',
                     'src/alps/numeric/matrix/matrix_element_iterator.hpp'
                 )
+                
 
     def cmake_args(self):
         args = []
@@ -163,6 +160,13 @@ class Alps(CMakePackage):
             "-DMPI_C_COMPILER={0}".format(self.spec['mpi'].mpicc)
         )
         
+        # Preserve link paths as RPATH in the installed binary
+        args.append("-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON")
+        args.append("-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON")
+        
+        # Tell CMake to use Spack’s HDF5 explicitly
+        args.append("-DHDF5_DIR={0}".format(self.spec['hdf5'].prefix))
+
         # Add Python support
         args.append(
             "-DPYTHON_EXECUTABLE={0}".format(self.spec['python'].command.path)
@@ -206,14 +210,3 @@ class Alps(CMakePackage):
         env.append_flags('CXXFLAGS', '-DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF')
         env.append_flags('CXXFLAGS', '-DBOOST_TIMER_ENABLE_DEPRECATED')
         env.append_flags('CXXFLAGS', self.compiler.cxx14_flag)
-
-
-    @run_after("install")
-    def relocate_python_stuff(self):
-        pyalps_dir = join_path(python_platlib, "pyalps")
-        with working_dir(self.prefix):
-            copy_tree("pyalps", pyalps_dir)
-        with working_dir(self.prefix.lib):
-            copy_tree("pyalps", pyalps_dir)
-            # in pip installed pyalps package, xml dir is provided under platlib/pyalps
-            copy_tree("xml", join_path(pyalps_dir, "xml"))

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -23,10 +23,12 @@ class Alps(CMakePackage):
 
     license("MIT", checked_by="Ooolab")
 
-    version("2.3.4-beta.2", sha256="ca2e1307630e6fccac279ab7711036f7c6dee43c386fd6f24cfc77c86a3c7f1c")
+    version(
+        "2.3.4-beta.2", sha256="ca2e1307630e6fccac279ab7711036f7c6dee43c386fd6f24cfc77c86a3c7f1c"
+    )
     version("2.3.3", sha256="73d8c9038d00c7f768f65474b2a657d5c49daf105ddfcaef7d16737500b5d02f")
 
-    variant("mpi", default=True,  description="Build with MPI support")
+    variant("mpi", default=True, description="Build with MPI support")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -23,14 +23,8 @@ class Alps(CMakePackage):
 
     license("MIT", checked_by="Ooolab")
 
-    version(
-        "2.3.4-beta.2",
-        sha256="ca2e1307630e6fccac279ab7711036f7c6dee43c386fd6f24cfc77c86a3c7f1c"
-    )
-    version(
-        "2.3.3",
-        sha256="73d8c9038d00c7f768f65474b2a657d5c49daf105ddfcaef7d16737500b5d02f"
-    )
+    version("2.3.4-beta.2", sha256="ca2e1307630e6fccac279ab7711036f7c6dee43c386fd6f24cfc77c86a3c7f1c")
+    version("2.3.3", sha256="73d8c9038d00c7f768f65474b2a657d5c49daf105ddfcaef7d16737500b5d02f")
 
     variant("mpi", default=True,  description="Build with MPI support")
 

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -15,15 +15,19 @@ class Alps(CMakePackage):
 
     homepage = "https://github.com/ALPSim/ALPS"
 
-    maintainers("Ooolab","egull")
+    maintainers("Ooolab", "egull")
 
     license("MIT", checked_by="Ooolab")
 
     version(
-        "2.3.4-beta.2", sha256="ca2e1307630e6fccac279ab7711036f7c6dee43c386fd6f24cfc77c86a3c7f1c", url = "https://github.com/ALPSim/ALPS/archive/refs/tags/v2.3.4-beta.2.tar.gz"
+        "2.3.4-beta.2",
+        sha256="ca2e1307630e6fccac279ab7711036f7c6dee43c386fd6f24cfc77c86a3c7f1c",
+        url="https://github.com/ALPSim/ALPS/archive/refs/tags/v2.3.4-beta.2.tar.gz",
     )
     version(
-        "2.3.3", sha256="73d8c9038d00c7f768f65474b2a657d5c49daf105ddfcaef7d16737500b5d02f", url = "https://github.com/ALPSim/ALPS/archive/refs/tags/v2.3.3.tar.gz"
+        "2.3.3",
+        sha256="73d8c9038d00c7f768f65474b2a657d5c49daf105ddfcaef7d16737500b5d02f",
+        url="https://github.com/ALPSim/ALPS/archive/refs/tags/v2.3.3.tar.gz",
     )
 
     depends_on("c", type="build")
@@ -72,59 +76,58 @@ class Alps(CMakePackage):
     def patch(self):
         # Only apply patch for Boost versions greater than 1.87
         # Check if boost dependency is specified and get its version
-        if 'boost' in self.spec:
-            boost_spec = self.spec['boost']
+        if "boost" in self.spec:
+            boost_spec = self.spec["boost"]
             # Compare versions: only apply patch if boost version > 1.87
-            if boost_spec.version > Version('1.87'):
+            if boost_spec.version > Version("1.87"):
                 # Fix boost::is_same and boost::add_const for >=Boost 1.88.0 compatibility
                 # These type traits were moved to std:: in >=Boost 1.88.0
-                
+
                 # First, let's add necessary includes
                 filter_file(
-                    '#include <boost/type_traits.hpp>',
-                    '#include <boost/type_traits.hpp>\n#include <type_traits>',
-                    'src/alps/numeric/matrix/strided_iterator.hpp'
+                    "#include <boost/type_traits.hpp>",
+                    "#include <boost/type_traits.hpp>\n#include <type_traits>",
+                    "src/alps/numeric/matrix/strided_iterator.hpp",
                 )
-                
+
                 filter_file(
-                    '#include <boost/type_traits.hpp>',
-                    '#include <boost/type_traits.hpp>\n#include <type_traits>',
-                    'src/alps/numeric/matrix/matrix_element_iterator.hpp'
+                    "#include <boost/type_traits.hpp>",
+                    "#include <boost/type_traits.hpp>\n#include <type_traits>",
+                    "src/alps/numeric/matrix/matrix_element_iterator.hpp",
                 )
-                
+
                 # Now replace boost::is_same with std::is_same
                 filter_file(
-                    'boost::is_same',
-                    'std::is_same',
-                    'src/alps/numeric/matrix/strided_iterator.hpp'
+                    "boost::is_same",
+                    "std::is_same",
+                    "src/alps/numeric/matrix/strided_iterator.hpp",
                 )
-                
+
                 filter_file(
-                    'boost::is_same',
-                    'std::is_same',
-                    'src/alps/numeric/matrix/matrix_element_iterator.hpp'
+                    "boost::is_same",
+                    "std::is_same",
+                    "src/alps/numeric/matrix/matrix_element_iterator.hpp",
                 )
-                
+
                 # Replace boost::add_const with std::add_const
                 filter_file(
-                    'boost::add_const',
-                    'std::add_const',
-                    'src/alps/numeric/matrix/strided_iterator.hpp'
+                    "boost::add_const",
+                    "std::add_const",
+                    "src/alps/numeric/matrix/strided_iterator.hpp",
                 )
-                
+
                 filter_file(
-                    'boost::add_const',
-                    'std::add_const',
-                    'src/alps/numeric/matrix/matrix_element_iterator.hpp'
+                    "boost::add_const",
+                    "std::add_const",
+                    "src/alps/numeric/matrix/matrix_element_iterator.hpp",
                 )
-                
 
     def cmake_args(self):
         args = []
-        #this will ensure availability of the cstddef header on darwin (mac)
-        cstdlibstr=""
+        # This will ensure availability of the cstddef header on darwin (mac)
+        cstdlibstr = ""
         if self.spec.satisfies("platform=darwin"):
-          cstdlibstr=" -stdlib=libc++"
+            cstdlibstr = " -stdlib=libc++"
 
         args.append(
             "-DCMAKE_CXX_FLAGS={0}".format(
@@ -134,78 +137,61 @@ class Alps(CMakePackage):
                 + cstdlibstr
             )
         )
-        
+
         # Point to boost source files that need to be compiled
         boost_src_dir = os.path.join(self.stage.source_path, "boost_source_files")
-        args.append(
-            "-DBoost_SRC_DIR={0}".format(boost_src_dir)
-        )
-        
+        args.append("-DBoost_SRC_DIR={0}".format(boost_src_dir))
+
         # Tell CMake to compile boost from source
-        args.append(
-            "-DBoost_USE_STATIC_LIBS=ON"
-        )
-        
-        args.append(
-            "-DBoost_USE_STATIC_RUNTIME=OFF"
-        )
-        
+        args.append("-DBoost_USE_STATIC_LIBS=ON")
+
+        args.append("-DBoost_USE_STATIC_RUNTIME=OFF")
+
         # Add MPI support - just specify compilers (minimal change)
-        args.append(
-            "-DMPI_CXX_COMPILER={0}".format(self.spec['mpi'].mpicxx)
-        )
-        
-        args.append(
-            "-DMPI_C_COMPILER={0}".format(self.spec['mpi'].mpicc)
-        )
-        
+        args.append("-DMPI_CXX_COMPILER={0}".format(self.spec["mpi"].mpicxx))
+
+        args.append("-DMPI_C_COMPILER={0}".format(self.spec["mpi"].mpicc))
+
         # Preserve link paths as RPATH in the installed binary
         args.append("-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON")
         args.append("-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON")
-        
+
         # Tell CMake to use Spack’s HDF5 explicitly
-        args.append("-DHDF5_DIR={0}".format(self.spec['hdf5'].prefix))
+        args.append("-DHDF5_DIR={0}".format(self.spec["hdf5"].prefix))
 
         # Add Python support
-        args.append(
-            "-DPYTHON_EXECUTABLE={0}".format(self.spec['python'].command.path)
-        )
-        
-        args.append(
-            "-DPYTHON_INCLUDE_DIR={0}".format(self.spec['python'].headers.directories[0])
-        )
-        
-        args.append(
-            "-DPYTHON_LIBRARY={0}".format(self.spec['python'].libs[0])
-        )
-        
+        args.append("-DPYTHON_EXECUTABLE={0}".format(self.spec["python"].command.path))
+
+        args.append("-DPYTHON_INCLUDE_DIR={0}".format(self.spec["python"].headers.directories[0]))
+
+        args.append("-DPYTHON_LIBRARY={0}".format(self.spec["python"].libs[0]))
+
         return args
-        
-        
+
     def setup_build_environment(self, env):
         # Set up environment for boost source compilation
-        boost_src_dir = os.path.join(self.stage.source_path, 'boost_source_files')
-        env.set('BOOST_ROOT', boost_src_dir)
-        env.set('Boost_SRC_DIR', boost_src_dir)
-        
+        boost_src_dir = os.path.join(self.stage.source_path, "boost_source_files")
+        env.set("BOOST_ROOT", boost_src_dir)
+        env.set("Boost_SRC_DIR", boost_src_dir)
+
         # Include paths for compilation
-        env.append_path('CPLUS_INCLUDE_PATH', self.spec['python'].headers.directories[0])
-        
+        env.append_path("CPLUS_INCLUDE_PATH", self.spec["python"].headers.directories[0])
+
         # For MPI - set compiler wrappers
-        env.set('MPI_CXX', self.spec['mpi'].mpicxx)
-        env.set('MPI_CC', self.spec['mpi'].mpicc)
-        env.set('MPICXX', self.spec['mpi'].mpicxx)
-        
+        env.set("MPI_CXX", self.spec["mpi"].mpicxx)
+        env.set("MPI_CC", self.spec["mpi"].mpicc)
+        env.set("MPICXX", self.spec["mpi"].mpicxx)
+
         # Add MPI include path if available
-        if hasattr(self.spec['mpi'], 'headers'):
-            env.append_path('CPLUS_INCLUDE_PATH', self.spec['mpi'].headers.directories[0])
-        
+        if hasattr(self.spec["mpi"], "headers"):
+            env.append_path("CPLUS_INCLUDE_PATH", self.spec["mpi"].headers.directories[0])
+
         # For Python
-        env.set('PYTHON', self.spec['python'].command.path)
-        
+        env.set("PYTHON", self.spec["python"].command.path)
+
         # Compiler flags
-        env.append_flags('CXXFLAGS', '-fpermissive')
-        env.append_flags('CXXFLAGS', '-DBOOST_NO_AUTO_PTR')
-        env.append_flags('CXXFLAGS', '-DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF')
-        env.append_flags('CXXFLAGS', '-DBOOST_TIMER_ENABLE_DEPRECATED')
-        env.append_flags('CXXFLAGS', self.compiler.cxx14_flag)
+        env.append_flags("CXXFLAGS", "-fpermissive")
+        env.append_flags("CXXFLAGS", "-DBOOST_NO_AUTO_PTR")
+        env.append_flags("CXXFLAGS", "-DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF")
+        env.append_flags("CXXFLAGS", "-DBOOST_TIMER_ENABLE_DEPRECATED")
+        env.append_flags("CXXFLAGS", self.compiler.cxx14_flag)

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -21,7 +21,8 @@ class Alps(CMakePackage):
 
     maintainers("Ooolab", "egull", "Sinan81")
 
-    license("MIT", checked_by="Ooolab")
+    license("BSL-1.0", when="@:2.3.3", checked_by="Sinan81")
+    license("MIT", when="@2.3.4:", checked_by="Ooolab")
 
     version(
         "2.3.4-beta.2",

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -171,7 +171,6 @@ class Alps(CMakePackage):
 
         return args
 
-
     def setup_build_environment(self, env):
         # Set up environment for boost source compilation
         boost_src_dir = os.path.join(self.stage.source_path, "boost_source_files")

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -2,10 +2,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack_repo.builtin.build_systems.cmake import CMakePackage
-
-from spack.package import *
 import os
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack.package import *
 
 class Alps(CMakePackage):
     """

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -24,7 +24,7 @@ class Alps(CMakePackage):
     license("MIT", checked_by="Ooolab")
 
     version(
-        "2.3.4-beta.2", sha256="ca2e1307630e6fccac279ab7711036f7c6dee43c386fd6f24cfc77c86a3c7f1c"
+        "2.3.4-beta.2", sha256="ca2e1307630e6fccac279ab7711036f7c6dee43c386fd6f24cfc77c86a3c7f1c", preferred=True
     )
     version("2.3.3", sha256="73d8c9038d00c7f768f65474b2a657d5c49daf105ddfcaef7d16737500b5d02f")
 
@@ -33,7 +33,7 @@ class Alps(CMakePackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
-    depends_on("boost@1.80:")  # Just for headers. Note that the checksums are listed below
+    depends_on("boost@1.80:", type="build")  # Just for headers. Note that the checksums are listed below
     depends_on("fftw")
     depends_on("lapack")
     depends_on("python", type=("build", "link", "run"))
@@ -43,7 +43,7 @@ class Alps(CMakePackage):
     depends_on("mpi", when="+mpi")
     depends_on("hdf5+mpi+hl", when="+mpi")
     depends_on("hdf5~mpi+hl", when="~mpi")
-    depends_on("zlib")
+    depends_on("zlib-api")
 
     extends("python")
 
@@ -77,99 +77,96 @@ class Alps(CMakePackage):
     def patch(self):
         # Only apply patch for Boost versions greater than 1.87
         # Check if boost dependency is specified and get its version
-        if "boost" in self.spec:
-            boost_spec = self.spec["boost"]
-            # Compare versions: only apply patch if boost version > 1.87
-            if boost_spec.version > Version("1.87"):
-                # Fix boost::is_same and boost::add_const for >=Boost 1.88.0 compatibility
-                # These type traits were moved to std:: in >=Boost 1.88.0
+        if "boost" not in self.spec:
+            return
 
-                # First, let's add necessary includes
-                filter_file(
-                    "#include <boost/type_traits.hpp>",
-                    "#include <boost/type_traits.hpp>\n#include <type_traits>",
-                    "src/alps/numeric/matrix/strided_iterator.hpp",
-                )
+        boost_spec = self.spec["boost"]
+        # Compare versions: only apply patch if boost version > 1.87
+        if boost_spec.version > Version("1.87"):
+            # Fix boost::is_same and boost::add_const for >=Boost 1.88.0 compatibility
+            # These type traits were moved to std:: in >=Boost 1.88.0
 
-                filter_file(
-                    "#include <boost/type_traits.hpp>",
-                    "#include <boost/type_traits.hpp>\n#include <type_traits>",
-                    "src/alps/numeric/matrix/matrix_element_iterator.hpp",
-                )
+            # First, let's add necessary includes
+            filter_file(
+                "#include <boost/type_traits.hpp>",
+                "#include <boost/type_traits.hpp>\n#include <type_traits>",
+                "src/alps/numeric/matrix/strided_iterator.hpp",
+            )
 
-                # Now replace boost::is_same with std::is_same
-                filter_file(
-                    "boost::is_same",
-                    "std::is_same",
-                    "src/alps/numeric/matrix/strided_iterator.hpp",
-                )
+            filter_file(
+                "#include <boost/type_traits.hpp>",
+                "#include <boost/type_traits.hpp>\n#include <type_traits>",
+                "src/alps/numeric/matrix/matrix_element_iterator.hpp",
+            )
 
-                filter_file(
-                    "boost::is_same",
-                    "std::is_same",
-                    "src/alps/numeric/matrix/matrix_element_iterator.hpp",
-                )
+            # Now replace boost::is_same with std::is_same
+            filter_file(
+                "boost::is_same",
+                "std::is_same",
+                "src/alps/numeric/matrix/strided_iterator.hpp",
+            )
 
-                # Replace boost::add_const with std::add_const
-                filter_file(
-                    "boost::add_const",
-                    "std::add_const",
-                    "src/alps/numeric/matrix/strided_iterator.hpp",
-                )
+            filter_file(
+                "boost::is_same",
+                "std::is_same",
+                "src/alps/numeric/matrix/matrix_element_iterator.hpp",
+            )
 
-                filter_file(
-                    "boost::add_const",
-                    "std::add_const",
-                    "src/alps/numeric/matrix/matrix_element_iterator.hpp",
-                )
+            # Replace boost::add_const with std::add_const
+            filter_file(
+                "boost::add_const",
+                "std::add_const",
+                "src/alps/numeric/matrix/strided_iterator.hpp",
+            )
+
+            filter_file(
+                "boost::add_const",
+                "std::add_const",
+                "src/alps/numeric/matrix/matrix_element_iterator.hpp",
+            )
 
     def cmake_args(self):
         args = []
-        # This will ensure availability of the cstddef header on darwin (mac)
+
+        # Platform-specific C++ flags (e.g., -stdlib=libc++ on macOS)
         cstdlibstr = ""
         if self.spec.satisfies("platform=darwin"):
             cstdlibstr = " -stdlib=libc++"
 
-        args.append(
-            "-DCMAKE_CXX_FLAGS={0}".format(
-                self.compiler.cxx14_flag
-                + " -fpermissive -DBOOST_NO_AUTO_PTR -DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF"
-                + " -DBOOST_TIMER_ENABLE_DEPRECATED"
-                + cstdlibstr
-            )
+        # Assemble the full C++ flags string
+        cxx_flags = (
+            self.compiler.cxx14_flag
+            + " -fpermissive -DBOOST_NO_AUTO_PTR -DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF"
+            + " -DBOOST_TIMER_ENABLE_DEPRECATED"
+            + cstdlibstr
         )
 
-        # Point to boost source files that need to be compiled
+        args.append(self.define('CMAKE_CXX_FLAGS', cxx_flags))
+
+        # Boost source directory
         boost_src_dir = os.path.join(self.stage.source_path, "boost_source_files")
-        args.append("-DBoost_SRC_DIR={0}".format(boost_src_dir))
+        args.append(self.define('Boost_SRC_DIR', boost_src_dir))
 
-        # Tell CMake to compile boost from source
-        args.append("-DBoost_USE_STATIC_LIBS=ON")
+        # Boost linking options
+        args.append(self.define('Boost_USE_STATIC_LIBS', True))        # → -DBoost_USE_STATIC_LIBS=ON
+        args.append(self.define('Boost_USE_STATIC_RUNTIME', False))    # → -DBoost_USE_STATIC_RUNTIME=OFF
 
-        args.append("-DBoost_USE_STATIC_RUNTIME=OFF")
-
-        # Add MPI support - just specify compilers (minimal change)
-        if "+mpi" in self.spec:
-            args.append("-DMPI_CXX_COMPILER={0}".format(self.spec["mpi"].mpicxx))
-            args.append("-DMPI_C_COMPILER={0}".format(self.spec["mpi"].mpicc))
+        # MPI support
+        if self.spec.satisfies("+mpi"):
+            args.append(self.define('MPI_CXX_COMPILER', self.spec["mpi"].mpicxx))
+            args.append(self.define('MPI_C_COMPILER', self.spec["mpi"].mpicc))
         else:
-            args.append("-DENABLE_MPI=OFF")
+            args.append(self.define('ENABLE_MPI', False))
 
-        # Preserve link paths as RPATH in the installed binary
-        args.append("-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON")
-        args.append("-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON")
+        # RPATH settings
+        args.append(self.define('CMAKE_INSTALL_RPATH_USE_LINK_PATH', True))
+        args.append(self.define('CMAKE_BUILD_WITH_INSTALL_RPATH', True))
 
-        # Tell CMake to use Spack’s HDF5 explicitly
-        args.append("-DHDF5_DIR={0}".format(self.spec["hdf5"].prefix))
-
-        # Add Python support
-        args.append("-DPYTHON_EXECUTABLE={0}".format(self.spec["python"].command.path))
-
-        args.append("-DPYTHON_INCLUDE_DIR={0}".format(self.spec["python"].headers.directories[0]))
-
-        args.append("-DPYTHON_LIBRARY={0}".format(self.spec["python"].libs[0]))
+        # Point to Spack's HDF5
+        args.append(self.define('HDF5_DIR', self.spec["hdf5"].prefix))
 
         return args
+
 
     def setup_build_environment(self, env):
         # Set up environment for boost source compilation

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -24,7 +24,8 @@ class Alps(CMakePackage):
     license("MIT", checked_by="Ooolab")
 
     version(
-        "2.3.4-beta.2", sha256="ca2e1307630e6fccac279ab7711036f7c6dee43c386fd6f24cfc77c86a3c7f1c", 
+        "2.3.4-beta.2", 
+        sha256="ca2e1307630e6fccac279ab7711036f7c6dee43c386fd6f24cfc77c86a3c7f1c", 
         preferred=True,
     )
     version("2.3.3", sha256="73d8c9038d00c7f768f65474b2a657d5c49daf105ddfcaef7d16737500b5d02f")
@@ -149,10 +150,10 @@ class Alps(CMakePackage):
         args.append(self.define("Boost_SRC_DIR", boost_src_dir))
 
         # Boost linking options
-        args.append(self.define("Boost_USE_STATIC_LIBS", True))        # → -DBoost_USE_STATIC_LIBS=ON
-        args.append(self.define(
-            "Boost_USE_STATIC_RUNTIME", False)
-        )    # → -DBoost_USE_STATIC_RUNTIME=OFF
+        args.append(self.define("Boost_USE_STATIC_LIBS", True)) # → -DBoost_USE_STATIC_LIBS=ON
+        args.append(
+            self.define("Boost_USE_STATIC_RUNTIME", False)
+        ) # → -DBoost_USE_STATIC_RUNTIME=OFF
 
         # MPI support
         if self.spec.satisfies("+mpi"):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
In this updated spack package, we added support for newer versions of Boost and macOS26. 