### PR TITLE
exodusii: Add missing releases

### DIFF
--- a/repos/spack_repo/builtin/packages/exodusii/package.py
+++ b/repos/spack_repo/builtin/packages/exodusii/package.py
@@ -32,6 +32,12 @@ class Exodusii(CMakePackage):
 
     version("master", branch="master")
     version(
+        "2025-10-14", sha256="d2442cff8ba963cd538f75fb4d7eb50b3f5c75cb01c8603af8185481f25db042"
+    )
+    version(
+        "2025-08-28", sha256="7a8092dec82af8c5074911ce1d156176948addf7ccf34362c16bba99eff0ee72"
+    )
+    version(
         "2025-08-19", sha256="cdd571a26e77f7a0053c1c5638fed19a111f43f82b8a4c0f7e7b3339dc4cd401"
     )
     version(


### PR DESCRIPTION
The seacas package which exodusII is a subset of has two releases which were not propogated over to exodusii package.  This fixes that.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
