### PR TITLE
root: enable builtin_civetweb until issues are fixed

### DIFF
--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -437,7 +437,8 @@ class Root(CMakePackage):
 
     # Optional dependencies
     depends_on("arrow", when="+arrow")
-    depends_on("civetweb +shared", when="+http")
+    # Commented out until it is fixed and builtin_civetweb can be turned off
+    # depends_on("civetweb +shared", when="+http")
     depends_on("cuda", when="+cuda")
     depends_on("cuda", when="+cudnn")
     depends_on("cudnn", when="+cudnn")
@@ -687,7 +688,7 @@ class Root(CMakePackage):
 
         options += [
             define("builtin_cfitsio", False),
-            define("builtin_civetweb", False),
+            define("builtin_civetweb", True),
             define("builtin_davix", False),
             define("builtin_fftw3", False),
             define("builtin_freetype", False),


### PR DESCRIPTION
There are crashes when running the browser when using an external civetweb (see
https://github.com/spack/spack-packages/issues/3400) and this feature seems not
to have been extensively tested. I tried disabling and enabling different options for civetweb but crashes were still happening both on Alma 9 and Ubuntu 24. The maintainer seems to only have tried this with the civetweb that comes in Fedora.