### PR TITLE
quantum-espresso: fix cmake compiler flags

### DIFF
--- a/repos/spack_repo/builtin/packages/quantum_espresso/package.py
+++ b/repos/spack_repo/builtin/packages/quantum_espresso/package.py
@@ -473,11 +473,6 @@ class CMakeBuilder(cmake.CMakeBuilder):
         if "+cuda" in self.spec:
             cmake_args.append(self.define("QE_ENABLE_OPENACC", True))
 
-        # QE prefers taking MPI compiler wrappers as CMake compilers.
-        if "+mpi" in spec:
-            cmake_args.append(self.define("CMAKE_C_COMPILER", spec["mpi"].mpicc))
-            cmake_args.append(self.define("CMAKE_Fortran_COMPILER", spec["mpi"].mpifc))
-
         if not spec.satisfies("hdf5=none"):
             cmake_args.append(self.define("QE_ENABLE_HDF5", True))
 


### PR DESCRIPTION
Fixes #3544

With some `openmpi` installation, CMake does not like using MPI wrappers as compilers.
By simply removing these flags, it is able to find the correct compilers and libraries.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
