### PR TITLE
ginkgo: add forward compat bound for rocthrust

### DIFF
--- a/repos/spack_repo/builtin/packages/ginkgo/package.py
+++ b/repos/spack_repo/builtin/packages/ginkgo/package.py
@@ -79,6 +79,8 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("mpi@3.1:", when="+mpi")
 
     depends_on("rocthrust", when="+rocm")
+    # https://github.com/ginkgo-project/ginkgo/issues/1983
+    depends_on("rocthrust@:7.1", when="@:1.11 +rocm")
     depends_on("hipsparse", when="+rocm")
     depends_on("hipblas", when="+rocm")
     depends_on("rocrand", when="+rocm")

--- a/repos/spack_repo/builtin/packages/ginkgo/package.py
+++ b/repos/spack_repo/builtin/packages/ginkgo/package.py
@@ -91,8 +91,7 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("rocprim", when="+rocm")
     depends_on("hip", when="+rocm")
     depends_on("hwloc@2.1:", when="+hwloc")
-    depends_on("papi@master+sde", when="+sde @:1.10.0")
-    depends_on("papi@7.1.0: +sde", when="+sde @1.11.0:")
+    depends_on("papi@7.1.0: +sde", when="+sde")
 
     depends_on("googletest", type="test")
     depends_on("numactl", type="test", when="+hwloc")


### PR DESCRIPTION
Hopefully fixes a failure in CI. See https://github.com/ginkgo-project/ginkgo/issues/1983

```
File: .../rocthrust-7.2.0/include/thrust/iterator/detail/tuple_of_iterator_references.h:177:7
Error: no member named 'thrust' in the global namespace; did you mean 'gko::thrust'?
  177 |     : ::thrust::tuple_element<Id, ::thrust::tuple<Ts...>>
      |       ^~
```

#2767 CI ran weeks before #3145 was merged