### PR TITLE
dust: add 1.2.4 (and missing versions)

### DIFF
--- a/repos/spack_repo/builtin/packages/dust/package.py
+++ b/repos/spack_repo/builtin/packages/dust/package.py
@@ -13,10 +13,20 @@ class Dust(Package):
     homepage = "https://github.com/bootandy/dust"
     url = "https://github.com/bootandy/dust/archive/v0.7.5.tar.gz"
 
-    maintainers("fangohr")
+    maintainers("fangohr", "yig")
 
     license("Apache-2.0")
 
+    version("1.2.4", sha256="2f6768534bd01727234e67f1dd3754c9547aa18c715f6ee52094e881ebac50e3")
+    version("1.2.3", sha256="424b26adfbafeac31da269ecb3f189eca09803e60fad90b3ff692cf52e0aeeee")
+    version("1.2.2", sha256="e72f539ebe2f30bd85f83f8efd87c70c11e27126eeccd93560d94d2f01e153fe")
+    version("1.2.1", sha256="d8ac1a78287a9ea9e6a0e350886dbef8902f5f1dcba9bbc25afafe2ed2ca0a95")
+    version("1.2.0", sha256="e879e6bf662e07cff2962b68529dd78c3bafb67541aaa76e8c9d25ecb505b850")
+    version("1.1.2", sha256="31da99483ee6110d43ed5e7c56a59f40f33b389e45d09d91fca022b42d442040")
+    version("1.1.1", sha256="98cae3e4b32514e51fcc1ed07fdbe6929d4b80942925348cc6e57b308d9c4cb0")
+    version("1.1.0", sha256="2429b4ac76ad8520b99e7167dbb70c8e0088b5fad2c79f799e22b7d137d5fc33")
+    version("1.0.0", sha256="34b72116ab6db9bdb97bc1e49dadf392a1619838204b44b0a4695539d54ffbe8")
+    version("0.9.0", sha256="70efd66e662fcd93bbc6cf2f8c3104a1de7e52090f709e9040a34bdc7c72ea9c")
     version("0.8.6", sha256="feede818e814011207c5bfeaf06dd9fc95825c59ab70942aa9b9314791c5d6b6")
     version("0.7.5", sha256="f892aaf7a0a7852e12d01b2ced6c2484fb6dc5fe7562abdf0c44a2d08aa52618")
 


### PR DESCRIPTION
I used checksum to get new versions for dust. The version in spack didn't work anymore with the current rust compiler due to a stricter ordering check.