### PR TITLE
py-awscrt: add v0.29.2, v0.31.2

### DIFF
--- a/repos/spack_repo/builtin/packages/py_awscrt/package.py
+++ b/repos/spack_repo/builtin/packages/py_awscrt/package.py
@@ -17,6 +17,8 @@ class PyAwscrt(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.31.2", sha256="552555de1beff02d72a1f6d384cd49c5a7c283418310eae29d21bcb749c65792")
+    version("0.29.2", sha256="c78d81b1308d42fda1eb21d27fcf26579137b821043e528550f2cfc6c09ab9ff")
     version("0.20.9", sha256="243785ac9ee64945e0479c2384325545f29597575743ce84c371556d1014e63e")
     version("0.19.19", sha256="1c1511535dee146a6c26a382ed3ead56259a105b3b7d7d823553ae567d038dfe")
     version("0.19.18", sha256="350b6efd8ebee082ea3f3e52c59a3c3ec594cdaf01db8b4853dceb9fec90c89d")

--- a/repos/spack_repo/builtin/packages/py_awscrt/package.py
+++ b/repos/spack_repo/builtin/packages/py_awscrt/package.py
@@ -30,6 +30,9 @@ class PyAwscrt(PythonPackage):
     depends_on("cmake@3.1:", type=("build"))
     depends_on("openssl", type=("build"), when="platform=linux")
     depends_on("py-setuptools", type=("build"))
+    # awscrt>=0.29 requires setuptools.command.bdist_wheel introduced in v71.
+    depends_on("py-setuptools@71:", when="@0.29:", type=("build"))
+    
 
     # On Linux, tell aws-crt-python to use libcrypto from spack (openssl)
     def setup_build_environment(self, env: EnvironmentModifications) -> None:

--- a/repos/spack_repo/builtin/packages/py_awscrt/package.py
+++ b/repos/spack_repo/builtin/packages/py_awscrt/package.py
@@ -31,7 +31,7 @@ class PyAwscrt(PythonPackage):
     depends_on("openssl", type=("build"), when="platform=linux")
     depends_on("py-setuptools", type=("build"))
     # awscrt>=0.29 requires setuptools.command.bdist_wheel introduced in v71.
-    depends_on("py-setuptools@71:", when="@0.29:", type=("build"))
+    depends_on("py-setuptools@75.3.1:", when="@0.29:", type=("build"))
 
     # On Linux, tell aws-crt-python to use libcrypto from spack (openssl)
     def setup_build_environment(self, env: EnvironmentModifications) -> None:

--- a/repos/spack_repo/builtin/packages/py_awscrt/package.py
+++ b/repos/spack_repo/builtin/packages/py_awscrt/package.py
@@ -32,7 +32,6 @@ class PyAwscrt(PythonPackage):
     depends_on("py-setuptools", type=("build"))
     # awscrt>=0.29 requires setuptools.command.bdist_wheel introduced in v71.
     depends_on("py-setuptools@71:", when="@0.29:", type=("build"))
-    
 
     # On Linux, tell aws-crt-python to use libcrypto from spack (openssl)
     def setup_build_environment(self, env: EnvironmentModifications) -> None:


### PR DESCRIPTION
Recent versions of boto3 require api features present in 0.29+

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
