### PR TITLE
lmod: Restrict dependency on procps to linux

### DIFF
--- a/repos/spack_repo/builtin/packages/lmod/package.py
+++ b/repos/spack_repo/builtin/packages/lmod/package.py
@@ -67,7 +67,7 @@ class Lmod(AutotoolsPackage):
 
     depends_on("c", type="build")
     depends_on("pkgconfig", type="build")
-    depends_on("procps", type="build")
+    depends_on("procps", type="build", when="platform=linux")
     depends_on("sed", type="build")
     depends_on("bc", type="build", when="@8.7.10:")
     depends_on("tcl", type=("build", "link", "run"))


### PR DESCRIPTION
Lmod has a dependency on the ps but the procps package is linux only.

However it is quite unlikely that a machine running MacOS would not have a ps command and the only time it could happen for Linux is in a minimalist container.

This would fix https://github.com/spack/spack-packages/issues/3552

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
