### PR TITLE
py-yarl: add cython constraint for PEP 703 compatibility

### DIFF
--- a/repos/spack_repo/builtin/packages/py_yarl/package.py
+++ b/repos/spack_repo/builtin/packages/py_yarl/package.py
@@ -31,6 +31,9 @@ class PyYarl(PythonPackage):
         depends_on("py-setuptools@40:", when="@1.7.2:")
         depends_on("py-setuptools")
         depends_on("py-tomli", when="@1.9.3: ^python@:3.10")
+        # The freethreading_compatible directive is supported only by Cython >= 3.1
+        # cf. PEP 703 and https://docs.python.org/3/howto/free-threading-python.html
+        depends_on("py-cython@3.1:", when="@1.21:")
         # requires https://github.com/cython/cython/commit/ea38521bf59edef9e6d22cbabf44229848091a76
         depends_on("py-cython@3:", when="@1.15.4:")
         depends_on("py-cython")

--- a/repos/spack_repo/builtin/packages/py_yarl/package.py
+++ b/repos/spack_repo/builtin/packages/py_yarl/package.py
@@ -33,6 +33,14 @@ class PyYarl(PythonPackage):
         depends_on("py-tomli", when="@1.9.3: ^python@:3.10")
         # The freethreading_compatible directive is supported only by Cython >= 3.1
         # cf. PEP 703 and https://docs.python.org/3/howto/free-threading-python.html
+        #
+        # In version 1.20.0 there is an enable = ["cpython-freethreading"] in the
+        # [tool.cibuildwheel] block of 'pyproject.toml'
+        # Similarly, it is also present in version 1.21.0 in the same block.
+        # However, this configuration only concern the CI/CD part of the yarl project.
+        # It's the addition of freethreading_compatible = "True" in the
+        # [tool.local.cythonize.kwargs.directive] block that causes an error if the Cython
+        # version is too old.
         depends_on("py-cython@3.1:", when="@1.21:")
         # requires https://github.com/cython/cython/commit/ea38521bf59edef9e6d22cbabf44229848091a76
         depends_on("py-cython@3:", when="@1.15.4:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
The `freethreading_compatible` option appears in `yarl`'s `pyproject.toml` file starting with version 1.21.
This option is only supported from `cython` version 3.1 onwards.