### PR TITLE
 Add ninja generator for composable-kernel builds

### DIFF
--- a/repos/spack_repo/builtin/packages/composable_kernel/package.py
+++ b/repos/spack_repo/builtin/packages/composable_kernel/package.py
@@ -72,7 +72,6 @@ class ComposableKernel(CMakePackage):
     depends_on("cmake@3.16:", type="build")
 
     generator("ninja")
-    depends_on("ninja", type="build")
 
     for ver in [
         "7.2.0",

--- a/repos/spack_repo/builtin/packages/composable_kernel/package.py
+++ b/repos/spack_repo/builtin/packages/composable_kernel/package.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
 from spack.package import *
@@ -71,6 +71,9 @@ class ComposableKernel(CMakePackage):
     depends_on("pkgconfig", type="build")
     depends_on("cmake@3.16:", type="build")
 
+    generator("ninja")
+    depends_on("ninja", type="build")
+
     for ver in [
         "7.2.0",
         "7.1.1",
@@ -137,11 +140,3 @@ class ComposableKernel(CMakePackage):
         if self.spec.satisfies("@6.2:"):
             args.append(self.define("BUILD_DEV", "OFF"))
         return args
-
-    def build(self, spec, prefix):
-        with working_dir(self.build_directory):
-            # only instances is necessary to build and install
-            if self.spec.satisfies("@5.6.0:"):
-                make()
-            else:
-                make("instances")


### PR DESCRIPTION
The PR enables ninja generator to composable-kernel builds.
Verified the build successfully on release 5.7.0 which is currently the oldest supported release 