### PR TITLE
bmi: add perl dependency and enable epoll

### DIFF
--- a/repos/spack_repo/builtin/packages/bmi/package.py
+++ b/repos/spack_repo/builtin/packages/bmi/package.py
@@ -25,11 +25,14 @@ class Bmi(AutotoolsPackage):
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
+    depends_on("perl", type="build")
 
     # need to override 'autoreconf' so we can run BMI's 'prepare' script
     def autoreconf(self, spec, prefix):
         Executable("./prepare")()
 
     def configure_args(self):
-        args = ["--enable-shared", "--enable-bmi-only"]
+        args = ["--enable-shared",
+                "--enable-bmi-only",
+                "--enable-epoll"]
         return args

--- a/repos/spack_repo/builtin/packages/bmi/package.py
+++ b/repos/spack_repo/builtin/packages/bmi/package.py
@@ -32,7 +32,5 @@ class Bmi(AutotoolsPackage):
         Executable("./prepare")()
 
     def configure_args(self):
-        args = ["--enable-shared",
-                "--enable-bmi-only",
-                "--enable-epoll"]
+        args = ["--enable-shared", "--enable-bmi-only", "--enable-epoll"]
         return args


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This PR adds a dependency on perl, which was missing, and adds the `--enable-epoll` flag. The configure script will normally check by itself if epoll is available, but (1) I have found that on some platforms this check fails even though epoll is available (so I have to manually add `--enable-epoll`) and (2) the non-epoll code path has errors and simply doesn't build, so if a platform really doesn't have epoll, BMI won't build anyway.