### PR TITLE
py-setuptools-scm: forward compat with setuptools

### DIFF
--- a/repos/spack_repo/builtin/packages/py_setuptools_scm/package.py
+++ b/repos/spack_repo/builtin/packages/py_setuptools_scm/package.py
@@ -48,6 +48,9 @@ class PySetuptoolsScm(PythonPackage):
         depends_on("py-setuptools@42:", when="@5:")
         depends_on("py-setuptools@34.4:")
 
+        # use of vendored pkg_resources
+        depends_on("py-setuptools@:80", when="@:6")
+
         depends_on("py-tomli@1:2.0.2", when="@8.2.0: ^python@:3.10")
         depends_on("py-tomli@1:", when="@7.1.0:8.1.0 ^python@:3.10")
         depends_on("py-tomli@1:", when="@7.0.0:7.0.5")


### PR DESCRIPTION
Fix CI on develop: old py-setuptools-scm needs old py-setuptools
