### PR TITLE
py-metaphlan: added version 4.2.4, fix py-cmseq requirement

### DIFF
--- a/repos/spack_repo/builtin/packages/py_metaphlan/package.py
+++ b/repos/spack_repo/builtin/packages/py_metaphlan/package.py
@@ -40,4 +40,3 @@ class PyMetaphlan(PythonPackage):
     depends_on("blast-plus@2.6:", type=("build", "run"))
     depends_on("raxml@8.2.10:", type=("build", "run"))
     depends_on("samtools@1.9:", type=("build", "run"))
-

--- a/repos/spack_repo/builtin/packages/py_metaphlan/package.py
+++ b/repos/spack_repo/builtin/packages/py_metaphlan/package.py
@@ -16,6 +16,7 @@ class PyMetaphlan(PythonPackage):
     homepage = "https://github.com/biobakery/MetaPhlAn/"
     pypi = "MetaPhlAn/MetaPhlAn-4.0.2.tar.gz"
 
+    version("4.2.4", sha256="58f9546820c937f258dd9142720422fa5665c6ea7ef90e89bd8f0adbc8a4efc8")
     version("4.0.2", sha256="2549fdf2de97a0024551a7bb8d639613b8a7b612054506c88cdb719353f466ff")
     version("3.1.0", sha256="4e7a7a36d07ed6f4f945afc4216db7f691d44a22b059c2404c917a160a687a6b")
 
@@ -31,7 +32,7 @@ class PyMetaphlan(PythonPackage):
     depends_on("py-requests", type=("build", "run"))
     depends_on("py-dendropy", type=("build", "run"))
     depends_on("py-pysam", type=("build", "run"))
-    depends_on("py-cmseq", type=("build", "run"))
+    depends_on("py-cmseq", type=("build", "run"), when="@:4.0.2")
     depends_on("py-phylophlan", type=("build", "run"))
     depends_on("py-matplotlib", type=("build", "run"))
     depends_on("bowtie2@2.3:", type=("build", "run"))
@@ -39,3 +40,4 @@ class PyMetaphlan(PythonPackage):
     depends_on("blast-plus@2.6:", type=("build", "run"))
     depends_on("raxml@8.2.10:", type=("build", "run"))
     depends_on("samtools@1.9:", type=("build", "run"))
+

--- a/repos/spack_repo/builtin/packages/py_metaphlan/package.py
+++ b/repos/spack_repo/builtin/packages/py_metaphlan/package.py
@@ -28,7 +28,7 @@ class PyMetaphlan(PythonPackage):
     depends_on("py-biopython", type=("build", "run"))
     depends_on("py-pandas", type=("build", "run"))
     depends_on("py-scipy", type=("build", "run"))
-    depends_on("py-hclust2", type=("build", "run"), when="@4.0.2:")
+    depends_on("py-hclust2", type=("build", "run"), when="@4.0.2")
     depends_on("py-requests", type=("build", "run"))
     depends_on("py-dendropy", type=("build", "run"))
     depends_on("py-pysam", type=("build", "run"))


### PR DESCRIPTION
Adding a new version for `py-metaphlan` and making sure it builds uses `py-cmseq` and `py-hclust2` properly