### PR TITLE
Bugfix: glib detection for glib when building with gobject-introspection

### DIFF
--- a/repos/spack_repo/builtin/packages/babl/package.py
+++ b/repos/spack_repo/builtin/packages/babl/package.py
@@ -37,6 +37,7 @@ class Babl(MesonPackage):
     depends_on("pkgconfig", type="build")
     depends_on("lcms")
     depends_on("gobject-introspection")
+    depends_on("glib", type="build")
 
     def setup_dependent_build_environment(
         self, env: EnvironmentModifications, dependent_spec: Spec

--- a/repos/spack_repo/builtin/packages/glib/package.py
+++ b/repos/spack_repo/builtin/packages/glib/package.py
@@ -97,6 +97,10 @@ class Glib(MesonPackage):
         depends_on("meson@0.48.0:")
         depends_on("pkgconfig")
         depends_on("gobject-introspection@1.80:", when="+introspection")
+        # glib-bootstrap is needed in the PKG_CONFIG_PATH during build to
+        # configure gobject-instrospection. After that glib itself can be
+        # used as the glib implementation.
+        depends_on("glib-bootstrap", type="build", when="%gobject-introspection@1.80:")
 
     depends_on("libffi")
     depends_on("zlib-api")

--- a/repos/spack_repo/builtin/packages/gobject_introspection/package.py
+++ b/repos/spack_repo/builtin/packages/gobject_introspection/package.py
@@ -158,9 +158,6 @@ class BuildEnvironment:
         env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))
         env.set("GI_SCANNER_DISABLE_CACHE", "1")
 
-        if self.spec.satisfies("^glib-bootstrap"):
-            env.append_path("PKG_CONFIG_PATH", self.spec["glib-bootstrap"].prefix.lib.pkgconfig)
-
 
 class AutotoolsBuilder(BuildEnvironment, autotools.AutotoolsBuilder):
     @run_before("build")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Path ordering when an system installed glib pkg config is in the same path as an external dependency results in failure to find the correct `glib-2.0` package.

The `gobject-introspection` package handles a transitive build dependency on `glib-2.0` by appending `glib-bootstrap` to the `PKG_CONFIG_PATH`. 

_Most_ of the cases in Spack already have a glib dependency which should be sufficient for using `gobject-introspection` for builds. Two cases not covered are `babl` and `glib`. `babl` just gets the `glib` package directly and `glib` needs to use the `glib-bootstrap` to avoid recursive dependencies.