### PR TITLE
cantera python dependencies include matplotlib and pip, while cti to …

### DIFF
--- a/repos/spack_repo/builtin/packages/cantera/package.py
+++ b/repos/spack_repo/builtin/packages/cantera/package.py
@@ -194,6 +194,9 @@ class Cantera(SConsPackage):
     depends_on("py-numpy", when="+python", type=("build", "run"))
     depends_on("py-scipy", when="+python", type=("build", "run"))
     depends_on("py-3to2", when="+python", type=("build", "run"))
+    depends_on("py-pip", when="+python", type=("build", "run"))
+    depends_on("py-matplotlib", when="+python", type=("build", "run"))
+    depends_on("py-ruamel-yaml@0.17.16:", when="+python", type=("build", "run"))
 
     # Matlab toolbox dependencies
     extends("matlab", when="+matlab")


### PR DESCRIPTION
Cantera Python dependencies include matplotlib and pip, while cti to yaml demands ruamel

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Cantera depends on matplotlib and compilation demanded pip.
Also, add "ruamel" for deprecated ".cti" files conversion to ".yaml".
