### PR TITLE
libxslt: depends on cmake >= 3.18 since version 1.1.38

### DIFF
--- a/repos/spack_repo/builtin/packages/libxslt/package.py
+++ b/repos/spack_repo/builtin/packages/libxslt/package.py
@@ -45,6 +45,7 @@ class Libxslt(CMakePackage, AutotoolsPackage):
     variant("python", default=False, description="Build Python bindings")
 
     depends_on("c", type="build")
+    depends_on("cmake@3.18:", when="@1.1.38:", type="build")
 
     depends_on("pkgconfig", type="build")
     depends_on("iconv")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
libxslt complains if cmake is lower than 3.18, and that from version 1.1.38 on.
