### PR TITLE
qt_base: depends on cmake>=3.19 since 6.8.1 and  >= 3.22 since 6.9.0

### DIFF
--- a/repos/spack_repo/builtin/packages/qt_base/package.py
+++ b/repos/spack_repo/builtin/packages/qt_base/package.py
@@ -39,6 +39,8 @@ class QtPackage(CMakePackage):
     # Default dependencies for all qt-* components
     generator("ninja")
     depends_on("cmake@3.16:", type="build")
+    depends_on("cmake@3.19:", when="@6.8.1:", type="build")
+    depends_on("cmake@3.22:", when="@6.9.0:", type="build")
     depends_on("pkgconfig", type="build", when="platform=linux")
     depends_on("python", type="build")
 


### PR DESCRIPTION
qt_base: depends on cmake >= 3.19 since version 6.8.1 and cmake >= 3.22 since 6.9.0

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
