### PR TITLE
Restore base image without gcc@12.3 installed

### DIFF
--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -568,7 +568,7 @@ tools-sdk-build:
 
 tutorial-generate:
   extends: [ ".tutorial", ".generate-x86_64"]
-  image: ghcr.io/spack/tutorial-ubuntu-22.04:v2023-10-30
+  image: ghcr.io/spack/tutorial-ubuntu-22.04:main
 
 tutorial-build:
   extends: [ ".tutorial", ".build" ]


### PR DESCRIPTION
Later on, we can decide whether we want to move to e.g. Ubuntu 24.04 for the ISC tutorial.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
