### PR TITLE
acts: add v45.3.0

### DIFF
--- a/repos/spack_repo/builtin/packages/acts/package.py
+++ b/repos/spack_repo/builtin/packages/acts/package.py
@@ -50,6 +50,7 @@ class Acts(CMakePackage, CudaPackage):
 
     # Supported Acts versions
     version("main", branch="main")
+    version("45.3.0", commit="d1323a298569942d98ff46ee413031ebd604290d")
     version("45.2.0", commit="c476557b74ccc8369fe1ef2c1f2e27cca4a356b6")
     version("45.1.1", commit="da50efc7b15cad8fdc5e194719c72d7d8b706823")
     version("45.1.0", commit="061a9d87b0fc07b554ec0b3849e875cf964f8323")
@@ -476,6 +477,7 @@ class Acts(CMakePackage, CudaPackage):
     depends_on("py-particle @0.24", when="@44:")
     depends_on("py-pybind11 @2.6.2:", when="+python @18:")
     depends_on("py-pybind11 @2.13.1:", when="+python @36:")
+    depends_on("py-pybind11 @3.0.1:", when="+python @45.3:")
     depends_on("py-pytest", when="+python +unit_tests")
     depends_on("py-setuptools", when="@44:44.1.0")
     depends_on("py-sympy @1.13", when="@44:")


### PR DESCRIPTION
This commit adds version 45.3.0 of the ACTS package and updates the dependency on pybind11 as required.