### PR TITLE
MPIBind: deprecation removals

### DIFF
--- a/repos/spack_repo/builtin/packages/mpibind/package.py
+++ b/repos/spack_repo/builtin/packages/mpibind/package.py
@@ -33,16 +33,6 @@ class Mpibind(AutotoolsPackage):
     version("0.21.0", commit="e8dca93adff52d464bffe7281f7ac0c3a63be4c0", no_cache=True)
     version("0.20.0", commit="8cd20ed9353a69336415193da90d86de789b1e3c", no_cache=True)
 
-    version(
-        "0.8.0", commit="ff38b9dcd150ca1e8a8796835d8e1e1847b3ba68", no_cache=True, deprecated=True
-    )
-    version(
-        "0.7.0", commit="3c437a97cd841b9c13abfbe1062a0285e1a29d3e", no_cache=True, deprecated=True
-    )
-    version(
-        "0.5.0", commit="8698f07412232e4dd4de4802b508374dc0de48c9", no_cache=True, deprecated=True
-    )
-
     # mpibind does not depend on CUDA or ROCm, but uses
     # these variants to configure hwloc accordingly
     variant("cuda", default=False, description="Build with support for NVIDIA GPUs")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Remove versions deprecated prior to v2025.11 in preparation for release.