### PR TITLE
qgis: add 3.44

### DIFF
--- a/repos/spack_repo/builtin/packages/py_psycopg2/package.py
+++ b/repos/spack_repo/builtin/packages/py_psycopg2/package.py
@@ -13,6 +13,7 @@ class PyPsycopg2(PythonPackage):
     homepage = "https://psycopg.org/"
     pypi = "psycopg2/psycopg2-2.8.6.tar.gz"
 
+    version("2.9.11", sha256="964d31caf728e217c697ff77ea69c2ba0865fa41ec20bb00f0977e62fdcc52e3")
     version("2.9.10", sha256="12ec0b40b0273f95296233e8750441339298e6a572f7039da5b260e3c8b60e11")
     version("2.9.6", sha256="f15158418fd826831b28585e2ab48ed8df2d0d98f502a2b4fe619e7d5ca29011")
     version("2.9.1", sha256="de5303a6f1d0a7a34b9d40e4d3bef684ccc44a49bbe3eb85e3c0bffb4a131b7c")
@@ -24,7 +25,8 @@ class PyPsycopg2(PythonPackage):
     # https://github.com/psycopg/psycopg2/blob/master/doc/src/install.rst
     # https://www.psycopg.org/docs/news.html#news
     # https://pypi.org/project/psycopg2/#history
-    depends_on("python@:3.13", when="@2.9.10:", type=("build", "link", "run"))
+    depends_on("python@:3.14", when="@2.9.11:", type=("build", "link", "run"))
+    depends_on("python@:3.13", when="@2.9.10", type=("build", "link", "run"))
     depends_on("python@:3.11", when="@2.9.5:2.9.9", type=("build", "link", "run"))
     depends_on("python@:3.10", when="@2.9.1:2.9.4", type=("build", "link", "run"))
     depends_on("python@:3.9", when="@2.8.6:2.9.0", type=("build", "link", "run"))

--- a/repos/spack_repo/builtin/packages/qgis/package.py
+++ b/repos/spack_repo/builtin/packages/qgis/package.py
@@ -235,8 +235,8 @@ class Qgis(CMakePackage):
         sip_inc_dir = join_path(self["qscintilla"].module.python_platlib, pyqtx, "bindings")
         sip_line = f'sip-include-dirs = ["{sip_inc_dir}"]'
 
-        # Recent QGis have added a @sipabi@ that expands to the [tool.sip.project] header. 
-        # The simple patch append approach  results in a duplicate header which causes a 
+        # Recent QGis have added a @sipabi@ that expands to the [tool.sip.project] header.
+        # The simple patch append approach  results in a duplicate header which causes a
         # build failure. The middle case is probably overkill but it is  kept as a just
         # in (edge) case
 

--- a/repos/spack_repo/builtin/packages/qgis/package.py
+++ b/repos/spack_repo/builtin/packages/qgis/package.py
@@ -134,6 +134,7 @@ class Qgis(CMakePackage):
     depends_on("libspatialite@4.2.0:")
     depends_on("libzip")
     depends_on("libtasn1")
+
     depends_on("proj@4.4.0:")
     depends_on("proj@4.9.3:", when="@3.8.2:")
     depends_on("proj@7.2:", when="@3.28:")
@@ -141,6 +142,8 @@ class Qgis(CMakePackage):
     # fails to build with proj 9.4+ until the backported patch in 3.34.5
     # https://github.com/qgis/QGIS/pull/56761
     depends_on("proj@:9.3", when="@:3.34.4")
+    depends_on("proj@:9.5", when="@3.34.5:3.34.15")
+
     depends_on("py-psycopg2", type=("build", "run"))  # TODO: is build dependency necessary?
     depends_on("py-pyqt4", when="@2")
     depends_on("py-pyqt5@5.3:", when="@3")

--- a/repos/spack_repo/builtin/packages/qgis/package.py
+++ b/repos/spack_repo/builtin/packages/qgis/package.py
@@ -235,7 +235,7 @@ class Qgis(CMakePackage):
         sip_inc_dir = join_path(self["qscintilla"].module.python_platlib, pyqtx, "bindings")
         sip_line = f'sip-include-dirs = ["{sip_inc_dir}"]'
 
-        # Recent QGis have added a @sipabi@ that expands to the [tool.sip.project] header.
+        # QGis 3.42.0 added a @sipabi@ that expands to the [tool.sip.project] header.
         # The simple patch append approach  results in a duplicate header which causes a
         # build failure. The middle case is probably overkill but it is  kept as a just
         # in (edge) case

--- a/repos/spack_repo/builtin/packages/qgis/package.py
+++ b/repos/spack_repo/builtin/packages/qgis/package.py
@@ -6,6 +6,8 @@ from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
 
+from pathlib import Path
+import re
 
 class Qgis(CMakePackage):
     """QGIS is a free and open-source cross-platform desktop geographic
@@ -14,12 +16,13 @@ class Qgis(CMakePackage):
     """
 
     homepage = "https://qgis.org"
-    url = "https://qgis.org/downloads/qgis-3.8.1.tar.bz2"
+    url = "https://qgis.org/downloads/qgis-3.44.7.tar.bz2"
 
     maintainers("adamjstewart", "Sinan81", "Chrismarsh")
 
     license("GPL-2.0-or-later")
 
+    version("3.44.7", sha256="1ab06f40600c84e928b4fe22a66997d80973201b10769e7a636e5be83459b814")
     # Prefer latest LTR
     version(
         "3.40.6",
@@ -122,7 +125,9 @@ class Qgis(CMakePackage):
     depends_on("gdal@2.1.0: +python", type=("build", "link", "run"))
     depends_on("gdal@3.2.0: +python", type=("build", "link", "run"), when="@3.28:")
     depends_on("geos@3.4.0:")
-    depends_on("libspatialindex")
+
+    # https://github.com/libspatialindex/libspatialindex/issues/276
+    depends_on("libspatialindex@:2.0.0")
     depends_on("libspatialite@4.2.0:")
     depends_on("libzip")
     depends_on("libtasn1")
@@ -163,6 +168,8 @@ class Qgis(CMakePackage):
     depends_on("py-owslib", type="run")
     depends_on("py-jinja2", type="run")
     depends_on("py-pygments", type="run")
+    depends_on("py-packaging", type="run", when="@3.44:")
+
 
     # optionals
     depends_on("postgresql@8:", when="+postgresql")  # for PostGIS support
@@ -223,9 +230,34 @@ class Qgis(CMakePackage):
         elif "^py-pyqt6" in self.spec:
             pyqtx = "PyQt6"
 
+        pp = Path("python/gui/pyproject.toml.in")
+        txt = pp.read_text(encoding="utf-8")
+
         sip_inc_dir = join_path(self["qscintilla"].module.python_platlib, pyqtx, "bindings")
-        with open(join_path("python", "gui", "pyproject.toml.in"), "a") as tomlfile:
-            tomlfile.write(f'\n[tool.sip.project]\nsip-include-dirs = ["{sip_inc_dir}"]\n')
+        sip_line = f'sip-include-dirs = ["{sip_inc_dir}"]'
+
+        # Recent QGis have added a @sipabi@ that expands to the [tool.sip.project] header. The simple patch to add the path
+        # results in a duplicate header which causes a build failure. The middle case is probably overkill but it is 
+        # kept as a just in (edge) case
+
+        # if it's already there, do nothing
+        if sip_line not in txt:
+            if "@sipabi@" in txt:
+                # @sipabi@ expands to the [tool.sip.project] table + abi-version,
+                # add just the key immediately after it
+                txt = txt.replace("@sipabi@", "@sipabi@\n" + sip_line, 1)
+
+            elif "[tool.sip.project]" in txt:
+                # insert right after the first header occurrence
+                txt = txt.replace("[tool.sip.project]", "[tool.sip.project]\n" + sip_line, 1)
+
+            else:
+                # no macro + no table, append a new table
+                if not txt.endswith("\n"):
+                    txt += "\n"
+                txt += "\n[tool.sip.project]\n" + sip_line + "\n"
+
+        pp.write_text(txt, encoding="utf-8")
 
     def cmake_args(self):
         spec = self.spec

--- a/repos/spack_repo/builtin/packages/qgis/package.py
+++ b/repos/spack_repo/builtin/packages/qgis/package.py
@@ -237,7 +237,7 @@ class Qgis(CMakePackage):
         sip_line = f'sip-include-dirs = ["{sip_inc_dir}"]'
 
         # Recent QGis have added a @sipabi@ that expands to the [tool.sip.project] header. The simple patch to add the path
-        # results in a duplicate header which causes a build failure. The middle case is probably overkill but it is 
+        # results in a duplicate header which causes a build failure. The middle case is probably overkill but it is
         # kept as a just in (edge) case
 
         # if it's already there, do nothing

--- a/repos/spack_repo/builtin/packages/qgis/package.py
+++ b/repos/spack_repo/builtin/packages/qgis/package.py
@@ -26,7 +26,8 @@ class Qgis(CMakePackage):
     license("GPL-2.0-or-later")
 
     # Prefer latest LTR
-    version("3.44.8",
+    version(
+        "3.44.8",
         sha256="146e197f34f1f9ede8cfdf5b9cc4d76667771720a302172c32d4117367356e96",
         preferred=True,
     )

--- a/repos/spack_repo/builtin/packages/qgis/package.py
+++ b/repos/spack_repo/builtin/packages/qgis/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import re
 from pathlib import Path
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
@@ -236,9 +235,10 @@ class Qgis(CMakePackage):
         sip_inc_dir = join_path(self["qscintilla"].module.python_platlib, pyqtx, "bindings")
         sip_line = f'sip-include-dirs = ["{sip_inc_dir}"]'
 
-        # Recent QGis have added a @sipabi@ that expands to the [tool.sip.project] header. The simple patch to add the path
-        # results in a duplicate header which causes a build failure. The middle case is probably overkill but it is
-        # kept as a just in (edge) case
+        # Recent QGis have added a @sipabi@ that expands to the [tool.sip.project] header. 
+        # The simple patch append approach  results in a duplicate header which causes a 
+        # build failure. The middle case is probably overkill but it is  kept as a just
+        # in (edge) case
 
         # if it's already there, do nothing
         if sip_line not in txt:

--- a/repos/spack_repo/builtin/packages/qgis/package.py
+++ b/repos/spack_repo/builtin/packages/qgis/package.py
@@ -25,13 +25,13 @@ class Qgis(CMakePackage):
 
     license("GPL-2.0-or-later")
 
-    version("3.44.7", sha256="1ab06f40600c84e928b4fe22a66997d80973201b10769e7a636e5be83459b814")
     # Prefer latest LTR
-    version(
-        "3.40.6",
-        sha256="dd68d39a2a29326031195bed2125e8b0fa7112fe9ee74d5f9850d06b02cef6a8",
+    version("3.44.8",
+        sha256="146e197f34f1f9ede8cfdf5b9cc4d76667771720a302172c32d4117367356e96",
         preferred=True,
     )
+    version("3.44.7", sha256="1ab06f40600c84e928b4fe22a66997d80973201b10769e7a636e5be83459b814")
+    version("3.40.6", sha256="dd68d39a2a29326031195bed2125e8b0fa7112fe9ee74d5f9850d06b02cef6a8")
     version("3.40.1", sha256="53110464c9f5ba5562c437e1563ab36dad2f218e6e7d1c0cfbe5b6effe241c8e")
     version("3.34.15", sha256="afb0bed05ffbc7bcb6d27dd1a8644b1e63ac2cb322baa058ff65b848c760efc2")
     version("3.34.13", sha256="a8873ca9bae346bae48ef3fe3eed702ef1f06d951201464464a64019302ba50b")

--- a/repos/spack_repo/builtin/packages/qgis/package.py
+++ b/repos/spack_repo/builtin/packages/qgis/package.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
+from pathlib import Path
+
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
 
-from pathlib import Path
-import re
 
 class Qgis(CMakePackage):
     """QGIS is a free and open-source cross-platform desktop geographic
@@ -169,7 +170,6 @@ class Qgis(CMakePackage):
     depends_on("py-jinja2", type="run")
     depends_on("py-pygments", type="run")
     depends_on("py-packaging", type="run", when="@3.44:")
-
 
     # optionals
     depends_on("postgresql@8:", when="+postgresql")  # for PostGIS support

--- a/repos/spack_repo/builtin/packages/qgis/package.py
+++ b/repos/spack_repo/builtin/packages/qgis/package.py
@@ -16,6 +16,9 @@ class Qgis(CMakePackage):
     """
 
     homepage = "https://qgis.org"
+
+    # the downloads are listed via json, so the spack checksum crawler won't find them
+    # spack checksum qgis x.y.z will provide the new checksum
     url = "https://qgis.org/downloads/qgis-3.44.7.tar.bz2"
 
     maintainers("adamjstewart", "Sinan81", "Chrismarsh")


### PR DESCRIPTION
- adds the last of the qgis 3.x line, `qgis@3.44`
- updated patch for py sip due to changed layout of toml file
- adds a new version of `py-psycopg2` to allow for `python@3.14` support with qgis
- bounds the `libspatialindex` version due to an upstream API change that broke qgis