### PR TITLE
cached cmake: check %cuda not ^cuda

### DIFF
--- a/repos/spack_repo/builtin/build_systems/cached_cmake.py
+++ b/repos/spack_repo/builtin/build_systems/cached_cmake.py
@@ -280,7 +280,7 @@ class CachedCMakeBuilder(CMakeBuilder):
         ]
 
         # Provide standard CMake arguments for dependent CachedCMakePackages
-        if spec.satisfies("^cuda"):
+        if spec.satisfies("%cuda"):
             entries.append("#------------------{0}".format("-" * 30))
             entries.append("# Cuda")
             entries.append("#------------------{0}\n".format("-" * 30))


### PR DESCRIPTION
If cuda is not a dependency of the root, but is used by any transitive link/run dependency, then errors like [this one](https://gitlab.spack.io/spack/spack-packages/-/jobs/20855918) are triggered.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
