### PR TITLE
py-illumina-utils: added version 2.14

### DIFF
--- a/repos/spack_repo/builtin/packages/py_illumina_utils/package.py
+++ b/repos/spack_repo/builtin/packages/py_illumina_utils/package.py
@@ -16,6 +16,11 @@ class PyIlluminaUtils(PythonPackage):
 
     license("GPL-2.0-or-later")
 
+    version(
+        "2.14",
+        sha256="5536158e97f9264d428fb7666b9f60a9a19568a2dbd77331426e8043f9d55564",
+        url="https://files.pythonhosted.org/packages/fb/10/c365f42d9a2e9d8d17773b7a8e5fbabdd4b55f6207b6cad8a7451674e27d/illumina_utils-2.14.tar.gz",
+    )
     version("2.3", sha256="0e8407b91d530d9a53d8ec3c83e60f25e7f8f80d06ce17b8e4f57a02d3262441")
     version("2.2", sha256="6039c72d077c101710fe4fdbfeaa30caa1c3c2c84ffa6295456927d82def8e6d")
 
@@ -25,3 +30,7 @@ class PyIlluminaUtils(PythonPackage):
     depends_on("py-matplotlib", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-python-levenshtein", type=("build", "run"))
+
+    with when("@2.14:"):
+        depends_on("py-setuptools@61:", type="build")
+        depends_on("py-wheel", type="build")


### PR DESCRIPTION
Adding a new version for `py-illumina-utils`
Url format changed on pypi so I added a `url=`

Alternatively if it's better for the style we could have a `url_for_version` but I'm not sure it's necessary