### PR TITLE
re2c@4.4 requires python@3.7:

### DIFF
--- a/repos/spack_repo/builtin/packages/re2c/package.py
+++ b/repos/spack_repo/builtin/packages/re2c/package.py
@@ -28,7 +28,7 @@ class Re2c(AutotoolsPackage, CMakePackage):
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
-    depends_on("python@3.7:", when="@3.1", type="build")
+    depends_on("python@3.7:", when="@3.1:", type="build")
 
     with when("build_system=cmake"):
         depends_on("cmake@3.12:", type="build")


### PR DESCRIPTION
### Reproducer

* **Spack:** 1.1.1 (https://github.com/spack/spack/commit/2e2169d5282d166f63e3ee4db8d4446c43cefa8a)
* **Builtin repo:** https://github.com/spack/spack-packages/commit/dfbaffe3cf07afa6850f921c3257402126568c90
* **Python:** 3.6.8
* **Platform:** linux-rocky8-zen5

```
$ docker pull rockylinux/rockylinux:8.10

$ docker run -it --rm rockylinux/rockylinux:8.10

[root@35da6031d476 /]# dnf update -y  && dnf -y install     autoconf     automake     binutils     bison     bzip2     csh     flex     curl     file     findutils     gcc     gcc-c++     gcc-gfortran     git     glibc-devel     jq     libtool     gnupg2     hg     hostname     iproute     make     patch     patchutils     perl     pkgconf     pkgconf-m4     pkgconf-pkg-config     python3     python3-pip     python3-setuptools     svn     unzip     vim     which     xz     zstd  && rm -rf /var/cache/dnf  && dnf clean all

[root@35da6031d476 /]# cd /opt/ && git clone --depth=2 https://github.com/spack/spack.git --branch releases/v1.1

[root@35da6031d476 opt]# cd spack/ && . share/spack/setup-env.sh
[root@35da6031d476 spack]# spack config add concretizer:targets:granularity:generic
[root@35da6031d476 spack]# spack config add concretizer:compiler_mixing:false
[root@35da6031d476 spack]# spack config add packages:all:target:[x86_64]
[root@35da6031d476 spack]# spack config blame repos
---                                               repos:
/opt/spack/etc/spack/defaults/base/repos.yaml:14    builtin:
/opt/spack/etc/spack/defaults/base/repos.yaml:15      git: https://github.com/spack/spack-packages.git
/opt/spack/etc/spack/defaults/base/repos.yaml:16      branch: develop

[root@35da6031d476 spack]# spack repo update
remote: Enumerating objects: 20001, done.
remote: Counting objects: 100% (20001/20001), done.
remote: Compressing objects: 100% (10814/10814), done.
remote: Total 20001 (delta 1326), reused 13923 (delta 1161), pack-reused 0 (from 0)
==> builtin: Updated sucessfully.

[root@35da6031d476 spack]# spack install gcc@15.1.0 ~binutils target=x86_64 %gcc@8.5.0

[root@35da6031d476 spack]# spack install re2c %gcc@15.1.0
...
==> Installing re2c-4.4-jlynpvon7fb4qctheq6blcu36gguzkmr [12/12]
==> Fetching https://mirror.spack.io/_source-cache/archive/6b/6b6b865924447ef992d5db4e52fb9307e5f65f26edd43efa91395da810f4280a.tar.xz
    [100%]    1.88 MB @   34.7 MB/s
==> No patches needed for re2c
==> re2c: Executing phase: 'autoreconf'
==> re2c: Executing phase: 'configure'
==> Error: ProcessError: Command exited with status 1:
    '/tmp/root/spack-stage/spack-stage-re2c-4.4-jlynpvon7fb4qctheq6blcu36gguzkmr/spack-src/configure' '--prefix=/opt/spack/opt/spack/linux-x86_64/re2c-4.4-jlynpvon7fb4qctheq6blcu36gguzkmr' '--disable-benchmarks' '--disable-debug' '--disable-dependency-tracking' '--disable-docs' '--disable-lexers' '--enable-libs' '--enable-golang'

1 error found in build log:
     17    checking whether make supports nested variables... yes
     18    checking xargs -n works... yes
     19    checking whether UID '0' is supported by ustar format... yes
     20    checking whether GID '0' is supported by ustar format... yes
     21    checking how to create a ustar tar archive... gnutar
     22    checking for a Python interpreter with version >= 3.7... none
  >> 23    configure: error: no suitable Python interpreter found

See build log for details:
  /tmp/root/spack-stage/spack-stage-re2c-4.4-jlynpvon7fb4qctheq6blcu36gguzkmr/spack-build-out.txt
```