### PR TITLE
qt: add v5.15.18

### DIFF
--- a/repos/spack_repo/builtin/packages/qt/package.py
+++ b/repos/spack_repo/builtin/packages/qt/package.py
@@ -32,6 +32,7 @@ class Qt(Package):
 
     license("LGPL-3.0-only")
 
+    version("5.15.18", sha256="cea1fbabf02455f3f0e8eaa839f5d6f45cdb56b62c8a83af5c1d00ac05f912ea")
     version("5.15.17", sha256="85eb566333d6ba59be3a97c9445a6e52f2af1b52fc3c54b8a2e7f9ea040a7de4")
     version("5.15.16", sha256="efa99827027782974356aceff8a52bd3d2a8a93a54dd0db4cca41b5e35f1041c")
     version("5.15.15", sha256="b423c30fe3ace7402e5301afbb464febfb3da33d6282a37a665be1e51502335e")


### PR DESCRIPTION
This PR adds `qt`, v5.15.18, [diff](https://github.com/qt/qtbase/compare/v5.15.17-lts-lgpl...v5.15.18-lts-lgpl), [release notes](https://code.qt.io/cgit/qt/qtreleasenotes.git/tree/qt/5.15.18/release-note.md). Bugfix/maintenance release. Did not notice any major dependency changes (as often is the case, the vendored dependencies are updated, but this does not imply an updated requirement). This package is built in CI.

Note: I have not built this locally yet but it will get built in CI.