### PR TITLE
ci: include remote file for per-package resource requests

### DIFF
--- a/.ci/gitlab/include.yaml
+++ b/.ci/gitlab/include.yaml
@@ -41,5 +41,13 @@ include:
   - path: configs/linux
     when: platform == "linux"
 
+  # === Per-package resource requests (Only used for Linux on Kubernetes) ===
+  - when: platform == "linux"
+    git: https://gitlab.spack.io/spack/resource-requests
+    branch: main
+    paths:
+    - ci.yaml
+    optional: true
+
   # === Generic ===
   - configs


### PR DESCRIPTION
The existing `linux/ci.yaml` only specifies resource requests for a small subset of the packages we build in CI. The practical consequence of this is that we overprovision cloud runners for the majority of GitLab CI rebuild jobs.

This commit chooses to host more complete resource usage data in a separate repository to avoid bloating the history of spack-packages over time.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
