### PR TITLE
gocryptfs: set cgo_enabled = True

### DIFF
--- a/repos/spack_repo/builtin/packages/gocryptfs/package.py
+++ b/repos/spack_repo/builtin/packages/gocryptfs/package.py
@@ -29,3 +29,5 @@ class Gocryptfs(GoPackage):
 
     depends_on("openssl")
     depends_on("pkgconfig", type="build")
+
+    cgo_enabled = True


### PR DESCRIPTION
#3196 disabled cgo by default, gocryptfs needs cgo to call out to openssl routines.