### PR TITLE
All CI jobs should use the same misc cache

### DIFF
--- a/.ci/gitlab/config.yaml
+++ b/.ci/gitlab/config.yaml
@@ -1,0 +1,2 @@
+config:
+  misc_cache: "$user_cache_path/cache"


### PR DESCRIPTION
At one point the misc cache was updated to be "per-spack": placed in a directory that was based on a hash of the spack prefix itself. This was intended to help different clones of spack avoid conflicting with one another.

It caused a slowdown with CI though, so was reverted in https://github.com/spack/spack/pull/50920 (https://github.com/spack/spack/pull/50919 also has a useful explanation of the issue).

https://github.com/spack/spack/pull/47615 intends to reintroduce this as default behavior, this is my attempt to get all pipelines to override that default and use a shared misc cache (and continue to do so after that PR merges).

