### PR TITLE
mgard: avoid applying patch to get commits

### DIFF
--- a/repos/spack_repo/builtin/packages/mgard/package.py
+++ b/repos/spack_repo/builtin/packages/mgard/package.py
@@ -125,9 +125,9 @@ class Mgard(CMakePackage, CudaPackage, ROCmPackage):
     # https://github.com/abseil/abseil-cpp/issues/1629
     conflicts("abseil-cpp@20240116.1", when="+cuda", msg="triggers nvcc parser bug")
 
-    patch("hip-pointer-attribute-struct-fix.patch", when="@:1.5")
-    patch("hip-cub-configure.patch", when="@:1.5")
-    patch("hip-abs-reduce-type.patch", when="@:1.5")
+    patch("hip-pointer-attribute-struct-fix.patch", when="@=1.5.2")
+    patch("hip-cub-configure.patch", when="@=1.5.2")
+    patch("hip-abs-reduce-type.patch", when="@=1.5.2")
 
     # https://github.com/CODARcode/MGARD/issues/252
     patch(


### PR DESCRIPTION
The mgard package has several patches designed specifically for MGARD 1.5. However, they were being applied for git commits (i.e., @git.master) To prevent the patches from being applied outside of the scope they are intended, fix the when clause for that specific version.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
