### PR TITLE
gcc: use link type dep for binutils

### DIFF
--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -244,9 +244,9 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     depends_on("diffutils", type="build")
     depends_on("iconv", when="platform=darwin")
     depends_on("gnat", when="languages=ada")
-    depends_on(
-        "binutils+gas+ld+plugins~libiberty", when="+binutils", type=("build", "link", "run")
-    )
+    # For binutils we use `link` because we don't rely on `PATH`, but on the
+    # automatic `-B` flag
+    depends_on("binutils+gas+ld+plugins~libiberty", when="+binutils", type=("build", "link"))
     depends_on("mold", when="+mold")
     depends_on("zip", type="build", when="languages=java")
 


### PR DESCRIPTION
Closes #3505.

To make GCC pick up the correct binutils we don't rely on PATH, but on the
config file's `-B<binutils>/bin`.

Now, that's not much different from rpath in link type deps, so drop the run
type dep.

Can be a temporary solution to #3505, which is caused by Spack tracking
run type deps of compiler build deps, and forces them to be reused, which
requires duplicates of zlib-ng/zstd, and those don't have duplicates allowed
by default.

Can also be a permanent thing -- I don't think type=run is really needed.