### PR TITLE
paraview: depend on scnlib

### DIFF
--- a/repos/spack_repo/builtin/packages/paraview/package.py
+++ b/repos/spack_repo/builtin/packages/paraview/package.py
@@ -316,6 +316,8 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
             depends_on("qt-svg")
             depends_on("libxslt")
 
+        depends_on("scnlib")
+
         # ParaView@6: and later will depend on OSMesa as a fallback for
         # OpenGL.
         # The search order for GL is:


### PR DESCRIPTION
ParaView 6 depends on the scnlib library. It is included in the third party code, but this is not always compiled.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
