### PR TITLE
paraview: Apply patch to find libraries from viskores package in build

### DIFF
--- a/repos/spack_repo/builtin/packages/paraview/package.py
+++ b/repos/spack_repo/builtin/packages/paraview/package.py
@@ -329,6 +329,10 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
             depends_on("viskores +vtktypes +64bitids +doubleprecision", when=f"{vk_variant}")
             depends_on("viskores +fpic", when=f"+shared {vk_variant}")
 
+        with when("+fides"):
+            depends_on("fides@1.3:")
+            depends_on("fides +mpi", when="+mpi")
+
         with when("+cuda"):
             # Kokkos vs Viskores Native CUDA is intentionally left configurable
             depends_on("viskores +cuda")
@@ -480,6 +484,17 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
 
     # https://gitlab.kitware.com/paraview/paraview/-/merge_requests/7593
     patch("paraview-cdireader-lazy.patch", when="@:6.0 +cdi")
+
+    # Fix for linking external Fides library
+    # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/13130
+    patch("vtk-external-fides-pv61.patch", working_dir="VTK", when="@6.0:6.1")
+
+    # Fixes for linking external Viskores library
+    # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/13094
+    # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/13127
+    patch("vtk-fine-grained-viskores-targets-pv61.patch", working_dir="VTK", when="@6.0:6.1")
+    patch("vtk-consolidate-viskores-wrapping-pv60.patch", working_dir="VTK", when="@6.0")
+    patch("vtk-consolidate-viskores-wrapping-pv61.patch", working_dir="VTK", when="@6.1")
 
     generator("ninja", "make", default="ninja")
     # https://gitlab.kitware.com/paraview/paraview/-/issues/21223

--- a/repos/spack_repo/builtin/packages/paraview/vtk-consolidate-viskores-wrapping-pv60.patch
+++ b/repos/spack_repo/builtin/packages/paraview/vtk-consolidate-viskores-wrapping-pv60.patch
@@ -1,0 +1,317 @@
+diff --git a/Accelerators/Vtkm/Core/CMakeLists.txt b/Accelerators/Vtkm/Core/CMakeLists.txt
+index 26de392719..386beb8ca1 100644
+--- a/Accelerators/Vtkm/Core/CMakeLists.txt
++++ b/Accelerators/Vtkm/Core/CMakeLists.txt
+@@ -36,34 +36,7 @@ vtk_module_set_property(VTK::AcceleratorsVTKmCore
+   VALUE     viskores_pool)
+ 
+ _vtk_module_real_target(vtkm_accel_target VTK::AcceleratorsVTKmCore)
+-viskores_add_target_information(${vtkm_accel_target}
+-                            DROP_UNUSED_SYMBOLS
+-                            EXTENDS_VISKORES
+-                            MODIFY_CUDA_FLAGS
+-                            DEVICE_SOURCES ${sources})
+-
+-list(TRANSFORM nowrap_classes APPEND ".cxx" OUTPUT_VARIABLE device_sources)
+-if(VTK_USE_KOKKOS)
+-  add_compile_definitions(VTK_USE_KOKKOS)
+-endif()
+-if (TARGET VTK::vtkviskores_cuda)
+-  # Temporarily suppress "has address taken but no possible call to it" warnings,
+-  # until we figure out its implications.
+-  # We are disabling all warnings as nvlink has no known way to suppress
+-  # individual warning types.
+-  string(APPEND CMAKE_CUDA_FLAGS " -Xnvlink -w")
+-  set_source_files_properties(${device_sources} PROPERTIES LANGUAGE CUDA)
+-  vtk_module_set_properties(VTK::AcceleratorsVTKmCore CUDA_SEPARABLE_COMPILATION ON)
+-
+-elseif (TARGET VTK::vtkviskores_kokkos_cuda)
+-  set_source_files_properties(${device_sources} PROPERTIES LANGUAGE CUDA)
+-  kokkos_compilation(SOURCE ${device_sources})
+-
+-elseif (TARGET VTK::vtkviskores_kokkos_hip)
+-  set_source_files_properties(${device_sources} PROPERTIES LANGUAGE HIP)
+-  kokkos_compilation(SOURCE ${device_sources})
+-
+-endif ()
++vtk_add_viskores_device_target_information(${vtkm_accel_target})
+ 
+ if (MSVC)
+   set(msvc_warning_flags
+diff --git a/Accelerators/Vtkm/Core/Testing/Cxx/CMakeLists.txt b/Accelerators/Vtkm/Core/Testing/Cxx/CMakeLists.txt
+index 1a32f156a7..c0c04adee7 100644
+--- a/Accelerators/Vtkm/Core/Testing/Cxx/CMakeLists.txt
++++ b/Accelerators/Vtkm/Core/Testing/Cxx/CMakeLists.txt
+@@ -6,32 +6,4 @@ vtk_add_test_cxx(vtkAcceleratorsVTKmCoreCxxTests tests
+   TestVTKMImplicitDataArray.cxx,NO_VALID
+   )
+ 
+-if (TARGET VTK::vtkviskores_cuda OR TARGET VTK::vtkviskores_kokkos_cuda)
+-  foreach(src IN LISTS tests)
+-    string(REPLACE "," ";" src ${src})
+-    list(GET src 0 src)
+-
+-    set_source_files_properties(${src} PROPERTIES LANGUAGE CUDA)
+-  endforeach()
+-
+-  #the tests aren't scoped as a child directory of vtkAcceleratorsVTKmCore
+-  #so we need to redo this logic
+-  viskores_get_cuda_flags(CMAKE_CUDA_FLAGS)
+-
+-  # Temporarily suppress "has address taken but no possible call to it" warnings,
+-  # until we figure out its implications.
+-  # We are disabling all warnings as nvlink has no known way to suppress
+-  # individual warning types.
+-  string(APPEND CMAKE_CUDA_FLAGS " -Xnvlink -w")
+-endif()
+-
+ vtk_test_cxx_executable(vtkAcceleratorsVTKmCoreCxxTests tests)
+-
+-if (TARGET VTK::vtkviskores_cuda)
+-  # When cuda is enabled VTK::AcceleratorsVTKmCore is built statically but with fpic
+-  # enabled so the tests are also built with fpic enabled
+-  set_target_properties(vtkAcceleratorsVTKmCoreCxxTests PROPERTIES
+-    CUDA_ARCHITECTURES OFF
+-    POSITION_INDEPENDENT_CODE ON
+-    )
+-endif()
+diff --git a/Accelerators/Vtkm/Core/vtkmlib/vtkmInitializer.cxx b/Accelerators/Vtkm/Core/vtkmlib/vtkmInitializer.cxx
+index 6cecef3bb9..33d787e38b 100644
+--- a/Accelerators/Vtkm/Core/vtkmlib/vtkmInitializer.cxx
++++ b/Accelerators/Vtkm/Core/vtkmlib/vtkmInitializer.cxx
+@@ -9,8 +9,6 @@
+ VTK_ABI_NAMESPACE_BEGIN
+ void InitializeVTKm()
+ {
+-// Kokkos enabled devices needs to be initialized
+-#ifdef VTK_USE_KOKKOS
+   static bool isInitialized{ false };
+   if (!isInitialized)
+   {
+@@ -19,7 +17,6 @@ void InitializeVTKm()
+     viskores::cont::Initialize(argc, const_cast<char**>(argv));
+     isInitialized = true;
+   }
+-#endif
+ }
+ 
+ vtkmInitializer::vtkmInitializer()
+diff --git a/Accelerators/Vtkm/DataModel/CMakeLists.txt b/Accelerators/Vtkm/DataModel/CMakeLists.txt
+index b653c23013..6a71610f4d 100644
+--- a/Accelerators/Vtkm/DataModel/CMakeLists.txt
++++ b/Accelerators/Vtkm/DataModel/CMakeLists.txt
+@@ -43,34 +43,7 @@ vtk_module_set_property(VTK::AcceleratorsVTKmDataModel
+   PROPERTY  JOB_POOL_COMPILE
+   VALUE     viskores_pool)
+ _vtk_module_real_target(vtkm_accel_target VTK::AcceleratorsVTKmDataModel)
+-viskores_add_target_information(${vtkm_accel_target}
+-                            EXTENDS_VISKORES
+-                            MODIFY_CUDA_FLAGS
+-                            DEVICE_SOURCES ${sources})
+-
+-if (TARGET VTK::vtkviskores_cuda)
+-  # Temporarily suppress "has address taken but no possible call to it" warnings,
+-  # until we figure out its implications.
+-  # We are disabling all warnings as nvlink has no known way to suppress
+-  # individual warning types.
+-  string(APPEND CMAKE_CUDA_FLAGS " -Xnvlink -w")
+-
+-  list(TRANSFORM nowrap_classes APPEND ".cxx" OUTPUT_VARIABLE nowrap_sources)
+-  set(cuda_impl ${nowrap_sources} vtkmDataSet.cxx)
+-  set_source_files_properties(${cuda_impl} PROPERTIES LANGUAGE CUDA)
+-
+-  vtk_module_set_properties(VTK::AcceleratorsVTKmDataModel CUDA_SEPARABLE_COMPILATION ON)
+-
+-  vtk_module_compile_options(VTK::AcceleratorsVTKmDataModel
+-    PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe --diag_suppress=extra_semicolon>)
+-
+-elseif (TARGET VTK::vtkviskores_kokkos_cuda)
+-  list(TRANSFORM nowrap_classes APPEND ".cxx" OUTPUT_VARIABLE nowrap_sources)
+-  set(cuda_impl ${nowrap_sources} vtkmDataSet.cxx)
+-  set_source_files_properties(${cuda_impl} PROPERTIES LANGUAGE CUDA)
+-  kokkos_compilation(SOURCE ${cuda_impl})
+-
+-endif()
++vtk_add_viskores_device_target_information(${vtkm_accel_target})
+ 
+ if (MSVC)
+   set(msvc_warning_flags
+diff --git a/Accelerators/Vtkm/DataModel/Testing/Cxx/CMakeLists.txt b/Accelerators/Vtkm/DataModel/Testing/Cxx/CMakeLists.txt
+index a105aaa49e..fdf8bc4580 100644
+--- a/Accelerators/Vtkm/DataModel/Testing/Cxx/CMakeLists.txt
++++ b/Accelerators/Vtkm/DataModel/Testing/Cxx/CMakeLists.txt
+@@ -15,34 +15,6 @@ vtk_add_test_cxx(vtkAcceleratorsVTKmDataModelCxxTests tests
+   TestVTKMDataSet.cxx,NO_VALID
+   )
+ 
+-if (TARGET VTK::vtkviskores_cuda)
+-  foreach(src IN LISTS tests)
+-    string(REPLACE "," ";" src ${src})
+-    list(GET src 0 src)
+-
+-    set_source_files_properties(${src} PROPERTIES LANGUAGE CUDA)
+-  endforeach()
+-
+-  #the tests aren't scoped as a child directory of vtkAcceleratorsVTKmDataModel
+-  #so we need to redo this logic
+-  viskores_get_cuda_flags(CMAKE_CUDA_FLAGS)
+-
+-  # Temporarily suppress "has address taken but no possible call to it" warnings,
+-  # until we figure out its implications.
+-  # We are disabling all warnings as nvlink has no known way to suppress
+-  # individual warning types.
+-  string(APPEND CMAKE_CUDA_FLAGS " -Xnvlink -w")
+-endif()
+-
+ vtk_test_cxx_executable(vtkAcceleratorsVTKmDataModelCxxTests tests
+   RENDERING_FACTORY
+   )
+-
+-if (TARGET VTK::vtkviskores_cuda)
+-  # When cuda is enabled VTK::AcceleratorsVTKmDataModel is built statically but with fpic
+-  # enabled so the tests are also built with fpic enabled
+-  set_target_properties(vtkAcceleratorsVTKmDataModelCxxTests PROPERTIES
+-    CUDA_ARCHITECTURES OFF
+-    POSITION_INDEPENDENT_CODE ON
+-    )
+-endif()
+diff --git a/Accelerators/Vtkm/Filters/CMakeLists.txt b/Accelerators/Vtkm/Filters/CMakeLists.txt
+index cd16f6d946..19b41df693 100644
+--- a/Accelerators/Vtkm/Filters/CMakeLists.txt
++++ b/Accelerators/Vtkm/Filters/CMakeLists.txt
+@@ -104,31 +104,7 @@ vtk_module_definitions(VTK::AcceleratorsVTKmFilters
+   PUBLIC "VTK_ENABLE_VISKORES_OVERRIDES=$<BOOL:${VTK_ENABLE_VISKORES_OVERRIDES}>")
+ 
+ _vtk_module_real_target(vtkm_accel_target VTK::AcceleratorsVTKmFilters)
+-viskores_add_target_information(${vtkm_accel_target}
+-                            EXTENDS_VISKORES
+-                            MODIFY_CUDA_FLAGS
+-                            DEVICE_SOURCES ${sources})
+-
+-if (TARGET VTK::vtkviskores_cuda)
+-  # Temporarily suppress "has address taken but no possible call to it" warnings,
+-  # until we figure out its implications.
+-  # We are disabling all warnings as nvlink has no known way to suppress
+-  # individual warning types.
+-  string(APPEND CMAKE_CUDA_FLAGS " -Xnvlink -w")
+-
+-  list(TRANSFORM classes APPEND ".cxx" OUTPUT_VARIABLE cuda_impl)
+-  set_source_files_properties(${cuda_impl} PROPERTIES LANGUAGE CUDA)
+-  vtk_module_set_properties(VTK::AcceleratorsVTKmFilters CUDA_SEPARABLE_COMPILATION ON)
+-
+-  vtk_module_compile_options(VTK::AcceleratorsVTKmFilters
+-    PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe --diag_suppress=extra_semicolon>)
+-elseif (TARGET VTK::vtkviskores_kokkos_cuda)
+-
+-  list(TRANSFORM classes APPEND ".cxx" OUTPUT_VARIABLE cuda_impl)
+-  set_source_files_properties(${cuda_impl} PROPERTIES LANGUAGE CUDA)
+-  kokkos_compilation(SOURCE ${cuda_impl})
+-
+-endif()
++vtk_add_viskores_device_target_information(${vtkm_accel_target})
+ 
+ if (MSVC)
+   set(msvc_warning_flags
+diff --git a/Accelerators/Vtkm/Filters/Testing/Cxx/CMakeLists.txt b/Accelerators/Vtkm/Filters/Testing/Cxx/CMakeLists.txt
+index 955747836f..8b8085026a 100644
+--- a/Accelerators/Vtkm/Filters/Testing/Cxx/CMakeLists.txt
++++ b/Accelerators/Vtkm/Filters/Testing/Cxx/CMakeLists.txt
+@@ -27,32 +27,6 @@ vtk_add_test_cxx(vtkAcceleratorsVTKmFiltersCxxTests tests
+   TestVTKMWarpVector.cxx
+   )
+ 
+-if (TARGET VTK::vtkviskores_cuda)
+-  foreach(src IN LISTS tests)
+-    string(REPLACE "," ";" src ${src})
+-    list(GET src 0 src)
+-
+-    set_source_files_properties(${src} PROPERTIES LANGUAGE CUDA)
+-  endforeach()
+-
+-  #the tests aren't scoped as a child directory of vtkAcceleratorsVTKmFilters
+-  #so we need to redo this logic
+-  viskores_get_cuda_flags(CMAKE_CUDA_FLAGS)
+-
+-  # Temporarily suppress "has address taken but no possible call to it" warnings,
+-  # until we figure out its implications.
+-  # We are disabling all warnings as nvlink has no known way to suppress
+-  # individual warning types.
+-  string(APPEND CMAKE_CUDA_FLAGS " -Xnvlink -w")
+-
+-endif()
+-
+-
+ vtk_test_cxx_executable(vtkAcceleratorsVTKmFiltersCxxTests tests
+   RENDERING_FACTORY
+   )
+-
+-if (TARGET VTK::vtkviskores_cuda)
+-  set_target_properties(vtkAcceleratorsVTKmFiltersCxxTests PROPERTIES
+-    CUDA_ARCHITECTURES OFF)
+-endif()
+diff --git a/IO/CatalystConduit/CMakeLists.txt b/IO/CatalystConduit/CMakeLists.txt
+index f54368c4af..be201a912f 100644
+--- a/IO/CatalystConduit/CMakeLists.txt
++++ b/IO/CatalystConduit/CMakeLists.txt
+@@ -36,26 +36,8 @@ configure_file(
+   "${CMAKE_CURRENT_BINARY_DIR}/vtkDeviceMemoryType.h"
+   @ONLY)
+ 
+-
+-if (TARGET VTK::vtkviskores_cuda)
+-  # Temporarily suppress "has address taken but no possible call to it" warnings,
+-  # until we figure out its implications.
+-  # We are disabling all warnings as nvlink has no known way to suppress
+-  # individual warning types.
+-  string(APPEND CMAKE_CUDA_FLAGS " -Xnvlink -w")
+-
+-  set_source_files_properties(${classes_cuda} PROPERTIES LANGUAGE CUDA)
+-
+-  vtk_module_set_properties(VTK::IOCatalystConduit
+-    CUDA_SEPARABLE_COMPILATION ON)
+-
+-  vtk_module_compile_options(VTK::IOCatalystConduit
+-    PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe --diag_suppress=extra_semicolon>)
+-
+-  find_package(CUDAToolkit REQUIRED)
+-  vtk_module_link(VTK::IOCatalystConduit PRIVATE CUDA::cudart)
+-endif ()
+-
++_vtk_module_real_target(vtkm_accel_target VTK::IOCatalystConduit)
++vtk_add_viskores_device_target_information(${vtkm_accel_target})
+ 
+ vtk_add_test_mangling(VTK::IOCatalystConduit)
+ add_subdirectory(Catalyst)
+diff --git a/ThirdParty/viskores/CMakeLists.txt b/ThirdParty/viskores/CMakeLists.txt
+index dd57459345..d85153c679 100644
+--- a/ThirdParty/viskores/CMakeLists.txt
++++ b/ThirdParty/viskores/CMakeLists.txt
+@@ -16,7 +16,7 @@ vtk_module_third_party(
+     STANDARD_INCLUDE_DIRS
+   EXTERNAL
+     PACKAGE Viskores
+-    TARGETS viskores::cont viskores::cont_testing viskores::filter viskores::worklet
++    TARGETS viskores::cont viskores::cont_testing viskores::filter
+     VERSION       "1.0.0"
+     STANDARD_INCLUDE_DIRS)
+ 
+@@ -47,3 +47,19 @@ foreach (viskores_target IN LISTS viskores_specific_targets)
+   _vtk_module_install("vtkviskores_${viskores_target}")
+   add_library("VTK::vtkviskores_${viskores_target}" ALIAS "vtkviskores_${viskores_target}")
+ endforeach ()
++
++# If a VTK library contains Viskores worklets or other Viskores device code, the files must be
++# declared as the proper language and the library must link to VTK::vtkviskores_worklet. This
++# function sets this up. Use this function by giving it the name of a target.
++function(vtk_add_viskores_device_target_information target)
++  target_link_libraries(${target} PRIVATE VTK::vtkviskores_worklet)
++  get_target_property(sources ${target} SOURCES)
++  list(FILTER sources INCLUDE REGEX "\\.(cpp|cxx|cc|C)$")
++  if(TARGET VTK::vtkviskores_cuda OR TARGET VTK::vtkviskores_kokkos_cuda)
++    set_source_files_properties(${sources} PROPERTIES LANGUAGE CUDA)
++  endif()
++  if(TARGET VTK::vtkviskores_kokkos_hip)
++    set_source_files_properties(${sources} PROPERTIES LANGUAGE HIP)
++    kokkos_compilation(SOURCE ${sources})
++  endif()
++endfunction()

--- a/repos/spack_repo/builtin/packages/paraview/vtk-consolidate-viskores-wrapping-pv61.patch
+++ b/repos/spack_repo/builtin/packages/paraview/vtk-consolidate-viskores-wrapping-pv61.patch
@@ -1,0 +1,345 @@
+From 9f09ea924e0f69fdbf4b504c99c4283a7daf3252 Mon Sep 17 00:00:00 2001
+From: Kenneth Moreland <morelandkd@ornl.gov>
+Date: Mon, 13 Apr 2026 11:35:34 -0400
+Subject: [PATCH] Consolidate configuration of Viskores device code
+
+When compiling Viskores device code, extra CMake configuration must
+be done to set the appropriate language and linking options. The
+previous setup was repeated several times through the code and contained
+lots of obsolete configuration. This change consolidates and cleans up
+the configuration.
+
+This also fixes an issue where flags for the device compiler could be
+given to the standard C++ compiler, which might not support the same
+flags.
+---
+ Accelerators/Vtkm/Core/CMakeLists.txt         | 32 +------------------
+ .../Vtkm/Core/Testing/Cxx/CMakeLists.txt      | 28 ----------------
+ .../Vtkm/Core/vtkmlib/vtkmInitializer.cxx     |  3 --
+ Accelerators/Vtkm/DataModel/CMakeLists.txt    | 29 +----------------
+ .../Vtkm/DataModel/Testing/Cxx/CMakeLists.txt | 28 ----------------
+ Accelerators/Vtkm/Filters/CMakeLists.txt      | 26 +--------------
+ .../Vtkm/Filters/Testing/Cxx/CMakeLists.txt   | 25 ---------------
+ IO/CatalystConduit/CMakeLists.txt             | 19 ++---------
+ ThirdParty/viskores/CMakeLists.txt            | 17 +++++++++-
+ 9 files changed, 21 insertions(+), 186 deletions(-)
+
+diff --git a/Accelerators/Vtkm/Core/CMakeLists.txt b/Accelerators/Vtkm/Core/CMakeLists.txt
+index 0501715be03..3e863bc7b4c 100644
+--- a/Accelerators/Vtkm/Core/CMakeLists.txt
++++ b/Accelerators/Vtkm/Core/CMakeLists.txt
+@@ -37,37 +37,7 @@ vtk_module_set_property(VTK::AcceleratorsVTKmCore
+   VALUE     viskores_pool)
+ 
+ _vtk_module_real_target(vtkm_accel_target VTK::AcceleratorsVTKmCore)
+-viskores_add_target_information(${vtkm_accel_target}
+-                            DROP_UNUSED_SYMBOLS
+-                            EXTENDS_VISKORES
+-                            MODIFY_CUDA_FLAGS
+-                            DEVICE_SOURCES ${sources})
+-
+-list(TRANSFORM nowrap_classes APPEND ".cxx" OUTPUT_VARIABLE device_sources)
+-if(VTK_USE_KOKKOS)
+-  add_compile_definitions(VTK_USE_KOKKOS)
+-endif()
+-if (TARGET VTK::vtkviskores_cuda)
+-  # Temporarily suppress "has address taken but no possible call to it" warnings,
+-  # until we figure out its implications.
+-  # We are disabling all warnings as nvlink has no known way to suppress
+-  # individual warning types.
+-  string(APPEND CMAKE_CUDA_FLAGS " -Xnvlink -w")
+-  set_source_files_properties(${device_sources} PROPERTIES LANGUAGE CUDA)
+-  vtk_module_set_properties(VTK::AcceleratorsVTKmCore CUDA_SEPARABLE_COMPILATION ON)
+-
+-  find_package(CUDAToolkit REQUIRED)
+-  vtk_module_link(VTK::AcceleratorsVTKmCore PRIVATE CUDA::cudart)
+-
+-elseif (TARGET VTK::vtkviskores_kokkos_cuda)
+-  set_source_files_properties(${device_sources} PROPERTIES LANGUAGE CUDA)
+-  kokkos_compilation(SOURCE ${device_sources})
+-
+-elseif (TARGET VTK::vtkviskores_kokkos_hip)
+-  set_source_files_properties(${device_sources} PROPERTIES LANGUAGE HIP)
+-  kokkos_compilation(SOURCE ${device_sources})
+-
+-endif ()
++vtk_add_viskores_device_target_information(${vtkm_accel_target})
+ 
+ if (MSVC)
+   set(msvc_warning_flags
+diff --git a/Accelerators/Vtkm/Core/Testing/Cxx/CMakeLists.txt b/Accelerators/Vtkm/Core/Testing/Cxx/CMakeLists.txt
+index 1a32f156a73..c0c04adee7e 100644
+--- a/Accelerators/Vtkm/Core/Testing/Cxx/CMakeLists.txt
++++ b/Accelerators/Vtkm/Core/Testing/Cxx/CMakeLists.txt
+@@ -6,32 +6,4 @@ vtk_add_test_cxx(vtkAcceleratorsVTKmCoreCxxTests tests
+   TestVTKMImplicitDataArray.cxx,NO_VALID
+   )
+ 
+-if (TARGET VTK::vtkviskores_cuda OR TARGET VTK::vtkviskores_kokkos_cuda)
+-  foreach(src IN LISTS tests)
+-    string(REPLACE "," ";" src ${src})
+-    list(GET src 0 src)
+-
+-    set_source_files_properties(${src} PROPERTIES LANGUAGE CUDA)
+-  endforeach()
+-
+-  #the tests aren't scoped as a child directory of vtkAcceleratorsVTKmCore
+-  #so we need to redo this logic
+-  viskores_get_cuda_flags(CMAKE_CUDA_FLAGS)
+-
+-  # Temporarily suppress "has address taken but no possible call to it" warnings,
+-  # until we figure out its implications.
+-  # We are disabling all warnings as nvlink has no known way to suppress
+-  # individual warning types.
+-  string(APPEND CMAKE_CUDA_FLAGS " -Xnvlink -w")
+-endif()
+-
+ vtk_test_cxx_executable(vtkAcceleratorsVTKmCoreCxxTests tests)
+-
+-if (TARGET VTK::vtkviskores_cuda)
+-  # When cuda is enabled VTK::AcceleratorsVTKmCore is built statically but with fpic
+-  # enabled so the tests are also built with fpic enabled
+-  set_target_properties(vtkAcceleratorsVTKmCoreCxxTests PROPERTIES
+-    CUDA_ARCHITECTURES OFF
+-    POSITION_INDEPENDENT_CODE ON
+-    )
+-endif()
+diff --git a/Accelerators/Vtkm/Core/vtkmlib/vtkmInitializer.cxx b/Accelerators/Vtkm/Core/vtkmlib/vtkmInitializer.cxx
+index 6cecef3bb9f..33d787e38b2 100644
+--- a/Accelerators/Vtkm/Core/vtkmlib/vtkmInitializer.cxx
++++ b/Accelerators/Vtkm/Core/vtkmlib/vtkmInitializer.cxx
+@@ -9,8 +9,6 @@
+ VTK_ABI_NAMESPACE_BEGIN
+ void InitializeVTKm()
+ {
+-// Kokkos enabled devices needs to be initialized
+-#ifdef VTK_USE_KOKKOS
+   static bool isInitialized{ false };
+   if (!isInitialized)
+   {
+@@ -19,7 +17,6 @@ void InitializeVTKm()
+     viskores::cont::Initialize(argc, const_cast<char**>(argv));
+     isInitialized = true;
+   }
+-#endif
+ }
+ 
+ vtkmInitializer::vtkmInitializer()
+diff --git a/Accelerators/Vtkm/DataModel/CMakeLists.txt b/Accelerators/Vtkm/DataModel/CMakeLists.txt
+index b653c230133..6a71610f4d5 100644
+--- a/Accelerators/Vtkm/DataModel/CMakeLists.txt
++++ b/Accelerators/Vtkm/DataModel/CMakeLists.txt
+@@ -43,34 +43,7 @@ vtk_module_set_property(VTK::AcceleratorsVTKmDataModel
+   PROPERTY  JOB_POOL_COMPILE
+   VALUE     viskores_pool)
+ _vtk_module_real_target(vtkm_accel_target VTK::AcceleratorsVTKmDataModel)
+-viskores_add_target_information(${vtkm_accel_target}
+-                            EXTENDS_VISKORES
+-                            MODIFY_CUDA_FLAGS
+-                            DEVICE_SOURCES ${sources})
+-
+-if (TARGET VTK::vtkviskores_cuda)
+-  # Temporarily suppress "has address taken but no possible call to it" warnings,
+-  # until we figure out its implications.
+-  # We are disabling all warnings as nvlink has no known way to suppress
+-  # individual warning types.
+-  string(APPEND CMAKE_CUDA_FLAGS " -Xnvlink -w")
+-
+-  list(TRANSFORM nowrap_classes APPEND ".cxx" OUTPUT_VARIABLE nowrap_sources)
+-  set(cuda_impl ${nowrap_sources} vtkmDataSet.cxx)
+-  set_source_files_properties(${cuda_impl} PROPERTIES LANGUAGE CUDA)
+-
+-  vtk_module_set_properties(VTK::AcceleratorsVTKmDataModel CUDA_SEPARABLE_COMPILATION ON)
+-
+-  vtk_module_compile_options(VTK::AcceleratorsVTKmDataModel
+-    PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe --diag_suppress=extra_semicolon>)
+-
+-elseif (TARGET VTK::vtkviskores_kokkos_cuda)
+-  list(TRANSFORM nowrap_classes APPEND ".cxx" OUTPUT_VARIABLE nowrap_sources)
+-  set(cuda_impl ${nowrap_sources} vtkmDataSet.cxx)
+-  set_source_files_properties(${cuda_impl} PROPERTIES LANGUAGE CUDA)
+-  kokkos_compilation(SOURCE ${cuda_impl})
+-
+-endif()
++vtk_add_viskores_device_target_information(${vtkm_accel_target})
+ 
+ if (MSVC)
+   set(msvc_warning_flags
+diff --git a/Accelerators/Vtkm/DataModel/Testing/Cxx/CMakeLists.txt b/Accelerators/Vtkm/DataModel/Testing/Cxx/CMakeLists.txt
+index a105aaa49ea..fdf8bc45806 100644
+--- a/Accelerators/Vtkm/DataModel/Testing/Cxx/CMakeLists.txt
++++ b/Accelerators/Vtkm/DataModel/Testing/Cxx/CMakeLists.txt
+@@ -15,34 +15,6 @@ vtk_add_test_cxx(vtkAcceleratorsVTKmDataModelCxxTests tests
+   TestVTKMDataSet.cxx,NO_VALID
+   )
+ 
+-if (TARGET VTK::vtkviskores_cuda)
+-  foreach(src IN LISTS tests)
+-    string(REPLACE "," ";" src ${src})
+-    list(GET src 0 src)
+-
+-    set_source_files_properties(${src} PROPERTIES LANGUAGE CUDA)
+-  endforeach()
+-
+-  #the tests aren't scoped as a child directory of vtkAcceleratorsVTKmDataModel
+-  #so we need to redo this logic
+-  viskores_get_cuda_flags(CMAKE_CUDA_FLAGS)
+-
+-  # Temporarily suppress "has address taken but no possible call to it" warnings,
+-  # until we figure out its implications.
+-  # We are disabling all warnings as nvlink has no known way to suppress
+-  # individual warning types.
+-  string(APPEND CMAKE_CUDA_FLAGS " -Xnvlink -w")
+-endif()
+-
+ vtk_test_cxx_executable(vtkAcceleratorsVTKmDataModelCxxTests tests
+   RENDERING_FACTORY
+   )
+-
+-if (TARGET VTK::vtkviskores_cuda)
+-  # When cuda is enabled VTK::AcceleratorsVTKmDataModel is built statically but with fpic
+-  # enabled so the tests are also built with fpic enabled
+-  set_target_properties(vtkAcceleratorsVTKmDataModelCxxTests PROPERTIES
+-    CUDA_ARCHITECTURES OFF
+-    POSITION_INDEPENDENT_CODE ON
+-    )
+-endif()
+diff --git a/Accelerators/Vtkm/Filters/CMakeLists.txt b/Accelerators/Vtkm/Filters/CMakeLists.txt
+index 4eb9989da51..c24edd94be7 100644
+--- a/Accelerators/Vtkm/Filters/CMakeLists.txt
++++ b/Accelerators/Vtkm/Filters/CMakeLists.txt
+@@ -109,31 +109,7 @@ vtk_module_definitions(VTK::AcceleratorsVTKmFilters
+   PUBLIC "VTK_ENABLE_VISKORES_OVERRIDES=$<BOOL:${VTK_ENABLE_VISKORES_OVERRIDES}>")
+ 
+ _vtk_module_real_target(vtkm_accel_target VTK::AcceleratorsVTKmFilters)
+-viskores_add_target_information(${vtkm_accel_target}
+-                            EXTENDS_VISKORES
+-                            MODIFY_CUDA_FLAGS
+-                            DEVICE_SOURCES ${sources})
+-
+-if (TARGET VTK::vtkviskores_cuda)
+-  # Temporarily suppress "has address taken but no possible call to it" warnings,
+-  # until we figure out its implications.
+-  # We are disabling all warnings as nvlink has no known way to suppress
+-  # individual warning types.
+-  string(APPEND CMAKE_CUDA_FLAGS " -Xnvlink -w")
+-
+-  list(TRANSFORM classes APPEND ".cxx" OUTPUT_VARIABLE cuda_impl)
+-  set_source_files_properties(${cuda_impl} PROPERTIES LANGUAGE CUDA)
+-  vtk_module_set_properties(VTK::AcceleratorsVTKmFilters CUDA_SEPARABLE_COMPILATION ON)
+-
+-  vtk_module_compile_options(VTK::AcceleratorsVTKmFilters
+-    PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe --diag_suppress=extra_semicolon>)
+-elseif (TARGET VTK::vtkviskores_kokkos_cuda)
+-
+-  list(TRANSFORM classes APPEND ".cxx" OUTPUT_VARIABLE cuda_impl)
+-  set_source_files_properties(${cuda_impl} PROPERTIES LANGUAGE CUDA)
+-  kokkos_compilation(SOURCE ${cuda_impl})
+-
+-endif()
++vtk_add_viskores_device_target_information(${vtkm_accel_target})
+ 
+ if (MSVC)
+   set(msvc_warning_flags
+diff --git a/Accelerators/Vtkm/Filters/Testing/Cxx/CMakeLists.txt b/Accelerators/Vtkm/Filters/Testing/Cxx/CMakeLists.txt
+index d72f0bd7ffe..6f6ec073cb7 100644
+--- a/Accelerators/Vtkm/Filters/Testing/Cxx/CMakeLists.txt
++++ b/Accelerators/Vtkm/Filters/Testing/Cxx/CMakeLists.txt
+@@ -28,32 +28,7 @@ vtk_add_test_cxx(vtkAcceleratorsVTKmFiltersCxxTests tests
+   TestVTKMWarpVector.cxx,NO_SERDES
+   )
+ 
+-if (TARGET VTK::vtkviskores_cuda)
+-  foreach(src IN LISTS tests)
+-    string(REPLACE "," ";" src ${src})
+-    list(GET src 0 src)
+-
+-    set_source_files_properties(${src} PROPERTIES LANGUAGE CUDA)
+-  endforeach()
+-
+-  #the tests aren't scoped as a child directory of vtkAcceleratorsVTKmFilters
+-  #so we need to redo this logic
+-  viskores_get_cuda_flags(CMAKE_CUDA_FLAGS)
+-
+-  # Temporarily suppress "has address taken but no possible call to it" warnings,
+-  # until we figure out its implications.
+-  # We are disabling all warnings as nvlink has no known way to suppress
+-  # individual warning types.
+-  string(APPEND CMAKE_CUDA_FLAGS " -Xnvlink -w")
+-
+-endif()
+-
+ 
+ vtk_test_cxx_executable(vtkAcceleratorsVTKmFiltersCxxTests tests
+   RENDERING_FACTORY
+   )
+-
+-if (TARGET VTK::vtkviskores_cuda)
+-  set_target_properties(vtkAcceleratorsVTKmFiltersCxxTests PROPERTIES
+-    CUDA_ARCHITECTURES OFF)
+-endif()
+diff --git a/IO/CatalystConduit/CMakeLists.txt b/IO/CatalystConduit/CMakeLists.txt
+index 91d60f1638c..d1d6049279a 100644
+--- a/IO/CatalystConduit/CMakeLists.txt
++++ b/IO/CatalystConduit/CMakeLists.txt
+@@ -16,23 +16,8 @@ vtk_module_add_module(VTK::IOCatalystConduit
+   CLASSES ${classes}
+   PRIVATE_CLASSES ${private_classes})
+ 
+-
+-if (TARGET VTK::vtkviskores_cuda)
+-  # Temporarily suppress "has address taken but no possible call to it" warnings,
+-  # until we figure out its implications.
+-  # We are disabling all warnings as nvlink has no known way to suppress
+-  # individual warning types.
+-  string(APPEND CMAKE_CUDA_FLAGS " -Xnvlink -w")
+-
+-  set_source_files_properties(${classes_cuda} PROPERTIES LANGUAGE CUDA)
+-
+-  vtk_module_set_properties(VTK::IOCatalystConduit
+-    CUDA_SEPARABLE_COMPILATION ON)
+-
+-  vtk_module_compile_options(VTK::IOCatalystConduit
+-    PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe --diag_suppress=extra_semicolon>)
+-endif ()
+-
++_vtk_module_real_target(vtkm_accel_target VTK::IOCatalystConduit)
++vtk_add_viskores_device_target_information(${vtkm_accel_target})
+ 
+ vtk_add_test_mangling(VTK::IOCatalystConduit)
+ add_subdirectory(Catalyst)
+diff --git a/ThirdParty/viskores/CMakeLists.txt b/ThirdParty/viskores/CMakeLists.txt
+index bbe1b38bce0..6ddb9104b3b 100644
+--- a/ThirdParty/viskores/CMakeLists.txt
++++ b/ThirdParty/viskores/CMakeLists.txt
+@@ -24,7 +24,7 @@ vtk_module_third_party(
+     STANDARD_INCLUDE_DIRS
+   EXTERNAL
+     PACKAGE Viskores
+-    TARGETS viskores::cont viskores::cont_testing viskores::filter viskores::worklet
++    TARGETS viskores::cont viskores::cont_testing viskores::filter
+     VERSION       "1.1.0"
+     STANDARD_INCLUDE_DIRS)
+ 
+@@ -55,3 +55,19 @@ foreach (viskores_target IN LISTS viskores_specific_targets)
+   _vtk_module_install("vtkviskores_${viskores_target}")
+   add_library("VTK::vtkviskores_${viskores_target}" ALIAS "vtkviskores_${viskores_target}")
+ endforeach ()
++
++# If a VTK library contains Viskores worklets or other Viskores device code, the files must be
++# declared as the proper language and the library must link to VTK::vtkviskores_worklet. This
++# function sets this up. Use this function by giving it the name of a target.
++function(vtk_add_viskores_device_target_information target)
++  target_link_libraries(${target} PRIVATE VTK::vtkviskores_worklet)
++  get_target_property(sources ${target} SOURCES)
++  list(FILTER sources INCLUDE REGEX "\\.(cpp|cxx|cc|C)$")
++  if(TARGET VTK::vtkviskores_cuda OR TARGET VTK::vtkviskores_kokkos_cuda)
++    set_source_files_properties(${sources} PROPERTIES LANGUAGE CUDA)
++  endif()
++  if(TARGET VTK::vtkviskores_kokkos_hip)
++    set_source_files_properties(${sources} PROPERTIES LANGUAGE HIP)
++    kokkos_compilation(SOURCE ${sources})
++  endif()
++endfunction()
+-- 
+GitLab

--- a/repos/spack_repo/builtin/packages/paraview/vtk-external-fides-pv61.patch
+++ b/repos/spack_repo/builtin/packages/paraview/vtk-external-fides-pv61.patch
@@ -1,0 +1,202 @@
+From 97799df970c090a5f18c6c60f7478036d54f0c43 Mon Sep 17 00:00:00 2001
+From: Fides Upstream <kwrobot@kitware.com>
+Date: Mon, 20 Apr 2026 12:22:58 -0400
+Subject: [PATCH 1/3] fides 2026-04-20 (ceedfb2f)
+
+Code extracted from:
+
+    https://gitlab.kitware.com/third-party/fides.git
+
+at commit ceedfb2f766eeb82742474bc7346647413577b36 (for/vtk-20260420-master-1e7e886).
+---
+ ThirdParty/fides/vtkfides/fides/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ThirdParty/fides/vtkfides/fides/CMakeLists.txt b/ThirdParty/fides/vtkfides/fides/CMakeLists.txt
+index d21e907420..deb18e37b8 100644
+--- a/ThirdParty/fides/vtkfides/fides/CMakeLists.txt
++++ b/ThirdParty/fides/vtkfides/fides/CMakeLists.txt
+@@ -87,7 +87,7 @@ vtk_module_include(VTK::fides
+   PUBLIC
+     $<BUILD_INTERFACE:${FIDES_SOURCE_DIR}>
+     $<BUILD_INTERFACE:${FIDES_BINARY_DIR}/fides>
+-    $<INSTALL_INTERFACE:${_vtk_build_HEADERS_DESTINATION}/vtkfides/fides>
++    $<INSTALL_INTERFACE:${_vtk_build_HEADERS_DESTINATION}/vtkfides>
+   )
+ 
+ include(GenerateExportHeader)
+-- 
+2.50.1 (Apple Git-155)
+
+From ff6b10bf7130479e0c0d316a77fd1ecfc8328a14 Mon Sep 17 00:00:00 2001
+From: Kenneth Moreland <morelandkd@ornl.gov>
+Date: Tue, 14 Apr 2026 13:24:02 -0400
+Subject: [PATCH 2/3] Enable linking to an externally built Fides
+
+---
+ IO/Fides/vtkFidesReader.cxx     |  6 +++++-
+ IO/Fides/vtkFidesWriter.cxx     |  6 +++++-
+ ThirdParty/fides/CMakeLists.txt | 31 ++++++++++++++++++++++---------
+ ThirdParty/fides/vtk_fides.h.in | 15 +++++++++++++++
+ 4 files changed, 47 insertions(+), 11 deletions(-)
+ create mode 100644 ThirdParty/fides/vtk_fides.h.in
+
+diff --git a/IO/Fides/vtkFidesReader.cxx b/IO/Fides/vtkFidesReader.cxx
+index 246e1c3ded..6450edebed 100644
+--- a/IO/Fides/vtkFidesReader.cxx
++++ b/IO/Fides/vtkFidesReader.cxx
+@@ -20,7 +20,11 @@
+ #include "vtkmlib/UnstructuredGridConverter.h"
+ #include "vtksys/SystemTools.hxx"
+ 
+-#include <fides/DataSetReader.h>
++// Fides includes
++#include <vtk_fides.h>
++// clang-format off
++#include VTK_FIDES(fides/DataSetReader.h)
++// clang-format on
+ 
+ #include <viskores/filter/clean_grid/CleanGrid.h>
+ 
+diff --git a/IO/Fides/vtkFidesWriter.cxx b/IO/Fides/vtkFidesWriter.cxx
+index 1eaf338f98..55259a9eb4 100644
+--- a/IO/Fides/vtkFidesWriter.cxx
++++ b/IO/Fides/vtkFidesWriter.cxx
+@@ -26,7 +26,11 @@
+ #include "vtkMPIController.h"
+ #endif
+ 
+-#include <fides/DataSetWriter.h>
++// Fides includes
++#include <vtk_fides.h>
++// clang-format off
++#include VTK_FIDES(fides/DataSetWriter.h)
++// clang-format on
+ 
+ #include <viskores/cont/DataSet.h>
+ #include <viskores/cont/PartitionedDataSet.h>
+diff --git a/ThirdParty/fides/CMakeLists.txt b/ThirdParty/fides/CMakeLists.txt
+index 2da2afa02b..a50b8eebcf 100644
+--- a/ThirdParty/fides/CMakeLists.txt
++++ b/ThirdParty/fides/CMakeLists.txt
+@@ -1,9 +1,22 @@
+-vtk_module_third_party_internal(
+-  LICENSE_FILES           "vtkfides/LICENSE.txt"
+-  SPDX_LICENSE_IDENTIFIER "BSD-3-Clause"
+-  SPDX_COPYRIGHT_TEXT     "Copyright (c) 2019 Kitware Inc."
+-  SPDX_DOWNLOAD_LOCATION  "git+https://gitlab.kitware.com/third-party/fides.git@for/vtk-20230505-master-6922a48e"
+-  VERSION                 "master"
+-  SUBDIRECTORY            vtkfides
+-  STANDARD_INCLUDE_DIRS
+-  INTERFACE)
++vtk_module_third_party(
++  INTERNAL
++    LICENSE_FILES           "vtkfides/LICENSE.txt"
++    SPDX_LICENSE_IDENTIFIER "BSD-3-Clause"
++    SPDX_COPYRIGHT_TEXT     "Copyright (c) 2019 Kitware Inc."
++    SPDX_DOWNLOAD_LOCATION  "git+https://gitlab.kitware.com/third-party/fides.git@for/vtk-20260420-master-1e7e886"
++    VERSION                 "master"
++    SUBDIRECTORY            vtkfides
++    STANDARD_INCLUDE_DIRS
++    INTERFACE
++  EXTERNAL
++    PACKAGE                 Fides
++    TARGETS                 fides
++    STANDARD_INCLUDE_DIRS
++  )
++
++configure_file(
++  "${CMAKE_CURRENT_SOURCE_DIR}/vtk_fides.h.in"
++  "${CMAKE_CURRENT_BINARY_DIR}/vtk_fides.h")
++
++vtk_module_install_headers(
++  FILES "${CMAKE_CURRENT_BINARY_DIR}/vtk_fides.h")
+diff --git a/ThirdParty/fides/vtk_fides.h.in b/ThirdParty/fides/vtk_fides.h.in
+new file mode 100644
+index 0000000000..5383f71c87
+--- /dev/null
++++ b/ThirdParty/fides/vtk_fides.h.in
+@@ -0,0 +1,15 @@
++// SPDX-FileCopyrightText: Copyright (c) Ken Martin, Will Schroeder, Bill Lorensen
++// SPDX-License-Identifier: BSD-3-Clause
++#ifndef vtk_fides_h
++#define vtk_fides_h
++
++/* Use the fides library configured for VTK.  */
++#cmakedefine01 VTK_MODULE_USE_EXTERNAL_VTK_fides
++
++#if VTK_MODULE_USE_EXTERNAL_VTK_fides
++# define VTK_FIDES(x) <x>
++#else
++# define VTK_FIDES(x) <vtkfides/x>
++#endif
++
++#endif
+-- 
+2.50.1 (Apple Git-155)
+
+From 86e8ce32b719aa9381268f547ff4e57b7a5e1e52 Mon Sep 17 00:00:00 2001
+From: Kenneth Moreland <morelandkd@ornl.gov>
+Date: Thu, 16 Apr 2026 07:50:44 -0400
+Subject: [PATCH 3/3] Add test for Fides third-party module include file
+
+---
+ ThirdParty/fides/Testing/CMakeLists.txt           |  1 +
+ ThirdParty/fides/Testing/Cxx/CMakeLists.txt       |  4 ++++
+ ThirdParty/fides/Testing/Cxx/TestIncludeFides.cxx | 11 +++++++++++
+ ThirdParty/fides/vtk.module                       |  4 ++++
+ 4 files changed, 20 insertions(+)
+ create mode 100644 ThirdParty/fides/Testing/CMakeLists.txt
+ create mode 100644 ThirdParty/fides/Testing/Cxx/CMakeLists.txt
+ create mode 100644 ThirdParty/fides/Testing/Cxx/TestIncludeFides.cxx
+
+diff --git a/ThirdParty/fides/Testing/CMakeLists.txt b/ThirdParty/fides/Testing/CMakeLists.txt
+new file mode 100644
+index 0000000000..35f9732a93
+--- /dev/null
++++ b/ThirdParty/fides/Testing/CMakeLists.txt
+@@ -0,0 +1 @@
++add_subdirectory(Cxx)
+diff --git a/ThirdParty/fides/Testing/Cxx/CMakeLists.txt b/ThirdParty/fides/Testing/Cxx/CMakeLists.txt
+new file mode 100644
+index 0000000000..d0f115663e
+--- /dev/null
++++ b/ThirdParty/fides/Testing/Cxx/CMakeLists.txt
+@@ -0,0 +1,4 @@
++vtk_add_test_cxx(vtkfidesCxxTests tests
++  NO_DATA NO_VALID NO_OUTPUT
++  TestIncludeFides.cxx)
++vtk_test_cxx_executable(vtkfidesCxxTests tests)
+diff --git a/ThirdParty/fides/Testing/Cxx/TestIncludeFides.cxx b/ThirdParty/fides/Testing/Cxx/TestIncludeFides.cxx
+new file mode 100644
+index 0000000000..b6b81a4948
+--- /dev/null
++++ b/ThirdParty/fides/Testing/Cxx/TestIncludeFides.cxx
+@@ -0,0 +1,11 @@
++#include "vtk_fides.h"
++// clang-format off
++#include VTK_FIDES(fides/DataSetReader.h)
++// clang-format on
++
++#include <cstdlib>
++
++int TestIncludeFides(int /*argc*/, char* /*argv*/[])
++{
++  return EXIT_SUCCESS;
++}
+diff --git a/ThirdParty/fides/vtk.module b/ThirdParty/fides/vtk.module
+index 07a6e0f2f9..197ff8ab03 100644
+--- a/ThirdParty/fides/vtk.module
++++ b/ThirdParty/fides/vtk.module
+@@ -10,4 +10,8 @@ DEPENDS
+   VTK::vtkviskores
+ OPTIONAL_DEPENDS
+   VTK::mpi
++TEST_DEPENDS
++  VTK::TestingCore
++TEST_OPTIONAL_DEPENDS
++  VTK::mpi
+ THIRD_PARTY
+-- 
+2.50.1 (Apple Git-155)
+

--- a/repos/spack_repo/builtin/packages/paraview/vtk-fine-grained-viskores-targets-pv61.patch
+++ b/repos/spack_repo/builtin/packages/paraview/vtk-fine-grained-viskores-targets-pv61.patch
@@ -1,0 +1,313 @@
+From c3514adb8fac48a0937de784d561c2f07c6f5945 Mon Sep 17 00:00:00 2001
+From: Ben Boeckel <ben.boeckel@kitware.com>
+Date: Tue, 31 Mar 2026 23:21:28 -0400
+Subject: [PATCH 1/4] vtkm: link to the proper viskores target
+
+---
+ ThirdParty/vtkm/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ThirdParty/vtkm/CMakeLists.txt b/ThirdParty/vtkm/CMakeLists.txt
+index 272306bdec..577e10cfe8 100644
+--- a/ThirdParty/vtkm/CMakeLists.txt
++++ b/ThirdParty/vtkm/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ vtk_module_add_module(VTK::vtkvtkm HEADER_ONLY)
+-vtk_module_link(VTK::vtkvtkm INTERFACE VTK::viskores)
++vtk_module_link(VTK::vtkvtkm INTERFACE VTK::vtkviskores)
+ 
+ set(deprecation_warning "Target VTK::vtkvtkm deprecated, VTK::vtkviskores enabled.")
+ message(DEPRECATION "${deprecation_warning}")
+-- 
+2.50.1 (Apple Git-155)
+
+From 8ac32d9610f21206ca812ab8abc28c5e41a88214 Mon Sep 17 00:00:00 2001
+From: Ben Boeckel <ben.boeckel@kitware.com>
+Date: Tue, 31 Mar 2026 23:21:43 -0400
+Subject: [PATCH 2/4] viskores: create fine-grained targets for components
+
+This gives a consistent interface for Viskores targets no matter how
+Viskores is provided: vendored or externally. For external usage, the
+`find_package` makes the imported targets scoped so that they are not
+visible elsewhere in the tree.
+---
+ ThirdParty/viskores/CMakeLists.txt | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+diff --git a/ThirdParty/viskores/CMakeLists.txt b/ThirdParty/viskores/CMakeLists.txt
+index 54031beeca..d23fdd5cb4 100644
+--- a/ThirdParty/viskores/CMakeLists.txt
++++ b/ThirdParty/viskores/CMakeLists.txt
+@@ -23,3 +23,27 @@ vtk_module_third_party(
+ if(VTK_MODULE_USE_EXTERNAL_vtkviskores)
+   viskores_setup_job_pool()
+ endif()
++
++set(viskores_specific_targets
++  cont
++  cont_testing
++  cuda
++  filter
++  kokkos_cuda
++  kokkos_hip
++  worklet)
++foreach (viskores_target IN LISTS viskores_specific_targets)
++  if (VTK_MODULE_USE_EXTERNAL_vtkviskores)
++    set(target "viskores::${viskores_target}")
++  else ()
++    set(target "viskores_${viskores_target}")
++  endif ()
++  if (NOT TARGET "${target}")
++    continue ()
++  endif()
++
++  add_library("vtkviskores_${viskores_target}" INTERFACE)
++  target_link_libraries("vtkviskores_${viskores_target}" INTERFACE "${target}")
++  _vtk_module_install("vtkviskores_${viskores_target}")
++  add_library("VTK::vtkviskores_${viskores_target}" ALIAS "vtkviskores_${viskores_target}")
++endforeach ()
+-- 
+2.50.1 (Apple Git-155)
+
+From 96c963f0817019c86f25851f4d550ecd312c9822 Mon Sep 17 00:00:00 2001
+From: Fides Upstream <kwrobot@kitware.com>
+Date: Wed, 22 Apr 2026 14:42:24 -0400
+Subject: [PATCH 3/4] fides 2026-04-22 (5330f6f2)
+
+Code extracted from:
+
+    https://gitlab.kitware.com/third-party/fides.git
+
+at commit 5330f6f2bf47cab1434bbaa71a20a20f3051a03f (for/vtk-20260422-master-1e7e886).
+---
+ ThirdParty/fides/vtkfides/fides/CMakeLists.txt | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/ThirdParty/fides/vtkfides/fides/CMakeLists.txt b/ThirdParty/fides/vtkfides/fides/CMakeLists.txt
+index deb18e37b8..72f0a9fbd8 100644
+--- a/ThirdParty/fides/vtkfides/fides/CMakeLists.txt
++++ b/ThirdParty/fides/vtkfides/fides/CMakeLists.txt
+@@ -82,7 +82,9 @@ endif()
+ vtk_module_link(VTK::fides
+   PRIVATE
+     adios2::adios2
+-    fides_rapidjson)
++    fides_rapidjson
++    VTK::vtkviskores_worklet
++  )
+ vtk_module_include(VTK::fides
+   PUBLIC
+     $<BUILD_INTERFACE:${FIDES_SOURCE_DIR}>
+-- 
+2.50.1 (Apple Git-155)
+
+From 33d22c1f141c963c8f5a2cbabcbab9428f5b04a8 Mon Sep 17 00:00:00 2001
+From: Ben Boeckel <ben.boeckel@kitware.com>
+Date: Tue, 31 Mar 2026 23:23:33 -0400
+Subject: [PATCH 4/4] viskores: use third party "bridge" targets
+
+These work regardless of internal versus external Viskores.
+---
+ Accelerators/Vtkm/Core/CMakeLists.txt                  | 8 ++++----
+ Accelerators/Vtkm/Core/Testing/Cxx/CMakeLists.txt      | 4 ++--
+ Accelerators/Vtkm/DataModel/CMakeLists.txt             | 6 +++---
+ Accelerators/Vtkm/DataModel/Testing/Cxx/CMakeLists.txt | 4 ++--
+ Accelerators/Vtkm/Filters/CMakeLists.txt               | 6 +++---
+ Accelerators/Vtkm/Filters/Testing/Cxx/CMakeLists.txt   | 4 ++--
+ IO/CatalystConduit/CMakeLists.txt                      | 2 +-
+ IO/CatalystConduit/Testing/Cxx/CMakeLists.txt          | 2 +-
+ 8 files changed, 18 insertions(+), 18 deletions(-)
+
+diff --git a/Accelerators/Vtkm/Core/CMakeLists.txt b/Accelerators/Vtkm/Core/CMakeLists.txt
+index 062661eccf..0501715be0 100644
+--- a/Accelerators/Vtkm/Core/CMakeLists.txt
++++ b/Accelerators/Vtkm/Core/CMakeLists.txt
+@@ -47,7 +47,7 @@ list(TRANSFORM nowrap_classes APPEND ".cxx" OUTPUT_VARIABLE device_sources)
+ if(VTK_USE_KOKKOS)
+   add_compile_definitions(VTK_USE_KOKKOS)
+ endif()
+-if (TARGET viskores::cuda)
++if (TARGET VTK::vtkviskores_cuda)
+   # Temporarily suppress "has address taken but no possible call to it" warnings,
+   # until we figure out its implications.
+   # We are disabling all warnings as nvlink has no known way to suppress
+@@ -59,11 +59,11 @@ if (TARGET viskores::cuda)
+   find_package(CUDAToolkit REQUIRED)
+   vtk_module_link(VTK::AcceleratorsVTKmCore PRIVATE CUDA::cudart)
+ 
+-elseif (TARGET viskores::kokkos_cuda)
++elseif (TARGET VTK::vtkviskores_kokkos_cuda)
+   set_source_files_properties(${device_sources} PROPERTIES LANGUAGE CUDA)
+   kokkos_compilation(SOURCE ${device_sources})
+ 
+-elseif (TARGET viskores::kokkos_hip)
++elseif (TARGET VTK::vtkviskores_kokkos_hip)
+   set_source_files_properties(${device_sources} PROPERTIES LANGUAGE HIP)
+   kokkos_compilation(SOURCE ${device_sources})
+ 
+@@ -87,7 +87,7 @@ if (MSVC)
+     )
+   set(viskores_msvc_flags)
+   foreach (msvc_warning_flag IN LISTS msvc_warning_flags)
+-    if (TARGET viskores::cuda)
++    if (TARGET VTK::vtkviskores_cuda)
+       list(APPEND viskores_msvc_flags
+         $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${msvc_warning_flag},${msvc_warning_flag}>)
+     else ()
+diff --git a/Accelerators/Vtkm/Core/Testing/Cxx/CMakeLists.txt b/Accelerators/Vtkm/Core/Testing/Cxx/CMakeLists.txt
+index a3b1851215..1a32f156a7 100644
+--- a/Accelerators/Vtkm/Core/Testing/Cxx/CMakeLists.txt
++++ b/Accelerators/Vtkm/Core/Testing/Cxx/CMakeLists.txt
+@@ -6,7 +6,7 @@ vtk_add_test_cxx(vtkAcceleratorsVTKmCoreCxxTests tests
+   TestVTKMImplicitDataArray.cxx,NO_VALID
+   )
+ 
+-if (TARGET viskores::cuda OR TARGET viskores::kokkos_cuda)
++if (TARGET VTK::vtkviskores_cuda OR TARGET VTK::vtkviskores_kokkos_cuda)
+   foreach(src IN LISTS tests)
+     string(REPLACE "," ";" src ${src})
+     list(GET src 0 src)
+@@ -27,7 +27,7 @@ endif()
+ 
+ vtk_test_cxx_executable(vtkAcceleratorsVTKmCoreCxxTests tests)
+ 
+-if (TARGET viskores::cuda)
++if (TARGET VTK::vtkviskores_cuda)
+   # When cuda is enabled VTK::AcceleratorsVTKmCore is built statically but with fpic
+   # enabled so the tests are also built with fpic enabled
+   set_target_properties(vtkAcceleratorsVTKmCoreCxxTests PROPERTIES
+diff --git a/Accelerators/Vtkm/DataModel/CMakeLists.txt b/Accelerators/Vtkm/DataModel/CMakeLists.txt
+index 1754ebe182..b653c23013 100644
+--- a/Accelerators/Vtkm/DataModel/CMakeLists.txt
++++ b/Accelerators/Vtkm/DataModel/CMakeLists.txt
+@@ -48,7 +48,7 @@ viskores_add_target_information(${vtkm_accel_target}
+                             MODIFY_CUDA_FLAGS
+                             DEVICE_SOURCES ${sources})
+ 
+-if (TARGET viskores::cuda)
++if (TARGET VTK::vtkviskores_cuda)
+   # Temporarily suppress "has address taken but no possible call to it" warnings,
+   # until we figure out its implications.
+   # We are disabling all warnings as nvlink has no known way to suppress
+@@ -64,7 +64,7 @@ if (TARGET viskores::cuda)
+   vtk_module_compile_options(VTK::AcceleratorsVTKmDataModel
+     PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe --diag_suppress=extra_semicolon>)
+ 
+-elseif (TARGET viskores::kokkos_cuda)
++elseif (TARGET VTK::vtkviskores_kokkos_cuda)
+   list(TRANSFORM nowrap_classes APPEND ".cxx" OUTPUT_VARIABLE nowrap_sources)
+   set(cuda_impl ${nowrap_sources} vtkmDataSet.cxx)
+   set_source_files_properties(${cuda_impl} PROPERTIES LANGUAGE CUDA)
+@@ -90,7 +90,7 @@ if (MSVC)
+     )
+   set(viskores_msvc_flags)
+   foreach (msvc_warning_flag IN LISTS msvc_warning_flags)
+-    if (TARGET viskores::cuda)
++    if (TARGET VTK::vtkviskores_cuda)
+       list(APPEND viskores_msvc_flags
+         $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${msvc_warning_flag},${msvc_warning_flag}>)
+     else ()
+diff --git a/Accelerators/Vtkm/DataModel/Testing/Cxx/CMakeLists.txt b/Accelerators/Vtkm/DataModel/Testing/Cxx/CMakeLists.txt
+index 627a3f5341..a105aaa49e 100644
+--- a/Accelerators/Vtkm/DataModel/Testing/Cxx/CMakeLists.txt
++++ b/Accelerators/Vtkm/DataModel/Testing/Cxx/CMakeLists.txt
+@@ -15,7 +15,7 @@ vtk_add_test_cxx(vtkAcceleratorsVTKmDataModelCxxTests tests
+   TestVTKMDataSet.cxx,NO_VALID
+   )
+ 
+-if (TARGET viskores::cuda)
++if (TARGET VTK::vtkviskores_cuda)
+   foreach(src IN LISTS tests)
+     string(REPLACE "," ";" src ${src})
+     list(GET src 0 src)
+@@ -38,7 +38,7 @@ vtk_test_cxx_executable(vtkAcceleratorsVTKmDataModelCxxTests tests
+   RENDERING_FACTORY
+   )
+ 
+-if (TARGET viskores::cuda)
++if (TARGET VTK::vtkviskores_cuda)
+   # When cuda is enabled VTK::AcceleratorsVTKmDataModel is built statically but with fpic
+   # enabled so the tests are also built with fpic enabled
+   set_target_properties(vtkAcceleratorsVTKmDataModelCxxTests PROPERTIES
+diff --git a/Accelerators/Vtkm/Filters/CMakeLists.txt b/Accelerators/Vtkm/Filters/CMakeLists.txt
+index 1b249d5f2d..4eb9989da5 100644
+--- a/Accelerators/Vtkm/Filters/CMakeLists.txt
++++ b/Accelerators/Vtkm/Filters/CMakeLists.txt
+@@ -114,7 +114,7 @@ viskores_add_target_information(${vtkm_accel_target}
+                             MODIFY_CUDA_FLAGS
+                             DEVICE_SOURCES ${sources})
+ 
+-if (TARGET viskores::cuda)
++if (TARGET VTK::vtkviskores_cuda)
+   # Temporarily suppress "has address taken but no possible call to it" warnings,
+   # until we figure out its implications.
+   # We are disabling all warnings as nvlink has no known way to suppress
+@@ -127,7 +127,7 @@ if (TARGET viskores::cuda)
+ 
+   vtk_module_compile_options(VTK::AcceleratorsVTKmFilters
+     PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe --diag_suppress=extra_semicolon>)
+-elseif (TARGET viskores::kokkos_cuda)
++elseif (TARGET VTK::vtkviskores_kokkos_cuda)
+ 
+   list(TRANSFORM classes APPEND ".cxx" OUTPUT_VARIABLE cuda_impl)
+   set_source_files_properties(${cuda_impl} PROPERTIES LANGUAGE CUDA)
+@@ -153,7 +153,7 @@ if (MSVC)
+     )
+   set(viskores_msvc_flags)
+   foreach (msvc_warning_flag IN LISTS msvc_warning_flags)
+-    if (TARGET viskores::cuda OR TARGET viskores::kokkos_cuda)
++    if (TARGET VTK::vtkviskores_cuda OR TARGET VTK::vtkviskores_kokkos_cuda)
+       list(APPEND viskores_msvc_flags
+         $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${msvc_warning_flag},${msvc_warning_flag}>)
+     else ()
+diff --git a/Accelerators/Vtkm/Filters/Testing/Cxx/CMakeLists.txt b/Accelerators/Vtkm/Filters/Testing/Cxx/CMakeLists.txt
+index 8506bc29fd..6e831b2f87 100644
+--- a/Accelerators/Vtkm/Filters/Testing/Cxx/CMakeLists.txt
++++ b/Accelerators/Vtkm/Filters/Testing/Cxx/CMakeLists.txt
+@@ -28,7 +28,7 @@ vtk_add_test_cxx(vtkAcceleratorsVTKmFiltersCxxTests tests
+   TestVTKMWarpVector.cxx
+   )
+ 
+-if (TARGET viskores::cuda)
++if (TARGET VTK::vtkviskores_cuda)
+   foreach(src IN LISTS tests)
+     string(REPLACE "," ";" src ${src})
+     list(GET src 0 src)
+@@ -53,7 +53,7 @@ vtk_test_cxx_executable(vtkAcceleratorsVTKmFiltersCxxTests tests
+   RENDERING_FACTORY
+   )
+ 
+-if (TARGET viskores::cuda)
++if (TARGET VTK::vtkviskores_cuda)
+   set_target_properties(vtkAcceleratorsVTKmFiltersCxxTests PROPERTIES
+     CUDA_ARCHITECTURES OFF)
+ endif()
+diff --git a/IO/CatalystConduit/CMakeLists.txt b/IO/CatalystConduit/CMakeLists.txt
+index d9f78669d5..91d60f1638 100644
+--- a/IO/CatalystConduit/CMakeLists.txt
++++ b/IO/CatalystConduit/CMakeLists.txt
+@@ -17,7 +17,7 @@ vtk_module_add_module(VTK::IOCatalystConduit
+   PRIVATE_CLASSES ${private_classes})
+ 
+ 
+-if (TARGET viskores::cuda)
++if (TARGET VTK::vtkviskores_cuda)
+   # Temporarily suppress "has address taken but no possible call to it" warnings,
+   # until we figure out its implications.
+   # We are disabling all warnings as nvlink has no known way to suppress
+diff --git a/IO/CatalystConduit/Testing/Cxx/CMakeLists.txt b/IO/CatalystConduit/Testing/Cxx/CMakeLists.txt
+index a8e42b6ff1..9a956fc3d8 100644
+--- a/IO/CatalystConduit/Testing/Cxx/CMakeLists.txt
++++ b/IO/CatalystConduit/Testing/Cxx/CMakeLists.txt
+@@ -31,7 +31,7 @@ if (TARGET VTK::ParallelMPI)
+   vtk_test_cxx_executable(vtkConduitCxxTests-MPI mpitests)
+ endif()
+ 
+-if (TARGET viskores::cuda)
++if (TARGET VTK::vtkviskores_cuda)
+   set_source_files_properties(TestConduitSourceDeviceMemory.cxx PROPERTIES LANGUAGE CUDA)
+ 
+ 
+-- 
+2.50.1 (Apple Git-155)
+

--- a/repos/spack_repo/builtin/packages/viskores/device-lib-private-vk11.patch
+++ b/repos/spack_repo/builtin/packages/viskores/device-lib-private-vk11.patch
@@ -1,0 +1,907 @@
+diff --git a/CMake/ViskoresWrappers.cmake b/CMake/ViskoresWrappers.cmake
+index e24068914..e5c53ea9e 100644
+--- a/CMake/ViskoresWrappers.cmake
++++ b/CMake/ViskoresWrappers.cmake
+@@ -438,17 +438,31 @@ function(viskores_add_target_information uses_viskores_target)
+     endif()
+   endforeach()
+ 
++  foreach(target IN LISTS targets)
++    target_compile_definitions(${target} PRIVATE VISKORES_IS_VISKORES_TARGET)
++  endforeach()
++
+   if(Viskores_TI_DROP_UNUSED_SYMBOLS)
+     foreach(target IN LISTS targets)
+       viskores_add_drop_unused_function_flags(${target})
+     endforeach()
+   endif()
+ 
+-  if(TARGET viskores_cuda OR TARGET viskores::cuda OR TARGET viskores_kokkos_cuda OR TARGET viskores::kokkos_cuda)
+-    set_source_files_properties(${Viskores_TI_DEVICE_SOURCES} PROPERTIES LANGUAGE "CUDA")
+-  elseif(TARGET viskores_kokkos_hip OR TARGET viskores::kokkos_hip)
+-    set_source_files_properties(${Viskores_TI_DEVICE_SOURCES} PROPERTIES LANGUAGE "HIP")
+-    kokkos_compilation(SOURCE ${Viskores_TI_DEVICE_SOURCES})
++  if(Viskores_TI_DEVICE_SOURCES)
++    foreach(target IN LISTS targets)
++      target_link_libraries(${target} 
++        PRIVATE $<TARGET_NAME_IF_EXISTS:viskores_exec>  $<TARGET_NAME_IF_EXISTS:viskores::viskores_exec>)
++    endforeach()
++
++    set_property(SOURCE ${Viskores_TI_DEVICE_SOURCES}
++      APPEND PROPERTY COMPILE_DEFINITIONS VISKORES_IS_DEVICE_SOURCE)
++
++    if(TARGET viskores_cuda OR TARGET viskores::cuda OR TARGET viskores_kokkos_cuda OR TARGET viskores::kokkos_cuda)
++      set_source_files_properties(${Viskores_TI_DEVICE_SOURCES} PROPERTIES LANGUAGE "CUDA")
++    elseif(TARGET viskores_kokkos_hip OR TARGET viskores::kokkos_hip)
++      set_source_files_properties(${Viskores_TI_DEVICE_SOURCES} PROPERTIES LANGUAGE "HIP")
++      kokkos_compilation(SOURCE ${Viskores_TI_DEVICE_SOURCES})
++    endif()
+   endif()
+ endfunction()
+ 
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6f0838151..52cb9f274 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -420,6 +420,27 @@ if (TARGET viskoresdiympi_nompi)
+   set(lib_args "${lib_args} \\
+     -lviskoresdiympi_nompi")
+ endif()
++# Also add depended device libraries
++macro(_viskores_add_imported_lib_to_list target_name)
++  if(TARGET ${target_name})
++    foreach(prop in IMPORTED_LOCATION_RELEASE IMPORTED_LOCATION IMPORTED_LOCATION_DEBUG)
++      get_target_property(libfile ${target_name} ${prop})
++      if(libfile)
++        set(lib_args "${lib_args} \\\n    ${libfile}")
++        return()
++      endif()
++    endforeach()
++  endif()
++endmacro()
++_viskores_add_imported_lib_to_list(Kokkos::kokkos)
++_viskores_add_imported_lib_to_list(TBB::tbb)
++_viskores_add_imported_lib_to_list(OpenMP::OpenMP_CXX)
++if(Viskores_ENABLE_CUDA OR TARGET viskores_kokkos_cuda)
++  find_package(CUDAToolkit)
++  _viskores_add_imported_lib_to_list(CUDA::cudart)
++  _viskores_add_imported_lib_to_list(CUDA::cudart_static)
++  _viskores_add_imported_lib_to_list(CUDA::cuda_driver)
++endif()
+ 
+ configure_file(${Viskores_SOURCE_DIR}/config/viskores_config.mk.in
+   ${Viskores_BINARY_DIR}/config/viskores_config.mk @ONLY)
+diff --git a/docs/Modules.md b/docs/Modules.md
+index 1262752e5..6361dea38 100644
+--- a/docs/Modules.md
++++ b/docs/Modules.md
+@@ -119,9 +119,10 @@ GROUPS
+   FiltersCommon
+   Filters
+ DEPENDS
+-  viskores_worklet
+   viskores_filter_core
+   viskores_filter_clean_grid
++PRIVATE_DEPENDS
++  viskores_worklet
+ TEST_DEPENDS
+   viskores_filter_clean_grid
+   viskores_filter_entity_extraction
+diff --git a/docs/changelog/device-lib-private.md b/docs/changelog/device-lib-private.md
+new file mode 100644
+index 000000000..ad2bf5956
+--- /dev/null
++++ b/docs/changelog/device-lib-private.md
+@@ -0,0 +1,7 @@
++## Made the device library private
++
++Viskores no longer makes the device libraries public on its exported
++`viskores::cont` target. Previously, the device libraries were linked to
++`viskores::cont` as `PUBLIC`, which means that pretty much anything that used
++Viskores also brought in any compiler flags for the device. This sometimes
++forced downstream code to use a device compiler when it did not need to.
+diff --git a/docs/users-guide/viskores.module b/docs/users-guide/viskores.module
+index 348d9fc24..c794c7baa 100644
+--- a/docs/users-guide/viskores.module
++++ b/docs/users-guide/viskores.module
+@@ -13,3 +13,4 @@ TEST_DEPENDS
+   viskores_filter_geometry_refinement
+   viskores_filter_mesh_info
+   viskores_rendering
++  viskores_worklet
+diff --git a/examples/contour_tree_augmented/CMakeLists.txt b/examples/contour_tree_augmented/CMakeLists.txt
+index 70315d3cc..192586f9f 100644
+--- a/examples/contour_tree_augmented/CMakeLists.txt
++++ b/examples/contour_tree_augmented/CMakeLists.txt
+@@ -72,7 +72,7 @@ endif()
+ # Serial
+ ####################################
+ add_executable(ContourTree_Augmented ContourTreeApp.cxx)
+-target_link_libraries(ContourTree_Augmented viskores::filter_scalar_topology viskores::io)
++target_link_libraries(ContourTree_Augmented PUBLIC viskores::filter_scalar_topology viskores::io viskores::worklet)
+ viskores_add_target_information(ContourTree_Augmented
+                             DROP_UNUSED_SYMBOLS MODIFY_CUDA_FLAGS
+                             DEVICE_SOURCES ContourTreeApp.cxx)
+@@ -92,7 +92,7 @@ endif()
+ ####################################
+ if (Viskores_ENABLE_MPI)
+   add_executable(ContourTree_Augmented_MPI ContourTreeApp.cxx)
+-  target_link_libraries(ContourTree_Augmented_MPI viskores::filter_scalar_topology viskores::io MPI::MPI_CXX)
++  target_link_libraries(ContourTree_Augmented_MPI viskores::filter_scalar_topology viskores::io viskores::worklet MPI::MPI_CXX)
+   viskores_add_target_information(ContourTree_Augmented_MPI
+                               MODIFY_CUDA_FLAGS
+                               DEVICE_SOURCES ContourTreeApp.cxx)
+diff --git a/examples/cosmotools/CMakeLists.txt b/examples/cosmotools/CMakeLists.txt
+index 1885b8876..969a50914 100644
+--- a/examples/cosmotools/CMakeLists.txt
++++ b/examples/cosmotools/CMakeLists.txt
+@@ -23,8 +23,8 @@ find_package(Viskores REQUIRED QUIET)
+ 
+ add_executable(CosmoCenterFinder CosmoCenterFinder.cxx)
+ add_executable(CosmoHaloFinder CosmoHaloFinder.cxx)
+-target_link_libraries(CosmoCenterFinder PRIVATE viskores::filter_core)
+-target_link_libraries(CosmoHaloFinder PRIVATE viskores::filter_core)
++target_link_libraries(CosmoCenterFinder PRIVATE viskores::filter_core viskores::worklet)
++target_link_libraries(CosmoHaloFinder PRIVATE viskores::filter_core viskores::worklet)
+ 
+ viskores_add_target_information(CosmoCenterFinder CosmoHaloFinder
+                             DROP_UNUSED_SYMBOLS
+diff --git a/examples/hello_worklet/CMakeLists.txt b/examples/hello_worklet/CMakeLists.txt
+index 37a213823..e93782a47 100644
+--- a/examples/hello_worklet/CMakeLists.txt
++++ b/examples/hello_worklet/CMakeLists.txt
+@@ -23,7 +23,8 @@ find_package(Viskores REQUIRED QUIET)
+ 
+ if(TARGET viskores::io)
+   add_executable(HelloWorklet HelloWorklet.cxx)
+-  target_link_libraries(HelloWorklet PRIVATE viskores::filter_core viskores::io)
++  target_link_libraries(HelloWorklet
++    PRIVATE viskores::filter_core viskores::worklet viskores::io)
+ 
+   viskores_add_target_information(HelloWorklet
+     DROP_UNUSED_SYMBOLS
+diff --git a/examples/logistic_map/CMakeLists.txt b/examples/logistic_map/CMakeLists.txt
+index fb33c5c7c..c9f2861a2 100644
+--- a/examples/logistic_map/CMakeLists.txt
++++ b/examples/logistic_map/CMakeLists.txt
+@@ -22,7 +22,7 @@ find_package(Viskores REQUIRED QUIET)
+ 
+ if(TARGET viskores::io)
+   add_executable(LogisticMap LogisticMap.cxx)
+-  target_link_libraries(LogisticMap PRIVATE viskores::io)
++  target_link_libraries(LogisticMap PRIVATE viskores::io viskores::worklet)
+ 
+   viskores_add_target_information(LogisticMap
+     DROP_UNUSED_SYMBOLS
+diff --git a/examples/multi_backend/CMakeLists.txt b/examples/multi_backend/CMakeLists.txt
+index 093be9076..e7600b7ff 100644
+--- a/examples/multi_backend/CMakeLists.txt
++++ b/examples/multi_backend/CMakeLists.txt
+@@ -36,7 +36,7 @@ set(srcs
+ 
+ if(TARGET viskores::filter_vector_analysis)
+   add_executable(MultiBackend ${srcs} ${headers})
+-  target_link_libraries(MultiBackend PRIVATE viskores::filter_vector_analysis Threads::Threads)
++  target_link_libraries(MultiBackend PRIVATE viskores::filter_vector_analysis viskores::worklet Threads::Threads)
+   viskores_add_target_information(MultiBackend
+     DROP_UNUSED_SYMBOLS
+     MODIFY_CUDA_FLAGS
+diff --git a/examples/polyline_archimedean_helix/CMakeLists.txt b/examples/polyline_archimedean_helix/CMakeLists.txt
+index 6005cd980..62de07727 100644
+--- a/examples/polyline_archimedean_helix/CMakeLists.txt
++++ b/examples/polyline_archimedean_helix/CMakeLists.txt
+@@ -20,16 +20,7 @@ project(PolyLineArchimedeanHelix CXX)
+ 
+ find_package(Viskores REQUIRED QUIET)
+ 
+-if (TARGET viskores::rendering)
+-  # TODO: This example should be changed from using the Tube worklet to using
+-  # the Tube filter (in the viskores::filter_geometry_refinement library). Then
+-  # compiling it would no longer require a device compiler and the example
+-  # would generally be simpler.
++if (TARGET viskores::rendering AND TARGET viskores::filter_geometry_refinement)
+   add_executable(PolyLineArchimedeanHelix PolyLineArchimedeanHelix.cxx)
+-  target_link_libraries(PolyLineArchimedeanHelix PRIVATE viskores::rendering)
+-  viskores_add_target_information(PolyLineArchimedeanHelix
+-    DROP_UNUSED_SYMBOLS
+-    MODIFY_CUDA_FLAGS
+-    DEVICE_SOURCES PolyLineArchimedeanHelix.cxx
+-    )
++  target_link_libraries(PolyLineArchimedeanHelix PRIVATE viskores::rendering viskores::filter_geometry_refinement)
+ endif()
+diff --git a/examples/polyline_archimedean_helix/PolyLineArchimedeanHelix.cxx b/examples/polyline_archimedean_helix/PolyLineArchimedeanHelix.cxx
+index 86d75d230..1893e4395 100644
+--- a/examples/polyline_archimedean_helix/PolyLineArchimedeanHelix.cxx
++++ b/examples/polyline_archimedean_helix/PolyLineArchimedeanHelix.cxx
+@@ -18,7 +18,7 @@
+ 
+ #include <complex>
+ #include <viskores/cont/DataSetBuilderExplicit.h>
+-#include <viskores/filter/geometry_refinement/worklet/Tube.h>
++#include <viskores/filter/geometry_refinement/Tube.h>
+ #include <viskores/io/VTKDataSetWriter.h>
+ 
+ #include <viskores/cont/ColorTable.h>
+@@ -66,25 +66,11 @@ void TubeThatSpiral(viskores::FloatDefault radius,
+ 
+   viskores::cont::DataSet ds = dsb.Create();
+ 
+-  viskores::worklet::Tube tubeWorklet(
+-    /*capEnds = */ true,
+-    /* how smooth the cylinder is; infinitely smooth as n->infty */ numSides,
+-    radius);
+-
+-  // You added lines, but you need to extend it to a tube.
+-  // This generates a new pointset, and new cell set.
+-  viskores::cont::ArrayHandle<viskores::Vec3f> tubePoints;
+-  viskores::cont::CellSetSingleType<> tubeCells;
+-  tubeWorklet.Run(ds.GetCoordinateSystem()
+-                    .GetData()
+-                    .AsArrayHandle<viskores::cont::ArrayHandle<viskores::Vec3f>>(),
+-                  ds.GetCellSet(),
+-                  tubePoints,
+-                  tubeCells);
+-
+-  viskores::cont::DataSet tubeDataset;
+-  tubeDataset.AddCoordinateSystem(viskores::cont::CoordinateSystem("coords", tubePoints));
+-  tubeDataset.SetCellSet(tubeCells);
++  viskores::filter::geometry_refinement::Tube tubeFilter;
++  tubeFilter.SetCapping(true);
++  tubeFilter.SetNumberOfSides(numSides);
++  tubeFilter.SetRadius(radius);
++  viskores::cont::DataSet tubeDataset = tubeFilter.Execute(ds);
+ 
+   viskores::Bounds coordsBounds = tubeDataset.GetCoordinateSystem().GetBounds();
+ 
+@@ -110,7 +96,7 @@ void TubeThatSpiral(viskores::FloatDefault radius,
+   viskores::rendering::Color bg(0.2f, 0.2f, 0.2f, 1.0f);
+ 
+ 
+-  std::vector<viskores::FloatDefault> v(static_cast<std::size_t>(tubePoints.GetNumberOfValues()));
++  std::vector<viskores::FloatDefault> v(static_cast<std::size_t>(tubeDataset.GetNumberOfPoints()));
+   // The first value is a cap:
+   v[0] = 0;
+   for (viskores::Id i = 1; i < viskores::Id(v.size()); i += numSides)
+diff --git a/examples/redistribute_points/CMakeLists.txt b/examples/redistribute_points/CMakeLists.txt
+index 65a79b424..5b116cbc3 100644
+--- a/examples/redistribute_points/CMakeLists.txt
++++ b/examples/redistribute_points/CMakeLists.txt
+@@ -23,7 +23,7 @@ find_package(Viskores REQUIRED QUIET)
+ 
+ if(TARGET viskores::io AND TARGET viskores::filter_entity_extraction)
+   add_executable(RedistributePoints RedistributePoints.cxx RedistributePoints.h main.cxx)
+-  target_link_libraries(RedistributePoints PRIVATE viskores::io viskores::filter_entity_extraction)
++  target_link_libraries(RedistributePoints PRIVATE viskores::io viskores::filter_entity_extraction viskores::worklet)
+   viskores_add_target_information(RedistributePoints
+     DROP_UNUSED_SYMBOLS
+     MODIFY_CUDA_FLAGS
+diff --git a/tutorial/CMakeLists.txt b/tutorial/CMakeLists.txt
+index 6ed90c34b..e205aad9c 100644
+--- a/tutorial/CMakeLists.txt
++++ b/tutorial/CMakeLists.txt
+@@ -51,19 +51,19 @@ if (Viskores_ENABLE_TUTORIALS)
+ endif()
+ 
+ add_executable(io io.cxx)
+-target_link_libraries(io viskores::io)
++target_link_libraries(io PRIVATE viskores::io)
+ 
+ add_executable(contour contour.cxx)
+-target_link_libraries(contour viskores::filter_core viskores::filter_contour viskores::io)
++target_link_libraries(contour PRIVATE viskores::filter_core viskores::filter_contour viskores::io)
+ 
+ add_executable(contour_two_fields contour_two_fields.cxx)
+-target_link_libraries(contour_two_fields viskores::filter_core viskores::filter_contour viskores::io)
++target_link_libraries(contour_two_fields PRIVATE viskores::filter_core viskores::filter_contour viskores::io)
+ 
+ add_executable(two_filters two_filters.cxx)
+-target_link_libraries(two_filters viskores::filter_core viskores::filter_contour viskores::io)
++target_link_libraries(two_filters PRIVATE viskores::filter_core viskores::filter_contour viskores::io)
+ 
+ add_executable(mag_grad mag_grad.cxx)
+-target_link_libraries(mag_grad viskores::filter_core viskores::filter_vector_analysis viskores::io)
++target_link_libraries(mag_grad PRIVATE viskores::filter_core viskores::filter_vector_analysis viskores::io viskores::worklet)
+ # Because mag_grad.cxx creates a worklet with code that
+ # runs on a GPU, it needs additional information.
+ viskores_add_target_information(mag_grad
+@@ -72,23 +72,23 @@ viskores_add_target_information(mag_grad
+ 
+ if (Viskores_ENABLE_RENDERING)
+   add_executable(rendering rendering.cxx)
+-  target_link_libraries(rendering viskores::io viskores::rendering)
++  target_link_libraries(rendering PRIVATE viskores::io viskores::rendering)
+ endif ()
+ 
+ add_executable(error_handling error_handling.cxx)
+-target_link_libraries(error_handling viskores::filter_core viskores::filter_contour viskores::io)
++target_link_libraries(error_handling PRIVATE viskores::filter_core viskores::filter_contour viskores::io)
+ 
+ add_executable(logging logging.cxx)
+-target_link_libraries(logging viskores::io)
++target_link_libraries(logging PRIVATE viskores::io)
+ 
+ add_executable(point_to_cell point_to_cell.cxx)
+-target_link_libraries(point_to_cell viskores::worklet viskores::filter_core viskores::io)
++target_link_libraries(point_to_cell PRIVATE viskores::worklet viskores::filter_core viskores::io)
+ viskores_add_target_information(point_to_cell
+   DROP_UNUSED_SYMBOLS MODIFY_CUDA_FLAGS
+   DEVICE_SOURCES point_to_cell.cxx)
+ 
+ add_executable(extract_edges extract_edges.cxx)
+-target_link_libraries(extract_edges viskores::cont viskores::filter_core viskores::filter_contour viskores::worklet viskores::io)
++target_link_libraries(extract_edges PRIVATE viskores::cont viskores::filter_core viskores::filter_contour viskores::worklet viskores::io)
+ viskores_add_target_information(extract_edges
+   DROP_UNUSED_SYMBOLS MODIFY_CUDA_FLAGS
+   DEVICE_SOURCES extract_edges.cxx)
+diff --git a/viskores/cont/AtomicArray.h b/viskores/cont/AtomicArray.h
+index 6a17d1d4c..6996a070a 100644
+--- a/viskores/cont/AtomicArray.h
++++ b/viskores/cont/AtomicArray.h
+@@ -21,7 +21,7 @@
+ #include <viskores/List.h>
+ #include <viskores/StaticAssert.h>
+ #include <viskores/cont/ArrayHandle.h>
+-#include <viskores/cont/DeviceAdapter.h>
++#include <viskores/cont/DeviceAdapterTag.h>
+ #include <viskores/cont/ExecutionObjectBase.h>
+ #include <viskores/exec/AtomicArrayExecutionObject.h>
+ 
+diff --git a/viskores/cont/CMakeLists.txt b/viskores/cont/CMakeLists.txt
+index 76df7b491..babe63cb1 100644
+--- a/viskores/cont/CMakeLists.txt
++++ b/viskores/cont/CMakeLists.txt
+@@ -307,19 +307,5 @@ target_sources(viskores_cont
+ add_subdirectory(internal)
+ add_subdirectory(arg)
+ 
+-set(backends )
+-if(TARGET viskores_tbb)
+-  list(APPEND backends viskores_tbb)
+-endif()
+-if(TARGET viskores_cuda)
+-  list(APPEND backends viskores_cuda)
+-endif()
+-if(TARGET viskores_openmp)
+-  list(APPEND backends viskores_openmp)
+-endif()
+-if(TARGET viskores_kokkos)
+-  list(APPEND backends viskores_kokkos)
+-endif()
+-
+-target_link_libraries(viskores_cont PUBLIC viskores_compiler_flags ${backends})
++target_link_libraries(viskores_cont PUBLIC viskores_compiler_flags)
+ target_link_libraries(viskores_cont PUBLIC Threads::Threads)
+diff --git a/viskores/cont/DataSetBuilderRectilinear.h b/viskores/cont/DataSetBuilderRectilinear.h
+index 82404469a..85f6be85d 100644
+--- a/viskores/cont/DataSetBuilderRectilinear.h
++++ b/viskores/cont/DataSetBuilderRectilinear.h
+@@ -23,7 +23,6 @@
+ #include <viskores/cont/ArrayPortalToIterators.h>
+ #include <viskores/cont/CoordinateSystem.h>
+ #include <viskores/cont/DataSet.h>
+-#include <viskores/cont/serial/DeviceAdapterSerial.h>
+ 
+ namespace viskores
+ {
+diff --git a/viskores/cont/DeviceAdapter.h b/viskores/cont/DeviceAdapter.h
+index 077f37bcc..7c97b0983 100644
+--- a/viskores/cont/DeviceAdapter.h
++++ b/viskores/cont/DeviceAdapter.h
+@@ -22,6 +22,15 @@
+ // order in which the sub-files are loaded.  (But the compile should still
+ // succeed if the order is changed.)  Turn off formatting to keep the order.
+ 
++#if defined(VISKORES_IS_VISKORES_TARGET) && !defined(VISKORES_NO_ERROR_ON_MIXED_CUDA_CXX_TAG)
++#ifndef VISKORES_IS_DEVICE_SOURCE
++#error Source file is including device code but not marked as a device source.
++#endif
++#ifndef VISKORES_DEVICE_LINKED
++#error Including device code without linking device libraries.
++#endif
++#endif
++
+ // clang-format off
+ #include <viskores/cont/cuda/DeviceAdapterCuda.h>
+ #include <viskores/cont/kokkos/DeviceAdapterKokkos.h>
+diff --git a/viskores/cont/Initialize.cxx b/viskores/cont/Initialize.cxx
+index 12fef4352..074bdc54e 100644
+--- a/viskores/cont/Initialize.cxx
++++ b/viskores/cont/Initialize.cxx
+@@ -216,12 +216,6 @@ InitializeResult Initialize(int& argc, char* argv[], InitializeOptions opts)
+       exit(1);
+     }
+ 
+-    if (options[opt::OptionIndex::HELP])
+-    {
+-      std::cerr << config.Usage;
+-      exit(0);
+-    }
+-
+     // The RuntimeDeviceConfiguration must be completed before calling GetRuntimeDeviceTracker()
+     // for all the devices. This is because GetRuntimeDeviceTracker will construct a given
+     // device's DeviceAdapterRuntimeDetector to determine if it exists and this constructor may
+@@ -234,6 +228,12 @@ InitializeResult Initialize(int& argc, char* argv[], InitializeOptions opts)
+         viskores::cont::DeviceAdapterTagAny{}, runtimeDeviceOptions, argc, argv);
+     }
+ 
++    if (options[opt::OptionIndex::HELP])
++    {
++      std::cerr << config.Usage;
++      exit(0);
++    }
++
+     // Check for device on command line.
+     if (options[opt::OptionIndex::DEVICE])
+     {
+diff --git a/viskores/cont/cuda/testing/CMakeLists.txt b/viskores/cont/cuda/testing/CMakeLists.txt
+index cb5c872db..a63a4e9b7 100644
+--- a/viskores/cont/cuda/testing/CMakeLists.txt
++++ b/viskores/cont/cuda/testing/CMakeLists.txt
+@@ -24,4 +24,9 @@ set(unit_tests
+   UnitTestCudaRuntimeDeviceConfiguration.cu
+   )
+ 
+-viskores_unit_tests(SOURCES ${unit_tests} LABEL "CUDA" LIBRARIES viskores_worklet BACKEND cuda)
++viskores_unit_tests(
++  LABEL "CUDA"
++  LIBRARIES viskores_worklet
++  BACKEND cuda
++  DEVICE_SOURCES ${unit_tests}
++  )
+diff --git a/viskores/cont/cuda/viskores.module b/viskores/cont/cuda/viskores.module
+index 8b847cef2..c9a09716a 100644
+--- a/viskores/cont/cuda/viskores.module
++++ b/viskores/cont/cuda/viskores.module
+@@ -4,6 +4,7 @@ GROUPS
+   Core
+ DEPENDS
+   viskores_cont
++  viskores_exec
+ TEST_DEPENDS
+   viskores_worklet
+   viskores_cuda
+diff --git a/viskores/cont/kokkos/testing/CMakeLists.txt b/viskores/cont/kokkos/testing/CMakeLists.txt
+index 38fc97ee8..a12b2b0fb 100644
+--- a/viskores/cont/kokkos/testing/CMakeLists.txt
++++ b/viskores/cont/kokkos/testing/CMakeLists.txt
+@@ -21,7 +21,11 @@ set(unit_tests
+   UnitTestKokkosRuntimeDeviceConfiguration.cxx
+   )
+ 
+-viskores_unit_tests(SOURCES ${unit_tests} LABEL "KOKKOS" LIBRARIES viskores_worklet BACKEND kokkos)
++viskores_unit_tests(DEVICE_SOURCES ${unit_tests}
++  LABEL "KOKKOS"
++  LIBRARIES viskores_worklet
++  BACKEND kokkos
++  )
+ 
+ if (TARGET viskores_kokkos_cuda)
+   set_source_files_properties(${unit_tests} PROPERTIES LANGUAGE CUDA)
+diff --git a/viskores/cont/kokkos/viskores.module b/viskores/cont/kokkos/viskores.module
+index b1a75e1a3..b25074bd0 100644
+--- a/viskores/cont/kokkos/viskores.module
++++ b/viskores/cont/kokkos/viskores.module
+@@ -4,6 +4,7 @@ GROUPS
+   Core
+ DEPENDS
+   viskores_cont
++  viskores_exec
+ TEST_DEPENDS
+   viskores_worklet
+   viskores_kokkos
+diff --git a/viskores/cont/openmp/testing/CMakeLists.txt b/viskores/cont/openmp/testing/CMakeLists.txt
+index e07da5ea4..fb8f2f52b 100644
+--- a/viskores/cont/openmp/testing/CMakeLists.txt
++++ b/viskores/cont/openmp/testing/CMakeLists.txt
+@@ -21,7 +21,7 @@ set(unit_tests
+   UnitTestOpenMPRuntimeDeviceConfiguration.cxx
+   )
+ 
+-viskores_unit_tests(SOURCES ${unit_tests}
++viskores_unit_tests(DEVICE_SOURCES ${unit_tests}
+                 LABEL "OPENMP"
+                 DEFINES VISKORES_NO_ERROR_ON_MIXED_CUDA_CXX_TAG
+                 LIBRARIES viskores_worklet
+diff --git a/viskores/cont/openmp/viskores.module b/viskores/cont/openmp/viskores.module
+index 5a6899e2c..e2beb6378 100644
+--- a/viskores/cont/openmp/viskores.module
++++ b/viskores/cont/openmp/viskores.module
+@@ -4,6 +4,7 @@ GROUPS
+   Core
+ DEPENDS
+   viskores_cont
++  viskores_exec
+ TEST_DEPENDS
+   viskores_worklet
+   viskores_openmp
+diff --git a/viskores/cont/serial/testing/CMakeLists.txt b/viskores/cont/serial/testing/CMakeLists.txt
+index 946737026..3e1ea972c 100644
+--- a/viskores/cont/serial/testing/CMakeLists.txt
++++ b/viskores/cont/serial/testing/CMakeLists.txt
+@@ -20,7 +20,7 @@ set(unit_tests
+   UnitTestSerialDeviceAdapter.cxx
+   )
+ 
+-viskores_unit_tests(SOURCES ${unit_tests}
++viskores_unit_tests(DEVICE_SOURCES ${unit_tests}
+                 LABEL "SERIAL"
+                 DEFINES VISKORES_NO_ERROR_ON_MIXED_CUDA_CXX_TAG
+                 LIBRARIES viskores_worklet
+diff --git a/viskores/cont/tbb/testing/CMakeLists.txt b/viskores/cont/tbb/testing/CMakeLists.txt
+index 670aa2b78..9b4753858 100644
+--- a/viskores/cont/tbb/testing/CMakeLists.txt
++++ b/viskores/cont/tbb/testing/CMakeLists.txt
+@@ -21,7 +21,7 @@ set(unit_tests
+   UnitTestTBBRuntimeDeviceConfiguration.cxx
+   )
+ 
+-viskores_unit_tests(SOURCES ${unit_tests}
++viskores_unit_tests(DEVICE_SOURCES ${unit_tests}
+                 LABEL "TBB"
+                 DEFINES VISKORES_NO_ERROR_ON_MIXED_CUDA_CXX_TAG
+                 LIBRARIES viskores_worklet
+diff --git a/viskores/cont/tbb/viskores.module b/viskores/cont/tbb/viskores.module
+index 7d3fcf695..3e745b830 100644
+--- a/viskores/cont/tbb/viskores.module
++++ b/viskores/cont/tbb/viskores.module
+@@ -4,6 +4,7 @@ GROUPS
+   Core
+ DEPENDS
+   viskores_cont
++  viskores_exec
+ TEST_DEPENDS
+   viskores_worklet
+   viskores_tbb
+diff --git a/viskores/cont/testing/CMakeLists.txt b/viskores/cont/testing/CMakeLists.txt
+index f1e70774d..ceab109a7 100644
+--- a/viskores/cont/testing/CMakeLists.txt
++++ b/viskores/cont/testing/CMakeLists.txt
+@@ -40,7 +40,6 @@ set(unit_tests
+   UnitTestArraySetValues.cxx
+   UnitTestBuffer.cxx
+   UnitTestComputeRange.cxx
+-  UnitTestControlSignatureTag.cxx
+   UnitTestContTesting.cxx
+   UnitTestDataSetBuilderCurvilinear.cxx
+   UnitTestDataSetBuilderExplicit.cxx
+@@ -50,7 +49,6 @@ set(unit_tests
+   UnitTestDataSetExplicit.cxx
+   UnitTestDataSetRectilinear.cxx
+   UnitTestDataSetUniform.cxx
+-  UnitTestDeviceAdapterAlgorithmGeneral.cxx
+   UnitTestDeviceSelectOnThreads.cxx
+   UnitTestError.cxx
+   UnitTestFieldRangeCompute.cxx
+@@ -72,7 +70,6 @@ set(unit_tests
+   UnitTestTypeCheckArray.cxx
+   UnitTestTypeCheckCellSet.cxx
+   UnitTestTypeCheckExecObject.cxx
+-  UnitTestTypeCheckKeys.cxx
+   UnitTestUnknownArrayHandle.cxx
+   UnitTestUnknownCellSet.cxx
+   )
+@@ -114,9 +111,11 @@ set(unit_tests_device
+   UnitTestCellSetExplicit.cxx
+   UnitTestCellSetPermutation.cxx
+   UnitTestColorTable.cxx
++  UnitTestControlSignatureTag.cxx
+   UnitTestDataSetPermutation.cxx
+   UnitTestDataSetSingleType.cxx
+   UnitTestDeviceAdapterAlgorithmDependency.cxx
++  UnitTestDeviceAdapterAlgorithmGeneral.cxx
+   UnitTestHints.cxx
+   UnitTestImplicitFunction.cxx
+   UnitTestParticleArrayCopy.cxx
+@@ -127,6 +126,7 @@ set(unit_tests_device
+   UnitTestTransportCellSetIn.cxx
+   UnitTestTransportExecObject.cxx
+   UnitTestTransportWholeArray.cxx
++  UnitTestTypeCheckKeys.cxx
+   )
+ if(TARGET viskores_filter_field_conversion)
+   list(APPEND unit_tests_device
+diff --git a/viskores/cont/testing/TestingDeviceAdapter.h b/viskores/cont/testing/TestingDeviceAdapter.h
+index 3859488b1..cd1865371 100644
+--- a/viskores/cont/testing/TestingDeviceAdapter.h
++++ b/viskores/cont/testing/TestingDeviceAdapter.h
+@@ -1265,17 +1265,17 @@ private:
+ 
+     //the output of reduce and scan inclusive should be the same
+     std::cout << "  Reduce with initial value of 0." << std::endl;
+-    viskores::Id reduce_sum = Algorithm::Reduce(array, 0);
++    viskores::Id reduce_sum = Algorithm::Reduce(array, viskores::Id(0));
+     std::cout << "  Reduce with initial value." << std::endl;
+     viskores::Id reduce_sum_with_intial_value = Algorithm::Reduce(array, viskores::Id(ARRAY_SIZE));
+     std::cout << "  Inclusive scan to check" << std::endl;
+     viskores::Id inclusive_sum = Algorithm::ScanInclusive(array, array);
+     std::cout << "  Reduce with 1 value." << std::endl;
+     array.Allocate(1, viskores::CopyFlag::On);
+-    viskores::Id reduce_sum_one_value = Algorithm::Reduce(array, 0);
++    viskores::Id reduce_sum_one_value = Algorithm::Reduce(array, viskores::Id(0));
+     std::cout << "  Reduce with 0 values." << std::endl;
+     array.Allocate(0);
+-    viskores::Id reduce_sum_no_values = Algorithm::Reduce(array, 0);
++    viskores::Id reduce_sum_no_values = Algorithm::Reduce(array, viskores::Id(0));
+     VISKORES_TEST_ASSERT(reduce_sum == OFFSET * ARRAY_SIZE, "Got bad sum from Reduce");
+     VISKORES_TEST_ASSERT(reduce_sum_with_intial_value == reduce_sum + ARRAY_SIZE,
+                          "Got bad sum from Reduce with initial value");
+diff --git a/viskores/cont/viskores.module b/viskores/cont/viskores.module
+index 0c41ecc4a..c72d84eb1 100644
+--- a/viskores/cont/viskores.module
++++ b/viskores/cont/viskores.module
+@@ -6,6 +6,8 @@ DEPENDS
+   viskores_optionparser
+   viskores_diy
+   viskores_lcl
++PRIVATE_DEPENDS
++  viskores_exec
+ OPTIONAL_DEPENDS
+   viskores_loguru
+ TEST_OPTIONAL_DEPENDS
+@@ -13,3 +15,5 @@ TEST_OPTIONAL_DEPENDS
+   viskores_filter_field_conversion
+ TEST_DEPENDS
+   viskores_source
++  viskores_filter_resampling
++  viskores_worklet
+diff --git a/viskores/exec/AtomicArrayExecutionObject.h b/viskores/exec/AtomicArrayExecutionObject.h
+index 4e7fb9993..0fb5f61c5 100644
+--- a/viskores/exec/AtomicArrayExecutionObject.h
++++ b/viskores/exec/AtomicArrayExecutionObject.h
+@@ -21,7 +21,7 @@
+ #include <viskores/Atomic.h>
+ #include <viskores/List.h>
+ #include <viskores/cont/ArrayHandle.h>
+-#include <viskores/cont/DeviceAdapter.h>
++#include <viskores/cont/DeviceAdapterTag.h>
+ 
+ #include <type_traits>
+ 
+diff --git a/viskores/exec/CMakeLists.txt b/viskores/exec/CMakeLists.txt
+index 5acd83b3d..e4e18653e 100644
+--- a/viskores/exec/CMakeLists.txt
++++ b/viskores/exec/CMakeLists.txt
+@@ -56,3 +56,22 @@ add_subdirectory(arg)
+ viskores_declare_headers(${headers}
+                     ${header_impls}
+                     )
++
++set(backends )
++if(TARGET viskores_tbb)
++  list(APPEND backends viskores_tbb)
++endif()
++if(TARGET viskores_cuda)
++  list(APPEND backends viskores_cuda)
++endif()
++if(TARGET viskores_openmp)
++  list(APPEND backends viskores_openmp)
++endif()
++if(TARGET viskores_kokkos)
++  list(APPEND backends viskores_kokkos)
++endif()
++
++add_library(viskores_exec INTERFACE)
++target_link_libraries(viskores_exec INTERFACE ${backends})
++target_compile_definitions(viskores_exec INTERFACE VISKORES_DEVICE_LINKED)
++install(TARGETS viskores_exec EXPORT ${Viskores_EXPORT_NAME})
+diff --git a/viskores/exec/serial/viskores.module b/viskores/exec/serial/viskores.module
+index 2f29d4da8..89ac43b6b 100644
+--- a/viskores/exec/serial/viskores.module
++++ b/viskores/exec/serial/viskores.module
+@@ -4,3 +4,5 @@ GROUPS
+   Core
+ DEPENDS
+   viskores_exec
++TEST_DEPENDS
++  viskores_exec
+diff --git a/viskores/exec/tbb/viskores.module b/viskores/exec/tbb/viskores.module
+index 62d908526..725c72b1a 100644
+--- a/viskores/exec/tbb/viskores.module
++++ b/viskores/exec/tbb/viskores.module
+@@ -6,3 +6,4 @@ DEPENDS
+   viskores_exec
+ TEST_DEPENDS
+   viskores_tbb
++  viskores_exec
+diff --git a/viskores/filter/connected_components/CMakeLists.txt b/viskores/filter/connected_components/CMakeLists.txt
+index 6fc1e20da..ff4c0fece 100644
+--- a/viskores/filter/connected_components/CMakeLists.txt
++++ b/viskores/filter/connected_components/CMakeLists.txt
+@@ -31,7 +31,6 @@ viskores_library(
+   USE_VISKORES_JOB_POOL
+ )
+ 
+-target_link_libraries(viskores_filter_connected_components PRIVATE viskores_worklet PUBLIC viskores_filter_core)
+ target_link_libraries(viskores_filter PUBLIC INTERFACE viskores_filter_connected_components)
+ 
+ add_subdirectory(worklet)
+diff --git a/viskores/filter/connected_components/viskores.module b/viskores/filter/connected_components/viskores.module
+index 607e03a70..2f1d14f47 100644
+--- a/viskores/filter/connected_components/viskores.module
++++ b/viskores/filter/connected_components/viskores.module
+@@ -10,3 +10,4 @@ TEST_DEPENDS
+   viskores_filter_contour
+   viskores_filter_connected_components
+   viskores_source
++  viskores_worklet
+diff --git a/viskores/filter/contour/viskores.module b/viskores/filter/contour/viskores.module
+index f5b5dc1ce..25cc41019 100644
+--- a/viskores/filter/contour/viskores.module
++++ b/viskores/filter/contour/viskores.module
+@@ -17,6 +17,7 @@ TEST_DEPENDS
+   viskores_filter_geometry_refinement
+   viskores_io
+   viskores_source
++  viskores_worklet
+ TEST_OPTIONAL_DEPENDS
+   viskores_rendering_testing
+   viskores_rendering
+diff --git a/viskores/filter/density_estimate/viskores.module b/viskores/filter/density_estimate/viskores.module
+index 2d77f6580..cc0c8d6a2 100644
+--- a/viskores/filter/density_estimate/viskores.module
++++ b/viskores/filter/density_estimate/viskores.module
+@@ -12,3 +12,4 @@ OPTIONAL_DEPENDS
+ TEST_DEPENDS
+   viskores_filter_density_estimate
+   viskores_source
++  viskores_worklet
+diff --git a/viskores/filter/field_transform/CMakeLists.txt b/viskores/filter/field_transform/CMakeLists.txt
+index 5b28a5a7e..a0120bb96 100644
+--- a/viskores/filter/field_transform/CMakeLists.txt
++++ b/viskores/filter/field_transform/CMakeLists.txt
+@@ -52,7 +52,6 @@ viskores_library(
+   USE_VISKORES_JOB_POOL
+ )
+ 
+-target_link_libraries(viskores_filter_field_transform PUBLIC viskores_worklet viskores_filter_core)
+ target_link_libraries(viskores_filter PUBLIC INTERFACE viskores_filter_field_transform)
+ 
+ add_subdirectory(worklet)
+diff --git a/viskores/filter/flow/viskores.module b/viskores/filter/flow/viskores.module
+index a2be1f1b4..aafc3d993 100644
+--- a/viskores/filter/flow/viskores.module
++++ b/viskores/filter/flow/viskores.module
+@@ -13,6 +13,7 @@ TEST_DEPENDS
+   viskores_filter_mesh_info
+   viskores_filter_flow
+   viskores_io
++  viskores_worklet
+ TEST_OPTIONAL_DEPENDS
+   viskores_rendering_testing
+   MPI::MPI_CXX
+diff --git a/viskores/filter/geometry_refinement/CMakeLists.txt b/viskores/filter/geometry_refinement/CMakeLists.txt
+index f1c84b5dd..8f748cda7 100644
+--- a/viskores/filter/geometry_refinement/CMakeLists.txt
++++ b/viskores/filter/geometry_refinement/CMakeLists.txt
+@@ -42,7 +42,6 @@ viskores_library(
+   USE_VISKORES_JOB_POOL
+ )
+ 
+-target_link_libraries(viskores_filter_geometry_refinement PUBLIC viskores_worklet viskores_filter_core)
+ target_link_libraries(viskores_filter PUBLIC INTERFACE viskores_filter_geometry_refinement)
+ 
+ add_subdirectory(worklet)
+diff --git a/viskores/filter/multi_block/viskores.module b/viskores/filter/multi_block/viskores.module
+index ba4668657..7bda54e6c 100644
+--- a/viskores/filter/multi_block/viskores.module
++++ b/viskores/filter/multi_block/viskores.module
+@@ -11,3 +11,4 @@ TEST_DEPENDS
+   viskores_rendering
+   viskores_rendering_testing
+   viskores_filter_geometry_refinement
++  viskores_worklet
+diff --git a/viskores/filter/resampling/viskores.module b/viskores/filter/resampling/viskores.module
+index f914bcbaa..83f503a9b 100644
+--- a/viskores/filter/resampling/viskores.module
++++ b/viskores/filter/resampling/viskores.module
+@@ -10,3 +10,4 @@ PRIVATE_DEPENDS
+   viskores_worklet
+ TEST_DEPENDS
+   viskores_filter_clean_grid
++  viskores_worklet
+diff --git a/viskores/filter/scalar_topology/CMakeLists.txt b/viskores/filter/scalar_topology/CMakeLists.txt
+index 8c5d57ea2..3a8d87c1d 100644
+--- a/viskores/filter/scalar_topology/CMakeLists.txt
++++ b/viskores/filter/scalar_topology/CMakeLists.txt
+@@ -48,7 +48,6 @@ viskores_library(
+   USE_VISKORES_JOB_POOL
+ )
+ 
+-target_link_libraries(viskores_filter_scalar_topology PUBLIC viskores_worklet viskores_filter_core)
+ if (Viskores_ENABLE_MPI)
+   target_link_libraries(viskores_filter_scalar_topology PUBLIC MPI::MPI_CXX)
+ endif ()
+diff --git a/viskores/filter/scalar_topology/viskores.module b/viskores/filter/scalar_topology/viskores.module
+index 6c44a1813..0a1fa98e0 100644
+--- a/viskores/filter/scalar_topology/viskores.module
++++ b/viskores/filter/scalar_topology/viskores.module
+@@ -4,6 +4,9 @@ GROUPS
+   Filters
+ DEPENDS
+   viskores_filter_core
++PRIVATE_DEPENDS
++  viskores_worklet
+ TEST_DEPENDS
+   viskores_io
+   viskores_source
++  viskores_worklet
+diff --git a/viskores/filter/viskores.module b/viskores/filter/viskores.module
+index 2ad7d069d..d50329908 100644
+--- a/viskores/filter/viskores.module
++++ b/viskores/filter/viskores.module
+@@ -4,11 +4,13 @@ GROUPS
+   Core
+ DEPENDS
+   viskores_cont
++PRIVATE_DEPENDS
+   viskores_worklet
+ TEST_DEPENDS
+   viskores_filter
+   viskores_io
+   viskores_source
++  viskores_worklet
+ TEST_OPTIONAL_DEPENDS
+   viskores_rendering
+   viskores_rendering_testing
+diff --git a/viskores/rendering/viskores.module b/viskores/rendering/viskores.module
+index 9caad9698..5a62fd648 100644
+--- a/viskores/rendering/viskores.module
++++ b/viskores/rendering/viskores.module
+@@ -6,6 +6,8 @@ DEPENDS
+   viskores_filter_image_processing
+   viskores_filter_entity_extraction
+   viskores_io
++PRIVATE_DEPENDS
++  viskores_worklet
+ TEST_DEPENDS
+   viskores_rendering_testing
+   viskores_source
+diff --git a/viskores/source/viskores.module b/viskores/source/viskores.module
+index 54dcd76ba..d981696f7 100644
+--- a/viskores/source/viskores.module
++++ b/viskores/source/viskores.module
+@@ -6,6 +6,8 @@ DEPENDS
+   viskores_cont
+   viskores_filter_field_conversion
+   viskores_filter_multi_block
++PRIVATE_DEPENDS
++  viskores_exec
+ TEST_DEPENDS
+   viskores_filter_contour
+ TEST_OPTIONAL_DEPENDS
+diff --git a/viskores/viskores.module b/viskores/viskores.module
+index ec514fe30..86176cf63 100644
+--- a/viskores/viskores.module
++++ b/viskores/viskores.module
+@@ -2,3 +2,5 @@ NAME
+   viskores
+ GROUPS
+   Core
++TEST_DEPENDS
++  viskores_worklet
+diff --git a/viskores/worklet/internal/DispatcherBase.h b/viskores/worklet/internal/DispatcherBase.h
+index 3c1b1d242..bc7ce332d 100644
+--- a/viskores/worklet/internal/DispatcherBase.h
++++ b/viskores/worklet/internal/DispatcherBase.h
+@@ -25,7 +25,9 @@
+ #include <viskores/internal/Invocation.h>
+ 
+ #include <viskores/cont/CastAndCall.h>
++#include <viskores/cont/DeviceAdapter.h>
+ #include <viskores/cont/ErrorBadType.h>
++#include <viskores/cont/ErrorExecution.h>
+ #include <viskores/cont/Logging.h>
+ #include <viskores/cont/TryExecute.h>
+ 
+diff --git a/viskores/worklet/viskores.module b/viskores/worklet/viskores.module
+index 4ff5c89c0..3aeff8134 100644
+--- a/viskores/worklet/viskores.module
++++ b/viskores/worklet/viskores.module
+@@ -4,6 +4,7 @@ GROUPS
+   Core
+ DEPENDS
+   viskores_cont
++  viskores_exec
+ TEST_DEPENDS
+   viskores_source
+   viskores_worklet

--- a/repos/spack_repo/builtin/packages/viskores/package.py
+++ b/repos/spack_repo/builtin/packages/viskores/package.py
@@ -111,6 +111,10 @@ class Viskores(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("+cuda~cuda_native~kokkos", msg="Cannot have +cuda without a cuda device")
     conflicts("+cuda", when="cuda_arch=none", msg="viskores +cuda requires that cuda_arch be set")
 
+    # https://github.com/Viskores/viskores/pull/161
+    # Must use patch file because PR has conflicts with 1.1 release.
+    patch("device-lib-private-vk11.patch", when="@1.1")
+
     def cmake_args(self):
         spec = self.spec
         options = []


### PR DESCRIPTION
When compiling for some GPUs, we need a patch to add an extra find package for Viskores.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
