### PR TITLE
Add style tools to the developer stack

### DIFF
--- a/repos/spack_repo/builtin/packages/py_ruff/package.py
+++ b/repos/spack_repo/builtin/packages/py_ruff/package.py
@@ -33,10 +33,12 @@ class PyRuff(PythonPackage):
     version("0.3.0", sha256="0886184ba2618d815067cf43e005388967b67ab9c80df52b32ec1152ab49f53a")
     version("0.1.6", sha256="1b09f29b16c6ead5ea6b097ef2764b42372aebe363722f1605ecbcd2b9207184")
 
-    depends_on("c", type="build")
-    depends_on("gmake", type="build")
+    
 
     with default_args(type="build"):
+        depends_on("c")
+        depends_on("gmake")
+
         depends_on("py-maturin@1.9:1", when="@0.12.7:")
         depends_on("py-maturin@1")
 

--- a/repos/spack_repo/builtin/packages/py_ruff/package.py
+++ b/repos/spack_repo/builtin/packages/py_ruff/package.py
@@ -33,8 +33,6 @@ class PyRuff(PythonPackage):
     version("0.3.0", sha256="0886184ba2618d815067cf43e005388967b67ab9c80df52b32ec1152ab49f53a")
     version("0.1.6", sha256="1b09f29b16c6ead5ea6b097ef2764b42372aebe363722f1605ecbcd2b9207184")
 
-    
-
     with default_args(type="build"):
         depends_on("c")
         depends_on("gmake")

--- a/repos/spack_repo/builtin/packages/py_ty/package.py
+++ b/repos/spack_repo/builtin/packages/py_ty/package.py
@@ -32,9 +32,12 @@ class PyTy(PythonPackage):
         deprecated=True,
     )
 
-    # ruff/Cargo.toml
-    depends_on("rust@1.91:", when="@0.0.15:")
-    depends_on("rust@1.90:", when="@0.0.2:")
-    depends_on("rust@1.89:")
+    with default_args(type="build"):
+        depends_on("c")
+        depends_on("gmake")
+        # ruff/Cargo.toml
+        depends_on("rust@1.91:", when="@0.0.15:")
+        depends_on("rust@1.90:", when="@0.0.2:")
+        depends_on("rust@1.89:")
 
-    depends_on("py-maturin@1", type="build")
+        depends_on("py-maturin@1")

--- a/stacks/developer-tools-aarch64-linux-gnu/spack.yaml
+++ b/stacks/developer-tools-aarch64-linux-gnu/spack.yaml
@@ -84,7 +84,7 @@ spack:
   # style
   - py-pytest@9.0.2
   - py-ruff@0.15.0
-  - py-ty@0.0.15
+  - py-ty@0.0.20
 
   ci:
     pipeline-gen:

--- a/stacks/developer-tools-aarch64-linux-gnu/spack.yaml
+++ b/stacks/developer-tools-aarch64-linux-gnu/spack.yaml
@@ -42,6 +42,11 @@ spack:
   - py-fprettify
   - py-fortran-language-server
   - py-python-lsp-server
+  - py-isort
+  - py-mypy-extensions
+  - py-mypy
+  - py-black
+  - py-flake8
     # cli dev tools
   - ripgrep
   - gh
@@ -77,11 +82,6 @@ spack:
   - meson
   # spack developer tools
   # style
-  - py-isort@5
-  - py-mypy-extensions@1.0
-  - py-mypy@1.19
-  - py-black@25.1.0
-  - py-flake8@7.3.0
   - py-pytest@9.0.2
   - py-ruff@0.15.0
   - py-ty@0.0.15

--- a/stacks/developer-tools-aarch64-linux-gnu/spack.yaml
+++ b/stacks/developer-tools-aarch64-linux-gnu/spack.yaml
@@ -78,10 +78,11 @@ spack:
   # spack developer tools
   # style
   - py-isort@5
-  - "py-mypy@0.900: ^py-mypy-extensions@:1.0"
-  - py-black@:25.1.0
-  - "py-flake8@3.8.2:"
-  - "py-pytest@6.2.4:"
+  - py-mypy-extensions@1.0
+  - py-mypy@1.19
+  - py-black@25.1.0
+  - py-flake8@7.3.0
+  - py-pytest@9.0.2
   - py-ruff@0.15.0
   - py-ty@0.0.15
 

--- a/stacks/developer-tools-aarch64-linux-gnu/spack.yaml
+++ b/stacks/developer-tools-aarch64-linux-gnu/spack.yaml
@@ -86,7 +86,6 @@ spack:
   - py-ruff@0.15.0
   - py-ty@0.0.15
 
-
   ci:
     pipeline-gen:
     - build-job:

--- a/stacks/developer-tools-aarch64-linux-gnu/spack.yaml
+++ b/stacks/developer-tools-aarch64-linux-gnu/spack.yaml
@@ -75,6 +75,16 @@ spack:
   - graphviz
   - doxygen
   - meson
+  # spack developer tools
+  # style
+  - py-isort@5
+  - "py-mypy@0.900: ^py-mypy-extensions@:1.0"
+  - py-black@:25.1.0
+  - "py-flake8@3.8.2:"
+  - "py-pytest@6.2.4:"
+  - py-ruff@0.15.0
+  - py-ty@0.0.15
+
 
   ci:
     pipeline-gen:

--- a/stacks/developer-tools-darwin/spack.yaml
+++ b/stacks/developer-tools-darwin/spack.yaml
@@ -91,6 +91,15 @@ spack:
     - gmake
     - ninja
     - meson
+    # spack developer tools
+    # style
+    - py-isort@5
+    - "py-mypy@0.900: ^py-mypy-extensions@:1.0"
+    - py-black@:25.1.0
+    - "py-flake8@3.8.2:"
+    - "py-pytest@6.2.4:"
+    - py-ruff@0.15.0
+    - py-ty@0.0.15
 
   ci:
     pipeline-gen:

--- a/stacks/developer-tools-darwin/spack.yaml
+++ b/stacks/developer-tools-darwin/spack.yaml
@@ -62,12 +62,13 @@ spack:
     - py-black
     - py-codespell
     - py-flake8
+    - py-isort
+    - py-mypy-extensions
     - py-fortran-language-server
     - py-fprettify
     - py-mypy
     - py-python-lsp-ruff
     - py-python-lsp-server
-    - py-ruff
     - typos
     - uncrustify
     - gopls
@@ -93,11 +94,6 @@ spack:
     - meson
     # spack developer tools
     # style
-    - py-isort@5
-    - py-mypy-extensions@1.0
-    - py-mypy@1.19
-    - py-black@25.1.0
-    - py-flake8@7.3.0
     - py-pytest@9.0.2
     - py-ruff@0.15.0
     - py-ty@0.0.15

--- a/stacks/developer-tools-darwin/spack.yaml
+++ b/stacks/developer-tools-darwin/spack.yaml
@@ -96,7 +96,7 @@ spack:
     # style
     - py-pytest@9.0.2
     - py-ruff@0.15.0
-    - py-ty@0.0.15
+    - py-ty@0.0.20
 
   ci:
     pipeline-gen:

--- a/stacks/developer-tools-darwin/spack.yaml
+++ b/stacks/developer-tools-darwin/spack.yaml
@@ -94,10 +94,11 @@ spack:
     # spack developer tools
     # style
     - py-isort@5
-    - "py-mypy@0.900: ^py-mypy-extensions@:1.0"
-    - py-black@:25.1.0
-    - "py-flake8@3.8.2:"
-    - "py-pytest@6.2.4:"
+    - py-mypy-extensions@1.0
+    - py-mypy@1.19
+    - py-black@25.1.0
+    - py-flake8@7.3.0
+    - py-pytest@9.0.2
     - py-ruff@0.15.0
     - py-ty@0.0.15
 

--- a/stacks/developer-tools-x86_64_v3-linux-gnu/spack.yaml
+++ b/stacks/developer-tools-x86_64_v3-linux-gnu/spack.yaml
@@ -69,9 +69,6 @@ spack:
   - libtree
   - patchelf
   - sed
-
-
-
   - which
   - elfutils
   - fontconfig

--- a/stacks/developer-tools-x86_64_v3-linux-gnu/spack.yaml
+++ b/stacks/developer-tools-x86_64_v3-linux-gnu/spack.yaml
@@ -87,7 +87,7 @@ spack:
   # style
   - py-pytest@9.0.2
   - py-ruff@0.15.0
-  - py-ty@0.0.15
+  - py-ty@0.0.20
 
   ci:
     pipeline-gen:

--- a/stacks/developer-tools-x86_64_v3-linux-gnu/spack.yaml
+++ b/stacks/developer-tools-x86_64_v3-linux-gnu/spack.yaml
@@ -78,13 +78,15 @@ spack:
   - graphviz
   - doxygen
   - meson
-  # dev bootstrap
+  # spack developer tools
+  # style
+  - py-isort@5
+  - "py-mypy@0.900: ^py-mypy-extensions@:1.0"
+  - py-black@:25.1.0
+  - "py-flake8@3.8.2:"
+  - "py-pytest@6.2.4:"
   - py-ruff@0.15.0
   - py-ty@0.0.15
-  - py-black
-  - py-flake8
-  - py-mpypy
-  - py-isort
 
   ci:
     pipeline-gen:

--- a/stacks/developer-tools-x86_64_v3-linux-gnu/spack.yaml
+++ b/stacks/developer-tools-x86_64_v3-linux-gnu/spack.yaml
@@ -78,6 +78,13 @@ spack:
   - graphviz
   - doxygen
   - meson
+  # dev bootstrap
+  - py-ruff@0.15.0
+  - py-ty@0.0.15
+  - py-black
+  - py-flake8
+  - py-mpypy
+  - py-isort
 
   ci:
     pipeline-gen:

--- a/stacks/developer-tools-x86_64_v3-linux-gnu/spack.yaml
+++ b/stacks/developer-tools-x86_64_v3-linux-gnu/spack.yaml
@@ -45,6 +45,11 @@ spack:
   - py-fprettify
   - py-fortran-language-server
   - py-python-lsp-server
+  - py-isort
+  - py-mypy-extensions
+  - py-mypy
+  - py-black
+  - py-flake8
     # cli dev tools
   - ripgrep
   - gh
@@ -80,11 +85,6 @@ spack:
   - meson
   # spack developer tools
   # style
-  - py-isort@5
-  - py-mypy-extensions@1.0
-  - py-mypy@1.19
-  - py-black@25.1.0
-  - py-flake8@7.3.0
   - py-pytest@9.0.2
   - py-ruff@0.15.0
   - py-ty@0.0.15

--- a/stacks/developer-tools-x86_64_v3-linux-gnu/spack.yaml
+++ b/stacks/developer-tools-x86_64_v3-linux-gnu/spack.yaml
@@ -69,6 +69,9 @@ spack:
   - libtree
   - patchelf
   - sed
+
+
+
   - which
   - elfutils
   - fontconfig
@@ -81,10 +84,11 @@ spack:
   # spack developer tools
   # style
   - py-isort@5
-  - "py-mypy@0.900: ^py-mypy-extensions@:1.0"
-  - py-black@:25.1.0
-  - "py-flake8@3.8.2:"
-  - "py-pytest@6.2.4:"
+  - py-mypy-extensions@1.0
+  - py-mypy@1.19
+  - py-black@25.1.0
+  - py-flake8@7.3.0
+  - py-pytest@9.0.2
   - py-ruff@0.15.0
   - py-ty@0.0.15
 


### PR DESCRIPTION
Add all of the tools required to run Spack style checks as well as ruff and ty, which will be added to the style checks in upcoming PRs, to the spack developer build stacks for binary mirror population.

Motivation: 

Support bootstrapping style checks from the binary mirror for a faster, ruff/ty enabled dev bootstrap.

Ruff and ty are going to be added to Spack style. Ruff and ty builds from source require a build of rust, which is expensive from both a time and disc space perspective. Bootstrapping from source, as we currently do with the style checks when dependencies are unresolved, would be a poor ux if users had to wait for a build of rust (which builds llvm) to run spack style, and for users with limited home drive storage, infeasible for a simple style check. 

Ruff and ty, will instead need to be pulled from the public binary mirror during a dev bootstrap to support the style command. To do so, we need to add them to the stacks, and what better stack than the dev stack. 

As dev boostrap is now incorporating the public binary mirror, we should also populate it with the other dev bootstrap so we can avoid more from source dev bootstrapping operations. 

