### PR TITLE
py-chardet: add v6, v7, update license

### DIFF
--- a/repos/spack_repo/builtin/packages/py_chardet/package.py
+++ b/repos/spack_repo/builtin/packages/py_chardet/package.py
@@ -13,8 +13,12 @@ class PyChardet(PythonPackage):
     homepage = "https://github.com/chardet/chardet"
     pypi = "chardet/chardet-3.0.4.tar.gz"
 
-    license("LGPL-2.1-or-later")
+    license("MIT", when="@7:")
+    license("LGPL-2.1-or-later", when="@:6")
 
+    version("7.0.1", sha256="6fce895c12c5495bb598e59ae3cd89306969b4464ec7b6dd609b9c86e3397fe3")
+    version("7.0.0", sha256="5272ea14c48cb5f38e87e698c641a7ea2a8b1db6c42ea729527fbe8bd621f39c")
+    version("6.0.0", sha256="aaa00ede13dd39a582de2b1254221a1f3e1c77e7738036431b6cb7e6a05b4f19")
     version("5.2.0", sha256="1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7")
     version("5.1.0", sha256="0d62712b956bc154f85fb0a266e2a3c5913c2967e00348701b32411d6def31e5")
     version("5.0.0", sha256="0368df2bfd78b5fc20572bb4e9bb7fb53e2c094f60ae9993339e8671d0afb8aa")
@@ -23,7 +27,10 @@ class PyChardet(PythonPackage):
     version("3.0.2", sha256="4f7832e7c583348a9eddd927ee8514b3bf717c061f57b21dbe7697211454d9bb")
     version("2.3.0", sha256="e53e38b3a4afe6d1132de62b7400a4ac363452dc5dfcf8d88e8e0cce663c68aa")
 
-    depends_on("py-setuptools", type="build")
+    with default_args(type="build"):
+        depends_on("py-hatch-vcs", when="@6:")
+        depends_on("py-hatchling", when="@6:")
 
-    # Historical dependencies
-    depends_on("py-pytest-runner", when="@3", type="build")
+        # Historical dependencies
+        depends_on("py-pytest-runner", when="@3")
+        depends_on("py-setuptools", when="@:5")


### PR DESCRIPTION
Extremely controversial license change: https://github.com/chardet/chardet/issues/327. Not going to publicly comment on whether this is right or wrong, just documenting the new license. Message me on Slack for candid opinions.