### PR TITLE
e4s: fix broken builds on `develop`

### DIFF
--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -374,7 +374,7 @@ spack:
   - group: rocm
     specs:
     # ROCM NOARCH
-    - hpctoolkit +rocm
+    #- hpctoolkit +rocm
     - tau +mpi +rocm +syscall           # tau: has issue with `spack env depfile` build
 
     # ROCM 90a

--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -100,7 +100,7 @@ spack:
     - chai ^umpire
     - chapel
     - cusz
-    - dealii~arborx cxxstd=17
+    - dealii~arborx~kokkos~vtk cxxstd=17
     - ecp-data-vis-sdk  +adios2 ~ascent +hdf5 +vtkm +zfp ~paraview
     # Exago still requires an old version of Raja that doesn't support the CUDA arch we want to build for
     # - exago +mpi +python +raja +hiop  ~ipopt ^hiop@1.0.0 ~sparse +mpi +raja ^raja~cuda
@@ -157,7 +157,7 @@ spack:
   - conduit
   - cp2k +mpi
   - datatransferkit
-  - dealii ~arborx ~vtk cxxstd=17 # https://github.com/spack/spack/pull/45554#issuecomment-2457255720
+  - dealii ~arborx ~kokkos ~vtk cxxstd=17 # https://github.com/spack/spack/pull/45554#issuecomment-2457255720
   - drishti
   - dxt-explorer
   - dyninst

--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -102,7 +102,8 @@ spack:
     - cusz
     - dealii
     - ecp-data-vis-sdk  +adios2 ~ascent +hdf5 +vtkm +zfp ~paraview
-    - exago +mpi +python +raja +hiop  ~ipopt ^hiop@1.0.0 ~sparse +mpi +raja
+    # Exago still requires an old version of Raja that doesn't support the CUDA arch we want to build for
+    - exago +mpi +python +raja +hiop  ~ipopt ^hiop@1.0.0 ~sparse +mpi +raja ^raja~cuda
     - fftx
     - flecsi
     - ginkgo

--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -100,7 +100,7 @@ spack:
     - chai ^umpire
     - chapel
     - cusz
-    - dealii cxxstd=17 ^arborx@1.5 cxxstd=17
+    - dealii cxxstd=17 ^arborx@1.5 cxxstd=20
     - ecp-data-vis-sdk  +adios2 ~ascent +hdf5 +vtkm +zfp ~paraview
     # Exago still requires an old version of Raja that doesn't support the CUDA arch we want to build for
     # - exago +mpi +python +raja +hiop  ~ipopt ^hiop@1.0.0 ~sparse +mpi +raja ^raja~cuda
@@ -157,7 +157,7 @@ spack:
   - conduit
   - cp2k +mpi
   - datatransferkit
-  - dealii ~vtk cxxstd=17 ^arborx@1.5 cxxstd=17 # https://github.com/spack/spack/pull/45554#issuecomment-2457255720
+  - dealii ~vtk cxxstd=17 ^arborx@1.5 cxxstd=20 # https://github.com/spack/spack/pull/45554#issuecomment-2457255720
   - drishti
   - dxt-explorer
   - dyninst

--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -56,7 +56,7 @@ spack:
       - +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext
         +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu
         +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos
-        +teko +tempus +thyra +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
+        +teko +tempus +thyra +tpetra +trilinoscouplings +zoltan +zoltan2 gotype=long_long
       - target=x86_64_v3
     mpich:
       require:
@@ -337,6 +337,13 @@ spack:
           - ~rocm
           - ~cuda
           - target=x86_64_v3
+        hdf5:
+          prefer:
+          - ~rocm +cuda cuda_arch=80
+        trilinos:
+          prefer:
+          - ~rocm +cuda cuda_arch=80
+          - ~superlu-dist
 
   - group: "cuda-90"
     specs:
@@ -362,6 +369,13 @@ spack:
           - ~rocm
           - ~cuda
           - target=x86_64_v3
+        hdf5:
+          prefer:
+          - ~rocm +cuda cuda_arch=90
+        trilinos:
+          prefer:
+          - ~rocm +cuda cuda_arch=90
+          - ~superlu-dist
 
   - group: rocm
     specs:

--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -100,7 +100,7 @@ spack:
     - chai ^umpire ~shared
     - chapel
     - cusz
-    - dealii ^arborx@1.5
+    - dealii cxxstd=17 ^arborx@1.5 cxxstd=17
     - ecp-data-vis-sdk  +adios2 ~ascent +hdf5 +vtkm +zfp ~paraview
     # Exago still requires an old version of Raja that doesn't support the CUDA arch we want to build for
     - exago +mpi +python +raja +hiop  ~ipopt ^hiop@1.0.0 ~sparse +mpi +raja ^raja~cuda
@@ -157,7 +157,7 @@ spack:
   - conduit
   - cp2k +mpi
   - datatransferkit
-  - dealii ~vtk ^arborx@1.5 # https://github.com/spack/spack/pull/45554#issuecomment-2457255720
+  - dealii ~vtk cxxstd=17 ^arborx@1.5 cxxstd=17 # https://github.com/spack/spack/pull/45554#issuecomment-2457255720
   - drishti
   - dxt-explorer
   - dyninst

--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -100,7 +100,7 @@ spack:
     - chai ^umpire
     - chapel
     - cusz
-    - dealii cxxstd=17 ^arborx@1.5 cxxstd=20
+    - dealii~arborx cxxstd=17
     - ecp-data-vis-sdk  +adios2 ~ascent +hdf5 +vtkm +zfp ~paraview
     # Exago still requires an old version of Raja that doesn't support the CUDA arch we want to build for
     # - exago +mpi +python +raja +hiop  ~ipopt ^hiop@1.0.0 ~sparse +mpi +raja ^raja~cuda
@@ -157,7 +157,7 @@ spack:
   - conduit
   - cp2k +mpi
   - datatransferkit
-  - dealii ~vtk cxxstd=17 ^arborx@1.5 cxxstd=20 # https://github.com/spack/spack/pull/45554#issuecomment-2457255720
+  - dealii ~arborx ~vtk cxxstd=17 # https://github.com/spack/spack/pull/45554#issuecomment-2457255720
   - drishti
   - dxt-explorer
   - dyninst

--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -402,7 +402,7 @@ spack:
     - sundials
     - superlu-dist
     - tasmanian ~openmp
-    - trilinos +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack ~ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu ~stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
+    - trilinos +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack ~ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu ~stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 gotype=long_long
     - umpire
     - upcxx
     # INCLUDED IN ECP DAV ROCM

--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -12,6 +12,7 @@ spack:
   packages:
     all:
       require:
+      - +shared
       - target=x86_64_v3
       variants: +mpi
     c:
@@ -97,13 +98,13 @@ spack:
     - axom
     - cabana ^kokkos +cuda_lambda
     - caliper
-    - chai ^umpire ~shared
+    - chai ^umpire
     - chapel
     - cusz
     - dealii cxxstd=17 ^arborx@1.5 cxxstd=17
     - ecp-data-vis-sdk  +adios2 ~ascent +hdf5 +vtkm +zfp ~paraview
     # Exago still requires an old version of Raja that doesn't support the CUDA arch we want to build for
-    - exago +mpi +python +raja +hiop  ~ipopt ^hiop@1.0.0 ~sparse +mpi +raja ^raja~cuda
+    # - exago +mpi +python +raja +hiop  ~ipopt ^hiop@1.0.0 ~sparse +mpi +raja ^raja~cuda
     - fftx
     - flecsi
     - ginkgo

--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -131,7 +131,7 @@ spack:
     - superlu-dist
     - tasmanian
     - trilinos
-    - umpire ~shared
+    - umpire
     - adios2
     - vtk-m
     - zfp

--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -100,7 +100,7 @@ spack:
     - chai ^umpire ~shared
     - chapel
     - cusz
-    - dealii
+    - dealii ^arborx@1.5
     - ecp-data-vis-sdk  +adios2 ~ascent +hdf5 +vtkm +zfp ~paraview
     # Exago still requires an old version of Raja that doesn't support the CUDA arch we want to build for
     - exago +mpi +python +raja +hiop  ~ipopt ^hiop@1.0.0 ~sparse +mpi +raja ^raja~cuda
@@ -157,7 +157,7 @@ spack:
   - conduit
   - cp2k +mpi
   - datatransferkit
-  - dealii ~vtk # https://github.com/spack/spack/pull/45554#issuecomment-2457255720
+  - dealii ~vtk ^arborx@1.5 # https://github.com/spack/spack/pull/45554#issuecomment-2457255720
   - drishti
   - dxt-explorer
   - dyninst

--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -12,7 +12,6 @@ spack:
   packages:
     all:
       require:
-      - +shared
       - target=x86_64_v3
       variants: +mpi
     c:

--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -337,9 +337,6 @@ spack:
           - ~rocm
           - ~cuda
           - target=x86_64_v3
-        hdf5:
-          prefer:
-          - ~rocm +cuda cuda_arch=80
         trilinos:
           prefer:
           - ~rocm +cuda cuda_arch=80
@@ -369,9 +366,6 @@ spack:
           - ~rocm
           - ~cuda
           - target=x86_64_v3
-        hdf5:
-          prefer:
-          - ~rocm +cuda cuda_arch=90
         trilinos:
           prefer:
           - ~rocm +cuda cuda_arch=90

--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -100,7 +100,7 @@ spack:
     - chai ^umpire
     - chapel
     - cusz
-    - dealii~arborx~kokkos~vtk cxxstd=17
+    #- dealii~arborx~kokkos~vtk cxxstd=17
     - ecp-data-vis-sdk  +adios2 ~ascent +hdf5 +vtkm +zfp ~paraview
     # Exago still requires an old version of Raja that doesn't support the CUDA arch we want to build for
     # - exago +mpi +python +raja +hiop  ~ipopt ^hiop@1.0.0 ~sparse +mpi +raja ^raja~cuda
@@ -157,7 +157,7 @@ spack:
   - conduit
   - cp2k +mpi
   - datatransferkit
-  - dealii ~arborx ~kokkos ~vtk cxxstd=17 # https://github.com/spack/spack/pull/45554#issuecomment-2457255720
+  #- dealii ~arborx ~kokkos ~vtk cxxstd=17 # https://github.com/spack/spack/pull/45554#issuecomment-2457255720
   - drishti
   - dxt-explorer
   - dyninst

--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -375,14 +375,15 @@ spack:
     specs:
     # ROCM NOARCH
     #- hpctoolkit +rocm
-    - tau +mpi +rocm +syscall           # tau: has issue with `spack env depfile` build
+    # - tau +mpi +rocm +syscall           # tau: has issue with `spack env depfile` build
 
     # ROCM 90a
     - adios2 +kokkos
     - amrex
     - arborx
     - cabana
-    - caliper
+    # Can't build one of its dependencies (py-llvmlite)
+    # - caliper
     - chai
     - ecp-data-vis-sdk ~paraview +vtkm # +paraview: CMake Error at VTK/ThirdParty/vtkm/vtkvtkm/vtk-m/CMakeLists.txt:272 (find_package): Could not find a package configuration file provided by "rocthrust" with any of the following names: rocthrustConfig.cmake rocthrust-config.cmake
     - gasnet

--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -433,7 +433,10 @@ spack:
             - ~cuda
             - +rocm
             - amdgpu_target=gfx90a
-
+        trilinos:
+          prefer:
+          - +rocm amdgpu_target=gfx90a ~cuda
+          - ~superlu-dist
 
   ci:
     pipeline-gen:


### PR DESCRIPTION
**Modifications**

1. Fix `raja` dependency for `exago`
2. Build most of the specs `+shared`
3. Disabled a couple configurations of `dealii`
4. Disabled `hpctoolkit+rocm`, `tau+rocm` and `caliper+rocm`

We can merge this to make `develop` :heavy_check_mark: again, and work on re-enabling the disabled specs in following PRs

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
