### PR TITLE
chapel: add v2.8

### DIFF
--- a/repos/spack_repo/builtin/packages/chapel/fix_spack_cc_wrapper_in_cray_prgenv_2.8.patch
+++ b/repos/spack_repo/builtin/packages/chapel/fix_spack_cc_wrapper_in_cray_prgenv_2.8.patch
@@ -1,0 +1,23 @@
+diff --git a/util/chplenv/chpl_llvm.py b/util/chplenv/chpl_llvm.py
+index 4da5d4648ba..4398b9704d9 100755
+--- a/util/chplenv/chpl_llvm.py
++++ b/util/chplenv/chpl_llvm.py
+@@ -1286,12 +1286,15 @@ def get_clang_prgenv_args():
+
+         # Use cc --cray-print-opts=... to get arguments from compiler driver
+
++        # find the actual cc in case something like spack has wrapped it
++        real_cc = os.path.join(os.environ["CRAYPE_DIR"], "bin", "cc")
++
+         # Get compilation arguments
+-        opts = run_command(["cc", "--cray-print-opts=cflags"])
++        opts = run_command([real_cc, "--cray-print-opts=cflags"])
+         comp_args.extend(opts.split())
+
+         # Get link arguments
+-        opts = run_command(["cc", "--cray-print-opts=libs"])
++        opts = run_command([real_cc, "--cray-print-opts=libs"])
+         link_args.extend(opts.split())
+
+     return (comp_args, link_args)
+

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -63,11 +63,17 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     version("main", branch="main")
 
+    version(
+        "2.8.0",
+        url="https://chapel-lang.org/tmp/chapel-2.8.0.tar.gz",
+        sha256="3e5e8da6c56"
+    )
+
     version("2.7.0", sha256="5e3269babdae334c80fc3f25114698fdfe53e84ea06626af22d2b54eeb75bee6")
     version("2.6.0", sha256="e469c35be601cf1f59af542ab885e8a14aa2b087b79af0d5372a4421976c74b6")
-    version("2.5.0", sha256="020220ca9bf52b9f416e9a029bdc465bb1f635c1e274c6ca3c18d1f83e41fce1")
 
     with default_args(deprecated=True):
+        version("2.5.0", sha256="020220ca9bf52b9f416e9a029bdc465bb1f635c1e274c6ca3c18d1f83e41fce1")
         version("2.4.0", sha256="a51a472488290df12d1657db2e7118ab519743094f33650f910d92b54c56f315")
         version("2.3.0", sha256="0185970388aef1f1fae2a031edf060d5eac4eb6e6b1089e7e3b15a130edd8a31")
         version("2.2.0", sha256="bb16952a87127028031fd2b56781bea01ab4de7c3466f7b6a378c4d8895754b6")

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -78,7 +78,8 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     sanity_check_is_dir = ["bin", join_path("lib", "chapel"), join_path("share", "chapel")]
     sanity_check_is_file = [join_path("bin", "chpl")]
 
-    patch("fix_spack_cc_wrapper_in_cray_prgenv.patch", when="@2.0.0:")
+    patch("fix_spack_cc_wrapper_in_cray_prgenv.patch", when="@2.0.0:2.7")
+    patch("fix_spack_cc_wrapper_in_cray_prgenv_2.8.patch", when="@2.8:")
     patch("fix_chpl_shared_lib_path.patch", when="@2.1.1:2.2 +python-bindings")  # PR 26388
     patch("fix_chpl_shared_lib_path_2.3.patch", when="@2.2.1:2.3 +python-bindings")  # PR 26388
     patch("fix_chpl_line_length.patch", when="@:2.3.0")  # PRs 26357, 26381, 26491
@@ -579,7 +580,8 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         depends_on("llvm@11:18", when="@2.1:2.2")
         depends_on("llvm@11:19", when="@2.3:2.4")
         depends_on("llvm@11:20", when="@2.5")
-        depends_on("llvm@14:20", when="@2.6:")
+        depends_on("llvm@14:20", when="@2.6:2.7")
+        depends_on("llvm@14:21", when="@2.8:")
 
     # Based on docs https://chapel-lang.org/docs/technotes/gpu.html#requirements
     depends_on("llvm@16:", when="llvm=spack +cuda ^cuda@12:")

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -63,12 +63,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     version("main", branch="main")
 
-    version(
-        "2.8.0",
-        url="https://chapel-lang.org/tmp/chapel-2.8.0.tar.gz",
-        sha256="3e5e8da6c56337c6eeb468f12e52ba70c9bc3b05a1cb4b9cd0f1a4b9bce77e9c",
-    )
-
+    version("2.8.0", sha256="80e8c3018e33e49674c7a2542e062547ea41d64d6595edb3b799e90c88f963f8")
     version("2.7.0", sha256="5e3269babdae334c80fc3f25114698fdfe53e84ea06626af22d2b54eeb75bee6")
     version("2.6.0", sha256="e469c35be601cf1f59af542ab885e8a14aa2b087b79af0d5372a4421976c74b6")
 

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -66,7 +66,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     version(
         "2.8.0",
         url="https://chapel-lang.org/tmp/chapel-2.8.0.tar.gz",
-        sha256="3e5e8da6c56337c6eeb468f12e52ba70c9bc3b05a1cb4b9cd0f1a4b9bce77e9c"
+        sha256="3e5e8da6c56337c6eeb468f12e52ba70c9bc3b05a1cb4b9cd0f1a4b9bce77e9c",
     )
 
     version("2.7.0", sha256="5e3269babdae334c80fc3f25114698fdfe53e84ea06626af22d2b54eeb75bee6")

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -66,7 +66,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     version(
         "2.8.0",
         url="https://chapel-lang.org/tmp/chapel-2.8.0.tar.gz",
-        sha256="3e5e8da6c56"
+        sha256="3e5e8da6c56337c6eeb468f12e52ba70c9bc3b05a1cb4b9cd0f1a4b9bce77e9c"
     )
 
     version("2.7.0", sha256="5e3269babdae334c80fc3f25114698fdfe53e84ea06626af22d2b54eeb75bee6")


### PR DESCRIPTION
This is a WIP PR to add the upcoming Chapel 2.8 release, which is scheduled for March 12th.

Changes include:
- Add 2.8
- Deprecate 2.5
- Add a new version of an existing patch for 2.8
- Update LLVM dependencies