### PR TITLE
py-pillow(-simd): deprecate versions due to CVEs

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pillow/package.py
+++ b/repos/spack_repo/builtin/packages/py_pillow/package.py
@@ -158,28 +158,55 @@ class PyPillow(PyPillowBase):
     license("HPND", when="@:10")
 
     version("12.1.1", sha256="9ad8fa5937ab05218e2b6a4cff30295ad35afd2f83ac592e68c0d871bb0fdbc4")
-    version("12.1.0", sha256="5c5ae0a06e9ea030ab786b0251b32c7e4ce10e58d983c0d5c56029455180b5b9")
-    version("12.0.0", sha256="87d4f8125c9988bfbed67af47dd7a953e2fc7b0cc1e7800ec6d2080d490bb353")
-    version("11.3.0", sha256="3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523")
-    version("11.2.1", sha256="a64dd61998416367b7ef979b73d3a85853ba9bec4c2925f74e588879a58716b6")
-    version("11.1.0", sha256="368da70808b36d73b4b390a8ffac11069f8a5c85f29eff1f1b01bcf3ef5b2a20")
-    version("11.0.0", sha256="72bacbaf24ac003fea9bff9837d1eedb6088758d41e100c1552930151f677739")
-    version("10.4.0", sha256="166c1cd4d24309b30d61f79f4a9114b7b2313d7450912277855ff5dfd7cd4a06")
-    version("10.3.0", sha256="9d2455fbf44c914840c793e89aa82d0e1763a14253a000743719ae5946814b2d")
-    version("10.2.0", sha256="e87f0b2c78157e12d7686b27d63c070fd65d994e8ddae6f328e0dcf4a0cd007e")
-    version("10.1.0", sha256="e6bf8de6c36ed96c86ea3b6e1d5273c53f46ef518a062464cd7ef5dd2cf92e38")
-    version("10.0.1", sha256="d72967b06be9300fed5cfbc8b5bafceec48bf7cdc7dab66b1d2549035287191d")
-    version("10.0.0", sha256="9c82b5b3e043c7af0d95792d0d20ccf68f61a1fec6b3530e718b688422727396")
-    version("9.5.0", sha256="bf548479d336726d7a0eceb6e767e179fbde37833ae42794602631a070d630f1")
-    version("9.4.0", sha256="a1c2d7780448eb93fbcc3789bf3916aa5720d942e37945f4056680317f1cd23e")
-    version("9.3.0", sha256="c935a22a557a560108d780f9a0fc426dd7459940dc54faa49d83249c8d3e760f")
-    version("9.2.0", sha256="75e636fd3e0fb872693f23ccb8a5ff2cd578801251f3a4f6854c6a5d437d3c04")
-    version("9.1.1", sha256="7502539939b53d7565f3d11d87c78e7ec900d3c72945d4ee0e2f250d598309a0")
-    version("9.1.0", sha256="f401ed2bbb155e1ade150ccc63db1a4f6c1909d3d378f7d1235a44e90d75fb97")
-    version("9.0.1", sha256="6c8bc8238a7dfdaf7a75f5ec5a663f4173f8c367e5a39f87e720495e1eed75fa")
-    version("9.0.0", sha256="ee6e2963e92762923956fe5d3479b1fdc3b76c83f290aad131a2f98c3df0593e")
-    version("8.4.0", sha256="b8e2f83c56e141920c39464b852de3719dfbfb6e3c99a2d8da0edf4fb33176ed")
-    version("8.0.0", sha256="59304c67d12394815331eda95ec892bf54ad95e0aa7bc1ccd8e0a4a5a25d4bf3")
+    with default_args(deprecated=True):
+        # https://www.cvedetails.com/cve/CVE-2026-25990/
+        version("12.1.0", sha256="5c5ae0a06e9ea030ab786b0251b32c7e4ce10e58d983c0d5c56029455180b5b9")
+        version("12.0.0", sha256="87d4f8125c9988bfbed67af47dd7a953e2fc7b0cc1e7800ec6d2080d490bb353")
+        version("11.3.0", sha256="3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523")
+        # https://www.cvedetails.com/cve/CVE-2025-48379/
+        version("11.2.1", sha256="a64dd61998416367b7ef979b73d3a85853ba9bec4c2925f74e588879a58716b6")
+        version("11.1.0", sha256="368da70808b36d73b4b390a8ffac11069f8a5c85f29eff1f1b01bcf3ef5b2a20")
+        version("11.0.0", sha256="72bacbaf24ac003fea9bff9837d1eedb6088758d41e100c1552930151f677739")
+        version("10.4.0", sha256="166c1cd4d24309b30d61f79f4a9114b7b2313d7450912277855ff5dfd7cd4a06")
+        version("10.3.0", sha256="9d2455fbf44c914840c793e89aa82d0e1763a14253a000743719ae5946814b2d")
+        # https://www.cvedetails.com/cve/CVE-2024-28219/
+        version("10.2.0", sha256="e87f0b2c78157e12d7686b27d63c070fd65d994e8ddae6f328e0dcf4a0cd007e")
+        version("10.1.0", sha256="e6bf8de6c36ed96c86ea3b6e1d5273c53f46ef518a062464cd7ef5dd2cf92e38")
+        # https://www.cvedetails.com/cve/CVE-2023-50447/
+        version("10.0.1", sha256="d72967b06be9300fed5cfbc8b5bafceec48bf7cdc7dab66b1d2549035287191d")
+        version("10.0.0", sha256="9c82b5b3e043c7af0d95792d0d20ccf68f61a1fec6b3530e718b688422727396")
+        # https://www.cvedetails.com/cve/CVE-2023-44271/
+        version("9.5.0", sha256="bf548479d336726d7a0eceb6e767e179fbde37833ae42794602631a070d630f1")
+        version("9.4.0", sha256="a1c2d7780448eb93fbcc3789bf3916aa5720d942e37945f4056680317f1cd23e")
+        version("9.3.0", sha256="c935a22a557a560108d780f9a0fc426dd7459940dc54faa49d83249c8d3e760f")
+        # https://www.cvedetails.com/cve/CVE-2022-45199/
+        version("9.2.0", sha256="75e636fd3e0fb872693f23ccb8a5ff2cd578801251f3a4f6854c6a5d437d3c04")
+        # https://www.cvedetails.com/cve/CVE-2022-45198/
+        version("9.1.1", sha256="7502539939b53d7565f3d11d87c78e7ec900d3c72945d4ee0e2f250d598309a0")
+        # https://www.cvedetails.com/cve/CVE-2022-30595/
+        version("9.1.0", sha256="f401ed2bbb155e1ade150ccc63db1a4f6c1909d3d378f7d1235a44e90d75fb97")
+        version("9.0.1", sha256="6c8bc8238a7dfdaf7a75f5ec5a663f4173f8c367e5a39f87e720495e1eed75fa")
+        # https://www.cvedetails.com/cve/CVE-2022-24303/
+        version("9.0.0", sha256="ee6e2963e92762923956fe5d3479b1fdc3b76c83f290aad131a2f98c3df0593e")
+        # https://www.cvedetails.com/cve/CVE-2022-22817/
+        # https://www.cvedetails.com/cve/CVE-2022-22816/
+        # https://www.cvedetails.com/cve/CVE-2022-22815/
+        version("8.4.0", sha256="b8e2f83c56e141920c39464b852de3719dfbfb6e3c99a2d8da0edf4fb33176ed")
+        # https://www.cvedetails.com/cve/CVE-2021-34552/
+        # https://www.cvedetails.com/cve/CVE-2021-28678/
+        # https://www.cvedetails.com/cve/CVE-2021-28677/
+        # https://www.cvedetails.com/cve/CVE-2021-28676/
+        # https://www.cvedetails.com/cve/CVE-2021-28675/
+        # https://www.cvedetails.com/cve/CVE-2021-27923/
+        # https://www.cvedetails.com/cve/CVE-2021-27922/
+        # https://www.cvedetails.com/cve/CVE-2021-27921/
+        # https://www.cvedetails.com/cve/CVE-2021-25293/
+        # https://www.cvedetails.com/cve/CVE-2021-25292/
+        # https://www.cvedetails.com/cve/CVE-2021-25291/
+        # https://www.cvedetails.com/cve/CVE-2021-25290/
+        # https://www.cvedetails.com/cve/CVE-2021-25289/
+        # and many, many more...
+        version("8.0.0", sha256="59304c67d12394815331eda95ec892bf54ad95e0aa7bc1ccd8e0a4a5a25d4bf3")
 
     depends_on("c", type="build")
 

--- a/repos/spack_repo/builtin/packages/py_pillow/package.py
+++ b/repos/spack_repo/builtin/packages/py_pillow/package.py
@@ -160,21 +160,45 @@ class PyPillow(PyPillowBase):
     version("12.1.1", sha256="9ad8fa5937ab05218e2b6a4cff30295ad35afd2f83ac592e68c0d871bb0fdbc4")
     with default_args(deprecated=True):
         # https://www.cvedetails.com/cve/CVE-2026-25990/
-        version("12.1.0", sha256="5c5ae0a06e9ea030ab786b0251b32c7e4ce10e58d983c0d5c56029455180b5b9")
-        version("12.0.0", sha256="87d4f8125c9988bfbed67af47dd7a953e2fc7b0cc1e7800ec6d2080d490bb353")
-        version("11.3.0", sha256="3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523")
+        version(
+            "12.1.0", sha256="5c5ae0a06e9ea030ab786b0251b32c7e4ce10e58d983c0d5c56029455180b5b9"
+        )
+        version(
+            "12.0.0", sha256="87d4f8125c9988bfbed67af47dd7a953e2fc7b0cc1e7800ec6d2080d490bb353"
+        )
+        version(
+            "11.3.0", sha256="3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523"
+        )
         # https://www.cvedetails.com/cve/CVE-2025-48379/
-        version("11.2.1", sha256="a64dd61998416367b7ef979b73d3a85853ba9bec4c2925f74e588879a58716b6")
-        version("11.1.0", sha256="368da70808b36d73b4b390a8ffac11069f8a5c85f29eff1f1b01bcf3ef5b2a20")
-        version("11.0.0", sha256="72bacbaf24ac003fea9bff9837d1eedb6088758d41e100c1552930151f677739")
-        version("10.4.0", sha256="166c1cd4d24309b30d61f79f4a9114b7b2313d7450912277855ff5dfd7cd4a06")
-        version("10.3.0", sha256="9d2455fbf44c914840c793e89aa82d0e1763a14253a000743719ae5946814b2d")
+        version(
+            "11.2.1", sha256="a64dd61998416367b7ef979b73d3a85853ba9bec4c2925f74e588879a58716b6"
+        )
+        version(
+            "11.1.0", sha256="368da70808b36d73b4b390a8ffac11069f8a5c85f29eff1f1b01bcf3ef5b2a20"
+        )
+        version(
+            "11.0.0", sha256="72bacbaf24ac003fea9bff9837d1eedb6088758d41e100c1552930151f677739"
+        )
+        version(
+            "10.4.0", sha256="166c1cd4d24309b30d61f79f4a9114b7b2313d7450912277855ff5dfd7cd4a06"
+        )
+        version(
+            "10.3.0", sha256="9d2455fbf44c914840c793e89aa82d0e1763a14253a000743719ae5946814b2d"
+        )
         # https://www.cvedetails.com/cve/CVE-2024-28219/
-        version("10.2.0", sha256="e87f0b2c78157e12d7686b27d63c070fd65d994e8ddae6f328e0dcf4a0cd007e")
-        version("10.1.0", sha256="e6bf8de6c36ed96c86ea3b6e1d5273c53f46ef518a062464cd7ef5dd2cf92e38")
+        version(
+            "10.2.0", sha256="e87f0b2c78157e12d7686b27d63c070fd65d994e8ddae6f328e0dcf4a0cd007e"
+        )
+        version(
+            "10.1.0", sha256="e6bf8de6c36ed96c86ea3b6e1d5273c53f46ef518a062464cd7ef5dd2cf92e38"
+        )
         # https://www.cvedetails.com/cve/CVE-2023-50447/
-        version("10.0.1", sha256="d72967b06be9300fed5cfbc8b5bafceec48bf7cdc7dab66b1d2549035287191d")
-        version("10.0.0", sha256="9c82b5b3e043c7af0d95792d0d20ccf68f61a1fec6b3530e718b688422727396")
+        version(
+            "10.0.1", sha256="d72967b06be9300fed5cfbc8b5bafceec48bf7cdc7dab66b1d2549035287191d"
+        )
+        version(
+            "10.0.0", sha256="9c82b5b3e043c7af0d95792d0d20ccf68f61a1fec6b3530e718b688422727396"
+        )
         # https://www.cvedetails.com/cve/CVE-2023-44271/
         version("9.5.0", sha256="bf548479d336726d7a0eceb6e767e179fbde37833ae42794602631a070d630f1")
         version("9.4.0", sha256="a1c2d7780448eb93fbcc3789bf3916aa5720d942e37945f4056680317f1cd23e")

--- a/repos/spack_repo/builtin/packages/py_pillow_simd/package.py
+++ b/repos/spack_repo/builtin/packages/py_pillow_simd/package.py
@@ -18,12 +18,19 @@ class PyPillowSimd(PyPillowBase):
 
     license("HPND")
 
-    version(
-        "9.5.0.post1", sha256="8c89b85c4085532752625f2cc066a28547cebb98529acf932d5d84c1a7ab2abc"
-    )
-    version(
-        "9.0.0.post1", sha256="918541cfaa90ba3c0e1bae5da31ba1b1f52b09c0009bd90183b787af4e018263"
-    )
+    with default_args(deprecated=True):
+        # https://www.cvedetails.com/cve/CVE-2024-28219/
+        # https://www.cvedetails.com/cve/CVE-2023-50447/
+        # https://www.cvedetails.com/cve/CVE-2023-44271/
+        version(
+            "9.5.0.post1", sha256="8c89b85c4085532752625f2cc066a28547cebb98529acf932d5d84c1a7ab2abc"
+        )
+        # https://www.cvedetails.com/cve/CVE-2022-45199/
+        # https://www.cvedetails.com/cve/CVE-2022-45198/
+        # https://www.cvedetails.com/cve/CVE-2022-24303/
+        version(
+            "9.0.0.post1", sha256="918541cfaa90ba3c0e1bae5da31ba1b1f52b09c0009bd90183b787af4e018263"
+        )
 
     depends_on("c", type="build")  # generated
 

--- a/repos/spack_repo/builtin/packages/py_pillow_simd/package.py
+++ b/repos/spack_repo/builtin/packages/py_pillow_simd/package.py
@@ -23,13 +23,15 @@ class PyPillowSimd(PyPillowBase):
         # https://www.cvedetails.com/cve/CVE-2023-50447/
         # https://www.cvedetails.com/cve/CVE-2023-44271/
         version(
-            "9.5.0.post1", sha256="8c89b85c4085532752625f2cc066a28547cebb98529acf932d5d84c1a7ab2abc"
+            "9.5.0.post1",
+            sha256="8c89b85c4085532752625f2cc066a28547cebb98529acf932d5d84c1a7ab2abc",
         )
         # https://www.cvedetails.com/cve/CVE-2022-45199/
         # https://www.cvedetails.com/cve/CVE-2022-45198/
         # https://www.cvedetails.com/cve/CVE-2022-24303/
         version(
-            "9.0.0.post1", sha256="918541cfaa90ba3c0e1bae5da31ba1b1f52b09c0009bd90183b787af4e018263"
+            "9.0.0.post1",
+            sha256="918541cfaa90ba3c0e1bae5da31ba1b1f52b09c0009bd90183b787af4e018263",
         )
 
     depends_on("c", type="build")  # generated


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Not sure why pillow has so many more CVEs than the average library. I believe almost all of these are severe enough to warrant deprecation. This will eventually allow us to remove py-pillow-simd (abandoned) and the pil provider.