### PR TITLE
py-pybind11: add v3.0.2

### DIFF
--- a/repos/spack_repo/builtin/packages/openpmd_api/package.py
+++ b/repos/spack_repo/builtin/packages/openpmd_api/package.py
@@ -83,6 +83,7 @@ class OpenpmdApi(CMakePackage):
     with when("+python"):
         depends_on("py-pybind11@2.6.2:", type="link")
         depends_on("py-pybind11@2.13.0:", type="link", when="@0.16.0:")
+        depends_on("py-pybind11@:3.0.1", type="link", when="@:0.17.0")
         depends_on("py-numpy@1.15.1:", type=("test", "run"))
         depends_on("py-mpi4py@2.1.0:", when="+mpi", type=("test", "run"))
         with default_args(type=("link", "test", "run")):

--- a/repos/spack_repo/builtin/packages/py_pybind11/package.py
+++ b/repos/spack_repo/builtin/packages/py_pybind11/package.py
@@ -28,6 +28,7 @@ class PyPybind11(CMakePackage, PythonExtension):
     maintainers("ax3l")
 
     version("master", branch="master")
+    version("3.0.2", sha256="2f20a0af0b921815e0e169ea7fec63909869323581b89d7de1553468553f6a2d")
     version("3.0.1", sha256="741633da746b7c738bb71f1854f957b9da660bcd2dce68d71949037f0969d0ca")
     version("3.0.0", sha256="453b1a3e2b266c3ae9da872411cadb6d693ac18063bd73226d96cfb7015a200c")
     version("2.13.6", sha256="e08cb87f4773da97fa7b5f035de8763abc656d87d5773e62f6da0587d1f0ec20")

--- a/repos/spack_repo/builtin/packages/py_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_torch/package.py
@@ -265,6 +265,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     depends_on("pthreadpool@2020-10-05", when="@1.8")
     depends_on("pthreadpool@2020-06-15", when="@1.6:1.7")
     with default_args(type=("build", "link", "run")):
+        depends_on("py-pybind11@:3.0.1", when="@:2.10")
         depends_on("py-pybind11@3.0.1:", when="@2.9:")
         depends_on("py-pybind11@2.13.6:", when="@2.6:")
         depends_on("py-pybind11@2.13.5:", when="@2.5")


### PR DESCRIPTION
This PR adds `py-pybind11`, v3.0.2 ([diff](https://github.com/pybind/pybind11/compare/v3.0.1...v3.0.2)). Bugfixes only; no significant changes to pyproject.toml or CMakeLists.txt (minimum version unchanged). This package will be built in CI.