### PR TITLE
libxext: add v1.3.7

### DIFF
--- a/repos/spack_repo/builtin/packages/libxext/package.py
+++ b/repos/spack_repo/builtin/packages/libxext/package.py
@@ -18,6 +18,7 @@ class Libxext(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
+    version("1.3.7", sha256="6564608dc3b816b0cfddf0c7ddc62bc579055dd70b2f28113a618df2acb64189")
     version("1.3.6", sha256="1a0ac5cd792a55d5d465ced8dbf403ed016c8e6d14380c0ea3646c4415496e3d")
     version("1.3.5", sha256="1a3dcda154f803be0285b46c9338515804b874b5ccc7a2b769ab7fd76f1035bd")
     version("1.3.4", sha256="8ef0789f282826661ff40a8eef22430378516ac580167da35cc948be9041aac1")


### PR DESCRIPTION
This PR adds `libxext`, v1.3.7 ([diff](https://gitlab.freedesktop.org/xorg/lib/libxext/-/compare/libXext-1.3.6...libXext-1.3.7?from_project_id=714)). No changes to configure.ac beyond version number. This package will be built in CI.