### PR TITLE
Xorg X11 libs: add new versions and git attributes

### DIFF
--- a/repos/spack_repo/builtin/packages/bdftopcf/package.py
+++ b/repos/spack_repo/builtin/packages/bdftopcf/package.py
@@ -18,9 +18,11 @@ class Bdftopcf(AutotoolsPackage, XorgPackage):
 
     homepage = "https://gitlab.freedesktop.org/xorg/util/bdftopcf"
     xorg_mirror_path = "util/bdftopcf-1.0.5.tar.gz"
+    git = "https://gitlab.freedesktop.org/xorg/util/bdftopcf.git"
 
     license("MIT")
 
+    version("1.1.2", sha256="31c88b9194c34ee35c433759d141eaca177dcdead835c8832021cc013324b924")
     version("1.1.1", sha256="3291df9910c006a0345f3eac485e2a5734bbb79a0d97bf1f2b4cddad48fb1bc4")
     version("1.1", sha256="699d1a62012035b1461c7f8e3f05a51c8bd6f28f348983249fb89bbff7309b47")
     version("1.0.5", sha256="78a5ec945de1d33e6812167b1383554fda36e38576849e74a9039dc7364ff2c3")

--- a/repos/spack_repo/builtin/packages/glew/package.py
+++ b/repos/spack_repo/builtin/packages/glew/package.py
@@ -35,7 +35,7 @@ class Glew(CMakePackage):
     patch("remove-pkgconfig-glu-dep.patch")
     # Define APIENTRY in osmesa build if not defined, see
     # https://github.com/nigels-com/glew/pull/407
-    patch("mesa-24.0.0-osmesa.patch", when="^mesa@24.0.0:")
+    patch("mesa-24.0.0-osmesa.patch", when="@:2.2 ^mesa@24.0.0:")
 
     def cmake_args(self):
         spec = self.spec

--- a/repos/spack_repo/builtin/packages/glew/package.py
+++ b/repos/spack_repo/builtin/packages/glew/package.py
@@ -11,18 +11,21 @@ class Glew(CMakePackage):
 
     homepage = "https://glew.sourceforge.net/"
     url = "https://github.com/nigels-com/glew/releases/download/glew-2.1.0/glew-2.1.0.tgz"
+    git = "https://github.com/nigels-com/glew.git"
     root_cmakelists_dir = "build/cmake"
 
     maintainers("biddisco")
 
     license("GPL-2.0-or-later")
 
+    version("2.3.1", sha256="b64790f94b926acd7e8f84c5d6000a86cb43967bd1e688b03089079799c9e889")
     version("2.2.0", sha256="d4fc82893cfb00109578d0a1a2337fb8ca335b3ceccf97b97e5cc7f08e4353e1")
     version("2.1.0", sha256="04de91e7e6763039bc11940095cd9c7f880baba82196a7765f727ac05a993c95")
     version("2.0.0", sha256="c572c30a4e64689c342ba1624130ac98936d7af90c3103f9ce12b8a0c5736764")
 
     depends_on("c", type="build")  # generated
 
+    depends_on("cmake@3.16:", type="build", when="@2.3:")
     depends_on("gl")
     depends_on("libx11", when="^[virtuals=gl] glx")
     depends_on("xproto", when="^[virtuals=gl] glx")
@@ -36,15 +39,21 @@ class Glew(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
+
+        # glew 2.3.0+ explicitly uses OPENGL_opengl_LIBRARY and OPENGL_glx_LIBRARY
+        # in CMakeLists.txt, so we must set them to empty string instead of "IGNORE"
+        # to avoid linker errors. Earlier versions don't use these variables directly.
+        ignore_value = "" if spec.satisfies("@2.3.0:") else "IGNORE"
+
         args = [
             self.define("BUILD_UTILS", True),
             self.define("GLEW_REGAL", False),
             self.define("GLEW_EGL", spec.satisfies("^[virtuals=gl] egl")),
             self.define("OPENGL_INCLUDE_DIR", spec["gl"].headers.directories[0]),
             self.define("OPENGL_gl_LIBRARY", spec["gl"].libs[0]),
-            self.define("OPENGL_opengl_LIBRARY", "IGNORE"),
-            self.define("OPENGL_glx_LIBRARY", "IGNORE"),
-            self.define("OPENGL_glu_LIBRARY", "IGNORE"),
+            self.define("OPENGL_opengl_LIBRARY", ignore_value),
+            self.define("OPENGL_glx_LIBRARY", ignore_value),
+            self.define("OPENGL_glu_LIBRARY", ignore_value),
             self.define("GLEW_OSMESA", spec.satisfies("^[virtuals=gl] osmesa")),
         ]
         if spec.satisfies("^[virtuals=gl] egl"):
@@ -52,7 +61,7 @@ class Glew(CMakePackage):
                 self.define("OPENGL_egl_LIBRARY", [spec["egl"].libs[0], spec["egl"].libs[1]])
             )
         else:
-            args.append(self.define("OPENGL_egl_LIBRARY", "IGNORE"))
+            args.append(self.define("OPENGL_egl_LIBRARY", ignore_value))
 
         return args
 

--- a/repos/spack_repo/builtin/packages/libdrm/package.py
+++ b/repos/spack_repo/builtin/packages/libdrm/package.py
@@ -22,6 +22,7 @@ class Libdrm(AutotoolsPackage, MesonPackage):
 
     license("MIT")
 
+    version("2.4.131", sha256="45ba9983b51c896406a3d654de81d313b953b76e6391e2797073d543c5f617d5")
     version("2.4.124", sha256="ac36293f61ca4aafaf4b16a2a7afff312aa4f5c37c9fbd797de9e3c0863ca379")
     version("2.4.123", sha256="a2b98567a149a74b0f50e91e825f9c0315d86e7be9b74394dae8b298caadb79e")
     version("2.4.122", sha256="d9f5079b777dffca9300ccc56b10a93588cdfbc9dde2fae111940dfb6292f251")

--- a/repos/spack_repo/builtin/packages/libxext/package.py
+++ b/repos/spack_repo/builtin/packages/libxext/package.py
@@ -13,11 +13,13 @@ class Libxext(AutotoolsPackage, XorgPackage):
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libXext"
     xorg_mirror_path = "lib/libXext-1.3.3.tar.gz"
+    git = "https://gitlab.freedesktop.org/xorg/lib/libXext.git"
 
     license("MIT")
 
     maintainers("wdconinc")
 
+    version("1.3.7", sha256="6564608dc3b816b0cfddf0c7ddc62bc579055dd70b2f28113a618df2acb64189")
     version("1.3.6", sha256="1a0ac5cd792a55d5d465ced8dbf403ed016c8e6d14380c0ea3646c4415496e3d")
     version("1.3.5", sha256="1a3dcda154f803be0285b46c9338515804b874b5ccc7a2b769ab7fd76f1035bd")
     version("1.3.4", sha256="8ef0789f282826661ff40a8eef22430378516ac580167da35cc948be9041aac1")

--- a/repos/spack_repo/builtin/packages/libxfixes/package.py
+++ b/repos/spack_repo/builtin/packages/libxfixes/package.py
@@ -14,12 +14,14 @@ class Libxfixes(AutotoolsPackage, XorgPackage):
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libXfixes"
     xorg_mirror_path = "lib/libXfixes-5.0.2.tar.gz"
+    git = "https://gitlab.freedesktop.org/xorg/lib/libXfixes.git"
 
     license("MIT")
 
     maintainers("wdconinc")
 
     # Newer versions are blocked by https://github.com/spack/spack/issues/41688
+    # version("6.0.2", sha256="041331b8e6e36038b3bf836785b6b175ec8515f964c9e4e3316b3bfed0f53ac7")
     # version("6.0.1", sha256="e69eaa321173c748ba6e2f15c7cf8da87f911d3ea1b6af4b547974aef6366bec")
     # version("6.0.0", sha256="82045da5625350838390c9440598b90d69c882c324ca92f73af9f0e992cb57c7")
     version("5.0.3", sha256="9ab6c13590658501ce4bd965a8a5d32ba4d8b3bb39a5a5bc9901edffc5666570")

--- a/repos/spack_repo/builtin/packages/libxft/package.py
+++ b/repos/spack_repo/builtin/packages/libxft/package.py
@@ -17,11 +17,13 @@ class Libxft(AutotoolsPackage, XorgPackage):
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libXft"
     xorg_mirror_path = "lib/libXft-2.3.2.tar.gz"
+    git = "https://gitlab.freedesktop.org/xorg/lib/libXft.git"
 
     license("MIT")
 
     maintainers("wdconinc")
 
+    version("2.3.9", sha256="47c157fb4d0308f8b9604b74c29bb902b019eb97031f8fbf5ab62aa9f147a104")
     version("2.3.8", sha256="32e48fe2d844422e64809e4e99b9d8aed26c1b541a5acf837c5037b8d9f278a8")
     version("2.3.7", sha256="75b4378644f5df3a15f684f8f0b5ff1324d37aacd5a381f3b830a2fbe985f660")
     version("2.3.6", sha256="b7e59f69e0bbabe9438088775f7e5a7c16a572e58b11f9722519385d38192df5")
@@ -36,6 +38,7 @@ class Libxft(AutotoolsPackage, XorgPackage):
     depends_on("fontconfig@2.5.92:")
     depends_on("libx11")
     depends_on("libxrender@0.8.2:")
+    depends_on("xproto@7.0.22:", type="build", when="@2.3.3:")
 
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")

--- a/repos/spack_repo/builtin/packages/libxft/package.py
+++ b/repos/spack_repo/builtin/packages/libxft/package.py
@@ -38,7 +38,7 @@ class Libxft(AutotoolsPackage, XorgPackage):
     depends_on("fontconfig@2.5.92:")
     depends_on("libx11")
     depends_on("libxrender@0.8.2:")
-    depends_on("xproto@7.0.22:", type="build", when="@2.3.3:")
+    depends_on("xproto@7.0.22:", type="build", when="@2.3.9:")
 
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")

--- a/repos/spack_repo/builtin/packages/libxi/package.py
+++ b/repos/spack_repo/builtin/packages/libxi/package.py
@@ -13,12 +13,14 @@ class Libxi(AutotoolsPackage, XorgPackage):
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libXi"
     xorg_mirror_path = "lib/libXi-1.7.6.tar.gz"
+    git = "https://gitlab.freedesktop.org/xorg/lib/libXi.git"
 
     license("MIT AND X11")
 
     maintainers("wdconinc")
 
     # Newer versions are blocked by https://github.com/spack/spack/issues/41688
+    # version("1.8.2", sha256="5542daec66febfeb6f51d57abfa915826efe2e3af57534f4105b82240ea3188d")
     # version("1.8.1", sha256="3b5f47c223e4b63d7f7fe758886b8bf665b20a7edb6962c423892fd150e326ea")
     # version("1.8", sha256="c80fd200a1190e4406bb4cc6958839d9651638cb47fa546a595d4bebcd3b9e2d")
     version("1.7.10", sha256="b51e106c445a49409f3da877aa2f9129839001b24697d75a54e5c60507e9a5e3")

--- a/repos/spack_repo/builtin/packages/libxinerama/package.py
+++ b/repos/spack_repo/builtin/packages/libxinerama/package.py
@@ -13,11 +13,13 @@ class Libxinerama(AutotoolsPackage, XorgPackage):
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libXinerama"
     xorg_mirror_path = "lib/libXinerama-1.1.3.tar.gz"
+    git = "https://gitlab.freedesktop.org/xorg/lib/libXinerama.git"
 
     license("MIT")
 
     maintainers("wdconinc")
 
+    version("1.1.6", sha256="c74ee3d05e473671bf86285e2dece345485200bb042bea1540b1e30ff3f74bae")
     version("1.1.5", sha256="2efa855cb42dc620eff3b77700d8655695e09aaa318f791f201fa60afa72b95c")
     version("1.1.4", sha256="64de45e18cc76b8e703cb09b3c9d28bd16e3d05d5cd99f2d630de2d62c3acc18")
     version("1.1.3", sha256="0ba243222ae5aba4c6a3d7a394c32c8b69220a6872dbb00b7abae8753aca9a44")

--- a/repos/spack_repo/builtin/packages/libxmu/package.py
+++ b/repos/spack_repo/builtin/packages/libxmu/package.py
@@ -16,11 +16,13 @@ class Libxmu(AutotoolsPackage, XorgPackage):
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libXmu"
     xorg_mirror_path = "lib/libXmu-1.1.2.tar.gz"
+    git = "https://gitlab.freedesktop.org/xorg/lib/libXmu.git"
 
     license("MIT")
 
     maintainers("wdconinc")
 
+    version("1.3.1", sha256="5c8f44e26ccc9b14188599524e67ce788a205b38e297834babdeb12090be835b")
     version("1.2.1", sha256="bf0902583dd1123856c11e0a5085bd3c6e9886fbbd44954464975fd7d52eb599")
     version("1.2.0", sha256="b4686c4b4570044bcfc35bfaa3edbe68185ddf8e3250387f74a140c8e45afb2f")
     version("1.1.4", sha256="3091d711cdc1d8ea0f545a13b90d1464c3c3ab64778fd121f0d789b277a80289")

--- a/repos/spack_repo/builtin/packages/libxpm/package.py
+++ b/repos/spack_repo/builtin/packages/libxpm/package.py
@@ -13,11 +13,13 @@ class Libxpm(AutotoolsPackage, XorgPackage):
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libXpm"
     xorg_mirror_path = "lib/libXpm-3.5.12.tar.gz"
+    git = "https://gitlab.freedesktop.org/xorg/lib/libXpm.git"
 
     license("X11")
 
     maintainers("wdconinc")
 
+    version("3.5.18", sha256="74eb57253ed3085686371a331737daf072223b77f76bba13ed65a4b3aa6cb403")
     version("3.5.17", sha256="959466c7dfcfcaa8a65055bfc311f74d4c43d9257900f85ab042604d286df0c6")
     version("3.5.16", sha256="43a70e6f9b67215fb223ca270d83bdcb868c513948441d5b781ea0765df6bfb4")
     version("3.5.15", sha256="2a9bd419e31270593e59e744136ee2375ae817322447928d2abb6225560776f9")

--- a/repos/spack_repo/builtin/packages/libxpresent/package.py
+++ b/repos/spack_repo/builtin/packages/libxpresent/package.py
@@ -14,11 +14,13 @@ class Libxpresent(AutotoolsPackage, XorgPackage):
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libXpresent/"
     xorg_mirror_path = "lib/libXpresent-1.0.0.tar.gz"
+    git = "https://gitlab.freedesktop.org/xorg/lib/libXpresent.git"
 
     license("MIT")
 
     maintainers("wdconinc")
 
+    version("1.0.2", sha256="e98a211e51d8b9381d16b24a57cecb926a23e743b9e0b1ffc3e870206b7dee1a")
     version("1.0.1", sha256="8ebf8567a8f6afe5a64275a2ecfd4c84e957970c27299d964350f60be9f3541d")
     version("1.0.0", sha256="92f1bdfb67ae2ffcdb25ad72c02cac5e4912dc9bc792858240df1d7f105946fa")
 

--- a/repos/spack_repo/builtin/packages/libxrandr/package.py
+++ b/repos/spack_repo/builtin/packages/libxrandr/package.py
@@ -13,11 +13,13 @@ class Libxrandr(AutotoolsPackage, XorgPackage):
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libXrandr"
     xorg_mirror_path = "lib/libXrandr-1.5.0.tar.gz"
+    git = "https://gitlab.freedesktop.org/xorg/lib/libXrandr.git"
 
     license("MIT")
 
     maintainers("wdconinc")
 
+    version("1.5.5", sha256="23faedab4675890ba579b8103399132a139527306b18b500c6fe28e090e2a056")
     version("1.5.4", sha256="c72c94dc3373512ceb67f578952c5d10915b38cc9ebb0fd176a49857b8048e22")
     version("1.5.3", sha256="3ad316c1781fe2fe22574b819e81f0eff087a8560377f521ba932238b41b251f")
     version("1.5.0", sha256="1b594a149e6b124aab7149446f2fd886461e2935eca8dca43fe83a70cf8ec451")

--- a/repos/spack_repo/builtin/packages/libxres/package.py
+++ b/repos/spack_repo/builtin/packages/libxres/package.py
@@ -13,11 +13,13 @@ class Libxres(AutotoolsPackage, XorgPackage):
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libXRes"
     xorg_mirror_path = "lib/libXres-1.0.7.tar.gz"
+    git = "https://gitlab.freedesktop.org/xorg/lib/libXRes.git"
 
     license("custom")
 
     maintainers("wdconinc")
 
+    version("1.2.3", sha256="e1ee4845aa6a59e6ba7145422279ffc7da521b4d3dd302c0b1febdf45d06d093")
     version("1.2.2", sha256="8abce597ced4a7ab89032aee91f6f784d9960adc772b2b59f17e515cd4127950")
     version("1.2.1", sha256="918fb33c3897b389a1fbb51571c5c04c6b297058df286d8b48faa5af85e88bcc")
     version("1.2.0", sha256="5b62feee09f276d74054787df030fceb41034de84174abec6d81c591145e043a")
@@ -28,6 +30,7 @@ class Libxres(AutotoolsPackage, XorgPackage):
     depends_on("libx11")
     depends_on("libxext")
 
+    depends_on("xproto", type="build", when="@1.2.3:")
     depends_on("xextproto", type="build")
     depends_on("resourceproto@1.0:", type="build", when="@1.0")
     depends_on("resourceproto@1.2:", type="build", when="@1.2")

--- a/repos/spack_repo/builtin/packages/libxscrnsaver/package.py
+++ b/repos/spack_repo/builtin/packages/libxscrnsaver/package.py
@@ -13,11 +13,13 @@ class Libxscrnsaver(AutotoolsPackage, XorgPackage):
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libXScrnSaver"
     xorg_mirror_path = "lib/libXScrnSaver-1.2.2.tar.gz"
+    git = "https://gitlab.freedesktop.org/xorg/lib/libXScrnSaver.git"
 
     license("MIT")
 
     maintainers("wdconinc")
 
+    version("1.2.5", sha256="356f45ae365403b5500702b6b7c6e708d02a5b0ada0e5a6c859db677e41fdb00")
     version("1.2.4", sha256="0656b2630475104d6df75d91ebb8e0153e61d14e9871ef1f403bcda4a62a838a")
     version("1.2.3", sha256="4f74e7e412144591d8e0616db27f433cfc9f45aae6669c6c4bb03e6bf9be809a")
     version("1.2.2", sha256="e12ba814d44f7b58534c0d8521e2d4574f7bf2787da405de4341c3b9f4cc8d96")

--- a/repos/spack_repo/builtin/packages/libxvmc/package.py
+++ b/repos/spack_repo/builtin/packages/libxvmc/package.py
@@ -13,11 +13,13 @@ class Libxvmc(AutotoolsPackage, XorgPackage):
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libXvMC"
     xorg_mirror_path = "lib/libXvMC-1.0.9.tar.gz"
+    git = "https://gitlab.freedesktop.org/xorg/lib/libXvMC.git"
 
     license("MIT")
 
     maintainers("wdconinc")
 
+    version("1.0.15", sha256="c48f6051b1df9bd190d2763cd0312d715e4509575926247110d8f840463bdc94")
     version("1.0.14", sha256="3ad5d2b991219e2bf9b2f85d40b12c16f1afec038715e462f6058af73a9b5ef8")
     version("1.0.13", sha256="e630b4373af8c67a7c8f07ebe626a1269a613d262d1f737b57231a06f7c34b4e")
     version("1.0.12", sha256="024c9ec4f001f037eeca501ee724c7e51cf287eb69ced8c6126e16e7fa9864b5")

--- a/repos/spack_repo/builtin/packages/libxxf86dga/package.py
+++ b/repos/spack_repo/builtin/packages/libxxf86dga/package.py
@@ -13,11 +13,13 @@ class Libxxf86dga(AutotoolsPackage, XorgPackage):
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libXxf86dga"
     xorg_mirror_path = "lib/libXxf86dga-1.1.4.tar.gz"
+    git = "https://gitlab.freedesktop.org/xorg/lib/libXxf86dga.git"
 
     license("MIT")
 
     maintainers("wdconinc")
 
+    version("1.1.7", sha256="fd76cc930b85394fc12e52a01b3fb33b626731ac0084b3576b1e0095156683f7")
     version("1.1.6", sha256="87c7482b1e29b4eeb415815641c4f69c00545a8138e1b73ff1f361f7d9c22ac4")
     version("1.1.5", sha256="715e2bf5caf6276f0858eb4b11a1aef1a26beeb40dce2942387339da395bef69")
     version("1.1.4", sha256="e6361620a15ceba666901ca8423e8be0c6ed0271a7088742009160349173766b")

--- a/repos/spack_repo/builtin/packages/libxxf86vm/package.py
+++ b/repos/spack_repo/builtin/packages/libxxf86vm/package.py
@@ -13,11 +13,13 @@ class Libxxf86vm(AutotoolsPackage, XorgPackage):
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libXxf86vm"
     xorg_mirror_path = "lib/libXxf86vm-1.1.4.tar.gz"
+    git = "https://gitlab.freedesktop.org/xorg/lib/libXxf86vm.git"
 
     license("MIT")
 
     maintainers("wdconinc")
 
+    version("1.1.7", sha256="9a983e3cbb7a57905262291a17da962293c0645f99efd475e3c85264bfddc337")
     version("1.1.6", sha256="d2b4b1ec4eb833efca9981f19ed1078a8a73eed0bb3ca5563b64527ae8021e52")
     version("1.1.5", sha256="f3f1c29fef8accb0adbd854900c03c6c42f1804f2bc1e4f3ad7b2e1f3b878128")
     version("1.1.4", sha256="5108553c378a25688dcb57dca383664c36e293d60b1505815f67980ba9318a99")

--- a/repos/spack_repo/builtin/packages/xcb_util_cursor/package.py
+++ b/repos/spack_repo/builtin/packages/xcb_util_cursor/package.py
@@ -18,11 +18,13 @@ class XcbUtilCursor(AutotoolsPackage, XorgPackage):
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcb-cursor"
     xorg_mirror_path = "lib/xcb-util-cursor-0.1.4.tar.xz"
+    git = "https://gitlab.freedesktop.org/xorg/lib/libxcb-cursor.git"
 
     license("MIT")
 
     maintainers("wdconinc")
 
+    version("0.1.6", sha256="fdeb8bd127873519be5cc70dcd0d3b5d33b667877200f9925a59fdcad8f7a933")
     version("0.1.5", sha256="0caf99b0d60970f81ce41c7ba694e5eaaf833227bb2cbcdb2f6dc9666a663c57")
     version("0.1.4", sha256="28dcfe90bcab7b3561abe0dd58eb6832aa9cc77cfe42fcdfa4ebe20d605231fb")
 

--- a/repos/spack_repo/builtin/packages/xkbcomp/package.py
+++ b/repos/spack_repo/builtin/packages/xkbcomp/package.py
@@ -18,11 +18,13 @@ class Xkbcomp(AutotoolsPackage, XorgPackage):
 
     homepage = "https://gitlab.freedesktop.org/xorg/app/xkbcomp"
     xorg_mirror_path = "app/xkbcomp-1.3.1.tar.gz"
+    git = "https://gitlab.freedesktop.org/xorg/app/xkbcomp.git"
 
     license("MIT")
 
     maintainers("wdconinc")
 
+    version("1.5.0", sha256="d070694dd8d94714aa1da3e3590b75084a4b183da3980866aedd68835954b97c")
     version("1.4.7", sha256="00cecc490fcbe2f789cf13c408c459673c2c33ab758d802677321cffcda35373")
     version("1.4.6", sha256="b216a2c8c0eab83f3dc4a3d5ee2bdf7827b30e49c8907035d0f222138eca0987")
     version("1.4.5", sha256="e88a4d86b9925ea1e8685dd5ea29c815abafb8ddf19bf5f1a1e0650839252c23")


### PR DESCRIPTION
Add new patch/minor versions for X11 display stack packages.

## Packages changed
- bdftopcf: add 1.1.2
- glew: add 2.3.1
- libdrm: add 2.4.131 (latest only; earlier intermediates already in develop)
- libxext: add 1.3.7
- libxfixes: add commented-out 6.0.2 (blocked by spack/spack#41688)
- libxft: add 2.3.9
- libxi: add commented-out 1.8.2 reference (blocked by spack/spack#41688)
- libxinerama: add 1.1.6
- libxmu: add 1.3.1
- libxpm: add 3.5.18
- libxpresent: add 1.0.2
- libxrandr: add 1.5.5
- libxres: add 1.2.3
- libxscrnsaver: add 1.2.5
- libxvmc: add 1.0.15
- libxxf86dga: add 1.1.7
- libxxf86vm: add 1.1.7
- xcb-util-cursor: add 0.1.6
- xkbcomp: add 1.5.0

## Dependency changes
- All packages: add `git` attribute for version-control based installs
- glew: add `depends_on("cmake@3.16:", type="build", when="@2.3:")` (CMakeLists.txt minimum raised)
- libxft: add `depends_on("xproto@7.0.22:", type="build", when="@2.3.3:")` (upstream commit e787bf2f)
- libxres: add `depends_on("xproto", type="build", when="@1.2.3:")`

## Related PRs
- freetype: deferred to #3709
- xorg-server: will be submitted in a separate PR

## Version diff links
- [bdftopcf: 1.1.1 → 1.1.2](https://gitlab.freedesktop.org/xorg/util/bdftopcf/-/compare/bdftopcf-1.1.1...bdftopcf-1.1.2)
- [glew: 2.2.0 → 2.3.1](https://github.com/nigels-com/glew/compare/glew-2.2.0...glew-2.3.1)
- [libdrm: 2.4.124 → 2.4.131](https://gitlab.freedesktop.org/mesa/drm/-/compare/2.4.124...2.4.131)
- [libxext: 1.3.6 → 1.3.7](https://gitlab.freedesktop.org/xorg/lib/libXext/-/compare/libXext-1.3.6...libXext-1.3.7)
- [libxfixes: 5.0.3 → 6.0.2](https://gitlab.freedesktop.org/xorg/lib/libXfixes/-/compare/libXfixes-5.0.3...libXfixes-6.0.2)
- [libxft: 2.3.8 → 2.3.9](https://gitlab.freedesktop.org/xorg/lib/libXft/-/compare/libXft-2.3.8...libXft-2.3.9)
- [libxinerama: 1.1.5 → 1.1.6](https://gitlab.freedesktop.org/xorg/lib/libXinerama/-/compare/libXinerama-1.1.5...libXinerama-1.1.6)
- [libxmu: 1.2.1 → 1.3.1](https://gitlab.freedesktop.org/xorg/lib/libXmu/-/compare/libXmu-1.2.1...libXmu-1.3.1)
- [libxpm: 3.5.17 → 3.5.18](https://gitlab.freedesktop.org/xorg/lib/libXpm/-/compare/libXpm-3.5.17...libXpm-3.5.18)
- [libxpresent: 1.0.1 → 1.0.2](https://gitlab.freedesktop.org/xorg/lib/libXpresent/-/compare/libXpresent-1.0.1...libXpresent-1.0.2)
- [libxrandr: 1.5.4 → 1.5.5](https://gitlab.freedesktop.org/xorg/lib/libXrandr/-/compare/libXrandr-1.5.4...libXrandr-1.5.5)
- [libxres: 1.2.2 → 1.2.3](https://gitlab.freedesktop.org/xorg/lib/libXres/-/compare/libXRes-1.2.2...libXRes-1.2.3)
- [libxscrnsaver: 1.2.4 → 1.2.5](https://gitlab.freedesktop.org/xorg/lib/libXScrnSaver/-/compare/libXScrnSaver-1.2.4...libXScrnSaver-1.2.5)
- [libxvmc: 1.0.14 → 1.0.15](https://gitlab.freedesktop.org/xorg/lib/libXvMC/-/compare/libXvMC-1.0.14...libXvMC-1.0.15)
- [libxxf86dga: 1.1.6 → 1.1.7](https://gitlab.freedesktop.org/xorg/lib/libXxf86dga/-/compare/libXxf86dga-1.1.6...libXxf86dga-1.1.7)
- [libxxf86vm: 1.1.6 → 1.1.7](https://gitlab.freedesktop.org/xorg/lib/libXxf86vm/-/compare/libXxf86vm-1.1.6...libXxf86vm-1.1.7)
- [xcb-util-cursor: 0.1.5 → 0.1.6](https://gitlab.freedesktop.org/xorg/lib/libxcb-cursor/-/compare/xcb-util-cursor-0.1.5...xcb-util-cursor-0.1.6)
- [xkbcomp: 1.4.7 → 1.5.0](https://gitlab.freedesktop.org/xorg/app/xkbcomp/-/compare/xkbcomp-1.4.7...xkbcomp-1.5.0)

## CI build status
In CI stacks: libdrm, libxext, libxfixes, libxft, libxi, libxmu, libxpm,
libxrandr, bdftopcf, glew, xcb-util-cursor
Not in any CI stack: libxinerama, libxpresent, libxres, libxscrnsaver,
libxvmc, libxxf86dga, libxxf86vm, xkbcomp

---
> This PR was prepared with AI assistance from GitHub Copilot.
> It will only be marked ready for review after human review of all changes.