### PR TITLE
go: add v1.26.0

### DIFF
--- a/repos/spack_repo/builtin/packages/apptainer/package.py
+++ b/repos/spack_repo/builtin/packages/apptainer/package.py
@@ -38,6 +38,7 @@ class Apptainer(SingularityBase):
     )
 
     version("main", branch="main", get_full_repo=True)  # apptainer version uses git describe
+    version("1.4.5", sha256="d323a8b9a0a9e5e131b396d0049fdaa99beceb83a3d7ffb80dd91d15331e3b9a")  # FIXME
     version("1.4.4", sha256="eb806e22dabfb6549c398b55e50c747e4c51b57f8879da9e29813de40af54b48")
     version("1.4.3", sha256="dfb85b8ad48bd366245c7f6a1d0b56d2ce480cfdf18d7a64397098184b4ade90")
     version("1.4.2", sha256="6dda1dd2ca8e42ed7f498d2bc8574f01d7ad3db68494e453639d76aef4424d1d")

--- a/repos/spack_repo/builtin/packages/conmon/package.py
+++ b/repos/spack_repo/builtin/packages/conmon/package.py
@@ -21,6 +21,8 @@ class Conmon(MakefilePackage):
     sanity_check_is_file = ["bin/conmon"]
 
     version("main", branch="main")
+    version("2.2.1", sha256="814fb5979a3a4b8576b1f901e606b482bebb41cb7e57926e6d5765ee786b96d3")  # FIXME
+    version("2.2.0", sha256="300d21c2244e1b5e90cc62d796da3e94812bec281bae6868d6e738432155319d")  # FIXME
     version("2.1.13", sha256="350992cb2fe4a69c0caddcade67be20462b21b4078dae00750e8da1774926d60")
     version("2.1.12", sha256="842f0b5614281f7e35eec2a4e35f9f7b9834819aa58ecdad8d0ff6a84f6796a6")
     version("2.1.7", sha256="7d0f9a2f7cb8a76c51990128ac837aaf0cc89950b6ef9972e94417aa9cf901fe")

--- a/repos/spack_repo/builtin/packages/go/package.py
+++ b/repos/spack_repo/builtin/packages/go/package.py
@@ -41,6 +41,7 @@ class Go(Package):
 
     license("BSD-3-Clause")
 
+    version("1.26.0", sha256="c9132a8a1f6bd2aa4aad1d74b8231d95274950483a4950657ee6c56e6e817790")
     version("1.25.7", sha256="178f2832820274b43e177d32f06a3ebb0129e427dd20a5e4c88df2c1763cf10a")
     version("1.25.6", sha256="58cbf771e44d76de6f56d19e33b77d745a1e489340922875e46585b975c2b059")
     version("1.25.5", sha256="22a5fd0a91efcd28a1b0537106b9959b2804b61f59c3758b51e8e5429c1a954f")
@@ -81,6 +82,7 @@ class Go(Package):
     depends_on("grep", type="build")
     depends_on("sed", type="build")
 
+    depends_on("go-or-gccgo-bootstrap@1.24.6:", type="build", when="@1.26:")
     depends_on("go-or-gccgo-bootstrap@1.22.6:", type="build", when="@1.24:")
     depends_on("go-or-gccgo-bootstrap@1.20.6:", type="build")
     depends_on("go-or-gccgo-bootstrap", type="build")

--- a/repos/spack_repo/builtin/packages/go_md2man/package.py
+++ b/repos/spack_repo/builtin/packages/go_md2man/package.py
@@ -15,6 +15,9 @@ class GoMd2man(GoPackage):
 
     license("MIT")
 
+    version("2.0.7", sha256="ca3a5b57e2c01759f5a00ad2a578d034c5370fae9aa7a6c3af5648b2fc802a92")
+    version("2.0.6", sha256="5fa29154237bc840a10a06231c066f9ddbe06bb31d1c3372eab12e1ed977271f")
+    version("2.0.5", sha256="6bb799e8fff06d82ca4617190157338d336e2361aa6c5b1786f763a684ffc3f2")
     version("2.0.4", sha256="b0a4c7c077ede56967deef6ab7e7696c0f46124b0b3360fd05564ec5a536f11f")
     version("2.0.3", sha256="7ca3a04bb4ab83387538235decc42a535097a05d2fb9f2266d0c47b33119501f")
     version("2.0.2", sha256="2f52e37101ea2734b02f2b54a53c74305b95b3a9a27792fdac962b5354aa3e4a")

--- a/repos/spack_repo/builtin/packages/shadow/package.py
+++ b/repos/spack_repo/builtin/packages/shadow/package.py
@@ -17,6 +17,12 @@ class Shadow(AutotoolsPackage):
 
     license("BSD-3-Clause")
 
+    version("4.18.0", sha256="ae486ce4c0bce55c42d76d8478e428c41586f1da2f89fbf5228243fb4d849db4")  # FIXME
+    version("4.17.4", sha256="0a288c251f339846af6bdfd4447b196153204deba42407bce5b0917998322e9b")  # FIXME
+    version("4.17.3", sha256="2a029091d2c2f116f51b3a817ec16e7da22310a6c8116394457483c668c84b36")  # FIXME
+    version("4.17.2", sha256="064a7c048e613ef5b5f3613e137d79d35d062ab434e89020f743e90844ec5c4f")  # FIXME
+    version("4.17.1", sha256="51a946bbce141c5de14b6d47cab167206cd685d2307e917611dbc1be46c84a18")  # FIXME
+    version("4.17.0", sha256="05afd78c6e57ef62c0198ccab220d554c06b2e26b54f3fed5f0253109a158368")  # FIXME
     version("4.16.0", sha256="1744f339e07a2b41056347ddd612839762ff565d7e9494fb049428002fa2e7e0")
     version("4.15.1", sha256="b34686b89b279887ffbf1f33128902ccc0fa1a998a3add44213bb12d7385b218")
     version("4.13", sha256="813057047499c7fe81108adcf0cffa3ad4ec75e19a80151f9cbaa458ff2e86cd")


### PR DESCRIPTION
Add new versions for Go and container runtime packages.

## Packages changed
- go: add 1.26.0
- go-md2man: add 2.0.5, 2.0.6, 2.0.7
- conmon: add 2.2.0, 2.2.1
- apptainer: add 1.4.5
- shadow: add 4.17.0-4.17.4, 4.18.0

## Dependency changes
- go: @1.26.0: requires go-or-gccgo-bootstrap@1.24.6:

## Version diff links
- [conmon: 2.1.13 → 2.2.1](https://github.com/containers/conmon/compare/v2.1.13...v2.2.1)
- [apptainer: 1.4.4 → 1.4.5](https://github.com/apptainer/apptainer/compare/v1.4.4...v1.4.5)
- [shadow: 4.16.0 → 4.18.0](https://github.com/shadow-maint/shadow/compare/4.16.0...4.18.0) (+1 intermediate)

## CI build status
In CI stacks: go
Not in any CI stack: go-md2man, conmon, apptainer, shadow

---
> This PR was prepared with AI assistance from GitHub Copilot.
> It will only be marked ready for review after human review of all changes.