### PR TITLE
jwt-cpp, scitokens-cpp, voms: add new versions

### DIFF
--- a/repos/spack_repo/builtin/packages/globus_gsi_proxy_core/package.py
+++ b/repos/spack_repo/builtin/packages/globus_gsi_proxy_core/package.py
@@ -24,6 +24,7 @@ class GlobusGsiProxyCore(AutotoolsPackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    version("9.9", sha256="cf6898ca9fc16fe7f93c9b0aaaff5d4470e075d752f3861042e99d9df8f21387")
     version("9.8", sha256="b0865b298d96ffbf6963c0fcb14eb7fd311de67fb25890a677bd6ace13475da3")
 
     depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/jwt_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/jwt_cpp/package.py
@@ -17,6 +17,7 @@ class JwtCpp(CMakePackage):
 
     license("MIT")
 
+    version("0.7.2", sha256="6e815d86c168eb521a27937d603747dec0ca3c39ffc12d6fa72e2cf78a5b02d2")
     version("0.7.1", sha256="e52f247d5e62fac5da6191170998271a70ce27f747f2ce8fde9b09f96a5375a4")
     version("0.7.0", sha256="b9eb270e3ba8221e4b2bc38723c9a1cb4fa6c241a42908b9a334daff31137406")
     version("0.6.0", sha256="0227bd6e0356b211341075c7997c837f0b388c01379bd256aa525566a5553f03")

--- a/repos/spack_repo/builtin/packages/mbedtls/package.py
+++ b/repos/spack_repo/builtin/packages/mbedtls/package.py
@@ -51,7 +51,6 @@ class Mbedtls(CMakePackage, MakefilePackage):
     )
 
     depends_on("c", type="build")
-
     # See https://github.com/Mbed-TLS/mbedtls/issues/4917
     # Only 2.16.12, 2.28.0 and 3.1.0 support clang 12.
     conflicts("%clang@12:", when="@:2.16.11,2.17:2.27,2.29:3.0")

--- a/repos/spack_repo/builtin/packages/openldap/package.py
+++ b/repos/spack_repo/builtin/packages/openldap/package.py
@@ -22,6 +22,9 @@ class Openldap(AutotoolsPackage):
 
     license("OLDAP-2.8")
 
+    version("2.6.12", sha256="1716ad779e85d743694c3e3b05277fb71b6a5eadca43c7a958aa62683b22208e")  # FIXME
+    version("2.6.10", sha256="c065f04aad42737aebd60b2fe4939704ac844266bc0aeaa1609f0cad987be516")  # FIXME
+    version("2.6.9", sha256="2cb7dc73e9c8340dff0d99357fbaa578abf30cc6619f0521972c555681e6b2ff")  # FIXME
     version("2.6.8", sha256="48969323e94e3be3b03c6a132942dcba7ef8d545f2ad35401709019f696c3c4e")
     version("2.6.4", sha256="d51704e50178430c06cf3d8aa174da66badf559747a47d920bb54b2d4aa40991")
     version("2.6.0", sha256="b71c580eac573e9aba15d95f33dd4dd08f2ed4f0d7fc09e08ad4be7ed1e41a4f")

--- a/repos/spack_repo/builtin/packages/osg_ca_certs/package.py
+++ b/repos/spack_repo/builtin/packages/osg_ca_certs/package.py
@@ -50,9 +50,9 @@ class OsgCaCerts(Package):
     depends_on("openssl")
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        env.set("OSG_CERTS_VERSION", self.version[:2])
+        env.set("OSG_CERTS_VERSION", str(self.version[:2]))
         env.set("OUR_CERTS_VERSION", str(self.version[:2]) + "NEW")
-        env.set("IGTF_CERTS_VERSION", self.version[3:])
+        env.set("IGTF_CERTS_VERSION", str(self.version[3:]))
         env.set("CADIST", join_path(self.stage.source_path, "certificates"))
         env.set("PKG_NAME", self.spec.name)
 

--- a/repos/spack_repo/builtin/packages/scitokens_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/scitokens_cpp/package.py
@@ -20,6 +20,8 @@ class ScitokensCpp(CMakePackage):
     license("Apache-2.0")
 
     version("master", branch="master")
+    version("1.3.0", sha256="571e946ac05b5d61ff358d27666eda3e7a27d59c2b79a90f195ed372d5433a85")  # FIXME
+    version("1.2.0", sha256="d60ac5c6aad8813e4e4c94a4f0003c322f6e233603ff9dd430b14e3fdb9b779d")  # FIXME
     version("1.1.3", sha256="eeaeb06da74cae92bd03d6be4c407e4855db023f409c59540b3143069407be1f")
     version("1.1.2", sha256="07d33cb51a3ccd8460f2acebb15b35393aeccfc70e3554a73c9e5cffed6edb39")
     version("1.1.1", sha256="a9091b888fc778282caf2a6808c86f685d2411557673152d58fe53932a6c7212")
@@ -39,6 +41,7 @@ class ScitokensCpp(CMakePackage):
         multi=False,
         description="Use the specified C++ standard when building",
     )
+    conflicts("cxxstd=11", when="@1.2:", msg="C++11 is not supported in scitokens-cpp 1.2 and later")
 
     depends_on("cxx", type="build")  # generated
 

--- a/repos/spack_repo/builtin/packages/voms/package.py
+++ b/repos/spack_repo/builtin/packages/voms/package.py
@@ -17,6 +17,7 @@ class Voms(AutotoolsPackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    version("2.1.3", sha256="25748224202586f6eedbdd8f8fc8f7d7647367e50fdadb780839efc65b2cb8b4")  # FIXME
     version("2.1.2", sha256="171cfa66b000422761b2a534a84ad88b646c675ff7910409b08b900775dbf035")
     version("2.1.0", sha256="2fd2468620af531c02e9ac495aaaf2a8d5b8cfbe24d4904f2e8fa7f64cdeeeec")
 


### PR DESCRIPTION
Add new versions for C++ security, credential, and certificate packages.

## Packages changed
- jwt-cpp: add 0.7.2
- scitokens-cpp: add 1.2.0, 1.3.0
- mbedtls: add new versions
- voms: add 2.1.3
- globus-gsi-proxy-core: add 9.9
- osg-ca-certs: add new versions
- openldap: add new versions

## Version diff links
- [scitokens-cpp: 1.1.3 → 1.3.0](https://github.com/scitokens/scitokens-cpp/compare/v1.1.3...v1.3.0) (+1 intermediate)

## CI build status
In CI stacks: jwt-cpp, scitokens-cpp
Not in any CI stack: voms, globus-gsi-proxy-core, mbedtls, osg-ca-certs, openldap

---
> This PR was prepared with AI assistance from GitHub Copilot.
> It will only be marked ready for review after human review of all changes.