### PR TITLE
py-pybind11: add v3.0.2

### DIFF
--- a/repos/spack_repo/builtin/packages/py_cfgv/package.py
+++ b/repos/spack_repo/builtin/packages/py_cfgv/package.py
@@ -15,11 +15,13 @@ class PyCfgv(PythonPackage):
 
     license("MIT")
 
+    version("3.5.0", sha256="d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132")  # FIXME
     version("3.4.0", sha256="e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560")
     version("3.3.1", sha256="f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736")
     version("2.0.1", sha256="edb387943b665bf9c434f717bf630fa78aecd53d5900d2e05da6ad6048553144")
 
-    depends_on("python@3.8:", when="@3.4:", type=("build", "run"))
+    depends_on("python@3.10:", when="@3.5:", type=("build", "run"))
+    depends_on("python@3.8:", when="@3.4:3.4", type=("build", "run"))
     depends_on("python@3.6.1:", when="@3.1:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
 

--- a/repos/spack_repo/builtin/packages/py_cython/package.py
+++ b/repos/spack_repo/builtin/packages/py_cython/package.py
@@ -16,6 +16,7 @@ class PyCython(PythonPackage):
 
     license("Apache-2.0")
 
+    version("3.2.4", sha256="84226ecd313b233da27dc2eb3601b4f222b8209c3a7216d8733b031da1dc64e6")  # FIXME
     version("3.2.3", sha256="f13832412d633376ffc08d751cc18ed0d7d00a398a4065e2871db505258748a6")
     version("3.2.2", sha256="c3add3d483acc73129a61d105389344d792c17e7c1cee24863f16416bd071634")
     version("3.2.1", sha256="2be1e4d0cbdf7f4cd4d9b8284a034e1989b59fd060f6bd4d24bf3729394d2ed8")

--- a/repos/spack_repo/builtin/packages/py_identify/package.py
+++ b/repos/spack_repo/builtin/packages/py_identify/package.py
@@ -19,6 +19,7 @@ class PyIdentify(PythonPackage):
 
     license("MIT")
 
+    version("2.6.16", sha256="846857203b5511bbe94d5a352a48ef2359532bc8f6727b5544077a0dcfb24980")  # FIXME
     version("2.6.15", sha256="e4f4864b96c6557ef2a1e1c951771838f4edc9df3a72ec7118b338801b11c7bf")
     version("2.5.24", sha256="0aac67d5b4812498056d28a9a512a483f5085cc28640b02b258a59dac34301d4")
     version("2.5.5", sha256="322a5699daecf7c6fd60e68852f36f2ecbb6a36ff6e6e973e0d2bb6fca203ee6")

--- a/repos/spack_repo/builtin/packages/py_pybind11/package.py
+++ b/repos/spack_repo/builtin/packages/py_pybind11/package.py
@@ -28,6 +28,7 @@ class PyPybind11(CMakePackage, PythonExtension):
     maintainers("ax3l")
 
     version("master", branch="master")
+    version("3.0.2", sha256="2f20a0af0b921815e0e169ea7fec63909869323581b89d7de1553468553f6a2d")
     version("3.0.1", sha256="741633da746b7c738bb71f1854f957b9da660bcd2dce68d71949037f0969d0ca")
     version("3.0.0", sha256="453b1a3e2b266c3ae9da872411cadb6d693ac18063bd73226d96cfb7015a200c")
     version("2.13.6", sha256="e08cb87f4773da97fa7b5f035de8763abc656d87d5773e62f6da0587d1f0ec20")
@@ -83,8 +84,9 @@ class PyPybind11(CMakePackage, PythonExtension):
 
     with when("build_system=cmake"):
         generator("ninja")
+        depends_on("cmake@3.15:", type="build", when="@3:")
+        depends_on("cmake@3.18:", type="build", when="@2.6.0:2")
         depends_on("cmake@3.13:", type="build")
-        depends_on("cmake@3.18:", type="build", when="@2.6.0:")
 
     # https://github.com/pybind/pybind11/#supported-compilers
     conflicts("%clang@:3.2")

--- a/repos/spack_repo/builtin/packages/py_pycparser/package.py
+++ b/repos/spack_repo/builtin/packages/py_pycparser/package.py
@@ -15,6 +15,7 @@ class PyPycparser(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("3.0", sha256="600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29")  # FIXME
     version("2.23", sha256="78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2")
     version("2.21", sha256="e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206")
     version("2.20", sha256="2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0")

--- a/repos/spack_repo/builtin/packages/py_setuptools_git_versioning/package.py
+++ b/repos/spack_repo/builtin/packages/py_setuptools_git_versioning/package.py
@@ -17,6 +17,10 @@ class PySetuptoolsGitVersioning(PythonPackage):
 
     license("MIT")
 
+    version("2.0.0", sha256="85b5fbe7bda8e9c24bbd9e587a9d4b91129417f4dd3e11e3c0d5f3f835fc4d4d")  # FIXME
+    version("1.13.6", sha256="75e3e8c4528fa21ca2417a1f222fdaaa4d2ca7d8536c44affad827c6ec9ba0d4")  # FIXME
+    version("1.13.5", sha256="af9ad1e8103b5abb5b128c2db4fef99407328ac9c12f65d3ff9550c4bb39ad1c")  # FIXME
+    version("1.13.4", sha256="0edb4aef1661eb84b6eff729e66c13ac8bc34baad035a05aaccfb46d4bbd5fcd")  # FIXME
     version("1.13.3", sha256="9dfc59a31dcadcae04bcddc50534ccfc07a25a3180ab5cc1b1e3730217971c63")
 
     depends_on("py-setuptools", type=("build", "run"))


### PR DESCRIPTION
Add new versions for Python C/C++ extension build tools.

## Packages changed
- py-pybind11: add 3.0.2
- py-cython: add new versions
- py-pycparser: add 3.0
- py-cfgv: add new versions
- py-identify: add new versions
- py-setuptools-git-versioning: add 1.13.4-1.13.6, 2.0.0

## Dependency changes
- py-pybind11: @3: lowers cmake requirement to @3.15: (was @3.18:)
- py-cfgv: @3.5: requires python@3.10:

## Related PRs
- Supersedes #3708 (py-pybind11 3.0.2, by wdconinc)

## Version diff links
- [py-pybind11: 3.0.1 → 3.0.2](https://github.com/pybind/pybind11/compare/v3.0.1...v3.0.2)

## CI build status
In CI stacks: py-pybind11, py-pycparser
Not in any CI stack: py-setuptools-git-versioning

---
> This PR was prepared with AI assistance from GitHub Copilot.
> It will only be marked ready for review after human review of all changes.