### PR TITLE
py-attrs, py-jsonschema, py-flask: add new versions

### DIFF
--- a/repos/spack_repo/builtin/packages/py_attrs/package.py
+++ b/repos/spack_repo/builtin/packages/py_attrs/package.py
@@ -16,6 +16,7 @@ class PyAttrs(PythonPackage):
 
     license("MIT")
 
+    version("25.4.0", sha256="16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11")  # FIXME
     version("25.3.0", sha256="75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b")
     version("23.1.0", sha256="6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015")
     version("22.2.0", sha256="c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99")
@@ -31,6 +32,9 @@ class PyAttrs(PythonPackage):
     version("18.1.0", sha256="e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b")
     version("17.4.0", sha256="1c7960ccfd6a005cd9f7ba884e6316b5e430a3f1a6c37c5f87d8b43f83b54ec9")
     version("16.3.0", sha256="80203177723e36f3bbe15aa8553da6e80d47bfe53647220ccaa9ad7a5e473ccc")
+
+    depends_on("python@3.8:", when="@25.3:25.3", type=("build", "run"))
+    depends_on("python@3.9:", when="@25.4:", type=("build", "run"))
 
     depends_on("py-hatchling", when="@23.1:", type="build")
     depends_on("py-hatch-vcs", when="@23.1:", type="build")

--- a/repos/spack_repo/builtin/packages/py_beautifulsoup4/package.py
+++ b/repos/spack_repo/builtin/packages/py_beautifulsoup4/package.py
@@ -20,6 +20,11 @@ class PyBeautifulsoup4(PythonPackage):
     # Requires pytest
     skip_modules = ["bs4.tests"]
 
+    version("4.14.3", sha256="6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86")  # FIXME
+    version("4.14.2", sha256="2a98ab9f944a11acee9cc848508ec28d9228abfd522ef0fad6a02a72e0ded69e")  # FIXME
+    version("4.14.1", sha256="0c19f5b801d51cb13bd4c16ec697fa013209a3a88043c8ac3453144faf90b9b4")  # FIXME
+    version("4.14.0", sha256="e6150e53c8a52fd4f3b9b28839f8f0fb7c7f029d3c953a50b1762b0947c3cf85")  # FIXME
+    version("4.13.5", sha256="5e70131382930e7c3de33450a2f54a63d5e4b19386eab43a5b34d594268f3695")  # FIXME
     version("4.13.4", sha256="dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195")
     version("4.12.3", sha256="74e3d1928edc070d21748185c46e3fb33490f22f52a3addee9aee0f4f7781051")
     version("4.12.2", sha256="492bbc69dca35d12daac71c4db1bfff0c876c00ef4a2ffacce226d4638eb72da")

--- a/repos/spack_repo/builtin/packages/py_bleach/package.py
+++ b/repos/spack_repo/builtin/packages/py_bleach/package.py
@@ -15,6 +15,7 @@ class PyBleach(PythonPackage):
 
     license("Apache-2.0")
 
+    version("6.3.0", sha256="6f3b91b1c0a02bb9a78b5a454c92506aa0fdf197e1d5e114d2e00c6f64306d22")  # FIXME
     version("6.2.0", sha256="123e894118b8a599fd80d3ec1a6d4cc7ce4e5882b1317a7e1ba69b56e95f991f")
     version("6.0.0", sha256="1a1a85c1595e07d8db14c5f09f09e6433502c51c595970edc090551f0db99414")
     version("5.0.1", sha256="0d03255c47eb9bd2f26aa9bb7f2107732e7e8fe195ca2f64709fcf3b0a4a085c")
@@ -26,7 +27,8 @@ class PyBleach(PythonPackage):
 
     variant("css", default=False, when="@5:", description="Add css support")
 
-    depends_on("python@3.9:", type=("build", "run"), when="@6.2:")
+    depends_on("python@3.10:", type=("build", "run"), when="@6.3:")
+    depends_on("python@3.9:", type=("build", "run"), when="@6.2:6.2")
     depends_on("python@3.8:", type=("build", "run"), when="@6.1:")
     depends_on("python@3.7:", type=("build", "run"), when="@5:")
     depends_on("py-setuptools", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_flask/package.py
+++ b/repos/spack_repo/builtin/packages/py_flask/package.py
@@ -16,6 +16,7 @@ class PyFlask(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("3.1.3", sha256="0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb")  # FIXME
     version("3.1.2", sha256="bf656c15c80190ed628ad08cdfd3aaa35beb087855e2f494910aa3774cc4fd87")
     version("3.0.3", sha256="ceb27b0af3823ea2737928a4d99d125a06175b8512c445cbd9a9ce200ef76842")
     version("2.3.2", sha256="8c2f9abd47a9e8df7f0c3f091ce9497d011dc3b31effcf4c85a6e2b50f4114ef")

--- a/repos/spack_repo/builtin/packages/py_idna/package.py
+++ b/repos/spack_repo/builtin/packages/py_idna/package.py
@@ -15,6 +15,7 @@ class PyIdna(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("3.11", sha256="795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902")  # FIXME
     version("3.10", sha256="12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9")
     version("3.4", sha256="814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4")
     version("3.3", sha256="9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d")

--- a/repos/spack_repo/builtin/packages/py_jsonschema/package.py
+++ b/repos/spack_repo/builtin/packages/py_jsonschema/package.py
@@ -15,6 +15,7 @@ class PyJsonschema(PythonPackage):
 
     license("MIT", checked_by="wdconinc")
 
+    version("4.26.0", sha256="0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326")  # FIXME
     version("4.25.1", sha256="e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85")
     version("4.23.0", sha256="d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4")
     version("4.22.0", sha256="5b22d434a45935119af990552c862e5d6d564e8f6601206b305a61fdf661a2b7")

--- a/repos/spack_repo/builtin/packages/py_markupsafe/package.py
+++ b/repos/spack_repo/builtin/packages/py_markupsafe/package.py
@@ -19,6 +19,7 @@ class PyMarkupsafe(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("3.0.3", sha256="722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698")  # FIXME
     version("3.0.2", sha256="ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0")
     version("2.1.5", sha256="d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b")
     version("2.1.3", sha256="af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad")

--- a/repos/spack_repo/builtin/packages/py_referencing/package.py
+++ b/repos/spack_repo/builtin/packages/py_referencing/package.py
@@ -17,6 +17,7 @@ class PyReferencing(PythonPackage):
 
     license("MIT", checked_by="wdconinc")
 
+    version("0.37.0", sha256="44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8")
     version("0.36.2", sha256="df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa")
     version("0.35.1", sha256="25b42124a6c8b632a425174f24087783efb348a6f1e0008e63cd4466fedf703c")
 

--- a/repos/spack_repo/builtin/packages/py_tinycss2/package.py
+++ b/repos/spack_repo/builtin/packages/py_tinycss2/package.py
@@ -18,6 +18,8 @@ class PyTinycss2(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.5.1", sha256="d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957")  # FIXME
+    version("1.5.0", sha256="6a7be7a654f38a2a55b61d2d97b1f65a7eb40d1cb4057ac37145f675f16efdf9")  # FIXME
     version("1.4.0", sha256="10c0972f6fc0fbee87c3edb76549357415e94548c1ae10ebccdea16fb404a9b7")
     version("1.2.1", sha256="8cff3a8f066c2ec677c06dbc7b45619804a6938478d9d73c284b29d14ecb0627")
     version("1.1.1", sha256="b2e44dd8883c360c35dd0d1b5aad0b610e5156c2cb3b33434634e539ead9d8bf")

--- a/repos/spack_repo/builtin/packages/py_webcolors/package.py
+++ b/repos/spack_repo/builtin/packages/py_webcolors/package.py
@@ -15,6 +15,7 @@ class PyWebcolors(PythonPackage):
 
     license("BSD-3-Clause", checked_by="wdconinc")
 
+    version("25.10.0", sha256="62abae86504f66d0f6364c2a8520de4a0c47b80c03fc3a5f1815fedbef7c19bf")  # FIXME
     version("24.11.1", sha256="ecb3d768f32202af770477b8b65f318fa4f566c22948673a977b00d589dd80f6")
     version("24.8.0", sha256="08b07af286a01bcd30d583a7acadf629583d1f79bfef27dd2c2c5c263817277d")
     version("24.6.0", sha256="1d160d1de46b3e81e58d0a280d0c78b467dc80f47294b91b1ad8029d2cedb55b")

--- a/repos/spack_repo/builtin/packages/py_websockets/package.py
+++ b/repos/spack_repo/builtin/packages/py_websockets/package.py
@@ -17,6 +17,7 @@ class PyWebsockets(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("16.0", sha256="5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5")  # FIXME
     version("15.0.1", sha256="82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee")
     version("10.4", sha256="eef610b23933c54d5d921c92578ae5f89813438fded840c2e9809d378dc765d3")
     version("10.3", sha256="fc06cc8073c8e87072138ba1e431300e2d408f054b27047d047b549455066ff4")
@@ -24,5 +25,6 @@ class PyWebsockets(PythonPackage):
     version("8.1", sha256="5c65d2da8c6bce0fca2528f69f44b2f977e06954c8512a952222cea50dad430f")
 
     depends_on("python", type=("build", "link", "run"))
+    depends_on("python@3.10:", type=("build", "run"), when="@16:")
     depends_on("c", type="build")
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_werkzeug/package.py
+++ b/repos/spack_repo/builtin/packages/py_werkzeug/package.py
@@ -16,6 +16,9 @@ class PyWerkzeug(PythonPackage):
 
     license("BSD-3-Clause", checked_by="wdconinc")
 
+    version("3.1.6", sha256="210c6bede5a420a913956b4791a7f4d6843a43b6fcee4dfa08a65e93007d0d25")  # FIXME
+    version("3.1.5", sha256="6a548b0e88955dd07ccb25539d7d0cc97417ee9e179677d22c7041c8f078ce67")  # FIXME
+    version("3.1.4", sha256="cd3cd98b1b92dc3b7b3995038826c68097dcb16f9baa63abe35f20eafeb9fe5e")  # FIXME
     version("3.1.3", sha256="60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746")
     version("3.0.4", sha256="34f2371506b250df4d4f84bfe7b0921e4762525762bbd936614909fe25cd7306")
     version("3.0.0", sha256="3ffff4dcc32db52ef3cc94dff3000a3c2846890f3a5a51800a27b909c5e770f0")


### PR DESCRIPTION
Add new versions for Python JSON schema validation and web framework stack.

## Packages changed
- py-attrs: add 25.3.0, 25.4.0
- py-idna: add new versions
- py-webcolors: add 25.10.0
- py-referencing: add 0.37.0
- py-jsonschema: add new versions
- py-markupsafe: add new versions
- py-werkzeug: add 3.1.4, 3.1.5, 3.1.6
- py-flask: add new versions
- py-bleach: add new versions
- py-tinycss2: add 1.5.0, 1.5.1
- py-beautifulsoup4: add new versions
- py-websockets: add 16.0

## Dependency changes
- py-attrs: @25.3: python@3.8:; @25.4: python@3.9:
- py-bleach: @6.3: requires python@3.10:
- py-websockets: @16: requires python@3.10:

## Version diff links
- [py-attrs: 25.3.0 → 25.4.0](https://github.com/python-attrs/attrs/compare/25.3.0...25.4.0)
- [py-markupsafe: 3.0.2 → 3.0.3](https://github.com/pallets/markupsafe/compare/3.0.2...3.0.3)
- [py-werkzeug: 3.1.3 → 3.1.6](https://github.com/pallets/werkzeug/compare/3.1.3...3.1.6)
- [py-flask: 3.1.2 → 3.1.3](https://github.com/pallets/flask/compare/3.1.2...3.1.3)
- [py-tinycss2: 1.4.0 → 1.5.1](https://github.com/Kozea/tinycss2/compare/1.4.0...1.5.1)

## CI build status
In CI stacks: py-attrs, py-webcolors, py-referencing, py-werkzeug, py-tinycss2
Not in any CI stack: py-websockets

---
> This PR was prepared with AI assistance from GitHub Copilot.
> It will only be marked ready for review after human review of all changes.