### PR TITLE
py-paramiko, py-gssapi, py-rucio-clients: add new versions

### DIFF
--- a/repos/spack_repo/builtin/packages/py_gssapi/package.py
+++ b/repos/spack_repo/builtin/packages/py_gssapi/package.py
@@ -16,6 +16,9 @@ class PyGssapi(PythonPackage):
 
     maintainers("wdconinc")
 
+    version("1.11.1", sha256="2049ee4b1d0c363163a1344b7282a363f9f4094e51d2c36de0cf01d4735e0ae2")  # FIXME
+    version("1.10.1", sha256="7b54335dc9a3c55d564624fb6e25fcf9cfc0b80296a5c51e9c7cf9781c7d295b")  # FIXME
+    version("1.10.0", sha256="f1495e0dc20bee3ad2839724d98ae723c7dae78c1ddea37a7c861c3c4bd77763")  # FIXME
     version("1.9.0", sha256="f468fac8f3f5fca8f4d1ca19e3cd4d2e10bd91074e7285464b22715d13548afe")
     version("1.8.3", sha256="aa3c8d0b1526f52559552bb2c9d2d6be013d76a8e5db00b39a1db5727e93b0b0")
     version("1.8.2", sha256="b78e0a021cc91158660e4c5cc9263e07c719346c35a9c0f66725e914b235c89a")
@@ -25,5 +28,6 @@ class PyGssapi(PythonPackage):
     depends_on("py-cython@3.0.3:3", type="build", when="@1.9.0:")
     depends_on("py-setuptools@40.6.0:", type="build")
 
+    depends_on("python@3.9:", when="@1.10:", type=("build", "run"))
     depends_on("py-decorator", type=("build", "run"))
     depends_on("krb5", type=("build", "link"))

--- a/repos/spack_repo/builtin/packages/py_htgettoken/package.py
+++ b/repos/spack_repo/builtin/packages/py_htgettoken/package.py
@@ -23,6 +23,13 @@ class PyHtgettoken(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("2.6", sha256="d553d40b8b1ad794d4fa36e4a88e4c6343f12bc4498b3143d297d1c60d1877b4")  # FIXME
+    version("2.5", sha256="a5fd9d81883d7bc3bcd192ee5e0e477e71b3297a25da063b97bc6779309eb67a")  # FIXME
+    version("2.4", sha256="0178e6ae14a9768c981f66bc9e68b99164a094ecf3120854eb23a5a9cef1763d")
+    version("2.3", sha256="73f7be0bca09c668928286c05d6786e841783ee87cdede5111bf0445620fd30a")
+    version("2.2-2", sha256="47fc2a416f4cca97546d4faa3b471a162692c274ab126ceb05dc4982cd4e6bf7")
+    version("2.2", sha256="5c323a7f8f04df558cd4e7b879a7a5e1d660f6a54904e914f799032c4c01139b")
+    version("2.1", sha256="eafd54ae81dc19390a2b9f8f5e93a64fa0ef407fa38416194a7179f8c093e294")
     version("2.0-2", sha256="80b1b15cc4957f9d1cb5e71a1fbdc5d0ac82de46a888aeb7fa503b1465978b13")
     # The following versions refer to setuptools-buildable commits after 1.16;
     # they are special reproducible version numbers from `git describe`

--- a/repos/spack_repo/builtin/packages/py_krb5/package.py
+++ b/repos/spack_repo/builtin/packages/py_krb5/package.py
@@ -17,6 +17,9 @@ class PyKrb5(PythonPackage):
 
     license("MIT", checked_by="wdconinc")
 
+    version("0.9.0", sha256="4cdd2c85ff4770108edaf48fedf19888cf956ff374e2e97e40f8412b048caee6")  # FIXME
+    version("0.8.0", sha256="daaf580cf563a2435cc889d4a0692e02c5788e1eb91f0246d56114cf4f08ba1c")  # FIXME
+    version("0.7.1", sha256="ed5f13d5031489b10d8655c0ada28a81c2391b3ecb8a08c6d739e1e5835bc450")  # FIXME
     version("0.7.0", sha256="6a308f2e17d151c395b24e6aec7bdff6a56fe3627a32042fc86d412398a92ddd")
     version("0.6.0", sha256="712ba092fbe3a28ec18820bb1b1ed2cc1037b75c5c7033f970c6a8c97bbd1209")
 

--- a/repos/spack_repo/builtin/packages/py_paramiko/package.py
+++ b/repos/spack_repo/builtin/packages/py_paramiko/package.py
@@ -15,6 +15,7 @@ class PyParamiko(PythonPackage):
 
     license("LGPL-2.1-or-later")
 
+    version("4.0.0", sha256="6a25f07b380cc9c9a88d2b920ad37167ac4667f8d9886ccebd8f90f654b5d69f")  # FIXME
     version("3.5.1", sha256="b2c665bc45b2b215bd7d7f039901b14b067da00f3a11e6640995fd58f2664822")
     version("3.5.0", sha256="ad11e540da4f55cedda52931f1a3f812a8238a7af7f62a60de538cd80bb28124")
     version("3.4.1", sha256="8b15302870af7f6652f2e038975c1d2973f06046cb5d7d65355668b3ecbece0c")
@@ -31,7 +32,7 @@ class PyParamiko(PythonPackage):
 
     variant("invoke", default=False, description="Enable invoke support")
 
-    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools", when="@:3", type="build")
     depends_on("py-bcrypt@3.1.3:", when="@2.7:", type=("build", "run"))
     depends_on("py-bcrypt@3.2:", when="@3:", type=("build", "run"))
     depends_on("py-cryptography@2.5:", when="@2.7:", type=("build", "run"))
@@ -40,5 +41,6 @@ class PyParamiko(PythonPackage):
     depends_on("py-pynacl@1.5:", when="@3:", type=("build", "run"))
     depends_on("py-six", when="@2.9.3:2", type=("build", "run"))
 
-    depends_on("py-invoke@1.3:", when="+invoke", type=("build", "run"))
-    depends_on("py-invoke@2:", when="@3: +invoke", type=("build", "run"))
+    depends_on("py-invoke@2:", when="@4:", type=("build", "run"))
+    depends_on("py-invoke@1.3:", when="@:3 +invoke", type=("build", "run"))
+    depends_on("py-invoke@2:", when="@3:3 +invoke", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_pyjwt/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyjwt/package.py
@@ -15,6 +15,10 @@ class PyPyjwt(PythonPackage):
 
     license("MIT")
 
+    version("2.8.0", sha256="57e28d156e3d5c10088e0c68abb90bfac3df82b40a71bd0daa20c65ccd5c23de")  # FIXME
+    version("2.7.0", sha256="bd6ca4a3c4285c1a2d4349e5a035fdf8fb94e04ccd0fcbe6ba289dae9cc3e074")  # FIXME
+    version("2.6.0", sha256="69285c7e31fc44f68a1feb309e948e0df53259d579295e6cfe2b1792329f05fd")  # FIXME
+    version("2.5.0", sha256="e77ab89480905d86998442ac5788f35333fa85f65047a534adc38edf3c88fc3b")  # FIXME
     version("2.4.0", sha256="d42908208c699b3b973cbeb01a969ba6a96c821eefb1c5bfe4c390c01d67abba")
     version("2.1.0", sha256="fba44e7898bbca160a2b2b501f492824fc8382485d3a6f11ba5d0c1937ce6130")
     version("1.7.1", sha256="8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96")

--- a/repos/spack_repo/builtin/packages/py_pyspnego/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyspnego/package.py
@@ -17,6 +17,8 @@ class PyPyspnego(PythonPackage):
 
     license("MIT", checked_by="wdconinc")
 
+    version("0.12.0", sha256="e1d9cd3520a87a1d6db8d68783b17edc4e1464eae3d51ead411a51c82dbaae67")  # FIXME
+    version("0.11.2", sha256="994388d308fb06e4498365ce78d222bf4f3570b6df4ec95738431f61510c971b")  # FIXME
     version("0.11.1", sha256="e92ed8b0a62765b9d6abbb86a48cf871228ddb97678598dc01c9c39a626823f6")
 
     variant("kerberos", default=False, description="Enable Kerberos authentication on Linux")

--- a/repos/spack_repo/builtin/packages/py_rucio_clients/package.py
+++ b/repos/spack_repo/builtin/packages/py_rucio_clients/package.py
@@ -17,6 +17,18 @@ class PyRucioClients(PythonPackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    version("39.3.0", sha256="e6890df6b25785a3ff2006774fceeafd9541e6b710b288efaf72ff1f598213eb")  # FIXME
+    version("39.2.0", sha256="830d232928b10aad2aa471ec2ea71023b930a3b73d4c7e895f79f1cba101af27")  # FIXME
+    version("39.1.0", sha256="5c83a6c0b1c0823e7b95f6569c6478698c433db1901d8398d3844f48a2728aca")  # FIXME
+    version("39.0.0", sha256="a83632897cfc2cc9052848b1b795fb71b2cf8d0a7920a6cff1f7367874bac72a")  # FIXME
+    version("38.5.3", sha256="7457d8d91e4b33bc760495974bc160b2e823f217f5cfaa98034e9bd644d8950b")  # FIXME
+    version("38.5.2", sha256="d3ef7f2a834df762aa28c6535ace4ee575b8096952f9d446f2d15da43a294507")  # FIXME
+    version("38.5.1", sha256="3cfe97c5e5996cfc5861b259ff0bed3369e7379bcaa826b6d181ee5b939ac401")  # FIXME
+    version("38.5.0", sha256="f0379a3efc9ba948ecbc8bf96d6c325aa79156b344a95b7f2358b43371792e9f")  # FIXME
+    version("38.4.0", sha256="bf4bbb21f514156f6ca975f981583a1f8f8af9ca7e41b77ae20c10147fc5d3fb")  # FIXME
+    version("38.3.0", sha256="49f8809b5378d1c9e9edc5f1a74fbf7eebe45db27084945f748b2c73a841efed")  # FIXME
+    version("38.2.0", sha256="7495d7274e17e4099f9ccd2672667236e17f806292954387145e99c7c688414a")  # FIXME
+    version("38.1.0", sha256="69a4197fdad548671a3ab8322f181f62b13d8aaa3e2e96ebdbc6d3a434fd0062")  # FIXME
     version("38.0.0", sha256="d49f912f2f98870cab2227e0464129ba0954e99b975d0225126cca1b9d9c983c")
     version("37.3.0", sha256="b4bca8d451bc34528797ca188884a0c8b5ddfef2d32803765e6333455879f819")
     version(

--- a/repos/spack_repo/builtin/packages/py_sspilib/package.py
+++ b/repos/spack_repo/builtin/packages/py_sspilib/package.py
@@ -17,6 +17,11 @@ class PySspilib(PythonPackage):
 
     license("MIT", checked_by="wdconinc")
 
+    version("0.5.0", sha256="b62f7f2602aa1add0505eee2417e2df24421224cb411e53bf3ae42a71b62fe98")  # FIXME
+    version("0.4.0", sha256="b482b3be8dc30e086f89e13831139129c022f90f6e7c0603b3c60209d9a4561d")  # FIXME
+    version("0.3.1", sha256="6df074ee54e3bd9c1bccc84233b1ceb846367ba1397dc52b5fae2846f373b154")  # FIXME
+    version("0.3.0", sha256="fd81593555a6ab5d3ef0dfb095fda005161ffe331dd991bbbe4592cfc4c27945")  # FIXME
+    version("0.2.0", sha256="4d6cd4290ca82f40705efeb5e9107f7abcd5e647cb201a3d04371305938615b8")  # FIXME
     version("0.1.0", sha256="58b5291553cf6220549c0f855e0e6973f4977375d8236ce47bb581efb3e9b1cf")
 
     depends_on("py-setuptools@61:", type="build")


### PR DESCRIPTION
Add new versions for Python authentication and secure communication stack.

## Packages changed
- py-pyjwt: add 2.5.0-2.8.0
- py-gssapi: add new versions
- py-krb5: add new versions
- py-sspilib: add 0.2.0-0.5.0
- py-pyspnego: add 0.11.2, 0.12.0
- py-paramiko: add 4.0.0
- py-htgettoken: add new versions
- py-rucio-clients: add 38.1.0-39.3.0

## Dependency changes
- py-gssapi: @1.10: requires python@3.9:
- py-paramiko: @4: makes invoke unconditionally required; setuptools scoped to @:3

## CI build status
In CI stacks: py-pyjwt, py-paramiko
Not in any CI stack: py-sspilib, py-pyspnego, py-rucio-clients

---
> This PR was prepared with AI assistance from GitHub Copilot.
> It will only be marked ready for review after human review of all changes.