### PR TITLE
py-ipython, py-ipykernel, py-jupyterlab: add new versions

### DIFF
--- a/repos/spack_repo/builtin/packages/py_asttokens/package.py
+++ b/repos/spack_repo/builtin/packages/py_asttokens/package.py
@@ -16,6 +16,7 @@ class PyAsttokens(PythonPackage):
     license("Apache-2.0")
 
     version("3.0.0", sha256="0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7")
+    version("2.4.1", sha256="b03869718ba9a6eb027e134bfdf69f38a236d681c83c160d510768af11254ba0")
     version("2.4.0", sha256="2e0171b991b2c959acc6c49318049236844a5da1d65ba2672c4880c1c894834e")
     version("2.2.1", sha256="4622110b2a6f30b77e1473affaa97e711bc2f07d3f10848420ff1898edbe94f3")
     version("2.0.8", sha256="c61e16246ecfb2cde2958406b4c8ebc043c9e6d73aaa83c941673b35e5d3a76b")

--- a/repos/spack_repo/builtin/packages/py_debugpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_debugpy/package.py
@@ -18,6 +18,8 @@ class PyDebugpy(PythonPackage):
 
     license("MIT")
 
+    version("1.8.17", sha256="fd723b47a8c08892b1a16b2c6239a8b96637c62a59b94bb5dab4bac592a58a8e")  # FIXME
+    version("1.8.16", sha256="31e69a1feb1cf6b51efbed3f6c9b0ef03bc46ff050679c4be7ea6d2e23540870")  # FIXME
     version("1.8.15", sha256="58d7a20b7773ab5ee6bdfb2e6cf622fdf1e40c9d5aef2857d85391526719ac00")
     version("1.6.7", sha256="c4c2f0810fa25323abfdfa36cbbbb24e5c3b1a42cb762782de64439c575d67f2")
     version("1.6.6", sha256="b9c2130e1c632540fbf9c2c88341493797ddf58016e7cba02e311de9b0a96b67")

--- a/repos/spack_repo/builtin/packages/py_ipykernel/package.py
+++ b/repos/spack_repo/builtin/packages/py_ipykernel/package.py
@@ -18,6 +18,10 @@ class PyIpykernel(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("7.1.0", sha256="58a3fc88533d5930c3546dc7eac66c6d288acde4f801e2001e65edc5dc9cf0db")  # FIXME
+    version("7.0.1", sha256="2d3fd7cdef22071c2abbad78f142b743228c5d59cd470d034871ae0ac359533c")  # FIXME
+    version("7.0.0", sha256="06aef83f27adbce00b23345aa70f749f907dc4ac6f4a41fe7bf5f780dc506225")  # FIXME
+    version("6.31.0", sha256="2372ce8bc1ff4f34e58cafed3a0feb2194b91fc7cad0fc72e79e47b45ee9e8f6")  # FIXME
     version("6.30.1", sha256="6abb270161896402e76b91394fcdce5d1be5d45f456671e5080572f8505be39b")
     version("6.29.5", sha256="f093a22c4a40f8828f8e330a9c297cb93dcab13bd9678ded6de8e5cf81c56215")
     version("6.29.4", sha256="3d44070060f9475ac2092b760123fadf105d2e2493c24848b6691a7c4f42af5c")
@@ -39,9 +43,11 @@ class PyIpykernel(PythonPackage):
     version("5.5.5", sha256="e976751336b51082a89fc2099fb7f96ef20f535837c398df6eab1283c2070884")
 
     depends_on("py-hatchling@1.4:", when="@6.13.1:", type="build")
+    depends_on("py-hatchling@1.22:", when="@7.1:", type="build")
 
     with default_args(type=("build", "run")):
-        depends_on("python@3.9:", when="@6.30:")
+        depends_on("python@3.10:", when="@7:")
+        depends_on("python@3.9:", when="@6.30:6")
         depends_on("python@3.8:", when="@6.11:")
         depends_on("python@3.8:3.11", when="@6:6.10")
         depends_on("python@3.6:3.9", when="@5.5:5")

--- a/repos/spack_repo/builtin/packages/py_ipython/package.py
+++ b/repos/spack_repo/builtin/packages/py_ipython/package.py
@@ -23,6 +23,11 @@ class PyIpython(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("9.10.0", sha256="cd9e656be97618a0676d058134cd44e6dc7012c0e5cb36a9ce96a8c904adaf77")  # FIXME
+    version("9.9.0", sha256="48fbed1b2de5e2c7177eefa144aba7fcb82dac514f09b57e2ac9da34ddb54220")  # FIXME
+    version("9.8.0", sha256="8e4ce129a627eb9dd221c41b1d2cdaed4ef7c9da8c17c63f6f578fe231141f83")  # FIXME
+    version("9.7.0", sha256="5f6de88c905a566c6a9d6c400a8fed54a638e1f7543d17aae2551133216b1e4e")  # FIXME
+    version("9.6.0", sha256="5603d6d5d356378be5043e69441a072b50a5b33b4503428c77b04cb8ce7bc731")  # FIXME
     version("9.5.0", sha256="129c44b941fe6d9b82d36fc7a7c18127ddb1d6f02f78f867f402e2e3adde3113")
     version("8.28.0", sha256="0d0d15ca1e01faeb868ef56bc7ee5a0de5bd66885735682e8a322ae289a13d1a")
     version("8.27.0", sha256="0b99a2dc9f15fd68692e898e5568725c6d49c527d36a9fb5960ffbdeaa82ff7e")
@@ -64,10 +69,14 @@ class PyIpython(PythonPackage):
 
     depends_on("py-colorama", when="platform=windows", type=("build", "run"))
     depends_on("py-decorator", type=("build", "run"))
+    depends_on("py-decorator@4.3.2:", when="@9.7:", type=("build", "run"))
     depends_on("py-ipython-pygments-lexers", when="@9:", type=("build", "run"))
+    depends_on("py-ipython-pygments-lexers@1:", when="@9.7:", type=("build", "run"))
+    depends_on("py-jedi@0.18.1:", when="@9.7:", type=("build", "run"))
     depends_on("py-jedi@0.16:", when="@7.18,7.20:", type=("build", "run"))
     depends_on("py-jedi@0.10:", when="@7.5:7.17,7.19", type=("build", "run"))
     depends_on("py-matplotlib-inline", when="@7.23:", type=("build", "run"))
+    depends_on("py-matplotlib-inline@0.1.5:", when="@9.7:", type=("build", "run"))
     depends_on("py-pexpect@4.4:", when="@7.18: platform=linux", type=("build", "run"))
     depends_on("py-pexpect@4.4:", when="@7.18: platform=darwin", type=("build", "run"))
     depends_on("py-pexpect", when="platform=linux", type=("build", "run"))
@@ -82,8 +91,10 @@ class PyIpython(PythonPackage):
     depends_on("py-prompt-toolkit@1.0.4:1", when="@:7.0.0", type=("build", "run"))
     depends_on("py-prompt-toolkit@1.0.3:1", when="@:7.0.0", type=("build", "run"))
     depends_on("py-pygments@2.4:", when="@8.1:", type=("build", "run"))
+    depends_on("py-pygments@2.11:", when="@9.7:", type=("build", "run"))
     depends_on("py-pygments", type=("build", "run"))
     depends_on("py-stack-data", when="@8:", type=("build", "run"))
+    depends_on("py-stack-data@0.6:", when="@9.7:", type=("build", "run"))
     depends_on("py-traitlets@5.13:", when="@8.22.1:", type=("build", "run"))
     depends_on("py-traitlets@5:", when="@8:", type=("build", "run"))
     depends_on("py-traitlets@4.2:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_json5/package.py
+++ b/repos/spack_repo/builtin/packages/py_json5/package.py
@@ -17,6 +17,7 @@ class PyJson5(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.13.0", sha256="b1edf8d487721c0bf64d83c28e91280781f6e21f4a797d3261c7c828d4c165bf")  # FIXME
     version("0.12.1", sha256="b2743e77b3242f8d03c143dd975a6ec7c52e2f2afe76ed934e53503dd4ad4990")
     version("0.9.14", sha256="9ed66c3a6ca3510a976a9ef9b8c0787de24802724ab1860bc0153c7fdd589b02")
     version("0.9.10", sha256="ad9f048c5b5a4c3802524474ce40a622fae789860a86f10cc4f7e5f9cf9b46ab")

--- a/repos/spack_repo/builtin/packages/py_jupyter_core/package.py
+++ b/repos/spack_repo/builtin/packages/py_jupyter_core/package.py
@@ -18,6 +18,8 @@ class PyJupyterCore(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("5.9.1", sha256="4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508")  # FIXME
+    version("5.9.0", sha256="5f8fba10cfc946fe1b4037e986458fc89430397207b21d741dc399d3d42951d4")  # FIXME
     version("5.8.1", sha256="0a5f9706f70e64786b75acba995988915ebd4601c8a52e534a40b51c95f59941")
     version("5.3.0", sha256="6db75be0c83edbf1b7c9f91ec266a9a24ef945da630f3120e1a0046dc13713fc")
     version("5.1.0", sha256="a5ae7c09c55c0b26f692ec69323ba2b62e8d7295354d20f6cd57b749de4a05bf")

--- a/repos/spack_repo/builtin/packages/py_jupyterlab/package.py
+++ b/repos/spack_repo/builtin/packages/py_jupyterlab/package.py
@@ -18,6 +18,7 @@ class PyJupyterlab(PythonPackage):
 
     license("BSD-3-Clause", checked_by="lgarrison")
 
+    version("4.5.0", sha256="aec33d6d8f1225b495ee2cf20f0514f45e6df8e360bdd7ac9bace0b7ac5177ea")  # FIXME
     version("4.4.10", sha256="521c017508af4e1d6d9d8a9d90f47a11c61197ad63b2178342489de42540a615")
     version("4.4.7", sha256="8c8e225492f4513ebde9bbbc00a05b651ab9a1f5b0013015d96fabf671c37188")
     version("4.3.5", sha256="c779bf72ced007d7d29d5bcef128e7fdda96ea69299e19b04a43635a7d641f9d")

--- a/repos/spack_repo/builtin/packages/py_pure_eval/package.py
+++ b/repos/spack_repo/builtin/packages/py_pure_eval/package.py
@@ -17,6 +17,7 @@ class PyPureEval(PythonPackage):
     license("MIT")
 
     version("master", branch="master")
+    version("0.2.3", sha256="5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42")  # FIXME
     version("0.2.2", sha256="2b45320af6dfaa1750f543d714b6d1c520a1688dec6fd24d339063ce0aaa9ac3")
 
     depends_on("python@3.5:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_tornado/package.py
+++ b/repos/spack_repo/builtin/packages/py_tornado/package.py
@@ -16,6 +16,8 @@ class PyTornado(PythonPackage):
 
     license("Apache-2.0")
 
+    version("6.5.4", sha256="a22fa9047405d03260b483980635f0b041989d8bcc9a313f8fe18b411d84b1d7")  # FIXME
+    version("6.5.3", sha256="16abdeb0211796ffc73765bc0a20119712d68afeeaf93d1a3f2edf6b3aee8d5a")  # FIXME
     version("6.5.2", sha256="ab53c8f9a0fa351e2c0741284e06c7a45da86afb544133201c5cc8578eb076a0")
     version("6.3.3", sha256="e7d8db41c0181c80d76c982aacc442c0783a2c54d6400fe028954201a2e032fe")
     version("6.2", sha256="9b630419bde84ec666bfd7ea0a4cb2a8a651c2d5cccdbdd1972a0c859dfc3c13")


### PR DESCRIPTION
Add new versions for the Jupyter notebook ecosystem.

## Packages changed
- py-ipython: add new versions
- py-ipykernel: add new versions
- py-jupyter-core: add new versions
- py-jupyterlab: add new versions
- py-tornado: add 6.5.3, 6.5.4
- py-debugpy: add new versions
- py-pure-eval: add 0.2.3
- py-asttokens: add new versions
- py-json5: add new versions

## Dependency changes
- py-ipykernel: @7: requires python@3.10:; @7.1: requires py-hatchling@1.22:
- py-ipython: @9.7: tightened dep minimums for decorator, jedi, pygments,
  prompt-toolkit, stack-data, traitlets

## Version diff links
- [py-ipython: 9.5.0 → 9.10.0](https://github.com/ipython/ipython/compare/9.5.0...9.10.0) (+4 intermediate)
- [py-jupyter-core: 5.8.1 → 5.9.1](https://github.com/jupyter/jupyter_core/compare/5.8.1...5.9.1)
- [py-pure-eval: 0.2.2 → 0.2.3](https://github.com/alexmojaki/pure_eval/compare/0.2.2...0.2.3)

## CI build status
In CI stacks: py-tornado, py-pure-eval

---
> This PR was prepared with AI assistance from GitHub Copilot.
> It will only be marked ready for review after human review of all changes.