### PR TITLE
py-prometheus-client, py-pulp, py-wcwidth, py-pyee: add new versions

### DIFF
--- a/repos/spack_repo/builtin/packages/py_prometheus_client/package.py
+++ b/repos/spack_repo/builtin/packages/py_prometheus_client/package.py
@@ -15,6 +15,8 @@ class PyPrometheusClient(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.23.1", sha256="6ae8f9081eaaaf153a2e959d2e6c4f4fb57b12ef76c8c7980202f1e57b48b2ce")  # FIXME
+    version("0.23.0", sha256="1f5eb6aeaf73891f15aa23ec44912c96410d90d027dc0618a3faae5911e1ff24")  # FIXME
     version("0.22.1", sha256="190f1331e783cf21eb60bca559354e0a4d4378facecf78f5428c39b675d20d28")
     version("0.17.0", sha256="9c3b26f1535945e85b8934fb374678d263137b78ef85f305b1156c7c881cd11b")
     version("0.14.1", sha256="5459c427624961076277fdc6dc50540e2bacb98eebde99886e59ec55ed92093a")

--- a/repos/spack_repo/builtin/packages/py_pulp/package.py
+++ b/repos/spack_repo/builtin/packages/py_pulp/package.py
@@ -19,6 +19,8 @@ class PyPulp(PythonPackage):
 
     license("MIT")
 
+    version("2.8.0", sha256="4903bf96110bbab8ed2c68533f90565ebb76aa367d9e4df38e51bf727927c125")  # FIXME
+    version("2.7.0", sha256="e73ee6b32d639c9b8cf4b4aded334ba158be5f8313544e056f796ace0a10ae63")  # FIXME
     version("2.6.0", sha256="4b4f7e1e954453e1b233720be23aea2f10ff068a835ac10c090a93d8e2eb2e8d")
 
     depends_on("python@2.7:2.8,3.4:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_pyee/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyee/package.py
@@ -16,6 +16,9 @@ class PyPyee(PythonPackage):
 
     license("MIT", checked_by="wdconinc")
 
+    version("13.0.0", sha256="b391e3c5a434d1f5118a25615001dbc8f669cf410ab67d04c4d4e07c55481c37")  # FIXME
+    version("12.1.1", sha256="bbc33c09e2ff827f74191e3e5bbc6be7da02f627b7ec30d86f5ce1a6fb2424a3")  # FIXME
+    version("12.1.0", sha256="6bfc28654a5448613272ca44b71a70111b51b66c1de907ab29a832a8876f00c8")  # FIXME
     version("12.0.0", sha256="c480603f4aa2927d4766eb41fa82793fe60a82cbfdb8d688e0d08c55a534e145")
     version("11.1.1", sha256="82e1eb1853f8497c4ff1a0c7fa26b9cd2f1253e2b6ffb93b4700fda907017302")
 

--- a/repos/spack_repo/builtin/packages/py_sspilib/package.py
+++ b/repos/spack_repo/builtin/packages/py_sspilib/package.py
@@ -17,6 +17,11 @@ class PySspilib(PythonPackage):
 
     license("MIT", checked_by="wdconinc")
 
+    version("0.5.0", sha256="b62f7f2602aa1add0505eee2417e2df24421224cb411e53bf3ae42a71b62fe98")  # FIXME
+    version("0.4.0", sha256="b482b3be8dc30e086f89e13831139129c022f90f6e7c0603b3c60209d9a4561d")  # FIXME
+    version("0.3.1", sha256="6df074ee54e3bd9c1bccc84233b1ceb846367ba1397dc52b5fae2846f373b154")  # FIXME
+    version("0.3.0", sha256="fd81593555a6ab5d3ef0dfb095fda005161ffe331dd991bbbe4592cfc4c27945")  # FIXME
+    version("0.2.0", sha256="4d6cd4290ca82f40705efeb5e9107f7abcd5e647cb201a3d04371305938615b8")  # FIXME
     version("0.1.0", sha256="58b5291553cf6220549c0f855e0e6973f4977375d8236ce47bb581efb3e9b1cf")
 
     depends_on("py-setuptools@61:", type="build")

--- a/repos/spack_repo/builtin/packages/py_wcwidth/package.py
+++ b/repos/spack_repo/builtin/packages/py_wcwidth/package.py
@@ -15,6 +15,17 @@ class PyWcwidth(PythonPackage):
 
     license("MIT")
 
+    version("0.6.0", sha256="cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159")  # FIXME
+    version("0.5.3", sha256="53123b7af053c74e9fe2e92ac810301f6139e64379031f7124574212fb3b4091")  # FIXME
+    version("0.5.2", sha256="c022c39a02a0134d1e10810da36d1f984c79648181efcc70a389f4569695f5ae")  # FIXME
+    version("0.5.0", sha256="f89c103c949a693bf563377b2153082bf58e309919dfb7f27b04d862a0089333")  # FIXME
+    version("0.4.0", sha256="46478e02cf7149ba150fb93c39880623ee7e5181c64eda167b6a1de51b7a7ba1")  # FIXME
+    version("0.3.5", sha256="7c3463f312540cf21ddd527ea34f3ae95c057fa191aa7a9e043898d20d636e59")  # FIXME
+    version("0.3.4", sha256="73d05c07549b4639b7956cd65a9edd35245d8700c0d3467fa723ad4b16dfe815")  # FIXME
+    version("0.3.3", sha256="f8f7d42c8a067d909b80b425342d02c423c5edc546347475e1d402fe3d35bb63")  # FIXME
+    version("0.3.2", sha256="d469b3059dab6b1077def5923ed0a8bf5738bd4a1a87f686d5e2de455354c4ad")  # FIXME
+    version("0.3.1", sha256="5aedb626a9c0d941b990cfebda848d538d45c9493a3384d080aff809143bd3be")  # FIXME
+    version("0.3.0", sha256="af1a2fb0b83ef4a7fc0682a4c95ca2576e14d0280bca2a9e67b7dc9f2733e123")  # FIXME
     version("0.2.14", sha256="4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605")
     version("0.2.7", sha256="1b6d30a98ddd5ce9bbdb33658191fd2423fc9da203fe3ef1855407dcb7ee4e26")
     version("0.2.5", sha256="c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83")


### PR DESCRIPTION
Add new versions for small standalone Python packages.

## Packages changed
- py-prometheus-client: add 0.23.0, 0.23.1
- py-pulp: add 2.7.0, 2.8.0
- py-wcwidth: add 0.3.0-0.6.0 series
- py-pyee: add 12.1.0, 12.1.1, 13.0.0
- py-sspilib: add 0.2.0-0.5.0 (Windows SSPI binding; used by py-pyspnego in PR #15)

## CI build status
In CI stacks: py-prometheus-client, py-pulp, py-wcwidth
Not in any CI stack: py-pyee

---
> This PR was prepared with AI assistance from GitHub Copilot.
> It will only be marked ready for review after human review of all changes.