### PR TITLE
.github/skills: add general package-update, py-package-update, and pr-review skills

### DIFF
--- a/.github/skills/cve-deprecation.md
+++ b/.github/skills/cve-deprecation.md
@@ -1,0 +1,362 @@
+# Skill: CVE-Driven Package Deprecation
+
+Identify Spack packages with known CVEs, assess severity, deprecate affected versions for
+HIGH/CRITICAL vulnerabilities, and ensure a fixed version is present for lower-severity ones.
+
+This skill complements [`package-update`](package-update.md). Read that skill for shared
+conventions (spack checksum, version ordering, PR workflow, etc.).
+
+## Usage
+
+```
+Audit packages in spack for CVE vulnerabilities and deprecate affected versions
+Audit py-requests for CVEs
+```
+
+## Step-by-Step Instructions
+
+---
+
+### Phase 1 — Enumerate vulnerable packages
+
+Fetch the full list of Spack packages with known vulnerabilities from Repology:
+
+```
+https://repology.org/projects/?inrepo=spack&vulnerable=1
+```
+
+The page is paginated. To advance past the last package name shown, append `&start=<last_name>`:
+
+```
+https://repology.org/projects/?inrepo=spack&vulnerable=1&start=<last_package_name>
+```
+
+For each entry, record:
+- The **Repology project name** (e.g., `apache`, `botan`, `openssl`)
+- The **version currently in Spack** (shown in bold with a triangle marker ▲)
+
+Continue paginating until all entries are collected or the target scope is met.
+
+---
+
+### Phase 2 — Collect CVEs for each package
+
+For each vulnerable package, fetch its CVE list from Repology:
+
+```
+https://repology.org/project/<repology-name>/cves
+```
+
+This page lists every CVE along with the **affected version ranges** as reported by NVD CPE
+data. Record:
+- Each CVE ID (e.g., `CVE-2025-55753`)
+- The affected version range(s) (e.g., `[2.4.30, 2.4.66)`, `(-∞, 2.2.14]`)
+
+Focus only on CVEs whose affected range **includes any version currently listed in the package's
+`package.py`**. Skip CVEs whose ranges do not overlap with any packaged version.
+
+---
+
+### Phase 3 — Fetch CVSS severity from NVD
+
+For each relevant CVE, query the NVD REST API:
+
+```
+https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=<CVE-ID>
+```
+
+The response JSON contains severity under `vulnerabilities[0].cve.metrics`. Check in priority
+order:
+
+1. `cvssMetricV40[*].cvssData.baseSeverity` — CVSS 4.0 (preferred if present)
+2. `cvssMetricV31[*].cvssData.baseSeverity` — CVSS 3.1
+3. `cvssMetricV30[*].cvssData.baseSeverity` — CVSS 3.0 (fallback)
+
+Use the **highest severity** across all available metric versions. Possible values: `CRITICAL`,
+`HIGH`, `MEDIUM`, `LOW`.
+
+If NVD has not yet assigned a CVSS score (`vulnStatus` is `"Awaiting Analysis"` or metrics are
+absent), treat the CVE as **unscored** and skip it — do not take action until a score is
+available.
+
+> **Rate limiting:** The NVD API allows 5 requests per 30 seconds without an API key, 50
+> requests per 30 second with one (set via `NVD_API_KEY` environment variable). Add a `0.6s`
+> delay between requests when unauthenticated, or use the `Nvd-Api-Key` request header:
+> ```sh
+> curl -H "apiKey: $NVD_API_KEY" \
+>   "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2025-55753"
+> ```
+
+---
+
+### Phase 4 — Determine action per package
+
+For each package, collect all relevant CVEs and their severities, then determine the highest
+severity CVE that affects the versions currently in `package.py`:
+
+| Highest severity of any affecting CVE | Action |
+|---|---|
+| **CRITICAL** or **HIGH** | Deprecate all affected versions (Phase 5) |
+| **MEDIUM** or **LOW** | Ensure a fixed version is present (Phase 6) |
+| Unscored / not affecting any packaged version | Skip |
+
+---
+
+### Phase 5 — Deprecate affected versions (CRITICAL / HIGH CVEs)
+
+#### 5a. Identify the Spack package directory
+
+Map the Repology project name to the Spack package directory name. The Spack name uses hyphens;
+the directory uses underscores. Check both:
+- `repos/spack_repo/builtin/packages/<repology_name>/package.py`
+- `repos/spack_repo/builtin/packages/<repology_name_with_underscores>/package.py`
+
+If the package does not exist under that name, search for it:
+```sh
+ls repos/spack_repo/builtin/packages/ | grep -i <repology_name>
+```
+
+#### 5b. Determine which versions in `package.py` are affected
+
+Using the NVD CPE version ranges for the CVE (from the NVD API response,
+`configurations[*].nodes[*].cpeMatch[*]`):
+- `versionStartIncluding` / `versionStartExcluding`: lower bound (inclusive/exclusive)
+- `versionEndIncluding` / `versionEndExcluding`: upper bound (inclusive/exclusive)
+
+Cross-reference against every `version(...)` call in `package.py`. Mark a version as affected
+if it falls within any CPE match range.
+
+**Example:** CVE affects `[2.4.30, 2.4.66)` → versions `2.4.30` through `2.4.65` are affected;
+`2.4.66` and later are safe.
+
+#### 5c. Add `deprecated=True` to affected version entries
+
+For a **single** affected version:
+```python
+version(
+    "2.4.62",
+    sha256="...",
+    deprecated=True,
+)
+```
+
+For **multiple consecutive** affected versions, use `default_args` to avoid repetition:
+```python
+with default_args(deprecated=True):
+    version("2.4.62", sha256="...")
+    version("2.4.61", sha256="...")
+    version("2.4.59", sha256="...")
+```
+
+Place the `with default_args(deprecated=True):` block immediately after the last non-deprecated
+version entry so that the newest-first ordering is preserved. If some versions in the list are
+**not** affected (e.g., an older series below the CVE's range), do not include them in the
+block — mark only the affected ones.
+
+**Do not remove any version entries.** Deprecation marks them as unsafe while keeping them
+buildable for users who explicitly opt in.
+
+#### 5d. Add a comment citing the CVE(s)
+
+Immediately above the deprecated block, add a comment listing the CVE IDs and the fix version:
+
+```python
+# Deprecated due to CVE-2025-55753 (HIGH): integer overflow in ACME renewal.
+# Upgrade to 2.4.66 or later.
+with default_args(deprecated=True):
+    version("2.4.62", sha256="...")
+```
+
+For multiple CVEs affecting the same versions, list them all:
+
+```python
+# Deprecated due to CVE-2024-XXXXX (CRITICAL), CVE-2025-YYYYY (HIGH).
+# Upgrade to 2.4.66 or later.
+```
+
+#### 5e. Ensure the fixed version is present
+
+The fix version is identified from the NVD description ("`upgrade to version X.Y.Z`") or from
+the CPE range upper bound. If the fixed version is **not already in `package.py`**, add it using
+`spack checksum` (see [`package-update`](package-update.md) Phase 3a) before adding the
+deprecation block. A deprecated version without an available fix leaves users with no upgrade
+path.
+
+---
+
+### Phase 6 — Add fixed version (MEDIUM / LOW CVEs)
+
+For packages with only MEDIUM or LOW severity CVEs, do not deprecate. Instead, verify that a
+version which resolves all known CVEs is present in `package.py`.
+
+1. Identify the minimum fixed version from the NVD CPE data (the `versionEndExcluding` value,
+   or the version recommended in the CVE description).
+2. If the fixed version (or any later version) is already in `package.py`, no action is needed —
+   log "fixed version already present" and skip.
+3. If no fixed version is present, add it using `spack checksum` following the instructions in
+   [`package-update`](package-update.md) Phase 3a.
+
+---
+
+### Phase 7 — Search for existing PRs
+
+Before opening new PRs, check for open PRs that already address any of the same packages:
+
+```sh
+gh pr list --repo spack/spack-packages --state open \
+  --search "<package-name> CVE" --limit 20
+gh pr list --repo spack/spack-packages --state open \
+  --search "<package-name> deprecat" --limit 20
+```
+
+Follow the coordination rules from [`package-update`](package-update.md) Phase 6: defer to
+existing PRs for overlapping packages and use `Needs: - [ ] #PR` for prerequisites.
+
+---
+
+### Phase 8 — Open draft PRs
+
+Group changes into PRs by package or ecosystem. Security PRs should be kept small and focused —
+prefer one package per PR unless packages are tightly coupled (e.g., `openssl` + `openssl@1.1`).
+
+#### 8a. Branch naming
+
+```
+cve/<package-name>-<CVE-ID-or-year>
+```
+
+Examples: `cve/apache-CVE-2025-55753`, `cve/openssl-2025`.
+
+#### 8b. Commit message
+
+```
+<pkg>: deprecate versions affected by <CVE-ID(s)>
+
+<pkg>@<range>: deprecated due to <CVE-ID> (<severity>).
+Fixed in <pkg>@<fix-version>.
+```
+
+For version additions only (MEDIUM/LOW):
+```
+<pkg>: add v<version>, fixing <CVE-ID(s)>
+```
+
+#### 8c. PR title
+
+```
+<pkg>: deprecate versions affected by <CVE-ID> (<severity>)
+<pkg>: add v<version>, fixing <CVE-ID(s)>
+```
+
+#### 8d. PR description template
+
+```markdown
+## Summary
+
+Security update for `<package>`:
+
+| CVE | Severity | Affected versions | Fixed in |
+|-----|----------|-------------------|----------|
+| [CVE-YYYY-NNNNN](https://nvd.nist.gov/vuln/detail/CVE-YYYY-NNNNN) | HIGH | `<range>` | `<fix-version>` |
+
+## Changes
+
+<Describe what was done: which versions deprecated, which version added, and why.>
+
+## Deprecation rationale
+
+<Quote or paraphrase the NVD description for each CVE. Include a link to the vendor advisory
+if one is listed in the NVD references.>
+
+## Needs
+
+<List prerequisite PRs if the fixed version depends on a not-yet-merged PR. Omit if none.>
+- [ ] #<PR-number>
+
+## Related PRs
+
+<List any coordinating or overlapping PRs. If none, write "None.">
+
+---
+> ⚠️ This PR was prepared with AI assistance from GitHub Copilot.
+> It will only be marked ready for review after human review of all changes.
+```
+
+#### 8e. Open as draft
+
+```sh
+gh pr create \
+  --draft \
+  --base develop \
+  --head <fork-owner>:<branch> \
+  --title "<title>" \
+  --body-file <body-file> \
+  --repo spack/spack-packages
+```
+
+---
+
+### Phase 9 — Validate before pushing
+
+1. For every `deprecated=True` version, confirm the CVE range includes that version by
+   re-checking the NVD CPE match criteria.
+2. Confirm the fixed version (if added) is **not** in the deprecated block.
+3. Confirm no version was removed — only `deprecated=True` added.
+4. Confirm each `deprecated=True` block has a CVE comment above it.
+5. Run style checks and package audit (see [`package-update`](package-update.md) Phase 8).
+
+---
+
+## Conventions Reference
+
+| Convention | Rule |
+|---|---|
+| Deprecation syntax (single) | `version("X.Y.Z", sha256="...", deprecated=True)` |
+| Deprecation syntax (bulk) | `with default_args(deprecated=True):` block |
+| CVE comment | Required above every deprecation block |
+| Fixed version | Must be present in `package.py`; add via `spack checksum` if absent |
+| Version removal | Never — only add `deprecated=True` |
+| Severity threshold for deprecation | HIGH or CRITICAL only |
+| Unscored CVEs | Skip; do not act without a CVSS score |
+| PR state | Always open as draft |
+| AI attribution | Required in every PR description |
+
+## Common Pitfalls
+
+- **Do not deprecate based on unscored CVEs.** NVD sometimes publishes CVEs before completing
+  analysis. If `vulnStatus` is `"Awaiting Analysis"` or no CVSS metrics are present, skip the
+  CVE and re-check later.
+- **Do not deprecate versions outside the CVE range.** Check each version individually against
+  the CPE match criteria — do not assume all older versions are affected.
+- **Do not deprecate the fixed version.** The version identified as the fix must remain
+  non-deprecated.
+- **Leave a migration path.** Never deprecate all versions without ensuring the fixed version is
+  present. If the fixed version is not yet in `package.py`, add it before (or in the same commit
+  as) the deprecation block.
+- **Repology names may differ from Spack names.** Repology uses its own canonical project names
+  (e.g., `apache` for `apache-http-server`). Always verify the Spack package name by checking
+  the packages directory.
+- **Multiple CVE ranges.** A package may have several CVEs with different affected ranges. Only
+  deprecate a version if **at least one** HIGH/CRITICAL CVE covers it.
+
+## Example
+
+**Scenario:** `apache` in Spack is at `2.4.62`. CVE-2025-55753 (HIGH, CVSS 7.5) affects
+`[2.4.30, 2.4.66)`. The fix is `2.4.66`, not yet in `package.py`.
+
+**Steps:**
+1. Run `spack checksum apache 2.4.66` → get the new version line.
+2. Add `version("2.4.66", sha256="<checksum>")` above the current highest version.
+3. Mark all `2.4.30`–`2.4.65` entries with `deprecated=True`:
+
+```python
+version("2.4.66", sha256="<new-checksum>")
+
+# Deprecated due to CVE-2025-55753 (HIGH): integer overflow in ACME renewal.
+# Upgrade to 2.4.66 or later.
+with default_args(deprecated=True):
+    version("2.4.62", sha256="...")
+    version("2.4.61", sha256="...")
+    version("2.4.59", sha256="...")
+    # ... all versions >= 2.4.30 and < 2.4.66
+```

--- a/.github/skills/package-update.md
+++ b/.github/skills/package-update.md
@@ -1,0 +1,352 @@
+# Skill: General Package Version Update (Bulk)
+
+Perform a bulk update of many packages across one or more ecosystems in this Spack repository.
+This skill covers the full workflow: inventorying locally modified packages, verifying dependency
+changes introduced by new versions, grouping the changes into coherent pull requests, and
+submitting all PRs as drafts for human review.
+
+Use the more focused [`py-package-update`](py-package-update.md) skill for smaller, targeted
+updates of Python packages.
+
+## Usage
+
+Invoke this skill when the working tree already contains many modified `package.py` files that
+need to be committed and submitted, or when you want to refresh a broad set of packages to their
+latest upstream releases:
+
+```
+Update all locally modified packages and open PRs
+Update all packages in the HEP stack to their latest versions
+```
+
+## Step-by-Step Instructions
+
+---
+
+### Phase 1 — Inventory the modified packages
+
+#### 1a. List all modified package files
+
+```sh
+git diff --name-only HEAD | grep 'packages/' | sort
+```
+
+Also check for new (untracked) package directories that should be included:
+
+```sh
+git status --short | grep '^\?\?' | grep 'packages/'
+```
+
+Note any new packages (entirely new directories), new patch files, and packages with
+structural changes beyond just version bumps.
+
+#### 1b. Classify each package
+
+For each modified file record:
+
+- Package name (Spack name with hyphens)
+- Highest new version being added
+- Whether the change is: version-only, dependency change, build-system change, new package,
+  or new patch file
+
+---
+
+### Phase 2 — Verify dependency changes for each package
+
+For every modified package, determine what dependency changes the **new versions** introduce.
+This requires comparing the upstream build specification of the new version against the
+previously packaged version.
+
+#### 2a. Locate the upstream source
+
+The upstream source is identified by the `pypi`, `url`, or `git` attribute in `package.py`.
+
+- **PyPI packages** (`pypi =`): fetch `https://pypi.org/pypi/<dist-name>/json` to get the
+  release list. Download and inspect the `pyproject.toml`, `setup.cfg`, or `setup.py` for the
+  new version from the sdist tarball link under `releases[<version>]`.
+- **GitHub-hosted packages** (`url =` or `git =`): use the GitHub API or `git ls-remote` to
+  check for new tags. Inspect the relevant build config files at the tagged commit.
+- **Autotools/CMake packages**: inspect `configure.ac`, `CMakeLists.txt`, and any
+  `*Config.cmake.in` or `*-config.cmake.in` files for `find_package`, `pkg_check_modules`, and
+  minimum version requirements.
+
+Use parallel sub-agents (one per ecosystem or logical group) to speed up the analysis phase.
+
+#### 2b. Inspect the upstream build config at the new version
+
+| Build system | Files to inspect | What to look for |
+|---|---|---|
+| Python/PyPI | `pyproject.toml`, `setup.cfg`, `setup.py` | `requires-python`, `dependencies`, `[build-system].requires` |
+| CMake | `CMakeLists.txt`, `cmake/Find*.cmake` | `find_package(Foo VERSION X.Y REQUIRED)` |
+| Autotools | `configure.ac`, `Makefile.am` | `AC_CHECK_LIB`, `PKG_CHECK_MODULES`, version constraints |
+| Meson | `meson.build` | `dependency(...)` calls with version constraints |
+
+#### 2c. Classify each detected change
+
+For every upstream change found:
+
+| Upstream change | Action in `package.py` |
+|---|---|
+| New runtime dependency added | Add `depends_on("pkg", type=("build","run"), when="@<new_version>:")` |
+| New build-only dependency added | Add `depends_on("pkg", type="build", when="@<new_version>:")` |
+| Dependency removed | Restrict existing `depends_on` with `when="@:<previous_version>"` |
+| Minimum version constraint tightened | Add a new `depends_on` with the tighter constraint gated with `when="@<new_version>:"` |
+| Python/language minimum version raised | Add `depends_on("python@X.Y:", ..., when="@<new_version>:")` |
+| Build system changed (e.g., autotools → CMake) | Change base class or add conditional `build_system()` |
+
+#### 2d. Version range notation
+
+Spack version ranges are **upper-limit-inclusive**: `@3.8:3.10` includes `3.10` itself.
+
+- Upstream `>=3.8` → `@3.8:`
+- Upstream `>=3.8,<3.11` → `@3.8:3.10` (3.10 is the last included version)
+- Upstream `>=1.20,<2` → `@1.20:1`
+- An exact half-open upper bound `<2` → `:1`
+
+Never write `:3.10.99` or `:1.99` — use the last actual release of the series.
+
+#### 2e. Python package name mapping
+
+Use the `py-` prefix for Python packages (e.g., `numpy` → `py-numpy`, `scipy` → `py-scipy`).
+Non-Python dependency names follow standard Spack naming (e.g., `libfoo`, `boost`).
+
+---
+
+### Phase 3 — Apply the changes
+
+Make all edits directly in the local `package.py` files (and add any patch files).
+
+#### 3a. Adding new versions
+
+Add `version(...)` lines **above** the currently highest version, maintaining newest-first order.
+Obtain SHA256 checksums using `spack checksum`:
+
+```sh
+spack checksum <package-name> <new-version>
+```
+
+Do not manually compute checksums. Do not modify `url`, `homepage`, `pypi`, `git`, `maintainers`,
+or the copyright header unless the upstream release requires it.
+
+#### 3b. Structural changes
+
+When a new version requires a build-system change (e.g., a package switching from Autotools to
+CMake at version 2.0):
+
+```python
+class Foo(AutotoolsPackage, CMakePackage):
+    build_system("autotools", default="autotools", when="@:1")
+    build_system("cmake", default="cmake", when="@2:")
+```
+
+Keep both base classes active so existing older versions continue to build.
+
+#### 3c. New packages
+
+If a new upstream dependency does not yet exist in the repository, create its `package.py` before
+adding the `depends_on(...)` reference. Follow the [`py-package-update`](py-package-update.md)
+conventions for Python packages.
+
+---
+
+### Phase 4 — Group changes into coherent PRs
+
+Avoid "kitchen-sink" PRs. Instead, group changes so that each PR is independently reviewable and
+mergeable.
+
+#### 4a. Grouping principles
+
+- **Dependency relationships**: if package A depends on package B and both are being updated,
+  include them in the same PR. Reviewers can then verify the full dependency chain at once.
+- **Ecosystem coherence**: packages that are always released together (e.g., `boto3` + `botocore`
+  + `s3transfer`) belong in the same PR.
+- **Technology area**: group by general purpose (e.g., X11 display libraries, HEP generators,
+  Python packaging infra) to reduce context-switching for reviewers.
+- **Size**: aim for 5–25 packages per PR. Fewer is better when the changes are structural or
+  involve new build-system classes.
+
+#### 4b. Branch naming
+
+```
+pr<NN>-<short-descriptor>
+```
+
+Examples: `pr01-xorg-x11-libs`, `pr12-python-packaging-infra`, `pr07-hep-generators`.
+
+Use zero-padded two-digit PR numbers for lexicographic ordering.
+
+#### 4c. Staging branch
+
+Create a single `staging-all-changes` branch that commits **all** modified files in one go.
+Then create each per-PR branch from `develop` and selectively cherry-pick files from staging:
+
+```sh
+git checkout develop
+git checkout -b pr<NN>-<descriptor>
+git checkout staging-all-changes -- repos/spack_repo/builtin/packages/<pkg1>/
+git checkout staging-all-changes -- repos/spack_repo/builtin/packages/<pkg2>/
+# ... repeat for each package in this PR group
+git commit -m "<title>
+
+<summary of changes>"
+```
+
+This approach keeps each branch independent and rebasing is trivial.
+
+---
+
+### Phase 5 — Check CI / cache status
+
+Before writing PR descriptions, determine which new versions are already in the binary cache
+(`cache.spack.io`) and which will need new CI builds. This helps reviewers set expectations.
+
+For each new version of a package, check:
+
+```sh
+curl -s "https://cache.spack.io/package/develop/<spack-pkg-name>/specs/" | \
+  python3 -c "import sys,re; data=sys.stdin.read(); vers=re.findall(r'\"versions\":\[\"([^\"]+)\"', data); [print(v) for v in sorted(set(vers))]"
+```
+
+Packages not appearing in any CI stack output should be noted in the PR description so reviewers
+know there is no automated build verification available for them.
+
+---
+
+### Phase 6 — Search for existing PRs
+
+Before opening new PRs, search for open or recently closed PRs that overlap with your changes:
+
+```sh
+gh pr list --repo spack/spack-packages --state open --search "<package-name>" --limit 20
+```
+
+For each overlapping PR found:
+
+- **Our PR is a strict superset of theirs**: note it in your PR description ("Supersedes #NNNN").
+  **Do not close the existing PR yourself.** Post a comment in the existing PR pointing to the
+  new PR number:
+  ```
+  This work has been superseded by #<new-PR>. Please see that PR for the same and additional changes.
+  ```
+  Let the maintainers or the existing PR author decide whether to close it.
+- **Our PR has partial overlap**: note it as a related PR ("Coordinates with #NNNN") and describe
+  which packages overlap, so maintainers can sequence the merges.
+- **Their PR introduces new packages or constraints we depend on**: mark it as a prerequisite
+  ("Requires #NNNN to be merged first") and coordinate with the author.
+
+> **Do not close other authors' PRs.** Even for your own previous PRs, prefer posting a comment
+> rather than closing them, unless you are certain the newer PR is a complete and correct
+> replacement. Human reviewers make the final call.
+
+---
+
+### Phase 7 — Open draft PRs
+
+#### 7a. PR description template
+
+Every PR must use the following template. Replace `<...>` placeholders throughout:
+
+```markdown
+## Summary
+
+Updated the following packages to their latest upstream releases:
+
+| Package | Old version | New version |
+|---------|-------------|-------------|
+| `<name>` | `<old>` | `<new>` |
+
+## Dependency changes
+
+<List each change: package, what changed, which version introduced the change.
+If none, write "No dependency changes.">
+
+## CI build status
+
+**In CI stacks (binary cache available):** <list>
+**Not in any CI stack (will trigger new builds):** <list, or "N/A">
+
+## Related PRs
+
+<List any superseded, coordinating, or prerequisite PRs. If none, write "None.">
+
+---
+> ⚠️ This PR was prepared with AI assistance from GitHub Copilot.
+> It will only be marked ready for review after human review of all changes.
+```
+
+#### 7b. Open as draft
+
+Always open PRs in **draft** mode:
+
+```sh
+gh pr create \
+  --draft \
+  --base develop \
+  --head <fork-owner>:<branch> \
+  --title "<title>" \
+  --body-file <body-file> \
+  --repo spack/spack-packages
+```
+
+Writing the body to a temporary file avoids shell quoting issues with multi-line descriptions.
+
+#### 7c. Post follow-up comments on related existing PRs
+
+After creating your PRs, post a comment on each existing PR that is superseded or coordinated
+with yours. Include the new PR number(s) so that maintainers can easily cross-reference:
+
+```sh
+gh pr comment <existing-PR-number> \
+  --repo spack/spack-packages \
+  --body "This work has been superseded by #<new-PR>, which includes the same changes as a subset of a broader update. Please see #<new-PR> for context."
+```
+
+---
+
+### Phase 8 — Validate before marking ready
+
+Before removing the draft status from any PR, verify:
+
+1. All `version(...)` lines were generated by `spack checksum` (correct SHA256).
+2. All new `depends_on` entries use the correct Spack name (with `py-` prefix for Python).
+3. All `depends_on` calls have a `type=` argument.
+4. All upper-bound version constraints are written in inclusive form.
+5. No pre-existing unrelated code was modified.
+6. If a new package was added, it has a proper `homepage`, `url`/`pypi`/`git`, `license`, and
+   at least one `version(...)` with a correct checksum.
+7. CI or the binary cache provides coverage for at least the most commonly used versions.
+
+---
+
+## Conventions Reference
+
+| Convention | Rule |
+|---|---|
+| Directory names | Use underscores: `py_numpy`, `libfoo_bar` |
+| Spack package names | Use hyphens: `py-numpy`, `libfoo-bar` |
+| Python deps | Always use `py-` prefix in `depends_on()` |
+| `type=` on all deps | Required; never omit |
+| Version ordering | Newest first |
+| Version upper bounds | Inclusive form: `:3.10`, `:1`, never `:3.10.99` |
+| PR state | Always open as draft; human removes draft status |
+| Closing PRs | Never close another author's PR; post a comment instead |
+| Copyright header | Do not modify |
+| License identifier | All packages: `Apache-2.0 OR MIT` |
+| AI attribution | Required in every PR description (see template above) |
+
+## Common Pitfalls
+
+- **Do not compute SHA256 manually** — always use `spack checksum`. Manual checksums are
+  error-prone.
+- **Do not add an upper bound speculatively** — e.g., do not write `@1.5:2` just because version
+  3 of a dep hasn't been tested. Only add upper bounds when the upstream package declares a
+  strict incompatibility.
+- **Dual build-system packages** — when a new major version switches build systems, keep both
+  base classes and use `build_system()` with `when=` guards, so older versions still build.
+- **Naming collision** — confirm the new package name doesn't already exist under a different
+  name before creating a new package.
+- **New package as a dep** — if you add `depends_on("py-foo")` but `py-foo` doesn't exist yet
+  in the repo, create it in the same PR or a prerequisite PR. A dangling dependency reference
+  will fail CI.
+- **`py-sspilib` / Windows-only packages** — some packages only install on specific platforms.
+  Use `sys_type()` or `when="platform=windows"` guards as appropriate.

--- a/.github/skills/package-update.md
+++ b/.github/skills/package-update.md
@@ -348,6 +348,20 @@ Before removing the draft status from any PR, verify:
    at least one `version(...)` with a correct checksum.
 7. CI or the binary cache provides coverage for at least the most commonly used versions.
 
+#### CI timing
+
+After a PR is pushed, two rounds of CI feedback are available:
+
+| Stage | When results appear | What is checked |
+|---|---|---|
+| First-stage checks (GitHub Actions) | ~10 minutes | Style (`spack style`), audit (`spack audit`), license headers, package naming conventions |
+| Full pipeline (GitLab CI at `gitlab.spack.io/spack/spack-packages`) | up to 1 hour | Package builds across all supported compilers and platforms; any build failures are visible here |
+
+Wait for first-stage results before asking a reviewer to look at the PR — style and audit
+failures are quick to fix and should be resolved before human review. Wait for (or note the
+status of) the full GitLab pipeline before marking the PR ready for review, so that build
+failures from the new versions are visible and can be addressed.
+
 ---
 
 ## Conventions Reference

--- a/.github/skills/package-update.md
+++ b/.github/skills/package-update.md
@@ -118,13 +118,16 @@ Make all edits directly in the local `package.py` files (and add any patch files
 
 #### 3a. Adding new versions
 
-**Add only the latest upstream release** — do not add every intermediate patch release.
-For example, if the current highest version in `package.py` is `1.2.3` and upstream has released
-`1.2.4`, `1.2.5`, and `1.3.0`, add only `1.3.0`. Keeping a long list of patch versions adds
-maintenance burden and slows resolution without benefiting users, who can always use the latest.
+**Add only the latest patch release per minor series** — do not add every intermediate patch
+release. For each `major.minor` series, add only the highest patch version. For example, if
+`package.py` currently has `1.2.3` and upstream has released `1.2.4`, `1.2.5`, and `1.3.0`,
+add `1.2.5` (latest of the 1.2.x series, if you need the 1.2.x entry at all) and `1.3.0`
+(latest of the new 1.3.x series). In most cases you only need the single latest release.
+Keeping a long list of patch versions adds maintenance burden and slows resolution without
+benefiting users, who can always use the latest.
 
 **Do not remove existing versions.** Removing versions breaks users who have pinned an older
-release in their `spack.yaml`. Only add the new entry.
+release in their `spack.yaml`. Only add new entries.
 
 Add the `version(...)` line **above** the currently highest version, maintaining newest-first order.
 Obtain SHA256 checksums using `spack checksum`:
@@ -132,6 +135,25 @@ Obtain SHA256 checksums using `spack checksum`:
 ```sh
 spack checksum <package-name> <new-version>
 ```
+
+> **Remove `# FIXME` comments from version lines.** `spack checksum` appends `# FIXME` to
+> `version(...)` lines when it cannot immediately verify the checksum against an existing entry.
+> These comments must be removed before committing — they are not informative once checksums are
+> confirmed and will be flagged as noise in review. After running `spack checksum`, strip any
+> trailing `# FIXME` from every version line you add:
+>
+> ```python
+> # Wrong — do not commit this:
+> version("1.3.0", sha256="abc123...")  # FIXME
+>
+> # Correct:
+> version("1.3.0", sha256="abc123...")
+> ```
+>
+> A quick way to remove all such comments in bulk before committing:
+> ```sh
+> sed -i 's/  # FIXME$//' repos/spack_repo/builtin/packages/<pkg>/package.py
+> ```
 
 Do not manually compute checksums. Do not modify `url`, `homepage`, `pypi`, `git`, `maintainers`,
 or the copyright header unless the upstream release requires it.
@@ -432,13 +454,29 @@ failures from the new versions are visible and can be addressed.
 
 ## Common Pitfalls
 
-- **Do not add every patch version** — add only the latest upstream release. If upstream has
-  released `1.2.4`, `1.2.5`, and `1.3.0` and the repo has `1.2.3`, add only `1.3.0`. Users
-  who need a specific patch can pin it themselves; listing every patch clutters the file.
+- **Add only the latest patch per minor series** — for each `major.minor` series, include
+  only the highest patch release. If upstream released `1.2.4`, `1.2.5`, `1.3.0`, `1.3.1`,
+  and the repo has `1.2.3`, add only `1.2.5` (if a 1.2.x entry is needed) and `1.3.1`. In
+  most cases only the single overall latest version is required. If you used `spack checksum`
+  and inadvertently generated a long list of patch versions, run the following to keep only
+  the highest per minor series before committing:
+  ```python
+  # For each (major, minor) group of newly-added versions, keep only the max patch.
+  # Pre-existing versions in the file are never removed.
+  import re, subprocess
+  from collections import defaultdict
+  def ver_tuple(v):
+      try: return tuple(int(x) for x in v.split("."))
+      except ValueError: return None
+  # see scripts/fix_patch_versions.py for a complete implementation
+  ```
 - **Do not remove old versions** — removing a version breaks users who have pinned it. Only
   add; never subtract.
 - **Do not compute SHA256 manually** — always use `spack checksum`. Manual checksums are
   error-prone.
+- **Remove `# FIXME` from version lines** — `spack checksum` appends `# FIXME` to lines whose
+  checksums it cannot verify inline. Always strip these before committing. The style checker
+  does not catch them, but they clutter the diff and confuse reviewers.
 - **Do not add an upper bound speculatively** — e.g., do not write `@1.5:2` just because version
   3 of a dep hasn't been tested. Only add upper bounds when the upstream package declares a
   strict incompatibility.

--- a/.github/skills/package-update.md
+++ b/.github/skills/package-update.md
@@ -173,8 +173,9 @@ mergeable.
 - **Size**: aim for 5–25 packages per PR. Fewer is better when the changes are structural or
   involve new build-system classes.
 
-#### 4b. Branch naming
+#### 4b. Branch naming and PR title
 
+**Branch name:**
 ```
 pr<NN>-<short-descriptor>
 ```
@@ -182,6 +183,29 @@ pr<NN>-<short-descriptor>
 Examples: `pr01-xorg-x11-libs`, `pr12-python-packaging-infra`, `pr07-hep-generators`.
 
 Use zero-padded two-digit PR numbers for lexicographic ordering.
+
+**PR title** — prefer the canonical form:
+
+```
+<pkgname>: add v<version>
+```
+
+For a single package: `py-dask: add v2025.7.0`
+
+When multiple packages in the same ecosystem are updated together, name the PR after the
+root/primary package:
+
+```
+<root-pkg>: add v<version>
+<root-pkg>, <pkg2>, <pkg3>: add v<version>
+<root-pkg> and related packages: add v<version>
+```
+
+Examples:
+- `py-awkward: add v2.9.0` (even though awkward-cpp is also bumped)
+- `py-boto3, py-botocore, py-s3transfer: add v1.42.x`
+- `boost: add v1.90.0`
+- `harfbuzz, cairo, pango: add v<version>` (rendering stack, listed dependency-first)
 
 #### 4c. Staging branch
 

--- a/.github/skills/package-update.md
+++ b/.github/skills/package-update.md
@@ -494,18 +494,9 @@ failures from the new versions are visible and can be addressed.
   only the highest patch release. If upstream released `1.2.4`, `1.2.5`, `1.3.0`, `1.3.1`,
   and the repo has `1.2.3`, add only `1.2.5` (if a 1.2.x entry is needed) and `1.3.1`. In
   most cases only the single overall latest version is required. If you used `spack checksum`
-  and inadvertently generated a long list of patch versions, run the following to keep only
-  the highest per minor series before committing:
-  ```python
-  # For each (major, minor) group of newly-added versions, keep only the max patch.
-  # Pre-existing versions in the file are never removed.
-  import re, subprocess
-  from collections import defaultdict
-  def ver_tuple(v):
-      try: return tuple(int(x) for x in v.split("."))
-      except ValueError: return None
-  # see scripts/fix_patch_versions.py for a complete implementation
-  ```
+  and inadvertently generated a long list of patch versions, run the helper script
+  `scripts/fix_patch_versions.py` to keep only the highest patch per minor series before
+  committing.
 - **Do not remove old versions** — removing a version breaks users who have pinned it. Only
   add; never subtract.
 - **Do not compute SHA256 manually** — always use `spack checksum`. Manual checksums are

--- a/.github/skills/package-update.md
+++ b/.github/skills/package-update.md
@@ -155,7 +155,7 @@ spack checksum <package-name> <new-version>
 > sed -i 's/  # FIXME$//' repos/spack_repo/builtin/packages/<pkg>/package.py
 > ```
 
-Do not manually compute checksums. Do not modify `url`, `homepage`, `pypi`, `git`, `maintainers`,
+Do not manually compute checksums. Do not modify `url`, `homepage`, `pypi`, `git`, `maintainers`, `license`
 or the copyright header unless the upstream release requires it.
 
 #### 3b. Structural changes
@@ -173,9 +173,8 @@ Keep both base classes active so existing older versions continue to build.
 
 #### 3c. New packages
 
-If a new upstream dependency does not yet exist in the repository, create its `package.py` before
-adding the `depends_on(...)` reference. Follow the [`py-package-update`](py-package-update.md)
-conventions for Python packages.
+If an upstream dependency does not yet exist in the repository, create the package before adding the `depends_on(...)` reference.
+The `spack create` command will generate a recipe scaffold.
 
 ---
 

--- a/.github/skills/package-update.md
+++ b/.github/skills/package-update.md
@@ -314,6 +314,23 @@ Updated the following packages to their latest upstream releases:
 <List each change: package, what changed, which version introduced the change.
 If none, write "No dependency changes.">
 
+## Version diff links
+
+For packages whose source is hosted on GitHub or GitLab, include a comparison link
+from the previous Spack version to the newly added version. This greatly aids reviewers
+in assessing the scope of changes without leaving the PR:
+
+- [pkg-name: old → new](https://github.com/org/repo/compare/old-tag...new-tag)
+
+To generate these links automatically, inspect the `git =` and `url =` attributes in
+`package.py` to determine:
+1. The hosting service (GitHub → `/compare/`, GitLab → `/-/compare/`)
+2. The tag format (inferred from the `url` pattern: `v{ver}`, `{ver}`, or `prefix-{ver}`)
+3. The previous Spack version (highest version in `develop` strictly below the new one)
+
+For packages hosted elsewhere (SourceForge, custom tarballs without a `git =`) omit the link.
+If `n_new > 1` (multiple intermediate versions were skipped), add a note like `(+N intermediate)`.
+
 ## CI build status
 
 **In CI stacks (binary cache available):** <list>

--- a/.github/skills/package-update.md
+++ b/.github/skills/package-update.md
@@ -268,29 +268,42 @@ know there is no automated build verification available for them.
 
 ### Phase 6 — Search for existing PRs
 
-Before opening new PRs, search for open or recently closed PRs that overlap with your changes:
+Before opening new PRs, search for open PRs that overlap with your changes:
 
 ```sh
 gh pr list --repo spack/spack-packages --state open --search "<package-name>" --limit 20
 ```
 
-For each overlapping PR found:
+**Existing PRs that include any of the same version upgrades take priority.** For each
+overlapping PR found, apply the following rules:
 
-- **Our PR is a strict superset of theirs**: note it in your PR description ("Supersedes #NNNN").
-  **Do not close the existing PR yourself.** Post a comment in the existing PR pointing to the
-  new PR number:
+- **An existing PR already upgrades some of the same packages**: those packages belong to that
+  PR. **Remove them from your PR** and instead list the existing PR as a dependency using the
+  `Needs:` block in your PR description (see template in Phase 7). Your PR must not be merged
+  before the dependency PR is merged.
+
+  Example `Needs:` block:
+  ```markdown
+  ## Needs
+  - [ ] #1234
   ```
-  This work has been superseded by #<new-PR>. Please see that PR for the same and additional changes.
+
+  Post a comment in the existing PR to signal awareness:
   ```
-  Let the maintainers or the existing PR author decide whether to close it.
-- **Our PR has partial overlap**: note it as a related PR ("Coordinates with #NNNN") and describe
-  which packages overlap, so maintainers can sequence the merges.
-- **Their PR introduces new packages or constraints we depend on**: mark it as a prerequisite
-  ("Requires #NNNN to be merged first") and coordinate with the author.
+  This PR (#<new-PR>) depends on your work here. I've removed the overlapping packages
+  from my PR and listed this one as a prerequisite.
+  ```
+
+- **An existing PR introduces new packages or constraints our new `depends_on` entries
+  reference**: mark it as a prerequisite with the same `Needs:` block and coordinate with the
+  author so both PRs can be merged in the correct order.
+
+- **The overlap is only incidental** (same package, different version ranges that do not
+  conflict): note it as a related PR in the "Related PRs" section and describe the relationship
+  so maintainers can sequence the merges.
 
 > **Do not close other authors' PRs.** Even for your own previous PRs, prefer posting a comment
-> rather than closing them, unless you are certain the newer PR is a complete and correct
-> replacement. Human reviewers make the final call.
+> rather than closing them. Human reviewers make the final call on which PR to merge.
 
 ---
 
@@ -336,9 +349,15 @@ If `n_new > 1` (multiple intermediate versions were skipped), add a note like `(
 **In CI stacks (binary cache available):** <list>
 **Not in any CI stack (will trigger new builds):** <list, or "N/A">
 
+## Needs
+
+<List prerequisite PRs that must be merged before this one, using unchecked task items.
+If none, omit this section entirely.>
+- [ ] #<PR-number>
+
 ## Related PRs
 
-<List any superseded, coordinating, or prerequisite PRs. If none, write "None.">
+<List any coordinating PRs that partially overlap but are not strict prerequisites. If none, write "None.">
 
 ---
 > ⚠️ This PR was prepared with AI assistance from GitHub Copilot.

--- a/.github/skills/package-update.md
+++ b/.github/skills/package-update.md
@@ -348,13 +348,61 @@ Before removing the draft status from any PR, verify:
    at least one `version(...)` with a correct checksum.
 7. CI or the binary cache provides coverage for at least the most commonly used versions.
 
+#### Run style and audit checks locally before pushing
+
+Run the style checker against the `develop` base to catch formatting issues before CI sees them.
+The repository uses `flake8`, `isort`, and `black` via a wrapper script:
+
+```sh
+# Check only (shows what would be fixed):
+.ci/style_check.sh develop
+
+# Auto-fix formatting issues:
+.ci/style_check.sh --fix develop
+```
+
+The script requires a `spack-core` directory (a clone of `spack/spack`) to be present in the
+repository root. Create it if absent:
+
+```sh
+git clone https://github.com/spack/spack spack-core
+```
+
+After fixing, verify the checks pass cleanly:
+
+```sh
+.ci/style_check.sh develop   # should print "style checks passed"
+```
+
+Run the package audit to catch semantic errors (missing dependencies, invalid version specs, etc.):
+
+```sh
+. spack-core/share/spack/setup-env.sh
+spack audit packages
+spack audit configs
+spack audit externals
+```
+
+The audit output is per-repository (not per-PR), so filter results to only the packages you
+changed. Pre-existing errors in unmodified packages can be ignored.
+
+If style or audit issues are found after a commit has already been pushed, fix them and amend:
+
+```sh
+# Fix, then amend the branch's commit:
+.ci/style_check.sh --fix develop
+git add -u
+git commit --amend --no-edit
+git push <fork-remote> <branch> --force-with-lease
+```
+
 #### CI timing
 
 After a PR is pushed, two rounds of CI feedback are available:
 
 | Stage | When results appear | What is checked |
 |---|---|---|
-| First-stage checks (GitHub Actions) | ~10 minutes | Style (`spack style`), audit (`spack audit`), license headers, package naming conventions |
+| First-stage checks (GitHub Actions) | ~10 minutes | Style (`flake8`/`isort`/`black` via `.ci/style_check.sh`), audit (`spack audit`), license headers, package naming conventions |
 | Full pipeline (GitLab CI at `gitlab.spack.io/spack/spack-packages`) | up to 1 hour | Package builds across all supported compilers and platforms; any build failures are visible here |
 
 Wait for first-stage results before asking a reviewer to look at the PR — style and audit

--- a/.github/skills/package-update.md
+++ b/.github/skills/package-update.md
@@ -118,7 +118,15 @@ Make all edits directly in the local `package.py` files (and add any patch files
 
 #### 3a. Adding new versions
 
-Add `version(...)` lines **above** the currently highest version, maintaining newest-first order.
+**Add only the latest upstream release** — do not add every intermediate patch release.
+For example, if the current highest version in `package.py` is `1.2.3` and upstream has released
+`1.2.4`, `1.2.5`, and `1.3.0`, add only `1.3.0`. Keeping a long list of patch versions adds
+maintenance burden and slows resolution without benefiting users, who can always use the latest.
+
+**Do not remove existing versions.** Removing versions breaks users who have pinned an older
+release in their `spack.yaml`. Only add the new entry.
+
+Add the `version(...)` line **above** the currently highest version, maintaining newest-first order.
 Obtain SHA256 checksums using `spack checksum`:
 
 ```sh
@@ -327,6 +335,8 @@ Before removing the draft status from any PR, verify:
 | Python deps | Always use `py-` prefix in `depends_on()` |
 | `type=` on all deps | Required; never omit |
 | Version ordering | Newest first |
+| New versions to add | Latest release only — do not add every intermediate patch |
+| Old versions | Never remove existing versions |
 | Version upper bounds | Inclusive form: `:3.10`, `:1`, never `:3.10.99` |
 | PR state | Always open as draft; human removes draft status |
 | Closing PRs | Never close another author's PR; post a comment instead |
@@ -336,6 +346,11 @@ Before removing the draft status from any PR, verify:
 
 ## Common Pitfalls
 
+- **Do not add every patch version** — add only the latest upstream release. If upstream has
+  released `1.2.4`, `1.2.5`, and `1.3.0` and the repo has `1.2.3`, add only `1.3.0`. Users
+  who need a specific patch can pin it themselves; listing every patch clutters the file.
+- **Do not remove old versions** — removing a version breaks users who have pinned it. Only
+  add; never subtract.
 - **Do not compute SHA256 manually** — always use `spack checksum`. Manual checksums are
   error-prone.
 - **Do not add an upper bound speculatively** — e.g., do not write `@1.5:2` just because version

--- a/.github/skills/package-update.md
+++ b/.github/skills/package-update.md
@@ -323,7 +323,7 @@ Updated the following packages to their latest upstream releases:
 
 ## Dependency changes
 
-<List each change: package, what changed, which version introduced the change.
+<List and justify each change: package, what changed, which version introduced the change. Always include links to the commit that introduced the dependency change to allow reviewers to validate, or justify by quoting the release notes if the package has no git attribute.
 If none, write "No dependency changes.">
 
 ## Version diff links

--- a/.github/skills/pr-review.md
+++ b/.github/skills/pr-review.md
@@ -1,0 +1,126 @@
+# Skill: PR Review
+
+Review a pull request in this Spack package repository for correctness, completeness, and
+justification. CI already handles automated checks (style, license headers, SHA256 checksums,
+`spack audit`), so this review focuses on what automation cannot verify.
+
+## Usage
+
+Invoke this skill by providing a PR number:
+
+```
+Review PR #<number>
+```
+
+## Review Checklist
+
+Work through the following in order. For each item, clearly state your finding and whether it
+passes, has a concern, or is a blocking issue.
+
+### 1. Fetch the PR
+
+- Retrieve the PR metadata (title, description, author, labels) and the full diff.
+- Identify which packages are being modified. List them upfront so the rest of the review is
+  scoped.
+
+### 2. PR Description Quality
+
+Check that the PR description adequately justifies the changes:
+
+- Does it explain **why** this update is being made (e.g., new upstream release, bug fix,
+  security patch, new feature needed by a dependent package)?
+- If it references an issue or upstream release, are those links present?
+- For version bumps, does it mention what changed upstream (e.g., changelog highlights)?
+- Flag vague descriptions like "update to latest version" with no further explanation as a
+  concern, not a blocker.
+
+### 3. Version Currency
+
+For every package version being added or updated:
+
+- Query PyPI (`https://pypi.org/pypi/<package-name>/json`) to retrieve the current latest stable
+  release. Compare it to the version being added. If the PR adds version X but PyPI already shows
+  a newer stable release Y, flag this.
+- If the package uses a non-PyPI source (e.g., a GitHub `url` or `git` attribute), check the
+  upstream repository's tags or releases page to verify the submitted version is the latest.
+- Do **not** flag pre-releases (alpha, beta, rc) as missing unless the PR explicitly targets
+  pre-releases.
+
+### 4. Dependency Completeness
+
+For each changed package, examine the upstream build configuration to verify that all dependency
+changes are reflected in `package.py`.
+
+#### 4a. Locate the upstream build spec
+
+Identify the upstream source from the `pypi`, `url`, or `git` field in the package. Then look at
+the build configuration file relevant to the version being added:
+
+| Upstream file | What to look for |
+|---|---|
+| `pyproject.toml` | `[project].dependencies`, `[project.optional-dependencies]`, `[build-system].requires` |
+| `setup.cfg` | `install_requires`, `extras_require`, `setup_requires` |
+| `setup.py` | `install_requires`, `setup_requires` in `setup()` call |
+| `CMakeLists.txt` | `find_package(Python ...)`, `find_package(...)` calls |
+| `requirements*.txt` | All listed packages |
+
+#### 4b. Compare against `package.py`
+
+For each dependency in the upstream build spec:
+
+- Is there a corresponding `depends_on(...)` in `package.py`? If a runtime dep is missing, that
+  is a **blocking issue**.
+- Are version constraints in `depends_on(...)` consistent with the constraints declared upstream?
+  A looser constraint is acceptable; a stricter constraint without justification is a concern.
+- Are build-only deps (e.g., listed only in `[build-system].requires` or `setup_requires`) marked
+  `type="build"` rather than `type=("build", "run")`?
+- Have any deps that were removed upstream (compared to the previous version's spec) been removed
+  from `package.py` as well? Missing removals are a concern.
+- Are newly required deps for the new version gated with a `when="@<new_version>:"` constraint
+  when older versions remain present?
+
+#### 4c. Ecosystem consistency
+
+If the PR touches multiple related packages (e.g., `py-dask` and `py-dask-expr`), verify that
+inter-package version constraints are mutually consistent.
+
+### 5. Spack Conventions
+
+Spot-check that the changes follow Spack package conventions. CI catches most of these, but flag
+obvious issues:
+
+- Package class name follows `PyPackageName` CamelCase derived from the PyPI name.
+- `pypi =` field (if present) uses the canonical PyPI distribution name and filename.
+- New `depends_on` entries use the `py-` prefix for Python packages.
+- `type=` annotation is present on all `depends_on` calls (no bare `depends_on` without type).
+
+## Output Format
+
+Structure your review as follows:
+
+```
+## PR Review: #<number> — <title>
+
+**Packages reviewed:** <list>
+
+### PR Description
+<PASS|CONCERN|BLOCKING> — <finding>
+
+### Version Currency
+<one entry per package>
+<PASS|CONCERN|BLOCKING> — <finding>
+
+### Dependency Completeness
+<one entry per package, with sub-bullets for individual deps if needed>
+<PASS|CONCERN|BLOCKING> — <finding>
+
+### Spack Conventions
+<PASS|CONCERN|BLOCKING> — <finding, or "No issues found.">
+
+---
+**Summary:** <Overall verdict: ready to merge / needs minor changes / needs major changes>
+<Optional: list the most important action items for the PR author>
+```
+
+Use **BLOCKING** for issues that must be resolved before merging, **CONCERN** for items worth
+discussing but not necessarily blockers, and **PASS** when a section looks correct.

--- a/.github/skills/pr-review.md
+++ b/.github/skills/pr-review.md
@@ -38,11 +38,8 @@ Check that the PR description adequately justifies the changes:
 
 For every package version being added or updated:
 
-- Query PyPI (`https://pypi.org/pypi/<package-name>/json`) to retrieve the current latest stable
-  release. Compare it to the version being added. If the PR adds version X but PyPI already shows
-  a newer stable release Y, flag this.
-- If the package uses a non-PyPI source (e.g., a GitHub `url` or `git` attribute), check the
-  upstream repository's tags or releases page to verify the submitted version is the latest.
+- If the package uses a non-PyPI source (e.g., a GitHub `url` or `git` attribute), check the upstream repository's tags or releases page to verify the submitted version is the latest.
+- Query PyPI (`https://pypi.org/pypi/<package-name>/json`) to retrieve the current latest stable release. Compare it to the version being added. If the PR adds version X but PyPI already shows a newer stable release Y, flag this.
 - Do **not** flag pre-releases (alpha, beta, rc) as missing unless the PR explicitly targets
   pre-releases.
 

--- a/.github/skills/pr-review.md
+++ b/.github/skills/pr-review.md
@@ -46,7 +46,7 @@ For every package version being added or updated:
 ### 4. Dependency Completeness
 
 For each changed package, examine the upstream build configuration to verify that all dependency
-changes are reflected in `package.py`.
+changes are reflected in `package.py`. Use links to the commit that introduced the dependency change to allow reviewers to validate the changes, or justify by quoting the release notes if the package has no git attribute.
 
 #### 4a. Locate the upstream build spec
 

--- a/.github/skills/py-package-update.md
+++ b/.github/skills/py-package-update.md
@@ -1,0 +1,321 @@
+# Skill: Python Package Update
+
+Update one or more `py-*` packages in this Spack repository to their latest upstream release.
+This skill is a Python-focused specialization of [`package-update`](package-update.md), which
+covers the full bulk-update workflow including staging branches, CI cache checks, and PR grouping
+strategy. Read that skill first for conventions and phases that apply equally here.
+
+This skill handles targeted updates of one or a small group of related Python packages: fetching
+the new version metadata, updating `package.py` with the new version and SHA256 checksum,
+reconciling dependency changes from the upstream build spec, and opening a draft PR.
+
+## Usage
+
+Invoke this skill by providing one or more package names (using either the Spack name with
+hyphens or the directory name with underscores):
+
+```
+Update py-dask
+Update py-dask, py-dask-expr, py-dask-awkward
+```
+
+To update all packages in an ecosystem, name the root package:
+
+```
+Update py-scipy ecosystem
+```
+
+## Step-by-Step Instructions
+
+### Step 1 — Identify the target packages
+
+- Resolve each provided name to a directory under
+  `repos/spack_repo/builtin/packages/` (replace hyphens with underscores).
+- For an ecosystem update, also identify packages that `depends_on` the named root package
+  and that are likely to release in lockstep (e.g., `py-dask-expr` when updating `py-dask`).
+- List all packages you will update before proceeding.
+
+### Step 2 — Determine the latest upstream version
+
+For each package:
+
+#### 2a. Check PyPI
+
+Fetch `https://pypi.org/pypi/<pypi-name>/json` where `<pypi-name>` is derived from the `pypi =`
+field in `package.py` (the first path component). Parse `info.version` for the latest stable
+release and `releases` for all available versions. Skip pre-releases (versions containing `a`,
+`b`, `rc`, or `.dev`) unless the existing `package.py` already tracks pre-releases.
+
+#### 2b. Check the upstream git history (when a `git` attribute is present)
+
+If `package.py` has a `git =` attribute, fetch the repository's tags or releases. Also look at
+the commit messages and any included `pyproject.toml` / `setup.cfg` / `CMakeLists.txt` diffs
+to understand what changed between the current packaged version and the new version.
+
+#### 2c. Decide whether an update is needed
+
+If the latest stable release on PyPI (or git) matches the highest version already listed in
+`package.py`, log "already up to date" and skip that package. Do not open a PR for it.
+
+**Add only the latest upstream release** — do not add every intermediate patch release. For
+example, if `package.py` currently has `1.2.3` and upstream has released `1.2.4`, `1.2.5`, and
+`1.3.0`, add only `1.3.0`. Listing every patch version adds maintenance burden without benefit.
+
+### Step 3 — Fetch the new release artifact and compute SHA256
+
+Use the `spack checksum` command to download the release artifact and emit a correctly formatted
+`version(...)` line with the SHA256 checksum already filled in:
+
+```sh
+spack checksum <package-name> <new-version>
+```
+
+For example:
+```sh
+spack checksum py-dask 2025.7.0
+```
+
+This will output a line such as:
+```python
+version("2025.7.0", sha256="c3a0d4e78882e85ea81dbc71e6459713e45676e2d17e776c2f3f19848039e4cf")
+```
+
+**Remove any trailing `# FIXME` comment** before committing — `spack checksum` appends `# FIXME`
+to lines whose checksums it cannot immediately verify inline. These must be stripped; they clutter
+the diff and the style checker will flag them:
+
+```sh
+sed -i 's/  # FIXME$//' repos/spack_repo/builtin/packages/<pkg>/package.py
+```
+
+Do not manually construct download URLs or compute SHA256 values — always use `spack checksum`.
+
+### Step 4 — Reconcile dependency changes from upstream
+
+Compare the build spec of the **new** version against the **currently packaged** version to
+identify dependency changes:
+
+| File to inspect | Relevant sections |
+|---|---|
+| `pyproject.toml` | `[project].dependencies`, `[project.optional-dependencies]`, `[build-system].requires`, `[project].requires-python` |
+| `setup.cfg` | `install_requires`, `extras_require`, `setup_requires`, `python_requires` |
+| `setup.py` | `install_requires`, `setup_requires`, `python_requires` in `setup()` |
+| `CMakeLists.txt` | `find_package(Python ...)`, `find_package(...)` |
+| `requirements*.txt` | All entries |
+
+For each change detected:
+
+- **New dependency added upstream** → add a `depends_on("py-<name>", type=(...))` entry in
+  `package.py`, gated with `when="@<new_version>:"` if older versions remain in the file.
+- **Dependency removed upstream** → restrict the existing `depends_on` with
+  `when="@:<previous_version>"`.
+- **Version constraint tightened upstream** (e.g., `>=1.20` → `>=1.24`) → add a new `depends_on`
+  with the tighter constraint gated with `when="@<new_version>:"`.
+- **Python version requirement changed** → update the `depends_on("python@X.Y:", ...)` entry
+  accordingly, scoped to the new version range.
+
+#### Version range notation
+
+Spack version ranges are **upper-limit-inclusive**: `@3.8:3.10` includes `3.10` itself.
+
+- Upstream `>=3.8` → `@3.8:`
+- Upstream `>=3.8,<3.11` → `@3.8:3.10` (3.10 is the last included version)
+- Upstream `>=1.20,<2` → `@1.20:1`
+- A half-open upper bound `<2` → `:1`
+
+Never write `:3.10.99` or `:1.99` — use the last actual release of the series.
+
+**Do not add upper bounds speculatively.** Only add an upper bound when the upstream package
+explicitly declares a strict incompatibility with a newer version. Do not write `@1.5:2` merely
+because version 3 of a dependency hasn't been tested.
+
+#### Python package name mapping
+
+Use the `py-` prefix for all Python packages (e.g., `numpy` → `py-numpy`, `scipy` → `py-scipy`).
+If a mapping is uncertain, note it as a TODO comment in the PR description.
+
+#### New packages as dependencies
+
+If a required upstream dependency does not yet exist in the repository, create its `package.py`
+in the same PR or a prerequisite PR before adding the `depends_on(...)` reference. A dangling
+dependency reference will fail CI.
+
+### Step 5 — Edit `package.py`
+
+Make the following changes to each package file:
+
+1. **Add a new `version(...)` entry** immediately above the existing most-recent version line.
+   Follow the existing ordering (newest first). Use the output of `spack checksum` and strip
+   any `# FIXME` comment.
+
+2. **Update or add `depends_on(...)` entries** as determined in Step 4. Preserve the existing
+   grouping style (build deps first, then runtime deps; grouped by dependency package).
+
+3. **Do not remove old versions.** Removing a version breaks users who have pinned an older
+   release in their `spack.yaml`. Only add; never subtract.
+
+4. **Do not modify** the copyright header, SPDX identifier, imports, docstring, `homepage`,
+   `pypi`, `url`, `git`, `maintainers`, or `license` lines unless a change is specifically
+   required by the upstream release.
+
+### Step 6 — Validate the changes
+
+- Confirm the new `version(...)` line is syntactically valid Python and has no `# FIXME` suffix.
+- Confirm all new `depends_on` entries use the `py-` prefix and have a `type=` argument.
+- Confirm any version range upper bounds are written in inclusive form (e.g., `:3.10`, not
+  `:3.10.99`).
+- Run the style checker and package audit before pushing (see
+  [`package-update`](package-update.md) Phase 8 for the full commands):
+
+  ```sh
+  .ci/style_check.sh develop          # shows what would be fixed
+  .ci/style_check.sh --fix develop    # auto-fixes formatting
+  . spack-core/share/spack/setup-env.sh && spack audit packages
+  ```
+
+### Step 7 — Search for existing PRs
+
+Before opening a new PR, search for open or recently closed PRs that may overlap:
+
+```sh
+gh pr list --repo spack/spack-packages --state open --search "<package-name>" --limit 20
+```
+
+If an overlapping PR exists, follow the coordination guidelines in
+[`package-update`](package-update.md) Phase 6 (supersede, coordinate, or mark as prerequisite).
+Do not close another author's PR — post a comment instead.
+
+### Step 8 — Group packages and open a draft PR
+
+Group related packages (same ecosystem, or packages that release in lockstep) into a single PR.
+Aim for 1–10 packages per PR for Python ecosystem updates.
+
+#### 8a. Branch naming
+
+```
+update/<ecosystem-or-package>-<new_version>
+```
+
+Examples: `update/dask-2025.7.0`, `update/scipy-1.15.0`.
+
+#### 8b. Commit message
+
+Write one commit per logical group of related packages:
+
+```
+<pkg1>, <pkg2>: add v<version>
+
+Updated packages: <list with old → new version for each>
+```
+
+#### 8c. PR title
+
+```
+<pkgname>: add v<version>
+```
+
+For multiple packages in the same ecosystem, name after the root package:
+
+```
+<root-pkg>: add v<version>
+<root-pkg>, <pkg2>, <pkg3>: add v<version>
+```
+
+Examples: `py-dask: add v2025.7.0`, `py-boto3, py-botocore, py-s3transfer: add v1.42.x`
+
+#### 8d. PR description
+
+Use the following template:
+
+```markdown
+## Summary
+
+Updated the following Python packages to their latest upstream release:
+
+| Package | Old version | New version |
+|---------|-------------|-------------|
+| `py-<name>` | `<old>` | `<new>` |
+
+## Dependency changes
+
+<List any dependency additions, removals, or constraint updates. If none, write "No dependency changes.">
+
+## Upstream changes
+
+<Brief summary of what changed upstream — link to the changelog, release notes, or relevant
+commits. If the upstream changelog was consulted, quote the most relevant line(s).>
+
+## CI build status
+
+**In CI stacks (binary cache available):** <list, or check cache.spack.io>
+**Not in any CI stack (will trigger new builds):** <list, or "N/A">
+
+## Related PRs
+
+<List any superseded, coordinating, or prerequisite PRs. If none, write "None.">
+
+---
+> ⚠️ This PR was prepared with AI assistance from GitHub Copilot.
+> It will only be marked ready for review after human review of all changes.
+```
+
+#### 8e. Open as draft
+
+Always open the PR in **draft** mode:
+
+```sh
+gh pr create \
+  --draft \
+  --base develop \
+  --head <fork-owner>:<branch> \
+  --title "<title>" \
+  --body-file <body-file> \
+  --repo spack/spack-packages
+```
+
+Writing the body to a temporary file avoids shell quoting issues with multi-line descriptions.
+
+#### 8f. Link to issues
+
+If a GitHub issue exists that requested this update (search open issues for the package name),
+add `Closes #<issue>` to the PR description.
+
+## Conventions Reference
+
+- Package directory names use underscores: `py_numpy` (not `py-numpy`).
+- Spack package names use hyphens: `py-numpy`.
+- Python package dependencies always use the `py-` prefix: `depends_on("py-numpy", ...)`.
+- All `depends_on` calls must include a `type=` argument.
+- Versions are listed newest-first in `package.py`.
+- Add only the latest upstream release; do not list every intermediate patch version.
+- Never remove existing versions.
+- Never add speculative upper-bound constraints.
+- All packages are licensed under `Apache-2.0 OR MIT`; do not change the header.
+- The `pypi =` field value is `<dist-name>/<filename>` matching the PyPI sdist filename.
+- Always open PRs as draft; human reviewers mark them ready.
+
+## Example
+
+Given `py-dask` currently at `2024.12.1` and PyPI showing `2025.7.0` as latest:
+
+```sh
+spack checksum py-dask 2025.7.0
+# → version("2025.7.0", sha256="c3a0d4e78...")  # FIXME
+# Strip the # FIXME before committing.
+```
+
+```python
+# Before
+version("2024.12.1", sha256="bac809af21c2dd7eb06827bccbfc612504f3ee6435580e548af912828f823195")
+
+# After (new entry added above, no # FIXME)
+version("2025.7.0", sha256="c3a0d4e78882e85ea81dbc71e6459713e45676e2d17e776c2f3f19848039e4cf")
+version("2024.12.1", sha256="bac809af21c2dd7eb06827bccbfc612504f3ee6435580e548af912828f823195")
+```
+
+If `pyproject.toml` for `2025.7.0` tightens `py-packaging` from `>=20` to `>=21:`:
+
+```python
+depends_on("py-packaging@20:", type="build", when="@2022.10.2:2024.12.1")
+depends_on("py-packaging@21:", type="build", when="@2025.7.0:")
+```

--- a/.github/skills/py-package-update.md
+++ b/.github/skills/py-package-update.md
@@ -175,14 +175,15 @@ Make the following changes to each package file:
 
 ### Step 7 — Search for existing PRs
 
-Before opening a new PR, search for open or recently closed PRs that may overlap:
+Before opening a new PR, search for open PRs that may overlap:
 
 ```sh
 gh pr list --repo spack/spack-packages --state open --search "<package-name>" --limit 20
 ```
 
-If an overlapping PR exists, follow the coordination guidelines in
-[`package-update`](package-update.md) Phase 6 (supersede, coordinate, or mark as prerequisite).
+**Existing PRs that already include any of the same version upgrades take priority.** Remove
+those packages from your PR and list the existing PR as a `Needs:` dependency (see Step 8d).
+Follow the full coordination rules in [`package-update`](package-update.md) Phase 6.
 Do not close another author's PR — post a comment instead.
 
 ### Step 8 — Group packages and open a draft PR
@@ -250,9 +251,14 @@ commits. If the upstream changelog was consulted, quote the most relevant line(s
 **In CI stacks (binary cache available):** <list, or check cache.spack.io>
 **Not in any CI stack (will trigger new builds):** <list, or "N/A">
 
+## Needs
+
+<List prerequisite PRs that must be merged before this one. If none, omit this section.>
+- [ ] #<PR-number>
+
 ## Related PRs
 
-<List any superseded, coordinating, or prerequisite PRs. If none, write "None.">
+<List any coordinating PRs with partial overlap. If none, write "None.">
 
 ---
 > ⚠️ This PR was prepared with AI assistance from GitHub Copilot.

--- a/.github/skills/py-package-update.md
+++ b/.github/skills/py-package-update.md
@@ -57,9 +57,10 @@ to understand what changed between the current packaged version and the new vers
 If the latest stable release on PyPI (or git) matches the highest version already listed in
 `package.py`, log "already up to date" and skip that package. Do not open a PR for it.
 
-**Add only the latest upstream release** — do not add every intermediate patch release. For
-example, if `package.py` currently has `1.2.3` and upstream has released `1.2.4`, `1.2.5`, and
-`1.3.0`, add only `1.3.0`. Listing every patch version adds maintenance burden without benefit.
+Follow the version-selection rules from [`package-update`](package-update.md) Phase 3a: add the
+latest patch release for each supported minor series, not every intermediate patch. For example,
+if `package.py` currently has `1.2.3` and upstream has released `1.2.4`, `1.2.5`, and `1.3.0`,
+add `1.2.5` and `1.3.0`; you do not need to add `1.2.4`.
 
 ### Step 3 — Fetch the new release artifact and compute SHA256
 
@@ -319,7 +320,7 @@ version("2025.7.0", sha256="c3a0d4e78882e85ea81dbc71e6459713e45676e2d17e776c2f3f
 version("2024.12.1", sha256="bac809af21c2dd7eb06827bccbfc612504f3ee6435580e548af912828f823195")
 ```
 
-If `pyproject.toml` for `2025.7.0` tightens `py-packaging` from `>=20` to `>=21:`:
+If `pyproject.toml` for `2025.7.0` tightens `py-packaging` from `>=20` to `>=21`:
 
 ```python
 depends_on("py-packaging@20:", type="build", when="@2022.10.2:2024.12.1")


### PR DESCRIPTION
Adds a Copilot skill documenting the bulk package-update workflow:

- Phase-by-phase instructions (inventory → dependency analysis → apply changes → PR grouping → CI check → PR submission)
- PR description template with AI attribution
- Policy: **do not close existing PRs** from other authors — post a comment linking to the new PR instead
- Conventions reference table and common pitfalls

Derived from the workflow used in the March 2026 bulk refresh of 237+ packages across 22 PRs.

---
> ⚠️ This PR was prepared with AI assistance from GitHub Copilot.
> It will only be marked ready for review after human review of all changes.