### PR TITLE
root: Set ROOT_INCLUDE_PATH in build as well

### DIFF
--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -906,6 +906,10 @@ class Root(CMakePackage):
             # warnings when building against ROOT
             env.unset("MACOSX_DEPLOYMENT_TARGET")
 
+        # https://github.com/root-project/root/issues/18949
+        if "+cxxmodules" in self.spec and "+vc" in self.spec:
+            env.prepend_path("ROOT_INCLUDE_PATH", self.spec["vc"].prefix.include)
+
     @property
     def root_library_path(self):
         # The ROOT_LIBRARY_PATH environment variable was added to ROOT 6.26.


### PR DESCRIPTION
Without this, starting from (I think) ROOT 3.38.02, the build fails when `+cxxmodules`, which is the default.

@jmcarcell pointed out that the LCG build sets `ROOT_INCLUDE_PATH` for the build: https://gitlab.cern.ch/sft/stacks/lcgcmake/-/blob/master/projects/CMakeLists.txt#L93

The spack package currently only does this for the run and dependent build. Adding it to the build seems to solve the issue.