### PR TITLE
stacks/hep: don't require `root +mysql +postgres` (restricts to @:6.36)

### DIFF
--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -825,11 +825,8 @@ class Root(CMakePackage):
             env.unset("MACOSX_DEPLOYMENT_TARGET")
 
         # https://github.com/root-project/root/issues/18949
-        if "+cxxmodules" in self.spec:
-            if "+vc" in self.spec:
-                env.prepend_path("ROOT_INCLUDE_PATH", self.spec["vc"].prefix.include)
-            if "+veccore" in self.spec:
-                env.prepend_path("ROOT_INCLUDE_PATH", self.spec["veccore"].prefix.include)
+        if "+cxxmodules" in self.spec and "+vc" in self.spec:
+            env.prepend_path("ROOT_INCLUDE_PATH", self.spec["vc"].prefix.include)
 
     @property
     def root_library_path(self):
@@ -850,11 +847,8 @@ class Root(CMakePackage):
         env.prepend_path(self.root_library_path, self.prefix.lib.root)
 
         # https://github.com/root-project/root/issues/18949
-        if "+cxxmodules" in self.spec:
-            if "+vc" in self.spec:
-                env.prepend_path("ROOT_INCLUDE_PATH", self.spec["vc"].prefix.include)
-            if "+veccore" in self.spec:
-                env.prepend_path("ROOT_INCLUDE_PATH", self.spec["veccore"].prefix.include)
+        if "+cxxmodules" in self.spec and "+vc" in self.spec:
+            env.prepend_path("ROOT_INCLUDE_PATH", self.spec["vc"].prefix.include)
 
     def setup_dependent_build_environment(self, env: EnvironmentModifications, dependent_spec):
         env.set("ROOTSYS", self.prefix)
@@ -870,11 +864,8 @@ class Root(CMakePackage):
         # library path
 
         # https://github.com/root-project/root/issues/18949
-        if "+cxxmodules" in self.spec:
-            if "+vc" in self.spec:
-                env.prepend_path("ROOT_INCLUDE_PATH", self.spec["vc"].prefix.include)
-            if "+veccore" in self.spec:
-                env.prepend_path("ROOT_INCLUDE_PATH", self.spec["veccore"].prefix.include)
+        if "+cxxmodules" in self.spec and "+vc" in self.spec:
+            env.prepend_path("ROOT_INCLUDE_PATH", self.spec["vc"].prefix.include)
 
     def setup_dependent_run_environment(self, env: EnvironmentModifications, dependent_spec):
         # Set up runtime dependencies *of downstream packages* that use ROOT

--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -825,8 +825,11 @@ class Root(CMakePackage):
             env.unset("MACOSX_DEPLOYMENT_TARGET")
 
         # https://github.com/root-project/root/issues/18949
-        if "+cxxmodules" in self.spec and "+vc" in self.spec:
-            env.prepend_path("ROOT_INCLUDE_PATH", self.spec["vc"].prefix.include)
+        if "+cxxmodules" in self.spec:
+            if "+vc" in self.spec:
+                env.prepend_path("ROOT_INCLUDE_PATH", self.spec["vc"].prefix.include)
+            if "+veccore" in self.spec:
+                env.prepend_path("ROOT_INCLUDE_PATH", self.spec["veccore"].prefix.include)
 
     @property
     def root_library_path(self):
@@ -847,8 +850,11 @@ class Root(CMakePackage):
         env.prepend_path(self.root_library_path, self.prefix.lib.root)
 
         # https://github.com/root-project/root/issues/18949
-        if "+cxxmodules" in self.spec and "+vc" in self.spec:
-            env.prepend_path("ROOT_INCLUDE_PATH", self.spec["vc"].prefix.include)
+        if "+cxxmodules" in self.spec:
+            if "+vc" in self.spec:
+                env.prepend_path("ROOT_INCLUDE_PATH", self.spec["vc"].prefix.include)
+            if "+veccore" in self.spec:
+                env.prepend_path("ROOT_INCLUDE_PATH", self.spec["veccore"].prefix.include)
 
     def setup_dependent_build_environment(self, env: EnvironmentModifications, dependent_spec):
         env.set("ROOTSYS", self.prefix)
@@ -864,8 +870,11 @@ class Root(CMakePackage):
         # library path
 
         # https://github.com/root-project/root/issues/18949
-        if "+cxxmodules" in self.spec and "+vc" in self.spec:
-            env.prepend_path("ROOT_INCLUDE_PATH", self.spec["vc"].prefix.include)
+        if "+cxxmodules" in self.spec:
+            if "+vc" in self.spec:
+                env.prepend_path("ROOT_INCLUDE_PATH", self.spec["vc"].prefix.include)
+            if "+veccore" in self.spec:
+                env.prepend_path("ROOT_INCLUDE_PATH", self.spec["veccore"].prefix.include)
 
     def setup_dependent_run_environment(self, env: EnvironmentModifications, dependent_spec):
         # Set up runtime dependencies *of downstream packages* that use ROOT

--- a/stacks/hep/spack.yaml
+++ b/stacks/hep/spack.yaml
@@ -52,9 +52,9 @@ spack:
       - target=x86_64_v3
     root:
       require:
-      - +arrow ~daos +davix +dcache +emacs +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +opengl +pythia8 +python +r +roofit +root7 +rpath ~shadow +spectrum +sqlite +ssl +tbb +tmva +tmva-cpu +unuran +vc +vdt ~veccore +webgui +x +xml +xrootd # cxxstd=20
+      - +arrow ~daos +davix +dcache +emacs +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +opengl +pythia8 +python +r +roofit +root7 +rpath ~shadow +spectrum +sqlite +ssl +tbb +tmva +tmva-cpu +unuran ~vc +vdt ~veccore +webgui +x +xml +xrootd # cxxstd=20
       # note: root cxxstd=20 not concretizable within sherpa
-      # ~veccore since path not added to DEFAULT_ROOT_INCLUDE_PATH
+      # ~vc ~veccore since PCM integration broken with runtime_cxxmodules=ON
       - target=x86_64_v3
     vecgeom:
       require:

--- a/stacks/hep/spack.yaml
+++ b/stacks/hep/spack.yaml
@@ -52,8 +52,9 @@ spack:
       - target=x86_64_v3
     root:
       require:
-      - +arrow ~daos +davix +dcache +emacs +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +opengl +pythia8 +python +r +roofit +root7 +rpath ~shadow +spectrum +sqlite +ssl +tbb +tmva +tmva-cpu +unuran +vc +vdt +veccore +webgui +x +xml +xrootd # cxxstd=20
+      - +arrow ~daos +davix +dcache +emacs +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +opengl +pythia8 +python +r +roofit +root7 +rpath ~shadow +spectrum +sqlite +ssl +tbb +tmva +tmva-cpu +unuran +vc +vdt ~veccore +webgui +x +xml +xrootd # cxxstd=20
       # note: root cxxstd=20 not concretizable within sherpa
+      # ~veccore since path not added to DEFAULT_ROOT_INCLUDE_PATH
       - target=x86_64_v3
     vecgeom:
       require:

--- a/stacks/hep/spack.yaml
+++ b/stacks/hep/spack.yaml
@@ -52,7 +52,7 @@ spack:
       - target=x86_64_v3
     root:
       require:
-      - +arrow ~daos +davix +dcache +emacs +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl +postgres +pythia8 +python +r +roofit +root7 +rpath ~shadow +spectrum +sqlite +ssl +tbb +tmva +tmva-cpu +unuran +vc +vdt +veccore +webgui +x +xml +xrootd # cxxstd=20
+      - +arrow ~daos +davix +dcache +emacs +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +opengl +pythia8 +python +r +roofit +root7 +rpath ~shadow +spectrum +sqlite +ssl +tbb +tmva +tmva-cpu +unuran +vc +vdt +veccore +webgui +x +xml +xrootd # cxxstd=20
       # note: root cxxstd=20 not concretizable within sherpa
       - target=x86_64_v3
     vecgeom:


### PR DESCRIPTION
This PR removes the `mysql` and `postgres` variants in the `root` package as required by the HEP stack. I was surprised the issue in https://github.com/spack/spack-packages/pull/3748 wasn't apparent in CI, so this PR should now cause us to rebuild with ROOT v6.38.02, and it will likely fail at first due to that issue.