### PR TITLE
py-cython: add v3.2.4

### DIFF
--- a/repos/spack_repo/builtin/packages/py_cython/package.py
+++ b/repos/spack_repo/builtin/packages/py_cython/package.py
@@ -16,6 +16,7 @@ class PyCython(PythonPackage):
 
     license("Apache-2.0")
 
+    version("3.2.4", sha256="84226ecd313b233da27dc2eb3601b4f222b8209c3a7216d8733b031da1dc64e6")
     version("3.2.3", sha256="f13832412d633376ffc08d751cc18ed0d7d00a398a4065e2871db505258748a6")
     version("3.2.2", sha256="c3add3d483acc73129a61d105389344d792c17e7c1cee24863f16416bd071634")
     version("3.2.1", sha256="2be1e4d0cbdf7f4cd4d9b8284a034e1989b59fd060f6bd4d24bf3729394d2ed8")


### PR DESCRIPTION
This PR adds `py-cython`, v3.2.4 ([diff](https://github.com/cython/cython/compare/3.2.3...3.2.4)), with no changes that need to be propagated to the package. This package will be built in CI. This PR was made by real live people.

Test build:
```
-- linux-ubuntu25.10-skylake / %c,cxx=clang@22.0.0 --------------
am5qa4r py-cython@3.2.4 build_system=python_pip
```