### PR TITLE
freeimage: deprecate 3.18.0 (CVE-2024-31570)

### DIFF
--- a/repos/spack_repo/builtin/packages/freeimage/package.py
+++ b/repos/spack_repo/builtin/packages/freeimage/package.py
@@ -14,7 +14,9 @@ class Freeimage(MakefilePackage):
 
     homepage = "https://freeimage.sourceforge.net/"
 
-    version("3.18.0", sha256="f41379682f9ada94ea7b34fe86bf9ee00935a3147be41b6569c9605a53e438fd")
+    # CVE-2024-31570
+    with default_args(deprecated=True):
+        version("3.18.0", sha256="f41379682f9ada94ea7b34fe86bf9ee00935a3147be41b6569c9605a53e438fd")
 
     patch("install_fixes.patch", when="@3.18.0")
 

--- a/repos/spack_repo/builtin/packages/freeimage/package.py
+++ b/repos/spack_repo/builtin/packages/freeimage/package.py
@@ -16,7 +16,9 @@ class Freeimage(MakefilePackage):
 
     # CVE-2024-31570
     with default_args(deprecated=True):
-        version("3.18.0", sha256="f41379682f9ada94ea7b34fe86bf9ee00935a3147be41b6569c9605a53e438fd")
+        version(
+            "3.18.0", sha256="f41379682f9ada94ea7b34fe86bf9ee00935a3147be41b6569c9605a53e438fd"
+        )
 
     patch("install_fixes.patch", when="@3.18.0")
 


### PR DESCRIPTION
This PR marks `freeimage`, v3.18.0, as deprecated due to CVE-2024-31570 (critical). This is the only version (package is in maintenance mode, no releases since 2018). This package is only used by `opencascade`, where the variant that enables it defaults to off.