### PR TITLE
Gitlab CI: Bump Windows CI image

### DIFF
--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -217,7 +217,7 @@ default:
     - $ErrorActionPreference=$ErrorActionOld
 
   tags: ["spack", "public", "medium", "x86_64-win"]
-  image: "ghcr.io/johnwparent/windows-server21h2:sha-1c12b61"
+  image: "ghcr.io/johnwparent/windows-server21h2:sha-e701163"
 
 .build:
   extends: [ ".base-job" ]

--- a/.ci/gitlab/configs/win64/ci.yaml
+++ b/.ci/gitlab/configs/win64/ci.yaml
@@ -22,4 +22,4 @@ ci:
       - spack.ps1 config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}/${SPACK_JOB_SPEC_DAG_HASH}:'morepadding/{hash}'"
       - mkdir ${SPACK_ARTIFACTS_ROOT}/user_data
       - spack.ps1 --backtrace ci rebuild | Tee-Object -FilePath "${env:SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt" 2>&1 | Tee-Object -FilePath "${env:SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt"
-      image: "ghcr.io/johnwparent/windows-server21h2:sha-1c12b61"
+      image: "ghcr.io/johnwparent/windows-server21h2:sha-e701163"

--- a/.ci/gitlab/configs/win64/packages.yaml
+++ b/.ci/gitlab/configs/win64/packages.yaml
@@ -7,6 +7,8 @@ packages:
     externals:
     - spec: cmake@3.28.0-msvc1
       prefix: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\Common7\\IDE\\CommonExtensions\\Microsoft\\CMake\\CMake"
+    - spec: cmake@4.2.3
+      prefix: "C:\\cmake\\4\\cmake-4.2.3-windows-x86_64"
     buildable: False
   ninja:
     externals:

--- a/repos/spack_repo/builtin/build_systems/cmake.py
+++ b/repos/spack_repo/builtin/build_systems/cmake.py
@@ -206,9 +206,7 @@ class CMakePackage(PackageBase):
         # must conflict.
         # this should be updated to reflect a oneapi fortran provider
         # once oneapi is usable with fortran on Windows
-        # NOTE: commented out for now because cmake@3 is used in Spack CI
-        # successfully with %fortran=msvc.
-        # depends_on("cmake@4.1:", type="build", when="%cxx=msvc %fortran=msvc")
+        depends_on("cmake@4.1:", type="build", when="%cxx=msvc %fortran=msvc")
 
     def flags_to_build_system_args(self, flags):
         """Return a list of all command line arguments to pass the specified


### PR DESCRIPTION
Adds CMake 4.2 to the image

Restores the conflict for `cmake@:3` and oneAPI on Windows (modeled by requiring CMake 4.1+ when using msvc+fortran) introduced in: https://github.com/spack/spack-packages/pull/3259