### PR TITLE
memcached: add v1.6.41; deprecate older versions (CVE-2023-46853)

### DIFF
--- a/repos/spack_repo/builtin/packages/memcached/package.py
+++ b/repos/spack_repo/builtin/packages/memcached/package.py
@@ -14,29 +14,43 @@ class Memcached(AutotoolsPackage):
     """
 
     homepage = "https://github.com/memcached/memcached"
-    url = "https://github.com/memcached/memcached/archive/1.5.20.tar.gz"
+    url = "https://www.memcached.org/files/memcached-1.5.20.tar.gz"
 
     license("BSD-3-Clause")
 
-    version("1.5.20", sha256="ee93aff47123e0b464e9f007b651b14c89c19e0c20352d8d1c399febbb038cb6")
-    version("1.5.19", sha256="7af7a2e9b1f468d7f6056f23ce21c04936ce6891f8cb8cd54e133f489a8226e8")
-    version("1.5.18", sha256="0bf8154f53d2781164421acd195a1665ac2f77316263c3526206c38e402c4b0d")
-    version("1.5.17", sha256="cb30ad851e95c0190e6b7e59695f1ed2e51d65a9e6c82c893e043dc066053377")
-    version("1.5.16", sha256="a0c1a7e72186722d7c0e9d5527a63beb339b933d768687f183e163adf935c662")
-    version("1.5.15", sha256="4ef8627308e99bdd4200ef4f260fbcdd65a4ba634bd593ca02dbbfd71222e9f7")
-    version("1.5.14", sha256="ae8ed2ed853b840a8430d8575d4e91b87c550b111874b416c551001403ac6a74")
-    version("1.5.13", sha256="ae59a8b49be17afb344e57c8a8d64f9ae38b6efbc3f9115a422dbcb2b23795fc")
+    version("1.6.41", sha256="e097073c156eeff9e12655b054f446d57374cfba5c132dcdbe7fac64e728286a")
 
-    depends_on("c", type="build")  # generated
+    # CVE-2023-46853
+    with default_args(deprecated=True):
+        version("1.5.20", sha256="ee93aff47123e0b464e9f007b651b14c89c19e0c20352d8d1c399febbb038cb6")
+        version("1.5.19", sha256="7af7a2e9b1f468d7f6056f23ce21c04936ce6891f8cb8cd54e133f489a8226e8")
+        version("1.5.18", sha256="0bf8154f53d2781164421acd195a1665ac2f77316263c3526206c38e402c4b0d")
+        version("1.5.17", sha256="cb30ad851e95c0190e6b7e59695f1ed2e51d65a9e6c82c893e043dc066053377")
+        version("1.5.16", sha256="a0c1a7e72186722d7c0e9d5527a63beb339b933d768687f183e163adf935c662")
+        version("1.5.15", sha256="4ef8627308e99bdd4200ef4f260fbcdd65a4ba634bd593ca02dbbfd71222e9f7")
+        version("1.5.14", sha256="ae8ed2ed853b840a8430d8575d4e91b87c550b111874b416c551001403ac6a74")
+        version("1.5.13", sha256="ae59a8b49be17afb344e57c8a8d64f9ae38b6efbc3f9115a422dbcb2b23795fc")
 
-    depends_on("autoconf", type="build")
-    depends_on("automake", type="build")
-    depends_on("libtool", type="build")
-    depends_on("m4", type="build")
+    depends_on("c", type="build")
+
+    with when("@:1.5"):
+        depends_on("autoconf", type="build")
+        depends_on("automake", type="build")
+        depends_on("libtool", type="build")
+        depends_on("m4", type="build")
+
     depends_on("libevent", type="build")
 
+    def url_for_version(self, version):
+        if self.satisfies("@:1.5"):
+            return f"https://github.com/memcached/memcached/archive/{version}.tar.gz"
+        else:
+            return f"https://www.memcached.org/files/memcached-{version}.tar.gz"
+
+    @when("@:1.5")
     def autoreconf(self, spec, prefix):
         sh = which("sh", required=True)
+        if self.satisfies("1.6:"):
         sh("./autogen.sh")
         autoreconf("--install", "--verbose", "--force")
 

--- a/repos/spack_repo/builtin/packages/memcached/package.py
+++ b/repos/spack_repo/builtin/packages/memcached/package.py
@@ -14,7 +14,8 @@ class Memcached(AutotoolsPackage):
     """
 
     homepage = "https://github.com/memcached/memcached"
-    url = "https://www.memcached.org/files/memcached-1.5.20.tar.gz"
+    url = "https://www.memcached.org/files/memcached-1.6.41.tar.gz"
+    git = "https://github.com/memcached/memcached.git"
 
     license("BSD-3-Clause")
 
@@ -58,7 +59,7 @@ class Memcached(AutotoolsPackage):
     depends_on("libevent", type="build")
 
     def url_for_version(self, version):
-        if self.spec.satisfies("@:1.5"):
+        if version <= Version("1.5"):
             return f"https://github.com/memcached/memcached/archive/{version}.tar.gz"
         else:
             return f"https://www.memcached.org/files/memcached-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/memcached/package.py
+++ b/repos/spack_repo/builtin/packages/memcached/package.py
@@ -22,14 +22,30 @@ class Memcached(AutotoolsPackage):
 
     # CVE-2023-46853
     with default_args(deprecated=True):
-        version("1.5.20", sha256="ee93aff47123e0b464e9f007b651b14c89c19e0c20352d8d1c399febbb038cb6")
-        version("1.5.19", sha256="7af7a2e9b1f468d7f6056f23ce21c04936ce6891f8cb8cd54e133f489a8226e8")
-        version("1.5.18", sha256="0bf8154f53d2781164421acd195a1665ac2f77316263c3526206c38e402c4b0d")
-        version("1.5.17", sha256="cb30ad851e95c0190e6b7e59695f1ed2e51d65a9e6c82c893e043dc066053377")
-        version("1.5.16", sha256="a0c1a7e72186722d7c0e9d5527a63beb339b933d768687f183e163adf935c662")
-        version("1.5.15", sha256="4ef8627308e99bdd4200ef4f260fbcdd65a4ba634bd593ca02dbbfd71222e9f7")
-        version("1.5.14", sha256="ae8ed2ed853b840a8430d8575d4e91b87c550b111874b416c551001403ac6a74")
-        version("1.5.13", sha256="ae59a8b49be17afb344e57c8a8d64f9ae38b6efbc3f9115a422dbcb2b23795fc")
+        version(
+            "1.5.20", sha256="ee93aff47123e0b464e9f007b651b14c89c19e0c20352d8d1c399febbb038cb6"
+        )
+        version(
+            "1.5.19", sha256="7af7a2e9b1f468d7f6056f23ce21c04936ce6891f8cb8cd54e133f489a8226e8"
+        )
+        version(
+            "1.5.18", sha256="0bf8154f53d2781164421acd195a1665ac2f77316263c3526206c38e402c4b0d"
+        )
+        version(
+            "1.5.17", sha256="cb30ad851e95c0190e6b7e59695f1ed2e51d65a9e6c82c893e043dc066053377"
+        )
+        version(
+            "1.5.16", sha256="a0c1a7e72186722d7c0e9d5527a63beb339b933d768687f183e163adf935c662"
+        )
+        version(
+            "1.5.15", sha256="4ef8627308e99bdd4200ef4f260fbcdd65a4ba634bd593ca02dbbfd71222e9f7"
+        )
+        version(
+            "1.5.14", sha256="ae8ed2ed853b840a8430d8575d4e91b87c550b111874b416c551001403ac6a74"
+        )
+        version(
+            "1.5.13", sha256="ae59a8b49be17afb344e57c8a8d64f9ae38b6efbc3f9115a422dbcb2b23795fc"
+        )
 
     depends_on("c", type="build")
 

--- a/repos/spack_repo/builtin/packages/memcached/package.py
+++ b/repos/spack_repo/builtin/packages/memcached/package.py
@@ -59,7 +59,7 @@ class Memcached(AutotoolsPackage):
     depends_on("libevent", type="build")
 
     def url_for_version(self, version):
-        if version <= Version("1.5"):
+        if version < Version("1.6"):
             return f"https://github.com/memcached/memcached/archive/{version}.tar.gz"
         else:
             return f"https://www.memcached.org/files/memcached-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/memcached/package.py
+++ b/repos/spack_repo/builtin/packages/memcached/package.py
@@ -42,7 +42,7 @@ class Memcached(AutotoolsPackage):
     depends_on("libevent", type="build")
 
     def url_for_version(self, version):
-        if self.satisfies("@:1.5"):
+        if self.spec.satisfies("@:1.5"):
             return f"https://github.com/memcached/memcached/archive/{version}.tar.gz"
         else:
             return f"https://www.memcached.org/files/memcached-{version}.tar.gz"
@@ -50,7 +50,6 @@ class Memcached(AutotoolsPackage):
     @when("@:1.5")
     def autoreconf(self, spec, prefix):
         sh = which("sh", required=True)
-        if self.satisfies("1.6:"):
         sh("./autogen.sh")
         autoreconf("--install", "--verbose", "--force")
 


### PR DESCRIPTION
This PR adds `memcached`, v1.6.41, and deprecates the older versions due to CVE-2023-46853 (critical). No other changes to the package (new functionality was added but is not exposed with variants here)

With the newer version, the autotools produce multiple warnings about unsupported macros, so it would require upper limits on automake and autoconf. Rather than mess with that, we use the 'prepared' official release tarball of the project where the configure script just works (TM).

Test build:
```
==> Installing memcached-1.6.41-rnzjle6ifduuzghgsuk7ctzwihvnsgsq [9/9]
==> Using cached archive: /opt/spack/cache/_source-cache/archive/e0/e097073c156eeff9e12655b054f446d57374cfba5c132dcdbe7fac64e728286a.tar.gz
==> No patches needed for memcached
==> memcached: Executing phase: 'autoreconf'
==> memcached: Executing phase: 'configure'
==> memcached: Executing phase: 'build'
==> memcached: Executing phase: 'install'
==> memcached: Successfully installed memcached-1.6.41-rnzjle6ifduuzghgsuk7ctzwihvnsgsq
  Stage: 0.05s.  Autoreconf: 0.00s.  Configure: 3.97s.  Build: 4.61s.  Install: 0.30s.  Post-install: 0.04s.  Total: 9.03s
[+] /opt/software/linux-skylake/memcached-1.6.41-rnzjle6ifduuzghgsuk7ctzwihvnsgsq
```