### PR TITLE
acts: add v45.4.0, v45.5.0, v46.0.0

### DIFF
--- a/repos/spack_repo/builtin/packages/acts/package.py
+++ b/repos/spack_repo/builtin/packages/acts/package.py
@@ -50,6 +50,9 @@ class Acts(CMakePackage, CudaPackage):
 
     # Supported Acts versions
     version("main", branch="main")
+    version("46.0.0", commit="a28f778b767fb8fcf9eba5675aecc71e28e30d50")
+    version("45.5.0", commit="1fe226214174c4b18b8d3a77c44a7d09de9c2e47")
+    version("45.4.0", commit="64ff294699e240c6935b18606be7c4b2ea213d6d")
     version("45.3.0", commit="d1323a298569942d98ff46ee413031ebd604290d")
     version("45.2.0", commit="c476557b74ccc8369fe1ef2c1f2e27cca4a356b6")
     version("45.1.1", commit="da50efc7b15cad8fdc5e194719c72d7d8b706823")
@@ -146,6 +149,8 @@ class Acts(CMakePackage, CudaPackage):
     requires("+svg", when="+traccc")
     requires("+json", when="+traccc")
 
+    variant("mille", default=False, description="Build the Mille plugin")
+
     # Variants that only affect Acts examples for now
     variant(
         "geant4", default=False, description="Build the Geant4-based examples", when="+examples"
@@ -203,6 +208,7 @@ class Acts(CMakePackage, CudaPackage):
     depends_on("hepmc3 @3.2.1:", when="+hepmc3")
     depends_on("hepmc3 @3.2.4:", when="@42: +hepmc3")
     depends_on("intel-tbb @2020.1:", when="+examples")
+    depends_on("millepede@01-00-00:", when="+mille")
     depends_on("nlohmann-json @3.10.5:", when="+json")
     depends_on("nlohmann-json @3.11.3:", when="@45: +json")
     depends_on("torch-scatter", when="+gnn")
@@ -319,6 +325,7 @@ class Acts(CMakePackage, CudaPackage):
             plugin_cmake_variant("ACTSVG", "svg"),
             plugin_cmake_variant("TGEO", "root"),
             plugin_cmake_variant("TRACCC", "traccc"),
+            plugin_cmake_variant("MILLE", "mille"),
             cmake_variant("UNITTESTS", "unit_tests"),
             "-DACTS_USE_EXAMPLES_TBB=ON",
         ]
@@ -342,6 +349,9 @@ class Acts(CMakePackage, CudaPackage):
 
         if spec.satisfies("+vecmem"):
             args.append("-DACTS_USE_SYSTEM_VECMEM=ON")
+
+        if spec.satisfies("+mille"):
+            args.append("-DACTS_USE_SYSTEM_MILLE=ON")
 
         if spec.satisfies("+cuda"):
             cuda_arch = spec.variants["cuda_arch"].value


### PR DESCRIPTION
This commit adds versions 45.4.0, 45.5.0, and 46.0.0 of the ACTS package and a new version with support for a Millipede plugin.