### PR TITLE
libxsmm: Fix JIT on aarch64

### DIFF
--- a/repos/spack_repo/builtin/packages/libxsmm/package.py
+++ b/repos/spack_repo/builtin/packages/libxsmm/package.py
@@ -120,7 +120,7 @@ class Libxsmm(MakefilePackage):
             "FC={0}".format(spack_fc),
             "PREFIX=%s" % prefix,
         ]
-        if spec.target.family == "aarch64":
+        if spec.satisfies("@1.17-cp2k") and spec.target.family == "aarch64":
             make_args += ["PLATFORM=1"]
         else:
             make_args += ["SYM=1"]


### PR DESCRIPTION
PR https://github.com/spack/spack/pull/42312 adds `PLATFORM=1` to the `aarch64` targets, disabling JIT.

I am not entirely sure why that was done (maybe historical reasons?), but over at [Palace](https://github.com/awslabs/palace), we have been running without this flag for a long time and found no problems on aarch64 (we are using `main` for libxsmm).

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Edit wdconinc: fixed link