### PR TITLE
TensorFlow: unable to find ml-dtypes headers

### DIFF
--- a/repos/spack_repo/builtin/packages/py_tensorflow/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow/package.py
@@ -273,13 +273,14 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         depends_on("py-h5py~mpi", when="~mpi")
         depends_on("hdf5+mpi", when="+mpi")
         depends_on("hdf5~mpi", when="~mpi")
-        depends_on("py-ml-dtypes@0.5.1:0", when="@2.19:")
-        depends_on("py-ml-dtypes@0.4:0", when="@2.18.1")
-        depends_on("py-ml-dtypes@0.4", when="@2.18.0")
-        depends_on("py-ml-dtypes@0.3.1:0.4", when="@2.17")
-        depends_on("py-ml-dtypes@0.3.1:0.3", when="@2.15.1:2.16")
-        depends_on("py-ml-dtypes@0.2", when="@2.15.0")
-        depends_on("py-ml-dtypes@0.2.0", when="@2.14")
+        with default_args(type=("build", "link", "run")):
+            depends_on("py-ml-dtypes@0.5.1:0", when="@2.19:")
+            depends_on("py-ml-dtypes@0.4:0", when="@2.18.1")
+            depends_on("py-ml-dtypes@0.4", when="@2.18.0")
+            depends_on("py-ml-dtypes@0.3.1:0.4", when="@2.17")
+            depends_on("py-ml-dtypes@0.3.1:0.3", when="@2.15.1:2.16")
+            depends_on("py-ml-dtypes@0.2", when="@2.15.0")
+            depends_on("py-ml-dtypes@0.2.0", when="@2.14")
 
         # Historical dependencies
         depends_on("py-jax@0.3.15:", when="@2.12")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Debugging the following build error in CI: https://gitlab.spack.io/spack/spack-packages/-/jobs/20949927