### PR TITLE
Git: Minor clean-ups

### DIFF
--- a/repos/spack_repo/builtin/packages/git/package.py
+++ b/repos/spack_repo/builtin/packages/git/package.py
@@ -193,6 +193,7 @@ class Git(AutotoolsPackage):
             f"--with-curl={spec['curl'].prefix}",
             f"--with-expat={spec['expat'].prefix}",
             f"--with-openssl={spec['openssl'].prefix}",
+            f"--with-libpcre2={spec['pcre2'].prefix}",
             f"--with-zlib={spec['zlib-api'].prefix}",
         ]
 
@@ -202,10 +203,6 @@ class Git(AutotoolsPackage):
         if self.spec.satisfies("+perl"):
             configure_args.append(f"--with-perl={spec['perl'].command.path}")
 
-        if self.spec.satisfies("^pcre"):
-            configure_args.append(f"--with-libpcre={spec['pcre'].prefix}")
-        if self.spec.satisfies("^pcre2"):
-            configure_args.append(f"--with-libpcre2={spec['pcre2'].prefix}")
         if self.spec.satisfies("+tcltk"):
             configure_args.append(f"--with-tcltk={self.spec['tk'].prefix.bin.wish}")
         else:


### PR DESCRIPTION
Remove some forgotten checks that were needed for old Git versions which depended on PCRE instead of PCRE2.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
