### PR TITLE
llvm-amdgpu: modify external detection

### DIFF
--- a/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
+++ b/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
@@ -252,8 +252,8 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
         try:
             compiler = Executable(exe)
             output = compiler(cls.compiler_version_argument, output=str, error=str)
-            # Reject if the executable is not under the InstalledDir reported
-            # by the compiler (e.g. /usr/bin is not valid).
+            # Reject if the compiler is not under the InstalledDir
+            # reported by --version (e.g. /usr/bin is not valid).
             installed_dir_match = re.search(cls.installed_dir_regex, output)
             if installed_dir_match:
                 installed_dir = os.path.normpath(installed_dir_match.group(1).strip())

--- a/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
+++ b/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
@@ -247,6 +247,31 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
             when=f"@{d_version}",
         )
 
+    @classmethod
+    def determine_version(cls, exe):
+        try:
+            compiler = Executable(exe)
+            output = compiler(cls.compiler_version_argument, output=str, error=str)
+            # Reject if the executable is not under the InstalledDir reported
+            # by the compiler (e.g. /usr/bin is not valid).
+            installed_dir_match = re.search(cls.installed_dir_regex, output)
+            if installed_dir_match:
+                installed_dir = os.path.normpath(installed_dir_match.group(1).strip())
+                exe_dir = os.path.normpath(os.path.dirname(os.path.abspath(str(exe))))
+                if exe_dir != installed_dir:
+                    return None
+            else:
+                return None
+            match = re.search(cls.compiler_version_regex, output)
+            if match:
+                version_str = match.group(1)
+                return version_str
+        except ProcessError:
+            pass
+        except Exception as e:
+            tty.debug(e)
+        return None
+
     def _standard_flag(self, *, language, standard):
         flags = {
             "cxx": {

--- a/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
+++ b/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
@@ -247,31 +247,6 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
             when=f"@{d_version}",
         )
 
-    @classmethod
-    def determine_version(cls, exe):
-        try:
-            compiler = Executable(exe)
-            output = compiler(cls.compiler_version_argument, output=str, error=str)
-            # Reject if the compiler is not under the InstalledDir
-            # reported by --version (e.g. /usr/bin is not valid).
-            installed_dir_match = re.search(cls.installed_dir_regex, output)
-            if installed_dir_match:
-                installed_dir = os.path.normpath(installed_dir_match.group(1).strip())
-                exe_dir = os.path.normpath(os.path.dirname(os.path.abspath(str(exe))))
-                if exe_dir != installed_dir:
-                    return None
-            else:
-                return None
-            match = re.search(cls.compiler_version_regex, output)
-            if match:
-                version_str = match.group(1)
-                return version_str
-        except ProcessError:
-            pass
-        except Exception as e:
-            tty.debug(e)
-        return None
-
     def _standard_flag(self, *, language, standard):
         flags = {
             "cxx": {
@@ -410,6 +385,32 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
     fortran_names = ["amdflang"]
     compiler_version_argument = "--version"
     compiler_version_regex = r"roc-(\d+[._]\d+[._]\d+)"
+    installed_dir_regex = r"InstalledDir:\s*(.+)"
+
+    @classmethod
+    def determine_version(cls, exe):
+        try:
+            compiler = Executable(exe)
+            output = compiler(cls.compiler_version_argument, output=str, error=str)
+            # Reject if the compiler is not under the InstalledDir
+            # reported by --version (e.g. /usr/bin is not valid).
+            installed_dir_match = re.search(cls.installed_dir_regex, output)
+            if installed_dir_match:
+                installed_dir = os.path.normpath(installed_dir_match.group(1).strip())
+                exe_dir = os.path.normpath(os.path.dirname(os.path.abspath(str(exe))))
+                if exe_dir != installed_dir:
+                    return None
+            else:
+                return None
+            match = re.search(cls.compiler_version_regex, output)
+            if match:
+                version_str = match.group(1)
+                return version_str
+        except ProcessError:
+            pass
+        except Exception as e:
+            tty.debug(e)
+        return None
 
     # Make sure that the compiler paths are in the LD_LIBRARY_PATH
     def setup_run_environment(self, env: EnvironmentModifications) -> None:


### PR DESCRIPTION
This PR checks that the detected `llvm-amdgpu` compiler’s directory matches the InstalledDir reported in its `--version` output.
That way Spack no longer treats system-installed ROCm LLVM (e.g. `/usr/bin/amdclang`) as the `llvm-amdgpu` compiler, avoiding `find_package(Clang)` failures when building dependents like `hipify-clang`.

fixes https://github.com/spack/spack-packages/issues/3777