### PR TITLE
kokkos: allow other LLVM-based compilers for ROCm

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -464,10 +464,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
             options.append(self.define("CMAKE_CXX_COMPILER", self.kokkos_cxx))
         elif "+rocm" in self.spec:
             if "+cmake_lang" in self.spec:
-                if (
-                    self.spec.satisfies("%cxx=clang")
-                    or self.spec.satisfies("%cxx=rocmcc")
-                ):
+                if self.spec.satisfies("%cxx=clang") or self.spec.satisfies("%cxx=rocmcc"):
                     options.append(self.define("CMAKE_HIP_COMPILER", self.compiler.cxx))
                 else:
                     options.append(
@@ -483,10 +480,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
                     )
                 )
                 options.append(self.define("CMAKE_HIP_EXTENSIONS", False))
-            elif not (
-                self.spec.satisfies("%cxx=clang")
-                or self.spec.satisfies("%cxx=rocmcc")
-            ):
+            elif not (self.spec.satisfies("%cxx=clang") or self.spec.satisfies("%cxx=rocmcc")):
                 options.append(self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc))
             options.append(self.define("Kokkos_ENABLE_ROCTHRUST", True))
         elif "+cuda" in self.spec and "+cmake_lang" in self.spec:

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -464,7 +464,10 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
             options.append(self.define("CMAKE_CXX_COMPILER", self.kokkos_cxx))
         elif "+rocm" in self.spec:
             if "+cmake_lang" in self.spec:
-                if self.spec.satisfies("%cxx=clang"):
+                if (
+                    self.spec.satisfies("%cxx=clang")
+                    or self.spec.satisfies("%cxx=rocmcc")
+                ):
                     options.append(self.define("CMAKE_HIP_COMPILER", self.compiler.cxx))
                 else:
                     options.append(
@@ -480,7 +483,10 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
                     )
                 )
                 options.append(self.define("CMAKE_HIP_EXTENSIONS", False))
-            else:
+            elif not (
+                self.spec.satisfies("%cxx=clang")
+                or self.spec.satisfies("%cxx=rocmcc")
+            ):
                 options.append(self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc))
             options.append(self.define("Kokkos_ENABLE_ROCTHRUST", True))
         elif "+cuda" in self.spec and "+cmake_lang" in self.spec:

--- a/repos/spack_repo/builtin/packages/kokkos_fft/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_fft/package.py
@@ -77,7 +77,6 @@ class KokkosFft(CMakePackage):
 
         if self.spec.satisfies("^kokkos+rocm") and not (
             self.spec.satisfies("^kokkos %cxx=clang")
-            or self.spec.satisfies("^kokkos %cxx=cce")
             or self.spec.satisfies("^kokkos %cxx=rocmcc")
         ):
             args.append(self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc))

--- a/repos/spack_repo/builtin/packages/kokkos_fft/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_fft/package.py
@@ -75,7 +75,11 @@ class KokkosFft(CMakePackage):
             self.define("KokkosFFT_ENABLE_ONEMKL", self.spec.satisfies("device_backend=onemkl")),
         ]
 
-        if self.spec.satisfies("^kokkos+rocm"):
+        if self.spec.satisfies("^kokkos+rocm") and not (
+            self.spec.satisfies("^kokkos %cxx=clang")
+            or self.spec.satisfies("^kokkos %cxx=cce")
+            or self.spec.satisfies("^kokkos %cxx=rocmcc")
+        ):
             args.append(self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc))
         else:
             args.append(self.define("CMAKE_CXX_COMPILER", self["kokkos"].kokkos_cxx))

--- a/repos/spack_repo/builtin/packages/kokkos_fft/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_fft/package.py
@@ -76,8 +76,7 @@ class KokkosFft(CMakePackage):
         ]
 
         if self.spec.satisfies("^kokkos+rocm") and not (
-            self.spec.satisfies("^kokkos %cxx=clang")
-            or self.spec.satisfies("^kokkos %cxx=rocmcc")
+            self.spec.satisfies("^kokkos %cxx=clang") or self.spec.satisfies("^kokkos %cxx=rocmcc")
         ):
             args.append(self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc))
         else:

--- a/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
@@ -225,7 +225,6 @@ class KokkosKernels(CMakePackage, CudaPackage):
         options.append(self.define("Kokkos_ROOT", spec["kokkos"].prefix))
         if spec.satisfies("^kokkos+rocm") and not (
             spec.satisfies("^kokkos %cxx=clang")
-            or spec.satisfies("^kokkos %cxx=cce")
             or spec.satisfies("^kokkos %cxx=rocmcc")
         ):
             options.append(self.define("CMAKE_CXX_COMPILER", spec["hip"].hipcc))

--- a/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
@@ -224,8 +224,7 @@ class KokkosKernels(CMakePackage, CudaPackage):
 
         options.append(self.define("Kokkos_ROOT", spec["kokkos"].prefix))
         if spec.satisfies("^kokkos+rocm") and not (
-            spec.satisfies("^kokkos %cxx=clang")
-            or spec.satisfies("^kokkos %cxx=rocmcc")
+            spec.satisfies("^kokkos %cxx=clang") or spec.satisfies("^kokkos %cxx=rocmcc")
         ):
             options.append(self.define("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
         else:

--- a/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
@@ -223,7 +223,11 @@ class KokkosKernels(CMakePackage, CudaPackage):
         ]
 
         options.append(self.define("Kokkos_ROOT", spec["kokkos"].prefix))
-        if spec.satisfies("^kokkos+rocm"):
+        if spec.satisfies("^kokkos+rocm") and not (
+            spec.satisfies("^kokkos %cxx=clang")
+            or spec.satisfies("^kokkos %cxx=cce")
+            or spec.satisfies("^kokkos %cxx=rocmcc")
+        ):
             options.append(self.define("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
         else:
             options.append(self.define("CMAKE_CXX_COMPILER", self["kokkos"].kokkos_cxx))


### PR DESCRIPTION
Instead of always forcing hipcc, allow kokkos to be compiled directly with either llvm or llvm-amdgpu (rocmcc).

The main motivation for this is to allow building directly with amdclang++ instead of hipcc to avoid different inlining defaults between hipcc and amdclang++. We've gotten the recommendation to move toward using amdclang++ directly. This enables this without also forcing CMake language support.