### PR TITLE
Unrestrict raja and umpire versions when using newer hiop versions

### DIFF
--- a/repos/spack_repo/builtin/packages/hiop/package.py
+++ b/repos/spack_repo/builtin/packages/hiop/package.py
@@ -157,11 +157,10 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("raja+openmp", when="+raja~cuda~rocm")
 
     # RAJA > 0.14 and Umpire > 6.0 require c++ std 14
-    # We are working on supporting newer Umpire/RAJA versions
-    depends_on("raja@2024.07.0", when="@1.1.1:+raja")
+    depends_on("raja@2024.07.0:", when="@1.1.1:+raja")
     depends_on("raja@0.14", when="@0.5:1.1.0+raja")
     depends_on("raja@:0.13", when="@0.3.99:0.4+raja")
-    depends_on("umpire@2024.07.0", when="@1.1.1:+raja")
+    depends_on("umpire@2024.07.0:", when="@1.1.1:+raja")
     depends_on("umpire@6", when="@0.5:1.1.0+raja")
     depends_on("umpire@:5", when="@0.3.99:0.4+raja")
     depends_on("camp@0.2.3:0.2", when="@0.3.99:1.1.0+raja")


### PR DESCRIPTION
When using a hiop version newer than 1.1.1, we should not be limited to using only raja/ umpire version 2024.07.0. I have tested using raja/ umpire version 2025.09.0 with hiop@1.1.1 for a few months now and have not experienced any issues.

@tepperly 