### PR TITLE
go-sh: add v3.13.0

### DIFF
--- a/repos/spack_repo/builtin/packages/go_sh/package.py
+++ b/repos/spack_repo/builtin/packages/go_sh/package.py
@@ -9,17 +9,25 @@ from spack.package import *
 
 class GoSh(GoPackage):
     """A shell parser, formatter, and interpreter. Supports POSIX
-    Shell, Bash, and mksh. Requires Go 1.23 or later."""
+    Shell, Bash, Zsh and mksh."""
 
     homepage = "https://github.com/mvdan/sh"
+    git = "https://github.com/mvdan/sh.git"
     url = "https://github.com/mvdan/sh/archive/refs/tags/v3.12.0.tar.gz"
 
     maintainers("mcmehrtens")
     license("BSD-3-Clause", checked_by="mcmehrtens")
 
+    version(
+        "3.13.0",
+        tag="v3.13.0",
+        commit="5c4d285c3e8fa3b85137b34cec5ce66b98d97bdc",
+        get_full_repo=True,
+    )
     version("3.12.0", sha256="ac15f42feeba55af29bd07698a881deebed1cd07e937effe140d9300e79d5ceb")
 
-    depends_on("go@1.23:", type="build", when="@3.12.0:")
+    depends_on("go@1.25:", type="build", when="@3.13:")
+    depends_on("go@1.23:", type="build", when="@3.12")
 
     variant("shfmt", default=True, description="Build and install shfmt")
     variant("gosh", default=False, description="Build and install gosh")
@@ -37,18 +45,17 @@ class GoSh(GoPackage):
     def build(self, spec: Spec, prefix: Prefix) -> None:
         """Runs ``go build`` in the source directory for the specified
         variants."""
-        common_flags = (
-            "-p",
-            str(make_jobs),
-            "-modcacherw",
-            "-ldflags",
-            f"-s -w -X main.version={spec.version}",
-        )
+        # v3.12 uses ldflags to set version; v3.13+ uses Go's VCS stamping
+        if spec.satisfies("@:3.12"):
+            ldflags = f"-s -w -X main.version={spec.version}"
+        else:
+            ldflags = "-s -w"
+        common_flags = ("-p", str(make_jobs), "-modcacherw", "-ldflags", ldflags)
         with working_dir(self.build_directory):
             if spec.satisfies("+shfmt"):
-                go("build", "-o", "shfmt", *common_flags, "cmd/shfmt/main.go")
+                go("build", "-o", "shfmt", *common_flags, "./cmd/shfmt")
             if spec.satisfies("+gosh"):
-                go("build", "-o", "gosh", *common_flags, "cmd/gosh/main.go")
+                go("build", "-o", "gosh", *common_flags, "./cmd/gosh")
 
     def install(self, spec: Spec, prefix: Prefix) -> None:
         """Install built binaries into prefix bin."""


### PR DESCRIPTION
- Added `sh` v3.13.0
- Updated Go dependency constraints for each version
- Starting with v3.13.0, `shfmt` no longer uses an ldflags-settable `main.version` variable (see https://github.com/mvdan/sh/issues/1284). Instead, the version is set by Go at build time using VCS (Git) metadata. This is why v3.13.0 references the Git repo rather than the release tarball.
- Updated Go build targets to use module paths instead of file paths