### PR TITLE
Update paraview patch conditions for VTK-m version 5.13.2

### DIFF
--- a/repos/spack_repo/builtin/packages/paraview/package.py
+++ b/repos/spack_repo/builtin/packages/paraview/package.py
@@ -472,10 +472,10 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     patch("kits_with_catalyst_5_12.patch", when="@5.12.0")
 
     # https://github.com/Kitware/VTK-m/commit/c805a6039ea500cb96158cfc11271987c9f67aa4
-    patch("vtkm-remove-unused-method-from-mir-tables.patch", when="@5.13.2 %oneapi@2025:")
+    patch("vtkm-remove-unused-method-from-mir-tables.patch", when="@5.13.2:5.13.3")
 
     # https://github.com/Kitware/VTK-m/commit/48e385af319543800398656645327243a29babfb
-    patch("vtkm-fix-problems-in-class-member-names.patch", when="@5.13.2 %oneapi@2025:")
+    patch("vtkm-fix-problems-in-class-member-names.patch", when="@5.13.2:5.13.3")
 
     # Vtk's findpegtl's include search is wrong: https://gitlab.kitware.com/vtk/vtk/-/issues/17876
     patch("pegtl_tao_find.patch", when="platform=windows")


### PR DESCRIPTION
Also required for newer gcc compilers. Since, it is not a compiler relevant patch and it is fixed in the upstream vtkm project, it should always be patched.

And still required for paraview version 5.13.3.

