### PR TITLE
stacks: restore hipblaslt on e4s

### DIFF
--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -49,8 +49,6 @@ spack:
       variants: threads=openmp
     rccl:
       variants: amdgpu_target=gfx90a
-    rocblas:
-      require: ~hipblaslt #hangs in ci
     trilinos:
       prefer:
       - +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext


### PR DESCRIPTION
hipblaslt was removed here because it was hanging in ci: https://github.com/spack/spack-packages/pull/825
Hopefully with https://github.com/spack/spack-packages/pull/3571 merged, this will no longer be an issue as it will only be building for a single GPU target.