### PR TITLE
The gcc package can misplace 'specs' when +nvptx

### DIFF
--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -1062,7 +1062,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         # Other lib directories might exist, so detect based on the existence of the libgcc.
         spec_dir = glob.glob(f"{self.prefix.lib}/gcc/*/*/libgcc.a")
         if spec_dir:
-            return spec_dir[0].rsplit('/', 1)[0]
+            return spec_dir[0].rsplit("/", 1)[0]
         else:
             return None
 

--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -1059,8 +1059,12 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     @property
     def spec_dir(self):
         # e.g. lib/gcc/x86_64-unknown-linux-gnu/4.9.2
-        spec_dir = glob.glob(f"{self.prefix.lib}/gcc/*/*")
-        return spec_dir[0] if spec_dir else None
+        # Other lib directories might exist, so detect based on the existence of the libgcc.
+        spec_dir = glob.glob(f"{self.prefix.lib}/gcc/*/*/libgcc.a")
+        if spec_dir:
+            return spec_dir[0].rsplit('/', 1)[0]
+        else:
+            return None
 
     @run_after("install")
     def write_specs_file(self):


### PR DESCRIPTION
Gcc finds multiple potential places to put the specs file when +nvptx is given. This picks the correct one. It assumes libgcc.a will only (and always) be in the gcc lib directory...

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
