### PR TITLE
kokkos: disable IMPL_HIP_MALLOC_ASYNC with ROCm 7

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -483,6 +483,11 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
             else:
                 options.append(self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc))
             options.append(self.define("Kokkos_ENABLE_ROCTHRUST", True))
+
+            # Using Kokkos_ENABLE_IMPL_HIP_MALLOC_ASYNC is problematic with ROCm 7
+            # Newer Kokkos versions disable this by default
+            if self.spec.satisfies("@4.5:5.0.0 %hip@7:"):
+                options.append(self.define("Kokkos_ENABLE_IMPL_HIP_MALLOC_ASYNC", False))
         elif "+cuda" in self.spec and "+cmake_lang" in self.spec:
             if self.spec.satisfies("%cxx=clang"):
                 options.append(self.define("CMAKE_CUDA_COMPILER", self.compiler.cxx))


### PR DESCRIPTION
This is enforced starting in Kokkos 5.0.1. Earlier versions defaulted to enable it when ROCm was enabled.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
