### PR TITLE
Fix ntpoly missing C dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/ntpoly/package.py
+++ b/repos/spack_repo/builtin/packages/ntpoly/package.py
@@ -27,6 +27,7 @@ class Ntpoly(CMakePackage):
 
     variant("shared", default=True, description="Build shared libraries.")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 


### PR DESCRIPTION
Fixes https://github.com/spack/spack-packages/issues/3788

The `ntpoly` package fails to build because the C compiler dependency is not
declared in `package.py`. During CMake configure, the build system
performs a C compiler test which fails when the `c` dependency is not present.

This PR adds the missing:

    depends_on("c", type="build")