### PR TITLE
intel-oneapi: constrain gcc-runtime to gcc version

### DIFF
--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
@@ -760,11 +760,15 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
 
         # If the compiler depends on gcc@X.Y, the runtime must depend on gcc-runtime@X.Y
         if spec.satisfies("%gcc"):
-            gcc = spec["gcc"]
-            pkg("intel-oneapi-runtime").requires(
-                f"@{spec.versions} %gcc-runtime@{gcc.version}",
-                when=f"%[deptypes=build] {spec.name}/{spec.dag_hash()}",
-            )
+            try:
+                gcc = spec["gcc"]
+                pkg("intel-oneapi-runtime").requires(
+                    f"@{spec.versions} %gcc-runtime@{gcc.version}",
+                    when=f"%[deptypes=build] {spec.name}/{spec.dag_hash()}",
+                )
+            except (RuntimeError, KeyError):
+                # Externals may not have gcc as a dependency, but still satisfy %gcc
+                pass
 
         # If a node used %intel-oneapi-runtime@X.Y its dependencies must use @:X.Y
         # (technically @:X is broader than ... <= @=X but this should work in practice)

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
@@ -758,6 +758,14 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
             f"@{spec.versions}", when=f"%[deptypes=build] {spec.name}@{spec.versions}"
         )
 
+        # If the compiler depends on gcc@X.Y, the runtime must depend on gcc-runtime@X.Y
+        if spec.satisfies("%gcc"):
+            gcc = spec["gcc"]
+            pkg("intel-oneapi-runtime").requires(
+                f"@{spec.versions} %gcc-runtime@{gcc.version}",
+                when=f"%[deptypes=build] {spec.name}/{spec.dag_hash()}",
+            )
+
         # If a node used %intel-oneapi-runtime@X.Y its dependencies must use @:X.Y
         # (technically @:X is broader than ... <= @=X but this should work in practice)
         pkg("*").propagate(


### PR DESCRIPTION
This is needed to constrain the `gcc-runtime` dependency of the `intel-oneapi-runtime` node, in case multiple `gcc` are available.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
