### PR TITLE
py-grpcio: match include directories to source code

### DIFF
--- a/repos/spack_repo/builtin/packages/py_grpcio/package.py
+++ b/repos/spack_repo/builtin/packages/py_grpcio/package.py
@@ -94,7 +94,7 @@ class PyGrpcio(PythonPackage):
         if "openssl" in self.spec:
             filter_file(
                 r"(\s+SSL_INCLUDE = ).*",
-                r"\1('{0}',)".format(self.spec["openssl"].prefix.include),
+                r"\1('{0}',)".format(self.spec["openssl"].prefix.include.openssl),
                 "setup.py",
             )
         if "zlib-api" in self.spec:
@@ -112,7 +112,7 @@ class PyGrpcio(PythonPackage):
         if "re2" in self.spec:
             filter_file(
                 r"(\s+RE2_INCLUDE = ).*",
-                r"\1('{0}',)".format(self.spec["re2"].prefix.include),
+                r"\1('{0}',)".format(self.spec["re2"].prefix.include.re2),
                 "setup.py",
             )
         if "abseil-cpp" in self.spec:


### PR DESCRIPTION
We are patching the following code:
```python
if BUILD_WITH_SYSTEM_OPENSSL:
    CORE_C_FILES = filter(
        lambda x: "third_party/boringssl" not in x, CORE_C_FILES
    )
    CORE_C_FILES = filter(lambda x: "src/boringssl" not in x, CORE_C_FILES)
    SSL_INCLUDE = (os.path.join("/usr", "include", "openssl"),)

if BUILD_WITH_SYSTEM_ZLIB:
    CORE_C_FILES = filter(lambda x: "third_party/zlib" not in x, CORE_C_FILES)
    ZLIB_INCLUDE = (os.path.join("/usr", "include"),)

if BUILD_WITH_SYSTEM_CARES:
    CORE_C_FILES = filter(lambda x: "third_party/cares" not in x, CORE_C_FILES)
    CARES_INCLUDE = (os.path.join("/usr", "include"),)

if BUILD_WITH_SYSTEM_RE2:
    CORE_C_FILES = filter(lambda x: "third_party/re2" not in x, CORE_C_FILES)
    RE2_INCLUDE = (os.path.join("/usr", "include", "re2"),)

if BUILD_WITH_SYSTEM_ABSL:
    CORE_C_FILES = filter(
        lambda x: "third_party/abseil-cpp" not in x, CORE_C_FILES
    )
    ABSL_INCLUDE = (os.path.join("/usr", "include"),)
```
Since openssl and re2 include the subdirectory originally, we should probably use it in our replacements to keep the expected directory structure the same.