### PR TITLE
py-html5lib: restrict py-setuptools to @:81

### DIFF
--- a/repos/spack_repo/builtin/packages/py_html5lib/package.py
+++ b/repos/spack_repo/builtin/packages/py_html5lib/package.py
@@ -21,5 +21,5 @@ class PyHtml5lib(PythonPackage):
 
     depends_on("py-six", type=("build", "run"))
     depends_on("py-six@1.9:", type=("build", "run"), when="@1.0.1:")
-    depends_on("py-setuptools", type="build", when="@1.0.1:")
+    depends_on("py-setuptools@:81", type="build", when="@1.0.1:")
     depends_on("py-webencodings", type=("build", "run"), when="@1.0.1:")


### PR DESCRIPTION
Doing this because this package tries to import pkg-resources which is removed in py-setuptools@82:

And of course it won't install without using this older setuptools or adding new versions
