### PR TITLE
chapel: add v2.8

### DIFF
--- a/repos/spack_repo/builtin/packages/chapel/fix_spack_cc_wrapper_in_cray_prgenv_2.8.patch
+++ b/repos/spack_repo/builtin/packages/chapel/fix_spack_cc_wrapper_in_cray_prgenv_2.8.patch
@@ -1,0 +1,23 @@
+diff --git a/util/chplenv/chpl_llvm.py b/util/chplenv/chpl_llvm.py
+index 4da5d4648ba..4398b9704d9 100755
+--- a/util/chplenv/chpl_llvm.py
++++ b/util/chplenv/chpl_llvm.py
+@@ -1286,12 +1286,15 @@ def get_clang_prgenv_args():
+
+         # Use cc --cray-print-opts=... to get arguments from compiler driver
+
++        # find the actual cc in case something like spack has wrapped it
++        real_cc = os.path.join(os.environ["CRAYPE_DIR"], "bin", "cc")
++
+         # Get compilation arguments
+-        opts = run_command(["cc", "--cray-print-opts=cflags"])
++        opts = run_command([real_cc, "--cray-print-opts=cflags"])
+         comp_args.extend(opts.split())
+
+         # Get link arguments
+-        opts = run_command(["cc", "--cray-print-opts=libs"])
++        opts = run_command([real_cc, "--cray-print-opts=libs"])
+         link_args.extend(opts.split())
+
+     return (comp_args, link_args)
+

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -699,20 +699,10 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
         # Undo spack compiler wrappers:
         # the C/C++ compilers must work post-install
-        if self.spec.satisfies("+rocm llvm=spack"):
-            env.set(
-                "CHPL_LLVM_CONFIG",
-                join_path(self.spec["llvm-amdgpu"].prefix, "bin", "llvm-config"),
-            )
-            real_cc = join_path(self.spec["llvm-amdgpu"].prefix, "bin", "clang")
-            real_cxx = join_path(self.spec["llvm-amdgpu"].prefix, "bin", "clang++")
-
-            # +rocm appears to also require a matching LLVM host compiler to guarantee linkage
-            env.set("CHPL_HOST_COMPILER", "llvm")
-            env.set("CHPL_HOST_CC", real_cc)
-            env.set("CHPL_HOST_CXX", real_cxx)
-
-        elif self.spec.satisfies("llvm=spack"):
+        # If we ever switch back to using llvm-amdgpu for some ROCm versions,
+        # we will need a separate case here to use the binaries it provides
+        # rather than those of vanilla LLVM.
+        if self.spec.satisfies("llvm=spack"):
             env.set("CHPL_LLVM_CONFIG", join_path(self.spec["llvm"].prefix, "bin", "llvm-config"))
             real_cc = join_path(self.spec["llvm"].prefix, "bin", "clang")
             real_cxx = join_path(self.spec["llvm"].prefix, "bin", "clang++")

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -63,11 +63,17 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     version("main", branch="main")
 
+    version(
+        "2.8.0",
+        url="https://chapel-lang.org/tmp/chapel-2.8.0.tar.gz",
+        sha256="3e5e8da6c56"
+    )
+
     version("2.7.0", sha256="5e3269babdae334c80fc3f25114698fdfe53e84ea06626af22d2b54eeb75bee6")
     version("2.6.0", sha256="e469c35be601cf1f59af542ab885e8a14aa2b087b79af0d5372a4421976c74b6")
-    version("2.5.0", sha256="020220ca9bf52b9f416e9a029bdc465bb1f635c1e274c6ca3c18d1f83e41fce1")
 
     with default_args(deprecated=True):
+        version("2.5.0", sha256="020220ca9bf52b9f416e9a029bdc465bb1f635c1e274c6ca3c18d1f83e41fce1")
         version("2.4.0", sha256="a51a472488290df12d1657db2e7118ab519743094f33650f910d92b54c56f315")
         version("2.3.0", sha256="0185970388aef1f1fae2a031edf060d5eac4eb6e6b1089e7e3b15a130edd8a31")
         version("2.2.0", sha256="bb16952a87127028031fd2b56781bea01ab4de7c3466f7b6a378c4d8895754b6")

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -519,6 +519,10 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
             depends_on("hsa-rocr-dev@6.0:6.2")
             depends_on("hip@6.0:6.2")
         with when("@2.8:"):
+            # ROCm 6.4 is specifically prohibited. Although Chapel allows it
+            # (see https://github.com/chapel-lang/chapel/pull/28220), the
+            # support is untested; being stricter here to reduce the amount of
+            # variables in getting the Spack package to work.
             depends_on("hsa-rocr-dev@6.0:6.3,7")
             depends_on("hip@6.0:6.3,7")
 

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -512,17 +512,33 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     with when("+rocm"):
         conflicts("llvm=none", msg="ROCm support requires building with LLVM")
 
-        # Chapel restricts the allowable ROCm versions
-        depends_on("hsa-rocr-dev@6.0:6.2")
-        depends_on("hip@6.0:6.2")
-
         conflicts("@:2.1", msg="ROCm support in spack requires Chapel 2.2.0 or later")
 
-        # This is the case because the package only supports ROCm 6, and Chapel
-        # requires bundled LLVM for that version.
-        # TODO: Modify this constrant and message if/when Chapel supports an
-        # additional ROCm version without tht requirement.
-        requires("llvm=bundled", msg="Chapel ROCm support requires llvm=bundled")
+        # Chapel restricts the allowable ROCm versions
+        with when("@:2.7"):
+            depends_on("hsa-rocr-dev@6.0:6.2")
+            depends_on("hip@6.0:6.2")
+        with when("@2.8:"):
+            depends_on("hsa-rocr-dev@6.0:6.3,7")
+            depends_on("hip@6.0:6.3,7")
+
+        # Chapel requires using the (patched) bundled LLVM for some versions
+        # of ROCm.
+        # Switching off of hsa-rocr-dev version rather than both it and hip,
+        # with the assumption they will always be the same, but if that changes
+        # this will need to be adjusted.
+        with when("^hsa-rocr-dev@6.0:6.2"):
+            requires("llvm=bundled", msg="Chapel ROCm 6.0-6.2 support requires llvm=bundled")
+        with when("^hsa-rocr-dev@6.3:6"):
+            # For 6.3-6.x, either bundled LLVM or system LLVM >= 21 is allowed.
+            depends_on("llvm@21:", when="llvm=spack")
+        with when("^hsa-rocr-dev@7"):
+            # For 7.x, we require LLVM >= 21, and as of release 2.8 the bundled
+            # LLVM is 19, so effectively we require _system_ LLVM >= 21.
+            # TODO: Modify this constraint and message when Chapel releases
+            # with a bundled LLVM >= 21.
+            requires("llvm=spack", msg="Chapel ROCm 7 support currently requires llvm=spack")
+            depends_on("llvm@21:")
 
         # Workaround for ROCmPackage forcing a dependency on llvm-amdgpu, which
         # provides %rocmcc, which we don't want to use.

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -841,6 +841,12 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         self.unset_chpl_env_vars(env)
         self.setup_env_vars(env)
 
+    @run_before("configure")
+    def print_configuration(self):
+        # print all the explicitly set CHPL_* config variables to assist in debugging
+        for var in self.chpl_env_vars:
+            tty.info(var + "=" + os.getenv(var, "<unset>"))
+
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         self.setup_env_vars(env)
         chpl_home = join_path(self.prefix.share, "chapel", self._output_version_short)

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -78,7 +78,8 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     sanity_check_is_dir = ["bin", join_path("lib", "chapel"), join_path("share", "chapel")]
     sanity_check_is_file = [join_path("bin", "chpl")]
 
-    patch("fix_spack_cc_wrapper_in_cray_prgenv.patch", when="@2.0.0:")
+    patch("fix_spack_cc_wrapper_in_cray_prgenv.patch", when="@2.0.0:2.7")
+    patch("fix_spack_cc_wrapper_in_cray_prgenv_2.8.patch", when="@2.8:")
     patch("fix_chpl_shared_lib_path.patch", when="@2.1.1:2.2 +python-bindings")  # PR 26388
     patch("fix_chpl_shared_lib_path_2.3.patch", when="@2.2.1:2.3 +python-bindings")  # PR 26388
     patch("fix_chpl_line_length.patch", when="@:2.3.0")  # PRs 26357, 26381, 26491
@@ -579,7 +580,8 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         depends_on("llvm@11:18", when="@2.1:2.2")
         depends_on("llvm@11:19", when="@2.3:2.4")
         depends_on("llvm@11:20", when="@2.5")
-        depends_on("llvm@14:20", when="@2.6:")
+        depends_on("llvm@14:20", when="@2.6:2.7")
+        depends_on("llvm@14:21", when="@2.8:")
 
     # Based on docs https://chapel-lang.org/docs/technotes/gpu.html#requirements
     depends_on("llvm@16:", when="llvm=spack +cuda ^cuda@12:")

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -54,7 +54,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     # A list of GitHub accounts to notify when the package is updated.
     # TODO: add chapel-project github account
-    maintainers("arezaii", "bonachea", "arifthpe", "e-kayrakli")
+    maintainers("arezaii", "bonachea", "arifthpe")
 
     tags = ["e4s"]
 

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -500,9 +500,9 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
             when="llvm=spack",
         )
         conflicts(
-            "^llvm@20",
+            "^llvm@20:",
             when="@:2.5",
-            msg="Chapel through 2.5 does not support Nvidia GPUs with LLVM 20, see "
+            msg="Chapel through 2.5 does not support Nvidia GPUs with LLVM 20+, see "
             "https://github.com/chapel-lang/chapel/issues/27273",
         )
 

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -63,12 +63,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     version("main", branch="main")
 
-    version(
-        "2.8.0",
-        url="https://chapel-lang.org/tmp/chapel-2.8.0.tar.gz",
-        sha256="3e5e8da6c56337c6eeb468f12e52ba70c9bc3b05a1cb4b9cd0f1a4b9bce77e9c",
-    )
-
+    version("2.8.0", sha256="80e8c3018e33e49674c7a2542e062547ea41d64d6595edb3b799e90c88f963f8")
     version("2.7.0", sha256="5e3269babdae334c80fc3f25114698fdfe53e84ea06626af22d2b54eeb75bee6")
     version("2.6.0", sha256="e469c35be601cf1f59af542ab885e8a14aa2b087b79af0d5372a4421976c74b6")
 

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -486,36 +486,51 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     conflicts("+rocm", when="+cuda", msg="Chapel must be built with either CUDA or ROCm, not both")
 
-    # CUDA conflicts and dependencies
-    conflicts(
-        "^llvm@20",
-        when="@:2.5 +cuda",
-        msg="Chapel through 2.5 does not support Nvidia GPUs with LLVM 20, see "
-        "https://github.com/chapel-lang/chapel/issues/27273",
-    )
+    # GPU requirements should encode the requirements documented at:
+    # https://chapel-lang.org/docs/technotes/gpu.html#requirements
 
-    conflicts("cuda@12.9:", when="+cuda")  # deprecation warnings otherwise
+    # CUDA conflicts and dependencies
+    with when("+cuda"):
+        conflicts("llvm=none", msg="Cuda support requires building with LLVM")
+
+        depends_on("llvm@16:", when="llvm=spack ^cuda@12:")
+        requires(
+            "^llvm targets=all",
+            msg="llvm=spack +cuda requires LLVM support the nvptx target",
+            when="llvm=spack",
+        )
+        conflicts(
+            "^llvm@20",
+            when="@:2.5",
+            msg="Chapel through 2.5 does not support Nvidia GPUs with LLVM 20, see "
+            "https://github.com/chapel-lang/chapel/issues/27273",
+        )
+
+        conflicts("cuda@12.9:")  # deprecation warnings otherwise
 
     # ROCm conflicts and dependencies
-    conflicts("+rocm", when="@:2.1", msg="ROCm support in spack requires Chapel 2.2.0 or later")
-    # Chapel restricts the allowable ROCm versions
-    with when("@2.2: +rocm"):
+    with when("+rocm"):
+        conflicts("llvm=none", msg="ROCm support requires building with LLVM")
+
+        # Chapel restricts the allowable ROCm versions
         depends_on("hsa-rocr-dev@6.0:6.2")
         depends_on("hip@6.0:6.2")
-    # This is the case because the package only supports ROCm 6, and Chapel
-    # requires bundled LLVM for that version.
-    # TODO: Modify this constrant and message if/when Chapel supports an
-    # additional ROCm version without that requirement.
-    requires("llvm=bundled", when="+rocm", msg="Chapel ROCm support requires llvm=bundled")
 
-    # Workaround for ROCmPackage forcing a dependency on llvm-amdgpu, which
-    # provides %rocmcc, which we don't want to use.
-    requires(
-        *("%" + comp for comp in compiler_map.keys() if comp != "rocmcc" and comp != "unset"),
-        policy="any_of",  # any to ensure %clang works
-        when="+rocm",
-        msg="Chapel ROCm support requires a supported host compiler other than rocmcc",
-    )
+        conflicts("@:2.1", msg="ROCm support in spack requires Chapel 2.2.0 or later")
+
+        # This is the case because the package only supports ROCm 6, and Chapel
+        # requires bundled LLVM for that version.
+        # TODO: Modify this constrant and message if/when Chapel supports an
+        # additional ROCm version without tht requirement.
+        requires("llvm=bundled", msg="Chapel ROCm support requires llvm=bundled")
+
+        # Workaround for ROCmPackage forcing a dependency on llvm-amdgpu, which
+        # provides %rocmcc, which we don't want to use.
+        requires(
+            *("%" + comp for comp in compiler_map.keys() if comp != "rocmcc" and comp != "unset"),
+            policy="any_of",  # any to ensure %clang works
+            msg="Chapel ROCm support requires a supported host compiler other than rocmcc",
+        )
 
     conflicts(
         "comm_substrate=unset",
@@ -553,14 +568,12 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         "https://chapel-lang.org/docs/usingchapel/chplenv.html#chpl-host-jemalloc",
     )
 
-    with when("llvm=none"):
-        conflicts("+cuda", msg="Cuda support requires building with LLVM")
-        conflicts("+rocm", msg="ROCm support requires building with LLVM")
-        conflicts(
-            "+python-bindings",
-            msg="Python bindings require building with LLVM, see "
-            "https://chapel-lang.org/docs/tools/chapel-py/chapel-py.html#installation",
-        )
+    conflicts(
+        "+python-bindings",
+        when="llvm=none",
+        msg="Python bindings require building with LLVM, see "
+        "https://chapel-lang.org/docs/tools/chapel-py/chapel-py.html#installation",
+    )
 
     # Add dependencies
     depends_on("c", type="build")  # generated
@@ -583,14 +596,6 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         depends_on("llvm@11:20", when="@2.5")
         depends_on("llvm@14:20", when="@2.6:2.7")
         depends_on("llvm@14:21", when="@2.8:")
-
-    # Based on docs https://chapel-lang.org/docs/technotes/gpu.html#requirements
-    depends_on("llvm@16:", when="llvm=spack +cuda ^cuda@12:")
-    requires(
-        "^llvm targets=all",
-        msg="llvm=spack +cuda requires LLVM support the nvptx target",
-        when="llvm=spack +cuda",
-    )
 
     # This is because certain systems have binutils installed as a system package
     # but do not include the headers. Spack incorrectly supplies those external

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -609,7 +609,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     requires("re2=bundled", when="+mason", msg="Mason requires re2=bundled")
 
     # TODO: keep up to date with util/chplenv/chpl_llvm.py
-    with when("llvm=spack ~rocm"):
+    with when("llvm=spack"):
         depends_on("llvm@11:17", when="@:2.0.1")
         depends_on("llvm@11:18", when="@2.1:2.2")
         depends_on("llvm@11:19", when="@2.3:2.4")

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -66,7 +66,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     version(
         "2.8.0",
         url="https://chapel-lang.org/tmp/chapel-2.8.0.tar.gz",
-        sha256="3e5e8da6c56337c6eeb468f12e52ba70c9bc3b05a1cb4b9cd0f1a4b9bce77e9c"
+        sha256="3e5e8da6c56337c6eeb468f12e52ba70c9bc3b05a1cb4b9cd0f1a4b9bce77e9c",
     )
 
     version("2.7.0", sha256="5e3269babdae334c80fc3f25114698fdfe53e84ea06626af22d2b54eeb75bee6")

--- a/repos/spack_repo/builtin/packages/chapel/package.py
+++ b/repos/spack_repo/builtin/packages/chapel/package.py
@@ -66,7 +66,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     version(
         "2.8.0",
         url="https://chapel-lang.org/tmp/chapel-2.8.0.tar.gz",
-        sha256="3e5e8da6c56"
+        sha256="3e5e8da6c56337c6eeb468f12e52ba70c9bc3b05a1cb4b9cd0f1a4b9bce77e9c"
     )
 
     version("2.7.0", sha256="5e3269babdae334c80fc3f25114698fdfe53e84ea06626af22d2b54eeb75bee6")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Add Chapel version 2.8, which was released March 12th.

Changes:
- Add 2.8
- Deprecate 2.5
- Add a new version of an existing patch for 2.8
- Refactor expression of ROCm and CUDA requirements for clarity
- Update LLVM and ROCm dependencies for 2.8
- Drop @e-kayrakli as a maintainer (with his permission given offline)

Replaces and is based off of https://github.com/spack/spack-packages/pull/3692, due to it taking longer for us to see through than @e-kayrakli has available time for at the moment.