### PR TITLE
ntpoly: add missing compiler dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/ntpoly/package.py
+++ b/repos/spack_repo/builtin/packages/ntpoly/package.py
@@ -27,7 +27,7 @@ class Ntpoly(CMakePackage):
 
     variant("shared", default=True, description="Build shared libraries.")
 
-    depends_on("c", type="build")
+    depends_on("c", type="build")  # required: CMake performs C compiler ABI/sanity checks
 
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/ntpoly/package.py
+++ b/repos/spack_repo/builtin/packages/ntpoly/package.py
@@ -27,6 +27,8 @@ class Ntpoly(CMakePackage):
 
     variant("shared", default=True, description="Build shared libraries.")
 
+    depends_on("c", type="build")
+
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 


### PR DESCRIPTION
### Problem
When building `ntpoly` with modern GCC versions (specifically tested with GCC 14.3.0 on a Skylake architecture), the CMake configuration phase fails. The Spack compiler wrapper exits with an error stating that `SPACK_CC_*` variables are not set.

This occurs because `ntpoly` is primarily a Fortran project, and its package.py did not explicitly declare a dependency on a C compiler. However, its CMake build system still performs standard C compiler ABI and sanity checks, which require the Spack wrapper to be correctly initialized with C environment variables.

### Solution
Added `depends_on("c", type="build")` to the ntpoly package definition. This ensures that Spack correctly injects the necessary C compiler wrappers and environment variables during the build phase, allowing CMake to complete its configuration successfully.

### Trivial Change
- [x] This is a trivial change (only adding a dependency line).