### PR TITLE
gmsh: new version 4.15.1

### DIFF
--- a/repos/spack_repo/builtin/packages/gmsh/package.py
+++ b/repos/spack_repo/builtin/packages/gmsh/package.py
@@ -26,6 +26,7 @@ class Gmsh(CMakePackage):
     license("GPL-2.0-or-later")
 
     version("master", branch="master")
+    version("4.15.1", sha256="eba8e4064f6586c8ca880f1cfdf697f4d70f026f398a93b458f247f7e4364fed")
     version("4.13.1", sha256="77972145f431726026d50596a6a44fb3c1c95c21255218d66955806b86edbe8d")
     version("4.13.0", sha256="c85f056ee549a433e814a61c385c97952bbfe514b442b999f6149fffb1e54f64")
     version("4.12.2", sha256="13e09d9ca8102e5c40171d6ee150c668742b98c3a6ca57f837f7b64e1e2af48f")
@@ -74,9 +75,9 @@ class Gmsh(CMakePackage):
     variant("voropp", default=True, description="Build with voro++ (built-in or 3rd party")
     variant("cgns", default=True, description="Build with CGNS")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
 
     # https://gmsh.info/doc/texinfo/gmsh.html#Compiling-the-source-code
     # We make changes to the GMSH default, such as external blas.


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
https://gitlab.onelab.info/gmsh/gmsh/-/releases#changelog
4.15.0:
New API functions: model/isEntityOrphan, occ/getClosestEntities
Incompatible API changes: new arguments to algorithm/tetrahedralize and fltk/run
4.14.0:
New API functions: model/getEntityProperties, model/getPhysicalGroupsEntities
Incompatible API changes: new optional arguments to occ/fillet2D; renamed model/getType as model/getEntityType; renamed mesh/triangulate as algorithm/triangulate and add new optional argument (edges); renamed mesh/tetrahedralize as algorithm/tetrahedralize