### PR TITLE
rust: setup_dep_build_env: CARGO_HOME

### DIFF
--- a/repos/spack_repo/builtin/packages/py_tensorboard_data_server/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorboard_data_server/package.py
@@ -36,9 +36,6 @@ class PyTensorboardDataServer(PythonPackage):
         when="@0.6.1",
     )
 
-    def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        env.set("CARGO_HOME", self.stage.source_path)
-
     def install(self, spec, prefix):
         with working_dir(join_path("tensorboard", "data", "server")):
             cargo = which("cargo", required=True)

--- a/repos/spack_repo/builtin/packages/rust/package.py
+++ b/repos/spack_repo/builtin/packages/rust/package.py
@@ -185,7 +185,7 @@ class Rust(Package):
     def setup_dependent_build_environment(
         self, env: EnvironmentModifications, dependent_spec: Spec
     ) -> None:
-        env.set("CARGO_HOME", dependent_spec.stage.path)
+        env.set("CARGO_HOME", dependent_spec.package.stage.path)
 
     def configure(self, spec, prefix):
         opts = []

--- a/repos/spack_repo/builtin/packages/rust/package.py
+++ b/repos/spack_repo/builtin/packages/rust/package.py
@@ -182,6 +182,11 @@ class Rust(Package):
         if certs is not None:
             env.set("CARGO_HTTP_CAINFO", certs)
 
+    def setup_dependent_build_environment(
+        self, env: EnvironmentModifications, dependent_spec: Spec
+    ) -> None:
+        env.set("CARGO_HOME", dependent_spec.stage.path)
+
     def configure(self, spec, prefix):
         opts = []
 


### PR DESCRIPTION
This PR modifies the build environment for packages that depend on `rust` such that `CARGO_HOME` points  to the stage path. This avoids the current situation for packages (`py-maturin`, `py-cramjam`, `py-uv`,...) that depend on `rust` and internally use cargo, but that don't set `CARGO_HOME`, and which write their cargo cache files to the user's `~/.cargo` directory.

Note: this adds download inefficiencies since different packages will not be able to take advantage of already downloaded cargo crates. This is (IMHO) preferred over breaking out of spack's usual stage 'sandbox'.

Build tests after this change:
```
[+] lygt4co py-maturin@1.10.2 /opt/software/linux-skylake/py-maturin-1.10.2-lygt4coi2lytzddz3v4tox2o5ceik3ga
[+] ycra4ur py-cramjam@2.11.0 /opt/software/linux-skylake/py-cramjam-2.11.0-ycra4urxpanrndkbrrzvovycvyg4gszd
```
and I prefer the stage directory to contain this (instead of my home directory):
```
16:33:49 wdconinc@menelaos /opt/spack/stage/wdconinc $ du -sh spack-stage-py-maturin-1.10.2-lygt4coi2lytzddz3v4tox2o5ceik3ga/registry/
640M    spack-stage-py-maturin-1.10.2-lygt4coi2lytzddz3v4tox2o5ceik3ga/registry/
16:36:28 wdconinc@menelaos /opt/spack/stage/wdconinc $ du -sh spack-stage-py-uv-0.7.22-hwevspz4vntxdniv5f6uil3jqrzst2f4/registry/
950M    spack-stage-py-uv-0.7.22-hwevspz4vntxdniv5f6uil3jqrzst2f4/registry/
```