### PR TITLE
blast-plus: Fix typo in sqlite3 configure option

### DIFF
--- a/repos/spack_repo/builtin/packages/blast_plus/package.py
+++ b/repos/spack_repo/builtin/packages/blast_plus/package.py
@@ -172,7 +172,7 @@ class BlastPlus(AutotoolsPackage):
             config_args.append("--without-python")
 
         with when("@2.15:"):
-            config_args.append(f"--with-sqlite={self.spec['sqlite'].prefix}")
+            config_args.append(f"--with-sqlite3={self.spec['sqlite'].prefix}")
 
         with when("@2.17:"):
             config_args.append(f"--with-zstd={self.spec['zstd'].prefix}")


### PR DESCRIPTION
Checked with source tarballs downloaded from https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/
```
~/Downloads/ncbi-blast-2.15.0+-src/c++
13:38 $ ./configure --help|grep sqlite
 --with-sqlite3=DIR      use SQLite 3.x installation in DIR
 --without-sqlite3       do not use SQLite 3.x
~/Downloads/ncbi-blast-2.16.0+-src/c++
13:38 $ ./configure --help|grep sqlite
 --with-sqlite3=DIR      use SQLite 3.x installation in DIR
 --without-sqlite3       do not use SQLite 3.x
~/Downloads/ncbi-blast-2.17.0+-src/c++
13:31 $ ./configure --help|grep sqlite           
 --with-sqlite3=DIR      use SQLite 3.x installation in DIR
 --without-sqlite3       do not use SQLite 3.x
```
