### PR TITLE
sepp: restrict py-setuptools version because of pkg-resources again

### DIFF
--- a/repos/spack_repo/builtin/packages/sepp/package.py
+++ b/repos/spack_repo/builtin/packages/sepp/package.py
@@ -20,7 +20,7 @@ class Sepp(Package):
     version("4.5.1", sha256="51e052569ae89f586a1a94c804f09fe1b7910a3ffff7664e2005f18c7d3f717b")
 
     depends_on("python@3.6:", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@:81", type="build")
     depends_on("py-dendropy@4:", type=("build", "run"))
 
     depends_on("java@1.8:", type="run")


### PR DESCRIPTION
This is again needed because of dependency on `pkg-resources` which is removed in `py-setuptools@82:`