### PR TITLE
Fix for cmake_cache builds with mixed compilers

### DIFF
--- a/repos/spack_repo/builtin/build_systems/cached_cmake.py
+++ b/repos/spack_repo/builtin/build_systems/cached_cmake.py
@@ -322,7 +322,7 @@ class CachedCMakeBuilder(CMakeBuilder):
                 cmake_cache_filepath("CMAKE_HIP_COMPILER", os.path.join(llvm_bin, "amdclang++"))
             )
 
-            if spec.satisfies("%gcc"):
+            if spec.satisfies("%cxx=gcc"):
                 entries.append(
                     cmake_cache_string(
                         "CMAKE_HIP_FLAGS", f"--gcc-toolchain={self.pkg.compiler.prefix}"


### PR DESCRIPTION
A cached_cmake build (in my case, umpire) using a mixed compiler toolchains (e.g. amdclang for C/C++ with gfortran) twigged on the gccness of gfortran and added the wrong flags for clang. This makes sure that the actual cxx compiler is actually gcc before adding the hip flags it would need. 