### PR TITLE
netlib-lapack: make `external-blas` variant sticky

### DIFF
--- a/repos/spack_repo/builtin/packages/netlib_lapack/package.py
+++ b/repos/spack_repo/builtin/packages/netlib_lapack/package.py
@@ -96,7 +96,12 @@ class NetlibLapack(CMakePackage):
 
     variant("shared", default=True, description="Build shared library version")
     variant("pic", default=True, description="Produce position-independent code")
-    variant("external-blas", default=False, description="Build lapack with an external blas")
+    variant(
+        "external-blas",
+        default=False,
+        sticky=True,
+        description="Build lapack with an external blas",
+    )
     variant("lapacke", default=True, description="Activates the build of the LAPACKE C interface")
     variant("xblas", default=False, description="Builds extended precision routines using XBLAS")
 


### PR DESCRIPTION
In this way clingo can't switch to use something else for blas, without the user being explicit about it.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
