### PR TITLE
py-openai: remove from e4s-oneapi test list

### DIFF
--- a/stacks/e4s-oneapi/spack.yaml
+++ b/stacks/e4s-oneapi/spack.yaml
@@ -204,7 +204,7 @@ spack:
   - opencv +python3
   - py-mpi4py
   - py-numpy
-  - py-openai
+  # - py-openai                     # py-maturin: rust-lld: error: undefined symbol: _intel_fast_memcpy
   - py-pooch
   - py-pytest
   - py-scikit-learn


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

`py-openai` depends on `py-jiter` in recent versions, which introduces a `py-maturin` dependent. For `e4s-oneapi` ci array fails to build `py-maturin`, this PR removes `py-openai` from this array.