### PR TITLE
PythonPackage: speed up import tests

### DIFF
--- a/repos/spack_repo/builtin/build_systems/python.py
+++ b/repos/spack_repo/builtin/build_systems/python.py
@@ -187,7 +187,7 @@ class PythonExtension(PackageBase):
         # Make sure we are importing the installed modules,
         # not the ones in the source directory
         python = self.module.python
-        with test_part(self, f"test_imports", purpose=f"checking imports", work_dir="spack-test"):
+        with test_part(self, "test_imports", purpose="checking imports", work_dir="spack-test"):
             python(
                 "-c",
                 f"""

--- a/repos/spack_repo/builtin/build_systems/python.py
+++ b/repos/spack_repo/builtin/build_systems/python.py
@@ -190,11 +190,15 @@ class PythonExtension(PackageBase):
         with test_part(self, "test_imports", purpose="checking imports", work_dir="spack-test"):
             python(
                 "-c",
-                f"""
+                """
 import importlib
-for module in {self.import_modules}:
+import sys
+
+for module in sys.argv[1:]:
+    print(module)
     importlib.import_module(module)
 """,
+                *self.import_modules
             )
 
 

--- a/repos/spack_repo/builtin/build_systems/python.py
+++ b/repos/spack_repo/builtin/build_systems/python.py
@@ -198,7 +198,7 @@ for module in sys.argv[1:]:
     print(module)
     importlib.import_module(module)
 """,
-                *self.import_modules
+                *self.import_modules,
             )
 
 

--- a/repos/spack_repo/builtin/build_systems/python.py
+++ b/repos/spack_repo/builtin/build_systems/python.py
@@ -187,14 +187,19 @@ class PythonExtension(PackageBase):
         # Make sure we are importing the installed modules,
         # not the ones in the source directory
         python = self.module.python
-        for module in self.import_modules:
-            with test_part(
-                self,
-                f"test_imports_{module}",
-                purpose=f"checking import of {module}",
-                work_dir="spack-test",
-            ):
-                python("-c", f"import {module}")
+        tty.debug(self.import_modules)
+        with test_part(
+            self,
+            f"test_imports",
+            purpose=f"checking imports",
+            work_dir="spack-test",
+        ):
+            python("-c", f"""
+import importlib
+for module in {self.import_modules}:
+    print(module)
+    importlib.import_module(module)
+""")
 
 
 def _homepage(cls: "PythonPackage") -> Optional[str]:

--- a/repos/spack_repo/builtin/build_systems/python.py
+++ b/repos/spack_repo/builtin/build_systems/python.py
@@ -187,17 +187,15 @@ class PythonExtension(PackageBase):
         # Make sure we are importing the installed modules,
         # not the ones in the source directory
         python = self.module.python
-        with test_part(
-            self,
-            f"test_imports",
-            purpose=f"checking imports",
-            work_dir="spack-test",
-        ):
-            python("-c", f"""
+        with test_part(self, f"test_imports", purpose=f"checking imports", work_dir="spack-test"):
+            python(
+                "-c",
+                f"""
 import importlib
 for module in {self.import_modules}:
     importlib.import_module(module)
-""")
+""",
+            )
 
 
 def _homepage(cls: "PythonPackage") -> Optional[str]:

--- a/repos/spack_repo/builtin/build_systems/python.py
+++ b/repos/spack_repo/builtin/build_systems/python.py
@@ -187,7 +187,6 @@ class PythonExtension(PackageBase):
         # Make sure we are importing the installed modules,
         # not the ones in the source directory
         python = self.module.python
-        tty.debug(self.import_modules)
         with test_part(
             self,
             f"test_imports",
@@ -197,7 +196,6 @@ class PythonExtension(PackageBase):
             python("-c", f"""
 import importlib
 for module in {self.import_modules}:
-    print(module)
     importlib.import_module(module)
 """)
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
### Before

```console
> time spack test run py-keras
==> Spack test 4y2u6jhhhgcv7pxrayesd54fzltdl7dl
==> Testing package py-keras-3.13.2-jrk3c5j
============================== 1 passed of 1 spec ==============================

________________________________________________________
Executed in  344.56 secs    fish           external
   usr time  290.48 secs    1.45 millis  290.48 secs
   sys time   51.96 secs    3.82 millis   51.95 secs
```

### After

```console
> time spack test run py-keras
==> Spack test 4y2u6jhhhgcv7pxrayesd54fzltdl7dl
==> Testing package py-keras-3.13.2-jrk3c5j
============================== 1 passed of 1 spec ==============================

________________________________________________________
Executed in    2.98 secs    fish           external
   usr time    2.58 secs    1.49 millis    2.58 secs
   sys time    0.58 secs    3.20 millis    0.58 secs
```
So a 10x speedup if you only invoke the Python executable a single time. Thanks for reporting this @haampie! Only downside is logging is a little less clear about which import actually failed and you only see a single failure at a time. An alternative would be to somehow parametrize this, but I think it would still be slower than a for-loop.