### PR TITLE
Suppress the incompatible-pointer-types error

### DIFF
--- a/repos/spack_repo/builtin/packages/py_lxml/package.py
+++ b/repos/spack_repo/builtin/packages/py_lxml/package.py
@@ -64,3 +64,9 @@ class PyLxml(PythonPackage):
     depends_on("py-cython@3.0.9:", type="build", when="@5.1.1:")
     depends_on("py-cython@3.0.8:", type="build", when="@5:")
     depends_on("py-cython@0.29.7:", type="build")
+
+    def flag_handler(self, name, flags):
+        if name == "cflags":
+            elif self.spec.satisfies("%gcc@14:"):
+                flags.append("-Wno-error=incompatible-pointer-types")
+        return (flags, None, None)


### PR DESCRIPTION
This was turned on as an error starting with gcc@14 https://gcc.gnu.org/gcc-14/porting_to.html#incompatible-pointer-types

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
