### PR TITLE
gtkorvo/libevpath/libffs: add new upstream versions

### DIFF
--- a/repos/spack_repo/builtin/packages/gtkorvo_atl/package.py
+++ b/repos/spack_repo/builtin/packages/gtkorvo_atl/package.py
@@ -16,6 +16,8 @@ class GtkorvoAtl(CMakePackage):
     url = "https://github.com/GTkorvo/atl/archive/v2.1.tar.gz"
     git = "https://github.com/GTkorvo/atl.git"
 
+    maintainers("eisenhauer", "vicentebolea")
+
     version("master", branch="master")
     version("2.3.0", sha256="8f5746bc2362fd7fe3aa1814f1704449972570f903b2391a7ae6e4efa4cd60be")
 

--- a/repos/spack_repo/builtin/packages/gtkorvo_atl/package.py
+++ b/repos/spack_repo/builtin/packages/gtkorvo_atl/package.py
@@ -17,24 +17,29 @@ class GtkorvoAtl(CMakePackage):
     git = "https://github.com/GTkorvo/atl.git"
 
     version("master", branch="master")
-    version("2.2.1", sha256="7ff2dca93702ed56e3bbfd8eb52da3bb5f0e7bef5006f3ca29aaa468cab89037")
-    version("2.2", sha256="d88b6eaa3926e499317973bfb2ae469c584bb064da198217ea5fede6d919e160")
-    version("2.1", sha256="379b493ba867b76d76eabfe5bfeec85239606e821509c31e8eb93c2dc238e4a8")
+    version("2.3.0", sha256="8f5746bc2362fd7fe3aa1814f1704449972570f903b2391a7ae6e4efa4cd60be")
+
+    with default_args(deprecated=True):
+        version("2.2.1", sha256="7ff2dca93702ed56e3bbfd8eb52da3bb5f0e7bef5006f3ca29aaa468cab89037")
+        version("2.2", sha256="d88b6eaa3926e499317973bfb2ae469c584bb064da198217ea5fede6d919e160")
+        version("2.1", sha256="379b493ba867b76d76eabfe5bfeec85239606e821509c31e8eb93c2dc238e4a8")
+
+    variant("shared", default=True, when="@2.3:", description="Build shared libraries")
 
     depends_on("c", type="build")  # generated
 
-    depends_on("gtkorvo-cercs-env")
+    depends_on("gtkorvo-cercs-env", when="@:2.2.1")
 
     def cmake_args(self):
         args = []
-        if self.spec.satisfies("@2.2:"):
+        if self.spec.satisfies("@2.3:"):
+            args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+        elif self.spec.satisfies("@2.2"):
             args.append("-DBUILD_SHARED_LIBS=OFF")
         else:
             args.append("-DENABLE_BUILD_STATIC=STATIC")
 
-        if self.run_tests:
-            args.append("-DENABLE_TESTING=1")
-        else:
-            args.append("-DENABLE_TESTING=0")
+        args.append(self.define("ENABLE_TESTING", self.run_tests))
+        args.append("-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE")
 
         return args

--- a/repos/spack_repo/builtin/packages/gtkorvo_dill/package.py
+++ b/repos/spack_repo/builtin/packages/gtkorvo_dill/package.py
@@ -17,6 +17,8 @@ class GtkorvoDill(CMakePackage):
     url = "https://github.com/GTkorvo/dill/archive/v2.1.tar.gz"
     git = "https://github.com/GTkorvo/dill.git"
 
+    maintainers("eisenhauer", "vicentebolea")
+
     version("develop", branch="master")
     version("3.3.0", sha256="b29b68ce0cb778ccee614db12405cb72e817b74e914ca909a39e6a4a62fdd9a5")
     version("3.2.0", sha256="80d7e80a7b4d532e71de860f0b138bdf63db350b4517f08c5a596a4c84a501a4")

--- a/repos/spack_repo/builtin/packages/gtkorvo_dill/package.py
+++ b/repos/spack_repo/builtin/packages/gtkorvo_dill/package.py
@@ -18,8 +18,15 @@ class GtkorvoDill(CMakePackage):
     git = "https://github.com/GTkorvo/dill.git"
 
     version("develop", branch="master")
-    version("2.4", sha256="ed7745d13e8c6a556f324dcc0e48a807fc993bdd5bb1daa94c1df116cb7e81fa")
-    version("2.1", sha256="7671e1f3c25ac6a4ec2320cec2c342a2f668efb170e3dba186718ed17d2cf084")
+    version("3.3.0", sha256="b29b68ce0cb778ccee614db12405cb72e817b74e914ca909a39e6a4a62fdd9a5")
+    version("3.2.0", sha256="80d7e80a7b4d532e71de860f0b138bdf63db350b4517f08c5a596a4c84a501a4")
+
+    with default_args(deprecated=True):
+        version("2.4.1", sha256="93c9e3c8e24ab91786639273a89934c2f384638b03aa0dd0f40e58cdf5a8f0f7")
+        version("2.4", sha256="ed7745d13e8c6a556f324dcc0e48a807fc993bdd5bb1daa94c1df116cb7e81fa")
+        version("2.1", sha256="7671e1f3c25ac6a4ec2320cec2c342a2f668efb170e3dba186718ed17d2cf084")
+
+    variant("shared", default=True, when="@3.2:", description="Build shared libraries")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
@@ -30,14 +37,14 @@ class GtkorvoDill(CMakePackage):
 
     def cmake_args(self):
         args = []
-        if self.spec.satisfies("@2.4:"):
+        if self.spec.satisfies("@3.2:"):
+            args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+        elif self.spec.satisfies("@2.4"):
             args.append("-DBUILD_SHARED_LIBS=OFF")
         else:
             args.append("-DENABLE_BUILD_STATIC=STATIC")
 
-        if self.run_tests:
-            args.append("-DENABLE_TESTING=1")
-        else:
-            args.append("-DENABLE_TESTING=0")
+        args.append(self.define("ENABLE_TESTING", self.run_tests))
+        args.append("-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE")
 
         return args

--- a/repos/spack_repo/builtin/packages/libevpath/package.py
+++ b/repos/spack_repo/builtin/packages/libevpath/package.py
@@ -18,6 +18,8 @@ class Libevpath(CMakePackage):
     url = "https://github.com/GTkorvo/evpath/archive/v4.1.1.tar.gz"
     git = "https://github.com/GTkorvo/evpath.git"
 
+    maintainers("eisenhauer", "vicentebolea")
+
     version("develop", branch="master")
     version("5.0.0", sha256="e55a3f888352b5deeb1a56e3e1b524cf5dc1226c3172163e418626d75a0ee297")
 

--- a/repos/spack_repo/builtin/packages/libevpath/package.py
+++ b/repos/spack_repo/builtin/packages/libevpath/package.py
@@ -19,15 +19,20 @@ class Libevpath(CMakePackage):
     git = "https://github.com/GTkorvo/evpath.git"
 
     version("develop", branch="master")
-    version("4.4.0", sha256="c8d20d33c84d8d826493f453760eceb792d601734ff61238662c16fa6243dc29")
-    version("4.2.4", sha256="070698a068798e2e34dd73debb936cf275af23987a4cb0d06aa3e50c481042ff")
-    version("4.2.1", sha256="c745946f2ecff65bfc80978c2038c37c3803076064cfd29ea3023d671c950770")
-    version("4.1.2", sha256="2c0d5acc0e1c5aadd32d7147d2f0ce26220e3870e21c7d5429372d8f881e519e")
-    version("4.1.1", sha256="cfc9587f98c1f057eb25712855d14311fd91d6284151eee7bd8936c4ff7ee001")
+    version("5.0.0", sha256="e55a3f888352b5deeb1a56e3e1b524cf5dc1226c3172163e418626d75a0ee297")
+
+    with default_args(deprecated=True):
+        version("4.4.0", sha256="c8d20d33c84d8d826493f453760eceb792d601734ff61238662c16fa6243dc29")
+        version("4.2.4", sha256="070698a068798e2e34dd73debb936cf275af23987a4cb0d06aa3e50c481042ff")
+        version("4.2.1", sha256="c745946f2ecff65bfc80978c2038c37c3803076064cfd29ea3023d671c950770")
+        version("4.1.2", sha256="2c0d5acc0e1c5aadd32d7147d2f0ce26220e3870e21c7d5429372d8f881e519e")
+        version("4.1.1", sha256="cfc9587f98c1f057eb25712855d14311fd91d6284151eee7bd8936c4ff7ee001")
 
     variant("enet_transport", default=False, description="Build an ENET transport for EVpath")
+    variant("shared", default=True, when="@5:", description="Build shared libraries")
 
     depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
 
     depends_on("gtkorvo-enet", when="@4.4.0: +enet_transport")
     depends_on("gtkorvo-enet@1.3.13", when="@:4.2.4 +enet_transport")
@@ -35,14 +40,18 @@ class Libevpath(CMakePackage):
 
     def cmake_args(self):
         args = ["-DTARGET_CNL=1"]
-        if self.spec.satisfies("@4.4.0:"):
+        if self.spec.satisfies("@5:"):
+            args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+        elif self.spec.satisfies("@4.4.0"):
             args.append("-DBUILD_SHARED_LIBS=OFF")
         else:
             args.append("-DENABLE_BUILD_STATIC=STATIC")
 
-        if self.run_tests:
-            args.append("-DENABLE_TESTING=1")
+        if self.spec.satisfies("@5.0.0:"):
+            args.append(self.define("BUILD_TESTING", self.run_tests))
         else:
-            args.append("-DENABLE_TESTING=0")
+            args.append(self.define("ENABLE_TESTING", self.run_tests))
+
+        args.append("-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE")
 
         return args

--- a/repos/spack_repo/builtin/packages/libffs/package.py
+++ b/repos/spack_repo/builtin/packages/libffs/package.py
@@ -20,11 +20,18 @@ class Libffs(CMakePackage):
     git = "https://github.com/GTkorvo/ffs.git"
 
     version("develop", branch="master")
-    version("1.5", sha256="e1f3df42eb36fa35c5445887d679e26b7e3c9be697a07cd38e4ae824dbcd8ef8")
-    version("1.1.1", sha256="9c3a82b3357e6ac255b65d4f45003dd270dea3ec0cd7a2aa40b59b3eab4bdb83")
-    version("1.1", sha256="008fd87c5a6cb216cd757b4dc04057fc987b39b7a367623eb4cf0fd32a9fd81e")
+    version("3.2.0", sha256="885578babae52394c3cabb4479b7a87053443d61b1c0975f777a22c3fd104d8c")
+
+    with default_args(deprecated=True):
+        version("1.6.0", sha256="2e5f547d9e4994d4f52fc4615cbf2e51e4aa82480c3624faade88a0e709a9172")
+        version("1.5", sha256="e1f3df42eb36fa35c5445887d679e26b7e3c9be697a07cd38e4ae824dbcd8ef8")
+        version("1.1.1", sha256="9c3a82b3357e6ac255b65d4f45003dd270dea3ec0cd7a2aa40b59b3eab4bdb83")
+        version("1.1", sha256="008fd87c5a6cb216cd757b4dc04057fc987b39b7a367623eb4cf0fd32a9fd81e")
+
+    variant("shared", default=True, when="@3.2:", description="Build shared libraries")
 
     depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
 
     depends_on("flex", type="build", when="@:1.4")
     depends_on("bison", type="build", when="@:1.4")
@@ -34,14 +41,15 @@ class Libffs(CMakePackage):
 
     def cmake_args(self):
         args = ["-DTARGET_CNL=1"]
-        if self.spec.satisfies("@1.5:"):
+        if self.spec.satisfies("@3.2:"):
+            args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+
+        elif self.spec.satisfies("@1.5:"):
             args.append("-DBUILD_SHARED_LIBS=OFF")
         else:
             args.append("-DENABLE_BUILD_STATIC=STATIC")
 
-        if self.run_tests:
-            args.append("-DENABLE_TESTING=0")
-        else:
-            args.append("-DENABLE_TESTING=0")
+        args.append(self.define("ENABLE_TESTING", self.run_tests))
+        args.append("-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE")
 
         return args

--- a/repos/spack_repo/builtin/packages/libffs/package.py
+++ b/repos/spack_repo/builtin/packages/libffs/package.py
@@ -19,6 +19,8 @@ class Libffs(CMakePackage):
     url = "https://github.com/GTkorvo/ffs/archive/v1.1.tar.gz"
     git = "https://github.com/GTkorvo/ffs.git"
 
+    maintainers("eisenhauer", "vicentebolea")
+
     version("develop", branch="master")
     version("3.2.0", sha256="885578babae52394c3cabb4479b7a87053443d61b1c0975f777a22c3fd104d8c")
 


### PR DESCRIPTION
## Summary
- libevpath: add v5.0.0
- gtkorvo-atl: add v2.3.0, restrict `gtkorvo-cercs-env` dependency to `@:2.2.1` (no longer needed by newer versions)
- gtkorvo-dill: add v2.4.1, v3.2.0, v3.3.0
- libffs: add v1.6.0, v3.2.0

Tested locally using `spack install libevpath@5.0.0 ^libffs@3.2.0 ^gtkorvo-atl@2.3.0 ^gtkorvo-dill@3.3.0`

Also tested with:

```
spack install libevpath@5.0.0 ^libffs@3.2.0+shared ^gtkorvo-atl@2.3.0~shared ^gtkorvo-dill@3.3.0~shared
```

We are also deprecating ancient versions of these rarely uses libs (other than in adios2)