### PR TITLE
llvm: add missing binutils and gcc-runtime dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/llvm/package.py
+++ b/repos/spack_repo/builtin/packages/llvm/package.py
@@ -354,7 +354,9 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
 
     # if gcc was built with newer binutils than the system default, we need the
     # same for our own build
-    depends_on("binutils+gas+ld+plugins~libiberty", type=("build", "link", "run"), when="%gcc+binutils")
+    depends_on(
+        "binutils+gas+ld+plugins~libiberty", type=("build", "link", "run"), when="%gcc+binutils"
+    )
 
     # Older LLVM do not build with newer compilers, and vice versa
     with when("@16:"):

--- a/repos/spack_repo/builtin/packages/llvm/package.py
+++ b/repos/spack_repo/builtin/packages/llvm/package.py
@@ -352,6 +352,10 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
     # gold support, required for some features
     depends_on("binutils+gold+ld+plugins+headers", when="+gold")
 
+    # if gcc was built with newer binutils than the system default, we need the
+    # same for our own build
+    depends_on("binutils+gas+ld+plugins~libiberty", type=("build", "link", "run"), when="%gcc+binutils")
+
     # Older LLVM do not build with newer compilers, and vice versa
     with when("@16:"):
         conflicts("%gcc@:7.0")

--- a/repos/spack_repo/builtin/packages/llvm/package.py
+++ b/repos/spack_repo/builtin/packages/llvm/package.py
@@ -1225,6 +1225,9 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
             for cfg in cfg_files:
                 with open(os.path.join(self.prefix.bin, cfg), "w") as f:
                     print(gcc_install_dir_flag, file=f)
+                    # make sure LLVM prefers binutils prefix over system default
+                    if self.spec.satisfies("^binutils"):
+                        print(f"-B{self.spec['binutils'].prefix.bin}", file=f)
 
     def llvm_config(self, *args, result=None, **kwargs):
         lc = Executable(self.prefix.bin.join("llvm-config"))

--- a/repos/spack_repo/builtin/packages/llvm/package.py
+++ b/repos/spack_repo/builtin/packages/llvm/package.py
@@ -901,6 +901,18 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
             env.set("FC", join_path(self.spec.prefix.bin, "flang"))
             env.set("F77", join_path(self.spec.prefix.bin, "flang"))
 
+    @classmethod
+    def runtime_constraints(cls, *, spec, pkg):
+        if spec.satisfies("%gcc"):
+            gcc = spec["gcc"]
+            for language in ("c", "cxx", "fortran"):
+                pkg("*").depends_on(
+                    f"gcc-runtime@{gcc.version}:",
+                    when=f"%[deptypes=build virtuals={language}] {spec.name}/{spec.dag_hash()}",
+                    type="link",
+                    description=f"Inject gcc-runtime when llvm is used as a {language} compiler",
+                )
+
     root_cmakelists_dir = "llvm"
 
     def cmake_args(self):

--- a/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
+++ b/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
@@ -466,6 +466,9 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
             for cfg in cfg_files:
                 with open(os.path.join(self.prefix.bin, cfg), "w") as f:
                     print(gcc_install_dir_flag, file=f)
+                    # make sure LLVM prefers binutils prefix over system default
+                    if self.spec.satisfies("^binutils"):
+                        print(f"-B{self.spec['binutils'].prefix.bin}", file=f)
 
     # Required for enabling asan on dependent packages
     def setup_dependent_build_environment(


### PR DESCRIPTION
Previously +gold pulled in binutils as dependency. That default was recently changed since gold is deprecated. See #3454.

However, building a custom GCC will typically pull in a newer binutils than what is on the system. Using such a GCC for building LLVM then fails if the system binutils is too old. We therefore need to make sure that LLVM also uses the newer binutils.

Also adds an explicit `-B<binutils-prefix>/bin` to the LLVM configuration files to it prefers using those binaries over defaulting to a location such as `/usr/bin`. Just having the binutils prefix in PATH is not good enough.

It further injects a gcc-runtime dependency for packages building with a llvm that is built with gcc.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
