### PR TITLE
llvm-amdgpu: add missing gcc-install-dir logic

### DIFF
--- a/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
+++ b/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
@@ -377,6 +377,21 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
             args.append(self.define("LLVM_EXTERNAL_SPIRV_LLVM_TRANSLATOR_SOURCE_DIR", spirv_dir))
         args.append(self.define("LLVM_ENABLE_PROJECTS", llvm_projects))
         args.append(self.define("LLVM_ENABLE_RUNTIMES", llvm_runtimes))
+
+        # CMake args passed just to runtimes
+        runtime_cmake_args = [self.define("CMAKE_INSTALL_RPATH_USE_LINK_PATH", True)]
+
+        # When building runtimes, just-built clang has to know where GCC is.
+        gcc_install_dir_flag = get_gcc_install_dir_flag(self.spec, self.compiler)
+        if gcc_install_dir_flag:
+            runtime_cmake_args.extend(
+                [
+                    self.define("CMAKE_C_FLAGS", gcc_install_dir_flag),
+                    self.define("CMAKE_CXX_FLAGS", gcc_install_dir_flag),
+                ]
+            )
+
+        args.append(self.define("RUNTIMES_CMAKE_ARGS", runtime_cmake_args))
         return args
 
     compiler_languages = ["c", "cxx", "fortran"]
@@ -443,6 +458,15 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
                 os.path.join(self.prefix, "amdgcn"),
             )
 
+        cfg_files = ["clang.cfg", "clang++.cfg"]
+        if self.spec.satisfies("@7:"):
+            cfg_files.append("flang.cfg")
+        gcc_install_dir_flag = get_gcc_install_dir_flag(self.spec, self.compiler)
+        if gcc_install_dir_flag:
+            for cfg in cfg_files:
+                with open(os.path.join(self.prefix.bin, cfg), "w") as f:
+                    print(gcc_install_dir_flag, file=f)
+
     # Required for enabling asan on dependent packages
     def setup_dependent_build_environment(
         self, env: EnvironmentModifications, dependent_spec: Spec
@@ -460,3 +484,15 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
 
     def _fortran_path(self):
         return os.path.join(self.spec.prefix.bin, "amdflang")
+
+
+def get_gcc_install_dir_flag(spec: Spec, compiler) -> Optional[str]:
+    """Get the --gcc-install-dir=... flag, so that clang does not do a system scan for GCC."""
+    if not spec.satisfies("%gcc"):
+        return None
+    gcc = Executable(compiler.cc)
+    libgcc_path = gcc("-print-file-name=libgcc.a", output=str, fail_on_error=False).strip()
+    if not os.path.isabs(libgcc_path):
+        return None
+    libgcc_dir = os.path.dirname(libgcc_path)
+    return f"--gcc-install-dir={libgcc_dir}" if os.path.exists(libgcc_dir) else None


### PR DESCRIPTION
Previous versions of llvm-amdgpu set `GCC_INSTALL_DIR` via CMake, but that option was deprecated some time ago. Instead llvm builds need to write config files as part of post install. Also, during runtime builds the just-built clang needs to know where to find the GCC installation. All this logic was backported from the llvm recipe.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
