### PR TITLE
Windows Gitlab CI: Explicitly override image entrypoint

### DIFF
--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -216,7 +216,10 @@ default:
     - $ErrorActionPreference=$ErrorActionOld
 
   tags: ["spack", "public", "medium", "x86_64-win"]
-  image: "ghcr.io/johnwparent/windows-server21h2:sha-1c12b61"
+  image: {
+    name: "ghcr.io/johnwparent/windows-server21h2:sha-1c12b61",
+    entrypoint: [""]
+  }
 
 .build:
   extends: [ ".base-job" ]

--- a/.ci/gitlab/configs/win64/ci.yaml
+++ b/.ci/gitlab/configs/win64/ci.yaml
@@ -22,4 +22,7 @@ ci:
       - spack.ps1 config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}/${SPACK_JOB_SPEC_DAG_HASH}:'morepadding/{hash}'"
       - mkdir ${SPACK_ARTIFACTS_ROOT}/user_data
       - spack.ps1 --backtrace ci rebuild | Tee-Object -FilePath "${env:SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt" 2>&1 | Tee-Object -FilePath "${env:SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt"
-      image: "ghcr.io/johnwparent/windows-server21h2:sha-1c12b61"
+      image: {
+        name: "ghcr.io/johnwparent/windows-server21h2:sha-1c12b61",
+        entrypoint: [""]
+      }


### PR DESCRIPTION
By default, all docker image entrypoints are overridden for CI runs on Gitlab as configured by the `default:image:override` setting in the base gitlab-ci yaml. When overriding part of an image definition in a job definition, gitlab will throw away the non overriden component as well. Windows specifies a specific docker image, and in doing so, removes the entrypoint override. This is fine for our cloud hosted runners as kube overrides the entrypoint itself. Docker+machine runners however will respect the non overridden entrypoint.

Explicitly override the entrypoint in our Windows CI config to bring Windows stacks in line with the rest of Spack's stacks.

Adds an explicit entrypoint override to the CI config image override for Windows generate and build jobs.


Fix spun out from https://github.com/spack/spack-packages/pull/3843 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
