### PR TITLE
pkg-config: fix build with @gcc14: 

### DIFF
--- a/repos/spack_repo/builtin/packages/pkg_config/package.py
+++ b/repos/spack_repo/builtin/packages/pkg_config/package.py
@@ -75,4 +75,7 @@ class PkgConfig(AutotoolsPackage):
                 config_args.append("CFLAGS=-Wno-error=int-conversion")
                 break
 
+        if spec.satisfies("%gcc@14:"):
+            config_args.append("CFLAGS=-std=gnu17")
+
         return config_args


### PR DESCRIPTION
Default standard changed to c23 in gcc which breaks the internal glib. Fix by changing back to c17.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
