### PR TITLE
lfortran: new version 0.61.0, fixing dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/lfortran/package.py
+++ b/repos/spack_repo/builtin/packages/lfortran/package.py
@@ -19,6 +19,7 @@ class Lfortran(CMakePackage):
 
     # The build process uses 'git describe --tags' to get the package version
     version("main", branch="main", get_full_repo=True)
+    version("0.61.0", sha256="e832c1d76c371da7a7e11ef9e7b686d9047788136dcfb20093da5dc165fcd20f")
     version("0.54.0", sha256="a46c44f8398ed0d14ca051a08982a3001642449c06a3be1c30944c3e027bbf51")
     version("0.49.0", sha256="a9225fd33d34ce786f72a964a1179579caff62dd176a6a1477d2594fecdc7cd6")
     version("0.30.0", sha256="aafdfbfe81d69ceb3650ae1cf9bcd8a1f1532d895bf88f3071fe9610859bcd6f")
@@ -38,6 +39,7 @@ class Lfortran(CMakePackage):
 
     depends_on("python@3:", type="build", when="@main")
     depends_on("cmake", type="build")
+    depends_on("cmake@3.22:", type="build", when="+kokkos")
     depends_on("kokkos", type=("build", "run"), when="+kokkos")
     depends_on("llvm@11:15", type=("build", "run"), when="@0.19.0+llvm")
     depends_on("llvm@11:16", type=("build", "run"), when="@0.30.0+llvm")
@@ -46,6 +48,8 @@ class Lfortran(CMakePackage):
     depends_on("re2c", type="build", when="@main")
     depends_on("bison@:3.4", type="build", when="@main")
     depends_on("binutils@2.38:", type="build", when="platform=linux")
+    depends_on("zstd")
+    depends_on("libunwind")
 
     def cmake_args(self):
         args = [
@@ -54,7 +58,7 @@ class Lfortran(CMakePackage):
             self.define_from_variant("WITH_KOKKOS", "kokkos"),
         ]
 
-        if self.spec.satisfies("@0.54.0:"):
+        if self.spec.satisfies("@main"):
             args.append("-DLFORTRAN_BUILD_ALL=yes")
 
         return args

--- a/repos/spack_repo/builtin/packages/lfortran/package.py
+++ b/repos/spack_repo/builtin/packages/lfortran/package.py
@@ -58,6 +58,7 @@ class Lfortran(CMakePackage):
             self.define_from_variant("WITH_KOKKOS", "kokkos"),
         ]
 
+        # Only call bootstrap script for git checkout
         if self.spec.satisfies("@main"):
             args.append("-DLFORTRAN_BUILD_ALL=yes")
 


### PR DESCRIPTION
new version 0.61.0, fixing dependencies to cmake for kokkos, adding dependency to zstd and libunwind

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Fixes #3890
Now compiles fine from at 0.49 to 0.61 (tested) on Ubuntu 20:
$ spack debug report
* **Spack:** 1.2.0.dev0 (https://github.com/spack/spack/commit/e0997bb279d5cc1e1a243dcd91e55ac63089ff29)
* **Builtin repo:** https://github.com/spack/spack-packages/commit/6996192cd696564eaaa4e9c87ab39d3b899bf617
* **Python:** 3.8.10
* **Platform:** linux-ubuntu20.04-zen2

and fine for 0.61 (only, failures from 0.49 to 0.60 has been tested) on Ubuntu 24:
$ spack debug report
* **Spack:** 1.2.0.dev0 (https://github.com/spack/spack/commit/e0997bb279d5cc1e1a243dcd91e55ac63089ff29)
* **Builtin repo:** https://github.com/spack/spack-packages/commit/6996192cd696564eaaa4e9c87ab39d3b899bf617
* **Python:** 3.12.3
* **Platform:** linux-ubuntu24.04-zen2
