### PR TITLE
star-ccm-plus: fix up doc installation

### DIFF
--- a/repos/spack_repo/builtin/packages/star_ccm_plus/package.py
+++ b/repos/spack_repo/builtin/packages/star_ccm_plus/package.py
@@ -74,7 +74,7 @@ class StarCcmPlus(Package):
             "-DINSTALLFLEX=false",
             "-DADDSYSTEMPATH=false",
             "-DCOMPUTE_NODE=false",
-            "-DNODOC={0}".format("false" if "+docs" in spec else "true"),
+            "-DNODOC={0}".format("false" if "+doc" in spec else "true"),
         )
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:


### PR DESCRIPTION
The variant is named `doc` instead of `docs`.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
