### PR TITLE
go: move build envs from builder into Go pkg

### DIFF
--- a/repos/spack_repo/builtin/build_systems/go.py
+++ b/repos/spack_repo/builtin/build_systems/go.py
@@ -104,9 +104,6 @@ class GoBuilder(BuilderWithDefaults):
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         env.set("CGO_ENABLED", "1" if self.cgo_enabled else "0")
-        env.set("GO111MODULE", "on")
-        env.set("GOTOOLCHAIN", "local")
-        env.set("GOPATH", join_path(self.pkg.stage.path, "go"))
 
     def build(self, pkg: GoPackage, spec: Spec, prefix: Prefix) -> None:
         """Runs ``go build`` in the source directory"""

--- a/repos/spack_repo/builtin/build_systems/go.py
+++ b/repos/spack_repo/builtin/build_systems/go.py
@@ -12,7 +12,6 @@ from spack.package import (
     depends_on,
     execute_install_time_tests,
     install,
-    join_path,
     mkdirp,
     register_builder,
     run_after,

--- a/repos/spack_repo/builtin/packages/go/package.py
+++ b/repos/spack_repo/builtin/packages/go/package.py
@@ -117,6 +117,12 @@ class Go(Package):
         install_tree(".", prefix.go)
         symlink(prefix.go.bin, prefix.bin)
 
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set("GO111MODULE", "on")
+        env.set("GOTOOLCHAIN", "local")
+        env.set("GOMAXPROCS", str(make_jobs))
+        env.set("GOPATH", join_path(dependent_spec.package.stage.path, "go"))
+
     def setup_dependent_package(self, module, dependent_spec):
         """Called before go modules' build(), install() methods.
 


### PR DESCRIPTION
There are still some packages that depend on `go` but are not technically `GoPackages`.

This allows those packages to not pollute users' home directories accidentally.