### PR TITLE
mvapich: adding fast and errs variants

### DIFF
--- a/repos/spack_repo/builtin/packages/mvapich/package.py
+++ b/repos/spack_repo/builtin/packages/mvapich/package.py
@@ -37,7 +37,9 @@ class Mvapich(MpichEnvironmentModifications, AutotoolsPackage):
     provides("mpi@:4.1")
 
     variant("wrapperrpath", default=True, description="Enable wrapper rpath")
-    variant("debug", default=False, description="Enable debug info and error messages at run-time")
+    variant("debug", default=False, description="Enable debug info at run-time")
+    variant("errs", default=False, description="Enable error messages at run-time")
+    variant("fast", default=True, description="Enable compiler optimizations")
 
     variant("regcache", default=True, description="Enable memory registration cache")
 
@@ -207,7 +209,6 @@ class Mvapich(MpichEnvironmentModifications, AutotoolsPackage):
         if "+debug" in self.spec:
             args.extend(
                 [
-                    "--disable-fast",
                     "--enable-error-checking=runtime",
                     "--enable-error-messages=all",
                     # Permits debugging with TotalView
@@ -215,9 +216,12 @@ class Mvapich(MpichEnvironmentModifications, AutotoolsPackage):
                     "--enable-debuginfo",
                 ]
             )
+        if "+errs" in self.spec:
+            args.extend(["--enable-error-checking=runtime", "--enable-error-messages=all"])
+        if "+fast" in self.spec:
+            args.append("--enable-fast=opt")
         else:
-            args.append("--enable-fast=O3,ndebug")
-
+            args.append("--enable-fast=none")
         if "+regcache" in self.spec:
             args.append("--enable-registration-cache")
         else:


### PR DESCRIPTION
Adds fast and errs variants to the mvapich package in order to have more granularity in setting debugging and optimization flags.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
