### PR TITLE
clustalw: add c dep, update urls

### DIFF
--- a/repos/spack_repo/builtin/packages/clustalw/package.py
+++ b/repos/spack_repo/builtin/packages/clustalw/package.py
@@ -10,11 +10,12 @@ from spack.package import *
 class Clustalw(AutotoolsPackage):
     """Multiple alignment of nucleic acid and protein sequences."""
 
-    homepage = "http://www.clustal.org/clustal2/"
-    url = "http://www.clustal.org/download/2.1/clustalw-2.1.tar.gz"
+    homepage = "https://ftp.ebi.ac.uk/pub/software/clustalw2"
+    url = "https://ftp.ebi.ac.uk/pub/software/clustalw2/2.1/clustalw-2.1.tar.gz"
 
     license("LGPL-3.0-only")
 
     version("2.1", sha256="e052059b87abfd8c9e695c280bfba86a65899138c82abccd5b00478a80f49486")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated


### PR DESCRIPTION
Add build dep for c

The clustal.org domain appears to have been sold and no longer relates to this software. The readme in the mirrored archive we have suggests https://ftp.ebi.ac.uk/pub/software/clustalw2/ as an alternative source, so I've updated that here.