### PR TITLE
rust: swap cargo cache to stage/cargo to limit collisions

### DIFF
--- a/repos/spack_repo/builtin/build_systems/cargo.py
+++ b/repos/spack_repo/builtin/build_systems/cargo.py
@@ -4,7 +4,6 @@
 
 from spack.package import (
     BuilderWithDefaults,
-    EnvironmentModifications,
     PackageBase,
     Prefix,
     Spec,

--- a/repos/spack_repo/builtin/build_systems/cargo.py
+++ b/repos/spack_repo/builtin/build_systems/cargo.py
@@ -90,9 +90,6 @@ class CargoBuilder(BuilderWithDefaults):
         """Argument for ``cargo test`` during check phase"""
         return []
 
-    def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        env.set("CARGO_HOME", self.stage.path)
-
     def build(self, pkg: CargoPackage, spec: Spec, prefix: Prefix) -> None:
         """Runs ``cargo install`` in the source directory"""
         with working_dir(self.build_directory):

--- a/repos/spack_repo/builtin/packages/rust/package.py
+++ b/repos/spack_repo/builtin/packages/rust/package.py
@@ -185,7 +185,7 @@ class Rust(Package):
     def setup_dependent_build_environment(
         self, env: EnvironmentModifications, dependent_spec: Spec
     ) -> None:
-        env.set("CARGO_HOME", dependent_spec.package.stage.path)
+        env.set("CARGO_HOME", join_path(dependent_spec.package.stage.path, "cargo"))
 
     def configure(self, spec, prefix):
         opts = []


### PR DESCRIPTION
- Swap `CARGO_HOME` to be within a `cargo/` directory within the stage to prevent possible collisions.
- Remove environment set from `CargoPackage` to reduce duplication