### PR TITLE
soapdenovo2: make build serial

### DIFF
--- a/repos/spack_repo/builtin/packages/soapdenovo2/package.py
+++ b/repos/spack_repo/builtin/packages/soapdenovo2/package.py
@@ -28,6 +28,8 @@ class Soapdenovo2(MakefilePackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
+    parallel = False
+
     def flag_handler(self, name, flags):
         if name.lower() == "cflags" and self.spec.satisfies("%gcc@10:"):
             flags.append("-fcommon")


### PR DESCRIPTION
parallel build for this package seems to be prone to fail, switching to ```parallel = False``` seems to make it reliable.