### PR TITLE
k8: fix install for @1.0:

### DIFF
--- a/repos/spack_repo/builtin/packages/k8/package.py
+++ b/repos/spack_repo/builtin/packages/k8/package.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import sys
 
 from spack_repo.builtin.build_systems.generic import Package
 

--- a/repos/spack_repo/builtin/packages/k8/package.py
+++ b/repos/spack_repo/builtin/packages/k8/package.py
@@ -19,14 +19,26 @@ class K8(Package):
     version("1.0", sha256="61504dad2d63404bf523d3f8d0a8bfd72ec78aa7bd79bdf9291a4f629cfb9c02")
     version("0.2.4", sha256="da8a99c7f1ce7f0cb23ff07ce10510e770686b906d5431442a5439743c0b3c47")
 
-    depends_on("cxx", type="build")  # generated
+    requires(
+        "platform=linux target=x86_64:",
+        "platform=darwin target=aarch64:",
+        policy="one_of",
+        msg="package is only available for darwin aarch64 or linux x86_64",
+    )
 
     depends_on("zlib-api", type="run")
 
     def install(self, spec, prefix):
-        if sys.platform == "darwin":
-            os.rename("k8-Darwin", "k8")
+        if self.spec.satisfies("platform=darwin target=aarch64:"):
+            if self.spec.satisfies("@=0.2.4"):
+                os.rename("k8-Darwin", "k8")
+            elif self.spec.satisfies("@1.0:"):
+                os.rename("k8-arm64-Darwin", "k8")
 
-        if sys.platform != "darwin":
-            os.rename("k8-Linux", "k8")
+        if self.spec.satisfies("platform=linux target=x86_64:"):
+            if self.spec.satisfies("@=0.2.4"):
+                os.rename("k8-Linux", "k8")
+            elif self.spec.satisfies("@1.0:"):
+                os.rename("k8-x86_64-Linux", "k8")
+
         install_tree(".", prefix.bin)


### PR DESCRIPTION
This recipe fetches a precompiled thing that contains binaries for mac and linux, sometime between 0.2.4 the name of the binaries changed, this updates the recipe to handle that.

I figured I'd also add in a requires to reflect what's actually in the download.

I don't think it'll be easy to modify this to actually build from source, it requires the v8 source at minimum. The k8 readme suggests building node if you want to get v8 since that's a more convenient way to get v8.
