### PR TITLE
dmlc-core: add c dep

### DIFF
--- a/repos/spack_repo/builtin/packages/dmlc_core/package.py
+++ b/repos/spack_repo/builtin/packages/dmlc_core/package.py
@@ -20,6 +20,7 @@ class DmlcCore(CMakePackage):
     version("master")
     version("20170508", commit="a6c5701219e635fea808d264aefc5b03c3aec314")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     variant("openmp", default=False, description="Enable OpenMP support")


### PR DESCRIPTION
configure fails without a c compiler. 
