### PR TITLE
ghex, oomph, hwmalloc, gridtools: add new packages

### DIFF
--- a/repos/spack_repo/builtin/packages/ghex/package.py
+++ b/repos/spack_repo/builtin/packages/ghex/package.py
@@ -34,6 +34,7 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
     variant("python", default=True, description="Build Python bindings")
 
     depends_on("cmake@3.21:", type="build")
+    depends_on("googletest", type="test")
     depends_on("mpi")
     depends_on("boost")
     depends_on("xpmem", when="+xpmem", type=("build", "run"))
@@ -62,10 +63,7 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
         spec = self.spec
 
         args = [
-            self.define("GHEX_USE_BUNDLED_LIBS", True),
-            self.define("GHEX_USE_BUNDLED_GRIDTOOLS", False),
-            self.define("GHEX_USE_BUNDLED_GTEST", self.run_tests),
-            self.define("GHEX_USE_BUNDLED_OOMPH", False),
+            self.define("GHEX_USE_BUNDLED_LIBS", False),
             self.define("GHEX_TRANSPORT_BACKEND", spec.variants["backend"].value.upper()),
             self.define_from_variant("GHEX_USE_XPMEM", "xpmem"),
             self.define_from_variant("GHEX_BUILD_PYTHON_BINDINGS", "python"),

--- a/repos/spack_repo/builtin/packages/ghex/package.py
+++ b/repos/spack_repo/builtin/packages/ghex/package.py
@@ -1,0 +1,87 @@
+from spack.package import *
+
+
+class Ghex(CMakePackage, CudaPackage, ROCmPackage):
+    """GHEX is a generic halo-exchange library."""
+
+    homepage = "https://github.com/ghex-org/GHEX"
+    url = "https://github.com/ghex-org/GHEX/archive/refs/tags/v0.0.0.tar.gz"
+    git = "https://github.com/ghex-org/GHEX.git"
+    maintainers = ["boeschf", "msimberg"]
+
+    version("master", branch="master", submodules=True)
+    # TODO: No submodules?
+    version("0.5.0", tag="v0.5.0", submodules=True)
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    generator("ninja")
+
+    backends = ("mpi", "ucx", "libfabric")
+    variant(
+        "backend", default="mpi", description="Transport backend", values=backends, multi=False
+    )
+    variant("xpmem", default=False, description="Use xpmem shared memory")
+    variant("python", default=True, description="Build Python bindings")
+
+    depends_on("cmake@3.21:", type="build")
+    depends_on("mpi")
+    depends_on("boost")
+    depends_on("xpmem", when="+xpmem", type=("build", "run"))
+
+    depends_on("oomph")
+    for backend in backends:
+        depends_on(f"oomph backend={backend}", when=f"backend={backend}")
+    depends_on("oomph+cuda", when="+cuda")
+    depends_on("oomph+rocm", when="+rocm")
+    depends_on("oomph~rocm~cuda", when="~rocm~cuda")
+
+    conflicts("+cuda +rocm", msg="CUDA and ROCm support are mutually exclusive")
+
+    with when("+python"):
+        extends("python")
+        depends_on("python@3.7:", type="build")
+        depends_on("py-pip", type="build")
+        depends_on("py-pybind11", type="build")
+        depends_on("py-mpi4py", type=("build", "run"))
+        depends_on("py-numpy", type=("build", "run"))
+
+        depends_on("py-pytest", when="+python", type=("test"))
+
+    def cmake_args(self):
+        spec = self.spec
+
+        args = [
+            self.define("GHEX_USE_BUNDLED_LIBS", True),
+            self.define("GHEX_USE_BUNDLED_GRIDTOOLS", True),
+            self.define("GHEX_USE_BUNDLED_GTEST", self.run_tests),
+            self.define("GHEX_USE_BUNDLED_OOMPH", False),
+            self.define("GHEX_TRANSPORT_BACKEND", spec.variants["backend"].value.upper()),
+            self.define_from_variant("GHEX_USE_XPMEM", "xpmem"),
+            self.define_from_variant("GHEX_BUILD_PYTHON_BINDINGS", "python"),
+            self.define("GHEX_WITH_TESTING", self.run_tests),
+        ]
+
+        if spec.satisfies("+python"):
+            args.append(self.define("GHEX_PYTHON_LIB_PATH", python_platlib))
+
+        if self.run_tests and spec.satisfies("^openmpi"):
+            args.append(self.define("MPIEXEC_PREFLAGS", "--oversubscribe"))
+
+        if "+cuda" in spec and spec.variants["cuda_arch"].value != "none":
+            arch_str = ";".join(spec.variants["cuda_arch"].value)
+            args.append(self.define("CMAKE_CUDA_ARCHITECTURES", arch_str))
+            args.append(self.define("GHEX_USE_GPU", True))
+            args.append(self.define("GHEX_GPU_TYPE", "CUDA"))
+
+        if "+rocm" in spec and spec.variants["amdgpu_target"].value != "none":
+            arch_str = ";".join(spec.variants["amdgpu_target"].value)
+            args.append(self.define("CMAKE_HIP_ARCHITECTURES", arch_str))
+            args.append(self.define("GHEX_USE_GPU", True))
+            args.append(self.define("GHEX_GPU_TYPE", "AMD"))
+
+        if spec.satisfies("~cuda~rocm"):
+            args.append(self.define("GHEX_USE_GPU", False))
+
+        return args

--- a/repos/spack_repo/builtin/packages/ghex/package.py
+++ b/repos/spack_repo/builtin/packages/ghex/package.py
@@ -77,7 +77,7 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
         if spec.satisfies("+python"):
             args.append(self.define("GHEX_PYTHON_LIB_PATH", python_platlib))
 
-        if self.run_tests and spec.satisfies("^openmpi"):
+        if self.run_tests and spec.satisfies("^mpi=openmpi"):
             args.append(self.define("MPIEXEC_PREFLAGS", "--oversubscribe"))
 
         if spec.satisfies("+cuda") and spec.variants["cuda_arch"].value != "none":

--- a/repos/spack_repo/builtin/packages/ghex/package.py
+++ b/repos/spack_repo/builtin/packages/ghex/package.py
@@ -89,14 +89,12 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
             args.append(self.define("CMAKE_CUDA_ARCHITECTURES", arch_str))
             args.append(self.define("GHEX_USE_GPU", True))
             args.append(self.define("GHEX_GPU_TYPE", "CUDA"))
-
-        if spec.satisfies("+rocm"):
+        elif spec.satisfies("+rocm"):
             arch_str = ";".join(spec.variants["amdgpu_target"].value)
             args.append(self.define("CMAKE_HIP_ARCHITECTURES", arch_str))
             args.append(self.define("GHEX_USE_GPU", True))
             args.append(self.define("GHEX_GPU_TYPE", "AMD"))
-
-        if spec.satisfies("~cuda~rocm"):
+        else:
             args.append(self.define("GHEX_USE_GPU", False))
 
         return args

--- a/repos/spack_repo/builtin/packages/ghex/package.py
+++ b/repos/spack_repo/builtin/packages/ghex/package.py
@@ -11,7 +11,8 @@ from spack.package import *
 
 
 class Ghex(CMakePackage, CudaPackage, ROCmPackage):
-    """Generic exascale-ready library for halo-exchange operations on variety of grids/meshes"""
+    """Generic exascale-ready library for halo-exchange operations on variety of
+    grids/meshes"""
 
     homepage = "https://ghex-org.github.io/GHEX"
     url = "https://github.com/ghex-org/GHEX/archive/refs/tags/v0.0.0.tar.gz"

--- a/repos/spack_repo/builtin/packages/ghex/package.py
+++ b/repos/spack_repo/builtin/packages/ghex/package.py
@@ -80,13 +80,13 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
         if self.run_tests and spec.satisfies("^openmpi"):
             args.append(self.define("MPIEXEC_PREFLAGS", "--oversubscribe"))
 
-        if "+cuda" in spec and spec.variants["cuda_arch"].value != "none":
+        if spec.satisfies("+cuda") and spec.variants["cuda_arch"].value != "none":
             arch_str = ";".join(spec.variants["cuda_arch"].value)
             args.append(self.define("CMAKE_CUDA_ARCHITECTURES", arch_str))
             args.append(self.define("GHEX_USE_GPU", True))
             args.append(self.define("GHEX_GPU_TYPE", "CUDA"))
 
-        if "+rocm" in spec and spec.variants["amdgpu_target"].value != "none":
+        if spec.satisfies("+rocm") and spec.variants["amdgpu_target"].value != "none":
             arch_str = ";".join(spec.variants["amdgpu_target"].value)
             args.append(self.define("CMAKE_HIP_ARCHITECTURES", arch_str))
             args.append(self.define("GHEX_USE_GPU", True))

--- a/repos/spack_repo/builtin/packages/ghex/package.py
+++ b/repos/spack_repo/builtin/packages/ghex/package.py
@@ -1,3 +1,12 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
+from spack_repo.builtin.build_systems.cuda import CudaPackage
+from spack_repo.builtin.build_systems.rocm import ROCmPackage
+
 from spack.package import *
 
 

--- a/repos/spack_repo/builtin/packages/ghex/package.py
+++ b/repos/spack_repo/builtin/packages/ghex/package.py
@@ -54,8 +54,12 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("oomph~rocm~cuda", when="~rocm~cuda")
 
     conflicts("+cuda +rocm", msg="CUDA and ROCm support are mutually exclusive")
-    conflicts("cuda_arch=none", when="+cuda", msg="CUDA support requires at least one architecture")
-    conflicts("amdgpu_target=none", when="+rocm", msg="ROCm support requires at least one architecture")
+    conflicts(
+        "cuda_arch=none", when="+cuda", msg="CUDA support requires at least one architecture"
+    )
+    conflicts(
+        "amdgpu_target=none", when="+rocm", msg="ROCm support requires at least one architecture"
+    )
 
     with when("+python"):
         extends("python")

--- a/repos/spack_repo/builtin/packages/ghex/package.py
+++ b/repos/spack_repo/builtin/packages/ghex/package.py
@@ -19,8 +19,7 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
     maintainers = ["boeschf", "msimberg"]
 
     version("master", branch="master")
-    # TODO: No submodules?
-    version("0.5.0", tag="v0.5.0", submodules=False)
+    version("0.5.0", sha256="b2324441c2210783a90e83439e0d5c8e0aa462a7797ebbc6e48a47dfcada4848")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")

--- a/repos/spack_repo/builtin/packages/ghex/package.py
+++ b/repos/spack_repo/builtin/packages/ghex/package.py
@@ -30,6 +30,8 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
 
     generator("ninja")
 
+    depends_on("ninja", type="build")
+
     backends = ("mpi", "ucx", "libfabric")
     variant(
         "backend", default="mpi", description="Transport backend", values=backends, multi=False

--- a/repos/spack_repo/builtin/packages/ghex/package.py
+++ b/repos/spack_repo/builtin/packages/ghex/package.py
@@ -52,6 +52,8 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("oomph~rocm~cuda", when="~rocm~cuda")
 
     conflicts("+cuda +rocm", msg="CUDA and ROCm support are mutually exclusive")
+    conflicts("cuda_arch=none", when="+cuda", msg="CUDA support requires at least one architecture")
+    conflicts("amdgpu_target=none", when="+rocm", msg="ROCm support requires at least one architecture")
 
     with when("+python"):
         extends("python")
@@ -80,13 +82,13 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
         if self.run_tests and spec.satisfies("^mpi=openmpi"):
             args.append(self.define("MPIEXEC_PREFLAGS", "--oversubscribe"))
 
-        if spec.satisfies("+cuda") and spec.variants["cuda_arch"].value != "none":
+        if spec.satisfies("+cuda"):
             arch_str = ";".join(spec.variants["cuda_arch"].value)
             args.append(self.define("CMAKE_CUDA_ARCHITECTURES", arch_str))
             args.append(self.define("GHEX_USE_GPU", True))
             args.append(self.define("GHEX_GPU_TYPE", "CUDA"))
 
-        if spec.satisfies("+rocm") and spec.variants["amdgpu_target"].value != "none":
+        if spec.satisfies("+rocm"):
             arch_str = ";".join(spec.variants["amdgpu_target"].value)
             args.append(self.define("CMAKE_HIP_ARCHITECTURES", arch_str))
             args.append(self.define("GHEX_USE_GPU", True))

--- a/repos/spack_repo/builtin/packages/ghex/package.py
+++ b/repos/spack_repo/builtin/packages/ghex/package.py
@@ -11,12 +11,15 @@ from spack.package import *
 
 
 class Ghex(CMakePackage, CudaPackage, ROCmPackage):
-    """GHEX is a generic halo-exchange library."""
+    """Generic exascale-ready library for halo-exchange operations on variety of grids/meshes"""
 
-    homepage = "https://github.com/ghex-org/GHEX"
+    homepage = "https://ghex-org.github.io/GHEX"
     url = "https://github.com/ghex-org/GHEX/archive/refs/tags/v0.0.0.tar.gz"
     git = "https://github.com/ghex-org/GHEX.git"
-    maintainers = ["boeschf", "msimberg"]
+
+    maintainers("boeschf", "msimberg")
+
+    license("BSD-3-Clause", checked_by="msimberg")
 
     version("master", branch="master")
     version("0.5.0", sha256="b2324441c2210783a90e83439e0d5c8e0aa462a7797ebbc6e48a47dfcada4848")
@@ -57,7 +60,7 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("py-mpi4py", type=("build", "run"))
         depends_on("py-numpy", type=("build", "run"))
 
-        depends_on("py-pytest", when="+python", type=("test"))
+        depends_on("py-pytest", when="+python", type="test")
 
     def cmake_args(self):
         spec = self.spec

--- a/repos/spack_repo/builtin/packages/ghex/package.py
+++ b/repos/spack_repo/builtin/packages/ghex/package.py
@@ -18,9 +18,9 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
     git = "https://github.com/ghex-org/GHEX.git"
     maintainers = ["boeschf", "msimberg"]
 
-    version("master", branch="master", submodules=True)
+    version("master", branch="master")
     # TODO: No submodules?
-    version("0.5.0", tag="v0.5.0", submodules=True)
+    version("0.5.0", tag="v0.5.0", submodules=False)
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
@@ -39,6 +39,7 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("boost")
     depends_on("xpmem", when="+xpmem", type=("build", "run"))
 
+    depends_on("gridtools")
     depends_on("oomph")
     for backend in backends:
         depends_on(f"oomph backend={backend}", when=f"backend={backend}")
@@ -63,7 +64,7 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
 
         args = [
             self.define("GHEX_USE_BUNDLED_LIBS", True),
-            self.define("GHEX_USE_BUNDLED_GRIDTOOLS", True),
+            self.define("GHEX_USE_BUNDLED_GRIDTOOLS", False),
             self.define("GHEX_USE_BUNDLED_GTEST", self.run_tests),
             self.define("GHEX_USE_BUNDLED_OOMPH", False),
             self.define("GHEX_TRANSPORT_BACKEND", spec.variants["backend"].value.upper()),

--- a/repos/spack_repo/builtin/packages/ghex/package.py
+++ b/repos/spack_repo/builtin/packages/ghex/package.py
@@ -55,7 +55,7 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
 
     with when("+python"):
         extends("python")
-        depends_on("python@3.7:", type="build")
+        depends_on("python@3.7:", type=("build", "run"))
         depends_on("py-pip", type="build")
         depends_on("py-pybind11", type="build")
         depends_on("py-mpi4py", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/gridtools/package.py
+++ b/repos/spack_repo/builtin/packages/gridtools/package.py
@@ -25,7 +25,7 @@ class Gridtools(CMakePackage):
     depends_on("cxx", type="build")
 
     generator("ninja")
-    
+
     depends_on("ninja", type="build")
 
     def cmake_args(self):

--- a/repos/spack_repo/builtin/packages/gridtools/package.py
+++ b/repos/spack_repo/builtin/packages/gridtools/package.py
@@ -1,0 +1,43 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
+
+from spack.package import *
+
+
+class Gridtools(CMakePackage):
+    """Libraries and utilities to develop performance portable applications for weather and climate."""
+
+    homepage = "https://gridtools.github.io"
+    url = "https://github.com/GridTools/gridtools/archive/refs/tags/v0.0.0.tar.gz"
+    git = "https://github.com/GridTools/gridtools.git"
+
+    maintainers("msimberg")
+
+    license("BSD-3-Clause", checked_by="msimberg")
+
+    version("master", branch="master")
+    version("2.3.9", sha256="463bd29c4cee7027e99ad0ba5a9f121be481efbc75c604af4256927c5670fd7c")
+    # TODO: Keep any of these?
+    # version("2.3.8", sha256="4a5e9171db65b4c4b4ea7a79cec19200ab2614ed0c320d1a15f98ba61f099fcd")
+    # version("2.3.7", sha256="2f1bb0f876e0bcea3c5695e6e186ed37fddf3bd71936a30a2f8e01d9d86544d7")
+    # version("2.3.6", sha256="e5b003afce041c7d56a2222f351cc3baf29e25fb616136b11bbe598127762056")
+    # version("2.3.5", sha256="028342c48e6c8a484cadecbef2cb955901a9402f704f6c719923c2f26eb464c8")
+    # version("2.3.4", sha256="ff151435ffe26f1f9508d8a07c7cb594878b90f22b9f7f9435fb2bc4d7e6f124")
+    # version("2.3.2", sha256="5271a92df69f492e254622d387cfa12d746b0538aeb2ff918296455f2fd58cda")
+    # version("2.3.1", sha256="54b62bfba45afc56561f0a7d14d34038a5c5b22a80aee67096ba60effe9f764e")
+    # version("2.3.0", sha256="56ec2612b04af89162462485adf8efc9c2958b27feb265a0645358c0eb187e93")
+    # version("2.0.1", sha256="de627980d5cd3403e5f802b0206320b1bfc3d0c94a3834b671469873c1325d27")
+
+    depends_on("cxx", type="build")
+
+    generator("ninja")
+
+    def cmake_args(self):
+        args = [
+            self.define("BUILD_TESTING", False),
+            self.define("GT_INSTALL_EXAMPLES", False),
+        ]
+        return args

--- a/repos/spack_repo/builtin/packages/gridtools/package.py
+++ b/repos/spack_repo/builtin/packages/gridtools/package.py
@@ -27,6 +27,8 @@ class Gridtools(CMakePackage):
     generator("ninja")
     
     depends_on("ninja", type="build")
+    
+    depends_on("ninja", type="build")
 
     def cmake_args(self):
         args = [self.define("BUILD_TESTING", False), self.define("GT_INSTALL_EXAMPLES", False)]

--- a/repos/spack_repo/builtin/packages/gridtools/package.py
+++ b/repos/spack_repo/builtin/packages/gridtools/package.py
@@ -27,8 +27,6 @@ class Gridtools(CMakePackage):
     generator("ninja")
     
     depends_on("ninja", type="build")
-    
-    depends_on("ninja", type="build")
 
     def cmake_args(self):
         args = [self.define("BUILD_TESTING", False), self.define("GT_INSTALL_EXAMPLES", False)]

--- a/repos/spack_repo/builtin/packages/gridtools/package.py
+++ b/repos/spack_repo/builtin/packages/gridtools/package.py
@@ -8,7 +8,7 @@ from spack.package import *
 
 
 class Gridtools(CMakePackage):
-    """Libraries and utilities to develop performance portable applications for weather and climate."""
+    """Libraries and utilities to develop performance portable applications for weather and climate"""
 
     homepage = "https://gridtools.github.io"
     url = "https://github.com/GridTools/gridtools/archive/refs/tags/v0.0.0.tar.gz"
@@ -26,8 +26,5 @@ class Gridtools(CMakePackage):
     generator("ninja")
 
     def cmake_args(self):
-        args = [
-            self.define("BUILD_TESTING", False),
-            self.define("GT_INSTALL_EXAMPLES", False),
-        ]
+        args = [self.define("BUILD_TESTING", False), self.define("GT_INSTALL_EXAMPLES", False)]
         return args

--- a/repos/spack_repo/builtin/packages/gridtools/package.py
+++ b/repos/spack_repo/builtin/packages/gridtools/package.py
@@ -8,7 +8,8 @@ from spack.package import *
 
 
 class Gridtools(CMakePackage):
-    """Libraries and utilities to develop performance portable applications for weather and climate"""
+    """Libraries and utilities to develop performance portable applications for
+    weather and climate"""
 
     homepage = "https://gridtools.github.io"
     url = "https://github.com/GridTools/gridtools/archive/refs/tags/v0.0.0.tar.gz"

--- a/repos/spack_repo/builtin/packages/gridtools/package.py
+++ b/repos/spack_repo/builtin/packages/gridtools/package.py
@@ -25,6 +25,8 @@ class Gridtools(CMakePackage):
     depends_on("cxx", type="build")
 
     generator("ninja")
+    
+    depends_on("ninja", type="build")
 
     def cmake_args(self):
         args = [self.define("BUILD_TESTING", False), self.define("GT_INSTALL_EXAMPLES", False)]

--- a/repos/spack_repo/builtin/packages/gridtools/package.py
+++ b/repos/spack_repo/builtin/packages/gridtools/package.py
@@ -20,16 +20,6 @@ class Gridtools(CMakePackage):
 
     version("master", branch="master")
     version("2.3.9", sha256="463bd29c4cee7027e99ad0ba5a9f121be481efbc75c604af4256927c5670fd7c")
-    # TODO: Keep any of these?
-    # version("2.3.8", sha256="4a5e9171db65b4c4b4ea7a79cec19200ab2614ed0c320d1a15f98ba61f099fcd")
-    # version("2.3.7", sha256="2f1bb0f876e0bcea3c5695e6e186ed37fddf3bd71936a30a2f8e01d9d86544d7")
-    # version("2.3.6", sha256="e5b003afce041c7d56a2222f351cc3baf29e25fb616136b11bbe598127762056")
-    # version("2.3.5", sha256="028342c48e6c8a484cadecbef2cb955901a9402f704f6c719923c2f26eb464c8")
-    # version("2.3.4", sha256="ff151435ffe26f1f9508d8a07c7cb594878b90f22b9f7f9435fb2bc4d7e6f124")
-    # version("2.3.2", sha256="5271a92df69f492e254622d387cfa12d746b0538aeb2ff918296455f2fd58cda")
-    # version("2.3.1", sha256="54b62bfba45afc56561f0a7d14d34038a5c5b22a80aee67096ba60effe9f764e")
-    # version("2.3.0", sha256="56ec2612b04af89162462485adf8efc9c2958b27feb265a0645358c0eb187e93")
-    # version("2.0.1", sha256="de627980d5cd3403e5f802b0206320b1bfc3d0c94a3834b671469873c1325d27")
 
     depends_on("cxx", type="build")
 

--- a/repos/spack_repo/builtin/packages/hwmalloc/package.py
+++ b/repos/spack_repo/builtin/packages/hwmalloc/package.py
@@ -11,7 +11,8 @@ from spack.package import *
 
 
 class Hwmalloc(CMakePackage, CudaPackage, ROCmPackage):
-    """hwmalloc provides a thread-safe heap class for allocating memory on given numa nodes and devices (GPUs) with memory registration"""
+    """hwmalloc provides a thread-safe heap class for allocating memory on given
+    numa nodes and devices (GPUs) with memory registration"""
 
     homepage = "https://github.com/ghex-org/hwmalloc"
     url = "https://github.com/ghex-org/hwmalloc/archive/refs/tags/v0.0.0.tar.gz"

--- a/repos/spack_repo/builtin/packages/hwmalloc/package.py
+++ b/repos/spack_repo/builtin/packages/hwmalloc/package.py
@@ -28,6 +28,8 @@ class Hwmalloc(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("cxx", type="build")
 
     generator("ninja")
+    
+    depends_on("ninja", type="build")
 
     depends_on("cmake@3.19:", type="build")
     depends_on("numactl", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/hwmalloc/package.py
+++ b/repos/spack_repo/builtin/packages/hwmalloc/package.py
@@ -1,0 +1,50 @@
+from spack.package import *
+
+
+class Hwmalloc(CMakePackage, CudaPackage, ROCmPackage):
+    """HWMALLOC is a allocator which supports memory registration for e.g. remote memory access"""
+
+    homepage = "https://github.com/ghex-org/hwmalloc"
+    url = "https://github.com/ghex-org/hwmalloc/archive/refs/tags/v0.0.0.tar.gz"
+    git = "https://github.com/ghex-org/hwmalloc.git"
+    maintainers = ["boeschf", "msimberg"]
+
+    version("0.4.0", sha256="1161048e915cf196a86a6241d7354dd56b0e02782000507bab19be5628763ab3")
+    version("master", branch="master")
+
+    depends_on("cxx", type="build")
+
+    generator("ninja")
+
+    depends_on("numactl", type=("build", "run"))
+    depends_on("boost", type=("build"))
+    depends_on("cmake@3.19:", type="build")
+
+    conflicts("+cuda +rocm", msg="CUDA and ROCm support are mutually exclusive")
+
+    variant(
+        "numa-throws",
+        default=False,
+        description="True if numa_tools may throw during initialization",
+    )
+    variant("numa-local", default=True, description="Use numa_tools for local node allocations")
+    variant("logging", default=False, description="print logging info to cerr")
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("HWMALLOC_NUMA_THROWS", "numa-throws"),
+            self.define_from_variant("HWMALLOC_NUMA_FOR_LOCAL", "numa-local"),
+            self.define_from_variant("HWMALLOC_ENABLE_LOGGING", "logging"),
+            self.define("HWMALLOC_WITH_TESTING", self.run_tests),
+        ]
+
+        if "+cuda" in self.spec:
+            args.append(self.define("HWMALLOC_ENABLE_DEVICE", True))
+            args.append(self.define("HWMALLOC_DEVICE_RUNTIME", "cuda"))
+        elif "+rocm" in self.spec:
+            args.append(self.define("HWMALLOC_ENABLE_DEVICE", True))
+            args.append(self.define("HWMALLOC_DEVICE_RUNTIME", "hip"))
+        else:
+            args.append(self.define("HWMALLOC_ENABLE_DEVICE", False))
+
+        return args

--- a/repos/spack_repo/builtin/packages/hwmalloc/package.py
+++ b/repos/spack_repo/builtin/packages/hwmalloc/package.py
@@ -11,12 +11,15 @@ from spack.package import *
 
 
 class Hwmalloc(CMakePackage, CudaPackage, ROCmPackage):
-    """HWMALLOC is a allocator which supports memory registration for e.g. remote memory access"""
+    """hwmalloc provides a thread-safe heap class for allocating memory on given numa nodes and devices (GPUs) with memory registration"""
 
     homepage = "https://github.com/ghex-org/hwmalloc"
     url = "https://github.com/ghex-org/hwmalloc/archive/refs/tags/v0.0.0.tar.gz"
     git = "https://github.com/ghex-org/hwmalloc.git"
-    maintainers = ["boeschf", "msimberg"]
+
+    maintainers("boeschf", "msimberg")
+
+    license("BSD-3-Clause", checked_by="msimberg")
 
     version("0.4.0", sha256="1161048e915cf196a86a6241d7354dd56b0e02782000507bab19be5628763ab3")
     version("master", branch="master")
@@ -25,9 +28,9 @@ class Hwmalloc(CMakePackage, CudaPackage, ROCmPackage):
 
     generator("ninja")
 
-    depends_on("numactl", type=("build", "run"))
-    depends_on("boost", type=("build"))
     depends_on("cmake@3.19:", type="build")
+    depends_on("numactl", type=("build", "run"))
+    depends_on("boost", type="build")
 
     conflicts("+cuda +rocm", msg="CUDA and ROCm support are mutually exclusive")
 

--- a/repos/spack_repo/builtin/packages/hwmalloc/package.py
+++ b/repos/spack_repo/builtin/packages/hwmalloc/package.py
@@ -1,3 +1,12 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
+from spack_repo.builtin.build_systems.cuda import CudaPackage
+from spack_repo.builtin.build_systems.rocm import ROCmPackage
+
 from spack.package import *
 
 

--- a/repos/spack_repo/builtin/packages/hwmalloc/package.py
+++ b/repos/spack_repo/builtin/packages/hwmalloc/package.py
@@ -4,13 +4,11 @@
 
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
-from spack_repo.builtin.build_systems.cuda import CudaPackage
-from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
 from spack.package import *
 
 
-class Hwmalloc(CMakePackage, CudaPackage, ROCmPackage):
+class Hwmalloc(CMakePackage):
     """hwmalloc provides a thread-safe heap class for allocating memory on given
     numa nodes and devices (GPUs) with memory registration"""
 
@@ -31,9 +29,14 @@ class Hwmalloc(CMakePackage, CudaPackage, ROCmPackage):
     
     depends_on("ninja", type="build")
 
+    variant("cuda", default=False, description="Enable CUDA support")
+    variant("rocm", default=False, description="Enable ROCm support")
+
     depends_on("cmake@3.19:", type="build")
     depends_on("numactl", type=("build", "run"))
     depends_on("boost", type="build")
+    depends_on("cuda", when="+cuda")
+    depends_on("hip", when="+rocm")
 
     conflicts("+cuda +rocm", msg="CUDA and ROCm support are mutually exclusive")
 

--- a/repos/spack_repo/builtin/packages/hwmalloc/package.py
+++ b/repos/spack_repo/builtin/packages/hwmalloc/package.py
@@ -51,10 +51,10 @@ class Hwmalloc(CMakePackage, CudaPackage, ROCmPackage):
             self.define("HWMALLOC_WITH_TESTING", self.run_tests),
         ]
 
-        if "+cuda" in self.spec:
+        if self.spec.satisfies("+cuda"):
             args.append(self.define("HWMALLOC_ENABLE_DEVICE", True))
             args.append(self.define("HWMALLOC_DEVICE_RUNTIME", "cuda"))
-        elif "+rocm" in self.spec:
+        elif self.spec.satisfies("+rocm"):
             args.append(self.define("HWMALLOC_ENABLE_DEVICE", True))
             args.append(self.define("HWMALLOC_DEVICE_RUNTIME", "hip"))
         else:

--- a/repos/spack_repo/builtin/packages/hwmalloc/package.py
+++ b/repos/spack_repo/builtin/packages/hwmalloc/package.py
@@ -26,7 +26,7 @@ class Hwmalloc(CMakePackage):
     depends_on("cxx", type="build")
 
     generator("ninja")
-    
+
     depends_on("ninja", type="build")
 
     variant("cuda", default=False, description="Enable CUDA support")

--- a/repos/spack_repo/builtin/packages/oomph/package.py
+++ b/repos/spack_repo/builtin/packages/oomph/package.py
@@ -63,7 +63,7 @@ class Oomph(CMakePackage):
     depends_on("hwmalloc+rocm", when="+rocm")
     depends_on("hwmalloc~rocm~cuda", when="~rocm~cuda")
     depends_on("cuda", when="+cuda")
-    depends_on("rocm", when="+rocm")
+    depends_on("hip", when="+rocm")
 
     conflicts("+cuda +rocm", msg="CUDA and ROCm support are mutually exclusive")
 

--- a/repos/spack_repo/builtin/packages/oomph/package.py
+++ b/repos/spack_repo/builtin/packages/oomph/package.py
@@ -1,0 +1,107 @@
+from spack.package import *
+
+
+class Oomph(CMakePackage, CudaPackage, ROCmPackage):
+    """Oomph is a non-blocking callback-based point-to-point communication library."""
+
+    homepage = "https://github.com/ghex-org/oomph"
+    url = "https://github.com/ghex-org/oomph/archive/refs/tags/v0.0.0.tar.gz"
+    git = "https://github.com/ghex-org/oomph.git"
+    maintainers = ["boeschf", "msimberg"]
+
+    version("main", branch="main")
+    version("0.5.0", sha256="4c79ff50d14efcde7ce4d14122714efb16443ccff437ab60973cf1db1032fc3d")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build", when="+fortran-bindings")
+
+    generator("ninja")
+
+    backends = ("mpi", "ucx", "libfabric")
+    variant(
+        "backend", default="mpi", description="Transport backend", values=backends, multi=False
+    )
+
+    variant("fortran-bindings", default=False, description="Build Fortran bindings")
+    with when("+fortran-bindings"):
+        variant(
+            "fortran-fp",
+            default="float",
+            description="Floating point type",
+            values=("float", "double"),
+            multi=False,
+        )
+        variant("fortran-openmp", default=True, description="Compile with OpenMP")
+
+    variant(
+        "enable-barrier",
+        default=True,
+        description="Enable thread barrier (disable for task based runtime)",
+    )
+
+    depends_on("hwmalloc")
+    depends_on("hwmalloc+cuda", when="+cuda")
+    depends_on("hwmalloc+rocm", when="+rocm")
+    depends_on("hwmalloc~rocm~cuda", when="~rocm~cuda")
+
+    conflicts("+cuda +rocm", msg="CUDA and ROCm support are mutually exclusive")
+
+    with when("backend=ucx"):
+        depends_on("ucx+thread_multiple")
+        depends_on("ucx+cuda", when="+cuda")
+        depends_on("ucx+rocm", when="+rocm")
+        variant("use-pmix", default="False", description="Use PMIx to establish out-of-band setup")
+        variant("use-spin-lock", default="False", description="Use pthread spin locks")
+        depends_on("pmix", when="+use-pmix")
+
+    libfabric_providers = ("cxi", "efa", "gni", "psm2", "tcp", "verbs")
+    with when("backend=libfabric"):
+        variant(
+            "libfabric-provider",
+            default="tcp",
+            description="fabric",
+            values=libfabric_providers,
+            multi=False,
+        )
+        for provider in libfabric_providers:
+            depends_on(f"libfabric fabrics={provider}", when=f"libfabric-provider={provider}")
+
+    depends_on("mpi")
+    depends_on("boost+thread")
+
+    depends_on("googletest", type=("build","test"))
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("OOMPH_BUILD_FORTRAN", "fortran-bindings"),
+            self.define_from_variant("OOMPH_FORTRAN_OPENMP", "fortran-openmp"),
+            self.define_from_variant("OOMPH_UCX_USE_PMI", "use-pmix"),
+            self.define_from_variant("OOMPH_UCX_USE_SPIN_LOCK", "use-spin-lock"),
+            self.define_from_variant("OOMPH_ENABLE_BARRIER", "enable-barrier"),
+            self.define("OOMPH_WITH_TESTING", self.run_tests),
+            self.define("OOMPH_GIT_SUBMODULE", False),
+            self.define("OOMPH_USE_BUNDLED_LIBS", False),
+        ]
+
+        if self.run_tests and self.spec.satisfies("^openmpi"):
+            args.append(self.define("MPIEXEC_PREFLAGS", "--oversubscribe"))
+
+        if self.spec.variants["fortran-bindings"].value == True:
+            args.append(self.define("OOMPH_FORTRAN_FP", self.spec.variants["fortran-fp"].value))
+
+        for backend in self.backends:
+            args.append(
+                self.define(
+                    f"OOMPH_WITH_{backend.upper()}", self.spec.variants["backend"].value == backend
+                )
+            )
+
+        if self.spec.satisfies("backend=libfabric"):
+            args.append(
+                self.define(
+                    "OOMPH_LIBFABRIC_PROVIDER", self.spec.variants["libfabric-provider"].value
+                )
+            )
+
+        return args

--- a/repos/spack_repo/builtin/packages/oomph/package.py
+++ b/repos/spack_repo/builtin/packages/oomph/package.py
@@ -100,7 +100,7 @@ class Oomph(CMakePackage, CudaPackage, ROCmPackage):
         if self.run_tests and self.spec.satisfies("^openmpi"):
             args.append(self.define("MPIEXEC_PREFLAGS", "--oversubscribe"))
 
-        if self.spec.variants["fortran-bindings"].value == True:
+        if self.spec.satisfies("+fortran-bindings"):
             args.append(self.define("OOMPH_FORTRAN_FP", self.spec.variants["fortran-fp"].value))
 
         for backend in self.backends:

--- a/repos/spack_repo/builtin/packages/oomph/package.py
+++ b/repos/spack_repo/builtin/packages/oomph/package.py
@@ -4,13 +4,11 @@
 
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
-from spack_repo.builtin.build_systems.cuda import CudaPackage
-from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
 from spack.package import *
 
 
-class Oomph(CMakePackage, CudaPackage, ROCmPackage):
+class Oomph(CMakePackage):
     """Oomph is a library for enabling high performance point-to-point,
     asynchronous communication over different fabrics"""
 
@@ -32,6 +30,9 @@ class Oomph(CMakePackage, CudaPackage, ROCmPackage):
     generator("ninja")
     
     depends_on("ninja", type="build")
+
+    variant("cuda", default=False, description="Enable CUDA support")
+    variant("rocm", default=False, description="Enable ROCm support")
 
     backends = ("mpi", "ucx", "libfabric")
     variant(
@@ -61,6 +62,8 @@ class Oomph(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("hwmalloc+cuda", when="+cuda")
     depends_on("hwmalloc+rocm", when="+rocm")
     depends_on("hwmalloc~rocm~cuda", when="~rocm~cuda")
+    depends_on("cuda", when="+cuda")
+    depends_on("rocm", when="+rocm")
 
     conflicts("+cuda +rocm", msg="CUDA and ROCm support are mutually exclusive")
 

--- a/repos/spack_repo/builtin/packages/oomph/package.py
+++ b/repos/spack_repo/builtin/packages/oomph/package.py
@@ -28,7 +28,7 @@ class Oomph(CMakePackage):
     depends_on("fortran", type="build", when="+fortran-bindings")
 
     generator("ninja")
-    
+
     depends_on("ninja", type="build")
 
     variant("cuda", default=False, description="Enable CUDA support")

--- a/repos/spack_repo/builtin/packages/oomph/package.py
+++ b/repos/spack_repo/builtin/packages/oomph/package.py
@@ -30,6 +30,8 @@ class Oomph(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("fortran", type="build", when="+fortran-bindings")
 
     generator("ninja")
+    
+    depends_on("ninja", type="build")
 
     backends = ("mpi", "ucx", "libfabric")
     variant(
@@ -97,7 +99,7 @@ class Oomph(CMakePackage, CudaPackage, ROCmPackage):
             self.define("OOMPH_USE_BUNDLED_LIBS", False),
         ]
 
-        if self.run_tests and self.spec.satisfies("^openmpi"):
+        if self.run_tests and self.spec.satisfies("^mpi=openmpi"):
             args.append(self.define("MPIEXEC_PREFLAGS", "--oversubscribe"))
 
         if self.spec.satisfies("+fortran-bindings"):

--- a/repos/spack_repo/builtin/packages/oomph/package.py
+++ b/repos/spack_repo/builtin/packages/oomph/package.py
@@ -1,3 +1,12 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
+from spack_repo.builtin.build_systems.cuda import CudaPackage
+from spack_repo.builtin.build_systems.rocm import ROCmPackage
+
 from spack.package import *
 
 

--- a/repos/spack_repo/builtin/packages/oomph/package.py
+++ b/repos/spack_repo/builtin/packages/oomph/package.py
@@ -11,12 +11,15 @@ from spack.package import *
 
 
 class Oomph(CMakePackage, CudaPackage, ROCmPackage):
-    """Oomph is a non-blocking callback-based point-to-point communication library."""
+    """Oomph is a library for enabling high performance point-to-point, asynchronous communication over different fabrics"""
 
     homepage = "https://github.com/ghex-org/oomph"
     url = "https://github.com/ghex-org/oomph/archive/refs/tags/v0.0.0.tar.gz"
     git = "https://github.com/ghex-org/oomph.git"
-    maintainers = ["boeschf", "msimberg"]
+
+    maintainers("boeschf", "msimberg")
+
+    license("BSD-3-Clause", checked_by="msimberg")
 
     version("main", branch="main")
     version("0.5.0", sha256="4c79ff50d14efcde7ce4d14122714efb16443ccff437ab60973cf1db1032fc3d")
@@ -49,6 +52,8 @@ class Oomph(CMakePackage, CudaPackage, ROCmPackage):
         description="Enable thread barrier (disable for task based runtime)",
     )
 
+    depends_on("cmake@3.17:", type="build")
+    depends_on("googletest", type="test")
     depends_on("hwmalloc")
     depends_on("hwmalloc+cuda", when="+cuda")
     depends_on("hwmalloc+rocm", when="+rocm")
@@ -78,8 +83,6 @@ class Oomph(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("mpi")
     depends_on("boost+thread")
-
-    depends_on("googletest", type=("build","test"))
 
     def cmake_args(self):
         args = [

--- a/repos/spack_repo/builtin/packages/oomph/package.py
+++ b/repos/spack_repo/builtin/packages/oomph/package.py
@@ -11,7 +11,8 @@ from spack.package import *
 
 
 class Oomph(CMakePackage, CudaPackage, ROCmPackage):
-    """Oomph is a library for enabling high performance point-to-point, asynchronous communication over different fabrics"""
+    """Oomph is a library for enabling high performance point-to-point,
+    asynchronous communication over different fabrics"""
 
     homepage = "https://github.com/ghex-org/oomph"
     url = "https://github.com/ghex-org/oomph/archive/refs/tags/v0.0.0.tar.gz"


### PR DESCRIPTION
This adds three packages from https://github.com/ghex-org and their dependency https://github.com/GridTools/gridtools. The ghex-org packages previously lived in https://github.com/ghex-org/spack-repos. The gridtools package is new.
