### PR TITLE
ants: add master

### DIFF
--- a/repos/spack_repo/builtin/packages/ants/package.py
+++ b/repos/spack_repo/builtin/packages/ants/package.py
@@ -20,6 +20,7 @@ class Ants(CMakePackage):
     git = "https://github.com/ANTsX/ANTs.git"
     url = "https://github.com/ANTsX/ANTs/archive/v2.2.0.tar.gz"
 
+    version("master", branch="master")
     version("2.5.1", sha256="8e3a7c0d3dab05883cba466aff262d78d832f679491318b94ce49b606565cebe")
     version("2.4.3", sha256="13ba78917aca0b20e69f4c43da607f8fe8c810edba23b6f5fd64fbd81b70a79a")
     version("2.4.0", sha256="a8ff78f4d2b16e495f340c9b0647f56c92cc4fc40b6ae04a60b941e5e239f9be")


### PR DESCRIPTION
Add master branch

Although there is a newer version of ants available (2.6.5) this does not build with gcc@15 because of [this](https://github.com/ANTsX/ANTsPy/issues/849) issue.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
