### PR TITLE
octopus: fix typos when using `~mpi`

### DIFF
--- a/repos/spack_repo/builtin/packages/octopus/package.py
+++ b/repos/spack_repo/builtin/packages/octopus/package.py
@@ -160,10 +160,10 @@ class Octopus(cmake.CMakePackage, autotools.AutotoolsPackage, CudaPackage):
         depends_on("libvdwxc~mpi", when="+libvdwxc")
         depends_on("arpack-ng~mpi", when="+arpack")
         depends_on("elpa~mpi", when="+elpa")
-        depends_on("netcdf-c~~mpi", when="+netcdf")  # Link dependency of NetCDF fortran lib
+        depends_on("netcdf-c ~mpi", when="+netcdf")  # Link dependency of NetCDF fortran lib
         with when("+berkeleygw"):
-            depends_on("berkeleygw@3:~~mpi", when="@14:")
-            depends_on("berkeleygw@2.1~~mpi", when="@:13")
+            depends_on("berkeleygw@3: ~mpi", when="@14:")
+            depends_on("berkeleygw@2.1 ~mpi", when="@:13")
 
     depends_on("etsf-io", when="+etsf-io")
     depends_on("py-numpy", when="+python")


### PR DESCRIPTION
Variant propagation is ignored in `package.py` because it's unsupported.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
