### PR TITLE
Libtiff: deprecate version due to CVEs

### DIFF
--- a/repos/spack_repo/builtin/packages/libtiff/package.py
+++ b/repos/spack_repo/builtin/packages/libtiff/package.py
@@ -41,7 +41,16 @@ class Libtiff(CMakePackage, AutotoolsPackage):
     license("libtiff")
 
     version("4.7.1", sha256="f698d94f3103da8ca7438d84e0344e453fe0ba3b7486e04c5bf7a9a3fabe9b69")
-    version("4.7.0", sha256="67160e3457365ab96c5b3286a0903aa6e78bdc44c4bc737d2e486bcecb6ba976")
+    # https://www.cvedetails.com/cve/CVE-2025-61145/
+    # https://www.cvedetails.com/cve/CVE-2025-61144/
+    # https://www.cvedetails.com/cve/CVE-2025-61143/
+    # https://www.cvedetails.com/cve/CVE-2025-9165/
+    # https://www.cvedetails.com/cve/CVE-2025-8961/
+    version(
+        "4.7.0",
+        sha256="67160e3457365ab96c5b3286a0903aa6e78bdc44c4bc737d2e486bcecb6ba976",
+        deprecated=True,
+    )
 
     # GUI
     variant("opengl", default=False, description="use OpenGL (required for tiffgt viewer)")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
