### PR TITLE
cloudpickle: Add missing upper bound

### DIFF
--- a/repos/spack_repo/builtin/packages/py_cloudpickle/package.py
+++ b/repos/spack_repo/builtin/packages/py_cloudpickle/package.py
@@ -27,5 +27,6 @@ class PyCloudpickle(PythonPackage):
     depends_on("python@3.5:", type=("build", "run"), when="@1.6.0:")
     depends_on("python@3.6:", type=("build", "run"), when="@2.2.0:")
     depends_on("python@3.8:", type=("build", "run"), when="@3:")
+    depends_on("python@:3.13", type=("build", "run"), when="@:3.0")
     depends_on("py-setuptools", type="build", when="@:2")
     depends_on("py-flit-core", type="build", when="@3:")


### PR DESCRIPTION
Add Python v3.13 upper bound based on the changelog of versions 3.1.1 and 3.1.2, see https://github.com/cloudpipe/cloudpickle/blob/master/CHANGES.md. 