### PR TITLE
ior: fixes for IOR 4.0.0 and add +aio suport

### DIFF
--- a/repos/spack_repo/builtin/packages/ior/package.py
+++ b/repos/spack_repo/builtin/packages/ior/package.py
@@ -29,8 +29,7 @@ class Ior(AutotoolsPackage):
     variant("hdf5", default=False, description="support IO with HDF5 backend")
     variant("ncmpi", default=False, description="support IO with NCMPI backend")
     variant("lustre", default=False, description="support configurable Lustre striping values")
-    variant("aio", default=False, description="support AIO backend API")
-    conflicts("+aio", when="@:3.9.9", msg="AIO support requires IOR version 4.0.0 or newer")
+    variant("aio", default=False, description="support AIO backend API", when="@4:")
 
     depends_on("c", type="build")  # generated
 
@@ -58,7 +57,7 @@ class Ior(AutotoolsPackage):
     patch(
         "https://github.com/glennklockwood/ior/commit/e49476be64d4100c2da662ea415f327348b3d11d.patch?full_index=1",
         sha256="ee3527023ef70ea9aee2e6208f8be7126d5a48f26c587deed3d6238b4f848a06",
-        when="+lustre @:3.9.9",
+        when="+lustre @:3",
     )
 
     @run_before("autoreconf")

--- a/repos/spack_repo/builtin/packages/ior/package.py
+++ b/repos/spack_repo/builtin/packages/ior/package.py
@@ -29,6 +29,8 @@ class Ior(AutotoolsPackage):
     variant("hdf5", default=False, description="support IO with HDF5 backend")
     variant("ncmpi", default=False, description="support IO with NCMPI backend")
     variant("lustre", default=False, description="support configurable Lustre striping values")
+    variant("aio", default=False, description="support AIO backend API")
+    conflicts("+aio", when="@:3.9.9", msg="AIO support requires IOR version 4.0.0 or newer")
 
     depends_on("c", type="build")  # generated
 
@@ -36,10 +38,12 @@ class Ior(AutotoolsPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
+    depends_on("pkgconf", type="build", when="@4.0.0:")
     depends_on("mpi")
     depends_on("hdf5+mpi", when="+hdf5")
     depends_on("parallel-netcdf", when="+ncmpi")
     depends_on("lustre", when="+lustre")
+    depends_on("libaio", when="+aio")
 
     # The build for 3.2.0 fails if hdf5 is enabled
     # See https://github.com/hpc/ior/pull/124
@@ -54,7 +58,7 @@ class Ior(AutotoolsPackage):
     patch(
         "https://github.com/glennklockwood/ior/commit/e49476be64d4100c2da662ea415f327348b3d11d.patch?full_index=1",
         sha256="ee3527023ef70ea9aee2e6208f8be7126d5a48f26c587deed3d6238b4f848a06",
-        when="+lustre",
+        when="+lustre @:3.9.9",
     )
 
     @run_before("autoreconf")
@@ -82,5 +86,10 @@ class Ior(AutotoolsPackage):
             config_args.append("--with-lustre")
         else:
             config_args.append("--without-lustre")
+
+        if spec.satisfies("+aio"):
+            config_args.append("--with-aio")
+        else:
+            config_args.append("--without-aio")
 
         return config_args


### PR DESCRIPTION
Support IOR and Lustre for IOR 4.0.0 version.

1. IOR 4.0.0 fixes the lustre issue and does not the patch.
2. Add AIO support for IOR, which is added on 4.0.0 
3. compiling of IOR 4.0.0 also requires pkgconf



<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
