### PR TITLE
octave: add v11.1.0

### DIFF
--- a/repos/spack_repo/builtin/packages/octave/package.py
+++ b/repos/spack_repo/builtin/packages/octave/package.py
@@ -31,6 +31,7 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
 
     license("GPL-3.0-or-later")
 
+    version("11.1.0", sha256="c0e7e2c91bc573256431b2cc989290b9bd13851dbadd59d0ac74714f1334b0e6")
     version("10.3.0", sha256="2fcb38dc062e440f1e06c069bbca840ed46dcc8f983e473e1558fcc38384ee6b")
     version("10.2.0", sha256="07fb6d9339d2f350735c91671be8e874d160018cc6b688f9efd9d558d237f69f")
     version("10.1.0", sha256="aed449cba379fc1e1186ec3fc3c96e0860789278fbc823ae2cebe60344344b78")

--- a/repos/spack_repo/builtin/packages/octave/package.py
+++ b/repos/spack_repo/builtin/packages/octave/package.py
@@ -25,7 +25,7 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
 
     homepage = "https://www.gnu.org/software/octave/"
     gnu_mirror_path = "octave/octave-4.0.0.tar.gz"
-    maintainers("mtmiller")
+    maintainers("cessenat")
 
     extendable = True
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
There are many smart features described in the release notes:
https://github.com/cessenat/spack-packages/pull/new/octave_newversion
Maintainer change since current one is no longer on the internet.