### PR TITLE
py-uv: deprecate versions due to CVE

### DIFF
--- a/repos/spack_repo/builtin/packages/py_uv/package.py
+++ b/repos/spack_repo/builtin/packages/py_uv/package.py
@@ -16,14 +16,16 @@ class PyUv(PythonPackage):
     license("APACHE 2.0 or MIT")
 
     version("0.10.1", sha256="c89e7fd708fb3474332d6fc54beb2ea48313ebdc82c6931df92a884fcb636d9d")
-    version("0.7.22", sha256="f5cf159907d594e33433f14737d1ee843dc8799edfcf57b5b8c0f282d1117051")
-    version("0.7.15", sha256="c608cd2d89db7482ab40fc6e7de27afc87b20595e145ed81a2a8702e9a0d7e2d")
-    version("0.7.5", sha256="ae2192283eb645ccab189b1dfd8b13d3264eae631469a903c0e0f2dffce65e3b")
-    version("0.6.8", sha256="45ecd70cfe42132ff84083ecb37fe7a8d2feac3eacd7a5872e7a002fb260940f")
-    version("0.4.27", sha256="c13eea45257362ecfa2a2b31de9b62fbd0542e211a573562d98ab7c8fc50d8fc")
-    version("0.4.17", sha256="01564bd760eff885ad61f44173647a569732934d1a4a558839c8088fbf75e53f")
-    version("0.4.16", sha256="2144995a87b161d063bd4ef8294b1e948677bd90d01f8394d0e3fca037bb847f")
-    version("0.4.15", sha256="8e36b8e07595fc6216d01e729c81a0b4ff029a93cc2ef987a73d3b650d6d559c")
+    with default_args(deprecated=True):
+        # https://www.cvedetails.com/cve/CVE-2025-13327/
+        version("0.7.22", sha256="f5cf159907d594e33433f14737d1ee843dc8799edfcf57b5b8c0f282d1117051")
+        version("0.7.15", sha256="c608cd2d89db7482ab40fc6e7de27afc87b20595e145ed81a2a8702e9a0d7e2d")
+        version("0.7.5", sha256="ae2192283eb645ccab189b1dfd8b13d3264eae631469a903c0e0f2dffce65e3b")
+        version("0.6.8", sha256="45ecd70cfe42132ff84083ecb37fe7a8d2feac3eacd7a5872e7a002fb260940f")
+        version("0.4.27", sha256="c13eea45257362ecfa2a2b31de9b62fbd0542e211a573562d98ab7c8fc50d8fc")
+        version("0.4.17", sha256="01564bd760eff885ad61f44173647a569732934d1a4a558839c8088fbf75e53f")
+        version("0.4.16", sha256="2144995a87b161d063bd4ef8294b1e948677bd90d01f8394d0e3fca037bb847f")
+        version("0.4.15", sha256="8e36b8e07595fc6216d01e729c81a0b4ff029a93cc2ef987a73d3b650d6d559c")
 
     # from Cargo.toml
     depends_on("rust@1.86:", type=("build", "run"), when="@0.7.16:")

--- a/repos/spack_repo/builtin/packages/py_uv/package.py
+++ b/repos/spack_repo/builtin/packages/py_uv/package.py
@@ -18,14 +18,26 @@ class PyUv(PythonPackage):
     version("0.10.1", sha256="c89e7fd708fb3474332d6fc54beb2ea48313ebdc82c6931df92a884fcb636d9d")
     with default_args(deprecated=True):
         # https://www.cvedetails.com/cve/CVE-2025-13327/
-        version("0.7.22", sha256="f5cf159907d594e33433f14737d1ee843dc8799edfcf57b5b8c0f282d1117051")
-        version("0.7.15", sha256="c608cd2d89db7482ab40fc6e7de27afc87b20595e145ed81a2a8702e9a0d7e2d")
+        version(
+            "0.7.22", sha256="f5cf159907d594e33433f14737d1ee843dc8799edfcf57b5b8c0f282d1117051"
+        )
+        version(
+            "0.7.15", sha256="c608cd2d89db7482ab40fc6e7de27afc87b20595e145ed81a2a8702e9a0d7e2d"
+        )
         version("0.7.5", sha256="ae2192283eb645ccab189b1dfd8b13d3264eae631469a903c0e0f2dffce65e3b")
         version("0.6.8", sha256="45ecd70cfe42132ff84083ecb37fe7a8d2feac3eacd7a5872e7a002fb260940f")
-        version("0.4.27", sha256="c13eea45257362ecfa2a2b31de9b62fbd0542e211a573562d98ab7c8fc50d8fc")
-        version("0.4.17", sha256="01564bd760eff885ad61f44173647a569732934d1a4a558839c8088fbf75e53f")
-        version("0.4.16", sha256="2144995a87b161d063bd4ef8294b1e948677bd90d01f8394d0e3fca037bb847f")
-        version("0.4.15", sha256="8e36b8e07595fc6216d01e729c81a0b4ff029a93cc2ef987a73d3b650d6d559c")
+        version(
+            "0.4.27", sha256="c13eea45257362ecfa2a2b31de9b62fbd0542e211a573562d98ab7c8fc50d8fc"
+        )
+        version(
+            "0.4.17", sha256="01564bd760eff885ad61f44173647a569732934d1a4a558839c8088fbf75e53f"
+        )
+        version(
+            "0.4.16", sha256="2144995a87b161d063bd4ef8294b1e948677bd90d01f8394d0e3fca037bb847f"
+        )
+        version(
+            "0.4.15", sha256="8e36b8e07595fc6216d01e729c81a0b4ff029a93cc2ef987a73d3b650d6d559c"
+        )
 
     # from Cargo.toml
     depends_on("rust@1.86:", type=("build", "run"), when="@0.7.16:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Only medium severity, but I don't know of any reason anyone would want to install an older version of uv other than to use an older rust version.