### PR TITLE
`cargo`: fall back to older versions if `rust` toolchain is old

### DIFF
--- a/repos/spack_repo/builtin/packages/rust/package.py
+++ b/repos/spack_repo/builtin/packages/rust/package.py
@@ -187,6 +187,18 @@ class Rust(Package):
     ) -> None:
         env.set("CARGO_HOME", join_path(dependent_spec.package.stage.path, "cargo"))
 
+        # Until we get a little more integration with cargo or offload solving to spack
+        # (how to do this is TBD), we need it to fall back to older package versions
+        # when the latest version doesn't support our rust toolchain version. This
+        # option allows Spack to be slightly behind the latest rust in CI.
+        #
+        # This is safe as long as rust is using static libraries and there are not ABI
+        # dependencies among rust packages in Spack.
+        #
+        # This is supported in Cargo 1.84 and higher.
+        if self.spec.satisfies("@1.84:"):
+            env.set("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
+
     def configure(self, spec, prefix):
         opts = []
 


### PR DESCRIPTION
We currently hit issues like this in CI:

```
  error: rustc 1.92.0 is not supported by the following packages:
    fixed@1.31.0 requires rustc 1.93
    fixed@1.31.0 requires rustc 1.93
    fixed@1.31.0 requires rustc 1.93
  Either upgrade rustc or select compatible dependency versions with
  `cargo update <name>@<current-ver> --precise <compatible-ver>`
  where `<compatible-ver>` is the latest version supporting rustc 1.92.0
```

When we are ever so slightly behind the latest rust version. This is because `cargo` by default picks the latest version of packages without regard to what rust version we are using. Rust 1.84 and higher have an option for `cargo` to fall back to older versions of packages when the latest is incompatible with the current toolchain:

```
export CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback
```

Setting this in CI should allow us to avoid CI breaking when we aren't quite at the latest rust version.  Obviously we still want to update, but we also want stable CI.

There may be packages that don't set their `rust-version` properly in `Cargo.toml`, so this may not be the end of the story, and we have a long way to go for proper `rust` integration, but it's a start at least.

- [x] set CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback in `setup_dependent_build_environment` in `rust`

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
