### PR TITLE
libsegfault: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/libsegfault/package.py
+++ b/repos/spack_repo/builtin/packages/libsegfault/package.py
@@ -19,7 +19,7 @@ class Libsegfault(AutotoolsPackage):
 
     license("GPL-2.0")
 
-    version("main", commit="ff16adff4a6af738eb4deabfb0eb107f6fa6e048")
+    version("2023-07-25", commit="ff16adff4a6af738eb4deabfb0eb107f6fa6e048")
 
     depends_on("c", type="build")
 

--- a/repos/spack_repo/builtin/packages/libsegfault/package.py
+++ b/repos/spack_repo/builtin/packages/libsegfault/package.py
@@ -1,0 +1,26 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+
+from spack.package import *
+
+
+class Libsegfault(AutotoolsPackage):
+    """This projects contains tools and library provided by glibc that either
+    have been deprecated of moved out from the project. currently, in contains:
+    LibSegFault."""
+
+    homepage = "https://github.com/zatrazz/glibc-tools"
+    git = "https://github.com/zatrazz/glibc-tools.git"
+
+    maintainers("etiennemlb")
+
+    license("GPL-2.0")
+
+    version("main", commit="ff16adff4a6af738eb4deabfb0eb107f6fa6e048")
+
+    depends_on("c", type="build")
+
+    flag_handler = build_system_flags


### PR DESCRIPTION
This used to be in glibc. This is a very useful, simple and lightweight tool that hooks signals and dump a stack trace on crash.

It can be linked at build time or at runtime with LD_PRELOAD (the provided `catchsegv` script).

Then using addr2line the executable and an address from the stack trace, you can deduce the line at which the program failed.

@spackbot fix style