### PR TITLE
Revert "gcc: use link type dep for binutils"

### DIFF
--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -244,9 +244,9 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     depends_on("diffutils", type="build")
     depends_on("iconv", when="platform=darwin")
     depends_on("gnat", when="languages=ada")
-    # For binutils we use `link` because we don't rely on `PATH`, but on the
-    # automatic `-B` flag
-    depends_on("binutils+gas+ld+plugins~libiberty", when="+binutils", type=("build", "link"))
+    depends_on(
+        "binutils+gas+ld+plugins~libiberty", when="+binutils", type=("build", "link", "run")
+    )
     depends_on("mold", when="+mold")
     depends_on("zip", type="build", when="languages=java")
 


### PR DESCRIPTION
Reverts spack/spack-packages#3671

A fix should be in place in Spack core now.