### PR TITLE
glib: explicitly disable sysprof

### DIFF
--- a/repos/spack_repo/builtin/packages/glib/package.py
+++ b/repos/spack_repo/builtin/packages/glib/package.py
@@ -259,6 +259,10 @@ class MesonBuilder(meson.MesonBuilder):
         args.append("-Dgtk_doc=false")
         args.append("-Dlibelf=enabled")
 
+        # https://github.com/GNOME/glib/commit/fa13c41da7fb03a710bfd8840cae4bb57cf14829
+        if self.spec.satisfies("@2.65.1:"):
+            args.append("-Dsysprof=disabled")
+
         # arguments for older versions
         if self.spec.satisfies("@:2.72"):
             args.append("-Dgettext=external")


### PR DESCRIPTION
This explicitly disables the `sysprof` optional dependency, which is not shipped in spack.

I've not run into this problem previously, but while building `libsecret` I ran into the following error:
```
checking for GLIB... no
configure: error: Package requirements (glib-2.0 >= 2.44.0
	gio-2.0
	gio-unix-2.0) were not met:

Package 'sysprof-capture-4', required by 'glib-2.0', not found
Package 'sysprof-capture-4', required by 'gio-2.0', not found
```
Explicitly disabling the dependency in `glib` resolved the problem. Further, according to https://www.linuxfromscratch.org/blfs/view/svn/general/glib2.html, 

> Note that if sysprof is not installed, removing this option will cause the build system to download a copy of sysprof from the Internet.

which is not optimal, so this should be explicitly turned off.