### PR TITLE
py-perfdump: add depends_on "c" to work with new build

### DIFF
--- a/repos/spack_repo/builtin/packages/py_perfdump/package.py
+++ b/repos/spack_repo/builtin/packages/py_perfdump/package.py
@@ -24,6 +24,7 @@ class PyPerfdump(CMakePackage):
     variant("hdf5", default=False, description="Enable HDF5 output")
 
     depends_on("cmake@3.15:", type="build")
+    depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("papi", type=("build", "link", "run"))
     depends_on("python@3:", type=("build", "link", "run"))


### PR DESCRIPTION
In order to build this package after the v1 update it needs to include depends_on("c") to pass the CMakeTestCCompiler.cmake step.