### PR TITLE
compadre: add v1.7.3 and specify kokkos location conditionally

### DIFF
--- a/repos/spack_repo/builtin/packages/compadre/package.py
+++ b/repos/spack_repo/builtin/packages/compadre/package.py
@@ -22,6 +22,7 @@ class Compadre(CMakePackage):
     maintainers("kuberry")
 
     version("master", branch="master")
+    version("1.7.3", sha256="982f918daa5d8ad46145b9fb91ae0c1ecbdc722bc030367cba51901c8fd4c3fe")
     version("1.7.2", sha256="4b7c2944300fd025957be44a1114177dfa0aafcf9e613d830a94e020b2f1751e")
     version(
         "1.6.2",
@@ -109,13 +110,21 @@ class Compadre(CMakePackage):
         kokkos_kernels = spec["kokkos-kernels"]
 
         options = []
-        options.extend(
-            [
-                "-DKokkos_ROOT={0}".format(kokkos.prefix),
-                "-DKokkosKernels_ROOT={0}".format(kokkos_kernels.prefix),
-                "-DCompadre_USE_PYTHON=OFF",
-            ]
-        )
+        if spec.satisfies("@:1.6"):
+            options.extend(
+                [
+                    "-DKokkosCore_PREFIX={0}".format(kokkos.prefix),
+                    "-DKokkosKernels_PREFIX={0}".format(kokkos_kernels.prefix),
+                ]
+            )
+        else:
+            options.extend(
+                [
+                    "-DKokkos_ROOT={0}".format(kokkos.prefix),
+                    "-DKokkosKernels_ROOT={0}".format(kokkos_kernels.prefix),
+                ]
+            )
+        options.append("-DCompadre_USE_PYTHON=OFF")
 
         # Compadre_DEBUG is default OFF and handled from CMAKE_BUILD_TYPE beginning in v1.7.0
         if spec.satisfies("@:1.6"):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Previous update to the package in #3651 doesn't use the correct CMake arguments for `compadre@:1.6`.
Also, this adds compadre v1.7.3.