### PR TITLE
Update Tensile_Compiler to use full path of amdclang++ in Rocblas recipe.

### DIFF
--- a/repos/spack_repo/builtin/packages/rocblas/package.py
+++ b/repos/spack_repo/builtin/packages/rocblas/package.py
@@ -238,7 +238,11 @@ class Rocblas(CMakePackage):
             return "."
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        env.set("CXX", self.spec["hip"].hipcc)
+        if self.spec.satisfies("@:7.0"):
+            env.set("CXX", self.spec["hip"].hipcc)
+        else:
+            env.set("CC", f"{self.spec['llvm-amdgpu'].prefix}/bin/amdclang")
+            env.set("CXX", f"{self.spec['llvm-amdgpu'].prefix}/bin/amdclang++")
         if self.spec.satisfies("+asan"):
             env.set("CC", f"{self.spec['llvm-amdgpu'].prefix}/bin/clang")
             env.set("CXX", f"{self.spec['llvm-amdgpu'].prefix}/bin/clang++")
@@ -282,12 +286,13 @@ class Rocblas(CMakePackage):
                 )
 
         if "+tensile" in self.spec:
-            if self.spec.satisfies("@:6.2"):
-                tensile_compiler = "hipcc"
+            if self.spec.satisfies("@:7.0"):
+                args.append(self.define("Tensile_COMPILER", "hipcc"))
             else:
-                tensile_compiler = "amdclang++"
+                args.append(
+                    self.define("Tensile_COMPILER", self.spec["llvm-amdgpu"].prefix + "/bin/amdclang++")
+                )
             args += [
-                self.define("Tensile_COMPILER", tensile_compiler),
                 self.define("Tensile_LOGIC", "asm_full"),
                 self.define("BUILD_WITH_TENSILE_HOST", "@3.7.0:" in self.spec),
                 self.define("Tensile_LIBRARY_FORMAT", "msgpack"),

--- a/repos/spack_repo/builtin/packages/rocblas/package.py
+++ b/repos/spack_repo/builtin/packages/rocblas/package.py
@@ -290,7 +290,9 @@ class Rocblas(CMakePackage):
                 args.append(self.define("Tensile_COMPILER", "hipcc"))
             else:
                 args.append(
-                    self.define("Tensile_COMPILER", self.spec["llvm-amdgpu"].prefix + "/bin/amdclang++")
+                    self.define(
+                        "Tensile_COMPILER", self.spec["llvm-amdgpu"].prefix + "/bin/amdclang++"
+                    )
                 )
             args += [
                 self.define("Tensile_LOGIC", "asm_full"),


### PR DESCRIPTION
Update the Tensile_Compiler to use the amdclang++ based on the install prefix of llvm-amdgpu.


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
