### PR TITLE
samtools: rework ncurses link flags

### DIFF
--- a/repos/spack_repo/builtin/packages/samtools/package.py
+++ b/repos/spack_repo/builtin/packages/samtools/package.py
@@ -78,26 +78,23 @@ class Samtools(Package):
     depends_on("htslib@1.3.1", when="@1.3.1")
 
     def install(self, spec, prefix):
-        if "+termlib" in spec["ncurses"]:
-            curses_lib = "-lncursesw -ltinfow"
-        else:
-            curses_lib = "-lncursesw"
+        curses_lib = self.spec["ncurses"].libs.link_flags
 
         if self.spec.version >= Version("1.3.1"):
             configure(
-                "--prefix={0}".format(prefix),
-                "--with-htslib={0}".format(self.spec["htslib"].prefix),
+                f"--prefix={prefix}",
+                f"--with-htslib={self.spec['htslib'].prefix}",
                 "--with-ncurses",
-                "CURSES_LIB={0}".format(curses_lib),
+                f"CURSES_LIB={curses_lib}",
             )
             make()
             make("install")
         else:
-            make("prefix={0}".format(prefix), "LIBCURSES={0}".format(curses_lib))
+            make(f"prefix={prefix}", f"LIBCURSES={curses_lib}")
             if self.spec.version == Version("0.1.8"):
-                make("prefix={0}".format(prefix))
+                make(f"prefix={prefix}")
             else:
-                make("prefix={0}".format(prefix), "install")
+                make(f"prefix={prefix}", "install")
 
         # Install dev headers and libs for legacy apps depending on them
         # per https://github.com/samtools/samtools/releases/tag/1.14


### PR DESCRIPTION
I was having issues compiling samtools with an external ncurses (distro provided ncurses lib and headers, redhat specifically). rhel (at least in 9) does not distribute their ncurses with a libtinfow, only a libtinfo, despite ncurses being built with wide support. So the hardcoded ```-ltinfow``` was causing problems.

After looking into how ncurses figures out its includes and libs, I think the most "correct" way would actually be ```spec["ncurses:wide"].libs.link_flags```, but that won't grab the tinfo flag on el9 as there is no libtinfow.so. If you do ```spec["ncurses"].libs.link_flags``` you get link flags for both the w and non w versions of the libs (if present). This works, and results in samtools binary that is linked against both ncursesw and ncurses, along with tinfo and tinfow (if present). This doesn't appear to be a problem though, tview seemed to work when I did a quick test with both the external ncurses and a spack compiled ncurses.

my preference would be to use this as it wouldn't require any modifications for a user to use an external ncurses (on rhel 9 at the least)

maintainer: @jbeal-work