### PR TITLE
glib: remove conflicting gettext, protect introspection flag

### DIFF
--- a/repos/spack_repo/builtin/packages/glib/package.py
+++ b/repos/spack_repo/builtin/packages/glib/package.py
@@ -230,10 +230,13 @@ class MesonBuilder(meson.MesonBuilder):
 
     def meson_args(self):
         args = []
-        if self.spec.satisfies("+introspection"):
-            args.append("-Dintrospection=enabled")
-        else:
-            args.append("-Dintrospection=disabled")
+
+        if self.spec.satisfies("@2.79:"):
+            if self.spec.satisfies("+introspection"):
+                args.append("-Dintrospection=enabled")
+            else:
+                args.append("-Dintrospection=disabled")
+
         if self.spec.satisfies("@2.63.5:"):
             if self.spec.satisfies("+libmount"):
                 args.append("-Dlibmount=enabled")
@@ -260,8 +263,6 @@ class MesonBuilder(meson.MesonBuilder):
         args.append("-Dlibelf=enabled")
 
         # arguments for older versions
-        if self.spec.satisfies("@:2.72"):
-            args.append("-Dgettext=external")
         if self.spec.satisfies("@:2.74"):
             if self.spec["iconv"].name == "libiconv":
                 if self.spec.satisfies("@2.61.0:"):


### PR DESCRIPTION
- protects the flag for `+introspection` by version, as with older versions one gets 
```
>> 9    ../spack-src/meson.build:1:0: ERROR: Unknown option: "introspection".
```
- removes the `-Dgettext=external` flag. This breaks intl detection
```
1 error found in build log:
     291    ../spack-src/meson.build:2072: WARNING: Project targets '>= 0.52.0' but uses feature introduced in '0.54.0': fallback arg in dependency.
     292    Run-time dependency libffi found: YES 3.5.2
     293    Run-time dependency zlib found: YES 1.3.2
     294    Library intl found: NO
     295    ERROR: Subproject proxy-libintl is buildable: NO
     296
  >> 297    ../spack-src/meson.build:2129:14: ERROR: Automatic wrap-based subproject downloading is disabled
```
I cannot find any reference to `gettext` in the meson.options (or the previous .txt version) and I have no idea how or what this is actually doing. Greps of the code base have not provided clarity. On Slack, @biddisco reported that setting it `=libc` worked when `'-Diconv=libc'`, however my concretization resolution resulted in `'-Dgettext=external' '-Diconv=external'`. As it builds without `-Dgettext=` I think removing it is best.