### PR TITLE
py-zensical: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/py_deepmerge/package.py
+++ b/repos/spack_repo/builtin/packages/py_deepmerge/package.py
@@ -1,0 +1,24 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyDeepmerge(PythonPackage):
+    """A tool to handle merging of nested data structures in Python."""
+
+    homepage = "https://deepmerge.readthedocs.io/en/latest/"
+    pypi = "deepmerge/deepmerge-2.0.tar.gz"
+
+    license("MIT", checked_by="abhishek1297")
+
+    version("2.0", sha256="5c3d86081fbebd04dd5de03626a0607b809a98fb6ccba5770b62466fe940ff20")
+
+    depends_on("py-setuptools@69:", type="build")
+    depends_on("py-setuptools-scm@8:", type="build")
+
+    depends_on("python@3.8:", type=("build", "run"))
+    depends_on("py-typing-extensions", when="^python@:3.9", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_markdown/package.py
+++ b/repos/spack_repo/builtin/packages/py_markdown/package.py
@@ -20,15 +20,26 @@ class PyMarkdown(PythonPackage):
 
     license("BSD-3-Clause")
 
+    # need to update the pypi as the older versions are not visible
+    # putting a url for the latest version temporarily
+    version(
+        "3.10.2",
+        sha256="994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950",
+        url="https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz",
+    )
     version("3.4.1", sha256="3b809086bb6efad416156e00a0da66fe47618a5d6918dd688f53f40c8e4cfeff")
     version("3.3.4", sha256="31b5b491868dcc87d6c24b7e3d19a0d730d59d3e46f4eea6430a321bed387a49")
     version("3.1.1", sha256="2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a")
 
-    depends_on("python@2.7:2.8,3.3.5:", type=("build", "run"))
-    depends_on("python@3.6:", when="@3.3.4:", type=("build", "run"))
-    depends_on("python@3.7:", when="@3.4.1:", type=("build", "run"))
+    with default_args(type="build"):
+        depends_on("py-setuptools@77.0:", when="@3.10.2:")
+        depends_on("py-setuptools@36.6:", when="@:3.4")
 
-    depends_on("py-setuptools", type="build")
-    depends_on("py-setuptools@36.6:", type="build")
-    depends_on("py-importlib-metadata", when="@3.3.4: ^python@:3.7", type=("build", "run"))
-    depends_on("py-importlib-metadata@4.4:", when="@3.4.1: ^python@:3.9", type=("build", "run"))
+    with default_args(type=("build", "run")):
+        depends_on("python@3.10:", when="@3.10.2:")
+        depends_on("python@3.7:", when="@3.4.1:")
+        depends_on("python@3.6:", when="@3.3.4:")
+        depends_on("python@2.7:2.8,3.3.5:", when="@3.3.1")
+
+        depends_on("py-importlib-metadata", when="@3.3.4: ^python@:3.7")
+        depends_on("py-importlib-metadata@4.4:", when="@3.4.1: ^python@:3.9")

--- a/repos/spack_repo/builtin/packages/py_markdown/package.py
+++ b/repos/spack_repo/builtin/packages/py_markdown/package.py
@@ -39,7 +39,7 @@ class PyMarkdown(PythonPackage):
         depends_on("python@3.10:", when="@3.10.2:")
         depends_on("python@3.7:", when="@3.4.1:")
         depends_on("python@3.6:", when="@3.3.4:")
-        depends_on("python@2.7:2.8,3.3.5:", when="@3.3.1")
+        depends_on("python@2.7:2.8,3.3.5:", when="@3.1.1")
 
         depends_on("py-importlib-metadata", when="@3.3.4: ^python@:3.7")
         depends_on("py-importlib-metadata@4.4:", when="@3.4.1: ^python@:3.9")

--- a/repos/spack_repo/builtin/packages/py_pymdown_extensions/package.py
+++ b/repos/spack_repo/builtin/packages/py_pymdown_extensions/package.py
@@ -16,8 +16,14 @@ class PyPymdownExtensions(PythonPackage):
 
     license("MIT")
 
+    version("10.21", sha256="39f4a020f40773f6b2ff31d2cd2546c2c04d0a6498c31d9c688d2be07e1767d5")
     version("9.5", sha256="3ef2d998c0d5fa7eb09291926d90d69391283561cf6306f85cd588a5eb5befa0")
 
-    depends_on("python@3.7:", type=("build", "run"))
     depends_on("py-hatchling@0.21.1:", type="build")
-    depends_on("py-markdown@3.2:", type=("build", "run"))
+
+    with default_args(type=("build", "run")):
+        depends_on("python@3.9:", when="@10.21:")
+        depends_on("python@3.7:", when="@9.5")
+        depends_on("py-markdown@3.6:", when="@10.21:")
+        depends_on("py-markdown@3.2:", when="@9.5")
+        depends_on("py-pyyaml", when="@10.21:")

--- a/repos/spack_repo/builtin/packages/py_zensical/package.py
+++ b/repos/spack_repo/builtin/packages/py_zensical/package.py
@@ -1,0 +1,37 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyZensical(PythonPackage):
+    """Zensical is a modern static site generator designed to simplify building
+    and maintaining project documentation. It's built by the creators of Material
+    for MkDocs and shares the same core design principles and philosophy –
+    batteries included, easy to use, with powerful customization options."""
+
+    homepage = "https://zensical.org"
+    pypi = "zensical/zensical-0.0.29.tar.gz"
+
+    license("MIT", checked_by="abhishek1297")
+
+    version("0.0.29", sha256="0d6282be7cb551e12d5806badf5e94c54a5e2f2cf07057a3e36d1eaf97c33ada")
+
+    # build-only dependencies
+    depends_on("py-maturin@1.8:1", type="build")
+
+    # build and runtime dependencies
+    with default_args(type=("build", "run")):
+        depends_on("python@3.10:")
+        depends_on("py-click@8.1.8:")
+        depends_on("py-deepmerge@2.0:")
+        depends_on("py-markdown@3.7:")
+        depends_on("py-pygments@2.16:")
+        depends_on("py-pymdown-extensions@10.15:")
+        depends_on("py-pyyaml@6.0.2:")
+        # tomli only needed on Python < 3.11
+        # (stdlib tomllib covers 3.11+)
+        depends_on("py-tomli@2.0:", when="^python@:3.10")


### PR DESCRIPTION
mkdocs-material will be discontinued. Zensical is their new project for a faster, lightweight site doc generation.

FYI: https://squidfunk.github.io/mkdocs-material/blog/


### Updates:
- `py-zensical`
  -  `py-deepmerge`
  -  `py-markdown`
  - `py-pymdown-extensions`