### PR TITLE
libunwind: added conflict for gcc@14

### DIFF
--- a/repos/spack_repo/builtin/packages/libunwind/package.py
+++ b/repos/spack_repo/builtin/packages/libunwind/package.py
@@ -104,6 +104,9 @@ class Libunwind(AutotoolsPackage):
 
     conflicts("target=aarch64:", when="@1.8:")
 
+    # https://github.com/libunwind/libunwind/issues/672
+    conflicts("%gcc@14:", when="@1.7.2")
+
     provides("unwind")
 
     # Fix bad prototype for malloc() in test


### PR DESCRIPTION
The versions of `libunwind` where this conflict is valid for is probably broader than just `@1.7.2`, but that's the only version I've tested with and the only version referenced in the [associated issue](https://github.com/libunwind/libunwind/issues/672).