### PR TITLE
blast-plus: fix sqlite configure, rework zstd/sqlite reqs

### DIFF
--- a/repos/spack_repo/builtin/packages/blast_plus/package.py
+++ b/repos/spack_repo/builtin/packages/blast_plus/package.py
@@ -70,6 +70,8 @@ class BlastPlus(AutotoolsPackage):
     variant("pcre", default=True, description="Build with pcre support")
     variant("perl", default=True, description="Build with perl support")
     variant("python", default=True, description="Build with python support")
+    variant("sqlite", default=False, description="Build with sqlite support")
+    variant("zstd", default=False, when="@2.10:", description="Build with zstd support")
 
     depends_on("jpeg", when="+jpeg")
     depends_on("libpng", when="+png")
@@ -87,10 +89,17 @@ class BlastPlus(AutotoolsPackage):
     depends_on("perl", when="+perl")
 
     depends_on("lmdb", when="@2.7.1:")
-    depends_on("sqlite", when="@2.15:")
-    depends_on("zstd", when="@2.17:")
+    depends_on("sqlite", when="+sqlite")
+    depends_on("zstd", when="+zstd")
 
     configure_directory = "c++"
+
+    requires("+sqlite", when="@2.15.0:", msg="sqlite support is required in 2.15 and later")
+    requires(
+        "+zstd+zlib+bzip2",
+        when="@2.17.0:",
+        msg="zstd, zlib, and bzip2 are required 2.17 and later",
+    )
 
     def configure_args(self):
         spec = self.spec
@@ -171,10 +180,10 @@ class BlastPlus(AutotoolsPackage):
         else:
             config_args.append("--without-python")
 
-        with when("@2.15:"):
-            config_args.append(f"--with-sqlite={self.spec['sqlite'].prefix}")
+        with when("+sqlite"):
+            config_args.append(f"--with-sqlite3={self.spec['sqlite'].prefix}")
 
-        with when("@2.17:"):
+        with when("+zstd"):
             config_args.append(f"--with-zstd={self.spec['zstd'].prefix}")
 
         return config_args


### PR DESCRIPTION
#2722 added zstd and sqlite deps, the added sqlite configure option was missing a character and failing to compile.

I also think it makes more sense to add these in as variants (they were previously optional functionality) and just make them required at the relevant versions.

maintainer: @weijianwen 