### PR TITLE
libsvm: sanitize version notation

### DIFF
--- a/repos/spack_repo/builtin/packages/libsvm/package.py
+++ b/repos/spack_repo/builtin/packages/libsvm/package.py
@@ -16,8 +16,22 @@ class Libsvm(MakefilePackage):
 
     license("BSD-3-Clause")
 
-    version("323", sha256="7a466f90f327a98f8ed1cb217570547bcb00077933d1619f3cb9e73518f38196")
-    version("322", sha256="a3469436f795bb3f8b1e65ea761e14e5599ec7ee941c001d771c07b7da318ac6")
+    version("3.23", sha256="7a466f90f327a98f8ed1cb217570547bcb00077933d1619f3cb9e73518f38196")
+    version("3.22", sha256="a3469436f795bb3f8b1e65ea761e14e5599ec7ee941c001d771c07b7da318ac6")
+
+    version(
+        "323",
+        sha256="7a466f90f327a98f8ed1cb217570547bcb00077933d1619f3cb9e73518f38196",
+        deprecated=True,
+    )
+    version(
+        "322",
+        sha256="a3469436f795bb3f8b1e65ea761e14e5599ec7ee941c001d771c07b7da318ac6",
+        deprecated=True,
+    )
+
+    def url_for_version(self, version):
+        return f"https://github.com/cjlin1/libsvm/archive/v{str(version).replace('.', '')}.tar.gz"
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated


### PR DESCRIPTION
Version notation in `libsvm` package is unconventional and confusing. It probably comes from the fact that the author is using unseparated version tags, for example `v323` for version 3.23. Nevertheless, even the author of `libsvm` is using normal version notation in other places. There is no need to use versions like `323` here.

Two packages that depend on `libsvm` do not specify version constraint, so there is no issue in changing it here.