### PR TITLE
ci: update pcluster-amazonlinux-2 tag

### DIFF
--- a/stacks/aws-pcluster-neoverse_v1/spack.yaml
+++ b/stacks/aws-pcluster-neoverse_v1/spack.yaml
@@ -90,7 +90,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: {name: ghcr.io/spack/pcluster-amazonlinux-2:2026-03-10, entrypoint: ['']}
+        image: {name: ghcr.io/spack/pcluster-amazonlinux-2:v2026-03-27, entrypoint: ['']}
         tags: [aarch64]
     - signing-job:
         before_script:

--- a/stacks/aws-pcluster-x86_64_v4/spack.yaml
+++ b/stacks/aws-pcluster-x86_64_v4/spack.yaml
@@ -131,7 +131,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: {name: ghcr.io/spack/pcluster-amazonlinux-2:2026-03-10, entrypoint: ['']}
+        image: {name: ghcr.io/spack/pcluster-amazonlinux-2:v2026-03-27, entrypoint: ['']}
     - signing-job:
         before_script:
             # Do not distribute Intel & ARM binaries


### PR DESCRIPTION
This should fix the failing pipelines on develop

For additional context, see
https://github.com/spack/gitlab-runners/pull/83
