### PR TITLE
Dev stacks: pin mypy to bootstrap requirement

### DIFF
--- a/stacks/developer-tools-aarch64-linux-gnu/spack.yaml
+++ b/stacks/developer-tools-aarch64-linux-gnu/spack.yaml
@@ -82,6 +82,7 @@ spack:
   - meson
   # spack developer tools
   # style
+  - py-mypy@0.900: ^py-mypy-extensions@:1.0
   - py-pytest@9.0.2
   - py-ruff@0.15.0
   - py-ty@0.0.20

--- a/stacks/developer-tools-aarch64-linux-gnu/spack.yaml
+++ b/stacks/developer-tools-aarch64-linux-gnu/spack.yaml
@@ -82,7 +82,7 @@ spack:
   - meson
   # spack developer tools
   # style
-  - py-mypy@0.900: ^py-mypy-extensions@:1.0
+  - "py-mypy@0.900: ^py-mypy-extensions@:1.0"
   - py-pytest@9.0.2
   - py-ruff@0.15.0
   - py-ty@0.0.20

--- a/stacks/developer-tools-darwin/spack.yaml
+++ b/stacks/developer-tools-darwin/spack.yaml
@@ -94,7 +94,7 @@ spack:
     - meson
     # spack developer tools
     # style
-    - py-mypy@0.900: ^py-mypy-extensions@:1.0
+    - "py-mypy@0.900: ^py-mypy-extensions@:1.0"
     - py-pytest@9.0.2
     - py-ruff@0.15.0
     - py-ty@0.0.20

--- a/stacks/developer-tools-darwin/spack.yaml
+++ b/stacks/developer-tools-darwin/spack.yaml
@@ -94,6 +94,7 @@ spack:
     - meson
     # spack developer tools
     # style
+    - py-mypy@0.900: ^py-mypy-extensions@:1.0
     - py-pytest@9.0.2
     - py-ruff@0.15.0
     - py-ty@0.0.20

--- a/stacks/developer-tools-x86_64_v3-linux-gnu/spack.yaml
+++ b/stacks/developer-tools-x86_64_v3-linux-gnu/spack.yaml
@@ -85,6 +85,7 @@ spack:
   - meson
   # spack developer tools
   # style
+  - py-mypy@0.900: ^py-mypy-extensions@:1.0
   - py-pytest@9.0.2
   - py-ruff@0.15.0
   - py-ty@0.0.20

--- a/stacks/developer-tools-x86_64_v3-linux-gnu/spack.yaml
+++ b/stacks/developer-tools-x86_64_v3-linux-gnu/spack.yaml
@@ -85,7 +85,7 @@ spack:
   - meson
   # spack developer tools
   # style
-  - py-mypy@0.900: ^py-mypy-extensions@:1.0
+  - "py-mypy@0.900: ^py-mypy-extensions@:1.0"
   - py-pytest@9.0.2
   - py-ruff@0.15.0
   - py-ty@0.0.20


### PR DESCRIPTION
Pin mypy to `py-mypy@0.900: ^py-mypy-extensions@:1.0` in dev stacks