### PR TITLE
autotools.py: satisfies %c instead of `c in spec`

### DIFF
--- a/repos/spack_repo/builtin/build_systems/autotools.py
+++ b/repos/spack_repo/builtin/build_systems/autotools.py
@@ -430,7 +430,7 @@ To resolve this problem, please try the following:
             else:
                 language = "fortran"
 
-            if language not in self.spec:
+            if not self.spec.satisfies(f"%{language}"):
                 continue
 
             x.filter(


### PR DESCRIPTION
Avoids an expensive code path related to virtuals in older versions of Spack
