### PR TITLE
py_torch: set PYTHON_SIX_SOURCE_DIR to avoid NNPACK to download 'six'

### DIFF
--- a/repos/spack_repo/builtin/packages/py_torch/nnpack_six_path.patch
+++ b/repos/spack_repo/builtin/packages/py_torch/nnpack_six_path.patch
@@ -1,0 +1,12 @@
+diff --git a/third_party/NNPACK/CMakeLists.txt.orig b/third_party/NNPACK/CMakeLists.txt
+index 5ecd2df..2def7f5 100644
+--- a/third_party/NNPACK/CMakeLists.txt.orig
++++ b/third_party/NNPACK/CMakeLists.txt
+@@ -15,6 +15,7 @@ OPTION(NNPACK_CUSTOM_THREADPOOL "Build NNPACK for custom thread pool" OFF)
+ SET(NNPACK_LIBRARY_TYPE "default" CACHE STRING "Type of library (shared, static, or default) to build")
+ SET_PROPERTY(CACHE NNPACK_LIBRARY_TYPE PROPERTY STRINGS default static shared)
+ OPTION(NNPACK_BUILD_TESTS "Build NNPACK unit tests" ON)
++SET(PYTHON_SIX_SOURCE_DIR $ENV{PYTHON_SIX_SOURCE_DIR})
+ 
+ # ---[ CMake options
+ IF(NNPACK_BUILD_TESTS)

--- a/repos/spack_repo/builtin/packages/py_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_torch/package.py
@@ -583,6 +583,9 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
         working_dir="third_party/fbgemm",
     )
 
+    # Force to use PYTHON_SIX_SOURCE_DIR to avoid NNPACK thirdparties downloads "six"
+    patch("nnpack_six_path.patch", when="@2.10.0+nnpack")
+
     def patch(self):
         # https://github.com/pytorch/pytorch/issues/52208
         filter_file(
@@ -820,6 +823,14 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
             env.set("BUILD_CUSTOM_PROTOBUF", "ON")
         else:
             env.set("BUILD_CUSTOM_PROTOBUF", "OFF")
+
+        # NNPACK thirdparties downloads "six" during the build if PYTHON_SIX_SOURCE_DIR is not set
+        if self.spec.satisfies("+nnpack"):
+            python_dir = "python{0}".format(self.spec["python"].version.up_to(2))
+            six_site_packages = join_path(
+                self.spec["py-six"].prefix.lib, python_dir, "site-packages"
+            )
+            env.set("PYTHON_SIX_SOURCE_DIR", six_site_packages)
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         self.torch_cuda_arch_list(env)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
NNPACK thirdparties downloads "six" during the build if `PYTHON_SIX_SOURCE_DIR` is not set.
However, I haven't been able to set this environment variable from the Spack recipe.
The  `nnpack_six_path.patch` will add a line to the NNPACK `CMakeLists.txt`  to explicitly define `PYTHON_SIX_SOURCE_DIR` from the `PYTHON_SIX_SOURCE_DIR` environment variable.

These modifications are intended to achieve an air gapped installation using the 'py-six' dependencies of the Spack recipe.