### PR TITLE
hipblaslt: add clang-offload-bundler path

### DIFF
--- a/repos/spack_repo/builtin/packages/hipblaslt/0005-add-offload-bundler-path.patch
+++ b/repos/spack_repo/builtin/packages/hipblaslt/0005-add-offload-bundler-path.patch
@@ -1,0 +1,14 @@
+diff --git a/projects/hipblaslt/device-library/CMakeLists.txt b/projects/hipblaslt/device-library/CMakeLists.txt
+index a9a698334e..c101f3ddb6 100644
+--- a/projects/hipblaslt/device-library/CMakeLists.txt
++++ b/projects/hipblaslt/device-library/CMakeLists.txt
+@@ -17,6 +17,9 @@ list(JOIN GPU_TARGETS "$<SEMICOLON>" TENSILELITE_GPU_TARGETS_SEMI_ESCAPED)
+
+ set(TENSILELITE_BUILD_OPTS ${TENSILELITE_BUILD_OPTS} "--architecture=${TENSILELITE_GPU_TARGETS_SEMI_ESCAPED}")
+ set(TENSILELITE_BUILD_OPTS ${TENSILELITE_BUILD_OPTS} "--cxx-compiler=${CMAKE_CXX_COMPILER}")
++if(TENSILELITE_OFFLOADBUNDLER)
++    set(TENSILELITE_BUILD_OPTS ${TENSILELITE_BUILD_OPTS} "--offload-bundler=${TENSILELITE_OFFLOADBUNDLER}")
++endif()
+ if(HIPBLASLT_ENABLE_ASAN)
+     set(TENSILELITE_BUILD_OPTS ${TENSILELITE_BUILD_OPTS} "--address-sanitizer")
+ endif()

--- a/repos/spack_repo/builtin/packages/hipblaslt/package.py
+++ b/repos/spack_repo/builtin/packages/hipblaslt/package.py
@@ -177,6 +177,8 @@ class Hipblaslt(CMakePackage):
         sha256="503555b92ccbc33e50a10e2ba1d38e8f3349b93d786c7f6b19aaacb736c9bf7c",
         when="@7.2",
     )
+    # https://github.com/ROCm/rocm-libraries/pull/5990
+    patch("0005-add-offload-bundler-path.patch", when="@7.1:")
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("@:6.4"):
@@ -320,6 +322,11 @@ class Hipblaslt(CMakePackage):
             )
         if self.spec.satisfies("@7.1:"):
             args.append(self.define("HIPBLASLT_ENABLE_CLIENT", self.run_tests))
+            args.append(
+                self.define(
+                    "TENSILELITE_OFFLOADBUNDLER", f"{self.spec['llvm-amdgpu'].prefix}/bin/clang-offload-bundler"
+                )
+            )
         else:
             args.append(self.define("BUILD_CLIENTS_TESTS", self.run_tests))
         if self.spec.satisfies("@7.1: %gcc@8.0:8.9"):

--- a/repos/spack_repo/builtin/packages/hipblaslt/package.py
+++ b/repos/spack_repo/builtin/packages/hipblaslt/package.py
@@ -324,7 +324,8 @@ class Hipblaslt(CMakePackage):
             args.append(self.define("HIPBLASLT_ENABLE_CLIENT", self.run_tests))
             args.append(
                 self.define(
-                    "TENSILELITE_OFFLOADBUNDLER", f"{self.spec['llvm-amdgpu'].prefix}/bin/clang-offload-bundler"
+                    "TENSILELITE_OFFLOADBUNDLER",
+                    f"{self.spec['llvm-amdgpu'].prefix}/bin/clang-offload-bundler",
                 )
             )
         else:

--- a/repos/spack_repo/builtin/packages/hipblaslt/package.py
+++ b/repos/spack_repo/builtin/packages/hipblaslt/package.py
@@ -189,7 +189,7 @@ class Hipblaslt(CMakePackage):
             env.set(
                 "TENSILE_ROCM_ASSEMBLER_PATH", f"{self.spec['llvm-amdgpu'].prefix}/bin/clang++"
             )
-        if self.spec.satisfies("@6.3.0:"):
+        if self.spec.satisfies("@6.3.0:7.0"):
             env.set(
                 "TENSILE_ROCM_OFFLOAD_BUNDLER_PATH",
                 f"{self.spec['llvm-amdgpu'].prefix}/bin/clang-offload-bundler",


### PR DESCRIPTION
When installing hipBLASLt on a system with ROCm already installed, the builds were previously directed to use the clang-offload-bundler binary located in `/opt/rocm/`. This PR addresses this issue by ensuring that the builds point to the correct clang-offload-bundler binary.
