### PR TITLE
COIN-OR packages: new versions and workarounds

### DIFF
--- a/repos/spack_repo/builtin/packages/cbc/package.py
+++ b/repos/spack_repo/builtin/packages/cbc/package.py
@@ -17,16 +17,20 @@ class Cbc(AutotoolsPackage):
 
     license("EPL-2.0")
 
+    version("2.10.13", sha256="62fde44dcf6f3d05c5cd291d7435cdd1b7e8acd3c78ec481dd39fe49cbc40399")
     version("2.10.11", sha256="1fb591dd88336fdaf096b8e42e46111e41671a5eb85d4ee36e45baff1678bd33")
     version("2.10.9", sha256="96d02593b01fd1460d421f002734384e4eb1e93ebe1fb3570dc2b7600f20a27e")
     version("2.10.8", sha256="8525abb541ee1b8e6ff03b00411b66e98bbc58f95be1aefd49d2bca571be2eaf")
     version("2.10.5", sha256="cc44c1950ff4615e7791d7e03ea34318ca001d3cac6dc3f7f5ee392459ce6719")
+    version("2.9.10", sha256="4fc4c3dbb57a6d14f6676159c814b1a921736a16c6052ec777a23e2663f2cbaf")
+    version("2.9.6", sha256="f0a14f7efed6fff9a3bec702e1b8a660570f2ebe064d9187a151b52479e3fe62")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("coinutils")
     depends_on("osi")
+    depends_on("clp")
     depends_on("cgl")
 
     build_directory = "spack-build"

--- a/repos/spack_repo/builtin/packages/cbc/package.py
+++ b/repos/spack_repo/builtin/packages/cbc/package.py
@@ -27,6 +27,7 @@ class Cbc(AutotoolsPackage):
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
+    depends_on("pkgconfig", type="build")
 
     depends_on("coinutils")
     depends_on("osi")

--- a/repos/spack_repo/builtin/packages/cgl/package.py
+++ b/repos/spack_repo/builtin/packages/cgl/package.py
@@ -16,20 +16,34 @@ class Cgl(AutotoolsPackage):
     with a solver. It does not directly call a solver."""
 
     homepage = "https://projects.coin-or.org/Cgl"
-    url = "https://github.com/coin-or/Cgl/archive/releases/0.60.3.tar.gz"
+    url = "https://github.com/coin-or/Cgl/archive/releases/0.60.10.tar.gz"
 
     license("EPL-2.0")
 
+    version("0.60.10", sha256="41b7ac9402db883d9c487eb7101e59eb513cefd726e6e7a669dc94664d9385e6")
     version("0.60.8", sha256="1482ba38afb783d124df8d5392337f79fdd507716e9f1fb6b98fc090acd1ad96")
     version("0.60.7", sha256="93b30a80b5d2880c2e72d5877c64bdeaf4d7c1928b3194ea2f88b1aa4517fb1b")
     version("0.60.6", sha256="9e2c51ffad816ab408763d6b931e2a3060482ee4bf1983148969de96d4b2c9ce")
     version("0.60.3", sha256="cfeeedd68feab7c0ce377eb9c7b61715120478f12c4dd0064b05ad640e20f3fb")
+    version("0.59.11", sha256="b670f69a81fed8eddd3198688b73bd8ee4b6382388901f78df92fcaf97c40a92")
+    version("0.59.7", sha256="1bf0fb2012ec535d1c44aea53469d9705967e7bbae5de1d87e1985c90fd6d6a8")
+    version("0.58.11", sha256="7503594257d08f48a48fa1cfdd9982aeac8b34b787efb6c9af475bf3f6563d16")
 
     depends_on("c", type="build")
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
 
+    depends_on("coinutils@2.11.0:", when="@0.60:")
+    depends_on("coinutils@2.10.3:", when="@0.59:")
     depends_on("coinutils")
+
     depends_on("osi")
     depends_on("clp")
 
     build_directory = "spack-build"
+
+    def setup_build_environment(self, env):
+        # With older versions of GCC, there was a high chance of math headers being included
+        # implicitly by other headers, allowing files with missing inclusion to build.
+
+        if self.spec.satisfies("%gcc@11:") and self.spec.satisfies("@:0.59.9"):
+            env.append_flags("CXXFLAGS", "-DHAVE_CFLOAT=1")

--- a/repos/spack_repo/builtin/packages/cgl/package.py
+++ b/repos/spack_repo/builtin/packages/cgl/package.py
@@ -31,6 +31,7 @@ class Cgl(AutotoolsPackage):
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
+    depends_on("pkgconfig", type="build")
 
     depends_on("coinutils@2.11.0:", when="@0.60:")
     depends_on("coinutils@2.10.3:", when="@0.59:")

--- a/repos/spack_repo/builtin/packages/clp/package.py
+++ b/repos/spack_repo/builtin/packages/clp/package.py
@@ -12,22 +12,33 @@ class Clp(AutotoolsPackage):
     linear programming solver written in C++."""
 
     homepage = "https://projects.coin-or.org/Clp"
-    url = "https://github.com/coin-or/Clp/archive/releases/1.17.6.tar.gz"
+    url = "https://github.com/coin-or/Clp/archive/releases/1.17.11.tar.gz"
 
     license("EPL-2.0")
 
+    version("1.17.11", sha256="2c078e174dc1a7a308e091b6256fb34b4017897fc140ea707ba207b2913ea46d")
     version("1.17.9", sha256="b02109be54e2c9c6babc9480c242b2c3c7499368cfca8c0430f74782a694a49f")
     version("1.17.7", sha256="c4c2c0e014220ce8b6294f3be0f3a595a37bef58a14bf9bac406016e9e73b0f5")
     version("1.17.6", sha256="afff465b1620cfcbb7b7c17b5d331d412039650ff471c4160c7eb24ae01284c9")
     version("1.17.4", sha256="ef412cde00cb1313d9041115a700d8d59d4b8b8b5e4dde43e9deb5108fcfbea8")
-    version("1.16.11", sha256="b525451423a9a09a043e6a13d9436e13e3ee7a7049f558ad41a110742fa65f39")
+    version("1.16.12", sha256="3ea36ea3d1500bec9d5c9a105dbc5dc282851272b6bb1412cd6edf2a4b5ea559")
+    version("1.16.11", sha256="ac42c00ba95e1e034ae75ba0e3a5ff03b452191e0c9b2f5e2d5e65bf652fb0a1")
+    version("1.16.8", sha256="22042aaf5857272b83039be8d1f84baff8f349a76f2527c62de7ad36717c7d04")
+    version("1.15.12", sha256="652c45aabbe06859ba2e7f702962447cf7af71f7c6835e847074dc44c327faf0")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    # Passing -DNDEBUG to CXXFLAGS allows building with %gcc@11: but with side-effects.
+    conflicts("gcc@11:", when="@:1.16.10")
 
     depends_on("pkgconfig", type="build")
+
+    depends_on("coinutils@2.11.2:", when="@1.17.2:")
+    depends_on("coinutils@2.11.0:", when="@1.17.0:1.17.1")
+    depends_on("coinutils@2.10.6:", when="@1.16.6:1.16")
     depends_on("coinutils")
+
     depends_on("osi")
-    depends_on("pkgconfig", type="build")
 
     build_directory = "spack-build"

--- a/repos/spack_repo/builtin/packages/coinmp/package.py
+++ b/repos/spack_repo/builtin/packages/coinmp/package.py
@@ -1,0 +1,31 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+
+from spack.package import *
+
+
+class Coinmp(AutotoolsPackage):
+    """C-API library for CLP, CBC, and CGL."""
+
+    homepage = "https://github.com/coin-or/CoinMP"
+    url = "https://github.com/coin-or/CoinMP/archive/refs/tags/releases/1.8.4.tar.gz"
+    git = "https://github.com/coin-or/CoinMP.git"
+
+    license("CPL-1.0")
+
+    version("1.8.4", sha256="ec03a5110d9d79da950669e3400f3b81c4391747b14821d8997f9f8755873150")
+    version("1.8.3", sha256="a7a70b5a2f19eb57f55ce079c0b83ca36507ba83118a1ade52e46cb75b35bcb1")
+    version("1.7.6", sha256="d7316e2f11886d1b14d0be82990305e33f4b034f2251f05c206168b854f5010a")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("pkgconfig", type="build")
+
+    depends_on("coinutils")
+    depends_on("osi")
+    depends_on("clp")
+    depends_on("cgl")
+    depends_on("cbc")

--- a/repos/spack_repo/builtin/packages/coinutils/package.py
+++ b/repos/spack_repo/builtin/packages/coinutils/package.py
@@ -13,17 +13,26 @@ class Coinutils(AutotoolsPackage):
     projects."""
 
     homepage = "https://projects.coin-or.org/Coinutils"
-    url = "https://github.com/coin-or/CoinUtils/archive/releases/2.11.4.tar.gz"
+    url = "https://github.com/coin-or/CoinUtils/archive/releases/2.11.13.tar.gz"
 
     license("EPL-2.0")
 
+    version("2.11.13", sha256="ddfea48e10209215748bc9f90a8c04abbb912b662c1aefaf280018d0a181ef79")
     version("2.11.10", sha256="80c7c215262df8d6bd2ba171617c5df844445871e9891ec6372df12ccbe5bcfd")
     version("2.11.9", sha256="15d572ace4cd3b7c8ce117081b65a2bd5b5a4ebaba54fadc99c7a244160f88b8")
     version("2.11.6", sha256="6ea31d5214f7eb27fa3ffb2bdad7ec96499dd2aaaeb4a7d0abd90ef852fc79ca")
     version("2.11.4", sha256="d4effff4452e73356eed9f889efd9c44fe9cd68bd37b608a5ebb2c58bd45ef81")
+    version("2.10.15", sha256="b10e4ef56118f6c090e637fc75b84e8e0001c1ce5d867a834e9ff5ef03f119ad")
+    version("2.10.10", sha256="f6c90b2a042faae84a6e8d56851283f594610372e0a54835f042de2d364541d6")
+    version("2.9.19", sha256="0eb6139ff6d4dcc8957ef6a73b74d62c48339471595e70d67ba3e6470a8eab05")
 
     depends_on("c", type="build")
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
     depends_on("fortran", type="build")
 
     build_directory = "spack-build"
+
+    def setup_build_environment(self, env):
+        if self.spec.satisfies("%gcc@11:") and self.spec.satisfies("@:2.10.13"):
+            # older autoconf script fails to set this variable with newer GCC versions
+            env.append_flags("CXXFLAGS", "-DHAVE_CFLOAT=1")

--- a/repos/spack_repo/builtin/packages/osi/package.py
+++ b/repos/spack_repo/builtin/packages/osi/package.py
@@ -23,15 +23,18 @@ class Osi(AutotoolsPackage):
 
     depends_on("pkgconfig", type="build")
     depends_on("coinutils")
-    depends_on("pkgconfig", type="build")
 
     license("EPL-2.0")
 
+    version("0.108.12", sha256="1d80d0b4275f2e1ceefc6dda66b8616e3a8c8b07a926ef4456db4a0d55249333")
     version("0.108.8", sha256="8b01a49190cb260d4ce95aa7e3948a56c0917b106f138ec0a8544fadca71cf6a")
     version("0.108.7", sha256="f1bc53a498585f508d3f8d74792440a30a83c8bc934d0c8ecf8cd8bc0e486228")
     version("0.108.6", sha256="984a5886825e2da9bf44d8a665f4b92812f0700e451c12baf9883eaa2315fad5")
+    version("0.107.10", sha256="f7f09612be8c863ec6a61f4b9c645537cf71b7c3118b9220d1e83444f3733628")
+    version("0.107.6", sha256="2320dd7016f00fb18be9036285ed7422d263e4bc88dbdde2830a2fbf003fbf82")
+    version("0.106.10", sha256="16ae796a7d650f45f9d8555574cc5c6dd2131342d504345d689a6a2adda80855")
 
     depends_on("c", type="build")
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
 
     build_directory = "spack-build"


### PR DESCRIPTION
Packages called `coinmp`, `cbc`, `cgl`, `clp`, `osi`, `coinutils` belong to [COIN-OR]( https://github.com/coin-or). It is a family of optimization algorithms and solvers.

This pull request adds some constraints, workarounds and recent versions of the packages. Because the authors don't publish compatibility information and the packages have issue with building against each other, I performed brute-force compatibility check to find the right constraints.

# Building of CoinUtils

Before:

<img width="431" height="196" alt="image" src="https://github.com/user-attachments/assets/4b0077ba-fd69-4a87-a9d2-278eed6fad87" />

<img width="1206" height="269" alt="image" src="https://github.com/user-attachments/assets/4034b0f2-ffa3-4e5d-b007-594523f56fac" />

After

<img width="1206" height="269" alt="image" src="https://github.com/user-attachments/assets/38c9b8d9-a5d8-4d6a-af1f-db2c822cbd43" />

# Building of Clp

Before

<img width="669" height="513" alt="image" src="https://github.com/user-attachments/assets/9df7de4e-90ee-477d-add9-1fceef436510" />

After

<img width="592" height="432" alt="image" src="https://github.com/user-attachments/assets/1a7f7c2a-7be8-41fb-bb3b-5e2928362224" />

# Building of Cgl

Before

<img width="630" height="263" alt="image" src="https://github.com/user-attachments/assets/debec74c-b413-4fcf-97a5-dbe05b0cb547" />

<img width="785" height="374" alt="image" src="https://github.com/user-attachments/assets/d9eb719c-1bbb-4cb5-9908-bb0ed2fde4a5" /> 

After

<img width="301" height="378" alt="image" src="https://github.com/user-attachments/assets/7d6d8a48-9e97-4106-83df-318036ed91de" />
