### PR TITLE
py-nibabel: add v5.4.2

### DIFF
--- a/repos/spack_repo/builtin/packages/py_nibabel/package.py
+++ b/repos/spack_repo/builtin/packages/py_nibabel/package.py
@@ -19,6 +19,7 @@ class PyNibabel(PythonPackage):
     # As detailed: https://nipy.org/nibabel/legal.html
     license("MIT AND BSD-3-Clause AND PSF-2.0 AND PDDL-1.0")
 
+    version("5.4.2", sha256="d5f4b9076a13178ae7f7acf18c8dbd503ee1c4d5c0c23b85df7be87efcbb49da")
     version("5.3.3", sha256="8d2006b70d727fd0a798a88ae5fd64339741f436fcfc83d6ea3256cdbc51c5b7")
     version("5.3.2", sha256="0bdca6503b1c784b446c745a4542367de7756cfba0d72143b91f9ffb78be569b")
     version("5.2.1", sha256="b6c80b2e728e4bc2b65f1142d9b8d2287a9102a8bf8477e115ef0d8334559975")
@@ -28,12 +29,15 @@ class PyNibabel(PythonPackage):
     version("3.2.1", sha256="4d2ff9426b740011a1c916b54fc25da9348282e727eaa2ea163f42e00f1fc29e")
     version("2.4.1", sha256="f165ff1cb4464902d6594eb2694e2cfb6f8b9fe233b856c976c3cff623ee0e17")
 
+    depends_on("python@3.10:", when="@5.4:", type=("build", "run"))
     depends_on("python@3.9:", when="@5.3:", type=("build", "run"))
     depends_on("python@3.8:", when="@5:", type=("build", "run"))
     depends_on("python@3.7:", when="@4:", type=("build", "run"))
+    depends_on("py-hatchling@1,27:", when="@5.4:", type="build")
     depends_on("py-hatchling", when="@5:", type="build")
     depends_on("py-hatch-vcs", when="@5:", type="build")
 
+    depends_on("py-numpy@1.25:", when="@5.4:", type=("build", "run"))
     depends_on("py-numpy@1.22:", when="@5.3:", type=("build", "run"))
     depends_on("py-numpy@1.20:", when="@5.2.1:", type=("build", "run"))
     depends_on("py-numpy@1.19:", when="@5:", type=("build", "run"))


### PR DESCRIPTION
https://github.com/nipy/nibabel/releases/tag/5.4.2

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
