### PR TITLE
print spec before doing rebuild

### DIFF
--- a/.ci/gitlab/configs/ci.yaml
+++ b/.ci/gitlab/configs/ci.yaml
@@ -23,6 +23,7 @@ ci:
       script::
       - - if [ -n "$SPACK_EXTRA_MIRROR" ]; then spack mirror add local "${SPACK_EXTRA_MIRROR}/${SPACK_CI_STACK_NAME}"; fi
         - spack config blame mirrors
+        - spack spec "/${SPACK_JOB_SPEC_DAG_HASH}"
       - - spack --color=always ci rebuild -j ${SPACK_BUILD_JOBS} --tests --timeout 300 > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
       after_script:
       - - cat /proc/loadavg || true


### PR DESCRIPTION
Multiple users have requested this to make debugging failed builds easier.

PR spack/spack#49021 makes this default for `spack ci`, but we override defaults so we re-enable it here.
