### PR TITLE
geant4: depends on gl when +qt

### DIFF
--- a/repos/spack_repo/builtin/packages/geant4/package.py
+++ b/repos/spack_repo/builtin/packages/geant4/package.py
@@ -197,6 +197,7 @@ class Geant4(CMakePackage):
     depends_on("libxmu", when="+x11")
     depends_on("motif", when="+motif")
     with when("+qt"):
+        depends_on("gl")
         depends_on("qmake")
         with when("^[virtuals=qmake] qt-base"):
             depends_on("qt-base +accessibility +gui +opengl")


### PR DESCRIPTION
Geant4 explicitly depends on GL when `+qt`, and the transitive dependency appears insufficient to get the correct rpath linking to `libGL.so`.
