### PR TITLE
c-raft: new versions and variants

### DIFF
--- a/repos/spack_repo/builtin/packages/c_raft/package.py
+++ b/repos/spack_repo/builtin/packages/c_raft/package.py
@@ -31,7 +31,7 @@ class CRaft(AutotoolsPackage):
     version(
         "0.17.1",
         sha256="e31c7fafbdd5f94913161c5d64341a203364e512524b47295c97a91e83c4198b",
-        url="https://github.com/canonical/raft/archive/refs/tags/v0.17.1.tar.gz"
+        url="https://github.com/canonical/raft/archive/refs/tags/v0.17.1.tar.gz",
     )
 
     variant("uv", default=True, description="Enable libuv support")

--- a/repos/spack_repo/builtin/packages/c_raft/package.py
+++ b/repos/spack_repo/builtin/packages/c_raft/package.py
@@ -28,8 +28,11 @@ class CRaft(AutotoolsPackage):
     version("0.18.2", sha256="cc3e12877150cb9cdfa82486a9bfe39e4050dba8a6e8a55aa27c86b7d21237b9")
     version("0.18.1", sha256="f863f395c0fefe9aa8491f1d1dd87686fa53f7fe2c2fd223e9a03b3141a08597")
     version("0.17.7", sha256="7d0249953c2e2b112e9006cbefa32b8449def3b6ed79ca8e80ddb0937fca9c72")
-    version("0.17.1", sha256="e31c7fafbdd5f94913161c5d64341a203364e512524b47295c97a91e83c4198b",
-            url="https://github.com/canonical/raft/archive/refs/tags/v0.17.1.tar.gz")
+    version(
+        "0.17.1",
+        sha256="e31c7fafbdd5f94913161c5d64341a203364e512524b47295c97a91e83c4198b",
+        url="https://github.com/canonical/raft/archive/refs/tags/v0.17.1.tar.gz"
+    )
 
     variant("uv", default=True, description="Enable libuv support")
     variant("lz4", default=True, when="+uv", description="Enable lz4 support")

--- a/repos/spack_repo/builtin/packages/c_raft/package.py
+++ b/repos/spack_repo/builtin/packages/c_raft/package.py
@@ -12,13 +12,28 @@ class CRaft(AutotoolsPackage):
     """C implementation of the Raft consensus protocol."""
 
     homepage = "https://raft.readthedocs.io/en/latest/"
-    git = "https://github.com/canonical/raft.git"
-    url = "https://github.com/canonical/raft/archive/refs/tags/v0.17.1.tar.gz"
+    git = "https://github.com/cowsql/raft.git"
+    url = "https://github.com/cowsql/raft/archive/refs/tags/v0.17.1.tar.gz"
 
     maintainers("mdorier")
 
-    version("master", branch="master")
-    version("0.17.1", sha256="e31c7fafbdd5f94913161c5d64341a203364e512524b47295c97a91e83c4198b")
+    version("main", branch="main")
+    version("0.22.1", sha256="385f91a0b542ebe8b81c8f8500310dcd575fd028ea0cd2ede8807fa920dcf604")
+    version("0.22.0", sha256="1534146ea40ca0c29abd5369037bc14927f7acd001b61486739ba6b49a28bdff")
+    version("0.21.0", sha256="131385e50ed964eed5b5ebac2a8f2789493969b3de3ffb871c009ff2515fab0e")
+    version("0.20.0", sha256="adb110fd4f3982f26d1ff2644b25c623e6794aa159bf85c3ae4824e91ceb249a")
+    version("0.19.1", sha256="fb75ec93c4f8c161f73e08a4d0273f36817a20c91b89035abe793ca9b3dd6fba")
+    version("0.19.0", sha256="60d5af9a9ade3b290819b936754eeeacfc66769bc49c9f9dd7be89054e98907f")
+    version("0.18.3", sha256="8709bd4fda9e871bf54b929d32265ce54f304fce94527566d2c44f723753838b")
+    version("0.18.2", sha256="cc3e12877150cb9cdfa82486a9bfe39e4050dba8a6e8a55aa27c86b7d21237b9")
+    version("0.18.1", sha256="f863f395c0fefe9aa8491f1d1dd87686fa53f7fe2c2fd223e9a03b3141a08597")
+    version("0.17.7", sha256="7d0249953c2e2b112e9006cbefa32b8449def3b6ed79ca8e80ddb0937fca9c72")
+    version("0.17.1", sha256="e31c7fafbdd5f94913161c5d64341a203364e512524b47295c97a91e83c4198b",
+            url="https://github.com/canonical/raft/archive/refs/tags/v0.17.1.tar.gz")
+
+    variant("uv", default=True, description="Enable libuv support")
+    variant("lz4", default=True, when="+uv", description="Enable lz4 support")
+    variant("legacy", default=False, when="@0.22.2:", description="Enable legacy API")
 
     depends_on("c", type="build")  # generated
 
@@ -27,14 +42,18 @@ class CRaft(AutotoolsPackage):
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
 
-    variant("uv", default=True, description="Enable libuv support")
-
     depends_on("libuv@1.18.0:", when="+uv")
+    depends_on("lz4", when="+lz4")
 
     def autoreconf(self, spec, prefix):
         autoreconf("--install", "--verbose", "--force")
 
     def configure_args(self):
-        args = ["--disable-lz4"]
+        args = []
+        args += self.enable_or_disable("lz4")
         args += self.enable_or_disable("uv")
+        if "+legacy" in self.spec:
+            args += ["--enable-v0"]
+        else:
+            args += ["--disable-v0", "--disable-fixture"]
         return args


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This PR adds a bunch of versions to the c-raft package, as well as the "lz4" and "legacy" variant. It also changes the git url. The previous repository  (https://github.com/canonical/raft) has been archived and its README.md points users to the new repository (https://github.com/cowsql/raft) for newer versions.