### PR TITLE
slepc, py-slepc4py, petsc, py-petsc4py  add v3.25.0

### DIFF
--- a/repos/spack_repo/builtin/packages/mfem/package.py
+++ b/repos/spack_repo/builtin/packages/mfem/package.py
@@ -570,6 +570,11 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     patch("mfem-4.7.patch", when="@4.7.0")
     patch("mfem-4.7-sundials-7.patch", when="@4.7.0+sundials ^sundials@7:")
     patch("mfem-4.8-nvcc-c++17.patch", when="@4.8.0+cuda")
+    patch(
+        "https://patch-diff.githubusercontent.com/raw/mfem/mfem/pull/5215.diff?full_index=1",
+        when="@4.8.0:4.9.0 +petsc ^petsc@3.25.0:",
+        sha256="51221b44f83c36042b0b126569591f29a706aae139f0f0d14035c357411f25ae",
+    )
 
     # Backport fix for potential leak (redundant allocation) in
     # FiniteElement::GetDofToQuad. PR: https://github.com/mfem/mfem/pull/5155

--- a/repos/spack_repo/builtin/packages/petsc/package.py
+++ b/repos/spack_repo/builtin/packages/petsc/package.py
@@ -24,6 +24,8 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     tags = ["e4s"]
 
     version("main", branch="main")
+    version("3.25.0", sha256="dc1c018c16bd9dcf40596959875725edb4ba8b854a0b67bbce62a0d4be1bd3be")
+    version("3.24.6", sha256="d6ad14652996b0e0d3da51068eec902118057f275de867e8cf258ffd64d90a7d")
     version("3.24.5", sha256="b538efa53ebfa5c7a1c3ac9783a57852a74ce4fb436f0ee4802564503c67269f")
     version("3.24.4", sha256="772bb47638f8335e4a5982c48947af250e58061100a817c9e1e2fdc50de2ce95")
     version("3.24.3", sha256="dde6f6ef2c5ef8c473a831d56a2e3192b5304c50c4cc5ded7f296ef6d86aaf13")

--- a/repos/spack_repo/builtin/packages/py_petsc4py/package.py
+++ b/repos/spack_repo/builtin/packages/py_petsc4py/package.py
@@ -21,6 +21,8 @@ class PyPetsc4py(PythonPackage):
     license("BSD-2-Clause")
 
     version("main", branch="main")
+    version("3.25.0", sha256="8eafd133adbb22a6b7cd963f5eb03f86d959b832c7e5843704caba29b79c5659")
+    version("3.24.6", sha256="1b9594c9aabcd76eaf6092086d8b3f0f2e6c71e3c6088b41dde40fdaf776812a")
     version("3.24.5", sha256="fd2eabafb9b683b964ab0517cfe2d1c42077cfae408dbdaf1560691be73d833e")
     version("3.24.4", sha256="21280b81aa536ff46176374b8f8a71b4d9fe061b1e8f2eef78f498473ae80a3b")
     version("3.24.3", sha256="62ed68d87fb3485b0b2fb2e9158b88dc56e64cce6bdc511d7f4630741218e868")
@@ -116,7 +118,19 @@ class PyPetsc4py(PythonPackage):
     depends_on("petsc+mpi", when="+mpi")
     depends_on("petsc~mpi", when="~mpi")
     depends_on("petsc@main", when="@main")
-    for ver in ["3.24", "3.23", "3.22", "3.21", "3.20", "3.19", "3.18", "3.17", "3.16", "3.15"]:
+    for ver in [
+        "3.25",
+        "3.24",
+        "3.23",
+        "3.22",
+        "3.21",
+        "3.20",
+        "3.19",
+        "3.18",
+        "3.17",
+        "3.16",
+        "3.15",
+    ]:
         depends_on(f"petsc@{ver}", when=f"@{ver}")
     depends_on("petsc@3.14.2:3.14", when="@3.14.1:3.14")
     depends_on("petsc@3.14.0:3.14.1", when="@3.14.0")

--- a/repos/spack_repo/builtin/packages/py_slepc4py/package.py
+++ b/repos/spack_repo/builtin/packages/py_slepc4py/package.py
@@ -19,6 +19,7 @@ class PySlepc4py(PythonPackage):
     license("BSD-2-Clause")
 
     version("main", branch="main")
+    version("3.25.0", sha256="8b81061b94a9c9a7586ff2b8cc1dfe40d373981b0c7d2a28bdad154bbc6f832e")
     version("3.24.3", sha256="7b814fd5561838b1e0a4821d5e83e6aad061cd57b3ce50549598caa2e65b13c0")
     version("3.24.2", sha256="cbcff24004e35cdb17587c534d68329b6467574df93028d04596bfaf3baccbb7")
     version("3.24.1", sha256="ce798d38355127bee3416bab2975d5fb51df0c3e124b73ba13225ff6311d966e")
@@ -66,7 +67,19 @@ class PySlepc4py(PythonPackage):
 
     depends_on("py-petsc4py@main", when="@main", type=("build", "run"))
     depends_on("slepc@main", when="@main")
-    for ver in ["3.24", "3.23", "3.22", "3.21", "3.20", "3.19", "3.18", "3.17", "3.16", "3.15"]:
+    for ver in [
+        "3.25",
+        "3.24",
+        "3.23",
+        "3.22",
+        "3.21",
+        "3.20",
+        "3.19",
+        "3.18",
+        "3.17",
+        "3.16",
+        "3.15",
+    ]:
         depends_on(f"py-petsc4py@{ver}", when=f"@{ver}", type=("build", "run"))
         depends_on(f"slepc@{ver}", when=f"@{ver}")
 

--- a/repos/spack_repo/builtin/packages/slepc/package.py
+++ b/repos/spack_repo/builtin/packages/slepc/package.py
@@ -25,6 +25,7 @@ class Slepc(Package, CudaPackage, ROCmPackage):
     test_requires_compiler = True
 
     version("main", branch="main")
+    version("3.25.0", sha256="ba2d1cd42d637a7577cab63b0f9e910921fdd60db58290dd1041d60152655f78")
     version("3.24.3", sha256="3f13421f3fcd68fd720a143088506e0f91e24243844703997597eee793225452")
     version("3.24.2", sha256="6f1f7e45b9bbd15631562f193284832ae4e9655eb3af7f1ba59bdf8bdaefb638")
     version("3.24.1", sha256="b07e1c335eb620dfc50a2b8d4fb12db03c6929ae624f0338ff8acf879a072abf")
@@ -78,6 +79,7 @@ class Slepc(Package, CudaPackage, ROCmPackage):
     # Cannot mix release and development versions of SLEPc and PETSc:
     depends_on("petsc@main", when="@main")
     for ver in [
+        "3.25",
         "3.24",
         "3.23",
         "3.22",


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
