### PR TITLE
prrte: update patch location

### DIFF
--- a/repos/spack_repo/builtin/packages/prrte/package.py
+++ b/repos/spack_repo/builtin/packages/prrte/package.py
@@ -81,9 +81,10 @@ class Prrte(AutotoolsPackage):
     depends_on("slurm", when="schedulers=slurm")
 
     # fixes a segfault in v4.1.0 for some Apple ARM architectures
+    # https://github.com/openpmix/prrte/pull/2417
     patch(
-        "https://patch-diff.githubusercontent.com/raw/openpmix/prrte/pull/2417.patch?full_index=1",
-        sha256="971e9beffac4cf32c842248a0f030babfd87203e252bfda9f750a010c58105ab",
+        "https://github.com/openpmix/prrte/commit/378c61c1d8eff9858a7774c869fbd332c48711a8.patch?full_index=1",
+        sha256="64faa1acb89eddea096307a2658b11ccdaf85dc8c870fed4b3f8670329706a4f",
         when="@4.1.0",
     )
 


### PR DESCRIPTION
The patch added in https://github.com/spack/spack-packages/pull/3961 uses the  `patch-diff.githubusercontent.com` subdomain. This subdomain doesn't seem to be consistently reachable from all machines (my HPC can't reach it). I've updated it to be consistent with the `commit.patch` style used elsewhere in spack 