### PR TITLE
RPackage: include archive URL for old versions in urls attribute

### DIFF
--- a/repos/spack_repo/builtin/build_systems/r.py
+++ b/repos/spack_repo/builtin/build_systems/r.py
@@ -109,3 +109,6 @@ class RPackage(Package):
     url: ClassProperty[Optional[str]] = classproperty(_url)
     list_url: ClassProperty[Optional[str]] = classproperty(_list_url)
     git: ClassProperty[Optional[str]] = classproperty(_git)
+
+    def url_for_version(self, version):
+        return f"https://cran.r-project.org/src/contrib/Archive/{self.cran}/{self.cran}_{version}.tar.gz"

--- a/repos/spack_repo/builtin/build_systems/r.py
+++ b/repos/spack_repo/builtin/build_systems/r.py
@@ -113,3 +113,5 @@ class RPackage(Package):
     def url_for_version(self, version):
         if self.cran:
             return f"https://cran.r-project.org/src/contrib/Archive/{self.cran}/{self.cran}_{version}.tar.gz"
+
+        return super().url_for_version(version)

--- a/repos/spack_repo/builtin/build_systems/r.py
+++ b/repos/spack_repo/builtin/build_systems/r.py
@@ -111,4 +111,5 @@ class RPackage(Package):
     git: ClassProperty[Optional[str]] = classproperty(_git)
 
     def url_for_version(self, version):
-        return f"https://cran.r-project.org/src/contrib/Archive/{self.cran}/{self.cran}_{version}.tar.gz"
+        if self.cran:
+            return f"https://cran.r-project.org/src/contrib/Archive/{self.cran}/{self.cran}_{version}.tar.gz"

--- a/repos/spack_repo/builtin/build_systems/r.py
+++ b/repos/spack_repo/builtin/build_systems/r.py
@@ -1,7 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 from spack.package import ClassProperty, classproperty, depends_on, extends, mkdirp
 
@@ -59,15 +59,18 @@ def _homepage(cls: "RPackage") -> Optional[str]:
     return None
 
 
-def _url(cls: "RPackage") -> Optional[str]:
+def _urls(cls: "RPackage") -> List[str]:
     if cls.cran:
-        return f"https://cloud.r-project.org/src/contrib/{cls.cran}_{str(list(cls.versions)[0])}.tar.gz"
-    return None
+        return [
+            f"https://cran.r-project.org/src/contrib/{cls.cran}_{str(list(cls.versions)[0])}.tar.gz",
+            f"https://cran.r-project.org/src/contrib/Archive/{cls.cran}/{cls.cran}_{str(list(cls.versions)[0])}.tar.gz",
+        ]
+    return []
 
 
 def _list_url(cls: "RPackage") -> Optional[str]:
     if cls.cran:
-        return f"https://cloud.r-project.org/src/contrib/Archive/{cls.cran}/"
+        return f"https://cran.r-project.org/src/contrib/Archive/{cls.cran}/"
     return None
 
 
@@ -106,12 +109,6 @@ class RPackage(Package):
     depends_on("gmake", type="build", when="%fortran")
 
     homepage: ClassProperty[Optional[str]] = classproperty(_homepage)
-    url: ClassProperty[Optional[str]] = classproperty(_url)
+    urls: ClassProperty[List[str]] = classproperty(_urls)
     list_url: ClassProperty[Optional[str]] = classproperty(_list_url)
     git: ClassProperty[Optional[str]] = classproperty(_git)
-
-    def url_for_version(self, version):
-        if self.cran:
-            return f"https://cran.r-project.org/src/contrib/Archive/{self.cran}/{self.cran}_{version}.tar.gz"
-
-        return super().url_for_version(version)


### PR DESCRIPTION
This PR fixes a bug where we had previously been silently falling back to spidering urls for old versions of `r-*` packages since we weren't correctly modeling the archive URL. This PR swaps to setting the url**s** attribute on the class with both the archive url path and the latest version path.