### PR TITLE
fvtkhdf: add 0.6.0 and mpi_f08 variant

### DIFF
--- a/repos/spack_repo/builtin/packages/fvtkhdf/package.py
+++ b/repos/spack_repo/builtin/packages/fvtkhdf/package.py
@@ -13,7 +13,7 @@ class Fvtkhdf(CMakePackage):
     maintainers("nncarlson")
 
     homepage = "https://github.com/nncarlson/fvtkhdf"
-    url = "https://github.com/nncarlson/fvtkhdf/releases/download/v0.5.1/fvtkhdf-0.5.1.tar.gz"
+    url = "https://github.com/nncarlson/fvtkhdf/releases/download/v0.6.0/fvtkhdf-0.6.0.tar.gz"
     git = "https://github.com/nncarlson/fvtkhdf.git"
 
     license("BSD-2-Clause")
@@ -22,9 +22,11 @@ class Fvtkhdf(CMakePackage):
         "platform=windows", msg="This package is not supported on native Windows; use WSL instead."
     )
 
+    version("0.6.0", sha256="3b3eb63cd4cfd29fbadb39f8518a751e64f385ac7c8e4bf3da0407e62728db2e")
     version("0.5.1", sha256="e7bf499335a2f29a44b34b0c833fb19574a934702eaa6bc6b38e82fc443bf50a")
 
     variant("shared", default=True, description="Build shared libraries")
+    variant("mpi_f08", default=True, description="Expose mpi_f08 communicator overloads")
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")
@@ -37,6 +39,7 @@ class Fvtkhdf(CMakePackage):
     def cmake_args(self):
         return [
             self.define("ENABLE_MPI", True),
+            self.define_from_variant("USE_MPI_F08", "mpi_f08"),
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define("BUILD_HTML", False),
             self.define("BUILD_EXAMPLES", False),


### PR DESCRIPTION
## Summary

- add `fvtkhdf@0.6.0`
- update the default release URL to the `v0.6.0` GitHub release archive
- expose the upstream CMake option `USE_MPI_F08` as a Spack variant:
  - `+mpi_f08` (default): enable `mpi_f08` communicator overloads
  - `~mpi_f08`: disable `mpi_f08` overloads while keeping MPI enabled
 
## Testing

Tested package metadata and variant mapping locally with:
- `spack spec fvtkhdf`
- `spack spec fvtkhdf~mpi_f08`

The new `0.6.0` checksum matches the published release archive:
- `3b3eb63cd4cfd29fbadb39f8518a751e64f385ac7c8e4bf3da0407e62728db2e`
