### PR TITLE
openmpi: add restriction for libfabric when @:4.0

### DIFF
--- a/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -715,6 +715,7 @@ with '-Wl,-commons,use_dylibs' and without
         depends_on("ucx@1.9.0:", when="@4.1.1:4.1")
         depends_on("ucx@1.9.0:", when="@5.0.0:")
     depends_on("libfabric", when="fabrics=ofi")
+    depends_on("libfabric@1", when="@:4.0 fabrics=ofi")
     depends_on("fca", when="fabrics=fca")
     depends_on("hcoll", when="fabrics=hcoll")
     depends_on("ucc", when="fabrics=ucc")


### PR DESCRIPTION
Was running into compilation issues with openmpi@3 and libfabric with libfabric versions later than 1.x. Tested a couple other versions and it seems that got resolved in 4.1 and later.