### PR TITLE
mumps: fix compilation with oneAPI

### DIFF
--- a/repos/spack_repo/builtin/packages/mumps/package.py
+++ b/repos/spack_repo/builtin/packages/mumps/package.py
@@ -260,6 +260,13 @@ class Mumps(Package):
         if "+blr_mt" in self.spec:
             optf.append("-DBLR_MT")
 
+        # Intel and oneAPI Fortran compilers link for_main.o which provides
+        # its own main(). This conflicts with the C examples' main(), causing
+        # "multiple definition of `main'" errors. The -nofor-main flag
+        # prevents this.
+        if using_intel or using_oneapi:
+            optl.append("-nofor-main")
+
         makefile_conf.extend(
             [
                 "OPTC = {0}".format(" ".join(optc)),

--- a/repos/spack_repo/builtin/packages/mumps/package.py
+++ b/repos/spack_repo/builtin/packages/mumps/package.py
@@ -180,9 +180,9 @@ class Mumps(Package):
         # Determine which compiler suite we are using
         using_gcc = self.compiler.name == "gcc"
         using_nvhpc = self.compiler.name == "nvhpc"
-        using_intel = self.compiler.name == "intel"
-        using_oneapi = self.compiler.name == "oneapi"
-        using_xl = self.compiler.name in ["xl", "xl_r"]
+        using_intel = self.compiler.name in ("intel", "intel-oneapi-compilers-classic")
+        using_oneapi = self.compiler.name in ("oneapi", "intel-oneapi-compilers")
+        using_xl = self.compiler.name in ("xl", "xl_r")
         using_fj = self.compiler.name == "fj"
 
         # The llvm compiler suite does not contain a Fortran compiler by


### PR DESCRIPTION
Fixes compilation errors with intel-oneapi-compilers
```c
652  c_example_save_restore.c:(.text+0x0): multiple definition of
`main';
.../intel-oneapi-compilers-2025.3.2-.../compiler/2025.3/lib/for_main.o:for_main.c:(.text+0x0):
first defined here
653  ld: c_example.o: in function `main':
654  c_example.c:(.text+0x0): multiple definition of `main';
.../intel-oneapi-compilers-2025.3.2-.../compiler/2025.3/lib/for_main.o:for_main.c:(.text+0x0):
first defined here
655  mpif90 -o dsimpletest -O2 -fPIC dsimpletest.o -L../lib -ldmumps
-lsmumps -lmumps_common -L../PORD/lib/ -lpord -lpthread
656  mpif90 -o dsimpletest_save_restore -O2 -fPIC
dsimpletest_save_restore.o -L../lib -ldmumps -lsmumps -lmumps_common
-L../PORD/lib/ -lpord -lpthread
657  ld:
.../intel-oneapi-compilers-2025.3.2-.../compiler/2025.3/lib/for_main.o:
in function `main':
658  for_main.c:(.text+0x19): undefined reference to `MAIN__'
659  ld:
.../intel-oneapi-compilers-2025.3.2-.../compiler/2025.3/lib/for_main.o: in function `main':
660  for_main.c:(.text+0x19): undefined reference to `MAIN__'
661  make[1]: *** [Makefile:44: c_example] Error 1
662  make[1]: *** Waiting for unfinished jobs....
663  make[1]: *** [Makefile:63: c_example_save_restore] Error 1
664  make[1]: Leaving directory '.../spack-stage-mumps-5.8.2-.../spack-src/examples'
665  make: *** [Makefile:24: d] Error 2
666  Traceback (most recent call last):
667  File ".../spack/new_installer.py", line 524, in worker_function
668    _install(
669  File ".../spack/new_installer.py", line 754, in _install
670 phase.execute()
671  File ".../spack/builder.py", line 382, in execute
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
