### PR TITLE
Add crtm@3.1.3 and deprecate crtm@2.3.0/crtm-fix@2.3.0

### DIFF
--- a/repos/spack_repo/builtin/packages/crtm/package.py
+++ b/repos/spack_repo/builtin/packages/crtm/package.py
@@ -31,6 +31,7 @@ class Crtm(CMakePackage):
 
     license("CC0-1.0")
 
+    version("3.1.3", sha256="4f72bb281d266063c902caa6613e508d6d80367c10ee4881dd67e08c146c9c33")
     version("3.1.2", sha256="a96598e5611c263fa80d6d6375a12d70d74389b261a8070515a6698e41563281")
     version(
         "3.1.1-build1", sha256="1ed49e594da5d3769cbaa52cc7fc19c1bb0325ee6324f6057227c31e2d95ca67"
@@ -66,16 +67,18 @@ class Crtm(CMakePackage):
     # REL-2.4.0_emc (v2.4.0 ecbuild does not work)
     version("2.4.0", commit="5ddd0d6b0138284764065feda73b5adf599082a2")
     # Uses the tip of REL-2.3.0_emc branch
-    version("2.3.0", commit="99760e693ce3b90a3b3b0e97d80972b4dfb61196")
+    version("2.3.0", commit="99760e693ce3b90a3b3b0e97d80972b4dfb61196", deprecated=True)
 
     variant(
         "fix", default=False, description='Download CRTM coefficient or "fix" files (several GBs).'
     )
 
+    depends_on("c", type="build")
     depends_on("fortran", type="build")
 
     depends_on("cmake@3.15:", type="build")
-    depends_on("git-lfs")
+    depends_on("cmake@3.20:", when="@3.1.3:", type="build")
+    depends_on("git-lfs", when="@:3.1.2")
     depends_on("netcdf-fortran", when="@2.4.0:")
     depends_on("netcdf-fortran", when="@v2.3")
     depends_on("netcdf-fortran", when="@v2.4")
@@ -86,6 +89,8 @@ class Crtm(CMakePackage):
     depends_on("crtm-fix@2.4.0.1_emc", when="@2.4.0.1 +fix")
     depends_on("crtm-fix@3.1.1", when="@3.1.1 +fix")
     depends_on("crtm-fix@3.1.2", when="@3.1.2 +fix")
+    # Note. crtm@3.1.3 uses crtm-fix@3.1.2
+    depends_on("crtm-fix@3.1.2", when="@3.1.3 +fix")
 
     depends_on("ecbuild", type=("build"), when="@v2.3")
     depends_on("ecbuild", type=("build"), when="@v2.4")

--- a/repos/spack_repo/builtin/packages/crtm_fix/package.py
+++ b/repos/spack_repo/builtin/packages/crtm_fix/package.py
@@ -26,7 +26,11 @@ class CrtmFix(Package):
         "2.4.0.1_emc", sha256="6e4005b780435c8e280d6bfa23808d8f12609dfd72f77717d046d4795cac0457"
     )
     version("2.4.0_emc", sha256="d0f1b2ae2905457f4c3731746892aaa8f6b84ee0691f6228dfbe48917df1e85e")
-    version("2.3.0_emc", sha256="1452af2d1d11d57ef3c57b6b861646541e7042a9b0f3c230f9a82854d7e90924", deprecated=True)
+    version(
+        "2.3.0_emc",
+        sha256="1452af2d1d11d57ef3c57b6b861646541e7042a9b0f3c230f9a82854d7e90924",
+        deprecated=True,
+    )
 
     variant("big_endian", default=True, description="Install big_endian fix files")
     variant("little_endian", default=False, description="Install little endian fix files")

--- a/repos/spack_repo/builtin/packages/crtm_fix/package.py
+++ b/repos/spack_repo/builtin/packages/crtm_fix/package.py
@@ -26,7 +26,7 @@ class CrtmFix(Package):
         "2.4.0.1_emc", sha256="6e4005b780435c8e280d6bfa23808d8f12609dfd72f77717d046d4795cac0457"
     )
     version("2.4.0_emc", sha256="d0f1b2ae2905457f4c3731746892aaa8f6b84ee0691f6228dfbe48917df1e85e")
-    version("2.3.0_emc", sha256="1452af2d1d11d57ef3c57b6b861646541e7042a9b0f3c230f9a82854d7e90924")
+    version("2.3.0_emc", sha256="1452af2d1d11d57ef3c57b6b861646541e7042a9b0f3c230f9a82854d7e90924", deprecated=True)
 
     variant("big_endian", default=True, description="Install big_endian fix files")
     variant("little_endian", default=False, description="Install little endian fix files")


### PR DESCRIPTION
## Description

Add crtm@3.1.3 and deprecate crtm@2.3.0/crtm-fix@2.3.0.

Notes.

1. This PR replaces https://github.com/spack/spack-packages/pull/3828 for now. Towards the end of 2026, a follow-up pull request will entirely remove version 2.3.0 and the logic to move the coefficients (crtm-fix) from the original directory structure to a flat directory. This update will allow us to run the tests (`ctests`) for crtm during the spack installation.
2. The missing dependency on the `c` compiler was identified during the installation of 2.4.0-3.1.3 on all the tier-1 platforms of the spack-stack project (NOAA RDHPCS, DOD HPCMP, MSU Hercules/Orion, NASA Discover/NAS, ...).

