### PR TITLE
amdblis: fix zen4

### DIFF
--- a/repos/spack_repo/builtin/packages/amdblis/package.py
+++ b/repos/spack_repo/builtin/packages/amdblis/package.py
@@ -34,6 +34,9 @@ class Amdblis(BlisBase):
 
     requires("target=x86_64:", msg="AMD blis available only on x86_64")
 
+    # AMD's BLIS fork has zen4/zen5 configs not available in upstream flame/blis
+    _targets = {"zen5": None, "zen4": None, **BlisBase._targets}
+
     license("BSD-3-Clause")
 
     version("5.2", sha256="c553bd543eedc87920df9b82634ae4c02662145ed737f51fdf4c9bca5e588028")

--- a/repos/spack_repo/builtin/packages/blis/package.py
+++ b/repos/spack_repo/builtin/packages/blis/package.py
@@ -11,23 +11,24 @@ from spack.package import *
 # https://github.com/flame/blis/issues/195
 # https://github.com/flame/blis/issues/197
 
-# Mapping from Spack target names to BLIS config targets, ordered
-# from most specific to most generic. The first match wins.
-# When the Spack name matches the BLIS config name, the value is None.
-_targets = {
-    "zen3": None,
-    "zen2": None,
-    "zen": None,
-    "skylake_avx512": "skx",
-    "haswell": None,
-    "x86_64": None,
-}
-
 
 class BlisBase(MakefilePackage):
     """Base class for building BLIS, shared with the AMD optimized version
     of the library in the 'amdblis' package.
     """
+
+    # Mapping from Spack target names to BLIS config targets, ordered from most
+    # specific to most generic. The first match wins. When the Spack name matches
+    # the BLIS config name, the value is None. Subclasses can override this to
+    # add targets (e.g. amdblis adds zen4/zen5).
+    _targets = {
+        "zen3": None,
+        "zen2": None,
+        "zen": None,
+        "skylake_avx512": "skx",
+        "haswell": None,
+        "x86_64": None,
+    }
 
     maintainers("jeffhammond")
 
@@ -96,7 +97,7 @@ class BlisBase(MakefilePackage):
 
     def edit(self, spec, prefix):
         target = "auto"
-        for spack_target, blis_target in _targets.items():
+        for spack_target, blis_target in self._targets.items():
             if self.spec.satisfies(f"target={spack_target}:"):
                 target = blis_target or spack_target
                 break


### PR DESCRIPTION
I was getting errors like:
```
libflame.so: undefined reference to `bli_dgemv_n_zen4_int_40x2_st'
```
on a zen4 target.

Adding the `zen4` target to the package.py fixed the error.

I also added zen5, assuming it is the same, but I have not tested that.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
