### PR TITLE
Package rename: py-pip -> pip

### DIFF
--- a/.ci/gitlab/configs/win64/x86_64/ci.yaml
+++ b/.ci/gitlab/configs/win64/x86_64/ci.yaml
@@ -21,7 +21,7 @@ ci:
       - py-flit-core
       - py-meson-python
       - py-packaging
-      - py-pip
+      - pip
       - py-pyproject-metadata
       - py-setuptools
       - py-soupsieve

--- a/repos/spack_repo/builtin/build_systems/python.py
+++ b/repos/spack_repo/builtin/build_systems/python.py
@@ -242,7 +242,7 @@ class PythonPackage(PythonExtension):
 
     with when("build_system=python_pip"):
         extends("python")
-        depends_on("py-pip", type="build")
+        depends_on("pip", type="build")
         # FIXME: technically wheel is only needed when building from source, not when
         # installing a downloaded wheel, but I don't want to add wheel as a dep to every
         # package manually
@@ -353,7 +353,7 @@ class PythonPipBuilder(BuilderWithDefaults):
         """Extra global options to be supplied to the setup.py call before the install
         or bdist_wheel command.
 
-        Deprecated in pip 23.1.
+        Requires pip 25.2 or older.
 
         Args:
             spec: Build spec.
@@ -373,7 +373,7 @@ class PythonPipBuilder(BuilderWithDefaults):
         config_settings = self.config_settings(spec, prefix)
 
         # Pass -jN for compile-args if supported and needed
-        if spec.satisfies("%py-pip@22.1: %py-meson-python@0.11:"):
+        if spec.satisfies("%pip@22.1: %py-meson-python@0.11:"):
             # get_effective_jobs returns None when a jobserver is active, then we don't pass -j.
             jobs = get_effective_jobs(
                 jobs=determine_number_of_jobs(parallel=pkg.parallel), supports_jobserver=True

--- a/repos/spack_repo/builtin/packages/aocl_da/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_da/package.py
@@ -86,7 +86,7 @@ class AoclDa(CMakePackage):
         depends_on("py-setuptools", type=("build", "run"))
         depends_on("py-pybind11", type=("build", "link", "run"))
         depends_on("py-numpy", type=("build", "run"))
-        depends_on("py-pip", type=("build", "run"))
+        depends_on("pip", type=("build", "run"))
         depends_on("patchelf", type="build")
         depends_on("py-pytest", type="test")
         depends_on("py-scikit-learn", type=("test", "run"))

--- a/repos/spack_repo/builtin/packages/ascent/package.py
+++ b/repos/spack_repo/builtin/packages/ascent/package.py
@@ -211,7 +211,7 @@ class Ascent(CMakePackage, CudaPackage, ROCmPackage):
 
         extends("python")
         depends_on("py-numpy", type=("build", "link", "run"))
-        depends_on("py-pip", type="build")
+        depends_on("pip", type="build")
         depends_on("py-wheel", when="@0.9.4:", type="build")
         depends_on("py-setuptools", type="build")
 

--- a/repos/spack_repo/builtin/packages/bohrium/package.py
+++ b/repos/spack_repo/builtin/packages/bohrium/package.py
@@ -94,7 +94,7 @@ class Bohrium(CMakePackage, CudaPackage):
     depends_on("swig", type="build", when="+python")
     depends_on("py-cython", type="build", when="+python")
     depends_on("py-virtualenv", type="build", when="+python")
-    depends_on("py-pip", type="build", when="+python")
+    depends_on("pip", type="build", when="+python")
     depends_on("py-wheel", type="build", when="+python")
 
     depends_on("zlib-api", when="+proxy")

--- a/repos/spack_repo/builtin/packages/bufr/package.py
+++ b/repos/spack_repo/builtin/packages/bufr/package.py
@@ -55,7 +55,7 @@ class Bufr(CMakePackage):
     depends_on("python@:3.11", type=("build", "run"), when="@:12.0 +python")
     depends_on("py-setuptools", type="build", when="+python")
     depends_on("py-numpy", type=("build", "run"), when="+python")
-    depends_on("py-pip", type="build", when="+python")
+    depends_on("pip", type="build", when="+python")
     depends_on("py-wheel", type="build", when="+python")
 
     conflicts("%oneapi@:2024.1", msg="Requires oneapi 2024.2 or later")

--- a/repos/spack_repo/builtin/packages/cantera/package.py
+++ b/repos/spack_repo/builtin/packages/cantera/package.py
@@ -194,7 +194,7 @@ class Cantera(SConsPackage):
     depends_on("py-numpy", when="+python", type=("build", "run"))
     depends_on("py-scipy", when="+python", type=("build", "run"))
     depends_on("py-3to2", when="+python", type=("build", "run"))
-    depends_on("py-pip", when="+python", type=("build", "run"))
+    depends_on("pip", when="+python", type=("build", "run"))
     depends_on("py-matplotlib", when="+python", type=("build", "run"))
     depends_on("py-ruamel-yaml@0.17.16:", when="+python", type=("build", "run"))
 

--- a/repos/spack_repo/builtin/packages/castep/package.py
+++ b/repos/spack_repo/builtin/packages/castep/package.py
@@ -69,7 +69,7 @@ class Castep(CMakePackage, MakefilePackage):
     depends_on("gcc@9:", when="@25:", type="build")
     depends_on("gcc@4.9:", when="@21.11:", type="build")
     extends("python@:3.11", type=("build", "run"))
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-scipy", type=("build", "run"))
     depends_on("py-matplotlib", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/charliecloud/package.py
+++ b/repos/spack_repo/builtin/packages/charliecloud/package.py
@@ -60,7 +60,7 @@ class Charliecloud(AutotoolsPackage):
     depends_on("bats@1.10.0:")
 
     # Require pip and wheel for git checkout builds (master).
-    depends_on("py-pip@21.1.2:", type="build", when="@master")
+    depends_on("pip@21.1.2:", type="build", when="@master")
     depends_on("py-wheel", type="build", when="@master")
 
     # See https://github.com/spack/spack/pull/16049.

--- a/repos/spack_repo/builtin/packages/cmor/package.py
+++ b/repos/spack_repo/builtin/packages/cmor/package.py
@@ -46,7 +46,7 @@ class Cmor(AutotoolsPackage):
     depends_on("udunits")
 
     extends("python", when="+python")
-    depends_on("py-pip", when="+python", type="build")
+    depends_on("pip", when="+python", type="build")
     depends_on("py-wheel", when="+python", type="build")
     depends_on("py-numpy", type=("build", "run"), when="+python")
 

--- a/repos/spack_repo/builtin/packages/conduit/package.py
+++ b/repos/spack_repo/builtin/packages/conduit/package.py
@@ -146,7 +146,7 @@ class Conduit(CMakePackage):
     extends("python", when="+python")
     depends_on("py-numpy", when="+python", type=("build", "run"))
     depends_on("py-mpi4py", when="+python+mpi", type=("build", "run"))
-    depends_on("py-pip", when="+python", type="build")
+    depends_on("pip", when="+python", type="build")
     depends_on("py-wheel", when="+python", type="build")
     depends_on("py-setuptools", when="+python", type="build")
 

--- a/repos/spack_repo/builtin/packages/costo/package.py
+++ b/repos/spack_repo/builtin/packages/costo/package.py
@@ -36,7 +36,7 @@ class Costo(CMakePackage):
     depends_on("py-scipy", type=("build", "run"))
     depends_on("py-mgmetis", type=("build", "run"))
     depends_on("py-colorama", type=("build", "run"))
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
 
     def cmake_args(self):
         args = [

--- a/repos/spack_repo/builtin/packages/dsqss/package.py
+++ b/repos/spack_repo/builtin/packages/dsqss/package.py
@@ -33,7 +33,7 @@ class Dsqss(CMakePackage):
     depends_on("py-toml", type=("build", "run"))
 
     depends_on("py-setuptools", type="build")
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
     depends_on("py-wheel", type="build")
 
     patch("spackpip.patch")

--- a/repos/spack_repo/builtin/packages/duckdb/package.py
+++ b/repos/spack_repo/builtin/packages/duckdb/package.py
@@ -71,7 +71,7 @@ class Duckdb(CMakePackage):
 
     with when("+python"):
         extends("python")
-        depends_on("py-pip", type="build")
+        depends_on("pip", type="build")
         depends_on("py-setuptools-scm", type="build")
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:

--- a/repos/spack_repo/builtin/packages/ecflow/package.py
+++ b/repos/spack_repo/builtin/packages/ecflow/package.py
@@ -47,7 +47,7 @@ class Ecflow(CMakePackage):
     depends_on("python@3:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy", type="build")
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
 
     # v4: Boost-1.7X release not working well on serialization
     depends_on("boost@1.53:1.69+python", when="@:4")

--- a/repos/spack_repo/builtin/packages/esmf/package.py
+++ b/repos/spack_repo/builtin/packages/esmf/package.py
@@ -110,7 +110,7 @@ class Esmf(MakefilePackage, PythonExtension):
     # python library
     with when("+python"):
         extends("python")
-        depends_on("py-pip")
+        depends_on("pip")
         depends_on("py-setuptools", type="build")
         depends_on("py-wheel", type="build")
         depends_on("py-mpi4py", when="+mpi")

--- a/repos/spack_repo/builtin/packages/exactextract/package.py
+++ b/repos/spack_repo/builtin/packages/exactextract/package.py
@@ -39,7 +39,7 @@ class Exactextract(CMakePackage, PythonExtension):
 
     with when("+python"):
         extends("python", type=("build", "link", "run"))
-        depends_on("py-pip")
+        depends_on("pip")
         depends_on("py-scikit-build-core", type="build")
         depends_on("py-pybind11")
 

--- a/repos/spack_repo/builtin/packages/faiss/package.py
+++ b/repos/spack_repo/builtin/packages/faiss/package.py
@@ -54,7 +54,7 @@ class Faiss(AutotoolsPackage, CMakePackage, CudaPackage):
 
     extends("python", when="+python")
     depends_on("python@3.7:", when="+python", type=("build", "run"))
-    depends_on("py-pip", when="+python", type="build")
+    depends_on("pip", when="+python", type="build")
     depends_on("py-wheel", when="+python", type="build")
     depends_on("py-setuptools", when="+python", type="build")
     depends_on("py-numpy", when="+python", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/fenics/package.py
+++ b/repos/spack_repo/builtin/packages/fenics/package.py
@@ -141,7 +141,7 @@ class Fenics(CMakePackage):
     depends_on("py-pybind11@2.2.4", type=("build", "run"))
     depends_on("cmake@3.17.3:", type="build")
 
-    depends_on("py-pip", when="+python", type="build")
+    depends_on("pip", when="+python", type="build")
     depends_on("py-wheel", when="+python", type="build")
     depends_on("py-setuptools", type="build", when="+python")
     depends_on("py-pkgconfig", type=("build", "run"), when="+python")

--- a/repos/spack_repo/builtin/packages/flatbuffers/package.py
+++ b/repos/spack_repo/builtin/packages/flatbuffers/package.py
@@ -34,7 +34,7 @@ class Flatbuffers(CMakePackage):
 
     extends("python", when="+python")
     depends_on("python@3.6:", when="+python", type=("build", "run"))
-    depends_on("py-pip", when="+python", type="build")
+    depends_on("pip", when="+python", type="build")
     depends_on("py-wheel", when="+python", type="build")
     depends_on("py-setuptools", when="+python", type="build")
 

--- a/repos/spack_repo/builtin/packages/ghex/package.py
+++ b/repos/spack_repo/builtin/packages/ghex/package.py
@@ -64,7 +64,7 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
     with when("+python"):
         extends("python")
         depends_on("python@3.7:", type=("build", "run"))
-        depends_on("py-pip", type="build")
+        depends_on("pip", type="build")
         depends_on("py-pybind11", type="build")
         depends_on("py-mpi4py", type=("build", "run"))
         depends_on("py-numpy", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/hipsparselt/package.py
+++ b/repos/spack_repo/builtin/packages/hipsparselt/package.py
@@ -153,7 +153,7 @@ class Hipsparselt(CMakePackage, ROCmPackage):
     depends_on("python@3.6:")
     depends_on("py-virtualenv")
     depends_on("py-wheel")
-    depends_on("py-pip")
+    depends_on("pip")
     depends_on("py-pyyaml", type="test")
     depends_on("py-joblib")
     depends_on("googletest@1.10.0:", type="test")

--- a/repos/spack_repo/builtin/packages/jsonnet/package.py
+++ b/repos/spack_repo/builtin/packages/jsonnet/package.py
@@ -43,7 +43,7 @@ class Jsonnet(MakefilePackage, CMakePackage):
 
     extends("python", when="+python")
     depends_on("py-setuptools", type=("build",), when="+python")
-    depends_on("py-pip", type=("build",), when="+python")
+    depends_on("pip", type=("build",), when="+python")
     depends_on("py-wheel", type=("build",), when="+python")
 
 

--- a/repos/spack_repo/builtin/packages/lammps/package.py
+++ b/repos/spack_repo/builtin/packages/lammps/package.py
@@ -406,7 +406,7 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage, PythonExtension):
     depends_on("py-cython", when="+mliap+python", type="build")
     depends_on("py-cython", when="+ml-iap+python", type="build")
     depends_on("py-mdi", when="+mdi", type=("build", "run"))
-    depends_on("py-pip", when="+python", type="build")
+    depends_on("pip", when="+python", type="build")
     depends_on("py-wheel", when="+python", type="build")
     depends_on("py-build", when="+python", type="build")
     depends_on("py-numpy", when="+python", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/legion/package.py
+++ b/repos/spack_repo/builtin/packages/legion/package.py
@@ -140,7 +140,7 @@ class Legion(CMakePackage, ROCmPackage):
     depends_on("python@3.8:", when="+python")
     depends_on("py-cffi", when="+python")
     depends_on("py-numpy", when="+python")
-    depends_on("py-pip", when="+python", type="build")
+    depends_on("pip", when="+python", type="build")
     depends_on("py-setuptools", when="+python", type="build")
 
     depends_on("papi", when="+papi")

--- a/repos/spack_repo/builtin/packages/mdb/package.py
+++ b/repos/spack_repo/builtin/packages/mdb/package.py
@@ -21,7 +21,7 @@ class Mdb(PythonPackage):
     version("1.0.3", sha256="c45cffb320a51274519753b950b7b72cd91a8a5804941556120ed41bb8b491d8")
 
     depends_on("python@3.10: +tkinter", type=("build", "run"))
-    depends_on("py-pip", type=("build", "run"))
+    depends_on("pip", type=("build", "run"))
     depends_on("py-setuptools", type="build")
 
     depends_on("py-click@8.1.7", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/mlpack/package.py
+++ b/repos/spack_repo/builtin/packages/mlpack/package.py
@@ -65,7 +65,7 @@ class Mlpack(CMakePackage):
         depends_on("py-numpy@:1", when="@:4.4.0")
         depends_on("py-pandas@0.15.0:")
         # ref: src/mlpack/bindings/python/PythonInstall.cmake
-        depends_on("py-pip")
+        depends_on("pip")
         depends_on("py-wheel")
         # ref: src/mlpack/bindings/python/setup.py.in
         depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/mozjs/package.py
+++ b/repos/spack_repo/builtin/packages/mozjs/package.py
@@ -32,7 +32,7 @@ class Mozjs(AutotoolsPackage):
     depends_on("curl", type="build")
     depends_on("llvm", type="build")
     depends_on("python@:3.13", type="build")
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
     depends_on("rust", type="build")
     depends_on("cbindgen@0.27:", type="build", when="@140:")
     depends_on("cbindgen", type="build")

--- a/repos/spack_repo/builtin/packages/mxnet/package.py
+++ b/repos/spack_repo/builtin/packages/mxnet/package.py
@@ -57,7 +57,7 @@ class Mxnet(CMakePackage, CudaPackage, PythonExtension):
 
     # python/setup.py
     extends("python", when="+python")
-    depends_on("py-pip", when="+python", type="build")
+    depends_on("pip", when="+python", type="build")
     depends_on("py-wheel", when="+python", type="build")
     depends_on("py-setuptools", when="+python", type="build")
     depends_on("py-cython", when="+python", type="build")

--- a/repos/spack_repo/builtin/packages/neuron/package.py
+++ b/repos/spack_repo/builtin/packages/neuron/package.py
@@ -87,7 +87,7 @@ class Neuron(CMakePackage):
     depends_on("py-pytest-cov", when="+tests")
 
     # next two needed after neuronsimulator/nrn#2235.
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
     depends_on("py-setuptools", type="build")
     depends_on("py-packaging", type="run")
 

--- a/repos/spack_repo/builtin/packages/nvtx/package.py
+++ b/repos/spack_repo/builtin/packages/nvtx/package.py
@@ -29,7 +29,7 @@ class Nvtx(Package, PythonExtension):
 
     variant("python", default=True, description="Install Python bindings.")
     extends("python", when="+python")
-    depends_on("py-pip", type="build", when="+python")
+    depends_on("pip", type="build", when="+python")
     depends_on("py-setuptools", type="build", when="+python")
     depends_on("py-wheel", type="build", when="+python")
     depends_on("py-cython", type="build", when="+python")

--- a/repos/spack_repo/builtin/packages/omniperf/package.py
+++ b/repos/spack_repo/builtin/packages/omniperf/package.py
@@ -26,7 +26,7 @@ class Omniperf(CMakePackage):
     version("6.2.0", sha256="febe9011e0628ad62367fdc6c81bdb0ad4ed45803f79c794757ecea8bcfab58c")
 
     depends_on("python@3.8:")
-    depends_on("py-pip", type="run")
+    depends_on("pip", type="run")
     depends_on("py-astunparse@1.6.2", type=("build", "run"))  # wants exact version
     depends_on("py-colorlover", type=("build", "run"))
     depends_on("py-pyyaml")

--- a/repos/spack_repo/builtin/packages/open3d/package.py
+++ b/repos/spack_repo/builtin/packages/open3d/package.py
@@ -53,7 +53,7 @@ class Open3d(CMakePackage, CudaPackage):
 
     extends("python", when="+python", type=("build", "link", "run"))
     depends_on("python@3.6:", when="+python", type=("build", "link", "run"))
-    depends_on("py-pip", when="+python", type="build")
+    depends_on("pip", when="+python", type="build")
     depends_on("py-setuptools@40.8:", when="+python", type="build")
     depends_on("py-wheel@0.36:", when="+python", type="build")
     depends_on("py-numpy@1.18:", when="+python", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/pip/package.py
+++ b/repos/spack_repo/builtin/packages/pip/package.py
@@ -10,11 +10,8 @@ from spack_repo.builtin.build_systems.python import PythonExtension, PythonPipBu
 from spack.package import *
 
 
-class PyPip(Package, PythonExtension):
-    """The PyPA recommended tool for installing Python packages.
-
-    Deprecated in favor of pip package.
-    """
+class Pip(Package, PythonExtension):
+    """The PyPA recommended tool for installing Python packages."""
 
     homepage = "https://pip.pypa.io/"
     url = "https://files.pythonhosted.org/packages/py3/p/pip/pip-20.2-py3-none-any.whl"
@@ -29,31 +26,30 @@ class PyPip(Package, PythonExtension):
 
     license("MIT")
 
-    with default_args(deprecated=True):
-        version("26.0.1", sha256="bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b")
-        version("25.1.1", sha256="2913a38a2abf4ea6b64ab507bd9e967f3b53dc1ede74b01b0931e1ce548751af")
-        version("25.1", sha256="13b4aa0aaad055020a11bec8a1c2a70a2b2d080e12d89b962266029fff0a16ba")
-        version("25.0.1", sha256="c46efd13b6aa8279f33f2864459c8ce587ea6a1a59ee20de055868d8f7688f7f")
-        version("25.0", sha256="b6eb97a803356a52b2dd4bb73ba9e65b2ba16caa6bcb25a7497350a4e5859b65")
-        version("24.3.1", sha256="3790624780082365f47549d032f3770eeb2b1e8bd1f7b2e02dace1afa361b4ed")
-        version("24.2", sha256="2cd581cf58ab7fcfca4ce8efa6dcacd0de5bf8d0a3eb9ec927e07405f4d9e2a2")
-        version("24.1.2", sha256="7cd207eed4c60b0f411b444cd1464198fe186671c323b6cd6d433ed80fc9d247")
-        version("24.0", sha256="ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc")
-        version("23.3.2", sha256="5052d7889c1f9d05224cd41741acb7c5d6fa735ab34e339624a614eaaa7e7d76")
-        version("23.2.1", sha256="7ccf472345f20d35bdc9d1841ff5f313260c2c33fe417f48c30ac46cccabf5be")
-        version("23.1.2", sha256="3ef6ac33239e4027d9a5598a381b9d30880a1477e50039db2eac6e8a8f6d1b18")
-        version("23.0", sha256="b5f88adff801f5ef052bcdef3daa31b55eb67b0fccd6d0106c206fa248e0463c")
-        version("22.2.2", sha256="b61a374b5bc40a6e982426aede40c9b5a08ff20e640f5b56977f4f91fed1e39a")
-        version("22.1.2", sha256="a3edacb89022ef5258bf61852728bf866632a394da837ca49eb4303635835f17")
-        version("21.3.1", sha256="deaf32dcd9ab821e359cd8330786bcd077604b5c5730c0b096eda46f95c24a2d")
-        version("21.1.2", sha256="f8ea1baa693b61c8ad1c1d8715e59ab2b93cd3c4769bacab84afcc4279e7a70e")
-        version("20.2", sha256="d75f1fc98262dabf74656245c509213a5d0f52137e40e8f8ed5cc256ddd02923")
-        version("19.3", sha256="e100a7eccf085f0720b4478d3bb838e1c179b1e128ec01c0403f84e86e0e2dfb")
-        version("19.1.1", sha256="993134f0475471b91452ca029d4390dc8f298ac63a712814f101cd1b6db46676")
-        version("19.0.3", sha256="bd812612bbd8ba84159d9ddc0266b7fbce712fc9bc98c82dee5750546ec8ec64")
-        version("18.1", sha256="7909d0a0932e88ea53a7014dfd14522ffef91a464daaaf5c573343852ef98550")
-        version("10.0.1", sha256="717cdffb2833be8409433a93746744b59505f42146e8d37de6c62b430e25d6d7")
-        version("9.0.1", sha256="690b762c0a8460c303c089d5d0be034fb15a5ea2b75bdf565f40421f542fefb0")
+    version("26.0.1", sha256="bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b")
+    version("25.1.1", sha256="2913a38a2abf4ea6b64ab507bd9e967f3b53dc1ede74b01b0931e1ce548751af")
+    version("25.1", sha256="13b4aa0aaad055020a11bec8a1c2a70a2b2d080e12d89b962266029fff0a16ba")
+    version("25.0.1", sha256="c46efd13b6aa8279f33f2864459c8ce587ea6a1a59ee20de055868d8f7688f7f")
+    version("25.0", sha256="b6eb97a803356a52b2dd4bb73ba9e65b2ba16caa6bcb25a7497350a4e5859b65")
+    version("24.3.1", sha256="3790624780082365f47549d032f3770eeb2b1e8bd1f7b2e02dace1afa361b4ed")
+    version("24.2", sha256="2cd581cf58ab7fcfca4ce8efa6dcacd0de5bf8d0a3eb9ec927e07405f4d9e2a2")
+    version("24.1.2", sha256="7cd207eed4c60b0f411b444cd1464198fe186671c323b6cd6d433ed80fc9d247")
+    version("24.0", sha256="ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc")
+    version("23.3.2", sha256="5052d7889c1f9d05224cd41741acb7c5d6fa735ab34e339624a614eaaa7e7d76")
+    version("23.2.1", sha256="7ccf472345f20d35bdc9d1841ff5f313260c2c33fe417f48c30ac46cccabf5be")
+    version("23.1.2", sha256="3ef6ac33239e4027d9a5598a381b9d30880a1477e50039db2eac6e8a8f6d1b18")
+    version("23.0", sha256="b5f88adff801f5ef052bcdef3daa31b55eb67b0fccd6d0106c206fa248e0463c")
+    version("22.2.2", sha256="b61a374b5bc40a6e982426aede40c9b5a08ff20e640f5b56977f4f91fed1e39a")
+    version("22.1.2", sha256="a3edacb89022ef5258bf61852728bf866632a394da837ca49eb4303635835f17")
+    version("21.3.1", sha256="deaf32dcd9ab821e359cd8330786bcd077604b5c5730c0b096eda46f95c24a2d")
+    version("21.1.2", sha256="f8ea1baa693b61c8ad1c1d8715e59ab2b93cd3c4769bacab84afcc4279e7a70e")
+    version("20.2", sha256="d75f1fc98262dabf74656245c509213a5d0f52137e40e8f8ed5cc256ddd02923")
+    version("19.3", sha256="e100a7eccf085f0720b4478d3bb838e1c179b1e128ec01c0403f84e86e0e2dfb")
+    version("19.1.1", sha256="993134f0475471b91452ca029d4390dc8f298ac63a712814f101cd1b6db46676")
+    version("19.0.3", sha256="bd812612bbd8ba84159d9ddc0266b7fbce712fc9bc98c82dee5750546ec8ec64")
+    version("18.1", sha256="7909d0a0932e88ea53a7014dfd14522ffef91a464daaaf5c573343852ef98550")
+    version("10.0.1", sha256="717cdffb2833be8409433a93746744b59505f42146e8d37de6c62b430e25d6d7")
+    version("9.0.1", sha256="690b762c0a8460c303c089d5d0be034fb15a5ea2b75bdf565f40421f542fefb0")
 
     extends("python")
 

--- a/repos/spack_repo/builtin/packages/py_abipy/package.py
+++ b/repos/spack_repo/builtin/packages/py_abipy/package.py
@@ -22,7 +22,7 @@ class PyAbipy(PythonPackage):
 
     depends_on("py-setuptools", type="build")
     # in newer pip versions --install-option does not exist
-    depends_on("py-pip@:23.0", when="+ipython", type="build")
+    depends_on("pip@:23.0", when="+ipython", type="build")
 
     depends_on("py-monty", when="@0.7:", type=("build", "run"))
     depends_on("py-tabulate", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_amrex/package.py
+++ b/repos/spack_repo/builtin/packages/py_amrex/package.py
@@ -66,7 +66,7 @@ class PyAmrex(CMakePackage, PythonExtension, CudaPackage, ROCmPackage):
     depends_on("py-mpi4py@2.1.0:", type=("build", "run"), when="+mpi")
     depends_on("py-numpy@1.15:", type=("build", "run"))
     depends_on("py-packaging@23:", type="build")
-    depends_on("py-pip@23:", type="build")
+    depends_on("pip@23:", type="build")
     depends_on("py-setuptools@42:", type="build")
     depends_on("py-pybind11@2.12.0:", type=("build", "link"))
     depends_on("py-pybind11@3.0.1:", type=("build", "link"), when="@25.08:")

--- a/repos/spack_repo/builtin/packages/py_ansi2html/package.py
+++ b/repos/spack_repo/builtin/packages/py_ansi2html/package.py
@@ -20,4 +20,4 @@ class PyAnsi2html(PythonPackage):
     version("1.6.0", sha256="0f124ea7efcf3f24f1f9398e527e688c9ae6eab26b0b84e1299ef7f94d92c596")
 
     depends_on("py-setuptools", type="build")
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")

--- a/repos/spack_repo/builtin/packages/py_arcgis/package.py
+++ b/repos/spack_repo/builtin/packages/py_arcgis/package.py
@@ -33,10 +33,10 @@ class PyArcgis(PythonPackage):
     depends_on("py-requests-toolbelt", type=("build", "run"))
     depends_on("py-requests-ntlm", type=("build", "run"))
 
-    @when("^py-pip@23.1:")
+    @when("^pip@23.1:")
     def config_settings(self, spec, prefix):
         return {"--global-option": "--conda-install-mode"}
 
-    @when("^py-pip@:23.0")
+    @when("^pip@:23.0")
     def global_options(self, spec, prefix):
         return ["--conda-install-mode"]

--- a/repos/spack_repo/builtin/packages/py_astropy/package.py
+++ b/repos/spack_repo/builtin/packages/py_astropy/package.py
@@ -54,7 +54,7 @@ class PyAstropy(PythonPackage):
     depends_on("pkgconfig", type="build")
 
     # in newer pip versions --install-option does not exist
-    depends_on("py-pip@:23.0", when="@:4.0", type="build")
+    depends_on("pip@:23.0", when="@:4.0", type="build")
 
     depends_on("py-astropy-iers-data@0.2025.9.29.0.35.48:", when="@7.1.1:", type=("build", "run"))
     depends_on("py-astropy-iers-data@0.2025.1.31.12.41.4:", when="@7.0.1:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_brian2/package.py
+++ b/repos/spack_repo/builtin/packages/py_brian2/package.py
@@ -29,7 +29,7 @@ class PyBrian2(PythonPackage):
     depends_on("python@3.6:", type=("build", "run"), when="@2.4:")
     depends_on("python@3.7:", type=("build", "run"), when="@2.5:")
     # in newer pip versions --install-option does not exist
-    depends_on("py-pip@:23.0", type="build")
+    depends_on("pip@:23.0", type="build")
 
     depends_on("py-numpy@1.10:", type=("build", "run"))
     depends_on("py-numpy@1.15:", type=("build", "run"), when="@2.4:")

--- a/repos/spack_repo/builtin/packages/py_chalice/package.py
+++ b/repos/spack_repo/builtin/packages/py_chalice/package.py
@@ -32,7 +32,7 @@ class PyChalice(PythonPackage):
     depends_on("py-botocore@1.12.86:2.0.0", type=("build", "run"))
     depends_on("py-mypy-extensions@0.4.3", type=("build", "run"))
     depends_on("py-six@1.10.0:2.0.0", type=("build", "run"))
-    depends_on("py-pip@9:20.0", type=("build", "run"))
+    depends_on("pip@9:20.0", type=("build", "run"))
     depends_on("py-attrs@19.3.0:20.0.0", type=("build", "run"))
     depends_on("py-jmespath@0.9.3:1.0.0", type=("build", "run"))
     depends_on("py-pyyaml@5.3.1:6.0.0", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_charm4py/package.py
+++ b/repos/spack_repo/builtin/packages/py_charm4py/package.py
@@ -36,7 +36,7 @@ class PyCharm4py(PythonPackage):
     depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     # in newer pip versions --install-option does not exist
-    depends_on("py-pip@:23.0", type="build")
+    depends_on("pip@:23.0", type="build")
     depends_on("py-cython@:2", type="build")
     depends_on("py-cffi@1.7:", type="build")
     depends_on("py-numpy@1.10.0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_cig_pythia/package.py
+++ b/repos/spack_repo/builtin/packages/py_cig_pythia/package.py
@@ -34,7 +34,7 @@ class PyCigPythia(AutotoolsPackage, PythonExtension):
 
     depends_on("mpi", when="+mpi")
     depends_on("python@3.8:")
-    depends_on("py-pip")
+    depends_on("pip")
     depends_on("py-setuptools")
 
     def configure_args(self):

--- a/repos/spack_repo/builtin/packages/py_devito/package.py
+++ b/repos/spack_repo/builtin/packages/py_devito/package.py
@@ -26,7 +26,7 @@ class PyDevito(PythonPackage):
     variant("mpi", default=False, description="Enable MPI support")
     variant("optional", default=False, description="Enable matplolib & pandas support")
 
-    depends_on("py-pip@9.0.1:", type="build")
+    depends_on("pip@9.0.1:", type="build")
     depends_on("py-setuptools", type="build")
 
     depends_on("py-numpy@1.17:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_dgl/package.py
+++ b/repos/spack_repo/builtin/packages/py_dgl/package.py
@@ -58,7 +58,7 @@ class PyDgl(CMakePackage, PythonExtension, CudaPackage):
     # See python/setup.py
     extends("python")
     depends_on("python@3.5:", type=("build", "run"))
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
     depends_on("py-wheel", type="build")
     depends_on("py-setuptools", type="build")
     depends_on("py-cython", type="build")

--- a/repos/spack_repo/builtin/packages/py_fastai/package.py
+++ b/repos/spack_repo/builtin/packages/py_fastai/package.py
@@ -25,7 +25,7 @@ class PyFastai(PythonPackage):
 
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools@36.2:", type="build")
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
     depends_on("py-packaging", type="build")
     depends_on("py-fastdownload@0.0.5:1", type=("build", "run"))
     depends_on("py-fastcore@1.3.22:1.3", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_fastcore/package.py
+++ b/repos/spack_repo/builtin/packages/py_fastcore/package.py
@@ -28,5 +28,5 @@ class PyFastcore(PythonPackage):
 
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
     depends_on("py-packaging", type="build")

--- a/repos/spack_repo/builtin/packages/py_fastrlock/package.py
+++ b/repos/spack_repo/builtin/packages/py_fastrlock/package.py
@@ -26,11 +26,11 @@ class PyFastrlock(PythonPackage):
     depends_on("py-cython@3.0.11:3.0", when="@0.8.3", type="build")
     depends_on("py-cython@3.0.0:3.0", when="@0.8.1", type="build")
     # in newer pip versions --install-option does not exist
-    depends_on("py-pip", type="build")
-    depends_on("py-pip@:23.0", when="@:0.8.1", type="build")
+    depends_on("pip", type="build")
+    depends_on("pip@:23.0", when="@:0.8.1", type="build")
 
     def install_options(self, spec, prefix):
-        if self.spec.satisfies("^py-pip@:23.0"):
+        if self.spec.satisfies("^pip@:23.0"):
             return ["--with-cython"]
         else:
             return []
@@ -38,7 +38,7 @@ class PyFastrlock(PythonPackage):
     def config_settings(self, spec, prefix):
         # pip deprecated --install-option, suggests using --global-option instead
         # in https://github.com/pypa/pip/issues/11859#issuecomment-1741867145
-        if self.spec.satisfies("^py-pip@23.1:"):
+        if self.spec.satisfies("^pip@23.1:"):
             return {"--global-option": "--with-cython"}
         else:
             return {}

--- a/repos/spack_repo/builtin/packages/py_flit/package.py
+++ b/repos/spack_repo/builtin/packages/py_flit/package.py
@@ -41,7 +41,7 @@ class PyFlit(PythonPackage):
         depends_on("py-flit-core@3.3.0:3", when="@3.3.0:3.3")
 
     with default_args(type=("run")):
-        depends_on("py-pip", when="@3.10:")
+        depends_on("pip", when="@3.10:")
 
         depends_on("py-requests")
 

--- a/repos/spack_repo/builtin/packages/py_grayskull/package.py
+++ b/repos/spack_repo/builtin/packages/py_grayskull/package.py
@@ -25,7 +25,7 @@ class PyGrayskull(PythonPackage):
     depends_on("py-colorama", type=("build", "run"))
     depends_on("py-conda-souschef@2.2.3:", type=("build", "run"))
     depends_on("py-packaging@21.3:", type=("build", "run"))
-    depends_on("py-pip", type=("build", "run"))
+    depends_on("pip", type=("build", "run"))
     depends_on("py-pkginfo", type=("build", "run"))
     depends_on("py-progressbar2@3.53:", type=("build", "run"))
     depends_on("py-rapidfuzz@3:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_hail/package.py
+++ b/repos/spack_repo/builtin/packages/py_hail/package.py
@@ -58,7 +58,7 @@ class PyHail(MakefilePackage):
     )
 
     depends_on("python@3.9:", type=("build", "run"))
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
     depends_on("py-wheel", type="build")
     depends_on("py-build@1.1+virtualenv", type="build", when="@0.2.131:")
     depends_on("c", type="build", when="+native")
@@ -199,7 +199,7 @@ class PyHail(MakefilePackage):
         # Hail likes variables passed in to Make
         variables = [
             f"HAIL_PYTHON3={spec['python'].home.bin.python3}",
-            f"PIP={spec['py-pip'].home.bin.pip}",
+            f"PIP={spec['pip'].home.bin.pip}",
             f"SCALA_VERSION={spec['scala'].version}",
             f"SPARK_VERSION={spec['spark'].version}",
         ]

--- a/repos/spack_repo/builtin/packages/py_illumina_utils/package.py
+++ b/repos/spack_repo/builtin/packages/py_illumina_utils/package.py
@@ -25,7 +25,7 @@ class PyIlluminaUtils(PythonPackage):
     version("2.2", sha256="6039c72d077c101710fe4fdbfeaa30caa1c3c2c84ffa6295456927d82def8e6d")
 
     depends_on("python@3:", type=("build", "run"))
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
     depends_on("py-setuptools", type="build")
     depends_on("py-matplotlib", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_imageio_ffmpeg/package.py
+++ b/repos/spack_repo/builtin/packages/py_imageio_ffmpeg/package.py
@@ -25,7 +25,7 @@ class PyImageioFfmpeg(PythonPackage):
     version("0.4.3", sha256="f826260a3207b872f1a4ba87ec0c8e02c00afba4fd03348a59049bdd8215841e")
 
     depends_on("python@3.4:", type=("build", "run"))
-    depends_on("py-pip@19:", type="build")
+    depends_on("pip@19:", type="build")
     # Needs setuptools at runtime so that `import pkg_resources` succeeds
     depends_on("py-setuptools", type=("build", "run"))
     depends_on("ffmpeg", type="run")

--- a/repos/spack_repo/builtin/packages/py_lightgbm/package.py
+++ b/repos/spack_repo/builtin/packages/py_lightgbm/package.py
@@ -24,7 +24,7 @@ class PyLightgbm(PythonPackage):
 
     depends_on("py-setuptools", type="build")
     # in newer pip versions --install-option does not exist
-    depends_on("py-pip@:23.0", when="+mpi", type="build")
+    depends_on("pip@:23.0", when="+mpi", type="build")
     depends_on("py-wheel", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"))
     # https://github.com/microsoft/LightGBM/issues/6454

--- a/repos/spack_repo/builtin/packages/py_meldmd/package.py
+++ b/repos/spack_repo/builtin/packages/py_meldmd/package.py
@@ -40,7 +40,7 @@ class PyMeldmd(CMakePackage, PythonExtension, CudaPackage):
     depends_on("py-parmed", type=("build", "run"))
     depends_on("py-tqdm", type=("build", "run"))
     depends_on("py-mpi4py", type=("build", "run"))
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
 
     # C++ / CUDA
     depends_on("eigen", type="link")

--- a/repos/spack_repo/builtin/packages/py_minkowskiengine/package.py
+++ b/repos/spack_repo/builtin/packages/py_minkowskiengine/package.py
@@ -24,7 +24,7 @@ class PyMinkowskiengine(PythonPackage, CudaPackage):
     depends_on("py-setuptools", type="build")
     depends_on("py-pybind11", type="link")
     # in newer pip versions --install-option does not exist
-    depends_on("py-pip@:23.0", type="build")
+    depends_on("pip@:23.0", type="build")
     # According to the documentation other BLAS should be possible too, but
     # they didn't work, see https://github.com/spack/spack/pull/38742
     depends_on("openblas")

--- a/repos/spack_repo/builtin/packages/py_napari_plugin_manager/package.py
+++ b/repos/spack_repo/builtin/packages/py_napari_plugin_manager/package.py
@@ -29,7 +29,7 @@ class PyNapariPluginManager(PythonPackage):
         depends_on("py-qtpy")
         depends_on("py-superqt")
         depends_on("py-packaging")
-        depends_on("py-pip")
+        depends_on("pip")
         # Other dependencies include napari - but that'd be circular
 
     patch("clean_pyproject_toml.patch")

--- a/repos/spack_repo/builtin/packages/py_networkit/package.py
+++ b/repos/spack_repo/builtin/packages/py_networkit/package.py
@@ -50,7 +50,7 @@ class PyNetworkit(PythonPackage):
     depends_on("py-setuptools", type="build")
     depends_on("python@3:", type=("build", "run"))
     # in newer pip versions --install-option does not exist
-    depends_on("py-pip@:23.0", type="build")
+    depends_on("pip@:23.0", type="build")
 
     def install_options(self, spec, prefix):
         # Enable ext. core-library + parallel build

--- a/repos/spack_repo/builtin/packages/py_numpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_numpy/package.py
@@ -103,7 +103,7 @@ class PyNumpy(PythonPackage):
 
     with default_args(type="build"):
         # Required to use --config-settings
-        depends_on("py-pip@23.1:", when="@1.26:")
+        depends_on("pip@23.1:", when="@1.26:")
 
         # Build dependencies (do not include upper bound unless known issues)
         depends_on("py-meson-python@0.18:", when="@2.4:")

--- a/repos/spack_repo/builtin/packages/py_onnxruntime/package.py
+++ b/repos/spack_repo/builtin/packages/py_onnxruntime/package.py
@@ -61,7 +61,7 @@ class PyOnnxruntime(CMakePackage, PythonExtension, ROCmPackage, CudaPackage):
 
     extends("python")
     depends_on("python", type=("build", "run"))
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
     depends_on("py-wheel", type="build")
     depends_on("py-setuptools", type="build")
     depends_on("py-pybind11", type="build")

--- a/repos/spack_repo/builtin/packages/py_opencv_python/package.py
+++ b/repos/spack_repo/builtin/packages/py_opencv_python/package.py
@@ -21,7 +21,7 @@ class PyOpencvPython(PythonPackage):
     depends_on("cxx", type="build")
 
     depends_on("py-packaging", type="build")
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
     depends_on("py-scikit-build@0.14:", type="build")
     # restrictions on setuptools not needed, builds fine with newer versions
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_openmim/package.py
+++ b/repos/spack_repo/builtin/packages/py_openmim/package.py
@@ -23,7 +23,7 @@ class PyOpenmim(PythonPackage):
     depends_on("py-model-index", type=("build", "run"))
     depends_on("py-opendatalab", type=("build", "run"))
     depends_on("py-pandas", type=("build", "run"))
-    depends_on("py-pip@19.3:", type=("build", "run"))
+    depends_on("pip@19.3:", type=("build", "run"))
     depends_on("py-requests", type=("build", "run"))
     depends_on("py-rich", type=("build", "run"))
     depends_on("py-tabulate", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_or_tools/package.py
+++ b/repos/spack_repo/builtin/packages/py_or_tools/package.py
@@ -24,7 +24,7 @@ class PyOrTools(CMakePackage):
     depends_on("cxx", type="build")  # generated
 
     depends_on("cmake@3.14:", type="build")
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
     depends_on("py-wheel", type="build")
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_pennylane/package.py
+++ b/repos/spack_repo/builtin/packages/py_pennylane/package.py
@@ -34,7 +34,7 @@ class PyPennylane(PythonPackage):
 
     depends_on("python@3.8:", type=("build", "run"), when="@:0.31.0")
     depends_on("python@3.9:", type=("build", "run"), when="@0.32.0:")
-    depends_on("py-pip", type=("build", "run"))  # Runtime req for pennylane.about()
+    depends_on("pip", type=("build", "run"))  # Runtime req for pennylane.about()
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools", type=("build", "run"), when="@0.33")
 

--- a/repos/spack_repo/builtin/packages/py_pennylane_lightning/package.py
+++ b/repos/spack_repo/builtin/packages/py_pennylane_lightning/package.py
@@ -68,7 +68,7 @@ class PyPennylaneLightning(CMakePackage, PythonExtension):
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-pybind11", type="link")
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
     depends_on("py-wheel", type="build")
     # depends_on("py-pennylane@0.28:", type=("build", "run"))  # circular dependency
 

--- a/repos/spack_repo/builtin/packages/py_pennylane_lightning_kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/py_pennylane_lightning_kokkos/package.py
@@ -86,7 +86,7 @@ class PyPennylaneLightningKokkos(CMakePackage, PythonExtension, CudaPackage, ROC
     depends_on("python@3.9:", type=("build", "run"), when="@0.32:")
     depends_on("py-setuptools", type="build")
     depends_on("py-pybind11", type="link")
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
     depends_on("py-wheel", type="build")
     depends_on("py-pennylane@0.28:0.30", type=("build", "run"), when="@:0.30")
     depends_on("py-pennylane@0.30:", type=("build", "run"), when="@0.31")

--- a/repos/spack_repo/builtin/packages/py_pillow/package.py
+++ b/repos/spack_repo/builtin/packages/py_pillow/package.py
@@ -58,7 +58,7 @@ class PyPillowBase(PythonPackage):
 
     # pyproject.toml
     with default_args(type="build"):
-        depends_on("py-pip@22.1:", when="@10:")
+        depends_on("pip@22.1:", when="@10:")
         depends_on("py-pybind11", when="@12:")
         depends_on("py-setuptools@77:", when="@11.2:")
         depends_on("py-setuptools@67.8:", when="@10:")

--- a/repos/spack_repo/builtin/packages/py_pip/package.py
+++ b/repos/spack_repo/builtin/packages/py_pip/package.py
@@ -30,29 +30,59 @@ class PyPip(Package, PythonExtension):
     license("MIT")
 
     with default_args(deprecated=True):
-        version("26.0.1", sha256="bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b")
-        version("25.1.1", sha256="2913a38a2abf4ea6b64ab507bd9e967f3b53dc1ede74b01b0931e1ce548751af")
+        version(
+            "26.0.1", sha256="bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b"
+        )
+        version(
+            "25.1.1", sha256="2913a38a2abf4ea6b64ab507bd9e967f3b53dc1ede74b01b0931e1ce548751af"
+        )
         version("25.1", sha256="13b4aa0aaad055020a11bec8a1c2a70a2b2d080e12d89b962266029fff0a16ba")
-        version("25.0.1", sha256="c46efd13b6aa8279f33f2864459c8ce587ea6a1a59ee20de055868d8f7688f7f")
+        version(
+            "25.0.1", sha256="c46efd13b6aa8279f33f2864459c8ce587ea6a1a59ee20de055868d8f7688f7f"
+        )
         version("25.0", sha256="b6eb97a803356a52b2dd4bb73ba9e65b2ba16caa6bcb25a7497350a4e5859b65")
-        version("24.3.1", sha256="3790624780082365f47549d032f3770eeb2b1e8bd1f7b2e02dace1afa361b4ed")
+        version(
+            "24.3.1", sha256="3790624780082365f47549d032f3770eeb2b1e8bd1f7b2e02dace1afa361b4ed"
+        )
         version("24.2", sha256="2cd581cf58ab7fcfca4ce8efa6dcacd0de5bf8d0a3eb9ec927e07405f4d9e2a2")
-        version("24.1.2", sha256="7cd207eed4c60b0f411b444cd1464198fe186671c323b6cd6d433ed80fc9d247")
+        version(
+            "24.1.2", sha256="7cd207eed4c60b0f411b444cd1464198fe186671c323b6cd6d433ed80fc9d247"
+        )
         version("24.0", sha256="ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc")
-        version("23.3.2", sha256="5052d7889c1f9d05224cd41741acb7c5d6fa735ab34e339624a614eaaa7e7d76")
-        version("23.2.1", sha256="7ccf472345f20d35bdc9d1841ff5f313260c2c33fe417f48c30ac46cccabf5be")
-        version("23.1.2", sha256="3ef6ac33239e4027d9a5598a381b9d30880a1477e50039db2eac6e8a8f6d1b18")
+        version(
+            "23.3.2", sha256="5052d7889c1f9d05224cd41741acb7c5d6fa735ab34e339624a614eaaa7e7d76"
+        )
+        version(
+            "23.2.1", sha256="7ccf472345f20d35bdc9d1841ff5f313260c2c33fe417f48c30ac46cccabf5be"
+        )
+        version(
+            "23.1.2", sha256="3ef6ac33239e4027d9a5598a381b9d30880a1477e50039db2eac6e8a8f6d1b18"
+        )
         version("23.0", sha256="b5f88adff801f5ef052bcdef3daa31b55eb67b0fccd6d0106c206fa248e0463c")
-        version("22.2.2", sha256="b61a374b5bc40a6e982426aede40c9b5a08ff20e640f5b56977f4f91fed1e39a")
-        version("22.1.2", sha256="a3edacb89022ef5258bf61852728bf866632a394da837ca49eb4303635835f17")
-        version("21.3.1", sha256="deaf32dcd9ab821e359cd8330786bcd077604b5c5730c0b096eda46f95c24a2d")
-        version("21.1.2", sha256="f8ea1baa693b61c8ad1c1d8715e59ab2b93cd3c4769bacab84afcc4279e7a70e")
+        version(
+            "22.2.2", sha256="b61a374b5bc40a6e982426aede40c9b5a08ff20e640f5b56977f4f91fed1e39a"
+        )
+        version(
+            "22.1.2", sha256="a3edacb89022ef5258bf61852728bf866632a394da837ca49eb4303635835f17"
+        )
+        version(
+            "21.3.1", sha256="deaf32dcd9ab821e359cd8330786bcd077604b5c5730c0b096eda46f95c24a2d"
+        )
+        version(
+            "21.1.2", sha256="f8ea1baa693b61c8ad1c1d8715e59ab2b93cd3c4769bacab84afcc4279e7a70e"
+        )
         version("20.2", sha256="d75f1fc98262dabf74656245c509213a5d0f52137e40e8f8ed5cc256ddd02923")
         version("19.3", sha256="e100a7eccf085f0720b4478d3bb838e1c179b1e128ec01c0403f84e86e0e2dfb")
-        version("19.1.1", sha256="993134f0475471b91452ca029d4390dc8f298ac63a712814f101cd1b6db46676")
-        version("19.0.3", sha256="bd812612bbd8ba84159d9ddc0266b7fbce712fc9bc98c82dee5750546ec8ec64")
+        version(
+            "19.1.1", sha256="993134f0475471b91452ca029d4390dc8f298ac63a712814f101cd1b6db46676"
+        )
+        version(
+            "19.0.3", sha256="bd812612bbd8ba84159d9ddc0266b7fbce712fc9bc98c82dee5750546ec8ec64"
+        )
         version("18.1", sha256="7909d0a0932e88ea53a7014dfd14522ffef91a464daaaf5c573343852ef98550")
-        version("10.0.1", sha256="717cdffb2833be8409433a93746744b59505f42146e8d37de6c62b430e25d6d7")
+        version(
+            "10.0.1", sha256="717cdffb2833be8409433a93746744b59505f42146e8d37de6c62b430e25d6d7"
+        )
         version("9.0.1", sha256="690b762c0a8460c303c089d5d0be034fb15a5ea2b75bdf565f40421f542fefb0")
 
     extends("python")

--- a/repos/spack_repo/builtin/packages/py_pyarrow/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyarrow/package.py
@@ -90,7 +90,7 @@ class PyPyarrow(PythonPackage):
 
     # Historical dependencies
     # In newer pip versions --install-option does not exist
-    depends_on("py-pip@:23.0", when="@:16", type="build")
+    depends_on("pip@:23.0", when="@:16", type="build")
 
     with default_args(type=("build", "run")):
         # pyproject.toml, setup.py

--- a/repos/spack_repo/builtin/packages/py_pybind11/package.py
+++ b/repos/spack_repo/builtin/packages/py_pybind11/package.py
@@ -74,7 +74,7 @@ class PyPybind11(CMakePackage, PythonExtension):
     depends_on("py-pytest", type="test")
     depends_on("py-build", type="test", when="@3:")
     depends_on("py-tomlkit", type="test", when="@3:")
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
     depends_on("py-wheel", type="build")
     extends("python")
 

--- a/repos/spack_repo/builtin/packages/py_pymol/package.py
+++ b/repos/spack_repo/builtin/packages/py_pymol/package.py
@@ -26,7 +26,7 @@ class PyPymol(PythonPackage):
     depends_on("python+tkinter@2.7:", type=("build", "link", "run"), when="@2.3.0:2.4.0")
     depends_on("python+tkinter@3.6:", type=("build", "link", "run"), when="@2.5.0:")
     # in newer pip versions --install-option does not exist
-    depends_on("py-pip@:23.0", type="build")
+    depends_on("pip@:23.0", type="build")
     depends_on("gl")
     depends_on("glew")
     depends_on("libpng")

--- a/repos/spack_repo/builtin/packages/py_pyomo/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyomo/package.py
@@ -141,13 +141,13 @@ class PyPyomo(PythonPackage):
     depends_on("py-pandas", when="@6.1:+optional", type=("run"))
     depends_on("py-seaborn", when="@6.1:+optional", type=("run"))
 
-    @when("^py-pip@23.1:")
+    @when("^pip@23.1:")
     def config_settings(self, spec, prefix):
         if "+cython" in self.spec:
             return {"--global-option": "--with-cython"}
         return {}
 
-    @when("^py-pip@:23.0")
+    @when("^pip@:23.0")
     def global_options(self, spec, prefix):
         options = []
         if "+cython" in self.spec:

--- a/repos/spack_repo/builtin/packages/py_pyprecice/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyprecice/package.py
@@ -68,7 +68,7 @@ class PyPyprecice(PythonPackage):
     depends_on("py-mpi4py", type=("build", "run"))
     depends_on("py-cython@0.29:", type="build")
     depends_on("py-packaging", type="build")
-    depends_on("py-pip@19.0.0:", type="build")
+    depends_on("pip@19.0.0:", type="build")
     depends_on("py-pkgconfig", type="build", when="@2.5:")
 
     @when("@:2.1")

--- a/repos/spack_repo/builtin/packages/py_pyside2/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyside2/package.py
@@ -53,7 +53,7 @@ class PyPyside2(PythonPackage):
     depends_on("py-packaging", type="build")
     depends_on("py-wheel", type="build")
     # in newer pip versions --install-option does not exist
-    depends_on("py-pip@:23.0", type="build")
+    depends_on("pip@:23.0", type="build")
     depends_on("qt@5.11:+opengl")
 
     depends_on("graphviz", when="+doc", type="build")

--- a/repos/spack_repo/builtin/packages/py_pyyaml/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyyaml/package.py
@@ -73,14 +73,14 @@ class PyPyyaml(PythonPackage):
 
         return modules
 
-    @when("^py-pip@23.1:")
+    @when("^pip@23.1:")
     def config_settings(self, spec, prefix):
         if "+libyaml" in self.spec:
             return {"--global-option": "--with-libyaml"}
         else:
             return {"--global-option": "--without-libyaml"}
 
-    @when("^py-pip@:23.0")
+    @when("^pip@:23.0")
     def global_options(self, spec, prefix):
         args = []
 

--- a/repos/spack_repo/builtin/packages/py_qiskit_aer/package.py
+++ b/repos/spack_repo/builtin/packages/py_qiskit_aer/package.py
@@ -27,7 +27,7 @@ class PyQiskitAer(PythonPackage, CudaPackage):
     depends_on("python@3.7:", type=("build", "run"), when="@0.11.1")
     depends_on("py-setuptools@40.1.0:", type="build")
     # in newer pip versions --install-option does not exist
-    depends_on("py-pip@:23.0", type="build")
+    depends_on("pip@:23.0", type="build")
     depends_on("py-numpy@1.16.3:", type=("build", "run"))
     depends_on("py-pybind11@2.6:", type="build")
     depends_on("py-qiskit-terra@0.17.0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_refgenie/package.py
+++ b/repos/spack_repo/builtin/packages/py_refgenie/package.py
@@ -22,7 +22,7 @@ class PyRefgenie(PythonPackage):
     depends_on("py-setuptools", type="build")
 
     depends_on("py-logmuse@0.2.6:", type=("build", "run"))
-    depends_on("piper@0.12.1:", type=("build", "run"))
+    depends_on("py-piper@0.12.1:", type=("build", "run"))
     depends_on("py-pyfaidx@0.5.5.2:", type=("build", "run"))
     depends_on("py-refgenconf@0.12.2:", type=("build", "run"))
     depends_on("py-yacman@0.8.3:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_refgenie/package.py
+++ b/repos/spack_repo/builtin/packages/py_refgenie/package.py
@@ -22,7 +22,7 @@ class PyRefgenie(PythonPackage):
     depends_on("py-setuptools", type="build")
 
     depends_on("py-logmuse@0.2.6:", type=("build", "run"))
-    depends_on("py-piper@0.12.1:", type=("build", "run"))
+    depends_on("piper@0.12.1:", type=("build", "run"))
     depends_on("py-pyfaidx@0.5.5.2:", type=("build", "run"))
     depends_on("py-refgenconf@0.12.2:", type=("build", "run"))
     depends_on("py-yacman@0.8.3:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_reportlab/package.py
+++ b/repos/spack_repo/builtin/packages/py_reportlab/package.py
@@ -26,7 +26,7 @@ class PyReportlab(PythonPackage):
     depends_on("python@3.7:3", type=("build", "run"), when="@3.6.9:4.4.3")
     # version restictions were taken over from release 3.4.0 setup.py
     depends_on("py-setuptools@2.2:", type="build")
-    depends_on("py-pip@1.4.1:", type="build")
+    depends_on("pip@1.4.1:", type="build")
 
     depends_on("pil@9:", type=("build", "run"), when="@3.6.10:")
     depends_on("pil@2.4.0:", type=("build", "run"), when="@3.4")

--- a/repos/spack_repo/builtin/packages/py_scipy/package.py
+++ b/repos/spack_repo/builtin/packages/py_scipy/package.py
@@ -122,7 +122,7 @@ class PyScipy(PythonPackage):
         depends_on("py-hypothesis@6.30:")
 
     # Required to use --config-settings
-    depends_on("py-pip@23.1:", when="@1.9:", type="build")
+    depends_on("pip@23.1:", when="@1.9:", type="build")
 
     # https://docs.scipy.org/doc/scipy/dev/toolchain.html#other-libraries
     depends_on("lapack@3.7.1:", when="@1.9:")

--- a/repos/spack_repo/builtin/packages/py_scs/package.py
+++ b/repos/spack_repo/builtin/packages/py_scs/package.py
@@ -39,7 +39,7 @@ class PyScs(PythonPackage, CudaPackage):
 
     # in newer pip versions --install-option does not exist
     # technically only the variants need this restriction
-    depends_on("py-pip@:23.0", type="build")
+    depends_on("pip@:23.0", type="build")
 
     def install_options(self, spec, prefix):
         args = []

--- a/repos/spack_repo/builtin/packages/py_setuptools/package.py
+++ b/repos/spack_repo/builtin/packages/py_setuptools/package.py
@@ -74,12 +74,12 @@ class PySetuptools(Package, PythonExtension):
         # https://github.com/pypa/setuptools/issues/3661
         depends_on("python@:3.11", when="@:67")
 
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
 
     conflicts(
-        "^python@:3.9 ^py-pip@25:",
+        "^python@:3.9 ^pip@25:",
         when="@:75.1.0",
-        msg="py-pip@25: vendors pyproject-hooks@1.2. "
+        msg="pip@25: vendors pyproject-hooks@1.2. "
         "The combination pyproject-hooks@1.2, python@:3.9, and py-setuptools@:75.1.0 is broken. "
         "See https://github.com/pypa/pyproject-hooks/issues/206 for details.",
     )

--- a/repos/spack_repo/builtin/packages/py_symengine/package.py
+++ b/repos/spack_repo/builtin/packages/py_symengine/package.py
@@ -38,7 +38,7 @@ class PySymengine(PythonPackage):
     depends_on("py-cython@0.19.1:", type="build", when="@0.2.0")
     depends_on("py-cython@0.29.24:", type="build", when="@0.8.1:")
     # in newer pip versions --install-option does not exist
-    depends_on("py-pip@:23.0", type="build")
+    depends_on("pip@:23.0", type="build")
     depends_on("cmake@2.8.12:", type="build")
     # see symengine_version.txt
     depends_on("symengine@0.2.0", when="@0.2.0")

--- a/repos/spack_repo/builtin/packages/py_tensorflow/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow/package.py
@@ -211,7 +211,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         depends_on("coreutils", when="@2.13: platform=darwin")
 
         depends_on("swig")
-        depends_on("py-pip")
+        depends_on("pip")
         depends_on("py-wheel")
 
     with default_args(type=("build", "run")):

--- a/repos/spack_repo/builtin/packages/py_tensorflow_estimator/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow_estimator/package.py
@@ -37,7 +37,7 @@ class PyTensorflowEstimator(Package):
 
     with default_args(type="build"):
         depends_on("bazel@0.19.0:")
-        depends_on("py-pip")
+        depends_on("pip")
         depends_on("py-wheel")
 
     # See expect_*_installed in tensorflow_estimator/python/estimator/BUILD

--- a/repos/spack_repo/builtin/packages/py_tensorflow_hub/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow_hub/package.py
@@ -28,7 +28,7 @@ class PyTensorflowHub(Package):
 
     # TODO: Directories have changed in Bazel 7, need to update manual install logic
     depends_on("bazel@:6", type="build")
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
     depends_on("py-wheel", type="build")
     depends_on("py-setuptools", type="build")
     depends_on("python@3.6:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_tensorflow_probability/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow_probability/package.py
@@ -38,7 +38,7 @@ class PyTensorflowProbability(Package):
     extends("python@3.9:", when="@0.22:")
     extends("python@3.8:", when="@0.20:0.21")
     extends("python@3.7:", when="@0.13:0.19")
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
     depends_on("py-wheel", type="build")
     depends_on("py-setuptools", type="build")
 

--- a/repos/spack_repo/builtin/packages/py_tern/package.py
+++ b/repos/spack_repo/builtin/packages/py_tern/package.py
@@ -22,4 +22,4 @@ class PyTern(PythonPackage):
 
     depends_on("py-setuptools", type="build")
     depends_on("py-wheel", type="build")
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")

--- a/repos/spack_repo/builtin/packages/py_tomopy/package.py
+++ b/repos/spack_repo/builtin/packages/py_tomopy/package.py
@@ -34,7 +34,7 @@ class PyTomopy(PythonPackage):
     depends_on("py-setuptools-scm", type=("build"))
     depends_on("py-setuptools-scm-git-archive", type=("build"))
     # in newer pip versions --install-option does not exist
-    depends_on("py-pip@:23.0", type="build")
+    depends_on("pip@:23.0", type="build")
     # Note: The module name of py-scikit-build is skbuild:
     depends_on("py-scikit-build", type=("build"))
     depends_on("py-scikit-image@0.17:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_torch_nvidia_apex/package.py
+++ b/repos/spack_repo/builtin/packages/py_torch_nvidia_apex/package.py
@@ -64,7 +64,7 @@ class PyTorchNvidiaApex(PythonPackage, CudaPackage):
     with default_args(type=("build")):
         depends_on("py-setuptools")
         depends_on("py-packaging")
-        depends_on("py-pip")
+        depends_on("pip")
     with default_args(type=("build", "link", "run")):
         depends_on("python@3:")
         depends_on("py-torch@0.4:")
@@ -113,7 +113,7 @@ class PyTorchNvidiaApex(PythonPackage, CudaPackage):
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         self.torch_cuda_arch_list(env)
 
-    @when("^py-pip@:23.0")
+    @when("^pip@:23.0")
     def global_options(self, spec, prefix):
         args = []
         if spec.satisfies("^py-torch@1.0:"):
@@ -152,7 +152,7 @@ class PyTorchNvidiaApex(PythonPackage, CudaPackage):
 
         return args
 
-    @when("^py-pip@23.1:")
+    @when("^pip@23.1:")
     def config_settings(self, spec, prefix):
         global_options = ""
         if spec.satisfies("^py-torch@1.0:"):

--- a/repos/spack_repo/builtin/packages/py_waves/package.py
+++ b/repos/spack_repo/builtin/packages/py_waves/package.py
@@ -39,7 +39,7 @@ class PyWaves(PythonPackage):
     depends_on("python@3.9:", type=("build", "run"))
 
     depends_on("git", when="@main", type="build")
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
     depends_on("py-build", type="build")
     depends_on("py-setuptools@64:", type="build")
     depends_on("py-setuptools-scm@8:", type="build")

--- a/repos/spack_repo/builtin/packages/py_wheel/package.py
+++ b/repos/spack_repo/builtin/packages/py_wheel/package.py
@@ -42,7 +42,7 @@ class PyWheel(Package, PythonExtension):
     depends_on("python +ctypes", type=("build", "run"))
     depends_on("python@3.8:", when="@0.43.0:", type=("build", "run"))
     depends_on("python@3.7:", when="@0.38:", type=("build", "run"))
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
 
     def url_for_version(self, version):
         url = "https://files.pythonhosted.org/packages/{0}/w/wheel/wheel-{1}-{0}-none-any.whl"

--- a/repos/spack_repo/builtin/packages/py_xgboost/package.py
+++ b/repos/spack_repo/builtin/packages/py_xgboost/package.py
@@ -42,12 +42,12 @@ class PyXgboost(PythonPackage):
     with default_args(type="build"):
         depends_on("py-hatchling@1.12.1:", type="build", when="@2:")
         # Required to use --config-settings
-        depends_on("py-pip@22.1:", when="@2:")
+        depends_on("pip@22.1:", when="@2:")
 
         # Historical dependencies
         depends_on("py-setuptools", when="@:1")
         # in newer pip versions --install-option does not exist
-        depends_on("py-pip@:23.0", when="@:1")
+        depends_on("pip@:23.0", when="@:1")
 
     with default_args(type=("build", "run")):
         depends_on("py-numpy", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/quandary/package.py
+++ b/repos/spack_repo/builtin/packages/quandary/package.py
@@ -59,7 +59,7 @@ class Quandary(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     with when("+test"):
         depends_on("python", type="run")
-        depends_on("py-pip", type="run")
+        depends_on("pip", type="run")
 
     build_targets = ["all"]
     install_targets = ["install"]

--- a/repos/spack_repo/builtin/packages/redis_ai/package.py
+++ b/repos/spack_repo/builtin/packages/redis_ai/package.py
@@ -36,7 +36,7 @@ class RedisAi(MakefilePackage):
     depends_on("git", type=("build", "link"))
     depends_on("git-lfs", type=("build", "link"))
     depends_on("python@3:", type=("build", "link"))
-    depends_on("py-pip", type=("build", "link"))
+    depends_on("pip", type=("build", "link"))
     depends_on("cmake@3.0:", type=("build", "link"))
     depends_on("gmake", type=("build", "link"))
 

--- a/repos/spack_repo/builtin/packages/rocblas/package.py
+++ b/repos/spack_repo/builtin/packages/rocblas/package.py
@@ -183,7 +183,7 @@ class Rocblas(CMakePackage):
         depends_on("py-pyyaml", type="build")
         depends_on("py-wheel", type="build")
         depends_on("py-msgpack", type="build")
-        depends_on("py-pip", type="build")
+        depends_on("pip", type="build")
         depends_on("py-joblib", type="build")
         depends_on("procps", type="build")
 

--- a/repos/spack_repo/builtin/packages/rocprofiler_compute/package.py
+++ b/repos/spack_repo/builtin/packages/rocprofiler_compute/package.py
@@ -37,7 +37,7 @@ class RocprofilerCompute(CMakePackage):
     version("6.3.2", sha256="317f19acfa6e6780923e6c8144c3c223b523c382588df528b6df001fae38d13d")
 
     depends_on("python@3.8:")
-    depends_on("py-pip", type="run")
+    depends_on("pip", type="run")
     depends_on("py-astunparse@1.6.2", type=("build", "run"))  # wants exact version
     depends_on("py-colorlover", type=("build", "run"))
     depends_on("py-pyyaml")

--- a/repos/spack_repo/builtin/packages/scine_database/package.py
+++ b/repos/spack_repo/builtin/packages/scine_database/package.py
@@ -36,7 +36,7 @@ class ScineDatabase(CMakePackage):
     depends_on("googletest", type="build")
     depends_on("mongo-cxx-driver@3.2.1:")
     depends_on("python@3.6:", when="+python", type=("build", "run"))
-    depends_on("py-pip", when="+python", type="build")
+    depends_on("pip", when="+python", type="build")
     depends_on("py-pybind11", when="+python", type="build")
     depends_on("scine-utilities@5:")
     depends_on("scine-utilities+python", when="+python")

--- a/repos/spack_repo/builtin/packages/scine_molassembler/package.py
+++ b/repos/spack_repo/builtin/packages/scine_molassembler/package.py
@@ -67,7 +67,7 @@ class ScineMolassembler(CMakePackage):
     depends_on("nauty")
     depends_on("nlohmann-json", type="build")
     depends_on("python@3.6:", when="+python", type=("build", "run"))
-    depends_on("py-pip", when="+python", type="build")
+    depends_on("pip", when="+python", type="build")
     depends_on("py-pybind11@2.6.2:", when="+python", type="build")
     # depends_on("ringdecomposerlib")
     depends_on("scine-core")

--- a/repos/spack_repo/builtin/packages/scine_readuct/package.py
+++ b/repos/spack_repo/builtin/packages/scine_readuct/package.py
@@ -37,7 +37,7 @@ class ScineReaduct(CMakePackage):
     depends_on("eigen@3:")
     depends_on("googletest")
     depends_on("python@3.6:", when="+python", type=("build", "run"))
-    depends_on("py-pip", when="+python", type="build")
+    depends_on("pip", when="+python", type="build")
     depends_on("py-pybind11@2.6.2:", when="+python", type=("build", "run"))
     depends_on("scine-core")
     depends_on("scine-utilities")

--- a/repos/spack_repo/builtin/packages/scine_serenity/package.py
+++ b/repos/spack_repo/builtin/packages/scine_serenity/package.py
@@ -34,7 +34,7 @@ class ScineSerenity(CMakePackage):
 
     depends_on("boost+system+filesystem+program_options cxxstd=17 @1.65.0:")
     depends_on("python@3.6:", when="+python", type=("build", "run"))
-    depends_on("py-pip", when="+python", type="build")
+    depends_on("pip", when="+python", type="build")
     depends_on("scine-core")
     depends_on("scine-utilities")
     depends_on("scine-utilities+python", when="+python", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/scine_sparrow/package.py
+++ b/repos/spack_repo/builtin/packages/scine_sparrow/package.py
@@ -53,7 +53,7 @@ class ScineSparrow(CMakePackage):
     depends_on("eigen@3.3.2:")
     depends_on("googletest", type="build")
     depends_on("python@3.6:", when="+python", type=("build", "run"))
-    depends_on("py-pip", when="+python", type="build")
+    depends_on("pip", when="+python", type="build")
     depends_on("scine-core")
     depends_on("scine-utilities")
     depends_on("scine-utilities+python", when="+python", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/scine_utilities/package.py
+++ b/repos/spack_repo/builtin/packages/scine_utilities/package.py
@@ -39,7 +39,7 @@ class ScineUtilities(CMakePackage):
     depends_on("lbfgspp", type="build")
     depends_on("python@3.6:", when="+python", type=("build", "run"))
     depends_on("py-numpy", when="+python", type=("build", "run"))
-    depends_on("py-pip", when="+python", type="build")
+    depends_on("pip", when="+python", type="build")
     depends_on("py-pybind11@2.6.2:", when="+python", type="build")
     depends_on("py-scipy", when="+python", type=("build", "run"))
     depends_on("scine-core")

--- a/repos/spack_repo/builtin/packages/scine_xtb/package.py
+++ b/repos/spack_repo/builtin/packages/scine_xtb/package.py
@@ -42,7 +42,7 @@ class ScineXtb(CMakePackage):
     depends_on("eigen@3:")
     depends_on("pkgconfig", type="build")
     depends_on("python@3.6:", when="+python", type=("build", "run"))
-    depends_on("py-pip", when="+python", type="build")
+    depends_on("pip", when="+python", type="build")
     depends_on("scine-core")
     depends_on("scine-utilities")
     depends_on("scine-utilities+python", when="+python", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/serenity/package.py
+++ b/repos/spack_repo/builtin/packages/serenity/package.py
@@ -46,7 +46,7 @@ class Serenity(CMakePackage):
     depends_on("libxc@5.0.0", when="@1.4.0")
     depends_on("pkgconfig", type="build")
     depends_on("python@3.6:", when="+python", type=("build", "run"))
-    depends_on("py-pip", when="+python", type="build")
+    depends_on("pip", when="+python", type="build")
     depends_on("py-pybind11", when="+python", type="build")
     depends_on("serenity-libint")
     depends_on("xcfun")

--- a/repos/spack_repo/builtin/packages/sgpp/package.py
+++ b/repos/spack_repo/builtin/packages/sgpp/package.py
@@ -105,7 +105,7 @@ class Sgpp(SConsPackage):
     depends_on("dakota", when="+dakota", type=("build", "run"))
     # Python dependencies
     extends("python", when="+python")
-    depends_on("py-pip", when="+python", type="build")
+    depends_on("pip", when="+python", type="build")
     depends_on("py-wheel", when="+python", type="build")
     depends_on("py-setuptools", type="build")
     depends_on("python@3.7:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/steps/package.py
+++ b/repos/spack_repo/builtin/packages/steps/package.py
@@ -76,7 +76,7 @@ class Steps(CMakePackage):
     depends_on("py-cython")
     depends_on("py-gcovr", when="+coverage", type="build")
     depends_on("py-h5py", type=("build", "test", "run"))
-    depends_on("py-pip", type="build", when="@5:")
+    depends_on("pip", type="build", when="@5:")
     depends_on("py-matplotlib", type=("build", "test"))
     depends_on("py-build", type="build", when="@5:")
     depends_on("py-mpi4py", when="+distmesh", type=("build", "test", "run"))

--- a/repos/spack_repo/builtin/packages/survey/package.py
+++ b/repos/spack_repo/builtin/packages/survey/package.py
@@ -78,7 +78,7 @@ class Survey(CMakePackage):
 
     depends_on("python@3:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
     depends_on("py-pandas", type=("build", "run"))
     depends_on("py-psutil", type=("build", "run"))
     depends_on("py-sqlalchemy", type=("build", "run"))
@@ -211,7 +211,7 @@ class Survey(CMakePackage):
             join_path(self.spec["py-importlib-resources"].prefix, self.site_packages_dir),
         )
         env.prepend_path(
-            "PYTHONPATH", join_path(self.spec["py-pip"].prefix, self.site_packages_dir)
+            "PYTHONPATH", join_path(self.spec["pip"].prefix, self.site_packages_dir)
         )
         env.prepend_path(
             "PYTHONPATH", join_path(self.spec["py-seaborn"].prefix, self.site_packages_dir)

--- a/repos/spack_repo/builtin/packages/survey/package.py
+++ b/repos/spack_repo/builtin/packages/survey/package.py
@@ -210,9 +210,7 @@ class Survey(CMakePackage):
             "PYTHONPATH",
             join_path(self.spec["py-importlib-resources"].prefix, self.site_packages_dir),
         )
-        env.prepend_path(
-            "PYTHONPATH", join_path(self.spec["pip"].prefix, self.site_packages_dir)
-        )
+        env.prepend_path("PYTHONPATH", join_path(self.spec["pip"].prefix, self.site_packages_dir))
         env.prepend_path(
             "PYTHONPATH", join_path(self.spec["py-seaborn"].prefix, self.site_packages_dir)
         )

--- a/repos/spack_repo/builtin/packages/tamaas/package.py
+++ b/repos/spack_repo/builtin/packages/tamaas/package.py
@@ -66,7 +66,7 @@ class Tamaas(SConsPackage):
         depends_on("py-scipy", when="+solvers", type="run")
         depends_on("py-pybind11", type="build")
         depends_on("py-wheel", type="build")
-        depends_on("py-pip", type="build")
+        depends_on("pip", type="build")
 
     depends_on("petsc", type="build", when="+petsc")
 

--- a/repos/spack_repo/builtin/packages/thrift/package.py
+++ b/repos/spack_repo/builtin/packages/thrift/package.py
@@ -88,7 +88,7 @@ class Thrift(CMakePackage, AutotoolsPackage):
 
     with when("+python"):
         extends("python", type=("build", "link", "run"))
-        depends_on("py-pip", type="build")
+        depends_on("pip", type="build")
         depends_on("py-setuptools", type="build")
         depends_on("py-six@1.7.2:", type=("build", "run"))
 

--- a/repos/spack_repo/builtin/packages/treelite/package.py
+++ b/repos/spack_repo/builtin/packages/treelite/package.py
@@ -27,7 +27,7 @@ class Treelite(CMakePackage):
 
     depends_on("protobuf", when="+protobuf")
     depends_on("python@3.6:", when="+python", type=("build", "run"))
-    depends_on("py-pip", when="+python", type="build")
+    depends_on("pip", when="+python", type="build")
     depends_on("py-wheel", when="+python", type="build")
     depends_on("py-setuptools", when="+python", type="build")
     depends_on("py-numpy", when="+python", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/uwtools/package.py
+++ b/repos/spack_repo/builtin/packages/uwtools/package.py
@@ -29,7 +29,7 @@ class Uwtools(PythonPackage):
     version("2.7.2", sha256="56816d543664792258bfa7dfb7e4cc66f794959dc92dc3710021f40a2b8571a4")
     version("2.6.2", sha256="d0922ddd2b3bdbeb925c2e4694f929f3e966145d2929e74ab9f9c9ecd27b674a")
 
-    depends_on("py-pip", type="build")
+    depends_on("pip", type="build")
     # Maximum Python version limited here for compatibility with the JCSDA unified environment
     depends_on("python@3.9:3.11")
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/visit/package.py
+++ b/repos/spack_repo/builtin/packages/visit/package.py
@@ -104,7 +104,7 @@ class Visit(CMakePackage):
     # Fix const-correctness in VTK interface
     patch("vtk-8.2-constcorrect.patch", when="@3.3.3 ^vtk@8.2.1a")
 
-    # Add dectection for py-pip and enable python extensions with building with GUI
+    # Add dectection for pip and enable python extensions with building with GUI
     patch("19958-enable-python-and-check-pip.patch", when="@3.4:3.4.1 +python")
     patch("20127-remove-relink-visitmodule-py-setup.patch", when="@3.4.1 +python")
 
@@ -160,7 +160,7 @@ class Visit(CMakePackage):
     # python@3.8 doesn't work with older VisIt.
     depends_on("python@3.2:3.7,3.9:", when="@:3.2 +python")
     depends_on("python@3.2:", when="@3.3: +python")
-    depends_on("py-pip", when="+python")
+    depends_on("pip", when="+python")
     extends("python", when="+python")
 
     # VisIt uses the hdf5 1.8 api

--- a/repos/spack_repo/builtin/packages/warpx/package.py
+++ b/repos/spack_repo/builtin/packages/warpx/package.py
@@ -183,7 +183,7 @@ class Warpx(CMakePackage, PythonExtension):
         depends_on("py-periodictable@1.5:1", type=("build", "run"))
         depends_on("py-picmistandard@0.33.0", type=("build", "run"), when="@25.01:25.10")
         depends_on("py-picmistandard@0.34.0", type=("build", "run"), when="@25.11:")
-        depends_on("py-pip@23:", type="build")
+        depends_on("pip@23:", type="build")
         depends_on("py-setuptools@42:", type="build")
         depends_on("py-pybind11@2.12.0:", type=("build", "link"))
         depends_on("py-pybind11@3.0.1:", when="@25.08:", type=("build", "link"))

--- a/repos/spack_repo/builtin/packages/xrootd/package.py
+++ b/repos/spack_repo/builtin/packages/xrootd/package.py
@@ -106,7 +106,7 @@ class Xrootd(CMakePackage):
     depends_on("openssl")
     depends_on("python", when="+python")
     depends_on("py-setuptools", type="build", when="@:5.5 +python")
-    depends_on("py-pip", type="build", when="@5.6: +python")
+    depends_on("pip", type="build", when="@5.6: +python")
     depends_on("readline", when="+readline")
     depends_on("xz")
     depends_on("zlib-api")

--- a/repos/spack_repo/builtin/packages/xyce/package.py
+++ b/repos/spack_repo/builtin/packages/xyce/package.py
@@ -89,7 +89,7 @@ class Xyce(CMakePackage):
     conflicts("@7.10:", when="%gcc@:8")
 
     depends_on("python@3:", type=("build", "link", "run"), when="+pymi")
-    depends_on("py-pip", type="run", when="+pymi")
+    depends_on("pip", type="run", when="+pymi")
     depends_on("py-pybind11@2.6.1:", type=("build", "link"), when="@:7.8 +pymi")
     depends_on("py-pybind11@2.13:", type=("build", "link"), when="@7.9: +pymi")
     depends_on("python-venv", when="+pymi")


### PR DESCRIPTION
There has long been discussion of how to name Python tools. According to our [docs](https://spack.readthedocs.io/en/latest/build_systems/pythonpackage.html#choosing-a-package-name):

> When in doubt, think about how this package will be used. Is it primarily a Python library that will be imported in other Python scripts? Or is it a command-line tool, or C/C++/Fortran program with optional Python modules? The former should be prepended with `py-`, while the latter should not.

Pip is not intended to be imported, it is a command-line tool, and therefore should be called `pip`, not `py-pip` following these docs.

This has come up a few times already, first with pipx in https://github.com/spack/spack/pull/38658 (@blue42u @eli-schwartz) and again with ruff/ty/uv in #3962 (@johnwparent). @manuelakuhn may also have opinions on this discussion.

@eli-schwartz makes a good point in https://github.com/spack/spack/pull/38658#issuecomment-1616862234 that tools like pip are only useful within the Python ecosystem, and therefore a `py-` prefix makes sense. I would suggest we either follow the above documentation (I wrote it, it's not gospel) or change the above documentation and close this PR. But let's settle this once and for all.

If this is approved, I'll make a similar PR in https://github.com/spack/spack, there are a couple things (e.g., `spack create`) that refer to `py-pip`. If this is rejected, we should consider renaming tools like pipx, conda, pyrefly, etc. to add a `py-` prefix.