### PR TITLE
py-numpy: update license

### DIFF
--- a/repos/spack_repo/builtin/packages/py_numpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_numpy/package.py
@@ -20,7 +20,8 @@ class PyNumpy(PythonPackage):
 
     maintainers("adamjstewart", "rgommers")
 
-    license("BSD-3-Clause")
+    license("BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0", when="@2.4:")
+    license("BSD-3-Clause", when="@:2.3")
 
     version("main", branch="main")
     version("2.4.4", sha256="2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0")

--- a/repos/spack_repo/builtin/packages/py_numpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_numpy/package.py
@@ -20,8 +20,7 @@ class PyNumpy(PythonPackage):
 
     maintainers("adamjstewart", "rgommers")
 
-    license("BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0", when="@2.4:")
-    license("BSD-3-Clause", when="@:2.3")
+    license("BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0")
 
     version("main", branch="main")
     version("2.4.4", sha256="2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0")


### PR DESCRIPTION
License was clarified in https://github.com/numpy/numpy/pull/29535

@rgommers do you think we should apply this retroactively to all versions? Like you, I didn't include sdist licenses, only bdist licenses assuming no vendoring.