### PR TITLE
z3: add gcc conflict

### DIFF
--- a/repos/spack_repo/builtin/packages/z3/package.py
+++ b/repos/spack_repo/builtin/packages/z3/package.py
@@ -43,6 +43,8 @@ class Z3(CMakePackage):
     depends_on("cmake@3.4:", type="build")
     depends_on("gmp", when="+gmp", type=("build", "link"))
 
+    conflicts("%gcc@:9", when="@4.15:")
+
     # Referenced: https://github.com/Z3Prover/z3/issues/1016
     patch("fix_1016_2.patch", when="@4.5.0")
 


### PR DESCRIPTION
Added `conflicts("%gcc@:9", when="@4.15:"`) to prevent build errors with GCC 9 and older when using Z3 version 4.15 and above. Currently getting the following errors:
```
/tmp/root/spack-stage/spack-stage-z3-4.15.4-bc7cawmnqubyspbqatypd3bt5chi3cjk/spack-src/src/util/hashtable.h:465:41: error: use of deleted function 'obj_map<Key, Value>::key_data::key_data(const obj_map<Key, Value>::key_data&) [with Key = expr; Value = ptr_vector<expr>]'
         return insert_if_not_there_core(data(e), et);
                                         ^~~~~~~
In file included from /tmp/root/spack-stage/spack-stage-z3-4.15.4-bc7cawmnqubyspbqatypd3bt5chi3cjk/spack-src/src/ast/ast.h:41,
                 from /tmp/root/spack-stage/spack-stage-z3-4.15.4-bc7cawmnqubyspbqatypd3bt5chi3cjk/spack-src/src/ast/expr_functors.h:24,
                 from /tmp/root/spack-stage/spack-stage-z3-4.15.4-bc7cawmnqubyspbqatypd3bt5chi3cjk/spack-src/src/ast/recfun_decl_plugin.cpp:23:
/tmp/root/spack-stage/spack-stage-z3-4.15.4-bc7cawmnqubyspbqatypd3bt5chi3cjk/spack-src/src/util/obj_hashtable.h:65:9: note: 'obj_map<Key, Value>::key_data::key_data(const obj_map<Key, Value>::key_data&) noexcept [with Key = expr; Value = ptr_vector<expr>]' is implicitly deleted because its exception-specification does not match the implicit exception-specification ''
         key_data(key_data const &kd) noexcept = default;
         ^~~~~~~~ 
```
I've confirmed that the build is successful with GCC 10 and newer. 
