### PR TITLE
clingo-bootstrap: flat multimap patch

### DIFF
--- a/repos/spack_repo/builtin/packages/clingo_bootstrap/package.py
+++ b/repos/spack_repo/builtin/packages/clingo_bootstrap/package.py
@@ -45,6 +45,20 @@ class ClingoBootstrap(Clingo):
         patch("version-script.patch", when="@spack,5.5:5.6")
         patch("version-script-5.4.patch", when="@5.2:5.4")
 
+    # flat multimap for performance: https://github.com/potassco/clasp/pull/118
+    patch(
+        "https://github.com/haampie/clasp/commit/d38fd66cb3f20cdd7474c7a3342304dac9eff78c.patch?full_index=1",
+        sha256="3355cd2905c84242fcdbb79a13651203224a5376aaeda40aa8c35cb2b6fe0bd0",
+        working_dir="clasp",
+        when="@:5.7 +optimized",
+    )
+    patch(
+        "https://github.com/haampie/clasp/commit/0fa3a19beab99006f788840ca84c485d5bb23a61.patch?full_index=1",
+        sha256="e3b8ab3576823754b04bbc3f54be9f3c9f02c48ab9e3faafeb7511e6cdcb7405",
+        working_dir="clasp",
+        when="@5.8: +optimized",
+    )
+
     # CMake at version 3.16.0 or higher has the possibility to force the
     # Python interpreter, which is crucial to build against external Python
     # in environment where more than one interpreter is in the same prefix

--- a/repos/spack_repo/builtin/packages/clingo_bootstrap/package.py
+++ b/repos/spack_repo/builtin/packages/clingo_bootstrap/package.py
@@ -63,6 +63,7 @@ class ClingoBootstrap(Clingo):
     # Python interpreter, which is crucial to build against external Python
     # in environment where more than one interpreter is in the same prefix
     depends_on("cmake@3.16.0:", type="build")
+    depends_on("clingo-bootstrap-pgo", type="build", when="+optimized")
 
     # On Linux we bootstrap with GCC or clang
     requires(
@@ -94,12 +95,15 @@ class ClingoBootstrap(Clingo):
                 Executable("xcrun")("-find", "llvm-profdata", output=str).strip()
             )
 
+        # Find the PGO script before starting the build
+        script = which_string("clingo-pgo.py", required=True)
+
         # First configure with PGO flags, and do build apps.
         reports = os.path.abspath("reports")
         sources = os.path.abspath(self.root_cmakelists_dir)
         cmake_options = self.std_cmake_args + self.cmake_args() + [sources]
 
-        # Set PGO training flags.
+        # Set PGO flags.
         generate_mods = EnvironmentModifications()
         generate_mods.append_flags("CFLAGS", f"-fprofile-generate={reports}")
         generate_mods.append_flags("CXXFLAGS", f"-fprofile-generate={reports}")
@@ -114,13 +118,8 @@ class ClingoBootstrap(Clingo):
         rmtree(reports, ignore_errors=True)
 
         # Run spack solve --fresh hdf5 with instrumented clingo.
-        python_runtime_env = EnvironmentModifications()
-        python_runtime_env.extend(
-            environment_modifications_for_specs(self.spec, set_package_py_globals=False)
-        )
-        python_runtime_env.unset("SPACK_ENV")
-        python_runtime_env.unset("SPACK_PYTHON")
-        python(spack_script, "solve", "--fresh", "hdf5", extra_env=python_runtime_env)
+        env = environment_modifications_for_specs(self.spec, set_package_py_globals=False)
+        python(script, extra_env=env)
 
         # Clean the build dir.
         rmtree(self.build_directory, ignore_errors=True)

--- a/repos/spack_repo/builtin/packages/clingo_bootstrap/package.py
+++ b/repos/spack_repo/builtin/packages/clingo_bootstrap/package.py
@@ -47,14 +47,14 @@ class ClingoBootstrap(Clingo):
 
     # flat multimap for performance: https://github.com/potassco/clasp/pull/118
     patch(
-        "https://github.com/haampie/clasp/commit/d38fd66cb3f20cdd7474c7a3342304dac9eff78c.patch?full_index=1",
-        sha256="3355cd2905c84242fcdbb79a13651203224a5376aaeda40aa8c35cb2b6fe0bd0",
+        "https://github.com/haampie/clasp/commit/0f43ac61e8576404c6a33f25954883d3e51ef0df.patch?full_index=1",
+        sha256="0a266a4d475c225af30607ccd2b541cfca0e4b31368219f6de71039c8df156b3",
         working_dir="clasp",
         when="@:5.7 +optimized",
     )
     patch(
-        "https://github.com/haampie/clasp/commit/0fa3a19beab99006f788840ca84c485d5bb23a61.patch?full_index=1",
-        sha256="e3b8ab3576823754b04bbc3f54be9f3c9f02c48ab9e3faafeb7511e6cdcb7405",
+        "https://github.com/haampie/clasp/commit/208972863506ecbd85ed0bd78fac580b5e9c9c90.patch?full_index=1",
+        sha256="c569fb439a99b709b6e6ac05253b344e4f3055d52223265baa55946db6d44e8b",
         working_dir="clasp",
         when="@5.8: +optimized",
     )

--- a/repos/spack_repo/builtin/packages/clingo_bootstrap_pgo/package.py
+++ b/repos/spack_repo/builtin/packages/clingo_bootstrap_pgo/package.py
@@ -1,0 +1,22 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.generic import Package
+
+from spack.package import *
+
+
+class ClingoBootstrapPgo(Package):
+    """Resources for profile-guided optimization for clingo-bootstrap"""
+
+    homepage = "https://github.com/spack/spack-clingo-pgo"
+    git = "https://github.com/spack/spack-clingo-pgo.git"
+
+    maintainers("haampie")
+
+    version("1.0.0", commit="64bec625ae06b32b7f5f01bccf9d27d0432a018f")
+
+    def install(self, spec, prefix):
+        install_tree("bin", prefix.bin)
+        install_tree("share", prefix.share)


### PR DESCRIPTION
Replace `unordered_multimap` with a flat map to reduce memory ops.

Seems to give a 10%+ reduction in ground/solve, resulting in about 6.2 - 7.5% runtime reduction overall.

See https://github.com/potassco/clasp/pull/118
