### PR TITLE
libsvm: build library part

### DIFF
--- a/repos/spack_repo/builtin/packages/libsvm/package.py
+++ b/repos/spack_repo/builtin/packages/libsvm/package.py
@@ -19,13 +19,46 @@ class Libsvm(MakefilePackage):
     version("323", sha256="7a466f90f327a98f8ed1cb217570547bcb00077933d1619f3cb9e73518f38196")
     version("322", sha256="a3469436f795bb3f8b1e65ea761e14e5599ec7ee941c001d771c07b7da318ac6")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    def build(self, spec, prefix):
+        make()
+        make("lib")
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         mkdirp(prefix.lib)
+        mkdirp(prefix.include)
+        mkdirp(prefix.lib.pkgconfig)
+
         install("svm-predict", prefix.bin)
         install("svm-scale", prefix.bin)
         install("svm-train", prefix.bin)
         install("svm.o", prefix.lib)
+        install("svm.h", prefix.include)
+
+        for libfile in glob("libsvm.so.*"):
+            install(libfile, prefix.lib)
+
+        ar = which("ar")
+        ar("rcs", "libsvm.a", "svm.o")
+        install("libsvm.a", prefix.lib)
+
+        pc = join_path(prefix.lib.pkgconfig, "libsvm.pc")
+
+        with open(pc, "w") as f:
+            f.write(
+                f"""\
+    prefix={prefix}
+    exec_prefix=${{prefix}}
+    libdir=${{prefix}}/lib
+    includedir=${{prefix}}/include
+
+    Name: libsvm
+    Description: LibSVM Support Vector Machines Library
+    Version: {self.version}
+    Libs: -L${{libdir}} -lsvm
+    Cflags: -I${{includedir}}
+    """
+            )


### PR DESCRIPTION
`libsvm` has very simple Makefile https://github.com/cjlin1/libsvm/blob/master/Makefile which is not fully usable downstream.

Downstream projects like OpenMS build the package by themselves https://github.com/OpenMS/contrib/tree/186aacfbc1157719735b497cd6de1b3e83289eea/patches/libsvm, although only when their CMake does package management.

With this changes `libsvm` is built and installed without need for any further workarounds downstream.

This change is needed for OpenMS.