### PR TITLE
roounfold: new pkg

### DIFF
--- a/repos/spack_repo/builtin/packages/roounfold/package.py
+++ b/repos/spack_repo/builtin/packages/roounfold/package.py
@@ -1,0 +1,33 @@
+# Copyright Belle2 Collaboration
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
+
+from spack.package import *
+
+
+class Roounfold(CMakePackage):
+    """RooUnfold — Unfolding framework based on RooFit/ROOT.
+
+    A framework implementing several unfolding algorithms for use in HEP analyses.
+    """
+
+    homepage = "https://gitlab.cern.ch/RooUnfold/RooUnfold"
+    url = "https://gitlab.cern.ch/RooUnfold/RooUnfold/-/archive/3.1.0/RooUnfold-3.1.0.zip"
+    git = "https://gitlab.cern.ch/RooUnfold/RooUnfold.git"
+
+    maintainers("wdconinc")
+
+    license("BSD-3-Clause", checked_by="wdconinc")
+
+    version("3.1.0", sha256="51daf6373971512ce5882574bb18a373e68a0a2e1f824141ff99d6488d43cbf9")
+
+    depends_on("cmake@3.18:", type="build")
+
+    depends_on("root")
+
+    def cmake_args(self):
+        args = [
+            self.define("CMAKE_DISABLE_FIND_PACKAGE_doxygen", True),
+        ]
+        return args

--- a/repos/spack_repo/builtin/packages/roounfold/package.py
+++ b/repos/spack_repo/builtin/packages/roounfold/package.py
@@ -30,7 +30,5 @@ class Roounfold(CMakePackage):
     depends_on("root+roofit")
 
     def cmake_args(self):
-        args = [
-            self.define("CMAKE_DISABLE_FIND_PACKAGE_Doxygen", True),
-        ]
+        args = [self.define("CMAKE_DISABLE_FIND_PACKAGE_Doxygen", True)]
         return args

--- a/repos/spack_repo/builtin/packages/roounfold/package.py
+++ b/repos/spack_repo/builtin/packages/roounfold/package.py
@@ -25,7 +25,7 @@ class Roounfold(CMakePackage):
 
     depends_on("cmake@3.18:", type="build")
 
-    depends_on("root")
+    depends_on("root+roofit")
 
     def cmake_args(self):
         args = [

--- a/repos/spack_repo/builtin/packages/roounfold/package.py
+++ b/repos/spack_repo/builtin/packages/roounfold/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
+from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
 

--- a/repos/spack_repo/builtin/packages/roounfold/package.py
+++ b/repos/spack_repo/builtin/packages/roounfold/package.py
@@ -1,4 +1,5 @@
-# Copyright Belle2 Collaboration
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage, generator

--- a/repos/spack_repo/builtin/packages/roounfold/package.py
+++ b/repos/spack_repo/builtin/packages/roounfold/package.py
@@ -17,6 +17,8 @@ class Roounfold(CMakePackage):
     url = "https://gitlab.cern.ch/RooUnfold/RooUnfold/-/archive/3.1.0/RooUnfold-3.1.0.zip"
     git = "https://gitlab.cern.ch/RooUnfold/RooUnfold.git"
 
+    tags = ["hep"]
+
     maintainers("wdconinc")
 
     license("BSD-3-Clause", checked_by="wdconinc")

--- a/repos/spack_repo/builtin/packages/roounfold/package.py
+++ b/repos/spack_repo/builtin/packages/roounfold/package.py
@@ -25,6 +25,8 @@ class Roounfold(CMakePackage):
 
     version("3.1.0", sha256="51daf6373971512ce5882574bb18a373e68a0a2e1f824141ff99d6488d43cbf9")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
     depends_on("cmake@3.18:", type="build")
 
     depends_on("root+roofit")

--- a/repos/spack_repo/builtin/packages/roounfold/package.py
+++ b/repos/spack_repo/builtin/packages/roounfold/package.py
@@ -29,6 +29,6 @@ class Roounfold(CMakePackage):
 
     def cmake_args(self):
         args = [
-            self.define("CMAKE_DISABLE_FIND_PACKAGE_doxygen", True),
+            self.define("CMAKE_DISABLE_FIND_PACKAGE_Doxygen", True),
         ]
         return args


### PR DESCRIPTION
This PR adds RooUnfold `roounfold`, a new package for unfolding analysis with ROOT and RooFit.

Test build:
```
[+] ef5fjlw roounfold@3.1.0 /opt/software/linux-skylake/roounfold-3.1.0-ef5fjlw3hgakcbolpvmstqgqx6jljzbl (48s)
```