### PR TITLE
g4hepem: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/g4hepem/package.py
+++ b/repos/spack_repo/builtin/packages/g4hepem/package.py
@@ -1,0 +1,41 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems.cuda import CudaPackage
+
+from spack.package import *
+
+
+class G4hepem(CMakePackage, CudaPackage):
+    """Geant4 EM physics simulation R&D project looking for solutions
+    to reduce the computing performance bottleneck experienced by
+    HEP detector simulation applications."""
+
+    homepage = "https://github.com/mnovak42/g4hepem"
+    url = "https://github.com/mnovak42/g4hepem/archive/refs/tags/20251114.tar.gz"
+    git = "https://github.com/mnovak42/g4hepem.git"
+
+    maintainers("wdconinc")
+
+    license("Apache-2.0", checked_by="wdconinc")
+
+    version("20251114", sha256="d1bf94fd9403043f0c5f3b8bb6d9b79d6108f07c19d8b7403de0acd66774f8af")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("cmake@3.17:", type="build")
+
+    depends_on("geant4@10.6:")
+
+    def cmake_args(self):
+        args = [
+            self.define("BUILD_TESTING", self.run_tests),
+            self.define("CMAKE_CXX_STANDARD", self.spec["geant4"].variants["cxxstd"].value),
+            self.define("G4HepEm_GEANT4_BUILD", True),
+            self.define_from_variant("G4HepEm_CUDA_BUILD", "cuda"),
+        ]
+        if self.spec.satisfies("cuda"):
+            args.append(self.define("CMAKE_CUDA_ARCHITECTURES", self.spec.variants["cuda_arch"].value))
+        return args

--- a/repos/spack_repo/builtin/packages/g4hepem/package.py
+++ b/repos/spack_repo/builtin/packages/g4hepem/package.py
@@ -23,6 +23,8 @@ class G4hepem(CMakePackage, CudaPackage):
 
     version("20251114", sha256="d1bf94fd9403043f0c5f3b8bb6d9b79d6108f07c19d8b7403de0acd66774f8af")
 
+    variant("early_tracking_exit", default=False, description="Enable user-defined early tracking exit")
+
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("cmake@3.17:", type="build")
@@ -35,9 +37,8 @@ class G4hepem(CMakePackage, CudaPackage):
             self.define("CMAKE_CXX_STANDARD", self.spec["geant4"].variants["cxxstd"].value),
             self.define("G4HepEm_GEANT4_BUILD", True),
             self.define_from_variant("G4HepEm_CUDA_BUILD", "cuda"),
+            self.define_from_variant("G4HepEm_EARLY_TRACKING_EXIT", "early_tracking_exit"),
         ]
         if self.spec.satisfies("+cuda"):
-            args.append(
-                self.define("CMAKE_CUDA_ARCHITECTURES", self.spec.variants["cuda_arch"].value)
-            )
+            args.append(CMakeBuilder.define_cuda_architectures(self))
         return args

--- a/repos/spack_repo/builtin/packages/g4hepem/package.py
+++ b/repos/spack_repo/builtin/packages/g4hepem/package.py
@@ -37,5 +37,7 @@ class G4hepem(CMakePackage, CudaPackage):
             self.define_from_variant("G4HepEm_CUDA_BUILD", "cuda"),
         ]
         if self.spec.satisfies("cuda"):
-            args.append(self.define("CMAKE_CUDA_ARCHITECTURES", self.spec.variants["cuda_arch"].value))
+            args.append(
+                self.define("CMAKE_CUDA_ARCHITECTURES", self.spec.variants["cuda_arch"].value)
+            )
         return args

--- a/repos/spack_repo/builtin/packages/g4hepem/package.py
+++ b/repos/spack_repo/builtin/packages/g4hepem/package.py
@@ -36,7 +36,7 @@ class G4hepem(CMakePackage, CudaPackage):
             self.define("G4HepEm_GEANT4_BUILD", True),
             self.define_from_variant("G4HepEm_CUDA_BUILD", "cuda"),
         ]
-        if self.spec.satisfies("cuda"):
+        if self.spec.satisfies("+cuda"):
             args.append(
                 self.define("CMAKE_CUDA_ARCHITECTURES", self.spec.variants["cuda_arch"].value)
             )

--- a/repos/spack_repo/builtin/packages/g4hepem/package.py
+++ b/repos/spack_repo/builtin/packages/g4hepem/package.py
@@ -23,7 +23,9 @@ class G4hepem(CMakePackage, CudaPackage):
 
     version("20251114", sha256="d1bf94fd9403043f0c5f3b8bb6d9b79d6108f07c19d8b7403de0acd66774f8af")
 
-    variant("early_tracking_exit", default=False, description="Enable user-defined early tracking exit")
+    variant(
+        "early_tracking_exit", default=False, description="Enable user-defined early tracking exit"
+    )
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")


### PR DESCRIPTION
This PR adds `g4hepem`, v20251114. This is a Geant4 EM physics simulation R&D project.

Test build (unable to try with CUDA):
```
-- linux-ubuntu26.04-skylake / %c,cxx=clang@23.0.0 --------------
h6yr537 g4hepem@20251114~cuda~ipo build_system=cmake build_type=Release dev_path=/home/wdconinc/git/g4hepem generator=make
==> 1 installed package
```