### PR TITLE
g4adept: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/g4adept/package.py
+++ b/repos/spack_repo/builtin/packages/g4adept/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems.cmake import CMakeBuilder, CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 
 from spack.package import *

--- a/repos/spack_repo/builtin/packages/g4adept/package.py
+++ b/repos/spack_repo/builtin/packages/g4adept/package.py
@@ -46,7 +46,7 @@ class G4adept(CMakePackage, CudaPackage):
     depends_on("xerces-c")
     depends_on("geant4")
     depends_on("g4vg@1.0.3:")
-    depends_on("g4hepem +cuda")
+    depends_on("g4hepem +cuda +early_tracking_exit")
     depends_on("hepmc3", type="test")
 
     depends_on("covfie", when="+covfie")

--- a/repos/spack_repo/builtin/packages/g4adept/package.py
+++ b/repos/spack_repo/builtin/packages/g4adept/package.py
@@ -52,6 +52,10 @@ class G4adept(CMakePackage, CudaPackage):
 
     depends_on("covfie", when="+covfie")
 
+    for pkg in ["vecgeom", "g4hepem"]:
+        for arch in CudaPackage.cuda_arch_values:
+            depends_on(f"{pkg} +cuda cuda_arch={arch}", when=f"+cuda cuda_arch={arch}")
+
     conflicts("~cuda", msg="G4adept requires CUDA support")
 
     def cmake_args(self):

--- a/repos/spack_repo/builtin/packages/g4adept/package.py
+++ b/repos/spack_repo/builtin/packages/g4adept/package.py
@@ -43,7 +43,7 @@ class G4adept(CMakePackage, CudaPackage):
     depends_on("veccore@0.5.2:")
     depends_on("vecgeom@2: +cuda +gdml")
     depends_on("xerces-c")
-    depends_on("geant4")
+    depends_on("geant4 ~vecgeom")
     depends_on("g4vg@1.0.3:")
     depends_on("g4hepem +cuda +early_tracking_exit")
     depends_on("hepmc3", type="test")

--- a/repos/spack_repo/builtin/packages/g4adept/package.py
+++ b/repos/spack_repo/builtin/packages/g4adept/package.py
@@ -19,6 +19,7 @@ class G4adept(CMakePackage, CudaPackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    version("0.3.0", sha256="e179d0b600beeeb34357c767bbc22498715ca6719917abbc14221fde39fb2885")
     version("0.2.0", sha256="4075ebb652b17d6cf94b341fdc64df088ce9538b0aba433e413606d5cb51c618")
 
     variant(

--- a/repos/spack_repo/builtin/packages/g4adept/package.py
+++ b/repos/spack_repo/builtin/packages/g4adept/package.py
@@ -15,7 +15,7 @@ class G4adept(CMakePackage, CudaPackage):
     url = "https://github.com/apt-sim/AdePT/archive/refs/tags/v0.2.0.tar.gz"
     git = "https://github.com/apt-sim/AdePT.git"
 
-    maintainers("wdconinc")
+    maintainers("wdconinc", "sethrj")
 
     license("Apache-2.0", checked_by="wdconinc")
 

--- a/repos/spack_repo/builtin/packages/g4adept/package.py
+++ b/repos/spack_repo/builtin/packages/g4adept/package.py
@@ -57,6 +57,7 @@ class G4adept(CMakePackage, CudaPackage):
             depends_on(f"{pkg} +cuda cuda_arch={arch}", when=f"+cuda cuda_arch={arch}")
 
     conflicts("~cuda", msg="G4adept requires CUDA support")
+    conflicts("cuda_arch=none", when="+cuda", msg="CUDA architecture is required")
 
     def cmake_args(self):
         args = [

--- a/repos/spack_repo/builtin/packages/g4adept/package.py
+++ b/repos/spack_repo/builtin/packages/g4adept/package.py
@@ -1,0 +1,55 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems.cuda import CudaPackage
+
+from spack.package import *
+
+
+class G4adept(CMakePackage, CudaPackage):
+    """Accelerated demonstrator of electromagnetic Particle Transport"""
+
+    homepage = "https://adept-project.readthedocs.io/"
+    url = "https://github.com/apt-sim/AdePT/archive/refs/tags/v0.2.0.tar.gz"
+    git = "https://github.com/apt-sim/AdePT.git"
+
+    maintainers("wdconinc")
+
+    license("Apache-2.0", checked_by="wdconinc")
+
+    version("0.2.0", sha256="4075ebb652b17d6cf94b341fdc64df088ce9538b0aba433e413606d5cb51c618")
+
+    variant("covfie", default=False, description="Use external B field from file via the covfie library")
+    variant("examples", default=False, description="Build examples")
+    variant("split_kernels", default=False, description="Run split version of the transport kernels")
+    variant("surf", default=False, description="Enable surface model navigation on GPU")
+    variant("mixed_precision", default=False, description="Use B-field integration and surface model in mixed precision")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("cmake@3.25.2:", type="build")
+
+    depends_on("veccore@0.5.2: +cuda")
+    depends_on("vecgeom +gdml")
+    depends_on("xerces-c")
+    depends_on("geant4")
+    depends_on("g4vg@1.0.3:")
+    depends_on("g4hepem +cuda")
+    depends_on("hepmc3", type="test")
+
+    depends_on("covfie", when="+covfie")
+
+    conflicts("~cuda", msg="G4adept requires CUDA support")
+
+    def cmake_args(self):
+        args = [
+            self.define("ADEPT_BUILD_TESTING", self.run_tests),
+            self.define_from_variants("ADEPT_BUILD_EXAMPLES", "examples"),
+            self.define_from_variant("ADEPT_USE_EXT_BFIELD", "covfie"),
+            self.define_from_variant("ADEPT_USE_SPLIT_KERNELS", "split_kernels"),
+            self.define_from_variant("ADEPT_USE_SURF", "surf"),
+            self.define("ADEPT_USE_BUILTIN_G4VG", False),
+        ]
+        return args

--- a/repos/spack_repo/builtin/packages/g4adept/package.py
+++ b/repos/spack_repo/builtin/packages/g4adept/package.py
@@ -23,9 +23,7 @@ class G4adept(CMakePackage, CudaPackage):
     version("0.2.0", sha256="4075ebb652b17d6cf94b341fdc64df088ce9538b0aba433e413606d5cb51c618")
 
     variant(
-        "covfie",
-        default=True,
-        description="Use external B field from file via the covfie library",
+        "covfie", default=True, description="Use external B field from file via the covfie library"
     )
     variant("examples", default=False, description="Build examples")
     variant(

--- a/repos/spack_repo/builtin/packages/g4adept/package.py
+++ b/repos/spack_repo/builtin/packages/g4adept/package.py
@@ -21,11 +21,21 @@ class G4adept(CMakePackage, CudaPackage):
 
     version("0.2.0", sha256="4075ebb652b17d6cf94b341fdc64df088ce9538b0aba433e413606d5cb51c618")
 
-    variant("covfie", default=False, description="Use external B field from file via the covfie library")
+    variant(
+        "covfie",
+        default=False,
+        description="Use external B field from file via the covfie library",
+    )
     variant("examples", default=False, description="Build examples")
-    variant("split_kernels", default=False, description="Run split version of the transport kernels")
+    variant(
+        "split_kernels", default=False, description="Run split version of the transport kernels"
+    )
     variant("surf", default=False, description="Enable surface model navigation on GPU")
-    variant("mixed_precision", default=False, description="Use B-field integration and surface model in mixed precision")
+    variant(
+        "mixed_precision",
+        default=False,
+        description="Use B-field integration and surface model in mixed precision",
+    )
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")

--- a/repos/spack_repo/builtin/packages/g4adept/package.py
+++ b/repos/spack_repo/builtin/packages/g4adept/package.py
@@ -56,10 +56,12 @@ class G4adept(CMakePackage, CudaPackage):
     def cmake_args(self):
         args = [
             self.define("ADEPT_BUILD_TESTING", self.run_tests),
-            self.define_from_variants("ADEPT_BUILD_EXAMPLES", "examples"),
+            self.define_from_variant("ADEPT_BUILD_EXAMPLES", "examples"),
             self.define_from_variant("ADEPT_USE_EXT_BFIELD", "covfie"),
+            self.define_from_variant("ADEPT_MIXED_PRECISION", "mixed_precision"),
             self.define_from_variant("ADEPT_USE_SPLIT_KERNELS", "split_kernels"),
             self.define_from_variant("ADEPT_USE_SURF", "surf"),
             self.define("ADEPT_USE_BUILTIN_G4VG", False),
         ]
+        args.append(CMakeBuilder.define_cuda_architectures(self))
         return args

--- a/repos/spack_repo/builtin/packages/g4adept/package.py
+++ b/repos/spack_repo/builtin/packages/g4adept/package.py
@@ -43,7 +43,7 @@ class G4adept(CMakePackage, CudaPackage):
     depends_on("cmake@3.25.2:", type="build")
 
     depends_on("veccore@0.5.2:")
-    depends_on("vecgeom@2: +gdml")
+    depends_on("vecgeom@2: +cuda +gdml")
     depends_on("xerces-c")
     depends_on("geant4")
     depends_on("g4vg@1.0.3:")

--- a/repos/spack_repo/builtin/packages/g4adept/package.py
+++ b/repos/spack_repo/builtin/packages/g4adept/package.py
@@ -43,7 +43,7 @@ class G4adept(CMakePackage, CudaPackage):
     depends_on("cmake@3.25.2:", type="build")
 
     depends_on("veccore@0.5.2:")
-    depends_on("vecgeom +gdml")
+    depends_on("vecgeom@2: +gdml")
     depends_on("xerces-c")
     depends_on("geant4")
     depends_on("g4vg@1.0.3:")

--- a/repos/spack_repo/builtin/packages/g4adept/package.py
+++ b/repos/spack_repo/builtin/packages/g4adept/package.py
@@ -24,7 +24,7 @@ class G4adept(CMakePackage, CudaPackage):
 
     variant(
         "covfie",
-        default=False,
+        default=True,
         description="Use external B field from file via the covfie library",
     )
     variant("examples", default=False, description="Build examples")

--- a/repos/spack_repo/builtin/packages/g4adept/package.py
+++ b/repos/spack_repo/builtin/packages/g4adept/package.py
@@ -50,7 +50,7 @@ class G4adept(CMakePackage, CudaPackage):
 
     with when("+covfie"):
         for arch in CudaPackage.cuda_arch_values:
-            depends_on(f"covfie +cuda cuda_arch={arch}", when="+cuda cuda_arch={arch}")
+            depends_on(f"covfie +cuda cuda_arch={arch}", when=f"+cuda cuda_arch={arch}")
 
     for pkg in ["vecgeom", "g4hepem"]:
         for arch in CudaPackage.cuda_arch_values:

--- a/repos/spack_repo/builtin/packages/g4adept/package.py
+++ b/repos/spack_repo/builtin/packages/g4adept/package.py
@@ -54,7 +54,7 @@ class G4adept(CMakePackage, CudaPackage):
         for arch in CudaPackage.cuda_arch_values:
             depends_on(f"{pkg} +cuda cuda_arch={arch}", when=f"+cuda cuda_arch={arch}")
 
-    conflicts("~cuda", msg="G4adept requires CUDA support")
+    conflicts("~cuda", msg="AdePT requires CUDA support")
     conflicts("cuda_arch=none", when="+cuda", msg="CUDA architecture is required")
 
     def cmake_args(self):

--- a/repos/spack_repo/builtin/packages/g4adept/package.py
+++ b/repos/spack_repo/builtin/packages/g4adept/package.py
@@ -41,7 +41,7 @@ class G4adept(CMakePackage, CudaPackage):
     depends_on("cxx", type="build")
     depends_on("cmake@3.25.2:", type="build")
 
-    depends_on("veccore@0.5.2: +cuda")
+    depends_on("veccore@0.5.2:")
     depends_on("vecgeom +gdml")
     depends_on("xerces-c")
     depends_on("geant4")

--- a/repos/spack_repo/builtin/packages/g4adept/package.py
+++ b/repos/spack_repo/builtin/packages/g4adept/package.py
@@ -48,7 +48,9 @@ class G4adept(CMakePackage, CudaPackage):
     depends_on("g4hepem +cuda +early_tracking_exit")
     depends_on("hepmc3", type="test")
 
-    depends_on("covfie", when="+covfie")
+    with when("+covfie"):
+        for arch in CudaPackage.cuda_arch_values:
+            depends_on(f"covfie +cuda cuda_arch={arch}", when="+cuda cuda_arch={arch}")
 
     for pkg in ["vecgeom", "g4hepem"]:
         for arch in CudaPackage.cuda_arch_values:

--- a/repos/spack_repo/builtin/packages/g4hepem/package.py
+++ b/repos/spack_repo/builtin/packages/g4hepem/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems.cmake import CMakeBuilder, CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 
 from spack.package import *


### PR DESCRIPTION
This PR adds `g4adept`, v0.2.0. This is an accelerated demonstrator of electromagnetic particle transport that builds on `g4hepem`.

Needs:
- [x] #4149 
- [ ] ~~#4151~~ (not needed)

Test build:
```
-- linux-ubuntu24.04-skylake_avx512 / %c,cxx=gcc@14.2.0 ---------
tde4urx g4adept@0.3.0+covfie+cuda+examples~ipo~mixed_precision~split_kernels~surf build_system=cmake build_type=Release cuda_arch:=75 generator=make
==> 1 installed package
```