### PR TITLE
veccore: add cuda support (ahem)

### DIFF
--- a/repos/spack_repo/builtin/packages/veccore/package.py
+++ b/repos/spack_repo/builtin/packages/veccore/package.py
@@ -3,11 +3,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems.cuda import CudaPackage
 
 from spack.package import *
 
 
-class Veccore(CMakePackage):
+class Veccore(CMakePackage, CudaPackage):
     """SIMD Vectorization Library for VecGeom and GeantV.
 
     VecCore is a header-only (interface) library so no cmake arguments are
@@ -52,5 +53,10 @@ class Veccore(CMakePackage):
     depends_on("vc@1.2.0:", when="@0.2.0: +vc")
     depends_on("vc@1.3.3:", when="@0.6.0: +vc")
 
+    depends_on("cuda@11:", type="build", when="+cuda")
+
     def cmake_args(self):
-        return [self.define_from_variant("VC", "vc")]
+        return [
+            self.define_from_variant("VC", "vc"),
+            self.define_from_variant("CUDA", "cuda"),
+        ]

--- a/repos/spack_repo/builtin/packages/veccore/package.py
+++ b/repos/spack_repo/builtin/packages/veccore/package.py
@@ -56,7 +56,4 @@ class Veccore(CMakePackage, CudaPackage):
     depends_on("cuda@11:", type="build", when="+cuda")
 
     def cmake_args(self):
-        return [
-            self.define_from_variant("VC", "vc"),
-            self.define_from_variant("CUDA", "cuda"),
-        ]
+        return [self.define_from_variant("VC", "vc"), self.define_from_variant("CUDA", "cuda")]


### PR DESCRIPTION
This PR adds to `veccore` a dependency on CudaPackage. This doesn't actually change what gets compiled (nothing) or installed in this header-only library, but it adds compile definitions to VecCoreConfig.cmake which are then available to downstream users when doing `find_package(VecCore COMPONENTS CUDA)` (e.g. https://github.com/apt-sim/AdePT/blob/master/CMakeLists.txt#L188-L189).