### PR TITLE
arrow on darwin: patch libtool version check to match newer apple output

### DIFF
--- a/repos/spack_repo/builtin/packages/arrow/package.py
+++ b/repos/spack_repo/builtin/packages/arrow/package.py
@@ -130,6 +130,12 @@ class Arrow(CMakePackage, CudaPackage):
 
     root_cmakelists_dir = "cpp"
 
+    patch(
+        "https://github.com/apache/arrow/pull/49370.patch?full_index=1",
+        sha256="ca55e18c4eaaf59bcb145ada2aa5b556b8b87a93415ace059166716864145ceb",
+        when="@22.0.0 platform=darwin",
+    )
+
     def patch(self):
         """Prevent `-isystem /usr/include` from appearing, since this confuses gcc."""
         filter_file(


### PR DESCRIPTION
Arrow package: update `libtool -V` validation to match what is given in newer Apple `libtool`

Fixes CI failure issue seen on recent develop pipeline:
* [arrow@22.0.0 /4olaq2j7nnx76gokdchchrfyvbtwcdit Machine Learning MPS ](https://gitlab.spack.io/spack/spack-packages/-/jobs/21304159)

CC @rbberger 