### PR TITLE
Gate: new version v9.4.2

### DIFF
--- a/repos/spack_repo/builtin/packages/gate/package.py
+++ b/repos/spack_repo/builtin/packages/gate/package.py
@@ -29,6 +29,7 @@ class Gate(CMakePackage):
 
     license("LGPL-3.0-or-later")
 
+    version("9.4.2", sha256="11dac0770a13b12647c1b8532d8f11bf401e768dec1e2d054ede71544d961b4d")
     version("9.1", sha256="aaab874198500b81d45b27cc6d6a51e72cca9519910b893a5c85c8e6d3ffa4fc")
     version("9.0", sha256="8354f392facc0b7ae2ddf0eed61cc43136195b198ba399df25e874886b8b69cb")
 
@@ -46,7 +47,10 @@ class Gate(CMakePackage):
 
     depends_on("geant4@:10.6~threads", when="@9.0")  # Gate needs a non-threaded geant4
     depends_on("geant4@:10.7~threads", when="@9.1")  # Gate needs a non-threaded geant4
+    depends_on("geant4@11.4~threads", when="@9.4")
+    depends_on("root@6", when="@9.4")
     depends_on("root")
+    depends_on("itk@5: +rtk", when="+rtk @9.4")
     depends_on("itk+rtk", when="+rtk")
 
     patch("cluster_tools_filemerger_Makefile.patch")

--- a/repos/spack_repo/builtin/packages/itk/package.py
+++ b/repos/spack_repo/builtin/packages/itk/package.py
@@ -66,6 +66,7 @@ class Itk(CMakePackage):
     depends_on("perl", type="build")
 
     depends_on("eigen")
+    depends_on("eigen@3.3:3", when="@:5")
     depends_on("expat")
     depends_on("fftw-api")
     depends_on("hdf5+cxx+hl")


### PR DESCRIPTION
New version for Gate9. Tested it with some different variants for Geant4/Root and it worked pretty well.

Also includes a patch for ITK. ITK only compiles with eigen3 (eigen 5 support will be added in ITK 6, which is not released yet).