### PR TITLE
clingo-bootstrap: add pgo build dep

### DIFF
--- a/repos/spack_repo/builtin/packages/clingo_bootstrap/package.py
+++ b/repos/spack_repo/builtin/packages/clingo_bootstrap/package.py
@@ -49,6 +49,7 @@ class ClingoBootstrap(Clingo):
     # Python interpreter, which is crucial to build against external Python
     # in environment where more than one interpreter is in the same prefix
     depends_on("cmake@3.16.0:", type="build")
+    depends_on("clingo-bootstrap-pgo", type="build", when="+optimized")
 
     # On Linux we bootstrap with GCC or clang
     requires(
@@ -80,12 +81,15 @@ class ClingoBootstrap(Clingo):
                 Executable("xcrun")("-find", "llvm-profdata", output=str).strip()
             )
 
+        # Find the PGO script before starting the build
+        script = which_string("clingo-pgo.py", required=True)
+
         # First configure with PGO flags, and do build apps.
         reports = os.path.abspath("reports")
         sources = os.path.abspath(self.root_cmakelists_dir)
         cmake_options = self.std_cmake_args + self.cmake_args() + [sources]
 
-        # Set PGO training flags.
+        # Set PGO flags.
         generate_mods = EnvironmentModifications()
         generate_mods.append_flags("CFLAGS", f"-fprofile-generate={reports}")
         generate_mods.append_flags("CXXFLAGS", f"-fprofile-generate={reports}")
@@ -100,13 +104,8 @@ class ClingoBootstrap(Clingo):
         rmtree(reports, ignore_errors=True)
 
         # Run spack solve --fresh hdf5 with instrumented clingo.
-        python_runtime_env = EnvironmentModifications()
-        python_runtime_env.extend(
-            environment_modifications_for_specs(self.spec, set_package_py_globals=False)
-        )
-        python_runtime_env.unset("SPACK_ENV")
-        python_runtime_env.unset("SPACK_PYTHON")
-        python(spack_script, "solve", "--fresh", "hdf5", extra_env=python_runtime_env)
+        env = environment_modifications_for_specs(self.spec, set_package_py_globals=False)
+        python(script, extra_env=env)
 
         # Clean the build dir.
         rmtree(self.build_directory, ignore_errors=True)

--- a/repos/spack_repo/builtin/packages/clingo_bootstrap/package.py
+++ b/repos/spack_repo/builtin/packages/clingo_bootstrap/package.py
@@ -103,7 +103,7 @@ class ClingoBootstrap(Clingo):
         # Clean the reports dir.
         rmtree(reports, ignore_errors=True)
 
-        # Run spack solve --fresh hdf5 with instrumented clingo.
+        # Generate profile data.
         env = environment_modifications_for_specs(self.spec, set_package_py_globals=False)
         python(script, extra_env=env)
 

--- a/repos/spack_repo/builtin/packages/clingo_bootstrap_pgo/package.py
+++ b/repos/spack_repo/builtin/packages/clingo_bootstrap_pgo/package.py
@@ -1,0 +1,22 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.generic import Package
+
+from spack.package import *
+
+
+class ClingoBootstrapPgo(Package):
+    """Resources for profile-guided optimization for clingo-bootstrap"""
+
+    homepage = "https://github.com/spack/spack-clingo-pgo"
+    git = "https://github.com/spack/spack-clingo-pgo.git"
+
+    maintainers("haampie")
+
+    version("1.0.0", commit="64bec625ae06b32b7f5f01bccf9d27d0432a018f")
+
+    def install(self, spec, prefix):
+        install_tree("bin", prefix.bin)
+        install_tree("share", prefix.share)


### PR DESCRIPTION
Currently the `clingo-bootstrap +optimized` build is impure:

* it runs Spack itself to collect profiling data
* it may `git clone` an arbitrary commit of `spack-packages`
* it can modify `~/.spack/cache` leading to CI failures seen in another PR

So, add a dedicated build dep for the PGO data and a script and run that.

