### PR TITLE
ascent: fix rocm compiler and cxxflags formating

### DIFF
--- a/repos/spack_repo/builtin/packages/ascent/package.py
+++ b/repos/spack_repo/builtin/packages/ascent/package.py
@@ -670,12 +670,6 @@ class Ascent(CMakePackage, CudaPackage, ROCmPackage):
             cfg.write(cmake_cache_path("HIP_CLANG_PATH", f"{spec['llvm-amdgpu'].prefix.bin}"))
             cfg.write(cmake_cache_string("CMAKE_HIP_ARCHITECTURES", amdgpu_archs))
 
-            clang_bindir = spec["llvm-amdgpu"].prefix.bin
-            cfg.write(cmake_cache_path("CMAKE_C_COMPILER", f"{clang_bindir}/clang", force=True))
-            cfg.write(
-                cmake_cache_path("CMAKE_CXX_COMPILER", f"{clang_bindir}/clang++", force=True)
-            )
-
             # This is needed for Kokkos
             kokkos_cxxstd = spec["kokkos"].variants["cxxstd"].value
             cfg.write(cmake_cache_entry("CMAKE_CXX_STANDARD", kokkos_cxxstd))

--- a/repos/spack_repo/builtin/packages/ascent/package.py
+++ b/repos/spack_repo/builtin/packages/ascent/package.py
@@ -516,8 +516,8 @@ class Ascent(CMakePackage, CudaPackage, ROCmPackage):
             cfg.write(cmake_cache_entry("CMAKE_C_FLAGS", cflags))
         cxxflags = cppflags + " ".join(spec.compiler_flags["cxxflags"])
         if spec.satisfies("%oneapi@2025:"):
-            cxxflags += "-Wno-error=missing-template-arg-list-after-template-kw "
-            cxxflags += "-Wno-missing-template-arg-list-after-template-kw"
+            cxxflags += " -Wno-error=missing-template-arg-list-after-template-kw"
+            cxxflags += " -Wno-missing-template-arg-list-after-template-kw"
         if cxxflags:
             cfg.write(cmake_cache_entry("CMAKE_CXX_FLAGS", cxxflags))
         fflags = " ".join(spec.compiler_flags["fflags"])


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
These fixes were necessary for Ascent 0.9.5 with intel-oneapi-compilers@2025.3.1/ llvm-amdgpu@7.2.0:
- do not override C/CXX compiler for +rocm (was forcing llvm-amdgpu clang and preventing amdclang)
- fix missing space in oneapi cxxflags concatenation