### PR TITLE
openmpi: Add check for 'cc' in spack_compiler

### DIFF
--- a/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -1495,9 +1495,10 @@ def get_spack_compiler_spec(compiler):
     actual_compiler = None
     # check if the compiler actually matches the one we want
     for spack_compiler in spack_compilers:
-        if spack_compiler.cc and spack_compiler.cc == compiler:
-            actual_compiler = spack_compiler
-            break
+        if "cc" in spack_compiler:
+            if spack_compiler.cc and spack_compiler.cc == compiler:
+                actual_compiler = spack_compiler
+                break
     return actual_compiler.spec if actual_compiler else None
 
 


### PR DESCRIPTION
This PR fixes finding external openmpi. Currently, get_spack_compiler_spec() (sometimes? always?) fails with:
```console
  File "/dev/shm/spack-20770/user_cache/package_repos/fncqgg4/repos/spack_repo/builtin/packages/openmpi/package.py", line 1498, in get_spack_compiler_spec
    if spack_compiler.cc and spack_compiler.cc == compiler:
       ^^^^^^^^^^^^^^^^^
AttributeError: 'Spec' object has no attribute 'cc'
```