### PR TITLE
helm: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/helm/package.py
+++ b/repos/spack_repo/builtin/packages/helm/package.py
@@ -1,0 +1,24 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.go import GoPackage
+
+from spack.package import *
+
+
+class Helm(GoPackage):
+    """The Kubernetes Package Manager"""
+
+    homepage = "https://helm.sh"
+    url = "https://github.com/helm/helm/archive/refs/tags/v4.1.3.tar.gz"
+
+    maintainers("alecbcs")
+
+    license("Apache-2.0")
+
+    version("4.1.3", sha256="a336010d2a5bebc0588995cfda20919c47b20c9f8ed3e4ada9241684854bbf9f")
+
+    depends_on("go@1.25:", type="build", when="@4.1:")
+
+    build_directory = "cmd/helm"


### PR DESCRIPTION
This PR adds a package for Helm (https://github.com/helm/helm) which is a package manager for Kubernetes.
