### PR TITLE
oc: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/oc/package.py
+++ b/repos/spack_repo/builtin/packages/oc/package.py
@@ -18,16 +18,11 @@ class Oc(GoPackage):
     license("Apache-2.0")
 
     version("main", branch="main")
-    version(
-        "4.21.0-202601121715",
-        tag="openshift-clients-4.21.0-202601121715",
-        commit="345800dc3c4164fbca313c1cbfb383f262547903",
-    )
+    version("4.21.0-202601121715", commit="345800dc3c4164fbca313c1cbfb383f262547903")
 
     variant("gssapi", default=False, description="Enable GSSAPI authentication support")
 
-    conflicts("+gssapi", when="platform=darwin os=tahoe")
-
+    depends_on("c", type="build")
     depends_on("go@1.22.5:", type="build", when="@4.20:")
 
     depends_on("gnupg")
@@ -36,7 +31,7 @@ class Oc(GoPackage):
     depends_on("krb5", when="+gssapi")
 
     build_directory = "cmd/oc"
-    cgo_enable = True
+    cgo_enabled = True
 
     @property
     def build_args(self):

--- a/repos/spack_repo/builtin/packages/oc/package.py
+++ b/repos/spack_repo/builtin/packages/oc/package.py
@@ -1,0 +1,50 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.go import GoPackage
+
+from spack.package import *
+
+
+class Oc(GoPackage):
+    """The OpenShift Command Line, part of OKD."""
+
+    homepage = "https://okd.io"
+    git = "https://github.com/openshift/oc.git"
+
+    maintainers("alecbcs")
+
+    license("Apache-2.0")
+
+    version("main", branch="main")
+    version(
+        "4.21.0-202601121715",
+        tag="openshift-clients-4.21.0-202601121715",
+        commit="345800dc3c4164fbca313c1cbfb383f262547903",
+    )
+
+    variant("gssapi", default=False, description="Enable GSSAPI authentication support")
+
+    conflicts("+gssapi", when="platform=darwin os=tahoe")
+
+    depends_on("go@1.22.5:", type="build", when="@4.20:")
+
+    depends_on("gnupg")
+    depends_on("libassuan")
+
+    depends_on("krb5", when="+gssapi")
+
+    build_directory = "cmd/oc"
+    cgo_enable = True
+
+    @property
+    def build_args(self):
+        args = super().build_args
+        tags = ["include_gcs", "include_oss", "containers_image_openpgp"]
+
+        if self.spec.satisfies("+gssapi"):
+            tags.append("gssapi")
+
+        args.extend(["-tags", " ".join(tags)])
+        return args


### PR DESCRIPTION
This PR adds the OpenShift Client CLI tool (https://github.com/openshift/oc) as a new package.