### PR TITLE
raja: patch for 2024.02 versions to fix clang 19 error

### DIFF
--- a/repos/spack_repo/builtin/packages/raja/package.py
+++ b/repos/spack_repo/builtin/packages/raja/package.py
@@ -216,6 +216,8 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
         when="@2024.02.1:2024.02.99 %oneapi@2025:",
     )
 
+    patch("tile-iterator-comparison-fix-2024.02.patch", when="@2024.02.0:2024.02.2")
+
     variant("openmp", default=False, description="Build OpenMP backend")
     variant("shared", default=False, description="Build shared libs")
     variant("desul", default=False, description="Build desul atomics backend")

--- a/repos/spack_repo/builtin/packages/raja/tile-iterator-comparison-fix-2024.02.patch
+++ b/repos/spack_repo/builtin/packages/raja/tile-iterator-comparison-fix-2024.02.patch
@@ -1,0 +1,20 @@
+diff --git a/include/RAJA/pattern/kernel/Tile.hpp b/include/RAJA/pattern/kernel/Tile.hpp
+index 351c263..9b1d65d 100644
+--- a/include/RAJA/pattern/kernel/Tile.hpp
++++ b/include/RAJA/pattern/kernel/Tile.hpp
+@@ -169,13 +169,13 @@ struct IterableTiler {
+     }
+ 
+     RAJA_HOST_DEVICE
+-    RAJA_INLINE bool operator!=(const IterableTiler &rhs) const
++    RAJA_INLINE bool operator!=(const iterator &rhs) const
+     {
+       return block_id != rhs.block_id;
+     }
+ 
+     RAJA_HOST_DEVICE
+-    RAJA_INLINE bool operator<(const IterableTiler &rhs) const
++    RAJA_INLINE bool operator<(const iterator &rhs) const
+     {
+       return block_id < rhs.block_id;
+     }


### PR DESCRIPTION
 Adds a patch for Tile.hpp iterator comparison operators in 2024.02 versions, fixing build issue seen with clang 19.1.3 (`no member named 'block_id' in 'IterableTiler<Iterable>'`). Equivalent to later change in RAJA ([bc27528](https://github.com/llnl/RAJA/commit/bc27528e1a37600c5f2231978d02618225f83491)), which landed after the 2024.02 release series.

I tested 2024.02.0, 2024.02.1, and 2024.02.2 with clang 19.1.3 on RZHound.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
