### PR TITLE
Tensorflow: remove type_traits spec and correct xla arg on mac

### DIFF
--- a/repos/spack_repo/builtin/packages/py_tensorflow/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow/package.py
@@ -439,16 +439,11 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     conflicts("os=tahoe", when="@:2.19")
 
     # https://github.com/tensorflow/tensorflow/pull/98321
-    # type traits specs in TF are not allowed in libc++ 21+
-    # backport patch bringing tf into compliance to 2.20 for
-    # compilers supporting libc++21
-    for compiler_spec in ["%apple-clang@26:", "%clang@21:"]:
-        with default_args(when="@2.20"):
-            patch(
-                "https://github.com/tensorflow/tensorflow/commit/b9c263c3df2bb4926618a9c63e1dac45dc39c48a.patch?full_index=1",
-                sha256="275116b21eb27b86a5119ec69bfb7a5c1a5e8b6a7040d2272b65dbdbe997e8b4",
-                when=f"{compiler_spec}",
-            )
+    patch(
+        "https://github.com/tensorflow/tensorflow/commit/b9c263c3df2bb4926618a9c63e1dac45dc39c48a.patch?full_index=1",
+        sha256="275116b21eb27b86a5119ec69bfb7a5c1a5e8b6a7040d2272b65dbdbe997e8b4",
+        when="@2.20",
+    )
 
     # Fix build error with CUDA
     patch(

--- a/repos/spack_repo/builtin/packages/py_tensorflow/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow/package.py
@@ -418,7 +418,6 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     # wheel 0.40 upgrades vendored packaging, trips over tensorflow-io-gcs-filesystem identifier
     conflicts("^py-wheel@0.40:", when="@2.11:2.13")
 
-    conflicts("%gcc@15", when="@:2.19")
     # https://www.tensorflow.org/install/source#tested_build_configurations
     # https://github.com/tensorflow/tensorflow/issues/70199
     # (-mavx512fp16 exists in gcc@12:)
@@ -443,21 +442,13 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     # type traits specs in TF are not allowed in libc++ 21+
     # backport patch bringing tf into compliance to 2.20 for
     # compilers supporting libc++21
-    patch(
-        "https://github.com/tensorflow/tensorflow/commit/b9c263c3df2bb4926618a9c63e1dac45dc39c48a.patch?full_index=1",
-        sha256="275116b21eb27b86a5119ec69bfb7a5c1a5e8b6a7040d2272b65dbdbe997e8b4",
-        when="@2.20 +xla %gcc@15:",
-    )
-    patch(
-        "https://github.com/tensorflow/tensorflow/commit/b9c263c3df2bb4926618a9c63e1dac45dc39c48a.patch?full_index=1",
-        sha256="275116b21eb27b86a5119ec69bfb7a5c1a5e8b6a7040d2272b65dbdbe997e8b4",
-        when="@2.20 +xla %apple-clang@26:",
-    )
-    patch(
-        "https://github.com/tensorflow/tensorflow/commit/b9c263c3df2bb4926618a9c63e1dac45dc39c48a.patch?full_index=1",
-        sha256="275116b21eb27b86a5119ec69bfb7a5c1a5e8b6a7040d2272b65dbdbe997e8b4",
-        when="@2.20 +xla %llvm@20:",
-    )
+    for compiler_spec in ["%apple-clang@26:", "%clang@21:"]:
+        with default_args(when="@2.20 +xla"):
+            patch(
+                "https://github.com/tensorflow/tensorflow/commit/b9c263c3df2bb4926618a9c63e1dac45dc39c48a.patch?full_index=1",
+                sha256="275116b21eb27b86a5119ec69bfb7a5c1a5e8b6a7040d2272b65dbdbe997e8b4",
+                when=f"{compiler_spec}"
+            )
 
     # Fix build error with CUDA
     patch(

--- a/repos/spack_repo/builtin/packages/py_tensorflow/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow/package.py
@@ -870,8 +870,8 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
                 join = "="
                 build = "build "
             filter_file(
-                rf"{build}--define{join}with_xla_support=true",
-                rf"{build}--define{join}with_xla_support=false",
+                f"{build}--define{join}with_xla_support=true",
+                f"{build}--define{join}with_xla_support=false",
                 ".tf_configure.bazelrc",
             )
 

--- a/repos/spack_repo/builtin/packages/py_tensorflow/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow/package.py
@@ -439,25 +439,24 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     )
     conflicts("os=tahoe", when="@:2.19")
 
-    
     # https://github.com/tensorflow/tensorflow/pull/98321
     # type traits specs in TF are not allowed in libc++ 21+
-    # backport patch bringing tf into compliance to 2.20 for 
+    # backport patch bringing tf into compliance to 2.20 for
     # compilers supporting libc++21
     patch(
         "https://github.com/tensorflow/tensorflow/commit/b9c263c3df2bb4926618a9c63e1dac45dc39c48a.patch?full_index=1",
         sha256="275116b21eb27b86a5119ec69bfb7a5c1a5e8b6a7040d2272b65dbdbe997e8b4",
-        when="@2.20 +xla %gcc@15:"
+        when="@2.20 +xla %gcc@15:",
     )
     patch(
         "https://github.com/tensorflow/tensorflow/commit/b9c263c3df2bb4926618a9c63e1dac45dc39c48a.patch?full_index=1",
         sha256="275116b21eb27b86a5119ec69bfb7a5c1a5e8b6a7040d2272b65dbdbe997e8b4",
-        when="@2.20 +xla %apple-clang@26:"
+        when="@2.20 +xla %apple-clang@26:",
     )
     patch(
         "https://github.com/tensorflow/tensorflow/commit/b9c263c3df2bb4926618a9c63e1dac45dc39c48a.patch?full_index=1",
         sha256="275116b21eb27b86a5119ec69bfb7a5c1a5e8b6a7040d2272b65dbdbe997e8b4",
-        when="@2.20 +xla %llvm@20:"
+        when="@2.20 +xla %llvm@20:",
     )
 
     # Fix build error with CUDA
@@ -880,10 +879,10 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
                 join = "="
                 build = "build "
             filter_file(
-                    fr"{build}--define{join}with_xla_support=true",
-                    fr"{build}--define{join}with_xla_support=false",
-                    ".tf_configure.bazelrc",
-                )
+                rf"{build}--define{join}with_xla_support=true",
+                rf"{build}--define{join}with_xla_support=false",
+                ".tf_configure.bazelrc",
+            )
 
         if spec.satisfies("~android"):
             # env variable is somehow ignored -> brute force

--- a/repos/spack_repo/builtin/packages/py_tensorflow/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow/package.py
@@ -637,7 +637,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         if "+xla" in spec:
             env.set("TF_ENABLE_XLA", "1")
         else:
-            env.set("TF_ENABLE_XLA", "OFF")
+            env.set("TF_ENABLE_XLA", "0")
 
         # Do you wish to build TensorFlow with GDR support?
         if "+gdr" in spec:

--- a/repos/spack_repo/builtin/packages/py_tensorflow/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow/package.py
@@ -440,23 +440,23 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     conflicts("os=tahoe", when="@:2.19")
 
     
-    https://github.com/tensorflow/tensorflow/pull/98321
+    # https://github.com/tensorflow/tensorflow/pull/98321
     # type traits specs in TF are not allowed in libc++ 21+
     # backport patch bringing tf into compliance to 2.20 for 
     # compilers supporting libc++21
     patch(
         "https://github.com/tensorflow/tensorflow/commit/b9c263c3df2bb4926618a9c63e1dac45dc39c48a.patch?full_index=1",
-        sha256="",
+        sha256="275116b21eb27b86a5119ec69bfb7a5c1a5e8b6a7040d2272b65dbdbe997e8b4",
         when="@2.20 +xla %gcc@15:"
     )
     patch(
         "https://github.com/tensorflow/tensorflow/commit/b9c263c3df2bb4926618a9c63e1dac45dc39c48a.patch?full_index=1",
-        sha256="",
+        sha256="275116b21eb27b86a5119ec69bfb7a5c1a5e8b6a7040d2272b65dbdbe997e8b4",
         when="@2.20 +xla %apple-clang@26:"
     )
     patch(
         "https://github.com/tensorflow/tensorflow/commit/b9c263c3df2bb4926618a9c63e1dac45dc39c48a.patch?full_index=1",
-        sha256="",
+        sha256="275116b21eb27b86a5119ec69bfb7a5c1a5e8b6a7040d2272b65dbdbe997e8b4",
         when="@2.20 +xla %llvm@20:"
     )
 
@@ -637,7 +637,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         if "+xla" in spec:
             env.set("TF_ENABLE_XLA", "1")
         else:
-            env.set("TF_ENABLE_XLA", "0")
+            env.set("TF_ENABLE_XLA", "OFF")
 
         # Do you wish to build TensorFlow with GDR support?
         if "+gdr" in spec:

--- a/repos/spack_repo/builtin/packages/py_tensorflow/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow/package.py
@@ -418,6 +418,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     # wheel 0.40 upgrades vendored packaging, trips over tensorflow-io-gcs-filesystem identifier
     conflicts("^py-wheel@0.40:", when="@2.11:2.13")
 
+    conflicts("%gcc@15", when="@:2.19")
     # https://www.tensorflow.org/install/source#tested_build_configurations
     # https://github.com/tensorflow/tensorflow/issues/70199
     # (-mavx512fp16 exists in gcc@12:)
@@ -437,6 +438,27 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         when="@2.20",
     )
     conflicts("os=tahoe", when="@:2.19")
+
+    
+    https://github.com/tensorflow/tensorflow/pull/98321
+    # type traits specs in TF are not allowed in libc++ 21+
+    # backport patch bringing tf into compliance to 2.20 for 
+    # compilers supporting libc++21
+    patch(
+        "https://github.com/tensorflow/tensorflow/commit/b9c263c3df2bb4926618a9c63e1dac45dc39c48a.patch?full_index=1",
+        sha256="",
+        when="@2.20 +xla %gcc@15:"
+    )
+    patch(
+        "https://github.com/tensorflow/tensorflow/commit/b9c263c3df2bb4926618a9c63e1dac45dc39c48a.patch?full_index=1",
+        sha256="",
+        when="@2.20 +xla %apple-clang@26:"
+    )
+    patch(
+        "https://github.com/tensorflow/tensorflow/commit/b9c263c3df2bb4926618a9c63e1dac45dc39c48a.patch?full_index=1",
+        sha256="",
+        when="@2.20 +xla %llvm@20:"
+    )
 
     # Fix build error with CUDA
     patch(
@@ -851,11 +873,17 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
 
         # make sure xla is actually turned off
         if spec.satisfies("~xla"):
+            if spec.satisfies("@:2.19"):
+                join = " "
+                build = ""
+            else:
+                join = "="
+                build = "build "
             filter_file(
-                r"--define with_xla_support=true",
-                r"--define with_xla_support=false",
-                ".tf_configure.bazelrc",
-            )
+                    fr"{build}--define{join}with_xla_support=true",
+                    fr"{build}--define{join}with_xla_support=false",
+                    ".tf_configure.bazelrc",
+                )
 
         if spec.satisfies("~android"):
             # env variable is somehow ignored -> brute force

--- a/repos/spack_repo/builtin/packages/py_tensorflow/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow/package.py
@@ -447,7 +447,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
             patch(
                 "https://github.com/tensorflow/tensorflow/commit/b9c263c3df2bb4926618a9c63e1dac45dc39c48a.patch?full_index=1",
                 sha256="275116b21eb27b86a5119ec69bfb7a5c1a5e8b6a7040d2272b65dbdbe997e8b4",
-                when=f"{compiler_spec}"
+                when=f"{compiler_spec}",
             )
 
     # Fix build error with CUDA

--- a/repos/spack_repo/builtin/packages/py_tensorflow/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow/package.py
@@ -443,7 +443,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     # backport patch bringing tf into compliance to 2.20 for
     # compilers supporting libc++21
     for compiler_spec in ["%apple-clang@26:", "%clang@21:"]:
-        with default_args(when="@2.20 +xla"):
+        with default_args(when="@2.20"):
             patch(
                 "https://github.com/tensorflow/tensorflow/commit/b9c263c3df2bb4926618a9c63e1dac45dc39c48a.patch?full_index=1",
                 sha256="275116b21eb27b86a5119ec69bfb7a5c1a5e8b6a7040d2272b65dbdbe997e8b4",


### PR DESCRIPTION
Tensorflow's vendored XLA library has type_traits specifications that are not allowed by libc++21+.
Our recipe also did not properly prevent XLA being being turned on when disabled, fix that.