### PR TITLE
GoPackage: remove cgo_enabled attribute in favor of `%c`

### DIFF
--- a/repos/spack_repo/builtin/build_systems/go.py
+++ b/repos/spack_repo/builtin/build_systems/go.py
@@ -68,14 +68,10 @@ class GoBuilder(BuilderWithDefaults):
         "check_args",
         "build_directory",
         "install_time_test_callbacks",
-        "cgo_enabled",
     )
 
     #: Callback names for install-time test
     install_time_test_callbacks = ["check"]
-
-    # Enable or Disable CGO functionality in builds. (Disabled by default)
-    cgo_enabled = False
 
     @property
     def build_directory(self):
@@ -102,7 +98,9 @@ class GoBuilder(BuilderWithDefaults):
         return []
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        env.set("CGO_ENABLED", "1" if self.cgo_enabled else "0")
+        """Setup build environment variables"""
+        # Enable CGO functionality if a package directly depends on a C compiler
+        env.set("CGO_ENABLED", "1" if self.spec.satisfies("%c") else "0")
 
     def build(self, pkg: GoPackage, spec: Spec, prefix: Prefix) -> None:
         """Runs ``go build`` in the source directory"""

--- a/repos/spack_repo/builtin/packages/gocryptfs/package.py
+++ b/repos/spack_repo/builtin/packages/gocryptfs/package.py
@@ -30,5 +30,3 @@ class Gocryptfs(GoPackage):
 
     depends_on("openssl")
     depends_on("pkgconfig", type="build")
-
-    cgo_enabled = True

--- a/repos/spack_repo/builtin/packages/hugo/package.py
+++ b/repos/spack_repo/builtin/packages/hugo/package.py
@@ -40,6 +40,9 @@ class Hugo(GoPackage):
     version("0.107.0", sha256="31d959a3c1633087d338147782d03bdef65323b67ff3efcec7b40241413e270a")
     version("0.106.0", sha256="9219434beb51466487b9f8518edcbc671027c1998e5a5820d76d517e1dfbd96a")
 
+    depends_on("c", type="build", when="+extended")
+    depends_on("cxx", type="build", when="+extended")
+
     depends_on("go@1.24:", type="build", when="@0.149:")
     depends_on("go@1.23:", type="build", when="@0.144:")
     depends_on("go@1.22.6:", type="build", when="@0.133:")
@@ -47,8 +50,6 @@ class Hugo(GoPackage):
     depends_on("go@1.20:", type="build", when="@0.123:")
     depends_on("go@1.18:", type="build", when="@0.106:")
     depends_on("go@1.11:", type="build", when="@0.48:")
-    depends_on("c", type="build", when="+extended")
-    depends_on("cxx", type="build", when="+extended")
 
     variant("extended", default=False, description="Enable extended features")
 
@@ -59,13 +60,6 @@ class Hugo(GoPackage):
         output = Executable(exe)("version", output=str, error=str)
         match = re.search(r"Hugo Static Site Generator v(\S+)", output)
         return match.group(1) if match else None
-
-    @property
-    def cgo_enabled(self):
-        if self.spec.satisfies("+extended"):
-            return True
-        else:
-            return False
 
     @property
     def build_args(self):


### PR DESCRIPTION
A while back I'd added a `cgo_enabled` property to GoPackages to disable CGO functionality by default. 

I realized we could better model this by simply checking if the package directly depends on a C compiler to set the environment variable without adding yet another package attribute to maintain. This change should be backwards compatible since the previous attribute didn't imply a C dependency and all packages here correctly specified both.