### PR TITLE
py-html5lib: Fix build with python 3.14 and new setuptools

### DIFF
--- a/repos/spack_repo/builtin/packages/py_html5lib/package.py
+++ b/repos/spack_repo/builtin/packages/py_html5lib/package.py
@@ -19,6 +19,7 @@ class PyHtml5lib(PythonPackage):
     version("1.0.1", sha256="66cb0dcfdbbc4f9c3ba1a63fdb511ffdbd4f513b2b6d81b80cd26ce6b3fb3736")
     version("0.99", sha256="aff6fd3031c563883197e5a04b7df324086ff5f358278a0386808c463a077e59")
 
+    depends_on("python@:3.13", type=("build", "run"), when="@:0.99")
     depends_on("py-six", type=("build", "run"))
     depends_on("py-six@1.9:", type=("build", "run"), when="@1.0.1:")
     # pkg_resources removed from v81

--- a/repos/spack_repo/builtin/packages/py_html5lib/package.py
+++ b/repos/spack_repo/builtin/packages/py_html5lib/package.py
@@ -21,5 +21,10 @@ class PyHtml5lib(PythonPackage):
 
     depends_on("py-six", type=("build", "run"))
     depends_on("py-six@1.9:", type=("build", "run"), when="@1.0.1:")
-    depends_on("py-setuptools", type="build", when="@1.0.1:")
+    # pkg_resources removed from v81
+    depends_on("py-setuptools@:80", type="build", when="@1.0.1:")
     depends_on("py-webencodings", type=("build", "run"), when="@1.0.1:")
+
+    # ast.Str removed from 3.14
+    # (https://docs.python.org/dev/whatsnew/3.14.html#id9)
+    patch("py314astfix.patch", when="python@3.14:")

--- a/repos/spack_repo/builtin/packages/py_html5lib/package.py
+++ b/repos/spack_repo/builtin/packages/py_html5lib/package.py
@@ -27,4 +27,4 @@ class PyHtml5lib(PythonPackage):
 
     # ast.Str removed from 3.14
     # (https://docs.python.org/dev/whatsnew/3.14.html#id9)
-    patch("py314astfix.patch", when="python@3.14:")
+    patch("py314astfix.patch", when="^python@3.14:")

--- a/repos/spack_repo/builtin/packages/py_html5lib/package.py
+++ b/repos/spack_repo/builtin/packages/py_html5lib/package.py
@@ -27,4 +27,4 @@ class PyHtml5lib(PythonPackage):
 
     # ast.Str removed from 3.14
     # (https://docs.python.org/dev/whatsnew/3.14.html#id9)
-    patch("py314astfix.patch", when="^python@3.14:")
+    patch("py314astfix.patch", when="@1:1.1 ^python@3.14:")

--- a/repos/spack_repo/builtin/packages/py_html5lib/py314astfix.patch
+++ b/repos/spack_repo/builtin/packages/py_html5lib/py314astfix.patch
@@ -1,0 +1,13 @@
+--- a/setup.py	2020-06-22 23:23:02.000000000 +0000
++++ b/setup.py	2026-04-09 09:14:32.850544088 +0000
+@@ -90,8 +90,8 @@
+         if (len(a.targets) == 1 and
+                 isinstance(a.targets[0], ast.Name) and
+                 a.targets[0].id == "__version__" and
+-                isinstance(a.value, ast.Str)):
+-            version = a.value.s
++                isinstance(a.value, ast.Constant)):
++            version = a.value.value
+ 
+ setup(name='html5lib',
+       version=version,


### PR DESCRIPTION
Correct for incompatible newer setuptools and removed ast types