### PR TITLE
intel-tbb: modify gcc conflict

### DIFF
--- a/repos/spack_repo/builtin/packages/intel_tbb/package.py
+++ b/repos/spack_repo/builtin/packages/intel_tbb/package.py
@@ -139,7 +139,7 @@ class IntelTbb(CMakePackage, MakefilePackage):
 
     # Patch and conflicts for GCC 13 support (#1031).
     patch("gcc_13-2021-v2.patch", when="@2021.1:2021.9")
-    conflicts("%gcc@13", when="@:2021.3")
+    conflicts("%gcc@13:", when="@:2021.3")
 
     # Patch cmakeConfig.cmake.in to find the libraries where we install them.
     patch("tbb_cmakeConfig-2019.5.patch", level=0, when="@2019.5:2021.0")


### PR DESCRIPTION
The GCC restriction was meant for versions 13 and newer. This update ensures the restriction now applies correctly to GCC 13 and above for Intel TBB versions up to 2021.3, fixing a build error I was getting with GCC 14.