### PR TITLE
py-b2luigi: add v1.2.8; fix build system and license

### DIFF
--- a/repos/spack_repo/builtin/packages/py_b2luigi/package.py
+++ b/repos/spack_repo/builtin/packages/py_b2luigi/package.py
@@ -15,23 +15,28 @@ class PyB2luigi(PythonPackage):
 
     homepage = "https://github.com/belle2/b2luigi"
     pypi = "b2luigi/b2luigi-1.2.6.tar.gz"
+    git = "https://github.com/belle2/b2luigi.git"
 
-    license("GNU")
+    license("GPL-3.0")
 
     tags = ["hep"]
 
     # To be decided
     # maintainers("github_user1", "github_user2")
 
-    # We start at 1.2.6 as this was the change from retry2->tenacity dependency
+    version("1.2.8", sha256="a87a77ac84adfa1dd2e003756ae310a89ba00843e6074db9c2dc50cdac1d7c74")
     version("1.2.7", sha256="9f2622bb5f8f8645a0ef2546c3125164e3d5ab167c1e2519b1593e930733df40")
     version("1.2.6", sha256="9f3be756f0961ca2241d36d9a9174ea5a23ebd7787cbfa78632047aae25f1202")
+    # We start at 1.2.6 as this was the change from retry2->tenacity dependency
 
     depends_on("python@3.8:", type=("build", "run"))
-    depends_on("py-luigi@3.0.2:", type=("build", "run"))
-    depends_on("py-parse@1.8:", type=("build", "run"))
-    depends_on("py-gitpython@2.1.11:", type=("build", "run"))
-    depends_on("py-colorama@0.3.9:", type=("build", "run"))
-    depends_on("py-cachetools@2.1.1:", type=("build", "run"))
-    depends_on("py-jinja2", type=("build", "run"))
-    depends_on("py-tenacity@8", type=("build", "run"))
+    depends_on("py-flit", tpye="build")
+    with default_args(type=("build", "run")):
+        depends_on("py-luigi@3.0.2:")
+        depends_on("py-parse@1.8:")
+        depends_on("py-gitpython@2.1.11:")
+        depends_on("py-colorama@0.3.9:")
+        depends_on("py-cachetools@2.1.1:")
+        depends_on("py-jinja2")
+        depends_on("py-tenacity@8")
+        depends_on("py-webdavclient3@3.14.7:", when="@1.2.8:")

--- a/repos/spack_repo/builtin/packages/py_b2luigi/package.py
+++ b/repos/spack_repo/builtin/packages/py_b2luigi/package.py
@@ -17,7 +17,7 @@ class PyB2luigi(PythonPackage):
     pypi = "b2luigi/b2luigi-1.2.6.tar.gz"
     git = "https://github.com/belle2/b2luigi.git"
 
-    license("GPL-3.0")
+    license("GPL-3.0", checked_by="wdconinc")
 
     tags = ["hep"]
 

--- a/repos/spack_repo/builtin/packages/py_b2luigi/package.py
+++ b/repos/spack_repo/builtin/packages/py_b2luigi/package.py
@@ -30,7 +30,7 @@ class PyB2luigi(PythonPackage):
     # We start at 1.2.6 as this was the change from retry2->tenacity dependency
 
     depends_on("python@3.8:", type=("build", "run"))
-    depends_on("py-flit", tpye="build")
+    depends_on("py-flit", type="build")
     with default_args(type=("build", "run")):
         depends_on("py-luigi@3.0.2:")
         depends_on("py-parse@1.8:")

--- a/repos/spack_repo/builtin/packages/py_webdavclient3/package.py
+++ b/repos/spack_repo/builtin/packages/py_webdavclient3/package.py
@@ -1,0 +1,32 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyWebdavclient3(PythonPackage):
+    """WebDAV client, based on original package
+    https://github.com/designerror/webdav-client-python
+    but uses requests instead of PyCURL."""
+
+    homepage = "https://github.com/ezhov-evgeny/webdav-client-python-3"
+    pypi = "webdavclient3/webdavclient3-3.14.7.tar.gz"
+    git = "https://github.com/ezhov-evgeny/webdav-client-python-3.git"
+
+    maintainers("wdconinc")
+
+    license("MIT", checked_by="wdconinc")
+
+    version("3.14.7", sha256="6c04252b579bc015cec78081480c63eadf1030f382768248777c6203f059b3f5")
+
+    with default_args(type="build"):
+        depends_on("py-setuptools")
+        depends_on("py-wheel")
+
+    with default_args(type=("build", "run")):
+        depends_on("py-requests")
+        depends_on("py-lxml")
+        depends_on("py-python-dateutil")


### PR DESCRIPTION
This PR adds to `py-b2luigi` the version 1.2.8 ([release notes](https://github.com/belle2/b2luigi/releases/tag/v1.2.8), [diff](https://github.com/belle2/b2luigi/compare/v1.2.7...v1.2.8)). Package was missing py-flit as build system, and a new webdavclient3 dependency was added. Corrected spdx to GPL-3.0 license.

New `py-webdavclient3` package added to satisfy new dependency.

Test builds:
```
[+] os4sknv py-webdavclient3@3.14.7 /opt/software/linux-skylake/py-webdavclient3-3.14.7-os4sknvbwgvr46e3ilmrqstr4d2kjmdc (4s)
[+] epgupf5 py-b2luigi@1.2.8 /opt/software/linux-skylake/py-b2luigi-1.2.8-epgupf54x7ctxewtp6ne5kyuueyxg6om (3s)
```