### PR TITLE
root: add builtin_llvm variant to allow external LLVM

### DIFF
--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -299,6 +299,11 @@ class Root(CMakePackage):
     variant("x", default=(not _is_macos), description="Enable set of graphical options")
     variant("xml", default=True, description="Enable XML parser interface")
     variant("xrootd", default=False, description="Build xrootd file server and its client")
+    variant(
+        "builtin_llvm",
+        default=True,
+        description="Use ROOT's bundled copy of LLVM (and Clang)",
+    )
 
     # ###################### Compiler variants ########################
 
@@ -415,6 +420,12 @@ class Root(CMakePackage):
     depends_on("libxml2", when="+xml")
     depends_on("xrootd", when="+xrootd")
 
+    # External LLVM (used when ~builtin_llvm).  ROOT bundles its own patched Clang
+    # (interpreter/llvm-project/clang) and builds it against the external LLVM, so
+    # vanilla LLVM is sufficient here.  ROOT's patches to llvm-project only touch
+    # clang/, not the LLVM core.  LLVM must be built with RTTI enabled.
+    depends_on("llvm@20.1.0:20.1 +rtti", when="@6.36: ~builtin_llvm")
+
     depends_on("googletest", when="@6.28.00:", type="test")
 
     # ###################### Conflicts ######################
@@ -422,6 +433,22 @@ class Root(CMakePackage):
     # I was unable to build root with any Intel compiler
     # See https://sft.its.cern.ch/jira/browse/ROOT-7517
     conflicts("%intel")
+
+    # External LLVM is only supported for ROOT 6.36+ (requires LLVM 20.1.x).
+    # Older ROOT versions have different LLVM major requirements that have not
+    # been mapped to spack dependencies yet.
+    conflicts(
+        "~builtin_llvm",
+        when="@:6.35",
+        msg="External LLVM is only supported for ROOT 6.36+ in this spack recipe",
+    )
+    # In order to avoid adding newer versions with incorrect LLVM versions,
+    # newer versions are explicitly added as conflicts as well.
+    conflicts(
+        "~builtin_llvm",
+        when="@6.39:",
+        msg="External LLVM support for ROOT 6.39+ has not been validated",
+    )
 
     # GCC 15 support was added in 6.34.04
     conflicts("%gcc@15:", when="@:6.34.02")
@@ -626,6 +653,7 @@ class Root(CMakePackage):
         options += [
             define("builtin_cfitsio", False),
             define("builtin_civetweb", False),
+            define("builtin_clang", True),  # use builtin_clang even when ~builtin_llvm
             define("builtin_davix", False),
             define("builtin_fftw3", False),
             define("builtin_freetype", False),
@@ -634,7 +662,7 @@ class Root(CMakePackage):
             define("builtin_gl2ps", False),
             define("builtin_glew", False),
             define("builtin_gsl", False),
-            define("builtin_llvm", True),
+            define_from_variant("builtin_llvm"),
             define("builtin_lz4", False),
             define("builtin_lzma", False),
             define("builtin_nlohmannjson", False),

--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -302,7 +302,7 @@ class Root(CMakePackage):
     variant(
         "builtin_llvm",
         default=True,
-        description="Use ROOT's bundled copy of LLVM (and Clang)",
+        description="Use ROOT's bundled copy of LLVM (but bundled clang is always used)",
     )
 
     # ###################### Compiler variants ########################
@@ -423,8 +423,8 @@ class Root(CMakePackage):
     # External LLVM (used when ~builtin_llvm).  ROOT bundles its own patched Clang
     # (interpreter/llvm-project/clang) and builds it against the external LLVM, so
     # vanilla LLVM is sufficient here.  ROOT's patches to llvm-project only touch
-    # clang/, not the LLVM core.  LLVM must be built with RTTI enabled.
-    depends_on("llvm@20.1.0:20.1 +rtti", when="@6.36: ~builtin_llvm")
+    # clang/, not the LLVM core.
+    depends_on("llvm@20.1.0:20.1", when="@6.36: ~builtin_llvm")
 
     depends_on("googletest", when="@6.28.00:", type="test")
 


### PR DESCRIPTION
This PR adds to `root` a user-settable `builtin_llvm` variant (default: true for backward compatibility).  When set to false, ROOT links against an external `llvm@20.1.0:20.1` package instead of building its own bundled copy.

ROOT's patches to llvm-project only touch `clang/` (65 files, zero in `llvm/` core), so vanilla LLVM is sufficient for this case.  ROOT still builds its own patched Clang from the bundled interpreter/llvm-project/clang sources (and `builtin_clang=ON` remains explicitly enforced), which is required because vanilla Clang cannot be used with ROOT.

External LLVM is gated to ROOT 6.36 to 6.38 where the required LLVM major version (20.1.x) is known.  A conflict is added to prevent `~builtin_llvm` on older and newer ROOT versions.