### PR TITLE
libfuse: force autoreconf due to patches

### DIFF
--- a/repos/spack_repo/builtin/packages/libfuse/package.py
+++ b/repos/spack_repo/builtin/packages/libfuse/package.py
@@ -147,6 +147,9 @@ class MesonBuilder(meson.MesonBuilder):
 
 
 class AutotoolsBuilder(autotools.AutotoolsBuilder):
+    # patches that change configure.ac require this
+    force_autoreconf = True
+
     def configure_args(self):
         args = [
             "MOUNT_FUSE_PATH={0}".format(self.prefix.sbin),


### PR DESCRIPTION
This showed up on LLNL systems. Without this it will complain about aclocal-15 not being available. This gets triggered because the patching of `configure.ac` changes the timestamp.