### PR TITLE
py-certifi: add v2026.2.25

### DIFF
--- a/repos/spack_repo/builtin/packages/py_certifi/package.py
+++ b/repos/spack_repo/builtin/packages/py_certifi/package.py
@@ -17,6 +17,7 @@ class PyCertifi(PythonPackage):
 
     license("MPL-2.0")
 
+    version("2026.2.25", sha256="e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7")
     version("2026.1.4", sha256="ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120")
     version("2025.7.14", sha256="8ea99dbdfaaf2ba2f9bac77b9249ef62ec5218e7c2b2e903378ed5fccf765995")
     version("2025.4.26", sha256="0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6")


### PR DESCRIPTION
https://github.com/certifi/python-certifi/releases/tag/2026.02.25
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
