### PR TITLE
asio: Add 1.38.0

### DIFF
--- a/repos/spack_repo/builtin/packages/asio/package.py
+++ b/repos/spack_repo/builtin/packages/asio/package.py
@@ -20,6 +20,7 @@ class Asio(AutotoolsPackage):
     license("BSL-1.0")
 
     # As uneven minor versions of asio are not considered stable, they wont be added anymore
+    version("1.38.0", sha256="5cf78ede456fd13b95fe692711f4f689be26c826f1f5541c7a1df3aa32bd9dbd")
     version("1.36.0", sha256="0310a76b27e1854f09f696b30de57dc490b5e1b17faed1eb8c9a2891f956e52b")
     version("1.34.2", sha256="f3bac015305fbb700545bd2959fbc52d75a1ec2e05f9c7f695801273ceb78cf5")
     version("1.34.0", sha256="061ed6c8b97527756aed3e34d2cbcbcb6d3c80afd26ed6304f51119e1ef6a1cd")
@@ -100,4 +101,7 @@ class Asio(AutotoolsPackage):
 
     @property
     def configure_directory(self):
-        return os.path.join(self.stage.source_path, "asio")
+        if self.spec.satisfies("@1.38:"):
+            return self.stage.source_path
+        else:
+            return os.path.join(self.stage.source_path, "asio")


### PR DESCRIPTION
All the contents of the `asio` subdirectory (which contained e.g. `configure.ac`) were lifted up to the root in 1.38.0, so the configure directory is now the more conventional repository root.