### PR TITLE
aws-ofi-nccl: Fix extend call with `+cuda`

### DIFF
--- a/repos/spack_repo/builtin/packages/aws_ofi_nccl/package.py
+++ b/repos/spack_repo/builtin/packages/aws_ofi_nccl/package.py
@@ -102,8 +102,10 @@ class AwsOfiNccl(AutotoolsPackage):
         )
         if spec.satisfies("+cuda"):
             args.extend(
-                "--with-cuda={0}".format(spec["cuda"].prefix),
-                "--with-nccl={0}".format(spec["nccl"].prefix),
+                [
+                    "--with-cuda={0}".format(spec["cuda"].prefix),
+                    "--with-nccl={0}".format(spec["nccl"].prefix),
+                ]
             )
         if spec.satisfies("+rocm"):
             args.extend(["--with-rocm={0}".format(spec["hip"].prefix)])


### PR DESCRIPTION
In https://github.com/spack/spack-packages/pull/3885 I managed to mess up the `extend` call in the cuda branch. `extend` only takes one argument (iterable) while I was passing it two arguments. This fixes it to pass a list of arguments instead (as is done elsewhere with `extend` in the package).