### PR TITLE
MPICH: add v5.0.1

### DIFF
--- a/repos/spack_repo/builtin/packages/mpich/package.py
+++ b/repos/spack_repo/builtin/packages/mpich/package.py
@@ -79,6 +79,7 @@ class Mpich(MpichEnvironmentModifications, AutotoolsPackage, CudaPackage, ROCmPa
     license("mpich2")
 
     version("develop", submodules=True)
+    version("5.0.1", sha256="8c1832a13ddacf071685069f5fadfd1f2877a29e1a628652892c65211b1f3327")
     version("5.0.0", sha256="e9350e32224283e95311f22134f36c98e3cd1c665d17fae20a6cc92ed3cffe11")
     version("4.3.2", sha256="47d774587a7156a53752218c811c852e70ac44db9c502dc3f399b4cb817e3818")
     version("4.3.1", sha256="acc11cb2bdc69678dc8bba747c24a28233c58596f81f03785bf2b7bb7a0ef7dc")


### PR DESCRIPTION
For https://github.com/pmodels/mpich/issues/7753.
Following up to the [latest release](https://github.com/pmodels/mpich/releases/tag/v5.0.1).
