### PR TITLE
openmpi: --disable-dependency-tracking

### DIFF
--- a/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -1147,7 +1147,12 @@ with '-Wl,-commons,use_dylibs' and without
 
     def configure_args(self):
         spec = self.spec
-        config_args = ["--enable-shared", "--disable-silent-rules", "--disable-sphinx"]
+        config_args = [
+            "--enable-shared",
+            "--disable-silent-rules",
+            "--disable-sphinx",
+            "--disable-dependency-tracking",
+        ]
 
         # Work around incompatibility with new apple-clang linker
         # https://github.com/open-mpi/ompi/issues/12427


### PR DESCRIPTION
With dependency tracking enabled, make parses about a million
lines of dependency info generated by configure. The overhead
of this for the build is about 30% on my macbook. (edit: on my
desktop with tmpfs it's just 10%)

Enabling dependency tracking is only relevant if you're developing
openmpi. In case people do that, they can conditionally add the flag,
like `if not spec.satisfies("dev_path=*"): args.append("...")`, but I
don't think that's used right now.

