### PR TITLE
awscli-v2: relax dependencies to support newer cryptography

### DIFF
--- a/repos/spack_repo/builtin/packages/awscli_v2/package.py
+++ b/repos/spack_repo/builtin/packages/awscli_v2/package.py
@@ -32,7 +32,8 @@ class AwscliV2(PythonPackage):
         depends_on("py-colorama@0.2.5:0.4.6")
         # Upper bound relaxed for Sphinx compatibility
         depends_on("py-docutils@0.10:")
-        depends_on("py-cryptography@40:43.0.1", when="@2.22:")
+        # Upper bound relaxed to avoid CVEs
+        depends_on("py-cryptography@40:", when="@2.22:")
         depends_on("py-cryptography@3.3.2:40.0.1", when="@:2.15")
         depends_on("py-ruamel-yaml@0.15:")
         # Upper bound relaxed for Python 3.14 support


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Starting to feel like a broken record. Perhaps we could remove upper bounds on all deps, they don't seem useful.