### PR TITLE
py-sphinxcontrib-bibtex: add v2.6.5

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pybtex/package.py
+++ b/repos/spack_repo/builtin/packages/py_pybtex/package.py
@@ -17,6 +17,7 @@ class PyPybtex(PythonPackage):
 
     license("MIT")
 
+    version("0.26.1", sha256="2e5543bea424e60e9e42eef70bff597be48649d8f68ba061a7a092b2477d5464")
     version("0.24.0", sha256="818eae35b61733e5c007c3fcd2cfb75ed1bc8b4173c1f70b56cc4c0802d34755")
     version("0.21", sha256="af8a6c7c74954ad305553b118d2757f68bc77c5dd5d5de2cc1fd16db90046000")
 

--- a/repos/spack_repo/builtin/packages/py_sphinxcontrib_bibtex/package.py
+++ b/repos/spack_repo/builtin/packages/py_sphinxcontrib_bibtex/package.py
@@ -12,6 +12,7 @@ class PySphinxcontribBibtex(PythonPackage):
 
     pypi = "sphinxcontrib-bibtex/sphinxcontrib-bibtex-0.3.5.tar.gz"
 
+    version("2.6.5", sha256="9b3224dd6fece9268ebd8c905dc0a83ff2f6c54148a9235fe70e9d1e9ff149c0")
     version("2.5.0", sha256="71b42e5db0e2e284f243875326bf9936aa9a763282277d75048826fef5b00eaa")
     version("2.4.2", sha256="65b023ee47f35f1f03ac4d71c824e67c624c7ecac1bb26e83623271a01f9da86")
     version("2.2.1", sha256="00d474092e04b1d941e645cf6c027632a975cd0b9337cf47d379f63a5928f334")
@@ -28,6 +29,7 @@ class PySphinxcontribBibtex(PythonPackage):
     depends_on("py-pybtex@0.17:", type=("build", "run"), when="@:1")
     depends_on("py-pybtex@0.20:", type=("build", "run"), when="@2:2.3")
     depends_on("py-pybtex@0.24:", type=("build", "run"), when="@2.4:")
+    depends_on("py-pybtex@0.25:", type=("build", "run"), when="@2.6.5:")
     depends_on("py-pybtex-docutils@0.2.0:", type=("build", "run"), when="@:1")
     depends_on("py-pybtex-docutils@0.2.2:", type=("build", "run"), when="@2:")
     depends_on("py-pybtex-docutils@1.0.0:", type=("build", "run"), when="@2.2:")
@@ -35,6 +37,17 @@ class PySphinxcontribBibtex(PythonPackage):
     depends_on("py-sphinx@1.0:", type=("build", "run"), when="@:1")
     depends_on("py-sphinx@2.0:", type=("build", "run"), when="@2.0.0:")
     depends_on("py-sphinx@2.1:", type=("build", "run"), when="@2.1.3:")
+    depends_on("py-sphinx@3.5:", type=("build", "run"), when="@2.6.5:")
     depends_on("py-oset@0.1.3:", type=("build", "run"), when="@:2.0.0")
     depends_on("py-docutils@0.8:", type=("build", "run"), when="@2.1.0:")
     depends_on("py-importlib-metadata@3.6:", when="@2.5.0: ^python@:3.9", type=("build", "run"))
+
+    conflicts("^py-docutils@0.18:0.19", when="@2.6.5")
+
+    def url_for_version(self, version):
+        url = "https://pypi.org/packages/source/s/sphinxcontrib-bibtex/sphinxcontrib{}bibtex-{}.tar.gz"
+        if version < Version("2.6.3"):
+            separator = "-"
+        else:
+            separator = "_"
+        return url.format(separator, version)


### PR DESCRIPTION
I bumped the compat bounds where applicable.

Actually, maybe I have should have bumped the compat bound of py-pybtex-docutils to `1.0.2:`, per https://github.com/mcmtroffaes/pybtex-docutils/issues/26 but I opted not too, since in the 2.6.5 release, `pyproject.toml` lists 1.0.0 as the lower bound, and I felt it could be confusing to have differing bounds. As soon as [2.6.6 is released](https://github.com/mcmtroffaes/sphinxcontrib-bibtex/blob/603d5ecbafa439eb4ee75d630b9f9094f2bd7221/CHANGELOG.rst), this will of course change.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->