### PR TITLE
Updated packages: furo (2025.12.19) and py-accessible-pygments (0.0.5)

### DIFF
--- a/repos/spack_repo/builtin/packages/py_accessible_pygments/package.py
+++ b/repos/spack_repo/builtin/packages/py_accessible_pygments/package.py
@@ -16,7 +16,19 @@ class PyAccessiblePygments(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.0.5", sha256="40918d3e6a2b619ad424cb91e556bd3bd8865443d9f22f1dcdf79e33c8046872")
     version("0.0.4", sha256="e7b57a9b15958e9601c7e9eb07a440c813283545a20973f2574a5f453d0e953e")
 
+    depends_on("python@3.9:", type=("build", "run"), when="@0.0.5:")
     depends_on("py-pygments@1.5:", type=("build", "run"))
     depends_on("py-setuptools", type=("build"))
+
+    def url_for_version(self, version):
+        url = (
+            "https://pypi.org/packages/source/a/accessible-pygments/accessible{}pygments-{}.tar.gz"
+        )
+        if version < Version("0.0.5"):
+            separator = "-"
+        else:
+            separator = "_"
+        return url.format(separator, version)

--- a/repos/spack_repo/builtin/packages/py_furo/package.py
+++ b/repos/spack_repo/builtin/packages/py_furo/package.py
@@ -15,6 +15,9 @@ class PyFuro(PythonPackage):
 
     license("MIT")
 
+    version(
+        "2025.12.19", sha256="188d1f942037d8b37cd3985b955839fea62baa1730087dc29d157677c857e2a7"
+    )
     version("2024.7.18", sha256="37b08c5fccc95d46d8712c8be97acd46043963895edde05b0f4f135d58325c83")
     version("2024.5.6", sha256="81f205a6605ebccbb883350432b4831c0196dd3d1bc92f61e1f459045b3d2b0b")
     version("2024.4.27", sha256="15a9b65269038def2cefafb86c71c6616e3969b8f07ba231f588c10c4aee6d88")
@@ -26,5 +29,7 @@ class PyFuro(PythonPackage):
 
     depends_on("py-beautifulsoup4", type=("build", "run"))
     depends_on("py-sphinx@6:7", type=("build", "run"))
+    depends_on("py-sphinx@7:10", type=("build", "run"), when="@2025.12.19:")
     depends_on("py-sphinx-basic-ng@1.0.0b2:", type=("build", "run"))
     depends_on("py-pygments@2.7:", type=("build", "run"))
+    depends_on("py-accessible-pygments@0.0.5:", type=("build", "run"), when="@2025.07.19:")


### PR DESCRIPTION
I opted to update py-accessible-pygments as well, since the new version of furo depends on it. Please let me know if you prefer the commits to be split over two PRs instead.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->