### PR TITLE
py-hatch-nodejs-version: add v0.4.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_hatch_nodejs_version/package.py
+++ b/repos/spack_repo/builtin/packages/py_hatch_nodejs_version/package.py
@@ -15,8 +15,12 @@ class PyHatchNodejsVersion(PythonPackage):
 
     license("MIT")
 
+    version("0.4.0", sha256="2428ea398dd053f019d2b7ac949dd6b690ca8e826b6d433ad13c5b6c475ae91b")
     version("0.3.2", sha256="8a7828d817b71e50bbbbb01c9bfc0b329657b7900c56846489b9c958de15b54c")
     version("0.3.1", sha256="0e55fd713d92c5c1ccfee778efecaa780fd8bcd276d4ca7aff9f6791f6f76d9c")
 
-    depends_on("python@3.7:", type=("build", "run"))
-    depends_on("py-hatchling@0.21:", type=("build", "run"))
+    with default_args(type=("build", "run")):
+        depends_on("python@3.9:", when="@4:")
+        depends_on("python@3.7:")
+
+        depends_on("py-hatchling@0.21:")

--- a/repos/spack_repo/builtin/packages/py_hatch_nodejs_version/package.py
+++ b/repos/spack_repo/builtin/packages/py_hatch_nodejs_version/package.py
@@ -20,7 +20,7 @@ class PyHatchNodejsVersion(PythonPackage):
     version("0.3.1", sha256="0e55fd713d92c5c1ccfee778efecaa780fd8bcd276d4ca7aff9f6791f6f76d9c")
 
     with default_args(type=("build", "run")):
-        depends_on("python@3.9:", when="@4:")
+        depends_on("python@3.9:", when="@0.4:")
         depends_on("python@3.7:")
 
         depends_on("py-hatchling@0.21:")


### PR DESCRIPTION
https://github.com/jupyterlab/hatch-nodejs-version/releases/tag/v0.4.0
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
