### PR TITLE
gperf: skip broken gnulib conftest when building with oneapi

### DIFF
--- a/repos/spack_repo/builtin/packages/gperf/package.py
+++ b/repos/spack_repo/builtin/packages/gperf/package.py
@@ -40,7 +40,9 @@ class Gperf(AutotoolsPackage, GNUMirrorPackage):
         # Intel oneAPI icx incorrectly marks glibc's error() as noreturn,
         # causing the gnulib gl_cv_func_working_error configure test to
         # infinite-loop and consume unbounded memory.
-        if self.spec.satisfies("%oneapi"):
+        # Fix available in icx 2026, but this workaround is needed for all versions of icx up to 2025.
+        # https://community.intel.com/t5/Intel-oneAPI-DPC-C-Compiler/All-versions-of-icx-miscompile-error-0-resulting-in-segfaults/m-p/1744208
+        if self.spec.satisfies("%oneapi@:2025"):
             args.append("gl_cv_func_working_error=yes")
 
         return args

--- a/repos/spack_repo/builtin/packages/gperf/package.py
+++ b/repos/spack_repo/builtin/packages/gperf/package.py
@@ -34,4 +34,15 @@ class Gperf(AutotoolsPackage, GNUMirrorPackage):
     # This has no impact on correctness.
     patch("register.patch", when="@:3.1")
 
+    def configure_args(self):
+        args = []
+
+        # Intel oneAPI icx incorrectly marks glibc's error() as noreturn,
+        # causing the gnulib gl_cv_func_working_error configure test to
+        # infinite-loop and consume unbounded memory.
+        if self.spec.satisfies("%oneapi"):
+            args.append("gl_cv_func_working_error=yes")
+
+        return args
+
     # NOTE: `make check` is known to fail tests

--- a/repos/spack_repo/builtin/packages/gperf/package.py
+++ b/repos/spack_repo/builtin/packages/gperf/package.py
@@ -40,9 +40,12 @@ class Gperf(AutotoolsPackage, GNUMirrorPackage):
         # Intel oneAPI icx incorrectly marks glibc's error() as noreturn,
         # causing the gnulib gl_cv_func_working_error configure test to
         # infinite-loop and consume unbounded memory.
-        # Fix available in icx 2026, but this workaround is needed for all versions of icx up to 2025.
+        # Fix available in icx 2026, but this workaround is needed for
+        # all versions of icx up to 2025.
         # https://community.intel.com/t5/Intel-oneAPI-DPC-C-Compiler/All-versions-of-icx-miscompile-error-0-resulting-in-segfaults/m-p/1744208
-        if self.spec.satisfies("%oneapi@:2025"):
+        if self.spec.satisfies(
+            "%oneapi@:2025"
+        ):
             args.append("gl_cv_func_working_error=yes")
 
         return args

--- a/repos/spack_repo/builtin/packages/gperf/package.py
+++ b/repos/spack_repo/builtin/packages/gperf/package.py
@@ -43,9 +43,7 @@ class Gperf(AutotoolsPackage, GNUMirrorPackage):
         # Fix available in icx 2026, but this workaround is needed for
         # all versions of icx up to 2025.
         # https://community.intel.com/t5/Intel-oneAPI-DPC-C-Compiler/All-versions-of-icx-miscompile-error-0-resulting-in-segfaults/m-p/1744208
-        if self.spec.satisfies(
-            "%oneapi@:2025"
-        ):
+        if self.spec.satisfies("%oneapi@:2025"):
             args.append("gl_cv_func_working_error=yes")
 
         return args


### PR DESCRIPTION
 **Change:** Add `configure_args()` that passes `gl_cv_func_working_error=yes` for `%oneapi`.

 **What happens:** Configure hangs forever, eating RAM until OOM kill.

 **Why:** icx has a bug where it unconditionally marks glibc's `error()` as `noreturn`. In reality, `error(status, ...)` only exits when `status != 0`. The gnulib conftest calls `error(0, 0, "foo")` expecting it to return. icx optimizes away the return path at `-O2`, so the program falls off the end of `main()` into an infinite loop.

 **Fix rationale:** Setting the cache variable skips the runtime test. The answer `yes` is correct — glibc's `error()` works fine, it's purely an icx misoptimization. Same pattern already used in libiconv for an NVHPC workaround (`gl_cv_cc_wallow=none`).


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
