### PR TITLE
libiconv: skip broken gnulib conftest when building with oneapi

### DIFF
--- a/repos/spack_repo/builtin/packages/libiconv/package.py
+++ b/repos/spack_repo/builtin/packages/libiconv/package.py
@@ -66,6 +66,12 @@ class Libiconv(AutotoolsPackage, GNUMirrorPackage):
         if self.spec.satisfies("@1.17:%nvhpc"):
             args.append("gl_cv_cc_wallow=none")
 
+        # Intel oneAPI icx incorrectly marks glibc's error() as noreturn,
+        # causing the gnulib gl_cv_func_working_error configure test to
+        # infinite-loop and consume unbounded memory.
+        if self.spec.satisfies("%oneapi"):
+            args.append("gl_cv_func_working_error=yes")
+
         # A hack to patch config.guess in the libcharset sub directory
         copy("./build-aux/config.guess", "libcharset/build-aux/config.guess")
         return args

--- a/repos/spack_repo/builtin/packages/libiconv/package.py
+++ b/repos/spack_repo/builtin/packages/libiconv/package.py
@@ -69,7 +69,9 @@ class Libiconv(AutotoolsPackage, GNUMirrorPackage):
         # Intel oneAPI icx incorrectly marks glibc's error() as noreturn,
         # causing the gnulib gl_cv_func_working_error configure test to
         # infinite-loop and consume unbounded memory.
-        if self.spec.satisfies("%oneapi"):
+        # Fix available in icx 2026, but this workaround is needed for all versions of icx up to 2025.
+        # https://community.intel.com/t5/Intel-oneAPI-DPC-C-Compiler/All-versions-of-icx-miscompile-error-0-resulting-in-segfaults/m-p/1744208
+        if self.spec.satisfies("%oneapi@:2025"):
             args.append("gl_cv_func_working_error=yes")
 
         # A hack to patch config.guess in the libcharset sub directory

--- a/repos/spack_repo/builtin/packages/libiconv/package.py
+++ b/repos/spack_repo/builtin/packages/libiconv/package.py
@@ -69,7 +69,8 @@ class Libiconv(AutotoolsPackage, GNUMirrorPackage):
         # Intel oneAPI icx incorrectly marks glibc's error() as noreturn,
         # causing the gnulib gl_cv_func_working_error configure test to
         # infinite-loop and consume unbounded memory.
-        # Fix available in icx 2026, but this workaround is needed for all versions of icx up to 2025.
+        # Fix available in icx 2026, but this workaround is needed for
+        # all versions of icx up to 2025.
         # https://community.intel.com/t5/Intel-oneAPI-DPC-C-Compiler/All-versions-of-icx-miscompile-error-0-resulting-in-segfaults/m-p/1744208
         if self.spec.satisfies("%oneapi@:2025"):
             args.append("gl_cv_func_working_error=yes")


### PR DESCRIPTION
**Change:** Add `gl_cv_func_working_error=yes` to `configure_args()` for `%oneapi`.
**What happens:** Configure hangs forever, eating RAM until OOM kill.

Same issue as https://github.com/spack/spack-packages/pull/4256

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
