### PR TITLE
pbzip2: include oneapi in reserved-user-defined-literal workaround

### DIFF
--- a/repos/spack_repo/builtin/packages/pbzip2/package.py
+++ b/repos/spack_repo/builtin/packages/pbzip2/package.py
@@ -32,6 +32,14 @@ class Pbzip2(MakefilePackage):
 
     def flag_handler(self, name: str, flags: List[str]):
         if name == "cxxflags":
-            if self.spec.satisfies("%cxx=clang") or self.spec.satisfies("%cxx=apple-clang"):
+            # pbzip2 uses C99 PRIuMAX macros without the C++11-required space
+            # between the string literal and the macro (e.g., "%"PRIuMAX).
+            # Clang-based compilers (including Intel oneAPI icpx) treat this
+            # as an error. Suppress it since the code is functionally correct.
+            if (
+                self.spec.satisfies("%cxx=clang")
+                or self.spec.satisfies("%cxx=apple-clang")
+                or self.spec.satisfies("%cxx=oneapi")
+            ):
                 flags.append("-Wno-reserved-user-defined-literal")
         return (flags, None, None)


### PR DESCRIPTION
**Change:** Add `or self.spec.satisfies("%cxx=oneapi")` to the existing `flag_handler` condition.

**What happens:** 6 compile errors from `"%"PRIuMAX` patterns (26 occurrences) — C++11 requires a space between the string
literal and the macro.

The package already suppresses this for `%cxx=clang` and `%cxx=apple-clang` with `-Wno-reserved-user-defined-literal`. oneAPI icpx is clang-based and needs the same flag, but wasn't included.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
