### PR TITLE
relion: make py-relion and ghostscript optional via variants

### DIFF
--- a/repos/spack_repo/builtin/packages/relion/package.py
+++ b/repos/spack_repo/builtin/packages/relion/package.py
@@ -44,6 +44,12 @@ class Relion(CMakePackage, CudaPackage):
     variant("cuda", default=True, description="enable compute on gpu")
     variant("double", default=True, description="double precision (cpu) code")
     variant("double-gpu", default=False, description="double precision gpu")
+    variant(
+        "python",
+        default=True,
+        description="Include py-relion Python tools (torch, napari, etc.)",
+        when="@5:",
+    )
 
     # if built with purpose=cluster then relion will link to gpfs libraries
     # if that's not desirable then use purpose=desktop
@@ -79,6 +85,12 @@ class Relion(CMakePackage, CudaPackage):
         default=False,
         description="Have external motioncor2 available in addition to Relion builtin",
     )
+    variant(
+        "ghostscript",
+        default=True,
+        description="Use ghostscript for merging EPS diagnostic plots into PDF logfiles",
+        when="@4:",
+    )
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
@@ -101,18 +113,22 @@ class Relion(CMakePackage, CudaPackage):
     depends_on("ctffind@:4", type="run")
     depends_on("motioncor2", type="run", when="+external_motioncor2")
 
-    depends_on("ghostscript", type="run", when="@4:")
+    # ghostscript is only needed at runtime for merging EPS diagnostic plots
+    # into PDF logfiles. Relion gracefully degrades when gs is missing
+    # (creates empty placeholder PDFs, individual EPS files are still produced).
+    depends_on("ghostscript", type="run", when="+ghostscript")
     depends_on("pbzip2", type="run", when="@5:")
     depends_on("xz", type="run", when="@5:")
     depends_on("zstd", type="run", when="@5:")
 
+    # py-relion is now gated behind +python variant
     for arch in CudaPackage.cuda_arch_values:
         depends_on(
             f"py-relion@5.0.1 +cuda cuda_arch={arch}",
             type=("build", "run"),
-            when=f"@5.0.1 +cuda cuda_arch={arch}",
+            when=f"@5.0.1 +python +cuda cuda_arch={arch}",
         )
-    depends_on("py-relion@5.0.1 ~cuda", type=("build", "run"), when="@5.0.1 ~cuda")
+    depends_on("py-relion@5.0.1 ~cuda", type=("build", "run"), when="@5.0.1 +python ~cuda")
 
     patch("0002-Simple-patch-to-fix-intel-mkl-linking.patch", when="@:3.1.1 os=ubuntu18.04")
     patch(
@@ -155,7 +171,10 @@ class Relion(CMakePackage, CudaPackage):
             args.append("-DCUDA=OFF")
 
         if self.spec.satisfies("@5:"):
-            args.append(f"-DPYTHON_EXE_PATH={self.spec['python'].command.path}")
+            if self.spec.satisfies("+python"):
+                args.append(f"-DPYTHON_EXE_PATH={self.spec['python'].command.path}")
+            else:
+                args.append("-DPYTHON_EXE_PATH=")
             args.append("-DFETCH_WEIGHTS=OFF")
 
         return args

--- a/repos/spack_repo/builtin/packages/relion/package.py
+++ b/repos/spack_repo/builtin/packages/relion/package.py
@@ -209,7 +209,11 @@ class Relion(CMakePackage, CudaPackage):
     def stub_python_scripts(self):
         """When ~python, replace relion_python_* scripts with a clear error stub."""
         if self.spec.satisfies("@5: ~python"):
-            stub = '#!/usr/bin/env bash\n\necho "This build of RELION does not support Python commands."\nexit 1\n'
+            stub = (
+                "#!/usr/bin/env bash\n\n"
+                'echo "This build of RELION does not support Python commands."\n'
+                "exit 1\n"
+            )
             for path in glob.glob(join_path(self.prefix.bin, "relion_python_*")):
                 with open(path, "w") as f:
                     f.write(stub)

--- a/repos/spack_repo/builtin/packages/relion/package.py
+++ b/repos/spack_repo/builtin/packages/relion/package.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import glob
+
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 
@@ -202,6 +204,15 @@ class Relion(CMakePackage, CudaPackage):
                 r'\1 "{0}"'.format(join_path(self.spec["motioncor2"].prefix.bin, "MotionCor2")),
                 join_path("src", "pipeline_jobs.h"),
             )
+
+    @run_after("install")
+    def stub_python_scripts(self):
+        """When ~python, replace relion_python_* scripts with a clear error stub."""
+        if self.spec.satisfies("@5: ~python"):
+            stub = '#!/usr/bin/env bash\n\necho "This build of RELION does not support Python commands."\nexit 1\n'
+            for path in glob.glob(join_path(self.prefix.bin, "relion_python_*")):
+                with open(path, "w") as f:
+                    f.write(stub)
 
     def setup_run_environment(self, env):
         env.set("RELION_CTFFIND_EXECUTABLE", self.spec["ctffind"].prefix.bin.ctffind)

--- a/repos/spack_repo/builtin/packages/relion/package.py
+++ b/repos/spack_repo/builtin/packages/relion/package.py
@@ -176,7 +176,8 @@ class Relion(CMakePackage, CudaPackage):
             if self.spec.satisfies("+python"):
                 args.append(f"-DPYTHON_EXE_PATH={self.spec['python'].command.path}")
             else:
-                args.append("-DPYTHON_EXE_PATH=")
+                # /does-not-exist prevents CMake from auto-discovering Conda Python
+                args.append("-DPYTHON_EXE_PATH=/does-not-exist")
             args.append("-DFETCH_WEIGHTS=OFF")
 
         return args


### PR DESCRIPTION
 ### `python` variant (default=true, `@5:`)

 **Problem:** `py-relion` is unconditionally pulled in for relion 5.x. It depends on py-torch, py-napari, model-angelo, py-pyqt5, and dozens more. This makes concretization extremely slow or impossible with non-default compilers — the solver has to reconcile hundreds of extra packages.

 **Fix:** Gate `py-relion` behind `+python`. HPC users who only need the core C++ binaries (`relion_refine`, `relion_autopick`, etc.) can build with `~python`. When `~python`, `cmake_args` sets `-DPYTHON_EXE_PATH=` to disable Python integration at the CMake level.

 ### `ghostscript` variant (default=true, `@4:`)

 **Problem:** ghostscript is unconditional for `@4:` and drags in GTK+3, librsvg, cairo, pango, fontconfig, gperf, libiconv, and many X11 libs — a heavy chain that significantly increases build time and surface area for compiler compatibility issues.

 **What ghostscript actually does:** Two functions in `src/CPlot2D.cpp` call `gs` via `system()` to merge EPS diagnostic plots into PDF logfiles. When `gs` is missing, relion catches the failure, prints a warning, and creates an empty placeholder PDF. Individual EPS plots are still produced. Core scientific computation is completely unaffected.

 **Fix:** Gate behind `+ghostscript`. Default=true preserves backward compatibility for both variants.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
