### PR TITLE
grpc: add protobuf conflicts

### DIFF
--- a/repos/spack_repo/builtin/packages/grpc/package.py
+++ b/repos/spack_repo/builtin/packages/grpc/package.py
@@ -69,6 +69,11 @@ class Grpc(CMakePackage):
 
     depends_on("protobuf")
     depends_on("protobuf@3.22:", when="@1.55:")
+    # older versions require the removed header file <google/protobuf/compiler/php/php_generator.h>
+    depends_on("protobuf@:33", when="@:1.71")
+    # https://github.com/grpc/grpc/commit/dfdda9eb9d308640ea6947f3ad16c86d7b89d7fd
+    depends_on("protobuf@:29", when="@:1.68")
+
     depends_on("openssl")
     depends_on("zlib-api")
     depends_on("c-ares")


### PR DESCRIPTION
protobuf removed the header file `php_generator.h` in version 33 which is required for versions 1.71 and older.
There was also a breaking api change in protobuf version 30(https://protobuf.dev/support/migration/#v30) that was resolved in grpc in version 1.69.
