### PR TITLE
py-trove-classifiers: add v2026.1.14.14

### DIFF
--- a/repos/spack_repo/builtin/packages/py_trove_classifiers/package.py
+++ b/repos/spack_repo/builtin/packages/py_trove_classifiers/package.py
@@ -17,6 +17,9 @@ class PyTroveClassifiers(PythonPackage):
     license("Apache-2.0")
 
     version(
+        "2026.1.14.14", sha256="00492545a1402b09d4858605ba190ea33243d361e2b01c9c296ce06b5c3325f3"
+    )
+    version(
         "2025.9.11.17", sha256="931ca9841a5e9c9408bc2ae67b50d28acf85bef56219b56860876dd1f2d024dd"
     )
     version(


### PR DESCRIPTION
Release notes:
- https://github.com/pypa/trove-classifiers/releases/tag/2025.11.14.15
- https://github.com/pypa/trove-classifiers/releases/tag/2025.12.1.14
- https://github.com/pypa/trove-classifiers/releases/tag/2026.1.12.15
- https://github.com/pypa/trove-classifiers/releases/tag/2026.1.14.14

Diff: https://github.com/pypa/trove-classifiers/compare/2025.9.11.17...2026.1.14.14