### PR TITLE
musica: add c compiler

### DIFF
--- a/repos/spack_repo/builtin/packages/musica/package.py
+++ b/repos/spack_repo/builtin/packages/musica/package.py
@@ -47,6 +47,7 @@ class Musica(CMakePackage):
 
     # Dependencies
     depends_on("cmake@3.21:", type="build")
+    depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
     depends_on("mpi", when="+mpi")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

I noticed we couldn't install one of our options because we needed the c compiler to be set