### PR TITLE
trivy: add v0.69.3

### DIFF
--- a/repos/spack_repo/builtin/packages/trivy/package.py
+++ b/repos/spack_repo/builtin/packages/trivy/package.py
@@ -17,6 +17,7 @@ class Trivy(GoPackage):
 
     license("Apache-2.0", checked_by="RobertMaaskant")
 
+    version("0.69.3", sha256="3ca5fa62932273dd7eef3b6ec762625da42304ebb8f13e4be9fdd61545ca1773")
     version("0.64.1", sha256="9e23c90bd1afd9c369f1582712907e8e0652c8f5825e599850183af174c65666")
     version("0.64.0", sha256="95f958c5cf46e063660c241d022a57f99309208c9725d6031b048c9c414ecfa7")
     version("0.63.0", sha256="ac26dcb16072e674b8a3bffa6fbd817ec5baa125660b5c49d9ad8659e14d0800")
@@ -25,6 +26,7 @@ class Trivy(GoPackage):
     version("0.61.1", sha256="f6ad43e008c008d67842c9e2b4af80c2e96854db8009fba48fc37b4f9b15f59b")
     version("0.61.0", sha256="1e97b1b67a4c3aee9c567534e60355033a58ce43a3705bdf198d7449d53b6979")
 
+    depends_on("go@1.25.6:", type="build", when="@0.69.1:")
     depends_on("go@1.24.4:", type="build", when="@0.64:")
     depends_on("go@1.24.2:", type="build", when="@0.62:")
     depends_on("go@1.24:", type="build")
@@ -46,3 +48,7 @@ class Trivy(GoPackage):
             args.extend(["-ldflags", " ".join(extra_ldflags)])
 
         return args
+
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        if self.spec.satisfies("@0.67.0:"):
+            env.set("GOEXPERIMENT", "jsonv2")


### PR DESCRIPTION
Release notes: https://github.com/aquasecurity/trivy/blob/main/CHANGELOG.md
Diff: https://github.com/aquasecurity/trivy/compare/v0.64.1...v0.69.3

The dependency on `GOEXPERIMENT=jsonv2` was added in https://github.com/aquasecurity/trivy/pull/9422 which is part of v0.67.0: https://github.com/aquasecurity/trivy/compare/v0.66.0...v0.67.0#diff-1c7213c2f02fce0c1d653f1fe32831b700931145e3d5b7245c0df732c492aba8.