### PR TITLE
topaz: adding v0.3.18

### DIFF
--- a/repos/spack_repo/builtin/packages/py_trove_classifiers/package.py
+++ b/repos/spack_repo/builtin/packages/py_trove_classifiers/package.py
@@ -17,6 +17,9 @@ class PyTroveClassifiers(PythonPackage):
     license("Apache-2.0")
 
     version(
+        "2026.1.14.14", sha256="00492545a1402b09d4858605ba190ea33243d361e2b01c9c296ce06b5c3325f3"
+    )
+    version(
         "2025.9.11.17", sha256="931ca9841a5e9c9408bc2ae67b50d28acf85bef56219b56860876dd1f2d024dd"
     )
     version(

--- a/repos/spack_repo/builtin/packages/topaz/package.py
+++ b/repos/spack_repo/builtin/packages/topaz/package.py
@@ -17,6 +17,7 @@ class Topaz(PythonPackage):
 
     license("GPL-3.0-or-later")
 
+    version("0.3.18", sha256="a68a426bea0c0999a714f868694d7a5f07cfb0456098e99ac3e7b33865abcd7b")
     version("0.3.7", sha256="ae3c0d6ccb1e8ad2e4926421442b8cb33a4d01d1ee1dff83174949a9f91cc8a9")
     version(
         "0.2.5",
@@ -25,13 +26,17 @@ class Topaz(PythonPackage):
     )
 
     depends_on("py-setuptools", type="build")
-    depends_on("py-torch@1:2.3.1", type=("build", "run"))
-    depends_on("py-torchvision", type=("build", "run"))
-    depends_on("py-numpy@1.11:", type=("build", "run"))
-    depends_on("py-pandas@0.20.3:", type=("build", "run"))
-    depends_on("py-scikit-learn@0.19.0:", type=("build", "run"))
-    depends_on("py-scipy@0.17.0:", type=("build", "run"))
-    depends_on("py-pillow@6.2.0:", type=("build", "run"))
-    depends_on("py-future", type=("build", "run"))
-    depends_on("py-tqdm@4.65.0:", type=("build", "run"), when="@0.3.7:")
-    depends_on("py-h5py@3.7.0:", type=("build", "run"), when="@0.3.7:")
+    with default_args(type=("build", "run")):
+        depends_on("python@3")
+        depends_on("python@3.8:3.12", when="@0.3.7:")
+        depends_on("py-torch@1:2.3.1", when="@:0.3.7")
+        depends_on("py-torch@1:", when="@0.3.18:")
+        depends_on("py-torchvision")
+        depends_on("py-numpy@1.11:")
+        depends_on("py-pandas@0.20.3:")
+        depends_on("py-scikit-learn@0.19.0:")
+        depends_on("py-scipy@0.17.0:")
+        depends_on("py-pillow@6.2.0:")
+        depends_on("py-future")
+        depends_on("py-tqdm@4.65.0:", when="@0.3.7:")
+        depends_on("py-h5py@3.7.0:", when="@0.3.7:")


### PR DESCRIPTION
new version, supposedly good to unbound the torch dep.

also bumps py-trove-classifiers as I was running into build errors with some dependencies with the older one. 
