### PR TITLE
ucx: add external package detection

### DIFF
--- a/repos/spack_repo/builtin/packages/ucx/package.py
+++ b/repos/spack_repo/builtin/packages/ucx/package.py
@@ -231,19 +231,22 @@ class Ucx(AutotoolsPackage, CudaPackage):
 
             # cm variant (only for UCX @:1.10)
             if version in ver(":1.10"):
-                if re.search(r"--with-cm\b", cfg) and "--without-cm" not in cfg:
+                if (re.search(r"--with-cm\b", cfg) and
+                        "--without-cm" not in cfg):
                     variant_list.append("+cm")
                 elif "--without-cm" in cfg:
                     variant_list.append("~cm")
 
             # MLX5 (flag name changed in v1.18: --with-mlx5-dv → --with-mlx5)
             if version in ver(":1.17"):
-                if re.search(r"--with-mlx5-dv(?!=no)", cfg) and "--without-mlx5-dv" not in cfg:
+                if (re.search(r"--with-mlx5-dv(?!=no)", cfg) and
+                        "--without-mlx5-dv" not in cfg):
                     variant_list.append("+mlx5_dv")
                 else:
                     variant_list.append("~mlx5_dv")
             else:
-                if re.search(r"--with-mlx5(?!=no)", cfg) and "--without-mlx5" not in cfg:
+                if (re.search(r"--with-mlx5(?!=no)", cfg) and
+                        "--without-mlx5" not in cfg):
                     variant_list.append("+mlx5_dv")
                 else:
                     variant_list.append("~mlx5_dv")
@@ -255,7 +258,8 @@ class Ucx(AutotoolsPackage, CudaPackage):
                 elif "--without-fuse3" in cfg:
                     variant_list.append("~vfs")
 
-            # backtrace_detail (version-specific: --enable-backtrace-detail → --with-bfd)
+            # backtrace_detail (version-specific: --enable-backtrace-detail
+            # → --with-bfd)
             if version in ver(":1.11"):
                 if re.search(r"--enable-backtrace-detail\b", cfg):
                     variant_list.append("+backtrace_detail")
@@ -273,7 +277,8 @@ class Ucx(AutotoolsPackage, CudaPackage):
             elif "--without-ib-hw-tm" in cfg:
                 variant_list.append("~ib_hw_tm")
 
-            # logging (detect actual build config; UCX default=enabled, Spack variant default=False)
+            # logging: detect actual build config
+            # (UCX default=enabled, Spack variant default=False)
             if "--disable-logging" in cfg:
                 variant_list.append("~logging")
             else:

--- a/repos/spack_repo/builtin/packages/ucx/package.py
+++ b/repos/spack_repo/builtin/packages/ucx/package.py
@@ -1,6 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import re
 import shutil
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
@@ -20,6 +21,8 @@ class Ucx(AutotoolsPackage, CudaPackage):
     maintainers("hppritcha")
 
     license("BSD-3-Clause")
+
+    executables = ["^ucx_info$"]
 
     version("master", branch="master", submodules=True)
 
@@ -158,6 +161,126 @@ class Ucx(AutotoolsPackage, CudaPackage):
 
     # https://github.com/openucx/ucx/issues/10589
     conflicts("%gcc@15:", when="@:1.18")
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)("-v", output=str, error=str)
+        match = re.search(r"# Library version:\s+(\S+)", output)
+        return Version(match.group(1)) if match else None
+
+    @classmethod
+    def determine_variants(cls, exes, version):
+        variants = []
+        for exe in exes:
+            # Get configure flags
+            ver_output = Executable(exe)("-v", output=str, error=str)
+            cfg_match = re.search(r"# Configured with:\s+(.*)", ver_output)
+            cfg = cfg_match.group(1) if cfg_match else ""
+
+            # Get build config defines
+            build_output = Executable(exe)("-b", output=str, error=str)
+            defines = {}
+            for line in build_output.strip().split("\n"):
+                m = re.match(r"#define\s+(\w+)\s+(.*)", line)
+                if m:
+                    defines[m.group(1)] = m.group(2).strip()
+
+            variant_list = []
+
+            # --- Variants from build defines ---
+            define_map = {
+                "thread_multiple": "ENABLE_MT",
+                "assertions": "ENABLE_ASSERT",
+                "debug": "ENABLE_DEBUG_DATA",
+                "parameter_checking": "ENABLE_PARAMS_CHECK",
+            }
+            for variant_name, define_key in define_map.items():
+                if defines.get(define_key) == "1":
+                    variant_list.append(f"+{variant_name}")
+                else:
+                    variant_list.append(f"~{variant_name}")
+
+            # CMA from defines
+            if defines.get("HAVE_CMA") == "1":
+                variant_list.append("+cma")
+            else:
+                variant_list.append("~cma")
+
+            # --- Variants from configure flags ---
+            flag_variants = {
+                "cuda": r"--with-cuda(?!=no)",
+                "rocm": r"--with-rocm(?!=no)",
+                "gdrcopy": r"--with-gdrcopy(?!=no)",
+                "rdmacm": r"--with-rdmacm(?!=no)",
+                "verbs": r"--with-verbs(?!=no)",
+                "knem": r"--with-knem(?!=no)",
+                "xpmem": r"--with-xpmem(?!=no)",
+                "rc": r"--with-rc\b",
+                "ud": r"--with-ud\b",
+                "dc": r"--with-dc\b",
+                "dm": r"--with-dm\b",
+                "java": r"--with-java(?!=no)",
+            }
+
+            for variant_name, pattern in flag_variants.items():
+                without = f"--without-{variant_name}"
+                if re.search(pattern, cfg) and without not in cfg:
+                    variant_list.append(f"+{variant_name}")
+                elif without in cfg:
+                    variant_list.append(f"~{variant_name}")
+
+            # cm variant (only for UCX @:1.10)
+            if Version(version) <= Version("1.10"):
+                if re.search(r"--with-cm\b", cfg) and "--without-cm" not in cfg:
+                    variant_list.append("+cm")
+                elif "--without-cm" in cfg:
+                    variant_list.append("~cm")
+
+            # MLX5 (flag name changed in v1.18: --with-mlx5-dv → --with-mlx5)
+            if Version(version) <= Version("1.17"):
+                if re.search(r"--with-mlx5-dv(?!=no)", cfg) and "--without-mlx5-dv" not in cfg:
+                    variant_list.append("+mlx5_dv")
+                else:
+                    variant_list.append("~mlx5_dv")
+            else:
+                if re.search(r"--with-mlx5(?!=no)", cfg) and "--without-mlx5" not in cfg:
+                    variant_list.append("+mlx5_dv")
+                else:
+                    variant_list.append("~mlx5_dv")
+
+            # VFS (fuse3) - only for UCX @1.11.0:
+            if Version(version) >= Version("1.11.0"):
+                if re.search(r"--with-fuse3(?!=no)", cfg):
+                    variant_list.append("+vfs")
+                elif "--without-fuse3" in cfg:
+                    variant_list.append("~vfs")
+
+            # backtrace_detail (version-specific: --enable-backtrace-detail → --with-bfd)
+            if Version(version) <= Version("1.11"):
+                if re.search(r"--enable-backtrace-detail\b", cfg):
+                    variant_list.append("+backtrace_detail")
+                else:
+                    variant_list.append("~backtrace_detail")
+            else:
+                if re.search(r"--with-bfd(?!=no)", cfg):
+                    variant_list.append("+backtrace_detail")
+                else:
+                    variant_list.append("~backtrace_detail")
+
+            # ib_hw_tm
+            if re.search(r"--with-ib-hw-tm(?!=no)", cfg):
+                variant_list.append("+ib_hw_tm")
+            elif "--without-ib-hw-tm" in cfg:
+                variant_list.append("~ib_hw_tm")
+
+            # logging (detect actual build config; UCX default=enabled, Spack variant default=False)
+            if "--disable-logging" in cfg:
+                variant_list.append("~logging")
+            else:
+                variant_list.append("+logging")
+
+            variants.append(" ".join(variant_list))
+        return variants
 
     configure_abs_path = "contrib/configure-release"
 

--- a/repos/spack_repo/builtin/packages/ucx/package.py
+++ b/repos/spack_repo/builtin/packages/ucx/package.py
@@ -230,14 +230,14 @@ class Ucx(AutotoolsPackage, CudaPackage):
                     variant_list.append(f"~{variant_name}")
 
             # cm variant (only for UCX @:1.10)
-            if Version(version) <= Version("1.10"):
+            if version in ver(":1.10"):
                 if re.search(r"--with-cm\b", cfg) and "--without-cm" not in cfg:
                     variant_list.append("+cm")
                 elif "--without-cm" in cfg:
                     variant_list.append("~cm")
 
             # MLX5 (flag name changed in v1.18: --with-mlx5-dv → --with-mlx5)
-            if Version(version) <= Version("1.17"):
+            if version in ver(":1.17"):
                 if re.search(r"--with-mlx5-dv(?!=no)", cfg) and "--without-mlx5-dv" not in cfg:
                     variant_list.append("+mlx5_dv")
                 else:
@@ -249,14 +249,14 @@ class Ucx(AutotoolsPackage, CudaPackage):
                     variant_list.append("~mlx5_dv")
 
             # VFS (fuse3) - only for UCX @1.11.0:
-            if Version(version) >= Version("1.11.0"):
+            if version in ver("1.11.0:"):
                 if re.search(r"--with-fuse3(?!=no)", cfg):
                     variant_list.append("+vfs")
                 elif "--without-fuse3" in cfg:
                     variant_list.append("~vfs")
 
             # backtrace_detail (version-specific: --enable-backtrace-detail → --with-bfd)
-            if Version(version) <= Version("1.11"):
+            if version in ver(":1.11"):
                 if re.search(r"--enable-backtrace-detail\b", cfg):
                     variant_list.append("+backtrace_detail")
                 else:

--- a/repos/spack_repo/builtin/packages/ucx/package.py
+++ b/repos/spack_repo/builtin/packages/ucx/package.py
@@ -1,6 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import re
 import shutil
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
@@ -20,6 +21,8 @@ class Ucx(AutotoolsPackage, CudaPackage):
     maintainers("hppritcha")
 
     license("BSD-3-Clause")
+
+    executables = ["^ucx_info$"]
 
     version("master", branch="master", submodules=True)
 
@@ -159,6 +162,99 @@ class Ucx(AutotoolsPackage, CudaPackage):
 
     # https://github.com/openucx/ucx/issues/10589
     conflicts("%gcc@15:", when="@:1.18")
+
+    # External detection is driven by the build configuration that "ucx_info -b"
+    # reports (i.e. the installed config.h), not by the configure line from
+    # "ucx_info -v".  The configure line is unreliable as a primary source
+    # because most UCX components are either on by default (rc, ud, dc, dm,
+    # ib_hw_tm, mlx5) or auto-detected (rdmacm, knem, xpmem, bfd, fuse3, cuda,
+    # rocm), so they never show up there unless a packager explicitly overrode
+    # them.  Parsing only the configure line badly under-detects vendor builds
+    # such as HPCX, MOFED and distro packages.
+
+    #: Variants detected from a single "#define <name> 1" in "ucx_info -b".
+    detection_defines = {
+        "assertions": "ENABLE_ASSERT",
+        "backtrace_detail": "HAVE_DETAILED_BACKTRACE",
+        "dc": "HAVE_TL_DC",
+        "debug": "ENABLE_DEBUG_DATA",
+        "dm": "HAVE_IBV_DM",
+        "ib_hw_tm": "IBV_HW_TM",
+        "parameter_checking": "ENABLE_PARAMS_CHECK",
+        "rc": "HAVE_TL_RC",
+        "thread_multiple": "ENABLE_MT",
+        "ud": "HAVE_TL_UD",
+        "verbs": "HAVE_IB",
+    }
+
+    #: Variants detected from the "<component>_MODULES" lists in "ucx_info -b".
+    #: A HAVE_* define is not usable for these: it only says the headers were
+    #: found at build time, not that the module was built.  A build that has
+    #: ROCm headers installed but was configured --without-rocm still reports
+    #: "HAVE_HIP 1" while uct_rocm_MODULES stays empty.
+    detection_modules = {
+        "cma": (("uct_MODULES", "cma"),),
+        "cuda": (("uct_MODULES", "cuda"), ("ucm_MODULES", "cuda")),
+        "gdrcopy": (("uct_cuda_MODULES", "gdrcopy"),),
+        "knem": (("uct_MODULES", "knem"),),
+        "rdmacm": (("uct_MODULES", "rdmacm"),),
+        "rocm": (("uct_MODULES", "rocm"), ("ucm_MODULES", "rocm")),
+        "vfs": (("ucs_MODULES", "fuse"),),
+        "xpmem": (("uct_MODULES", "xpmem"),),
+    }
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)("-v", output=str, error=str)
+        match = re.search(r"# Library version:\s+(\S+)", output)
+        # Must be a Version, not a str: determine_variants compares it against
+        # ver() ranges, which do not accept plain strings.
+        return Version(match.group(1)) if match else None
+
+    @classmethod
+    def determine_variants(cls, exes, version):
+        results = []
+        for exe in exes:
+            defines = {}
+            for line in Executable(exe)("-b", output=str, error=str).splitlines():
+                match = re.match(r"#define\s+(\w+)\s+(.*)", line)
+                if match:
+                    defines[match.group(1)] = match.group(2).strip().strip('"')
+
+            def is_defined(name):
+                return defines.get(name, "0") not in ("0", "")
+
+            def has_module(candidates):
+                return any(mod in defines.get(key, "").split(":") for key, mod in candidates)
+
+            found = {v: is_defined(d) for v, d in cls.detection_defines.items()}
+            found.update({v: has_module(c) for v, c in cls.detection_modules.items()})
+
+            # mlx5 is folded into the ib module before v1.18 and is a module of
+            # its own from v1.18 on, so accept either signal.
+            found["mlx5_dv"] = is_defined("HAVE_MLX5_DV") or has_module(
+                (("uct_ib_MODULES", "mlx5"),)
+            )
+
+            # UCX compiles in logging by default; --disable-logging caps the
+            # highest compiled-in level at DEBUG instead of TRACE_POLL.
+            found["logging"] = "TRACE" in defines.get("UCS_MAX_LOG_LEVEL", "")
+
+            # Java support is only an automake conditional, so it leaves no
+            # trace in the build config.  The configure line is all we have.
+            cfg = defines.get("UCX_CONFIGURE_FLAGS", "")
+            found["java"] = bool(re.search(r"--with-java(?!=no)", cfg))
+
+            # Variants that only exist for a subset of versions.
+            if version in ver(":1.10"):
+                found["cm"] = is_defined("HAVE_TL_CM")
+            if version not in ver("1.11.0:"):
+                found.pop("vfs", None)
+
+            results.append(
+                " ".join(("+" if on else "~") + name for name, on in sorted(found.items()))
+            )
+        return results
 
     configure_abs_path = "contrib/configure-release"
 


### PR DESCRIPTION
## What
Add external package detection for ucx (`executables`, `determine_version`,`determine_variants`), so `spack external find ucx` picks up system/vendor UCX installs (distro packages, NVIDIA OFED/HPCX, etc.).

## Why
Addresses [openucx/ucx#8497](https://github.com/openucx/ucx/issues/8497) - users want Spack to auto-detect externally installed UCX.

## How
Detection reads the build configuration reported by `ucx_info -b` (the installed `config.h`), not the `# Configured with:` line from `ucx_info -v`. The configure line is unreliable as a source because most UCX components are either enabled by default (`rc`, `ud`, `dc`, `dm`, `ib_hw_tm`, `mlx5`) or auto-detected (`rdmacm`, `knem`, `xpmem`, `bfd`, `fuse3`, `cuda`, `rocm`), so they never appear there unless a packager explicitly overrode them — which badly under-detects vendor and distro builds.

From `ucx_info -b`:
- transports / build options come from their `#define`s (`HAVE_TL_RC`, `HAVE_IBV_DM`, `IBV_HW_TM`, `ENABLE_MT`, ...)
- components come from the `<component>_MODULES` lists (`uct_MODULES`, `uct_cuda_MODULES`, `uct_ib_MODULES`, `ucm_MODULES`, `ucs_MODULES`)

Module-backed components key off the module lists rather than a `HAVE_*` define because a `HAVE_*` define only records that headers were found, not that the module was built (e.g. a build with ROCm headers but configured `--without-rocm reports `HAVE_HIP 1` while `uct_rocm_MODULES` stays empty). `java` is the only variant with no build-config signal, so it still comes from the configure line.

## Testing
Verified on Ubuntu 24.04 (x86_64) with real `spack external find ucx`, against a distro UCX **1.16.0** and a source-built **1.18.0** configured with explicit negatives. Detected specs pass Spack's variant validation. Reading the build config instead of the configure line corrected 7 variants on the stock distro

build:

before: ucx@1.16.0 +assertions ~backtrace_detail ~cma ~debug +logging +mlx5_dv
                      +parameter_checking +thread_multiple +verbs
                      
after:  ucx@1.16.0 +assertions ~backtrace_detail +cma ~cuda +dc ~debug +dm
                   ~gdrcopy +ib_hw_tm ~java ~knem +logging +mlx5_dv
                   +parameter_checking +rc +rdmacm ~rocm +thread_multiple +ud
                   +verbs ~vfs ~xpmem

The CUDA/ROCm/gdrcopy/knem/xpmem/vfs positive paths are covered by synthetic `ucx_info -b` inputs (module token names taken from UCX's own `configure.m4`); they haven't been confirmed on a real GPU/IB build or on aarch64 / Grace Hopper
