### PR TITLE
py-protobuf: fix build error with gcc@14:

### DIFF
--- a/repos/spack_repo/builtin/packages/py_protobuf/package.py
+++ b/repos/spack_repo/builtin/packages/py_protobuf/package.py
@@ -89,3 +89,10 @@ class PyProtobuf(PythonPackage):
         depends_on(f"protobuf@3.{ver}", when=f"@3.{ver}")
 
     conflicts("%gcc@14:", when="@:4.24.3")
+
+    def flag_handler(self, name, flags):
+        if name == "cflags":
+            if self.spec.satisfies("%gcc@14:"):
+                flags.append("-Wno-error=int-conversion")
+
+        return flags, None, None

--- a/repos/spack_repo/builtin/packages/py_protobuf/package.py
+++ b/repos/spack_repo/builtin/packages/py_protobuf/package.py
@@ -92,7 +92,7 @@ class PyProtobuf(PythonPackage):
 
     def flag_handler(self, name, flags):
         if name == "cflags":
-            if self.spec.satisfies("%gcc@14:"):
+            if self.spec.satisfies("@4.24.4 %gcc@14:"):
                 flags.append("-Wno-error=int-conversion")
 
         return flags, None, None


### PR DESCRIPTION
## Description

In `py-protobuf`: add flag `-Wno-error=int-conversion`, required by `gcc@14:` for `py-protobuf` version 4.24.4.

This fixes the build error I got for `py-protobuf@4.24.4`.:
```
 /home/dom/work/spack-stack/spack-stack-gcc-14-test/envs/ce-gcc-14.2.1-build/install/[padded-to-200-chars]/none/none/compiler-wrapper-1.0-lh7m4sj/libexec/spack/gcc/gcc -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -fPIC -I/home/dom/work/spack-stack/spack-stack-gcc-14-test/cache/build_stage/spack-stage-py-protobuf-4.24.4-7rcewbaeqd4ydjczvz6rhzoms4ovcgm7/spack-src -I/home/dom/work/spack-stack/spack-stack-gcc-14-test/cache/build_stage/spack-stage-py-protobuf-4.24.4-7rcewbaeqd4ydjczvz6rhzoms4ovcgm7/spack-src/utf8_range -I/home/dom/work/spack-stack/spack-stack-gcc-14-test/envs/ce-gcc-14.2.1-build/install/[padded-to-200-chars]/none/none/python-venv-1.0-xtfdp2o/include -I/home/dom/work/spack-stack/spack-stack-gcc-14-test/envs/ce-gcc-14.2.1-build/install/[padded-to-200-chars]/gcc/14.2.1/python-3.11.11-hrr6lk7/include/python3.11 -c python/message.c -o build/temp.linux-x86_64-cpython-311/python/message.o
  python/message.c: In function 'PyUpb_Message_CopyFrom':
  python/message.c:1238:54: error: passing argument 1 of 'upb_MessageDef_MiniTable' makes pointer from integer without a cast [-Wint-conversion]
   1238 |                        upb_MessageDef_MiniTable(other->def),
        |                                                 ~~~~~^~~~~
        |                                                      |
        |                                                      uintptr_t {aka long unsigned int}
```
Note that there is already a conflict in the package for versions up to `4.24.3`. While it is possible that the bug fix presented here also works for older versions than 4.24.4, I don't think it's worth the effort, especially because I need specifically version `4.24.4` to support a specific version of `py-cylc-flow`.

Newer versions don't need the patch; 4.25.3 works fine without it (but cylc is really picky about the version).

## Testing

Tested on Alma Linux 9 with `gcc@14.2.1` and `py-protobuf@4.24.4`.