### PR TITLE
NetCDF-c: Ensure plugin path is posix

### DIFF
--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -402,11 +402,15 @@ class CMakeBuilder(AnyBuilder, cmake.CMakeBuilder):
             base_cmake_args.extend(
                 [
                     self.define("ENABLE_PLUGIN_INSTALL", True),
-                    self.define("NETCDF_WITH_PLUGIN_DIR", pathlib.Path(self.prefix.plugins).as_posix()),
+                    self.define(
+                        "NETCDF_WITH_PLUGIN_DIR", pathlib.Path(self.prefix.plugins).as_posix()
+                    ),
                 ]
             )
         elif self.spec.satisfies("@4.9.0:+shared"):
-            base_cmake_args.append(self.define("PLUGIN_INSTALL_DIR", pathlib.Path(self.prefix.plugins).as_posix()))
+            base_cmake_args.append(
+                self.define("PLUGIN_INSTALL_DIR", pathlib.Path(self.prefix.plugins).as_posix())
+            )
         return base_cmake_args
 
     @run_after("install")

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -4,6 +4,7 @@
 
 import itertools
 import os
+import pathlib
 import sys
 
 from spack_repo.builtin.build_systems import autotools, cmake
@@ -401,11 +402,11 @@ class CMakeBuilder(AnyBuilder, cmake.CMakeBuilder):
             base_cmake_args.extend(
                 [
                     self.define("ENABLE_PLUGIN_INSTALL", True),
-                    self.define("NETCDF_WITH_PLUGIN_DIR", self.prefix.plugins),
+                    self.define("NETCDF_WITH_PLUGIN_DIR", pathlib.Path(self.prefix.plugins).as_posix()),
                 ]
             )
         elif self.spec.satisfies("@4.9.0:+shared"):
-            base_cmake_args.append(self.define("PLUGIN_INSTALL_DIR", self.prefix.plugins))
+            base_cmake_args.append(self.define("PLUGIN_INSTALL_DIR", pathlib.Path(self.prefix.plugins).as_posix()))
         return base_cmake_args
 
     @run_after("install")


### PR DESCRIPTION
Otherwise CMake will choke on a Windows escape character if based in the C: drive


Fixes some CI failures holding up other PRs on Windows
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
