### PR TITLE
adios2: add min version numbers to yaml-cpp and pugixml dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/adios2/package.py
+++ b/repos/spack_repo/builtin/packages/adios2/package.py
@@ -128,8 +128,9 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("cmake@3.12.0:", type="build")
 
     depends_on("yaml-cpp")
+    depends_on("yaml-cpp@0.7.0:", when="@2.9:")
     depends_on("nlohmann-json")
-    depends_on("pugixml")
+    depends_on("pugixml@1.10:")
 
     # Standalone CUDA support
     depends_on("cuda", when="+cuda ~kokkos")


### PR DESCRIPTION
Minimum version numbers on some dependencies are missing. I encountered a build problem when I added `adios2` to an environment with a pre-existing `yaml-cpp` with version 0.6.3. The minimum version number on `yaml-cpp` appears to have been added with `adios2` v2.9. While looking at the `CMakeLists.txt` file, I noticed also that `pugixml` was missing a minimum version number in the Spack package.