### PR TITLE
re2: add patch method for header includes for gcc@13: and clang@15:

### DIFF
--- a/repos/spack_repo/builtin/packages/re2/package.py
+++ b/repos/spack_repo/builtin/packages/re2/package.py
@@ -84,3 +84,16 @@ class Re2(CMakePackage):
         if abseil:
             args.append(self.define("CMAKE_CXX_STANDARD", abseil[0].variants["cxxstd"].value))
         return args
+
+def patch(self):
+        # GCC 13+ and Clang 15+ removed many implicit header includes (like <cstring>).
+        # We only apply this if the header doesn't already exist to avoid conflicts.
+        if self.spec.satisfies("%gcc@13:") or self.spec.satisfies("%clang@15:"):
+            # Check if the fix is already there (for future-proofing)
+            prog_h = join_path(self.stage.source_path, 're2/prog.h')
+            if not any('<cstring>' in line for line in open(prog_h)):
+                filter_file(
+                    r'#include "re2/sparse_set.h"',
+                    '#include "re2/sparse_set.h"\n#include <cstring>',
+                    're2/prog.h'
+                )

--- a/repos/spack_repo/builtin/packages/re2/package.py
+++ b/repos/spack_repo/builtin/packages/re2/package.py
@@ -85,15 +85,16 @@ class Re2(CMakePackage):
             args.append(self.define("CMAKE_CXX_STANDARD", abseil[0].variants["cxxstd"].value))
         return args
 
+
 def patch(self):
-        # GCC 13+ and Clang 15+ removed many implicit header includes (like <cstring>).
-        # We only apply this if the header doesn't already exist to avoid conflicts.
-        if self.spec.satisfies("%gcc@13:") or self.spec.satisfies("%clang@15:"):
-            # Check if the fix is already there (for future-proofing)
-            prog_h = join_path(self.stage.source_path, 're2/prog.h')
-            if not any('<cstring>' in line for line in open(prog_h)):
-                filter_file(
-                    r'#include "re2/sparse_set.h"',
-                    '#include "re2/sparse_set.h"\n#include <cstring>',
-                    're2/prog.h'
-                )
+    # GCC 13+ and Clang 15+ removed many implicit header includes (like <cstring>).
+    # We only apply this if the header doesn't already exist to avoid conflicts.
+    if self.spec.satisfies("%gcc@13:") or self.spec.satisfies("%clang@15:"):
+        # Check if the fix is already there (for future-proofing)
+        prog_h = join_path(self.stage.source_path, "re2/prog.h")
+        if not any("<cstring>" in line for line in open(prog_h)):
+            filter_file(
+                r'#include "re2/sparse_set.h"',
+                '#include "re2/sparse_set.h"\n#include <cstring>',
+                "re2/prog.h",
+            )


### PR DESCRIPTION
Add patch method to handle missing implicit header includes for GCC 13+ and Clang 15+.

This patch is necessary and sufficient for me to build this spec:
 -   re2@2024-07-02~icu~ipo+pic~shared build_system=cmake build_type=Release generator=make platform=linux os=rhel8 target=zen3 %cxx=gcc@13.4.0 

Without errors like:

 [e]          ^gcc@8.5.0+binutils+bootstrap~graphite+libsanitizer~nvptx~piclibs~profiled~strip build_system=autotools build_type=RelWithDebInfo languages:='c,c++,fortran' platform=linux os=rhel8 target=x86_64

[+]          ^gcc-runtime@8.5.0 build_system=generic platform=linux os=rhel8 target=zen


...and the 'top' of the error output:

[ 73%] Building CXX object CMakeFiles/re2.dir/re2/simplify.cc.o

/storage/users/wspear/bin/SPACK/gilgamesh/spack/opt/spack/linux-zen3/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/gcc/g++  -I/tmp/wspear/spack-stage/spack-stage-re2-2023-09-01-o2docgedch6htv5uscgaiek7ygdv6gy2/spack-src -isystem /storage/users/wspear/bin/SPACK/gilgamesh/spack/opt/spack/linux-zen3/abseil-cpp-20260107.1-t6vh5x4y757uaf4a7ho3xoa7cayf5fz2/include -O3 -DNDEBUG -std=gnu++17 -fPIC -pthread -MD -MT CMakeFiles/re2.dir/re2/simplify.cc.o -MF CMakeFiles/re2.dir/re2/simplify.cc.o.d -o CMakeFiles/re2.dir/re2/simplify.cc.o -c /tmp/wspear/spack-stage/spack-stage-re2-2023-09-01-o2docgedch6htv5uscgaiek7ygdv6gy2/spack-src/re2/simplify.cc

In file included from /tmp/wspear/spack-stage/spack-stage-re2-2023-09-01-o2docgedch6htv5uscgaiek7ygdv6gy2/spack-src/re2/set.cc:14:

/tmp/wspear/spack-stage/spack-stage-re2-2023-09-01-o2docgedch6htv5uscgaiek7ygdv6gy2/spack-src/re2/prog.h: In member function 'const void* re2::Prog::PrefixAccel(const void*, size_t)':

/tmp/wspear/spack-stage/spack-stage-re2-2023-09-01-o2docgedch6htv5uscgaiek7ygdv6gy2/spack-src/re2/prog.h:230:14: error: 'memchr' was not declared in this scope

  230 |       return memchr(data, prefix_front_, size);

      |              ^~~~~~

/tmp/wspear/spack-stage/spack-stage-re2-2023-09-01-o2docgedch6htv5uscgaiek7ygdv6gy2/spack-src/re2/prog.h:25:1: note: 'memchr' is defined in header '<cstring>'; did you forget to '#include <cstring>'?

   24 | #include "re2/sparse_set.h"

  +++ |+#include <cstring>

   25 |

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
