### PR TITLE
wrf: adding gmake build dep

### DIFF
--- a/repos/spack_repo/builtin/packages/wrf/package.py
+++ b/repos/spack_repo/builtin/packages/wrf/package.py
@@ -254,7 +254,7 @@ class Wrf(Package):
     depends_on("fortran", type="build")  # generated
 
     depends_on("gmake", type="build")
-    depends_on("pkgconfig", type=("build"))
+    depends_on("pkgconfig", type="build")
     depends_on("libtirpc")
 
     depends_on("mpi")

--- a/repos/spack_repo/builtin/packages/wrf/package.py
+++ b/repos/spack_repo/builtin/packages/wrf/package.py
@@ -253,6 +253,7 @@ class Wrf(Package):
     depends_on("c", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
+    depends_on("gmake", type="build")
     depends_on("pkgconfig", type=("build"))
     depends_on("libtirpc")
 


### PR DESCRIPTION
When wrf tests if netcdf was built with the features it's looking for it invokes make on a target that runs a test.

This works fine in most circumstances from what I can tell, but if you're building wrf in a spack environment with gmake in the tree that isn't the same as the make in $PATH it's apparently error prone. The netcdf test will fail. If you look at the resulting file that test makes (tools/nc4_test.log) you'll see a message from make saying "invalid --jobserver-auth string". The wrf configure script only checks the return code of the netcdf test, so it reports this as netcdf not having the io feature it needs.

I spent too much time comparing two concretized specs trying to spot the difference before actually looking at the configure script to figure out what it was doing. Bluh.

Anyway, actually adding in gmake as a dep seems to resolve it.