### PR TITLE
grpc: add patch for missing includes

### DIFF
--- a/repos/spack_repo/builtin/packages/grpc/package.py
+++ b/repos/spack_repo/builtin/packages/grpc/package.py
@@ -110,3 +110,27 @@ class Grpc(CMakePackage):
         if self.spec.satisfies("@1.33.1:"):
             args.append("-DgRPC_RE2_PROVIDER:String=package")
         return args
+
+    def patch(self):
+        # GCC 13+ and Clang 15+ removed implicit transitive includes (e.g. <string>,
+        # <cstdint>, <limits>, <algorithm>). Inject them into the portability header
+        if self.spec.satisfies("%gcc@13:") or self.spec.satisfies("%clang@15:"):
+            filter_file(
+                r"(#define GRPC_SUPPORT_PORT_PLATFORM_H)",
+                r"\1"
+                "\n// Added by Spack: fix missing transitive includes for GCC 13+ / Clang 15+\n"
+                "#if defined(__cplusplus)\n"
+                "#include <algorithm>\n"
+                "#include <cstdint>\n"
+                "#include <limits>\n"
+                "#include <string>\n"
+                "#endif\n",
+                join_path(self.stage.source_path, "include/grpc/support/port_platform.h"),
+            )
+
+        # glob.cc uses std::min/std::max but omits <algorithm>
+        filter_file(
+            r'(#include "absl/strings/string_view.h")',
+            '#include <algorithm>\n#include "absl/strings/string_view.h"',
+            join_path(self.stage.source_path, "src/core/util/glob.cc"),
+        )


### PR DESCRIPTION
Add patches for GCC 13+ and Clang 15+ compatibility.

Targets top level port_platform.h header which gets most of the missing includes where they need to go. The only outlier is glob.cc which gets its own filter call.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
