### PR TITLE
gflags: improve spack build isolation

### DIFF
--- a/repos/spack_repo/builtin/packages/gflags/package.py
+++ b/repos/spack_repo/builtin/packages/gflags/package.py
@@ -28,6 +28,6 @@ class Gflags(CMakePackage):
 
     def cmake_args(self):
         return [
-            self.define("BUILD_SHARED_LIBS", True), 
+            self.define("BUILD_SHARED_LIBS", True),
             self.define("REGISTER_INSTALL_PREFIX", False),
         ]

--- a/repos/spack_repo/builtin/packages/gflags/package.py
+++ b/repos/spack_repo/builtin/packages/gflags/package.py
@@ -27,4 +27,4 @@ class Gflags(CMakePackage):
     depends_on("cmake@2.8.12:", type="build")
 
     def cmake_args(self):
-        return ["-DBUILD_SHARED_LIBS=ON"]
+        return ["-DBUILD_SHARED_LIBS=ON", "-DREGISTER_INSTALL_PREFIX=OFF"]

--- a/repos/spack_repo/builtin/packages/gflags/package.py
+++ b/repos/spack_repo/builtin/packages/gflags/package.py
@@ -27,4 +27,7 @@ class Gflags(CMakePackage):
     depends_on("cmake@2.8.12:", type="build")
 
     def cmake_args(self):
-        return ["-DBUILD_SHARED_LIBS=ON", "-DREGISTER_INSTALL_PREFIX=OFF"]
+        return [
+            self.define("BUILD_SHARED_LIBS", True), 
+            self.define("REGISTER_INSTALL_PREFIX", False),
+        ]


### PR DESCRIPTION
Gflags will try to write to the home directory of the user. 
https://github.com/gflags/gflags/issues/386

This breaks spack containment and is not needed due to spack handles dependencies.