### PR TITLE
py-imagesize: add v2.0.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_imagesize/package.py
+++ b/repos/spack_repo/builtin/packages/py_imagesize/package.py
@@ -16,10 +16,11 @@ class PyImagesize(PythonPackage):
 
     license("MIT")
 
+    version("2.0.0", sha256="8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3")
     version("1.4.1", sha256="69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a")
     version("1.3.0", sha256="cd1750d452385ca327479d45b64d9c7729ecf0b3969a58148298c77092261f9d")
     version("1.1.0", sha256="f3832918bc3c66617f92e35f5d70729187676313caa60c187eb0f28b8fe5e3b5")
     version("0.7.1", sha256="0ab2c62b87987e3252f89d30b7cedbec12a01af9274af9ffa48108f2c13c6062")
 
-    depends_on("python@2.7:2,3.4:", when="@1.2:", type=("build", "run"))
+    depends_on("python@3.10:3.14", type=("build", "run"), when="@2:")
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
https://github.com/shibukawa/imagesize_py/releases/tag/2.0.0
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
