### PR TITLE
intel-oneapi-runtime: fix samefile error

### DIFF
--- a/repos/spack_repo/builtin/packages/intel_oneapi_runtime/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_runtime/package.py
@@ -57,7 +57,7 @@ class IntelOneapiRuntime(Package):
             return
 
         for path, name in libraries:
-            install(path, os.path.join(prefix.lib, name))
+            install(path, os.path.join(prefix.lib, os.path.basename(name)))
 
     @property
     def libs(self):


### PR DESCRIPTION
I was getting SameFileErrors when trying to install intel-oneapi-runtime 
```
==> [2026-04-15-16:25:04.204882] intel-oneapi-runtime: Executing phase: 'install'                                                                             
==> [2026-04-15-16:25:04.395864] Error: SameFileError: '/opt/rit/el9/testing/app/linux-rhel9-x86_64_v3/none-none/intel-oneapi-compilers-2025.3.2-tv6ancyche2zrefd7ryv4354nisek6ne/compiler/2025.3/lib/libimf.so' and '/opt/rit/el9/testing/app/linux-rhel9-x86_64_v3/none-none/intel-oneapi-compilers-2025.3.2-tv6ancyche2zr
efd7ryv4354nisek6ne/compiler/2025.3/lib/libimf.so' are the same file                                                                                          
                                                                                                                                                              
/opt/rit/spack/builtin_repo/repos/spack_repo/builtin/packages/intel_oneapi_runtime/package.py:65, in install:                                                 
         62            print(f"prefix in install is {prefix}")                                                                                                                                                                                                                                                              
         63            print(f"prefix.lib in install is {prefix.lib}")                                                                                                                                                                                                                                                      
         64            print(f"source is {path}, dest is {join_path(prefix.lib, name)}")                                                                                                                                                                                                                                    
  >>     65            install(path, os.path.join(prefix.lib, name))                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                            
See build log for details:                                                                                                                                                                                                                                                                                                  
  /tmp/root/spack-stage/spack-stage-intel-oneapi-runtime-2025.3.2-4ims4prriaphnqz3qh57cy5zuwkprt5l/spack-build-out.txt                                                                                                                                                                                                      

Traceback (most recent call last):
  File "/opt/rit/spack/lib/spack/spack/build_environment.py", line 1195, in _setup_pkg_and_run
    return_value = function(pkg, kwargs)
  File "/opt/rit/spack/lib/spack/spack/installer.py", line 2783, in build_process
    return installer.run()
  File "/opt/rit/spack/lib/spack/spack/installer.py", line 2663, in run
    self._real_install()
  File "/opt/rit/spack/lib/spack/spack/installer.py", line 2748, in _real_install
    phase_fn.execute()
  File "/opt/rit/spack/lib/spack/spack/builder.py", line 382, in execute
    self.phase_fn(pkg, pkg.spec, pkg.prefix)
  File "/opt/rit/spack/lib/spack/spack/builder.py", line 254, in _adapter
    return phase_fn(spec, prefix)
  File "/opt/rit/spack/builtin_repo/repos/spack_repo/builtin/packages/intel_oneapi_runtime/package.py", line 65, in install
    install(path, os.path.join(prefix.lib, name))
  File "/opt/rit/spack/lib/spack/spack/llnl/util/filesystem.py", line 724, in install
    copy(src, dest, _permissions=True)
  File "/opt/rit/spack/lib/spack/spack/llnl/util/filesystem.py", line 701, in copy
    shutil.copy(src, dst)
  File "/usr/lib64/python3.9/shutil.py", line 427, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib64/python3.9/shutil.py", line 244, in copyfile
    raise SameFileError("{!r} and {!r} are the same file".format(src, dst))
shutil.SameFileError: '/opt/rit/el9/testing/app/linux-rhel9-x86_64_v3/none-none/intel-oneapi-compilers-2025.3.2-tv6ancyche2zrefd7ryv4354nisek6ne/compiler/2025.3/lib/libimf.so' and '/opt/rit/el9/testing/app/linux-rhel9-x86_64_v3/none-none/intel-oneapi-compilers-2025.3.2-tv6ancyche2zrefd7ryv4354nisek6ne/compiler/2025
.3/lib/libimf.so' are the same file
==> [2026-04-15-16:25:04.396157] Flagging intel-oneapi-runtime-2025.3.2-4ims4prriaphnqz3qh57cy5zuwkprt5l as failed: SameFileError: '/opt/rit/el9/testing/app/linux-rhel9-x86_64_v3/none-none/intel-oneapi-compilers-2025.3.2-tv6ancyche2zrefd7ryv4354nisek6ne/compiler/2025.3/lib/libimf.so' and '/opt/rit/el9/testing/app/l
inux-rhel9-x86_64_v3/none-none/intel-oneapi-compilers-2025.3.2-tv6ancyche2zrefd7ryv4354nisek6ne/compiler/2025.3/lib/libimf.so' are the same file
==> [2026-04-15-16:25:04.397522] ChildError: SameFileError: '/opt/rit/el9/testing/app/linux-rhel9-x86_64_v3/none-none/intel-oneapi-compilers-2025.3.2-tv6ancyche2zrefd7ryv4354nisek6ne/compiler/2025.3/lib/libimf.so' and '/opt/rit/el9/testing/app/linux-rhel9-x86_64_v3/none-none/intel-oneapi-compilers-2025.3.2-tv6ancyc
he2zrefd7ryv4354nisek6ne/compiler/2025.3/lib/libimf.so' are the same file
```
it seems some of the names from ```get_elf_libraries``` are full paths while others are single files. If the second argument to os.path.join/join_path is a full path the result will be the second argument instead of a joined path, which is what was leading to this (confusing) error.

I think calling basename here should be okay since there is no nested structure under prefix.lib.
