### PR TITLE
gsi-ncdiag: Add git repository URL

### DIFF
--- a/repos/spack_repo/builtin/packages/gsi_ncdiag/package.py
+++ b/repos/spack_repo/builtin/packages/gsi_ncdiag/package.py
@@ -12,6 +12,7 @@ class GsiNcdiag(CMakePackage):
 
     homepage = "https://github.com/NOAA-EMC/GSI-ncdiag"
     url = "https://github.com/NOAA-EMC/GSI-ncdiag/archive/refs/tags/v1.1.1.tar.gz"
+    git = "https://github.com/NOAA-EMC/GSI-ncdiag"
 
     maintainers("ulmononian")
 


### PR DESCRIPTION
This PR adds a git URL for gsi-ncdiag so we can spec with git refs.