### PR TITLE
Arrow: Patch 23

### DIFF
--- a/repos/spack_repo/builtin/packages/arrow/package.py
+++ b/repos/spack_repo/builtin/packages/arrow/package.py
@@ -135,7 +135,7 @@ class Arrow(CMakePackage, CudaPackage):
     patch(
         "https://github.com/apache/arrow/pull/49370.patch?full_index=1",
         sha256="ca55e18c4eaaf59bcb145ada2aa5b556b8b87a93415ace059166716864145ceb",
-        when="@19:22.0.0 platform=darwin",
+        when="@19:23.0 platform=darwin",
     )
     conflicts("%apple-clang@21:", when="@:18")
 


### PR DESCRIPTION
Same libtool failure as other arrow versions, extend patch to new arrow versions

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
