### PR TITLE
beast2: correct bound on template dir name

### DIFF
--- a/repos/spack_repo/builtin/packages/beast2/package.py
+++ b/repos/spack_repo/builtin/packages/beast2/package.py
@@ -67,7 +67,7 @@ class Beast2(Package):
         install_tree("examples", join_path(self.prefix, "examples"))
         install_tree("images", join_path(self.prefix, "images"))
         install_tree("lib", prefix.lib)
-        if spec.satisfies("@:2.6.4"):
+        if spec.satisfies("@:2.6.7"):
             template_dir = "templates"
         else:
             template_dir = "fxtemplates"


### PR DESCRIPTION
The directory is called "templates" up to 2.6.7.
