### PR TITLE
cyrus-sasl: don't install to /Library on macOS by default

### DIFF
--- a/repos/spack_repo/builtin/packages/cyrus_sasl/package.py
+++ b/repos/spack_repo/builtin/packages/cyrus_sasl/package.py
@@ -69,9 +69,7 @@ class CyrusSasl(AutotoolsPackage):
     depends_on("libxcrypt", type="link")
     depends_on("krb5", type="link")
 
+    @when("platform=darwin")
     def configure_args(self):
-        args = []
         # avoid installing to /Library/Frameworks/SASL2.framework
-        if self.spec.satisfies("platform=darwin"):
-            args.append("--disable-macos-framework")
-        return args
+        return ["--disable-macos-framework"]

--- a/repos/spack_repo/builtin/packages/cyrus_sasl/package.py
+++ b/repos/spack_repo/builtin/packages/cyrus_sasl/package.py
@@ -68,3 +68,10 @@ class CyrusSasl(AutotoolsPackage):
     depends_on("openssl", type="link")
     depends_on("libxcrypt", type="link")
     depends_on("krb5", type="link")
+
+    def configure_args(self):
+        args = []
+        # avoid installing to /Library/Frameworks/SASL2.framework
+        if self.spec.satisfies("platform=darwin"):
+            args.append("--disable-macos-framework")
+        return args


### PR DESCRIPTION
This package will attempt to install to a privileged location by default. I can make this a variant but I'm not sure if people are really installing Spack packages with sudo.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
