### PR TITLE
py-python-xmp-toolkit: add v2.1.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_python_xmp_toolkit/package.py
+++ b/repos/spack_repo/builtin/packages/py_python_xmp_toolkit/package.py
@@ -11,13 +11,32 @@ class PyPythonXmpToolkit(PythonPackage):
     """Python XMP Toolkit for working with metadata."""
 
     homepage = "https://github.com/python-xmp-toolkit/python-xmp-toolkit"
-    pypi = "python-xmp-toolkit/python-xmp-toolkit-2.0.1.tar.gz"
+    pypi = "python_xmp_toolkit/python_xmp_toolkit-2.1.0.tar.gz"
 
     license("BSD-3-Clause")
 
+    version("2.1.0", sha256="ca0aa2c60d418dd2558767db59953ab5954fb5b87dc0b50cecd60566b0b4e2da")
     version("2.0.1", sha256="f8d912946ff9fd46ed5c7c355aa5d4ea193328b3f200909ef32d9a28a1419a38")
 
-    depends_on("python@2.6:2.7,3.3:", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
-    depends_on("py-pytz", type=("build", "run"))
-    depends_on("exempi@2.2.0:", type=("build", "run"))
+    with default_args(type="build"):
+        depends_on("py-flit-core@3.2:3", when="@2.1:")
+
+        # Historical dependencies
+        depends_on("py-setuptools", when="@2.0")
+
+    with default_args(type=("build", "run")):
+        depends_on("py-pytz")
+        depends_on("exempi@2.2.0:")
+
+        # needed for ld used in ctypes.util.find_library to find exempi
+        depends_on("binutils")
+
+    def setup_run_environment(self, env: EnvironmentModifications) -> None:
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["exempi"].prefix.lib)
+
+    def url_for_version(self, version):
+        if self.spec.satisfies("@2.1:"):
+            name = "python_xmp_toolkit"
+        else:
+            name = "python-xmp-toolkit"
+        return f"https://files.pythonhosted.org/packages/source/{name[0]}/{name}/{name}-{version}.tar.gz"


### PR DESCRIPTION
https://github.com/python-xmp-toolkit/python-xmp-toolkit/releases/tag/v2.1.0

This fixes the changed url on pypi and also that exempi is found. Without the latter, the build was fine but running the examples from the homepage resulted in `libxmp.ExempiLoadError: Exempi library not found.`
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
