### PR TITLE
py-lazy-loader: add v0.5

### DIFF
--- a/repos/spack_repo/builtin/packages/py_lazy_loader/package.py
+++ b/repos/spack_repo/builtin/packages/py_lazy_loader/package.py
@@ -12,9 +12,11 @@ class PyLazyLoader(PythonPackage):
 
     homepage = "https://scientific-python.org/specs/spec-0001/"
     pypi = "lazy_loader/lazy_loader-0.1.tar.gz"
+    git = "https://github.com/scientific-python/lazy-loader.git"
 
     license("BSD-3-Clause")
 
+    version("0.5", sha256="717f9179a0dbed357012ddad50a5ad3d5e4d9a0b8712680d4e687f5e6e6ed9b3")
     version("0.4", sha256="47c75182589b91a4e1a85a136c074285a5ad4d9f39c63e0d7fb76391c4574cd1")
     version("0.3", sha256="3b68898e34f5b2a29daaaac172c6555512d0f32074f147e2254e4a6d9d838f37")
     version("0.1", sha256="77ce7f2737ebabf9c0ff73b4a99c947876d74d24c2f026544e32246ecca5feca")


### PR DESCRIPTION
https://github.com/scientific-python/lazy-loader/releases/tag/v0.5
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
