### PR TITLE
just: add 1.49.0

### DIFF
--- a/repos/spack_repo/builtin/packages/just/package.py
+++ b/repos/spack_repo/builtin/packages/just/package.py
@@ -19,6 +19,7 @@ class Just(CargoPackage):
     license("CC0-1.0", checked_by="Dando18")
 
     version("master", branch="master")
+    version("1.49.0", sha256="442406ee14eb9a59414525cf262354fe2e752b22c224ce2a5e42b2c493226e09")
     version("1.46.0", sha256="f60a578502d0b29eaa2a72c5b0d91390b2064dfd8d1a1291c3b2525d587fd395")
     version("1.42.2", sha256="9929acc303b881106d2bf2d3440d44f413372c14b0e44bf47cda8ada8801553a")
     version("1.42.1", sha256="6a6ec94ae02791c2101fd65201032d7c1929fc6294e4deebc92d0e846882fe15")
@@ -33,6 +34,7 @@ class Just(CargoPackage):
 
     depends_on("c", type="build")
 
+    depends_on("rust@1.85:", type="build", when="@1.49.0:")
     depends_on("rust@1.82:", type="build", when="@1.46.0:")
     depends_on("rust@1.77:", type="build", when="@1.41.0:")
     depends_on("rust@1.74:", type="build", when="@1.35.0:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This PR adds 1.49.0 of just. I tested the build locally.

Ref: https://github.com/casey/just/releases/tag/1.49.0