### PR TITLE
libsvm: adding missing import

### DIFF
--- a/repos/spack_repo/builtin/packages/libsvm/package.py
+++ b/repos/spack_repo/builtin/packages/libsvm/package.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from glob import glob
+
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
 
 from spack.package import *


### PR DESCRIPTION
changes in #4142 introduced a call to glob without importing it causing installation failures.