### PR TITLE
py-msgpack: add v1.1.2

### DIFF
--- a/repos/spack_repo/builtin/packages/py_msgpack/package.py
+++ b/repos/spack_repo/builtin/packages/py_msgpack/package.py
@@ -17,6 +17,7 @@ class PyMsgpack(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.1.2", sha256="3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e")
     version("1.1.1", sha256="77b79ce34a2bdab2594f490c8e80dd62a02d650b91a75159a63ec413b8d104cd")
     version("1.0.5", sha256="c075544284eadc5cddc70f4757331d99dcbc16b2bbd4849d15f8aae4cf36d31c")
     version("1.0.4", sha256="f5d869c18f030202eb412f08b28d2afeea553d6613aee89e200d7aca7ef01f5f")
@@ -28,12 +29,20 @@ class PyMsgpack(PythonPackage):
     version("0.6.1", sha256="734e1abc6f14671f28acd5266de336ae6d8de522fe1c8d0b7146365ad1fe6b0f")
     version("0.6.0", sha256="4478a5f68142414084cd43af8f21cef9619ad08bb3c242ea505330dade6ca9ea")
 
-    depends_on("cxx", type="build")  # generated
+    with default_args(type="build"):
+        depends_on("cxx")
 
-    depends_on("python@3.8:", type="build", when="@1.0.6:")
-    depends_on("py-setuptools", type="build")
-    depends_on("py-setuptools@75.3:", type="build", when="@1.1.1:")
-    depends_on("py-setuptools@35.0.2:", type="build", when="@1.0.4:")
-    # in requirements.txt
-    depends_on("py-cython@3.1.1:3.1", type="build", when="@1.1.1:")
-    depends_on("py-cython@0.29.30:0.29", type="build", when="@1.0.4:1.0.5")
+        depends_on("py-setuptools@80.9.0:", when="@1.1.2:")
+        depends_on("py-setuptools@75.3:", when="@1.1.1:")
+        depends_on("py-setuptools@35.0.2:", when="@1.0.4:")
+        depends_on("py-setuptools")
+        # in requirements.txt
+        # ignore upper version limit, because it builds fine with newer
+        # versions of py-cython
+        depends_on("py-cython@3.1.4:", when="@1.1.2:")
+        depends_on("py-cython@3.1.1:3.1", when="@1.1.1")
+        depends_on("py-cython@0.29.30:0.29", when="@1.0.4:1.0.5")
+
+    with default_args(type=("build", "run")):
+        depends_on("python@3.9:", when="@1.1.2:")
+        depends_on("python@3.8:", when="@1.0.6:")


### PR DESCRIPTION
https://github.com/msgpack/msgpack-python/releases/tag/v1.1.2
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
