### PR TITLE
p3dfft3: Fix compilation for modern GCC versions

### DIFF
--- a/repos/spack_repo/builtin/packages/p3dfft3/package.py
+++ b/repos/spack_repo/builtin/packages/p3dfft3/package.py
@@ -55,6 +55,8 @@ class P3dfft3(AutotoolsPackage):
 
         if "%gcc" in self.spec:
             args.append("--enable-gnu")
+            args.append("CFLAGS=-Wno-error=implicit-int")
+            args.append("FCFLAGS=-fallow-argument-mismatch")
 
         if "%intel" in self.spec:
             args.append("--enable-intel")


### PR DESCRIPTION
As stated in multiple closed GitHub issues, the p3dfft3 package cannot be compiled with modern GCC versions because it lacks the required compilation flags. This PR adds two C and FC flags to resolve the compilation issues.

Spack issues:
https://github.com/spack/spack/issues/25509
https://github.com/spack/spack/issues/45875

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
