### PR TITLE
kokkos: convert `openmptarget` from conflict to conditional

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -110,12 +110,12 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("^cuda@13:", when="@:4.7.0")
 
     devices_variants = {
-        "cuda": [False, "Whether to build CUDA backend"],
-        "openmp": [False, "Whether to build OpenMP backend"],
-        "threads": [False, "Whether to build the C++ threads backend"],
-        "serial": [False, "Whether to build serial backend"],
-        "rocm": [False, "Whether to build HIP backend"],
-        "sycl": [False, "Whether to build the SYCL backend"],
+        "cuda": [False, None, "Whether to build CUDA backend"],
+        "openmp": [False, None, "Whether to build OpenMP backend"],
+        "threads": [False, None, "Whether to build the C++ threads backend"],
+        "serial": [False, None, "Whether to build serial backend"],
+        "rocm": [False, None, "Whether to build HIP backend"],
+        "sycl": [False, None, "Whether  to build the SYCL backend"],
         "openmptarget": [False, "@;5.0", "Whether to build the OpenMPTarget backend"],
     }
     requires(
@@ -307,8 +307,8 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     # FIXME this should move to the apu part
     variant("apu", default=False, description="Enable APU support", when="@4.5: +rocm")
 
-    for dev, (dflt, desc) in devices_variants.items():
-        variant(dev, default=dflt, description=desc)
+    for dev, (dflt, when, desc) in devices_variants.items():
+        variant(dev, default=dflt, description=desc, when=when)
     conflicts("+cuda", when="+rocm", msg="CUDA and ROCm are not compatible in Kokkos.")
     depends_on("intel-oneapi-dpl", when="+sycl")
     depends_on("rocthrust", when="@4.3: +rocm")

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -116,12 +116,11 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         "serial": [False, "Whether to build serial backend"],
         "rocm": [False, "Whether to build HIP backend"],
         "sycl": [False, "Whether to build the SYCL backend"],
-        "openmptarget": [False, "Whether to build the OpenMPTarget backend"],
+        "openmptarget": [False, "@;5.0", "Whether to build the OpenMPTarget backend"],
     }
     requires(
         "+serial", when="~hpx ~openmp ~threads", msg="Kokkos requires at least one host backend"
     )
-    conflicts("+openmptarget", when="@5.1:")
 
     tpls_variants = {
         "hpx": [False, None, "Whether to enable the HPX library"],

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -116,7 +116,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         "serial": [False, None, "Whether to build serial backend"],
         "rocm": [False, None, "Whether to build HIP backend"],
         "sycl": [False, None, "Whether  to build the SYCL backend"],
-        "openmptarget": [False, "@;5.0", "Whether to build the OpenMPTarget backend"],
+        "openmptarget": [False, "@:5.0", "Whether to build the OpenMPTarget backend"],
     }
     requires(
         "+serial", when="~hpx ~openmp ~threads", msg="Kokkos requires at least one host backend"


### PR DESCRIPTION
As discussed when adding 5.1: the backend`openmptarget` is removed and should not be in the list of options for version >5.0

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
