### PR TITLE
parmgridgen: GCC 14: build issues

### DIFF
--- a/repos/spack_repo/builtin/packages/parmgridgen/package.py
+++ b/repos/spack_repo/builtin/packages/parmgridgen/package.py
@@ -29,7 +29,7 @@ class Parmgridgen(Package):
     depends_on("gmake", type="build")
 
     def flag_handler(self, name, flags):
-        if name in ("cflags",):
+        if name == "cflags":
             if self.spec.satisfies("%gcc@14:"):
                 flags.extend(
                     ["-Wno-implicit-function-declaration", "-Wno-incompatible-pointer-types"]

--- a/repos/spack_repo/builtin/packages/parmgridgen/package.py
+++ b/repos/spack_repo/builtin/packages/parmgridgen/package.py
@@ -32,19 +32,12 @@ class Parmgridgen(Package):
         if name in ("cflags",):
             if self.spec.satisfies("%gcc@14:"):
                 flags.extend(
-                    [
-                        "-Wno-implicit-function-declaration",
-                        "-Wno-incompatible-pointer-types",
-                    ]
+                    ["-Wno-implicit-function-declaration", "-Wno-incompatible-pointer-types"]
                 )
         return (flags, [], [])
 
     def install(self, spec, prefix):
-        make_opts = [
-            "make=make",
-            "LIBDIR=-L../..",
-            "LIBS=-L../.. -lmgrid -lm",
-        ]
+        make_opts = ["make=make", "LIBDIR=-L../..", "LIBS=-L../.. -lmgrid -lm"]
 
         if "+mpi" in spec:
             make_opts.extend(

--- a/repos/spack_repo/builtin/packages/parmgridgen/package.py
+++ b/repos/spack_repo/builtin/packages/parmgridgen/package.py
@@ -28,13 +28,20 @@ class Parmgridgen(Package):
     depends_on("mpi", when="+mpi")
     depends_on("gmake", type="build")
 
+    def flag_handler(self, name, flags):
+        if name in ("cflags",):
+            if self.spec.satisfies("%gcc@14:"):
+                flags.extend(
+                    [
+                        "-Wno-implicit-function-declaration",
+                        "-Wno-incompatible-pointer-types",
+                    ]
+                )
+        return (flags, [], [])
+
     def install(self, spec, prefix):
         make_opts = [
             "make=make",
-            "COPTIONS={0}".format(self.compiler.cc_pic_flag),
-            "LDOPTIONS={0}".format(self.compiler.cc_pic_flag),
-            "CC={0}".format(self.compiler.cc),
-            "LD={0}".format(self.compiler.cc),
             "LIBDIR=-L../..",
             "LIBS=-L../.. -lmgrid -lm",
         ]


### PR DESCRIPTION
Since GCC 14, some flags are needed to make this software compiler. Indeed, it is not standard conformant.
