### PR TITLE
py-parso: add v0.8.6

### DIFF
--- a/repos/spack_repo/builtin/packages/py_parso/package.py
+++ b/repos/spack_repo/builtin/packages/py_parso/package.py
@@ -13,10 +13,12 @@ class PyParso(PythonPackage):
     Parso is also able to list multiple syntax errors
     in your python file."""
 
+    homepage = "https://github.com/davidhalter/parso"
     pypi = "parso/parso-0.6.1.tar.gz"
 
     license("MIT")
 
+    version("0.8.6", sha256="2b9a0332696df97d454fa67b81618fd69c35a7b90327cbe6ba5c92d2c68a7bfd")
     version("0.8.5", sha256="034d7354a9a018bdce352f48b2a8a450f05e9d6ee85db84764e9b6bd96dafe5a")
     version("0.8.4", sha256="eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d")
     version("0.8.3", sha256="8c07be290bb59f03588915921e29e8a50002acaf2cdc5fa0e0114f91709fafa0")
@@ -28,7 +30,7 @@ class PyParso(PythonPackage):
 
     with default_args(type=("build", "run")):
         # See parso/python/grammar*.txt
-        depends_on("python@:3.14", when="@:0.8.5")
+        depends_on("python@:3.14", when="@:0.8.6")
         # https://github.com/davidhalter/parso/commit/f670e6e7dc01e07576ec5c84cbf9fbce1a02c3eb
         depends_on("python@:3.13", when="@:0.8.4")
         # https://github.com/davidhalter/parso/commit/f7bea28bcc3a1862075e5b61a08d703d72be94aa


### PR DESCRIPTION
https://github.com/davidhalter/parso/releases/tag/v0.8.6
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
