### PR TITLE
adios-catalyst: new package for AdiosCatalyst

### DIFF
--- a/repos/spack_repo/builtin/packages/adios_catalyst/package.py
+++ b/repos/spack_repo/builtin/packages/adios_catalyst/package.py
@@ -1,0 +1,29 @@
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class AdiosCatalyst(CMakePackage):
+    """AdiosCatalyst is a new Catalyst implementation for Adios2.
+
+    The aim of this specific implementation is to be able to make in-transit simulation
+    with the SST engine of ADIOS2."""
+
+    homepage = "https://gitlab.kitware.com/paraview/adioscatalyst"
+    url = "https://gitlab.kitware.com/paraview/adioscatalyst"
+    git = "https://gitlab.kitware.com/paraview/adioscatalyst.git"
+
+    maintainers("albestro")
+
+    license("Apache-2.0", checked_by="albestro")
+
+    version("main", branch="main")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    depends_on("cmake@3.20:", type="build")
+
+    depends_on("libcatalyst")
+    depends_on("adios2")
+    depends_on("mpi")


### PR DESCRIPTION
This is one of the `libcatalyst` implementations.

For the moment I'd just add this as the simplest package possible.

The need for becoming a provider of `libcatalyst` as virtual provider, might be evaluated at a later time.