### PR TITLE
btop: v1.4.6+ needs C++23 compiler

### DIFF
--- a/repos/spack_repo/builtin/packages/btop/package.py
+++ b/repos/spack_repo/builtin/packages/btop/package.py
@@ -41,6 +41,7 @@ class Btop(MakefilePackage, CMakePackage):
     patch("link-dl.patch", when="+gpu @:1.4.0")
 
     requires("%gcc@10:", "%clang@16:", policy="one_of", msg="C++ 20 is required")
+    requires("%gcc@14:", "%clang@19:", policy="one_of", msg="C++ 23 is required", when="@1.4.6:")
 
 
 class MakefileBuilder(makefile.MakefileBuilder):


### PR DESCRIPTION
See https://github.com/aristocratos/btop/pull/1315