### PR TITLE
fftw: fix compilation on Asahi Linux

### DIFF
--- a/repos/spack_repo/builtin/packages/fftw/package.py
+++ b/repos/spack_repo/builtin/packages/fftw/package.py
@@ -108,7 +108,7 @@ class FftwBase(AutotoolsPackage):
 
         # On Apple Arm machines, force to use aarch64 rather than arm
         # to check for NEON due to logic in configure.
-        if self.spec.satisfies("target=m1:"):
+        if self.spec.satisfies("platform=darwin target=m1:"):
             uname = Executable("uname")
             uname_r = uname("-r", output=str)
             options.append("--build=aarch64-apple-darwin{0}".format(uname_r))


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
These flags are meant to the darwin platform, so I restricted the condition. Now I can compile fftw on Asahi Linux.