### PR TITLE
trivy: add v0.70.0

### DIFF
--- a/repos/spack_repo/builtin/packages/trivy/package.py
+++ b/repos/spack_repo/builtin/packages/trivy/package.py
@@ -17,6 +17,7 @@ class Trivy(GoPackage):
 
     license("Apache-2.0", checked_by="RobertMaaskant")
 
+    version("0.70.0", sha256="ff9ac06468aab89802388f16d1d179f4680db714afbf6a8132a417d288aa008e")
     version("0.69.3", sha256="3ca5fa62932273dd7eef3b6ec762625da42304ebb8f13e4be9fdd61545ca1773")
     version("0.64.1", sha256="9e23c90bd1afd9c369f1582712907e8e0652c8f5825e599850183af174c65666")
     version("0.64.0", sha256="95f958c5cf46e063660c241d022a57f99309208c9725d6031b048c9c414ecfa7")
@@ -26,6 +27,7 @@ class Trivy(GoPackage):
     version("0.61.1", sha256="f6ad43e008c008d67842c9e2b4af80c2e96854db8009fba48fc37b4f9b15f59b")
     version("0.61.0", sha256="1e97b1b67a4c3aee9c567534e60355033a58ce43a3705bdf198d7449d53b6979")
 
+    depends_on("go@1.25.8:", type="build", when="@0.70.0:")
     depends_on("go@1.25.6:", type="build", when="@0.69.1:")
     depends_on("go@1.24.4:", type="build", when="@0.64:")
     depends_on("go@1.24.2:", type="build", when="@0.62:")


### PR DESCRIPTION
Release notes: https://github.com/aquasecurity/trivy/releases/tag/v0.70.0
Diff: https://github.com/aquasecurity/trivy/compare/v0.69.3...v0.70.0