### PR TITLE
osmosis: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/osmosis/package.py
+++ b/repos/spack_repo/builtin/packages/osmosis/package.py
@@ -1,0 +1,31 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack_repo.builtin.build_systems.generic import Package
+
+from spack.package import *
+
+
+class Osmosis(Package):
+    """Osmosis is a Java application and library for processing OSM data."""
+
+    homepage = "https://wiki.openstreetmap.org/wiki/Osmosis"
+    url = "https://github.com/openstreetmap/osmosis/archive/refs/tags/0.49.2.tar.gz"
+
+    license("Unlicense", checked_by="mtpham99")  # "Public Domain" specified in "build.gradle"
+
+    version("0.49.2", sha256="b355771c35f326ee45431916c2ebe3f81a09ba571c03c3302f5268103f7b7e3c")
+
+    depends_on("java@17", type=("build", "run"), when="@0.49:")
+    depends_on("tar", type="build")
+
+    def install(self, spec, prefix):
+        tar = which("tar", required=True)
+        gradlew = Executable("./gradlew")
+
+        gradlew("--info", "--debug", "clean", "assemble")
+
+        with working_dir("osmosis/build/distributions"):
+            tar("xvf", "osmosis--SNAPSHOT.tar", "--strip-components", "1", "--directory", prefix)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

`Osmosis` is a command line Java application for processing openstreetmap (OSM) data.

No license file in repo, but "Public Domain" is specified in [build.gradle](https://github.com/openstreetmap/osmosis/blob/0.49.2/build.gradle#L99) file. Also listed as "public" in [maven repository](https://mvnrepository.com/artifact/org.openstreetmap.osmosis).

homepage: [https://wiki.openstreetmap.org/wiki/Osmosis](https://wiki.openstreetmap.org/wiki/Osmosis)
github: [https://github.com/openstreetmap/osmosis](https://github.com/openstreetmap/osmosis)