### PR TITLE
dftd4 and dependencies: build shared libs

### DIFF
--- a/repos/spack_repo/builtin/packages/dftd4/package.py
+++ b/repos/spack_repo/builtin/packages/dftd4/package.py
@@ -42,6 +42,8 @@ class Dftd4(MesonPackage, CMakePackage):
         when="build_system=meson",
         description="Build Python extension module",
     )
+    with when("build_system=cmake"):
+        variant("shared", default=True)
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")

--- a/repos/spack_repo/builtin/packages/dftd4/package.py
+++ b/repos/spack_repo/builtin/packages/dftd4/package.py
@@ -90,4 +90,7 @@ class MesonBuilder(meson.MesonBuilder):
 
 class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
-        return [self.define_from_variant("WITH_OPENMP", "openmp"), "-DBUILD_SHARED_LIBS=On"]
+        return [
+            self.define_from_variant("WITH_OPENMP", "openmp"),
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+        ]

--- a/repos/spack_repo/builtin/packages/dftd4/package.py
+++ b/repos/spack_repo/builtin/packages/dftd4/package.py
@@ -88,4 +88,4 @@ class MesonBuilder(meson.MesonBuilder):
 
 class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
-        return [self.define_from_variant("WITH_OPENMP", "openmp")]
+        return [self.define_from_variant("WITH_OPENMP", "openmp"), "-DBUILD_SHARED_LIBS=On"]

--- a/repos/spack_repo/builtin/packages/dftd4/package.py
+++ b/repos/spack_repo/builtin/packages/dftd4/package.py
@@ -43,7 +43,7 @@ class Dftd4(MesonPackage, CMakePackage):
         description="Build Python extension module",
     )
     with when("build_system=cmake"):
-        variant("shared", default=True)
+        variant("shared", default=True, description="Build shared libraries")
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")

--- a/repos/spack_repo/builtin/packages/jonquil/package.py
+++ b/repos/spack_repo/builtin/packages/jonquil/package.py
@@ -27,6 +27,9 @@ class Jonquil(MesonPackage, CMakePackage):
     version("0.2.0", sha256="68448be7f399942e15a05ed7a149cc226a8ee81a8ce66cd68a2d01d9fc86527e")
     version("0.1.0", sha256="0c8854da047306cad357143fe56f7afe3d323d89aa7383b6614b2b587f580044")
 
+    with when("build_system=cmake"):
+        variant("shared", default=True)
+
     depends_on("fortran", type="build")
     depends_on("meson@0.57.2:", type="build", when="build_system=meson")
 
@@ -37,7 +40,7 @@ class Jonquil(MesonPackage, CMakePackage):
 
 class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
-        return ["-DBUILD_SHARED_LIBS=On"]
+        return [self.define_from_variant("BUILD_SHARED_LIBS", "shared")]
 
 
 class MesonBuilder(meson.MesonBuilder):

--- a/repos/spack_repo/builtin/packages/jonquil/package.py
+++ b/repos/spack_repo/builtin/packages/jonquil/package.py
@@ -28,7 +28,7 @@ class Jonquil(MesonPackage, CMakePackage):
     version("0.1.0", sha256="0c8854da047306cad357143fe56f7afe3d323d89aa7383b6614b2b587f580044")
 
     with when("build_system=cmake"):
-        variant("shared", default=True)
+        variant("shared", default=True, description="Build shared libraries")
 
     depends_on("fortran", type="build")
     depends_on("meson@0.57.2:", type="build", when="build_system=meson")

--- a/repos/spack_repo/builtin/packages/jonquil/package.py
+++ b/repos/spack_repo/builtin/packages/jonquil/package.py
@@ -37,7 +37,7 @@ class Jonquil(MesonPackage, CMakePackage):
 
 class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
-        return []
+        return ["-DBUILD_SHARED_LIBS=On"]
 
 
 class MesonBuilder(meson.MesonBuilder):

--- a/repos/spack_repo/builtin/packages/mctc_lib/package.py
+++ b/repos/spack_repo/builtin/packages/mctc_lib/package.py
@@ -54,7 +54,7 @@ class CMakeBuilder(cmake.CMakeBuilder):
         return [
             self.define_from_variant("WITH_JSON", "json"),
             self.define_from_variant("WITH_OpenMP", "openmp"),
-            "-DBUILD_SHARED_LIBS=On"
+            "-DBUILD_SHARED_LIBS=On",
         ]
 
 

--- a/repos/spack_repo/builtin/packages/mctc_lib/package.py
+++ b/repos/spack_repo/builtin/packages/mctc_lib/package.py
@@ -54,6 +54,7 @@ class CMakeBuilder(cmake.CMakeBuilder):
         return [
             self.define_from_variant("WITH_JSON", "json"),
             self.define_from_variant("WITH_OpenMP", "openmp"),
+            "-DBUILD_SHARED_LIBS=On"
         ]
 
 

--- a/repos/spack_repo/builtin/packages/mctc_lib/package.py
+++ b/repos/spack_repo/builtin/packages/mctc_lib/package.py
@@ -35,6 +35,8 @@ class MctcLib(MesonPackage, CMakePackage):
 
     variant("json", default=False, description="Enable support for JSON")
     variant("openmp", default=False, description="Enable OpenMP support")
+    with when("build_system=cmake"):
+        variant("shared", default=True)
 
     depends_on("fortran", type="build")  # generated
 
@@ -54,7 +56,7 @@ class CMakeBuilder(cmake.CMakeBuilder):
         return [
             self.define_from_variant("WITH_JSON", "json"),
             self.define_from_variant("WITH_OpenMP", "openmp"),
-            "-DBUILD_SHARED_LIBS=On",
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
         ]
 
 

--- a/repos/spack_repo/builtin/packages/mctc_lib/package.py
+++ b/repos/spack_repo/builtin/packages/mctc_lib/package.py
@@ -36,7 +36,7 @@ class MctcLib(MesonPackage, CMakePackage):
     variant("json", default=False, description="Enable support for JSON")
     variant("openmp", default=False, description="Enable OpenMP support")
     with when("build_system=cmake"):
-        variant("shared", default=True)
+        variant("shared", default=True, description="Build shared libraries")
 
     depends_on("fortran", type="build")  # generated
 

--- a/repos/spack_repo/builtin/packages/multicharge/package.py
+++ b/repos/spack_repo/builtin/packages/multicharge/package.py
@@ -31,7 +31,7 @@ class Multicharge(CMakePackage, MesonPackage):
     variant("openmp", default=True, description="Enable OpenMP support")
 
     with when("build_system=cmake"):
-        variant("shared", default=True)
+        variant("shared", default=True, description="Build shared libraries")
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")

--- a/repos/spack_repo/builtin/packages/multicharge/package.py
+++ b/repos/spack_repo/builtin/packages/multicharge/package.py
@@ -30,6 +30,9 @@ class Multicharge(CMakePackage, MesonPackage):
 
     variant("openmp", default=True, description="Enable OpenMP support")
 
+    with when("build_system=cmake"):
+        variant("shared", default=True)
+
     depends_on("c", type="build")
     depends_on("fortran", type="build")
     depends_on("lapack")
@@ -47,7 +50,10 @@ class Multicharge(CMakePackage, MesonPackage):
 
 class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
-        args = [self.define_from_variant("WITH_OpenMP", "openmp"), "-DBUILD_SHARED_LIBS=On"]
+        args = [
+            self.define_from_variant("WITH_OpenMP", "openmp"),
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+        ]
         return args
 
 

--- a/repos/spack_repo/builtin/packages/multicharge/package.py
+++ b/repos/spack_repo/builtin/packages/multicharge/package.py
@@ -47,7 +47,7 @@ class Multicharge(CMakePackage, MesonPackage):
 
 class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
-        args = [self.define_from_variant("WITH_OpenMP", "openmp")]
+        args = [self.define_from_variant("WITH_OpenMP", "openmp"), "-DBUILD_SHARED_LIBS=On"]
         return args
 
 

--- a/repos/spack_repo/builtin/packages/toml_f/package.py
+++ b/repos/spack_repo/builtin/packages/toml_f/package.py
@@ -39,7 +39,7 @@ class TomlF(MesonPackage, CMakePackage):
 
 class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
-        return []
+        return ["-DBUILD_SHARED_LIBS=On"]
 
 
 class MesonBuilder(meson.MesonBuilder):

--- a/repos/spack_repo/builtin/packages/toml_f/package.py
+++ b/repos/spack_repo/builtin/packages/toml_f/package.py
@@ -32,7 +32,7 @@ class TomlF(MesonPackage, CMakePackage):
     version("0.2.3", sha256="2dca7ff6d3e35415cd92454c31560d2b656c014af8236be09c54c13452e4539c")
 
     with when("build_system=cmake"):
-        variant("shared", default=True)
+        variant("shared", default=True, description="Build shared libraries")
 
     depends_on("fortran", type="build")  # generated
     depends_on("meson@0.57.2:", type="build", when="build_system=meson")

--- a/repos/spack_repo/builtin/packages/toml_f/package.py
+++ b/repos/spack_repo/builtin/packages/toml_f/package.py
@@ -40,7 +40,6 @@ class TomlF(MesonPackage, CMakePackage):
     depends_on("pkgconfig", type="build")
 
 
-
 class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
         return [self.define_from_variant("BUILD_SHARED_LIBS", "shared")]

--- a/repos/spack_repo/builtin/packages/toml_f/package.py
+++ b/repos/spack_repo/builtin/packages/toml_f/package.py
@@ -31,15 +31,19 @@ class TomlF(MesonPackage, CMakePackage):
     version("0.2.4", sha256="ebfeb1e201725b98bae3e656bde4eea2db90154efa8681de758f1389fec902cf")
     version("0.2.3", sha256="2dca7ff6d3e35415cd92454c31560d2b656c014af8236be09c54c13452e4539c")
 
+    with when("build_system=cmake"):
+        variant("shared", default=True)
+
     depends_on("fortran", type="build")  # generated
     depends_on("meson@0.57.2:", type="build", when="build_system=meson")
 
     depends_on("pkgconfig", type="build")
 
 
+
 class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
-        return ["-DBUILD_SHARED_LIBS=On"]
+        return [self.define_from_variant("BUILD_SHARED_LIBS", "shared")]
 
 
 class MesonBuilder(meson.MesonBuilder):


### PR DESCRIPTION
add variant shared when using cmake as build system.

The static library lack a dependency on gfortran in their cmake config.