### PR TITLE
py-torch: disable SME and KleidiAI on A64FX

### DIFF
--- a/repos/spack_repo/builtin/packages/py_torch/disable-arm-sme-kernels-on-a64fx.patch
+++ b/repos/spack_repo/builtin/packages/py_torch/disable-arm-sme-kernels-on-a64fx.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/setup_helpers/cmake.py b/tools/setup_helpers/cmake.py
+index 02ab011..0a61f65 100644
+--- a/tools/setup_helpers/cmake.py
++++ b/tools/setup_helpers/cmake.py
+@@ -293,6 +293,8 @@ class CMake:
+                     "TORCH_XPU_ARCH_LIST",
+                     "TRACING_BASED",
+                     "PYTHON_LIB_REL_PATH",
++                    "XNNPACK_ENABLE_ARM_SME",
++                    "XNNPACK_ENABLE_ARM_SME2",
+                 )
+             }
+         )

--- a/repos/spack_repo/builtin/packages/py_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_torch/package.py
@@ -467,6 +467,9 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     patch("fj-ssl2_1.8.patch", when="@1.8^fujitsu-ssl2")
     patch("fj-ssl2_1.6-1.7.patch", when="@1.6:1.7^fujitsu-ssl2")
 
+    # Disable XNNPACK SME on A64FX
+    patch("disable-arm-sme-kernels-on-a64fx.patch", when="target=a64fx")
+
     # Fix compilation of +distributed~tensorpipe
     # https://github.com/pytorch/pytorch/issues/68002
     patch(
@@ -820,6 +823,12 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
             env.set("BUILD_CUSTOM_PROTOBUF", "ON")
         else:
             env.set("BUILD_CUSTOM_PROTOBUF", "OFF")
+
+        # Disable XNNPACK SME and KleidiAI on A64FX
+        if self.spec.satisfies("target=a64fx"):
+            env.set("XNNPACK_ENABLE_ARM_SME", "OFF")
+            env.set("XNNPACK_ENABLE_ARM_SME2", "OFF")
+            env.set("USE_KLEIDIAI", "OFF")
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         self.torch_cuda_arch_list(env)


### PR DESCRIPTION
### Summary

This PR fixes `py-torch` builds on Fujitsu A64FX by disabling
unsupported AArch64 SME/SME2 and KleidiAI code paths for
`target=a64fx`.

The change does the following:

- disables `XNNPACK_ENABLE_ARM_SME`
- disables `XNNPACK_ENABLE_ARM_SME2`
- disables `USE_KLEIDIAI`
- patches PyTorch's CMake helper so that the XNNPACK SME options are
  forwarded from the environment to CMake

### Motivation

On Fugaku / A64FX, the PyTorch build failed when newer AArch64
XNNPACK / KleidiAI code paths were enabled.

A64FX supports Armv8.2-A SVE, but it does not support Arm SME or
SME2. Therefore, SME/SME2-specific kernels should not be enabled for
`target=a64fx`.

`USE_KLEIDIAI=OFF` is passed through automatically because PyTorch
forwards `USE_*` environment variables to CMake. However,
`XNNPACK_ENABLE_ARM_SME` and `XNNPACK_ENABLE_ARM_SME2` do not use a
`USE_`, `BUILD_`, or `CMAKE_` prefix, so they need to be added to
PyTorch's explicit environment allow list.

### Tested on

Fugaku / Fujitsu A64FX:
