### PR TITLE
Update py-pandas Cython dependency to 3.1.0 for version for v3.0.2

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pandas/package.py
+++ b/repos/spack_repo/builtin/packages/py_pandas/package.py
@@ -80,6 +80,7 @@ class PyPandas(PythonPackage):
         depends_on("py-meson-python@0.13.1:", when="@2.1:")
         depends_on("meson@1.2.1:", when="@2.1.1:")
         depends_on("meson@1.0.1:", when="@2.1.0")
+        depends_on("py-cython@3.1.0:", when="@3.0.2:")
         depends_on("py-cython@3.0.5:3", when="@2.2:")
         depends_on("py-cython@0.29.33:2", when="@2.0:2.1")
         depends_on("py-cython@0.29.32:2", when="@1.4.4:1")


### PR DESCRIPTION
3.0.2 seems to make use of the `@cython.critical_section` decorator which was added in Cython 3.1.0 beta 1 (2025-04-03) so the Cython dependency needs to be updated.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
