### PR TITLE
kokkos-kernels: route spec cxxflags through CMAKE_CXX_FLAGS

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
@@ -255,4 +255,12 @@ class KokkosKernels(CMakePackage, CudaPackage):
         layout_value = spec.variants["layouts"].value
         options.append(self.define(f"KokkosKernels_INST_LAYOUT{layout_value.upper()}", True))
 
+        # kokkos_launch_compiler strips the Spack compiler wrapper on TUs
+        # tagged -DKOKKOS_DEPENDENCE, which loses SPACK_CXXFLAGS injected by
+        # the wrapper. Route the spec's cxxflags through CMAKE_CXX_FLAGS so
+        # they live in the command CMake assembles and survive forwarding.
+        cxxflags = spec.compiler_flags["cxxflags"]
+        if cxxflags:
+            options.append(self.define("CMAKE_CXX_FLAGS", " ".join(cxxflags)))
+
         return options


### PR DESCRIPTION
`kokkos_launch_compiler` is installed as the launcher on every target that links `Kokkos::kokkoscore` and strips the Spack compiler wrapper on TUs tagged `-DKOKKOS_DEPENDENCE`, which drops `SPACK_CXXFLAGS`.

We hit this building `kokkos-kernels %clang@19 +cuda` (clang as the CUDA device compiler) against a clang toolchain whose default libstdc++ ships a `<format>` header incompatible with clang-CUDA (llvm/llvm-project#69288). Setting `cxxflags='--gcc-install-dir=...'` on the spec picks a working libstdc++, but because the wrapper is stripped, the flag never reaches the real compiler.

Routing `cxxflags` through `CMAKE_CXX_FLAGS` keeps them in the command CMake assembles, so the launcher forwards them unchanged.