### PR TITLE
iq-tree: restricting to eigen@3

### DIFF
--- a/repos/spack_repo/builtin/packages/iq_tree/package.py
+++ b/repos/spack_repo/builtin/packages/iq_tree/package.py
@@ -52,7 +52,7 @@ class IqTree(CMakePackage):
     # Depends on Eigen3 and zlib
 
     depends_on("boost+container+math+exception")
-    depends_on("eigen")
+    depends_on("eigen@3")
     depends_on("zlib-api")
     depends_on("mpi", when="+mpi")
 


### PR DESCRIPTION
doesn't detect newer eigen.