### PR TITLE
termcap: fix build with gcc@15

### DIFF
--- a/repos/spack_repo/builtin/packages/termcap/package.py
+++ b/repos/spack_repo/builtin/packages/termcap/package.py
@@ -27,4 +27,6 @@ class Termcap(AutotoolsPackage, GNUMirrorPackage):
         if name == "cflags":
             if self.spec.satisfies("%gcc@14:"):
                 flags.append("-Wno-error=implicit-function-declaration")
+            if self.spec.satisfies("%gcc@15:"):
+                flags.append("-std=gnu17")
         return (flags, None, None)


### PR DESCRIPTION
Specify use of gnu17 standard as default in gcc@14

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
