### PR TITLE
gcc-runtime: fixing samefiles error

### DIFF
--- a/repos/spack_repo/builtin/packages/gcc_runtime/package.py
+++ b/repos/spack_repo/builtin/packages/gcc_runtime/package.py
@@ -68,7 +68,7 @@ class GccRuntime(Package):
             return
 
         for path, name in libraries:
-            install(path, os.path.join(prefix.lib, name))
+            install(path, os.path.join(prefix.lib, os.path.basename(name)))
 
         if spec.platform in ("linux", "freebsd"):
             _drop_libgfortran_zlib(prefix.lib)


### PR DESCRIPTION
similar issue to #4313 

I only seem to hit this with compilers I've installed with spack, so maybe it's a common cause that can be better resolved elsewhere.