### PR TITLE
bridger: limiting boost versions

### DIFF
--- a/repos/spack_repo/builtin/packages/bridger/package.py
+++ b/repos/spack_repo/builtin/packages/bridger/package.py
@@ -23,7 +23,7 @@ class Bridger(MakefilePackage, SourceforgePackage):
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
-    depends_on("boost + exception + filesystem + system + serialization + graph")
+    depends_on("boost@:1.83+exception+filesystem+system+serialization+graph")
     depends_on("ncurses~termlib")
     depends_on("perl", type="run")
 


### PR DESCRIPTION
newer versions of boost aren't compatible.