### PR TITLE
kokkos: convert openmptarget from conflict to conditional

### DIFF
--- a/repos/spack_repo/builtin/packages/cabana/package.py
+++ b/repos/spack_repo/builtin/packages/cabana/package.py
@@ -32,7 +32,9 @@ class Cabana(CMakePackage, CudaPackage, ROCmPackage):
     _kokkos_backends = Kokkos.devices_variants
     for _backend in _kokkos_backends:
         _deflt, _when, _descr = _kokkos_backends[_backend]
-        variant(_backend.lower(), default=_deflt, description=_descr, when=f"^kokkos{_when}")
+        if _when is not None:
+            _when = f"^kokkos{_when}"
+        variant(_backend.lower(), default=_deflt, description=_descr, when=_when)
 
     variant("shared", default=True, description="Build shared libraries")
     variant("mpi", default=True, description="Build with mpi support")

--- a/repos/spack_repo/builtin/packages/cabana/package.py
+++ b/repos/spack_repo/builtin/packages/cabana/package.py
@@ -31,8 +31,8 @@ class Cabana(CMakePackage, CudaPackage, ROCmPackage):
 
     _kokkos_backends = Kokkos.devices_variants
     for _backend in _kokkos_backends:
-        _deflt, _descr = _kokkos_backends[_backend]
-        variant(_backend.lower(), default=_deflt, description=_descr)
+        _deflt, _when, _descr = _kokkos_backends[_backend]
+        variant(_backend.lower(), default=_deflt, description=_descr, when=f"^kokkos{_when}")
 
     variant("shared", default=True, description="Build shared libraries")
     variant("mpi", default=True, description="Build with mpi support")

--- a/repos/spack_repo/builtin/packages/exaca/package.py
+++ b/repos/spack_repo/builtin/packages/exaca/package.py
@@ -34,7 +34,9 @@ class Exaca(CMakePackage, CudaPackage, ROCmPackage):
     _kokkos_backends = Kokkos.devices_variants
     for _backend in _kokkos_backends:
         _deflt, _when, _descr = _kokkos_backends[_backend]
-        variant(_backend.lower(), default=_deflt, description=_descr, when=f"^kokkos{_when}")
+        if _when is not None:
+            _when = f"^kokkos{_when}"
+        variant(_backend.lower(), default=_deflt, description=_descr, when=_when)
 
     variant("shared", default=True, description="Build shared libraries")
     variant("testing", default=False, description="Build unit tests")

--- a/repos/spack_repo/builtin/packages/exaca/package.py
+++ b/repos/spack_repo/builtin/packages/exaca/package.py
@@ -33,8 +33,8 @@ class Exaca(CMakePackage, CudaPackage, ROCmPackage):
 
     _kokkos_backends = Kokkos.devices_variants
     for _backend in _kokkos_backends:
-        _deflt, _descr = _kokkos_backends[_backend]
-        variant(_backend.lower(), default=_deflt, description=_descr)
+        _deflt, _when, _descr = _kokkos_backends[_backend]
+        variant(_backend.lower(), default=_deflt, description=_descr, when=f"^kokkos{_when}")
 
     variant("shared", default=True, description="Build shared libraries")
     variant("testing", default=False, description="Build unit tests")

--- a/repos/spack_repo/builtin/packages/finch/package.py
+++ b/repos/spack_repo/builtin/packages/finch/package.py
@@ -28,8 +28,8 @@ class Finch(CMakePackage, CudaPackage, ROCmPackage):
 
     _kokkos_backends = Kokkos.devices_variants
     for _backend in _kokkos_backends:
-        _deflt, _descr = _kokkos_backends[_backend]
-        variant(_backend.lower(), default=_deflt, description=_descr)
+        _deflt, _when, _descr = _kokkos_backends[_backend]
+        variant(_backend.lower(), default=_deflt, description=_descr, when=f"^kokkos{_when}")
 
     variant("shared", default=True, description="Build shared libraries")
 

--- a/repos/spack_repo/builtin/packages/finch/package.py
+++ b/repos/spack_repo/builtin/packages/finch/package.py
@@ -29,7 +29,9 @@ class Finch(CMakePackage, CudaPackage, ROCmPackage):
     _kokkos_backends = Kokkos.devices_variants
     for _backend in _kokkos_backends:
         _deflt, _when, _descr = _kokkos_backends[_backend]
-        variant(_backend.lower(), default=_deflt, description=_descr, when=f"^kokkos{_when}")
+        if _when is not None:
+            _when = f"^kokkos{_when}"
+        variant(_backend.lower(), default=_deflt, description=_descr, when=_when)
 
     variant("shared", default=True, description="Build shared libraries")
 

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -110,14 +110,15 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("^cmake@3.28", when="@:4.2.01 +cuda")
     conflicts("^cuda@13:", when="@:4.7.0")
 
+    # device : (default value, when clause, description)
     devices_variants = {
-        "cuda": [False, "Whether to build CUDA backend"],
-        "openmp": [False, "Whether to build OpenMP backend"],
-        "threads": [False, "Whether to build the C++ threads backend"],
-        "serial": [False, "Whether to build serial backend"],
-        "rocm": [False, "Whether to build HIP backend"],
-        "sycl": [False, "Whether to build the SYCL backend"],
-        "openmptarget": [False, "@;5.0", "Whether to build the OpenMPTarget backend"],
+        "cuda": [False, None, "Whether to build CUDA backend"],
+        "openmp": [False, None, "Whether to build OpenMP backend"],
+        "threads": [False, None, "Whether to build the C++ threads backend"],
+        "serial": [False, None, "Whether to build serial backend"],
+        "rocm": [False, None, "Whether to build HIP backend"],
+        "sycl": [False, None, "Whether to build the SYCL backend"],
+        "openmptarget": [False, "@:5.0", "Whether to build the OpenMPTarget backend"],
     }
     requires(
         "+serial", when="~hpx ~openmp ~threads", msg="Kokkos requires at least one host backend"
@@ -308,8 +309,8 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     # FIXME this should move to the apu part
     variant("apu", default=False, description="Enable APU support", when="@4.5: +rocm")
 
-    for dev, (dflt, desc) in devices_variants.items():
-        variant(dev, default=dflt, description=desc)
+    for dev, (dflt, when, desc) in devices_variants.items():
+        variant(dev, default=dflt, description=desc, when=when)
     conflicts("+cuda", when="+rocm", msg="CUDA and ROCm are not compatible in Kokkos.")
     depends_on("intel-oneapi-dpl", when="+sycl")
     depends_on("rocthrust", when="@4.3: +rocm")

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -117,12 +117,11 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         "serial": [False, "Whether to build serial backend"],
         "rocm": [False, "Whether to build HIP backend"],
         "sycl": [False, "Whether to build the SYCL backend"],
-        "openmptarget": [False, "Whether to build the OpenMPTarget backend"],
+        "openmptarget": [False, "@;5.0", "Whether to build the OpenMPTarget backend"],
     }
     requires(
         "+serial", when="~hpx ~openmp ~threads", msg="Kokkos requires at least one host backend"
     )
-    conflicts("+openmptarget", when="@5.1:")
 
     tpls_variants = {
         "hpx": [False, None, "Whether to enable the HPX library"],


### PR DESCRIPTION
Supersedes #4345, as listed in https://github.com/kokkos/kokkos/blob/develop/CHANGELOG.md#incompatibilities-ie-breaking-changes, the OpenMP target backend has beend removed in 5.1