### PR TITLE
healpix-cxx: restrict cfitsio@3

### DIFF
--- a/repos/spack_repo/builtin/packages/healpix_cxx/package.py
+++ b/repos/spack_repo/builtin/packages/healpix_cxx/package.py
@@ -3,31 +3,20 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.build_systems.sourceforge import SourceforgePackage
 
 from spack.package import *
 
 
-class HealpixCxx(AutotoolsPackage):
+class HealpixCxx(AutotoolsPackage, SourceforgePackage):
     """Healpix-CXX is a C/C++ library for calculating
     Hierarchical Equal Area isoLatitude Pixelation of a sphere."""
 
     homepage = "https://healpix.sourceforge.io"
-    url = "https://ayera.dl.sourceforge.net/project/healpix/Healpix_3.50/healpix_cxx-3.50.0.tar.gz"
+    sourceforge_mirror_path = "healpix/healpix_cxx-3.50.0.tar.gz"
 
     license("GPL-2.0-or-later")
 
     version("3.50.0", sha256="6538ee160423e8a0c0f92cf2b2001e1a2afd9567d026a86ff6e2287c1580cb4c")
 
-    depends_on("cfitsio")
-    depends_on("libsharp", type="build")
-
-    def patch(self):
-        spec = self.spec
-        configure_fix = FileFilter("configure")
-        # Link libsharp static libs
-        configure_fix.filter(
-            r"^SHARP_LIBS=.*$",
-            'SHARP_LIBS="-L{0} -lsharp -lc_utils -lfftpack -lm"'.format(
-                spec["libsharp"].prefix.lib
-            ),
-        )
+    depends_on("cfitsio@3")

--- a/repos/spack_repo/builtin/packages/healpix_cxx/package.py
+++ b/repos/spack_repo/builtin/packages/healpix_cxx/package.py
@@ -19,4 +19,7 @@ class HealpixCxx(AutotoolsPackage, SourceforgePackage):
 
     version("3.50.0", sha256="6538ee160423e8a0c0f92cf2b2001e1a2afd9567d026a86ff6e2287c1580cb4c")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("cfitsio@3")


### PR DESCRIPTION
Needs cfitsio@3.

The libsharp dep is actually vendored in this version and isn't necessary as a dependency. 

I tried for a while to update this to the latest version but was hitting compilation issues that seem to stem from compatibility issues with libsharp, which they do not vendor in later versions.

The patch method doesn't actually seem to be needed with this version, but would in subsequent versions.