### PR TITLE
SAMRAI: fix the finding of the CMakeBuilder class

### DIFF
--- a/repos/spack_repo/builtin/packages/samrai/package.py
+++ b/repos/spack_repo/builtin/packages/samrai/package.py
@@ -9,6 +9,7 @@ from spack_repo.builtin.build_systems.cached_cmake import (
     CachedCMakeBuilder,
     CachedCMakePackage,
     cmake_cache_option,
+    cmake_cache_path,
     cmake_cache_string,
 )
 from spack_repo.builtin.build_systems.cuda import CudaPackage
@@ -167,7 +168,7 @@ class Samrai(AutotoolsPackage, CachedCMakePackage, CudaPackage):
         return []
 
 
-class CachedCMakeBuilder(CachedCMakeBuilder):
+class CMakeBuilder(CachedCMakeBuilder):
 
     @property
     def libs(self):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
The build system finding does not look for a `CachedCMakeBuilder`. This works around that and a missing import.