### PR TITLE
percolator: add boost constraints

### DIFF
--- a/repos/spack_repo/builtin/packages/percolator/package.py
+++ b/repos/spack_repo/builtin/packages/percolator/package.py
@@ -40,8 +40,8 @@ class Percolator(CMakePackage):
 
     depends_on("cmake@3.5:", type="build", when="@3.8:")
     depends_on("cmake@2.8.11:", type="build", when="@3.6:3.7")
-    depends_on("boost@1.70:", type="build", when="@3.8:")
-    depends_on("boost@1.46:", type="build", when="@3.6:3.7")
+    depends_on("boost@1.70:1.88", type="build", when="@3.8:")
+    depends_on("boost@1.46:1.86", type="build", when="@3.6:3.7")
     depends_on("boost+system+filesystem", type="build")
 
     depends_on("xerces-c transcoder=none netaccessor=none", when="+xml")

--- a/repos/spack_repo/builtin/packages/percolator/package.py
+++ b/repos/spack_repo/builtin/packages/percolator/package.py
@@ -40,9 +40,8 @@ class Percolator(CMakePackage):
 
     depends_on("cmake@3.5:", type="build", when="@3.8:")
     depends_on("cmake@2.8.11:", type="build", when="@3.6:3.7")
-    depends_on("boost@1.70:1.88", type="build", when="@3.8:")
-    depends_on("boost@1.46:1.86", type="build", when="@3.6:3.7")
-    depends_on("boost+system+filesystem", type="build")
+    depends_on("boost@1.70:+filesystem+thread", type="build", when="@3.8:")
+    depends_on("boost@1.46:1.86+filesystem", type="build", when="@3.6:3.7")
 
     depends_on("xerces-c transcoder=none netaccessor=none", when="+xml")
     depends_on("xsd", when="+xml")
@@ -53,3 +52,10 @@ class Percolator(CMakePackage):
 
     def cmake_args(self):
         return [self.define_from_variant("XML_SUPPORT", "xml")]
+
+    def patch(self):
+        # The Boost::system target was removed in 1.88
+        filter_file(r"(COMPONENTS filesystem) system", r"\1 ", "src/CMakeLists.txt")
+
+        if self.spec.satisfies("@3.8.1:"):
+            filter_file("Boost::system", "", "src/CMakeLists.txt")


### PR DESCRIPTION
* Boost >= 1.89 is not detected by CMake files of Percolator, due to intentional deprecation on CMake and Boost side.

   ```
   >> 45 CMake Error at [...]/spack/opt/spack/linux-zen3/boost-1.89.0-d3bmnsb 4yddvoy3y4tlr7brdxnb5clqi/lib/cmake/Boost-1.89.0/BoostConfig.cmake:141 (find_package): 46 Could not find a package configuration file provided by "boost_system" 47 (requested version 1.89.0) with any of the following names: 48 49 boost_systemConfig.cmake 50 boost_system-config.cmake
   ```

* Older Percolator versions fail to build with Boost newer than 1.86

   ```
        176    [...]/spack-stage-percolator-3.6.5-ghyjcoseajgxrccdtdeiggojwulca5jq/spack-src/src/GoogleA
            nalytics.cpp: In static member function 'static void GoogleAnalytics::httpRequest(const std::string&, const
             std::string&)':
     >> 177    [...]/spack-stage/spack-stage-percolator-3.6.5-ghyjcoseajgxrccdtdeiggojwulca5jq/spack-src/src/GoogleA
            nalytics.cpp:51:3: error: 'io_service' was not declared in this scope
        178       51 |   io_service service;
        179          |   ^~~~~~~~~~
   ```

* Build grid

   <img width="195" height="257" alt="image" src="https://github.com/user-attachments/assets/4be903f8-b2ef-47d0-95d0-8a51274b3289" />
   
Added necessary constraints.