### PR TITLE
nvbandwidth: Add v0.9

### DIFF
--- a/repos/spack_repo/builtin/packages/nvbandwidth/package.py
+++ b/repos/spack_repo/builtin/packages/nvbandwidth/package.py
@@ -20,10 +20,16 @@ class Nvbandwidth(CMakePackage, CudaPackage):
     version("main", branch="main")
 
     version(
+        "v0.9",
+        url="https://github.com/NVIDIA/nvbandwidth/archive/refs/tags/v0.9.tar.gz",
+        sha256="552e7b2595c4b95ab1da86ba002f239185d247b2fb9929ed3cb9dc7f57bcd67c",
+        preferred=True,
+    )
+
+    version(
         "v0.8",
         url="https://github.com/NVIDIA/nvbandwidth/archive/refs/tags/v0.8.tar.gz",
         sha256="b3622945eb7fce2b4e1aea7d13de04f415f4d998db602893201a904320cf2d39",
-        preferred=True,
     )
 
     version(


### PR DESCRIPTION
Add v0.9 of nvbandwidth (released 2 weeks ago).

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
