### PR TITLE
fides: add 1.3.0

### DIFF
--- a/repos/spack_repo/builtin/packages/ascent/package.py
+++ b/repos/spack_repo/builtin/packages/ascent/package.py
@@ -310,7 +310,7 @@ class Ascent(CMakePackage, CudaPackage, ROCmPackage):
 
     # fides
     with when("+fides"):
-        depends_on("fides", when="+fides")
+        depends_on("fides")
         depends_on("fides@:1.2", when="@:0.9.5")
 
     # Adios2

--- a/repos/spack_repo/builtin/packages/ascent/package.py
+++ b/repos/spack_repo/builtin/packages/ascent/package.py
@@ -309,7 +309,9 @@ class Ascent(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("occa", when="+occa")
 
     # fides
-    depends_on("fides", when="+fides")
+    with when("+fides"):
+        depends_on("fides", when="+fides")
+        depends_on("fides@:1.2", when="@:0.9.5")
 
     # Adios2
     depends_on("adios2", when="+adios2")

--- a/repos/spack_repo/builtin/packages/fides/package.py
+++ b/repos/spack_repo/builtin/packages/fides/package.py
@@ -17,6 +17,7 @@ class Fides(CMakePackage):
     maintainers("caitlinross", "dpugmire")
 
     version("master", branch="master")
+    version("1.3.0", sha256="1ba00efd68a1dde418dbc774b19b6c6a02d56c0ee696bdcaeb8c9e54697c6ae0")
     version("1.2.0", sha256="12be939d75c765dab9241f9ed2b64af01cce2b10281de402f64fb685e6ccd7df")
     version("1.1.0", sha256="40d2e08b8d5cfdfc809eae6ed2ae0731108ce3b1383485f4934a5ec8aaa9425e")
     version("1.0.0", sha256="c355fdb4ca3790c1fa9a4491a0d294b8f883b6946c540ad9e5633c9fd8c8c3aa")

--- a/repos/spack_repo/builtin/packages/viskores/package.py
+++ b/repos/spack_repo/builtin/packages/viskores/package.py
@@ -60,6 +60,8 @@ class Viskores(CMakePackage, CudaPackage, ROCmPackage):
     variant("tbb", default=(sys.platform == "darwin"), description="build TBB support")
     variant("sycl", default=False, description="Build with SYCL backend")
 
+    conflicts("vtk-m")
+
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 

--- a/repos/spack_repo/builtin/packages/viskores/package.py
+++ b/repos/spack_repo/builtin/packages/viskores/package.py
@@ -60,8 +60,6 @@ class Viskores(CMakePackage, CudaPackage, ROCmPackage):
     variant("tbb", default=(sys.platform == "darwin"), description="build TBB support")
     variant("sycl", default=False, description="Build with SYCL backend")
 
-    conflicts("vtk-m")
-
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 


### PR DESCRIPTION
Fides 1.3.0 has been recently released https://gitlab.kitware.com/vtk/fides/-/releases/v1.3.0 

Which is the first that uses `viskores` in place of `vtk-m` (~I added a `conflict` in `viskores` to avoid having both in the same concretization~ we opted for constraining ascent pre-viskores migration to use fides pre-viskores in order to match dependencies, see [CI error](https://gitlab.spack.io/spack/spack-packages/-/jobs/21614672#L485)).

This dependency was already correctly set up in a previous PR, so no further changes should be needed for it.

https://github.com/spack/spack-packages/blob/6845f1ce71052a4e8228a9b9b80c6615f1e54b81/repos/spack_repo/builtin/packages/fides/package.py#L39-L42