### PR TITLE
boost: fix failing builds with apple-clang

### DIFF
--- a/repos/spack_repo/builtin/packages/boost/package.py
+++ b/repos/spack_repo/builtin/packages/boost/package.py
@@ -543,6 +543,7 @@ class Boost(Package):
             "%gcc": "gcc",
             "%intel": "intel",
             "%oneapi": "intel",
+            "%apple-clang": "clang",
             "%clang": "clang",
             "%arm": "clang",
             "%xl": "xlcpp",


### PR DESCRIPTION
## Summary

Map `%apple-clang` to Boost's `clang` b2 toolset.

## Root cause

`Boost.determine_toolset()` did not have an `%apple-clang` entry, so Apple Clang builds on Darwin fell through to the `gcc` fallback. That caused Spack to write:

```text
using gcc : : <spack clang++ wrapper>
```

into `user-config.jam` even though the actual compiler was Apple Clang. On macOS arm64 this mis-selected the Boost.Context assembly/toolset rules and broke installs that depend on `boost+context`, including HPX with generic coroutines.

## Impact

This fixes Boost builds that use `%apple-clang` on Darwin, including:

```bash
spack install hpx networking=tcp malloc=system cxxstd=20
```

## Validation

Validated locally against this checkout by running:

```bash
./bin/spack -e ./.spack-env-packages-pr install --reuse hpx networking=tcp malloc=system cxxstd=20
```

The install completed successfully on macOS arm64 with `%apple-clang@17.0.0`.
