### PR TITLE
chore: extra xorg mirrors

### DIFF
--- a/repos/spack_repo/builtin/build_systems/xorg.py
+++ b/repos/spack_repo/builtin/build_systems/xorg.py
@@ -24,6 +24,8 @@ class XorgPackage(PackageBase):
         "https://mirror.transip.net/xorg/individual/",
         "ftp://ftp.freedesktop.org/pub/xorg/individual/",
         "http://xorg.mirrors.pair.com/individual/",
+        "https://artfiles.org/x.org/pub/individual/",
+        "https://xorg.freedesktop.org/releases/individual/",
     ]
 
     @property


### PR DESCRIPTION
Based on https://wiki.x.org/wiki/Releases/Download/. I added them because x.org was down and the existing mirrors did not have recent enough versions of some packages.