### PR TITLE
adios2: add version 2.12.0 + upper bound for cuda@13 support + patch aarch64

### DIFF
--- a/repos/spack_repo/builtin/packages/adios2/package.py
+++ b/repos/spack_repo/builtin/packages/adios2/package.py
@@ -30,14 +30,8 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
     license("Apache-2.0")
 
     version("master", branch="master")
-    version(
-        "2.12.0-rc1", sha256="c2f2e1e594a85ff46623a99c7a8d71e3f8bf2249b1c6f8be6a9e472daaf12889"
-    )
-    version(
-        "2.11.0",
-        sha256="0a2bd745e3f39745f07587e4a5f92d72f12fa0e2be305e7957bdceda03735dbf",
-        preferred=True,
-    )
+    version("2.12.0", sha256="c59aeb75f3ea9949c4ae2d597115536ee593dedb50592784917ba8d29c8a3b34")
+    version("2.11.0", sha256="0a2bd745e3f39745f07587e4a5f92d72f12fa0e2be305e7957bdceda03735dbf")
     version("2.10.2", sha256="14cf0bcd94772194bce0f2c0e74dba187965d1cffd12d45f801c32929158579e")
     version("2.10.1", sha256="ce776f3a451994f4979c6bd6d946917a749290a37b7433c0254759b02695ad85")
     version("2.10.0", sha256="e5984de488bda546553dd2f46f047e539333891e63b9fe73944782ba6c2d95e4")

--- a/repos/spack_repo/builtin/packages/adios2/package.py
+++ b/repos/spack_repo/builtin/packages/adios2/package.py
@@ -116,7 +116,7 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("%oneapi@:2022.1.0", when="+fortran")
 
     # https://github.com/ornladios/ADIOS2/issues/4620
-    conflicts("^cuda@13:", when="+cuda")
+    conflicts("^cuda@13:", when="@:2.11 +cuda")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")

--- a/repos/spack_repo/builtin/packages/adios2/package.py
+++ b/repos/spack_repo/builtin/packages/adios2/package.py
@@ -116,7 +116,10 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("%oneapi@:2022.1.0", when="+fortran")
 
     # https://github.com/ornladios/ADIOS2/issues/4620
-    conflicts("^cuda@13:", when="@:2.11 +cuda")
+    conflicts("%cuda@13:", when="@:2.11 +cuda")
+
+    # https://github.com/ornladios/ADIOS2/issues/5005
+    conflicts("@2.12.0", when="target=aarch64:")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")


### PR DESCRIPTION
Changelog:
- I dropped `2.12.0-rc1` in favour of the new `2.12.0` official release. Not sure if it was a good move, in case I can add it back (probably deprecated?)
- Since we have a newer official release, I also dropped the preference for `2.11.0` version.
- Added an upper bound for `cuda@13` conflict, now that 2.12.0 should support it
- Due to https://github.com/ornladios/ADIOS2/issues/5005#issuecomment-4302092413 I had to add also 4d2f27e8286be002a31b6438abc3b0098e4e41db with a conflict for target `aarch64`

On the latter point, in case a 2.12.1 patch version will be release, we can add it later.
For the moment on `aarch64` we can use
- `adios2@git.release_212=2.12.1`
- `adios2@git.98c51cc2207fd178d2f84f493d19710cf21f84c1=2.12.1`
- or simply `adios2@master`.