### PR TITLE
netcdf-fortran: Configure fix for NAG Fortran on macOS

### DIFF
--- a/repos/spack_repo/builtin/packages/netcdf_fortran/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_fortran/package.py
@@ -133,12 +133,12 @@ class NetcdfFortran(AutotoolsPackage):
             filter_file(
                 r"-install_name \$rpath/\$soname",
                 r"-Wl,-Xlinker,-install_name,-Xlinker,$rpath/$soname",
-                "libtool"
+                "libtool",
             )
             filter_file(
                 r"single_module=\$wl-Wl,-single_module",
                 r"single_module=\$wl-single_module",
-                "libtool"
+                "libtool",
             )
 
     def configure_args(self):

--- a/repos/spack_repo/builtin/packages/netcdf_fortran/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_fortran/package.py
@@ -120,6 +120,27 @@ class NetcdfFortran(AutotoolsPackage):
             msg.format("shared" if shared else "static", self.spec.name, self.spec.prefix)
         )
 
+    @run_after("configure")
+    def fix_darwin_libtool(self):
+        if self.spec.satisfies("%nag platform=darwin"):
+            filter_file(r'wl="-Wl,-Wl,,"', r'wl="-Wl,-Xlinker,"', "libtool")
+            filter_file(r'wl="-Wl,-Wl,"', r'wl="-Wl,-Xlinker,"', "libtool")
+            filter_file(
+                r"-compatibility_version \$minor_current -current_version \$minor_current\.\$revision",
+                r"-Wl,-Xlinker,-compatibility_version,-Xlinker,$minor_current,-Xlinker,-current_version,-Xlinker,$minor_current.$revision",
+                "libtool",
+            )
+            filter_file(
+                r"-install_name \$rpath/\$soname",
+                r"-Wl,-Xlinker,-install_name,-Xlinker,$rpath/$soname",
+                "libtool"
+            )
+            filter_file(
+                r"single_module=\$wl-Wl,-single_module",
+                r"single_module=\$wl-single_module",
+                "libtool"
+            )
+
     def configure_args(self):
         config_args = ["--enable-static"]
         config_args += self.enable_or_disable("shared")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

One of a series of NAG related PRs I've found in testing.

This PR has a set of `filter_file` changes I found I needed when building `netcdf-fortran` with NAG Fortran on macOS.

NAG is unique and doubly so when it comes to linking with Apple Clang it seems.

I'm sure the "right" thing to do is fix this in netcdf-fortran itself. Hopefully I can figure out how to do that soon, but for now, I found this is needed for NAG work I'm doing.
