### PR TITLE
hdf5: Updates for NAG Fortran

### DIFF
--- a/repos/spack_repo/builtin/packages/hdf5/nag_macos_linker.patch
+++ b/repos/spack_repo/builtin/packages/hdf5/nag_macos_linker.patch
@@ -1,0 +1,12 @@
+--- a/config/cmake/HDF5Macros.cmake
++++ b/config/cmake/HDF5Macros.cmake
+@@ -30,7 +30,7 @@
+     endif ()
+     if (CMAKE_C_OSX_CURRENT_VERSION_FLAG)
+-      set_property(TARGET ${libtarget} APPEND PROPERTY
+-          LINK_FLAGS "${CMAKE_C_OSX_CURRENT_VERSION_FLAG}${PACKAGE_CURRENT} ${CMAKE_C_OSX_COMPATIBILITY_VERSION_FLAG}${PACKAGE_COMPATIBILITY}"
++      set_property(TARGET ${libtarget} APPEND PROPERTY
++          LINK_FLAGS "-Wl,-current_version -Wl,${PACKAGE_CURRENT} -Wl,-compatibility_version -Wl,${PACKAGE_COMPATIBILITY}"
+       )
+     endif ()
+   endif ()

--- a/repos/spack_repo/builtin/packages/hdf5/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5/package.py
@@ -246,7 +246,8 @@ class Hdf5(CMakePackage):
     # See https://github.com/HDFGroup/hdf5/pull/3837
     patch("hdf5_1_14_3_fpe.patch", when="@1.14.3")
 
-    # Fix Apple linker flags (-current_version and -compatibility_version) when building with NAG compiler
+    # Fix Apple linker flags (-current_version and -compatibility_version)
+    # when building with NAG compiler
     patch("nag_macos_linker.patch", when="@1.12.0:1.14.99 %nag platform=darwin")
 
     # There are known build failures with intel@18.0.1. This issue is

--- a/repos/spack_repo/builtin/packages/hdf5/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5/package.py
@@ -246,6 +246,9 @@ class Hdf5(CMakePackage):
     # See https://github.com/HDFGroup/hdf5/pull/3837
     patch("hdf5_1_14_3_fpe.patch", when="@1.14.3")
 
+    # Fix Apple linker flags (-current_version and -compatibility_version) when building with NAG compiler
+    patch("nag_macos_linker.patch", when="@1.12.0:1.14.99 %nag platform=darwin")
+
     # There are known build failures with intel@18.0.1. This issue is
     # discussed and patch is provided at
     # https://software.intel.com/en-us/forums/intel-fortran-compiler-for-linux-and-mac-os-x/topic/747951.


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

One of a series of NAG related PRs I've found in testing.

Much like my netcdf-fortran fix in #4455, NAG Fortran and Darwin can be "exciting" when it comes to linking. 

For now, just so I can get things to work, this is the ugly patch I came up with. It works, but it's not pretty.

Note: I made it only for 1.12 to 1.14 as this file is actually in a different spot in HDF5 2 and I only really confirmed the file looked as it did going back to 1.12.

The right thing is probably to fix the CMake in the HDF5 mother repo, especially for HDF5 2+.  I'll try and get to that at some point soon once I get my NAG Spack stack settled.

