### PR TITLE
py-roman-numerals: add v4.1.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_roman_numerals/package.py
+++ b/repos/spack_repo/builtin/packages/py_roman_numerals/package.py
@@ -15,6 +15,13 @@ class PyRomanNumerals(PythonPackage):
 
     license("0BSD OR CC0-1.0")
 
+    version("4.1.0", sha256="1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2")
     version("3.1.0", sha256="384e36fc1e8d4bd361bdb3672841faae7a345b3f708aae9895d074c878332551")
 
-    depends_on("py-flit-core@3.7:3", type="build")
+    with default_args(type="build"):
+        depends_on("py-flit-core@3.12:3", when="@4:")
+        depends_on("py-flit-core@3.7:3", when="@:3")
+
+    with default_args(type=("build", "run")):
+        depends_on("python@3.10:", when="@4:")
+        depends_on("python@3.9:")


### PR DESCRIPTION
https://github.com/AA-Turner/roman-numerals/releases/tag/v4.1.0
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
