### PR TITLE
py-send2trash: add v2.1.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_send2trash/package.py
+++ b/repos/spack_repo/builtin/packages/py_send2trash/package.py
@@ -15,8 +15,11 @@ class PySend2trash(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("2.1.0", sha256="7503447b1ae6ce211a71b0325acb7455e8397e3cea516043e52b79a5dd8949ee")
     version("1.8.3", sha256="90bcdf2ed2a18b687040c0f58bfccd6ad2e1b7ec495a9903119dc3c47c615052")
     version("1.8.0", sha256="937b038abd9f1e7b8c5d7a116be5dc4663beb71df74dcccffe56cacf992c7a9c")
     version("1.5.0", sha256="7cebc0ffc8b6d6e553bce9c6bb915614610ba2dec17c2f0643b1b97251da2a41")
 
-    depends_on("py-setuptools", type="build")
+    with default_args(type="build"):
+        depends_on("py-setuptools@75.3.1:", when="@2:")
+        depends_on("py-setuptools")


### PR DESCRIPTION
https://github.com/arsenetar/send2trash/releases/tag/2.1.0
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
