### PR TITLE
py-pyscf: add v2.10.0 to v2.13.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pyscf/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyscf/package.py
@@ -19,6 +19,11 @@ class PyPyscf(PythonPackage):
 
     license("Apache-2.0")
 
+    version("2.13.0", sha256="5381c77568cc894df57f82aca1f025275322ac52b32b5aa86806a4649baa1eae")
+    version("2.12.1", sha256="cae3b026a928ce866965242056a833a17e46b89035d2e3abbf5429a158da4d48")
+    version("2.12.0", sha256="6c1ddb594ccc12f2b7411cfff977ab4b0cd0ade25cc454646cc26f93f97ce16e")
+    version("2.11.0", sha256="832b3ff4a84886e003fab272a49a7eec7b29e58733faadb94abc7b169956423a")
+    version("2.10.0", sha256="064bf7d27b2dd2684727cb703362e83c3a1f1505f23236965024422b1772c985")
     version("2.9.0", sha256="821dc882f3a5485d8f202abb093330cf1497b26767ba2a1a63b7fa600ddc58a3")
     version("2.8.0", sha256="db720372e7f7d1aa2df0fb90c07f483da363730197c937a6378952d34b6abf3d")
     version("2.7.0", sha256="ca8efc2f28d72c3130f26a967e7fa8d0bbc4a6b47d16a7c4c732ec85a31b7eec")
@@ -40,8 +45,10 @@ class PyPyscf(PythonPackage):
     depends_on("cxx", type="build")
 
     # dependencies
+    depends_on("cmake@3", type="build", when="@:2.13.0")
     depends_on("cmake@3.10:", type="build", when="@2.1:")
     depends_on("cmake@2.8:", type="build")
+    depends_on("python@3.7:", type=("build", "run"), when="@2.13.0:")
     depends_on("python@3.6:", type=("build", "run"), when="@2.1:")
     depends_on("python@2.6:", type=("build", "run"))
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
Add the most recent releases of pyscf. https://github.com/pyscf/pyscf/releases

Added python 3.7.0 minimum for v2.13.0+ and present ncompatibility with cmake>=4 (general).
