### PR TITLE
dock: adding v6.13.1, reworking recipe

### DIFF
--- a/repos/spack_repo/builtin/packages/dock/package.py
+++ b/repos/spack_repo/builtin/packages/dock/package.py
@@ -18,13 +18,16 @@ class Dock(Package):
 
     homepage = "http://dock.compbio.ucsf.edu/DOCK_6/index.htm"
     url = "https://github.com/docking-org/dock6/archive/refs/tags/v6.13.1.tar.gz"
-    license("BSD-3-Clause", checked_by="snehring")
+
     maintainers("snehring")
+
+    license("BSD-3-Clause", checked_by="snehring")
 
     with when("@=6.9"):
         manual_download = True
 
     version("6.13.1", sha256="1bfe7ff777e60af6bff785dc74f9f7d1b0403c518c34ce4d1e6db98ac0865db1")
+
     # I don't think you can actually get 6.9 anymore since they moved to github
     version(
         "6.9",

--- a/repos/spack_repo/builtin/packages/dock/package.py
+++ b/repos/spack_repo/builtin/packages/dock/package.py
@@ -18,6 +18,7 @@ class Dock(Package):
 
     homepage = "http://dock.compbio.ucsf.edu/DOCK_6/index.htm"
     url = "https://github.com/docking-org/dock6/archive/refs/tags/v6.13.1.tar.gz"
+    license("BSD-3-Clause", checked_by="snehring")
     maintainers("snehring")
 
     with when("@=6.9"):

--- a/repos/spack_repo/builtin/packages/dock/package.py
+++ b/repos/spack_repo/builtin/packages/dock/package.py
@@ -17,48 +17,60 @@ class Dock(Package):
     site, and the associated binding energy."""
 
     homepage = "http://dock.compbio.ucsf.edu/DOCK_6/index.htm"
-    url = "file://{0}/dock.6.9_source.tar.gz".format(os.getcwd())
+    url = "https://github.com/docking-org/dock6/archive/refs/tags/v6.13.1.tar.gz"
     maintainers("snehring")
-    manual_download = True
 
-    version("6.9", sha256="c2caef9b4bb47bb0cb437f6dc21f4c605fd3d0d9cc817fa13748c050dc87a5a8")
+    with when("@=6.9"):
+        manual_download = True
+
+    version("6.13.1", sha256="1bfe7ff777e60af6bff785dc74f9f7d1b0403c518c34ce4d1e6db98ac0865db1")
+    # I don't think you can actually get 6.9 anymore since they moved to github
+    version(
+        "6.9",
+        sha256="c2caef9b4bb47bb0cb437f6dc21f4c605fd3d0d9cc817fa13748c050dc87a5a8",
+        deprecated=True,
+        url=f"file://{os.getcwd()}/dock.6.9_source.tar.gz",
+    )
 
     variant("mpi", default=True, description="Enable mpi")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
+
+    depends_on("gmake", type="build")
     depends_on("bison", type="build")
     depends_on("flex", type="build")
     depends_on("mpi", when="+mpi")
 
-    def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        if self.spec.satisfies("+mpi"):
-            env.set("MPICH_HOME", self.spec["mpi"].prefix)
-
     def install(self, spec, prefix):
-        compiler_targets = {"gcc": "gnu", "intel": "intel", "sgi": "sgi"}
-
-        if self.compiler.name not in compiler_targets:
-            template = "Unsupported compiler {0}! Supported compilers: {1}"
-            err = template.format(self.compiler.name, ", ".join(list(compiler_targets.keys())))
-
-            raise InstallError(err)
-
+        mkdirp("bin")
+        # the object files aren't regenerated after the clean target runs, so let's just not do it
+        with working_dir(join_path("src", "docktools", "convgrids")):
+            for i in ["gridrdsl.mk", "gridconv.mk"]:
+                filter_file("install: clean all", "install: all", i)
         with working_dir("install"):
-            sh_args = ["./configure", compiler_targets[self.compiler.name]]
-            config_source = compiler_targets[self.compiler.name]
+            copy("gnu", "config.h")
+            for i in [r"^CC=.*$", r"^CXX=.*$", r"^FC=.*$"]:
+                filter_file(i, "", "config.h")
+            filter_file(
+                r"^FFLAGS=.*$",
+                "FFLAGS=-fno-automatic -fno-second-underscore -fallow-argument-mismatch",
+                "config.h",
+            )
+            if self.spec.satisfies("+mpi"):
+                filter_file(r"^CXXFLAGS=.*$", "CXXFLAGS=-DBUILD_DOCK_WITH_MPI", "config.h")
+                filter_file(r"CFLAGS=.*$", "CFLAGS=-DBUILD_DOCK_WITH_MPI", "config.h")
+                filter_file(r"^DOCK_SUFFIX=.*", "DOCK_SUFFIX=.mpi", "config.h")
+                filter_file(r"^LOAD=.*$", f"LOAD={self.spec['mpi'].mpicxx}", "config.h")
+            else:
+                filter_file(r"^LOAD=.*$", f"LOAD={self.compiler.cxx}", "config.h")
+                filter_file(r"^CFLAGS=.*", "", "config.h")
 
-            if spec.satisfies("+mpi"):
-                sh_args.append("parallel")
-                config_source = config_source + ".parallel"
-
-            if self.spec.satisfies("@6.9%gcc@10:"):
-                # Versions of gcc before 10 treat mismatched arguments as a warning
-                # 10+ makes it an error. This makes it a warning again
-                filter_file(
-                    r"(-fno-second-underscore)", r"\1 -fallow-argument-mismatch", config_source
-                )
-
-            which("sh", required=True)(*sh_args)
-            which("make", required=True)("YACC=bison -o y.tab.c")
+            with open("config.h", "a", encoding="UTF-8") as f:
+                f.write(f"DOCKHOME={self.spec.prefix}")
+            which("make")("dock")
+            which("make")("utils")
 
         mkdirp(prefix.bin)
         install_tree("bin", prefix.bin)


### PR DESCRIPTION
New version, it's also available without a manual download now!

Reworking the recipe to bypass their configure script. I suspect this will work fine for about any compiler. The package limitations just seem to be 'these are the config templates we've made'. With this rework we make our own template from the gcc template as a base.

I don't have the time, but I am dangerously tempted to submit a PR upstream to switch this to cmake.