### PR TITLE
libarchive: fix configure flags issues from issue 39381

### DIFF
--- a/repos/spack_repo/builtin/packages/libarchive/package.py
+++ b/repos/spack_repo/builtin/packages/libarchive/package.py
@@ -89,7 +89,6 @@ class Libarchive(AutotoolsPackage):
         args = ["--without-libb2"]
         args += self.with_or_without("compression")
         args += self.with_or_without("crypto")
-        args += self.with_or_without("xar")
         args += self.enable_or_disable("programs")
 
         if spec.satisfies("+iconv"):
@@ -99,5 +98,15 @@ class Libarchive(AutotoolsPackage):
                 args.append("--without-libiconv-prefix")
         else:
             args.append("--without-iconv")
+
+        if spec.satisfies("xar=expat"):
+            args.append("--with-expat")
+        else:
+            args.append("--without-expat")
+
+        if spec.satisfies("xar=libxml2"):
+            args.append("--with-xml2")
+        else:
+            args.append("--without-xml2")
 
         return args


### PR DESCRIPTION
There are no with or without flags for libxml2 in libarchive. That package refers to them as xml2. This results in warnings that spack ignores during configure time and ultimately an incorrect build.

I've put in a fix below, but I also suggest a different patch in the issue.

See #39381
