### PR TITLE
Correct toolset determination for boost %apple-clang, fixes #4479

### DIFF
--- a/repos/spack_repo/builtin/packages/boost/package.py
+++ b/repos/spack_repo/builtin/packages/boost/package.py
@@ -544,6 +544,7 @@ class Boost(Package):
             "%intel": "intel",
             "%oneapi": "intel",
             "%clang": "clang",
+            "%apple-clang": "clang",
             "%arm": "clang",
             "%xl": "xlcpp",
             "%xl_r": "xlcpp",


### PR DESCRIPTION
Thanks to @scheibelp

Fixes #4479 

-------

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->