### PR TITLE
py-webcolors: add v25.10.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_webcolors/package.py
+++ b/repos/spack_repo/builtin/packages/py_webcolors/package.py
@@ -10,11 +10,13 @@ from spack.package import *
 class PyWebcolors(PythonPackage):
     """Working with color names and values formats defined by HTML and CSS."""
 
-    homepage = "https://pypi.org/project/webcolors/"
+    homepage = "https://webcolors.readthedocs.io/"
     pypi = "webcolors/webcolors-1.11.1.tar.gz"
+    git = "https://github.com/ubernostrum/webcolors.git"
 
     license("BSD-3-Clause", checked_by="wdconinc")
 
+    version("25.10.0", sha256="62abae86504f66d0f6364c2a8520de4a0c47b80c03fc3a5f1815fedbef7c19bf")
     version("24.11.1", sha256="ecb3d768f32202af770477b8b65f318fa4f566c22948673a977b00d589dd80f6")
     version("24.8.0", sha256="08b07af286a01bcd30d583a7acadf629583d1f79bfef27dd2c2c5c263817277d")
     version("24.6.0", sha256="1d160d1de46b3e81e58d0a280d0c78b467dc80f47294b91b1ad8029d2cedb55b")
@@ -22,9 +24,14 @@ class PyWebcolors(PythonPackage):
     version("1.12", sha256="16d043d3a08fd6a1b1b7e3e9e62640d09790dce80d2bdd4792a175b35fe794a9")
     version("1.11.1", sha256="76f360636957d1c976db7466bc71dcb713bb95ac8911944dffc55c01cb516de6")
 
-    depends_on("python@3.5:", type=("build", "run"))
-    depends_on("python@3.7:", type=("build", "run"), when="@1.12:")
-    depends_on("python@3.8:", type=("build", "run"), when="@24.6:")
-    depends_on("python@3.9:", type=("build", "run"), when="@24.11:")
-    depends_on("py-setuptools@61:", type=("build"), when="@:24.10")
-    depends_on("py-pdm-backend", type=("build"), when="@24.11:")
+    with default_args(type="build"):
+        depends_on("py-pdm-backend", when="@24.11:")
+
+        # Historical dependencies
+        depends_on("py-setuptools@61:", when="@:24.10")
+
+    with default_args(type=("build", "run")):
+        depends_on("python@3.10:", when="@25:")
+        depends_on("python@3.9:", when="@24.11:")
+        depends_on("python@3.8:", when="@24.6:")
+        depends_on("python@3.7:", when="@1.12:")


### PR DESCRIPTION
https://github.com/ubernostrum/webcolors/releases/tag/25.10.0
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
