### PR TITLE
Added perl-bio-ensembl* dependencies to vep/113

### DIFF
--- a/repos/spack_repo/builtin/packages/perl_bio_ensembl/package.py
+++ b/repos/spack_repo/builtin/packages/perl_bio_ensembl/package.py
@@ -19,6 +19,7 @@ class PerlBioEnsembl(Package):
 
     license("APACHE-2.0", checked_by="teaguesterling")
 
+    version("113", sha256="0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5")
     version("112", sha256="7c2c5265abe74b462cd4f8b26f140a4c4945cd0e2971f40711afbb4b38db5997")
     version("111", sha256="346c47c75a6fa8dcfd9f9d22e9f1e0ccc35b2fb99f75980a0c74d892e4ab2b6d")
     version("110", sha256="fdf725cad1a980ddf900f1af1a72bf1de355f15e408664930ed84aeccfefad15")

--- a/repos/spack_repo/builtin/packages/perl_bio_ensembl_funcgen/package.py
+++ b/repos/spack_repo/builtin/packages/perl_bio_ensembl_funcgen/package.py
@@ -16,6 +16,7 @@ class PerlBioEnsemblFuncgen(Package):
 
     license("APACHE-2.0", checked_by="teaguesterling")
 
+    version("113", sha256="1dcb973d54058a89de950fb1d8aa2dea3ed44ed686258744642e0bb812b39b46")
     version("112", sha256="d7398921779a6865b5e2f0269d51d268f9b8cd96e4ca3577c88e6f34593e683d")
     version("111", sha256="67b1b7d6efde9e8be7b4ef73c54c0b5e7e3eadcd590a94bc980984514ef746d0")
     version("110", sha256="c9e85a423a8c8653741aed799aea9762fa1dfb301f50dc11d291925e81d7aeee")

--- a/repos/spack_repo/builtin/packages/perl_bio_ensembl_io/package.py
+++ b/repos/spack_repo/builtin/packages/perl_bio_ensembl_io/package.py
@@ -17,6 +17,7 @@ class PerlBioEnsemblIo(Package):
     license("APACHE-2.0", checked_by="teaguesterling")
 
     for vers, sha in [
+        ("112", "2e914af0096af98e5a99986600adeba4e07d5775e708df2fcd033034f2e13272"),
         ("112", "ccbffe7c15318075463db46be348655a5914762e05ff47da2d72a4c99414d39a"),
         ("111", "f81d4c1aea88aac7105aaa3fec548e39b79f129c7abc08b55be7d0345aa5482c"),
         ("110", "83cf00ecdb6184be480fc3cbf0ffc322d3e9411e14602396fda8d153345d6c2e"),

--- a/repos/spack_repo/builtin/packages/perl_bio_ensembl_io/package.py
+++ b/repos/spack_repo/builtin/packages/perl_bio_ensembl_io/package.py
@@ -17,7 +17,7 @@ class PerlBioEnsemblIo(Package):
     license("APACHE-2.0", checked_by="teaguesterling")
 
     for vers, sha in [
-        ("112", "2e914af0096af98e5a99986600adeba4e07d5775e708df2fcd033034f2e13272"),
+        ("113", "2e914af0096af98e5a99986600adeba4e07d5775e708df2fcd033034f2e13272"),
         ("112", "ccbffe7c15318075463db46be348655a5914762e05ff47da2d72a4c99414d39a"),
         ("111", "f81d4c1aea88aac7105aaa3fec548e39b79f129c7abc08b55be7d0345aa5482c"),
         ("110", "83cf00ecdb6184be480fc3cbf0ffc322d3e9411e14602396fda8d153345d6c2e"),

--- a/repos/spack_repo/builtin/packages/perl_bio_ensembl_variation/package.py
+++ b/repos/spack_repo/builtin/packages/perl_bio_ensembl_variation/package.py
@@ -17,6 +17,7 @@ class PerlBioEnsemblVariation(Package):
     license("APACHE-2.0", checked_by="teaguesterling")
 
     for vers, sha in [
+        ("113", "6e930e34ecf524a635c848636e1b479eba9102b3a386f49597640571c25e9e94"),
         ("112", "ad75ff0a9efbf2d5c10ab5087d414bac685819664d01fbe4a9765393bd742a7c"),
         ("111", "b2171b3f5f82a2b7e849c0ec8dc254f4bace4b3faba1b3ab75c5eea596e33bef"),
         ("110", "210d627dcb867d9fda3a0d94428da256f394c32e34df5171b9b9e604507e1f05"),

--- a/repos/spack_repo/builtin/packages/vep/package.py
+++ b/repos/spack_repo/builtin/packages/vep/package.py
@@ -60,7 +60,7 @@ class Vep(Package):
     # This is a workaround for the VEP installer which downloads
     # and manually installs dependent packages
     with default_args(type=("build", "run"), when="~vep_installer"):
-        for ver in ["110", "111", "112"]:
+        for ver in ["110", "111", "112", "113"]:
             depends_on(f"perl-bio-ensembl@{ver}", when=f"@{ver}")
             depends_on(f"perl-bio-ensembl-variation@{ver}", when=f"@{ver}")
             depends_on(f"perl-bio-ensembl-funcgen@{ver}", when=f"@{ver}")


### PR DESCRIPTION
As title implies, added perl-bio-ensembl dependenciese to vep/113 and updates perl-bio-ensembl sha256sums.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
