### PR TITLE
Cleanup post ruff

### DIFF
--- a/.ci/style_check.sh
+++ b/.ci/style_check.sh
@@ -26,11 +26,10 @@ if ! python_files > /dev/null; then
   info "skipping style checks: no Python files changed"
   exit 0
 fi
-[ -d "spack-core" ] ||  die "no 'spack-core' dir found: should be a clone of 'spack/spack'"
 python_files | xargs -0 printf "%s\n"
 info "running ruff format"
-ruff format $format_flags || error=1
+python_files | xargs -0 -n 100 ruff format $format_flags || error=1
 info "running ruff check"
-ruff check $check_flags || error=1
+python_files | xargs -0 -n 100 ruff check $check_flags || error=1
 [ "$error" = "1" ] && die "style checks failed"
 info "style checks passed"

--- a/.github/workflows/prechecks.yml
+++ b/.github/workflows/prechecks.yml
@@ -41,10 +41,6 @@ jobs:
     - name: Install Python packages
       run: |
         pip install -r .github/workflows/requirements/style/requirements.txt
-    - uses: ./.github/actions/checkout-spack
-      with:
-        # This path must match the path in pyprojects.toml
-        path: spack-core
     - name: Run style tests
       run: .ci/style_check.sh HEAD^
     # todo: license check


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Post-ruff merge cleanup.

Fixes bug where linting is applied to untouched files.
Removes now unnecessary clone of spack core from style check.