### PR TITLE
 expat: 2.8.0 + deprecate vulnerable 2.7.5 (for CVE-2026-41080)

### DIFF
--- a/repos/spack_repo/builtin/packages/expat/package.py
+++ b/repos/spack_repo/builtin/packages/expat/package.py
@@ -18,6 +18,7 @@ class Expat(AutotoolsPackage, CMakePackage):
     url = "https://github.com/libexpat/libexpat/releases/download/R_2_2_9/expat-2.2.9.tar.bz2"
 
     license("MIT")
+    version("2.8.0", sha256="586494499ac3ad46d87f3beda7b1f770c1c8026a9b60e151593f8b29089a52ca")
     version("2.7.5", sha256="386a423d40580f1e392e8b512b7635cac5083fe0631961e74e036b0a7a830d77")
     # deprecate all releases before 2.7.5 because of various security issues
     version(

--- a/repos/spack_repo/builtin/packages/expat/package.py
+++ b/repos/spack_repo/builtin/packages/expat/package.py
@@ -19,8 +19,12 @@ class Expat(AutotoolsPackage, CMakePackage):
 
     license("MIT")
     version("2.8.0", sha256="586494499ac3ad46d87f3beda7b1f770c1c8026a9b60e151593f8b29089a52ca")
-    version("2.7.5", sha256="386a423d40580f1e392e8b512b7635cac5083fe0631961e74e036b0a7a830d77")
-    # deprecate all releases before 2.7.5 because of various security issues
+    # deprecate all releases before 2.8.0 because of various security issues
+    version(
+        "2.7.5",
+        sha256="386a423d40580f1e392e8b512b7635cac5083fe0631961e74e036b0a7a830d77",
+        deprecated=True,
+    )
     version(
         "2.7.4",
         sha256="e6af11b01e32e5ef64906a5cca8809eabc4beb7ff2f9a0e6aabbd42e825135d0",


### PR DESCRIPTION
Similar to #4113

Related blog post: https://blog.hartwork.org/posts/expat-2-8-0-released/

CVE-2026-41080
