### PR TITLE
uriparser: 1.0.1 + deprecate vulnerable 0.9.6 and 0.9.7 (for CVE-2026-42371)

### DIFF
--- a/repos/spack_repo/builtin/packages/uriparser/package.py
+++ b/repos/spack_repo/builtin/packages/uriparser/package.py
@@ -9,13 +9,17 @@ from spack.package import *
 
 class Uriparser(CMakePackage):
     """uriparser is a strictly RFC 3986 compliant URI parsing and handling
-    library written in C89 ("ANSI C")."""
+    library written in C99."""
 
     homepage = "https://uriparser.github.io/"
     url = "https://github.com/uriparser/uriparser/releases/download/uriparser-0.9.3/uriparser-0.9.3.tar.gz"
 
     license("BSD-3-Clause")
 
+    version(
+        "1.0.1",
+        sha256="5a3b7c491a1e9033d86b9c00a947bafc46407187938578daf799a4155cb7c88a",
+    )
     version("0.9.7", sha256="11553b2abd2b5728a6c88e35ab08e807d0a0f23c44920df937778ce8cc4d40ff")
     version("0.9.6", sha256="10e6f90d359c1087c45f907f95e527a8aca84422251081d1533231e031a084ff")
 
@@ -24,7 +28,7 @@ class Uriparser(CMakePackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    depends_on("cmake@3.3:", type="build")
+    depends_on("cmake@3.15:", type="build")
     depends_on("googletest@1.8.1", type="link")
     depends_on("doxygen", when="+docs", type="build")
     depends_on("graphviz", when="+docs", type="build")

--- a/repos/spack_repo/builtin/packages/uriparser/package.py
+++ b/repos/spack_repo/builtin/packages/uriparser/package.py
@@ -20,8 +20,17 @@ class Uriparser(CMakePackage):
         "1.0.1",
         sha256="5a3b7c491a1e9033d86b9c00a947bafc46407187938578daf799a4155cb7c88a",
     )
-    version("0.9.7", sha256="11553b2abd2b5728a6c88e35ab08e807d0a0f23c44920df937778ce8cc4d40ff")
-    version("0.9.6", sha256="10e6f90d359c1087c45f907f95e527a8aca84422251081d1533231e031a084ff")
+    # deprecate all releases before 1.0.1 because of various security issues
+    version(
+        "0.9.7",
+        sha256="11553b2abd2b5728a6c88e35ab08e807d0a0f23c44920df937778ce8cc4d40ff",
+        deprecated=True,
+    )
+    version(
+        "0.9.6",
+        sha256="10e6f90d359c1087c45f907f95e527a8aca84422251081d1533231e031a084ff",
+        deprecated=True,
+    )
 
     variant("docs", default=False, description="Build API documentation")
 


### PR DESCRIPTION
Similar to #4506

CVE-2026-42371