### PR TITLE
root: add v6.36.12 (and other missing bugfix version)

### DIFF
--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -36,6 +36,9 @@ class Root(CMakePackage):
     version("develop", branch="master")
 
     # Production release series
+    version("6.36.12", sha256="1243fc48b7c1358ebf69e6140a13d9c27e0fd84663632cc6217beda875a4a317")
+    version("6.36.10", sha256="8ccbfbca9d05016c8c324dd61c25a1091ae61847fb9404298652b83bf0cd3be0")
+    version("6.36.08", sha256="1678fd272cf3172d7ba602e2786ec659bd3ca28b38f0471005d456d968ef55a1")
     version("6.36.06", sha256="62f9d38d2f2ed3d46653529c98e8cbc9b8866776494eb40ba0c23e2f46b681c4")
     version("6.36.04", sha256="cc6367d8f563c6d49ca34c09d0b53cb0f41a528db6f86af111fd76744cda4596")
     version("6.36.02", sha256="510d677b33ac7ca48aa0d712bdb88d835a1ff6a374ef86f1a1e168fa279eb470")


### PR DESCRIPTION
This PR adds to `root` the versions v6.36.{12,10,08} (release notes: https://github.com/root-project/root/releases/tag/v6-36-12, https://github.com/root-project/root/releases/tag/v6-36-10, https://github.com/root-project/root/releases/tag/v6-36-08). Only bugfixes to this LTS series. Not built in CI since 6.38  (non-LTS) is preferred.