### PR TITLE
nvtx: support libc without char8_t

### DIFF
--- a/repos/spack_repo/builtin/packages/nvtx/package.py
+++ b/repos/spack_repo/builtin/packages/nvtx/package.py
@@ -50,9 +50,7 @@ class Nvtx(Package, PythonExtension):
         setup.filter("include_dirs=include_dirs", f"include_dirs=['{include_dir}']", string=True)
         # see comment in patch below
         if self.spec.satisfies("@3.3.0:"):
-            header = FileFilter(
-                "c/include/nvtx3/nvtxDetail/nvtxExtPayloadTypeInfo.h"
-            )
+            header = FileFilter("c/include/nvtx3/nvtxDetail/nvtxExtPayloadTypeInfo.h")
             header.filter(
                 "#define NVTX_HAVE_CHAR8 1",
                 "/* Fallback for systems where glibc < 2.36 does not define char8_t\n"
@@ -74,4 +72,3 @@ class Nvtx(Package, PythonExtension):
 
         with working_dir(self.build_directory):
             pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")
-

--- a/repos/spack_repo/builtin/packages/nvtx/package.py
+++ b/repos/spack_repo/builtin/packages/nvtx/package.py
@@ -34,6 +34,11 @@ class Nvtx(Package, PythonExtension):
 
     build_directory = "python"
 
+    # nvtxExtPayloadTypeInfo.h (included transitively via nvToolsExtPayload.h)
+    # uses char8_t, which requires C23 (-std=c23).  GCC gained C23 char8_t
+    # support in 13.0, so earlier compilers cannot build the Python extension.
+    conflicts("%gcc@:12", when="@3.3.0: +python")
+
     # Create a nvtx-config.cmake file to make calls to find_package(nvtx) to
     # work as expected
     patch("nvtx-config.patch")
@@ -43,6 +48,21 @@ class Nvtx(Package, PythonExtension):
         include_dir = prefix.include
         setup = FileFilter("python/setup.py")
         setup.filter("include_dirs=include_dirs", f"include_dirs=['{include_dir}']", string=True)
+        # see comment in patch below
+        if self.spec.satisfies("@3.3.0:"):
+            header = FileFilter(
+                "c/include/nvtx3/nvtxDetail/nvtxExtPayloadTypeInfo.h"
+            )
+            header.filter(
+                "#define NVTX_HAVE_CHAR8 1",
+                "/* Fallback for systems where glibc < 2.36 does not define char8_t\n"
+                " * in uchar.h even when the compiler supports C23 (e.g. RHEL 9). */\n"
+                "#ifndef __cpp_char8_t\n"
+                "typedef unsigned char char8_t;\n"
+                "#endif\n"
+                "#define NVTX_HAVE_CHAR8 1",
+                string=True,
+            )
 
     def install(self, spec, prefix):
         install_tree("c/include", prefix.include)
@@ -54,3 +74,4 @@ class Nvtx(Package, PythonExtension):
 
         with working_dir(self.build_directory):
             pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")
+


### PR DESCRIPTION
This PR addresses a compilation issue with the nvtx package with the python bindings enabled (as a dep of py-torch) when built with GCC 15.2.0 and glibc 2.34 on a RHEL9 system.  IIUC, glibc 2.36 or newer is needed to use char8_t from the c20 standard (https://lists.gnu.org/archive/html/info-gnu/2022-08/msg00000.html).

A PR to the nvtx repo is here: https://github.com/NVIDIA/NVTX/pull/163

On our system, the following code reproduces the bug:

```
$ cat foo.c 
#include <stdio.h> 
//---- uncomment the following block to compile ----
//#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
//#ifndef __cpp_char8_t
//typedef unsigned char char8_t;
//#endif
//#endif
int main() { char8_t a; printf("%ld\n", (long)__STDC_VERSION__); return 0; }

$ gcc --version
gcc (Spack GCC) 15.2.0
Copyright (C) 2025 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

##  show glibc version
$ ldd --version   
ldd (GNU libc) 2.34
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Written by Roland McGrath and Ulrich Drepper.

$ gcc foo.c -o foo
foo.c: In function 'main':
foo.c:9:14: error: unknown type name 'char8_t'; did you mean 'char'?
    9 | int main() { char8_t a; printf("%ld\n", (long)__STDC_VERSION__); return 0; }
      |              ^~~~~~~
      |              char
```
