### PR TITLE
libvdwxc bugfix

### DIFF
--- a/repos/spack_repo/builtin/packages/libvdwxc/package.py
+++ b/repos/spack_repo/builtin/packages/libvdwxc/package.py
@@ -45,7 +45,9 @@ class Libvdwxc(AutotoolsPackage):
         spec = self.spec
 
         args = [
-            "--with-fftw3={0}".format(self["fftw-api"].prefix),  # make sure that fftw path is given
+            "--with-fftw3={0}".format(
+                self["fftw-api"].prefix
+            ),  # make sure that fftw path is given
             "--{0}-pfft".format("with" if self.spec.satisfies("+pfft") else "without"),
             "MPICC=",  # make sure both variables are always unset
             "MPIFC=",  # otherwise the configure scripts complains

--- a/repos/spack_repo/builtin/packages/libvdwxc/package.py
+++ b/repos/spack_repo/builtin/packages/libvdwxc/package.py
@@ -45,7 +45,7 @@ class Libvdwxc(AutotoolsPackage):
         spec = self.spec
 
         args = [
-            "--with-fftw3={0}".format(self["fftw"].prefix),  # make sure that fftw path is given
+            "--with-fftw3={0}".format(self["fftw-api"].prefix),  # make sure that fftw path is given
             "--{0}-pfft".format("with" if self.spec.satisfies("+pfft") else "without"),
             "MPICC=",  # make sure both variables are always unset
             "MPIFC=",  # otherwise the configure scripts complains


### PR DESCRIPTION
`libvdwxc` currently does not correctly get the path of the `fftw-api` provider. This small PR fixes that.
My guess is that when this line was added in https://github.com/spack/spack-packages/commit/5f376d73e480ac6d71f789938a950083820c3635 that the committer had `fftw` installed, so this didn't fail.

Tested by successfully building `libvdwxc ^amdfftw` (which was failing before, which was how I found the issue).