### PR TITLE
dcm2niix: add jpeg2000 variant

### DIFF
--- a/repos/spack_repo/builtin/packages/dcm2niix/package.py
+++ b/repos/spack_repo/builtin/packages/dcm2niix/package.py
@@ -14,7 +14,7 @@ class Dcm2niix(CMakePackage):
     homepage = "https://github.com/rordenlab/dcm2niix"
     url = "https://github.com/rordenlab/dcm2niix/archive/refs/tags/v1.0.20220720.tar.gz"
 
-    license("BSD-3-Clause", checked_by="Markus92")
+    license("BSD-3-Clause AND MIT", checked_by="Markus92")
 
     version(
         "1.0.20250506", sha256="1b24658678b6c24141e58760dbea9fe2786ffdd736bcc37a36d9cdabc731bafa"

--- a/repos/spack_repo/builtin/packages/dcm2niix/package.py
+++ b/repos/spack_repo/builtin/packages/dcm2niix/package.py
@@ -14,7 +14,7 @@ class Dcm2niix(CMakePackage):
     homepage = "https://github.com/rordenlab/dcm2niix"
     url = "https://github.com/rordenlab/dcm2niix/archive/refs/tags/v1.0.20220720.tar.gz"
 
-    license("Zlib")
+    license("BSD-3-Clause", checked_by="Markus92")
 
     version(
         "1.0.20250506", sha256="1b24658678b6c24141e58760dbea9fe2786ffdd736bcc37a36d9cdabc731bafa"
@@ -29,7 +29,29 @@ class Dcm2niix(CMakePackage):
         "1.0.20210317", sha256="42fb22458ebfe44036c3d6145dacc6c1dc577ebbb067bedc190ed06f546ee05a"
     )
 
+    # Only compile the console app. The superbuild pulls in lot of dependencies through Git
+    # and doesn't propagate some Spack-controlled CMake parameters (most notably RPath)
+    # In practice, the app is what we want anyways
+    root_cmakelists_dir = "console"
+
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
+    variant("jp2k", default=False, description="Enable JPEG2000 support")
+    variant("jpegls", default=False, description="Enable JPEG-LS support")
+
     depends_on("pkgconfig", type="build")
+
+    depends_on("openjpeg", when="+jp2k")
+    depends_on("zlib-api")
+
+    def cmake_args(self):
+        args = [self.define("ZLIB_IMPLEMENTATION", "System"),
+                # Not all systems have a libstdc++.a while dynamic is always there
+                self.define("USE_STATIC_RUNTIME", "OFF"),
+                self.define_from_variant("USE_JPEGLS", "jpegls")]
+
+        if self.spec.satisfies("+jp2k"):
+            args.append(self.define("USE_OPENJPEG", "System"))
+
+        return args

--- a/repos/spack_repo/builtin/packages/dcm2niix/package.py
+++ b/repos/spack_repo/builtin/packages/dcm2niix/package.py
@@ -46,10 +46,12 @@ class Dcm2niix(CMakePackage):
     depends_on("zlib-api")
 
     def cmake_args(self):
-        args = [self.define("ZLIB_IMPLEMENTATION", "System"),
-                # Not all systems have a libstdc++.a while dynamic is always there
-                self.define("USE_STATIC_RUNTIME", "OFF"),
-                self.define_from_variant("USE_JPEGLS", "jpegls")]
+        args = [
+            self.define("ZLIB_IMPLEMENTATION", "System"),
+            # Not all systems have a libstdc++.a while dynamic is always there
+            self.define("USE_STATIC_RUNTIME", "OFF"),
+            self.define_from_variant("USE_JPEGLS", "jpegls"),
+        ]
 
         if self.spec.satisfies("+jp2k"):
             args.append(self.define("USE_OPENJPEG", "System"))


### PR DESCRIPTION
One of my users asked for JPEG2000 support, so I took the time to overhaul dcm2niix.

The superbuild pulls in a lot of third party stuff but Spack is better at managing that, so I only compile the console app (the previous version resulted in the same output, too, so nothing really lost).