### PR TITLE
n2p2: C++ standard to C++14 and add py-setuptools dep

### DIFF
--- a/repos/spack_repo/builtin/packages/n2p2/package.py
+++ b/repos/spack_repo/builtin/packages/n2p2/package.py
@@ -42,6 +42,7 @@ class N2p2(MakefilePackage):
     depends_on("doxygen", type="build", when="+doc")
     depends_on("texlive", type="build", when="+doc")
     depends_on("py-cython", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
     depends_on("py-breathe", type="build", when="+doc")
     depends_on("py-sphinx", type="build", when="+doc")
     depends_on("py-sphinx-rtd-theme", type="build", when="+doc")
@@ -67,7 +68,7 @@ class N2p2(MakefilePackage):
         blas_libs = self.spec["blas"].libs
         makefile.filter("PROJECT_CC=.*", f"PROJECT_CC={spack_cxx}")
         makefile.filter("PROJECT_MPICC=.*", f"PROJECT_MPICC={self.spec['mpi'].mpicxx}")
-        makefile.filter("PROJECT_CFLAGS=.*", f"PROJECT_CFLAGS={self.compiler.cxx11_flag}")
+        makefile.filter("PROJECT_CFLAGS=.*", f"PROJECT_CFLAGS={self.compiler.cxx14_flag}")
         makefile.filter(
             "PROJECT_LDFLAGS_BLAS.*", f"PROJECT_LDFLAGS_BLAS={blas_libs.ld_flags} -lgsl -lgslcblas"
         )


### PR DESCRIPTION
1. Change cxx11_flag to cxx14_flag for Eigen 5.x compatibility. Eigen 5.x uses std::enable_if_t which requires C++14.
2. Add py-setuptools build dependency for Python 3.12+ where distutils was removed from stdlib.


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
