### PR TITLE
conquest: fix oneAPI compiler support

### DIFF
--- a/repos/spack_repo/builtin/packages/conquest/package.py
+++ b/repos/spack_repo/builtin/packages/conquest/package.py
@@ -64,7 +64,9 @@ class Conquest(MakefilePackage):
             return ["Conquest"]
 
     def edit(self, spec, prefix):
-        fflags = "-O3 -fallow-argument-mismatch"
+        fflags = "-O3"
+        if self.spec.satisfies("%gcc@10:"):
+            fflags += " -fallow-argument-mismatch"
         ldflags = ""
 
         if self.spec.satisfies("+openmp"):
@@ -96,6 +98,7 @@ class Conquest(MakefilePackage):
         defs_file.filter(".*BLAS=.*", f"BLAS= {lapack_ld} {blas_ld}")
         defs_file.filter(".*FFT_LIB=.*", f"FFT_LIB={fftw_ld}")
         defs_file.filter(".*XC_LIB=.*", f"XC_LIB={libxc_ld} -lxcf90 -lxc")
+        defs_file.filter("-lscalapack", "")
 
         if self.spec.satisfies("+openmp"):
             defs_file.filter("OMP_DUMMY = DUMMY", "OMP_DUMMY = ")


### PR DESCRIPTION
Two fixes for building with Intel oneAPI compilers (ifx):
1. Make -fallow-argument-mismatch conditional on %gcc@10: only, since it's a GCC-specific flag not recognized by ifx.
2. Remove hardcoded -lscalapack from LIBS line, since MKL provides scalapack as libmkl_scalapack_lp64.so (already linked via scalapack.libs.ld_flags in LINKFLAGS).

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
