### PR TITLE
palace: add ifx Fortran runtime library detection for STRUMPACK

### DIFF
--- a/repos/spack_repo/builtin/packages/palace/package.py
+++ b/repos/spack_repo/builtin/packages/palace/package.py
@@ -411,6 +411,8 @@ class Palace(CMakePackage, CudaPackage, ROCmPackage):
                 # Add Fortran libraries
                 if "gfortran" in self.compiler.fc:
                     strumpack_libs += ";gfortran"
+                elif "ifx" in self.compiler.fc:
+                    strumpack_libs += ";ifport;ifcore"
 
                 args.append(self.define("STRUMPACK_REQUIRED_LIBRARIES", strumpack_libs))
             if self.spec.satisfies("+superlu-dist"):


### PR DESCRIPTION
When building Palace with the Intel oneAPI compiler (ifx), the STRUMPACK sparse direct solver needs ifport and ifcore runtime libraries linked.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
