### PR TITLE
hpctoolkit: add version 2026.0.0

### DIFF
--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -359,7 +359,7 @@ e4s-rocm-external-build:
 
 e4s-oneapi-generate:
   extends: [ ".e4s-oneapi", ".generate-x86_64"]
-  image: ghcr.io/spack/e4s-oneapi-base-x86_64:v2025.3-1772472165
+  image: ghcr.io/spack/e4s-oneapi-base-x86_64:v2025.3-1777667538
 
 e4s-oneapi-build:
   extends: [ ".e4s-oneapi", ".build" ]

--- a/repos/spack_repo/builtin/packages/hpctoolkit/package.py
+++ b/repos/spack_repo/builtin/packages/hpctoolkit/package.py
@@ -33,6 +33,8 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
     license("BSD-3-Clause", when="@:2024")
 
     version("develop", branch="develop")
+    version("2026.0.stable", branch="release/2026.0")
+    version("2026.0.0", tag="2026.0.0", commit="7134ddc4bc68b0c7a92f31d1268bdd01e177efc0")
     version("2025.1.stable", branch="release/2025.1")
     version("2025.1.2", tag="2025.1.2", commit="b2f42a93d7f40a20398d35905d8d54a4568cb52e")
     version("2025.1.1", tag="2025.1.1", commit="a1ffae9da0e7da042c70e6ed592db35286e4483d")
@@ -207,7 +209,7 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
 
     depends_on("cuda", when="+cuda")
     depends_on("oneapi-level-zero", when="+level_zero")
-    depends_on("oneapi-igc", when="+gtpin")
+    depends_on("oneapi-igc", when="+level_zero")
     depends_on("intel-gtpin", when="+gtpin")
     depends_on("opencl-c-headers", when="+opencl")
 
@@ -391,11 +393,11 @@ class AutotoolsBuilder(autotools.AutotoolsBuilder):
 
         if spec.satisfies("+level_zero"):
             args.append("--with-level0=%s" % spec["oneapi-level-zero"].prefix)
+            args.append("--with-igc=%s" % spec["oneapi-igc"].prefix)
 
             # gtpin requires level_zero
             if spec.satisfies("+gtpin"):
                 args.append("--with-gtpin=%s" % spec["intel-gtpin"].prefix)
-                args.append("--with-igc=%s" % spec["oneapi-igc"].prefix)
 
         if spec.satisfies("+opencl"):
             args.append("--with-opencl=%s" % spec["opencl-c-headers"].prefix)
@@ -513,10 +515,10 @@ class MesonBuilder(meson.MesonBuilder):
 
         if spec.satisfies("+level_zero"):
             cfg["properties"]["prefix_level0"] = f"'''{spec['oneapi-level-zero'].prefix}'''"
+            cfg["properties"]["prefix_igc"] = f"'''{spec['oneapi-igc'].prefix}'''"
 
         if spec.satisfies("+gtpin"):
             cfg["properties"]["prefix_gtpin"] = f"'''{spec['intel-gtpin'].prefix}'''"
-            cfg["properties"]["prefix_igc"] = f"'''{spec['oneapi-igc'].prefix}'''"
 
         if spec.satisfies("+opencl"):
             cfg["properties"]["prefix_opencl"] = f"'''{spec['opencl-c-headers'].prefix}'''"

--- a/repos/spack_repo/builtin/packages/hpctoolkit/package.py
+++ b/repos/spack_repo/builtin/packages/hpctoolkit/package.py
@@ -34,6 +34,7 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
 
     version("develop", branch="develop")
     version("2026.0.stable", branch="release/2026.0")
+    version("2026.0.1", tag="2026.0.1", commit="fc620c4751e6e233725620b2f22b1bcaa07c967f")
     version("2026.0.0", tag="2026.0.0", commit="7134ddc4bc68b0c7a92f31d1268bdd01e177efc0")
     version("2025.1.stable", branch="release/2025.1")
     version("2025.1.2", tag="2025.1.2", commit="b2f42a93d7f40a20398d35905d8d54a4568cb52e")

--- a/repos/spack_repo/builtin/packages/hpctoolkit/package.py
+++ b/repos/spack_repo/builtin/packages/hpctoolkit/package.py
@@ -209,7 +209,8 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
 
     depends_on("cuda", when="+cuda")
     depends_on("oneapi-level-zero", when="+level_zero")
-    depends_on("oneapi-igc", when="+level_zero")
+    depends_on("oneapi-igc", when="+gtpin")
+    depends_on("oneapi-igc", when="@2026: +level_zero")
     depends_on("intel-gtpin", when="+gtpin")
     depends_on("opencl-c-headers", when="+opencl")
 
@@ -393,11 +394,11 @@ class AutotoolsBuilder(autotools.AutotoolsBuilder):
 
         if spec.satisfies("+level_zero"):
             args.append("--with-level0=%s" % spec["oneapi-level-zero"].prefix)
-            args.append("--with-igc=%s" % spec["oneapi-igc"].prefix)
 
             # gtpin requires level_zero
             if spec.satisfies("+gtpin"):
                 args.append("--with-gtpin=%s" % spec["intel-gtpin"].prefix)
+                args.append("--with-igc=%s" % spec["oneapi-igc"].prefix)
 
         if spec.satisfies("+opencl"):
             args.append("--with-opencl=%s" % spec["opencl-c-headers"].prefix)
@@ -515,10 +516,10 @@ class MesonBuilder(meson.MesonBuilder):
 
         if spec.satisfies("+level_zero"):
             cfg["properties"]["prefix_level0"] = f"'''{spec['oneapi-level-zero'].prefix}'''"
-            cfg["properties"]["prefix_igc"] = f"'''{spec['oneapi-igc'].prefix}'''"
 
         if spec.satisfies("+gtpin"):
             cfg["properties"]["prefix_gtpin"] = f"'''{spec['intel-gtpin'].prefix}'''"
+            cfg["properties"]["prefix_igc"] = f"'''{spec['oneapi-igc'].prefix}'''"
 
         if spec.satisfies("+opencl"):
             cfg["properties"]["prefix_opencl"] = f"'''{spec['opencl-c-headers'].prefix}'''"

--- a/stacks/e4s-oneapi/spack.yaml
+++ b/stacks/e4s-oneapi/spack.yaml
@@ -227,7 +227,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: ghcr.io/spack/e4s-oneapi-base-x86_64:v2025.3-1772472165
+        image: ghcr.io/spack/e4s-oneapi-base-x86_64:v2025.3-1777667538
 
   cdash:
     build-group: E4S OneAPI

--- a/stacks/e4s-oneapi/spack.yaml
+++ b/stacks/e4s-oneapi/spack.yaml
@@ -59,6 +59,11 @@ spack:
     # externals
     mpi:
       require: intel-oneapi-mpi
+    oneapi-igc:
+      buildable: false
+      externals:
+      - spec: oneapi-igc@1.0.10409
+        prefix: /usr
 
   specs:
   # CPU Specs:


### PR DESCRIPTION
Add version 2026.0.0 and the 2026.0.stable branch. Move the oneapi-igc prereq from +gtpin to +level_zero.

@blue42u You want to check that I moved the `oneapi-igc` prereq correctly?
It did build cleanly on aurora with and without `+gtpin`.

@hainest Would you like to use your new found powers to review?

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
