### PR TITLE
bufr: add v12.3.0

### DIFF
--- a/repos/spack_repo/builtin/packages/bufr/package.py
+++ b/repos/spack_repo/builtin/packages/bufr/package.py
@@ -24,6 +24,7 @@ class Bufr(CMakePackage):
     maintainers("AlexanderRichert-NOAA", "edwardhartnett", "Hang-Lei-NOAA", "jbathegit")
 
     version("develop", branch="develop")
+    version("12.3.0", sha256="6c55923d6b6db251f4e8b16513395a1874ba8c0b3b14d7730e807780f3156ff4")
     version("12.2.0", sha256="a0dad13b905f3e0311e2b50df47418660b47442dfc3843232712044b47f26a71")
     version("12.1.0", sha256="b5eae61b50d4132b2933b6e6dfc607e5392727cdc4f46ec7a94a19109d91dcf3")
     version("12.0.1", sha256="525f26238dba6511a453fc71cecc05f59e4800a603de2abbbbfb8cbb5adf5708")


### PR DESCRIPTION
This PR adds bufr@12.3.0. No new build options etc.