### PR TITLE
gsi-ncdiag: add v1.1.3

### DIFF
--- a/repos/spack_repo/builtin/packages/gsi_ncdiag/package.py
+++ b/repos/spack_repo/builtin/packages/gsi_ncdiag/package.py
@@ -16,6 +16,7 @@ class GsiNcdiag(CMakePackage):
 
     maintainers("ulmononian")
 
+    version("1.1.3", commit="7a9a5c2d4795e2badfabd429bc04d921b4b34b0d")
     version("1.1.2", sha256="085884106be1f8fd94a70292102e9351c0efdf1e619a233831fafcd9ed32cd99")
     version("1.1.1", sha256="26fc10cf448dd62daa1385e38921d338778416342956c478337e6c6d1b20bf8c")
     version("1.1.0", sha256="9195801301209d6f93890944d58ffee4e24a4e35502ab27560a8c440ee53df4c")


### PR DESCRIPTION
This PR adds v1.1.3 of gsi-ncdiag. No new build options etc.