### PR TITLE
just: add v1.50.0

### DIFF
--- a/repos/spack_repo/builtin/packages/just/package.py
+++ b/repos/spack_repo/builtin/packages/just/package.py
@@ -19,6 +19,7 @@ class Just(CargoPackage):
     license("CC0-1.0", checked_by="Dando18")
 
     version("master", branch="master")
+    version("1.50.0", sha256="cca015e07739a1c26c6fc459f7d46e1e36ce0f7613114eddedd8cd3af55a10b7")
     version("1.49.0", sha256="442406ee14eb9a59414525cf262354fe2e752b22c224ce2a5e42b2c493226e09")
     version("1.46.0", sha256="f60a578502d0b29eaa2a72c5b0d91390b2064dfd8d1a1291c3b2525d587fd395")
     version("1.42.2", sha256="9929acc303b881106d2bf2d3440d44f413372c14b0e44bf47cda8ada8801553a")


### PR DESCRIPTION
Release notes: https://github.com/casey/just/releases/tag/1.50.0
Diff: https://github.com/casey/just/compare/1.49.0...1.50.0