### PR TITLE
py-packaging: add v26.2

### DIFF
--- a/repos/spack_repo/builtin/packages/py_packaging/package.py
+++ b/repos/spack_repo/builtin/packages/py_packaging/package.py
@@ -15,6 +15,7 @@ class PyPackaging(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("26.2", sha256="ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661")
     version("26.1", sha256="f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de")
     version("26.0", sha256="00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4")
     version("25.0", sha256="d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f")


### PR DESCRIPTION
Release notes: https://github.com/pypa/packaging/releases/tag/26.2
Diff: https://github.com/pypa/packaging/compare/26.1...26.2