### PR TITLE
py-wheel: add v0.47.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_wheel/package.py
+++ b/repos/spack_repo/builtin/packages/py_wheel/package.py
@@ -19,6 +19,7 @@ class PyWheel(Package, PythonExtension):
 
     tags = ["build-tools"]
 
+    version("0.47.0", sha256="212281cab4dff978f6cedd499cd893e1f620791ca6ff7107cf270781e587eced")
     version("0.46.3", sha256="4b399d56c9d9338230118d705d9737a2a468ccca63d5e813e2a4fc7815d8bc4d")
     version("0.45.1", sha256="708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248")
     version("0.45.0", sha256="52f0baa5e6522155090a09c6bd95718cc46956d1b51d537ea5454249edb671c7")


### PR DESCRIPTION
Release notes: https://github.com/pypa/wheel/blob/0.47.0/docs/news.rst
Diff: https://github.com/pypa/wheel/compare/0.46.3...0.47.0