### PR TITLE
libxml2: add external find

### DIFF
--- a/repos/spack_repo/builtin/packages/libxml2/package.py
+++ b/repos/spack_repo/builtin/packages/libxml2/package.py
@@ -22,6 +22,8 @@ class Libxml2(AutotoolsPackage, CMakePackage, NMakePackage):
 
     maintainers("AlexanderRichert-NOAA")
 
+    executables = ["xml2-config"]
+
     def url_for_version(self, version):
         if version >= Version("2.9.13"):
             url = "https://download.gnome.org/sources/libxml2/{0}/libxml2-{1}.tar.xz"
@@ -74,6 +76,12 @@ class Libxml2(AutotoolsPackage, CMakePackage, NMakePackage):
     build_system(
         conditional("nmake", when="platform=windows"), "cmake", "autotools", default="autotools"
     )
+
+    @classmethod
+    def determine_version(cls, exe):
+        # Output from --version is just the version, nothing else
+        output = Executable(exe)("--version", output=str)
+        return output.strip()
 
     def flag_handler(self, name, flags):
         if name == "cflags" and self.spec.satisfies("+pic"):


### PR DESCRIPTION
This adds `spack external find` support for libxml2, which is *nominally* a dependency of the (binary-installed) CUDA. I couldn't find any evidence of CUDA linking against or loading it though, so I may just remove that requirement for 12+ in a subsequent PR.