### PR TITLE
openblas: use default make target

### DIFF
--- a/repos/spack_repo/builtin/packages/openblas/package.py
+++ b/repos/spack_repo/builtin/packages/openblas/package.py
@@ -621,15 +621,10 @@ class MakefileBuilder(makefile.MakefileBuilder):
 
     def build(self, pkg: MakefilePackage, spec: Spec, prefix: Prefix) -> None:
         """Override 'make all' with sequential builds due to race conditions."""
-        # Due to the verbosity of the command line and number of object files
-        # created, we suppress makefile command echoing via `-s`.
-        args = ["-s"] + self.make_defs
-
-        # Make each target sequentially
         with working_dir(self.build_directory):
-            for target in ["libs", "netlib", "shared"]:
-                tty.info("Building target", target)
-                make(*(args + [target]))
+            # Due to the verbosity of the command line and number of object
+            # files created, we suppress makefile command echoing via `-s`.
+            make("-s", *self.make_defs)
 
     @run_after("build")
     @on_package_attributes(run_tests=True)

--- a/repos/spack_repo/builtin/packages/openblas/package.py
+++ b/repos/spack_repo/builtin/packages/openblas/package.py
@@ -9,7 +9,6 @@ from spack_repo.builtin.build_systems import cmake, makefile
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
 
-from spack.llnl.util import tty
 from spack.package import *
 
 


### PR DESCRIPTION
Running `make libs && make netlib && make shared` causes the `ar`
commands two run twice, which is surprisingly slow.

The reason we didn't run just `make` was because it builds and runs tests
unconditionally, and that sometimes broke. I think if it's broken then the
underlying problem should be fixed.

