### PR TITLE
plumed: Fix Spack compilers wrappers injection

### DIFF
--- a/repos/spack_repo/builtin/packages/plumed/package.py
+++ b/repos/spack_repo/builtin/packages/plumed/package.py
@@ -181,6 +181,14 @@ class Plumed(AutotoolsPackage):
 
     parallel = True
 
+    # Filter Spack's compiler wrapper
+    # so that "plumed mklib" works correctly 
+    filter_compiler_wrappers(
+        "config.txt",
+        "compile_options.sh",
+        relative_root=join_path("lib", "plumed", "src", "config"),
+    )
+
     def apply_patch(self, other):
         # The name of MD engines differ slightly from the ones used in Spack
         format_strings = collections.defaultdict(lambda: "{0.name}-{0.version}")

--- a/repos/spack_repo/builtin/packages/plumed/package.py
+++ b/repos/spack_repo/builtin/packages/plumed/package.py
@@ -182,7 +182,7 @@ class Plumed(AutotoolsPackage):
     parallel = True
 
     # Filter Spack's compiler wrapper
-    # so that "plumed mklib" works correctly 
+    # so that "plumed mklib" works correctly
     filter_compiler_wrappers(
         "config.txt",
         "compile_options.sh",


### PR DESCRIPTION
The Spack compiler wrappers are injected into `plumed` at build time, resulting in the following error with `plumed mklib`:

```
[spack cc]: Error: Spack compiler must be run from Spack! Input 'SPACK_COMPILER_WRAPPER_PATH' is missing.
```

I'm not sure if this is the correct way forward, but this PR uses `filter_compiler_wrappers` to filter out the Spack compiler wrappers so that `plumed mklib` works correctly.