### PR TITLE
Axom: set CAMP_DIR for raja or umpire

### DIFF
--- a/repos/spack_repo/builtin/packages/axom/package.py
+++ b/repos/spack_repo/builtin/packages/axom/package.py
@@ -670,7 +670,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
             else:
                 entries.append("# %s not built\n" % dep.upper())
 
-        if spec.satisfies("+umpire") and spec.satisfies("^camp"):
+        if (spec.satisfies("+raja") or spec.satisfies("+umpire")) and spec.satisfies("^camp"):
             dep_dir = get_spec_path(spec, "camp", path_replacements)
             entries.append(cmake_cache_path("CAMP_DIR", dep_dir))
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Set `CAMP_DIR` when using raja or umpire. This fixes CMake error:
```
  >> 66    CMake Error at cmake/thirdparty/SetupAxomThirdParty.cmake:35 (message):
     67      CAMP_DIR is required if RAJA_DIR or UMPIRE_DIR is provided.
```
when building `axom+raja~umpire`.
