### PR TITLE
ParaView: Make OSMesa a link dep when +osmesa_fallback

### DIFF
--- a/repos/spack_repo/builtin/packages/paraview/package.py
+++ b/repos/spack_repo/builtin/packages/paraview/package.py
@@ -322,7 +322,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
         # * the system rendering default (WGL/AGL/GLX)
         # * EGL
         # * OSMesa (guarenteed to exist and work on all systems)
-        depends_on("osmesa", type=("run"), when="+osmesa_fallback")
+        depends_on("osmesa", type=("link", "run"), when="+osmesa_fallback")
 
         # Depend on Viskores when it is needed
         for vk_variant in viskores_dependency_variants:


### PR DESCRIPTION
This is not really true, but it solves the explicit fallback not being found in LD_LIBRARY_PATH problem by putting it in the rpath.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
