### PR TITLE
add gcc to darwin aarch64 devtools stack

### DIFF
--- a/stacks/developer-tools-darwin/spack.yaml
+++ b/stacks/developer-tools-darwin/spack.yaml
@@ -19,8 +19,10 @@ spack:
     # - neovim
     - py-pynvim
 
-      # runtimes and language compilers
-    - gcc languages=c,c++,fortran
+    # runtimes and language compilers
+    # for gcc, overspecify the variant to ensure we do not use the external
+    # gcc platform=darwin conflicts with +binutils, so this isn't restrictive
+    - gcc languages=c,c++,fortran ~binutils
     - cmake
     - go
     - libtool

--- a/stacks/developer-tools-darwin/spack.yaml
+++ b/stacks/developer-tools-darwin/spack.yaml
@@ -20,7 +20,7 @@ spack:
     - py-pynvim
 
       # runtimes and language compilers
-    - gcc languages=c,cxx,fortran
+    - gcc languages=c,c++,fortran
     - cmake
     - go
     - libtool

--- a/stacks/developer-tools-darwin/spack.yaml
+++ b/stacks/developer-tools-darwin/spack.yaml
@@ -20,6 +20,7 @@ spack:
     - py-pynvim
 
       # runtimes and language compilers
+    - gcc languages=c,cxx,fortran
     - cmake
     - go
     - libtool


### PR DESCRIPTION
Makes gcc available as a binary package for developers and ensures we notice if we suddenly can no longer build gcc.