### PR TITLE
r-dbplyr: add version 2.5.2

### DIFF
--- a/repos/spack_repo/builtin/packages/r_dbplyr/package.py
+++ b/repos/spack_repo/builtin/packages/r_dbplyr/package.py
@@ -19,6 +19,7 @@ class RDbplyr(RPackage):
 
     license("MIT")
 
+    version("2.5.2", sha256="215ae869bcdfb55ea9391086a816185fdd7174579437252d5f96ba87ef6d3b89")
     version("2.5.0", sha256="bb475bdbe89487b189ecc257b5c92007a7458803c81aa77bfc4ed46f5f24bcff")
     version("2.3.2", sha256="0ddc00595ec6b21962d0bb6f470f5f7c9d61c74a4f92681a37e94e1295707fac")
     version("2.2.1", sha256="a6f3f644c068fe1a3b3e99a3a10de55a150d43ef20b5130e6724d142afcb0df7")
@@ -31,46 +32,65 @@ class RDbplyr(RPackage):
     version("1.2.0", sha256="02a5fa8dcf8a81c061fdaefa74f17896bee913720418b44dbd226a0d6b30799d")
     version("1.1.0", sha256="7b1e456a2d1056fa6284582cd82d2df66d06b3eea92e9995f5a91a45f246f69d")
 
-    depends_on("r@3.1:", type=("build", "run"))
-    depends_on("r@3.6:", type=("build", "run"), when="@2.4.0:")
-    depends_on("r-blob@1.2.0:", type=("build", "run"), when="@2.0.0:")
-    depends_on("r-cli@3.3.0:", type=("build", "run"), when="@2.2.1:")
-    depends_on("r-cli@3.4.1:", type=("build", "run"), when="@2.3.2:")
-    depends_on("r-cli@3.6.1:", type=("build", "run"), when="@2.4.0:")
-    depends_on("r-dbi@1.0.0:", type=("build", "run"))
-    depends_on("r-dbi@1.1.3:", type=("build", "run"), when="@2.4.0:")
-    depends_on("r-dplyr@0.8.0:", type=("build", "run"))
-    depends_on("r-dplyr@1.0.3:", type=("build", "run"), when="@2.1.0")
-    depends_on("r-dplyr@1.0.4:", type=("build", "run"), when="@2.1.1:")
-    depends_on("r-dplyr@1.0.9:", type=("build", "run"), when="@2.2.1:")
-    depends_on("r-dplyr@1.1.0:", type=("build", "run"), when="@2.3.2:")
-    depends_on("r-dplyr@1.1.2:", type=("build", "run"), when="@2.4.0:")
-    depends_on("r-glue@1.2.0:", type=("build", "run"))
-    depends_on("r-glue@1.6.2:", type=("build", "run"), when="@2.4.0:")
-    depends_on("r-lifecycle", type=("build", "run"), when="@2.0.0:")
-    depends_on("r-lifecycle@1.0.0:", type=("build", "run"), when="@2.1.1:")
-    depends_on("r-lifecycle@1.0.3:", type=("build", "run"), when="@2.3.2:")
-    depends_on("r-magrittr", type=("build", "run"), when="@2.0.0:")
-    depends_on("r-pillar@1.5.0:", type=("build", "run"), when="@2.2.1:")
-    depends_on("r-pillar@1.9.0:", type=("build", "run"), when="@2.4.0:")
-    depends_on("r-purrr@0.2.5:", type=("build", "run"))
-    depends_on("r-purrr@1.0.1:", type=("build", "run"), when="@2.3.2:")
-    depends_on("r-r6@2.2.2:", type=("build", "run"))
-    depends_on("r-rlang@0.2.0:", type=("build", "run"))
-    depends_on("r-rlang@1.0.0:", type=("build", "run"), when="@2.2.1:")
-    depends_on("r-rlang@1.0.6:", type=("build", "run"), when="@2.3.2:")
-    depends_on("r-rlang@1.1.1:", type=("build", "run"), when="@2.4.0:")
-    depends_on("r-tibble@1.4.2:", type=("build", "run"))
-    depends_on("r-tibble@3.2.1:", type=("build", "run"), when="@2.4.0:")
-    depends_on("r-tidyr@1.3.0:", type=("build", "run"), when="@2.3.2:")
-    depends_on("r-tidyselect@0.2.4:", type=("build", "run"))
-    depends_on("r-tidyselect@1.2.0:", type=("build", "run"), when="@2.3.2:")
-    depends_on("r-tidyselect@1.2.1:", type=("build", "run"), when="@2.4.0:")
-    depends_on("r-vctrs", type=("build", "run"), when="@2.1:")
-    depends_on("r-vctrs@0.4.1:", type=("build", "run"), when="@2.2.1:")
-    depends_on("r-vctrs@0.5.0:", type=("build", "run"), when="@2.3.2:")
-    depends_on("r-vctrs@0.6.3:", type=("build", "run"), when="@2.4.0:")
-    depends_on("r-withr", type=("build", "run"), when="@2.0.0:")
-    depends_on("r-withr@2.5.0:", type=("build", "run"), when="@2.4.0:")
-    depends_on("r-ellipsis", type=("build", "run"), when="@2.1.1")
-    depends_on("r-assertthat", type=("build", "run"), when="@:2.2.1")
+    with default_args(type=("build", "run")):
+        depends_on("r@3.6:", when="@2.4.0:")
+        depends_on("r@3.1:")
+
+        depends_on("r-blob@1.2.0:", when="@2.0.0:")
+
+        depends_on("r-cli@3.6.1:", when="@2.4.0:")
+        depends_on("r-cli@3.4.1:", when="@2.3.2:")
+        depends_on("r-cli@3.3.0:", when="@2.2.1:")
+
+        depends_on("r-dbi@1.1.3:", when="@2.4.0:")
+        depends_on("r-dbi@1.0.0:")
+
+        depends_on("r-dplyr@1.1.2:", when="@2.4.0:")
+        depends_on("r-dplyr@1.1.0:", when="@2.3.2:")
+        depends_on("r-dplyr@1.0.9:", when="@2.2.1:")
+        depends_on("r-dplyr@1.0.4:", when="@2.1.1:")
+        depends_on("r-dplyr@1.0.3:", when="@2.1.0")
+        depends_on("r-dplyr@0.8.0:")
+
+        depends_on("r-glue@1.6.2:", when="@2.4.0:")
+        depends_on("r-glue@1.2.0:")
+
+        depends_on("r-lifecycle@1.0.3:", when="@2.3.2:")
+        depends_on("r-lifecycle@1.0.0:", when="@2.1.1:")
+        depends_on("r-lifecycle", when="@2.0.0:")
+
+        depends_on("r-magrittr", when="@2.0.0:")
+
+        depends_on("r-pillar@1.9.0:", when="@2.4.0:")
+        depends_on("r-pillar@1.5.0:", when="@2.2.1:")
+
+        depends_on("r-purrr@1.0.1:", when="@2.3.2:")
+        depends_on("r-purrr@0.2.5:")
+
+        depends_on("r-r6@2.2.2:")
+
+        depends_on("r-rlang@1.1.1:", when="@2.4.0:")
+        depends_on("r-rlang@1.0.6:", when="@2.3.2:")
+        depends_on("r-rlang@1.0.0:", when="@2.2.1:")
+        depends_on("r-rlang@0.2.0:")
+
+        depends_on("r-tibble@3.2.1:", when="@2.4.0:")
+        depends_on("r-tibble@1.4.2:")
+
+        depends_on("r-tidyr@1.3.0:", when="@2.3.2:")
+
+        depends_on("r-tidyselect@1.2.1:", when="@2.4.0:")
+        depends_on("r-tidyselect@1.2.0:", when="@2.3.2:")
+        depends_on("r-tidyselect@0.2.4:")
+
+        depends_on("r-vctrs@0.6.3:", when="@2.4.0:")
+        depends_on("r-vctrs@0.5.0:", when="@2.3.2:")
+        depends_on("r-vctrs@0.4.1:", when="@2.2.1:")
+        depends_on("r-vctrs", when="@2.1:")
+
+        depends_on("r-withr@2.5.0:", when="@2.4.0:")
+        depends_on("r-withr", when="@2.0.0:")
+
+        # Historical dependencies
+        depends_on("r-ellipsis", when="@2.1.1")
+        depends_on("r-assertthat", when="@:2.2.1")


### PR DESCRIPTION
https://cloud.r-project.org/web/packages/dbplyr/

no changes to the dependencies, just restructuring
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
