### PR TITLE
acts: require +hepmc3 when @41: +examples

### DIFF
--- a/repos/spack_repo/builtin/packages/acts/package.py
+++ b/repos/spack_repo/builtin/packages/acts/package.py
@@ -161,6 +161,7 @@ class Acts(CMakePackage, CudaPackage):
     variant(
         "hepmc3", default=False, description="Build the HepMC3-based examples", when="+examples"
     )
+    requires("+hepmc3", when="@41: +examples")
     variant(
         "pythia8", default=False, description="Build the Pythia8-based examples", when="+examples"
     )


### PR DESCRIPTION
Since https://github.com/acts-project/acts/commit/4990a809885540abcea36423a93790a719b8e3fb, `acts +examples` requires `hepmc3`, and `ACTS_BUILD_EXAMPLES_HEPMC3` is not an option anymore. This PR prevents building `acts +examples` with the default `~hepmc3`.