### PR TITLE
prrte: fixes for develop

### DIFF
--- a/repos/spack_repo/builtin/packages/prrte/package.py
+++ b/repos/spack_repo/builtin/packages/prrte/package.py
@@ -45,7 +45,12 @@ class Prrte(AutotoolsPackage):
     version("2.0.0", sha256="9f4abc0b1410e0fa74ed7b00cfea496aa06172e12433c6f2864d11b534becc25")
     version("1.0.0", sha256="a9b3715e059c10ed091bd6e3a0d8896f7752e43ee731abcc95fb962e67132a2d")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
+
+    # Python is used to generate the docs and the show-help array,
+    # both of which are included pre-built in tarballs.
+    # https://github.com/openpmix/prrte/issues/2438
+    depends_on("python@3.7:", type="build", when="@develop")
 
     depends_on("pmix")
     depends_on("pmix@6.1:", when="@4.1:")

--- a/repos/spack_repo/builtin/packages/prrte/package.py
+++ b/repos/spack_repo/builtin/packages/prrte/package.py
@@ -23,7 +23,7 @@ class Prrte(AutotoolsPackage):
 
     license("BSD-3-Clause-Open-MPI")
 
-    version("develop", branch="master")
+    version("develop", branch="master", no_cache=True, submodules=True)
     version("4.1.0", sha256="285ad62b670075708b9fcfe14c54baa599733bc274d10502a82e8eebba0b7c70")
     version("4.0.0", sha256="3c2ec961e0ba0c99128c7bf3545f4789d55a85a70ce958e868ae5e3db6ed4de4")
     version("3.0.13", sha256="635a546b3d3cfa587f4122bfaa0038df07b56381ffd649e57b089893712fa231")
@@ -66,7 +66,6 @@ class Prrte(AutotoolsPackage):
     depends_on("libtool", type=("build"))
     depends_on("flex", type=("build"))
     depends_on("pkgconfig", type="build")
-    depends_on("python@3.7:", type="build", when="@develop")
 
     # https://github.com/openpmix/openpmix/blob/master/docs/installing-pmix/configure-cli-options/runtime.rst
     SCHEDULERS = ("alps", "lsf", "tm", "slurm", "sge")
@@ -128,7 +127,11 @@ class Prrte(AutotoolsPackage):
             config_args.append("--with-sge")
 
         if spec.satisfies("schedulers=tm"):
-            config_args.append(f"--with-tm={self.spec['pbs'].prefix}")
+            if spec.satisfies("@develop"):
+                # https://github.com/openpmix/prrte/pull/2434
+                config_args.append(f"--with-pbs={self.spec['pbs'].prefix}")
+            else:
+                config_args.append(f"--with-tm={self.spec['pbs'].prefix}")
 
         if spec.satisfies("schedulers=slurm"):
             config_args.append("--with-slurm")


### PR DESCRIPTION
- Fixes for being able to build git@develop
- This includes the new flags to support the PBS changes from https://github.com/openpmix/prrte/pull/2434 