### PR TITLE
Only run Gitlab CI Stacks if there are changes that may require it

### DIFF
--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -83,6 +83,11 @@ default:
       variables:
         <<: *common_pr_vars
         SPACK_PRUNE_UNTOUCHED: "True"
+      changes:
+        - .ci/env
+        - .ci/gitlab/*
+        - repos/spack_repo/builtin/packages/*
+        - stacks/$SPACK_CI_STACK_NAME/*
 
     - if: $CI_COMMIT_REF_NAME =~ /^pr[\d]+_.*$/ && $CI_PROJECT_NAME == "spack"
       # Pipelines on PR branches rebuild only what's missing, and do extra pruning
@@ -247,6 +252,19 @@ dotenv:
   - echo "$WRITE_DOTENV_SCRIPT_SHA256  write_dotenv.py" | sha256sum -c
   - python3 write_dotenv.py .ci/env
   - cat env
+
+force_pipeline_status:
+  stage: generate
+  tags: ["spack", "service_noop"]
+  image: busybox@sha256:37f7b378a29ceb4c551b1b5582e27747b855bbfaa73fa11914fe0df028dc581f
+  variables:
+    CI_OIDC_REQUIRED: 0
+    GIT_STRATEGY: "none"
+    CI_JOB_SIZE: "small"
+    KUBERNETES_CPU_REQUEST: "100m"
+    KUBERNETES_MEMORY_REQUEST: "5M"
+  script:
+  - echo "This job is a placeholder job to ensure a pipeline status is posted even if no jobs are run"
 
 ########################################
 # TEMPLATE FOR ADDING ANOTHER PIPELINE

--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -89,7 +89,7 @@ default:
           - .ci/gitlab/*
           - repos/spack_repo/*
           - stacks/$SPACK_CI_STACK_NAME/*
-        compare_to: develop
+        compare_to: HEAD~1
 
     - if: $CI_COMMIT_REF_NAME =~ /^pr[\d]+_.*$/ && $CI_PROJECT_NAME == "spack"
       # Pipelines on PR branches rebuild only what's missing, and do extra pruning

--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -84,10 +84,12 @@ default:
         <<: *common_pr_vars
         SPACK_PRUNE_UNTOUCHED: "True"
       changes:
-        - .ci/env
-        - .ci/gitlab/*
-        - repos/spack_repo/builtin/packages/*
-        - stacks/$SPACK_CI_STACK_NAME/*
+        paths:
+          - .ci/env
+          - .ci/gitlab/*
+          - repos/spack_repo/builtin/packages/*
+          - stacks/$SPACK_CI_STACK_NAME/*
+        compare_to: develop
 
     - if: $CI_COMMIT_REF_NAME =~ /^pr[\d]+_.*$/ && $CI_PROJECT_NAME == "spack"
       # Pipelines on PR branches rebuild only what's missing, and do extra pruning

--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -46,6 +46,14 @@ default:
     PIPELINE_MIRROR_TEMPLATE: "multi-src-mirrors.yaml.in"
     OIDC_TOKEN_AUDIENCE: "pr_binary_mirror"
 
+.package_on_change: &package_on_change
+    paths:
+      - .ci/env
+      - .ci/gitlab/*
+      - repos/spack_repo/*
+      - stacks/$SPACK_CI_STACK_NAME/*
+    compare_to: HEAD~1
+
   ########################################
 # Job templates
 ########################################
@@ -83,13 +91,7 @@ default:
       variables:
         <<: *common_pr_vars
         SPACK_PRUNE_UNTOUCHED: "True"
-      changes:
-        paths:
-          - .ci/env
-          - .ci/gitlab/*
-          - repos/spack_repo/*
-          - stacks/$SPACK_CI_STACK_NAME/*
-        compare_to: HEAD~1
+      changes: *package_on_change
 
     - if: $CI_COMMIT_REF_NAME =~ /^pr[\d]+_.*$/ && $CI_PROJECT_NAME == "spack"
       # Pipelines on PR branches rebuild only what's missing, and do extra pruning
@@ -256,6 +258,15 @@ dotenv:
   - cat env
 
 force_pipeline_status:
+  rules:
+    - if: $CI_COMMIT_REF_NAME =~ /^pr[\d]+_.*$/ && $CI_PROJECT_NAME == "spack-packages"
+      changes: *package_on_change
+      when: never
+    - if: $CI_PROJECT_NAME == "spack"
+      when: never
+    - if: $CI_COMMIT_REF_NAME =~ /^pr[\d]+_.*$/
+      when: always
+    - when: never
   stage: generate
   tags: ["spack", "service_noop"]
   retry: 0

--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -87,7 +87,7 @@ default:
         paths:
           - .ci/env
           - .ci/gitlab/*
-          - repos/spack_repo/builtin/packages/*
+          - repos/spack_repo/*
           - stacks/$SPACK_CI_STACK_NAME/*
         compare_to: develop
 

--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -258,6 +258,8 @@ dotenv:
 force_pipeline_status:
   stage: generate
   tags: ["spack", "service_noop"]
+  retry: 0
+  allow_failure: true
   image: busybox@sha256:37f7b378a29ceb4c551b1b5582e27747b855bbfaa73fa11914fe0df028dc581f
   variables:
     CI_OIDC_REQUIRED: 0


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Try to save some resources for the odd job that does not change anything that affects CI.

The current unaffected pruning rules will attempt to rebuild all missing shas (ie. if there are develop failures, they will be forced to run) on changes only to `README.md`. This results in unnecessary friction and CI cost  on PRs that should otherwise be very quick to turn around.

CC: @tgamblin 