### PR TITLE
r-fs: add v2.1.0

### DIFF
--- a/repos/spack_repo/builtin/packages/r_fs/package.py
+++ b/repos/spack_repo/builtin/packages/r_fs/package.py
@@ -17,18 +17,23 @@ class RFs(RPackage):
 
     license("MIT")
 
+    version("2.1.0", sha256="7088af1117d65c4ceb144b532e323f197fc8243b1d704bf6edf40774789829cd")
     version("1.6.4", sha256="7e06290f2dbe36f54fdf51b748a4b00b8b0f68967b5754e37e0c83df7fea5ac8")
     version("1.6.2", sha256="548b7c0ed5ab26dc4fbd88707ae12987bcaef834dbc6de4e17d453846dc436b2")
     version("1.5.2", sha256="35cad1781d6d17c1feb56adc4607079c6844b63794d0ce1e74bb18dbc11e1987")
     version("1.5.0", sha256="36df1653571de3c628a4f769c4627f6ac53d0f9e4106d9d476afb22ae9603897")
     version("1.3.1", sha256="d6934dca8f835d8173e3fb9fd4d5e2740c8c04348dd2bcc57df1b711facb46bc")
 
-    depends_on("c", type="build")
-    depends_on("cxx", type="build")
+    with default_args(type="build"):
+        depends_on("c")
+        depends_on("cxx")
+        depends_on("cmake")
 
-    depends_on("r@3.1:", type=("build", "run"))
-    depends_on("r@3.4:", type=("build", "run"), when="@1.6.2:")
-    depends_on("r@3.6:", type=("build", "run"), when="@1.6.4:")
-    depends_on("gmake", type="build")
+    with default_args(type=("build", "run")):
+        depends_on("r@4.1:", when="@1.6.7:")
+        depends_on("r@3.6:", when="@1.6.4:")
+        depends_on("r@3.4:", when="@1.6.2:")
+        depends_on("r@3.1:")
 
-    depends_on("r-rcpp", type=("build", "run"), when="@:1.3.1")
+        # Historical dependencies
+        depends_on("r-rcpp", when="@:1.3.1")


### PR DESCRIPTION
https://cran.r-project.org/package=fs

Exchanged `gmake` build dependency with `cmake` because I got the following error otherwise:
```
  /bin/sh: line 1: cmake: command not found
```
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
