### PR TITLE
libtool: needs file

### DIFF
--- a/repos/spack_repo/builtin/packages/libtool/package.py
+++ b/repos/spack_repo/builtin/packages/libtool/package.py
@@ -37,6 +37,7 @@ class Libtool(AutotoolsPackage, GNUMirrorPackage):
     # https://github.com/autotools-mirror/libtool/blob/v2.4.7/build-aux/ltmain.in#L3296
     # https://github.com/autotools-mirror/libtool/blob/v2.4.6/build-aux/ltmain.in#L3278
     depends_on("findutils", type="run")
+    depends_on("file", type="run")
 
     with when("@2.4.6"):
         depends_on("autoconf@2.62:", type="test")


### PR DESCRIPTION
Otherwise

```
FILECMD="file"  # with
FILECMD=":"  # without
```

