### PR TITLE
ascent: propagate fortran variant to adios2

### DIFF
--- a/repos/spack_repo/builtin/packages/ascent/package.py
+++ b/repos/spack_repo/builtin/packages/ascent/package.py
@@ -322,7 +322,6 @@ class Ascent(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("adios2+shared", when="+shared")
         depends_on("adios2~shared", when="~shared")
         depends_on("adios2+fortran", when="+fortran")
-        depends_on("adios2~fortran", when="~fortran")
 
     # Catalyst
     with when("+catalyst"):

--- a/repos/spack_repo/builtin/packages/ascent/package.py
+++ b/repos/spack_repo/builtin/packages/ascent/package.py
@@ -314,12 +314,15 @@ class Ascent(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("fides@:1.2", when="@:0.9.5")
 
     # Adios2
-    depends_on("adios2", when="+adios2")
-    # propagate relevent variants to adios2
-    depends_on("adios2+mpi", when="+adios2+mpi")
-    depends_on("adios2~mpi", when="+adios2~mpi")
-    depends_on("adios2+shared", when="+adios2+shared")
-    depends_on("adios2~shared", when="+adios2~shared")
+    with when("+adios2"):
+        depends_on("adios2")
+        # propagate relevent variants to adios2
+        depends_on("adios2+mpi", when="+mpi")
+        depends_on("adios2~mpi", when="~mpi")
+        depends_on("adios2+shared", when="+shared")
+        depends_on("adios2~shared", when="~shared")
+        depends_on("adios2+fortran", when="+fortran")
+        depends_on("adios2~fortran", when="~fortran")
 
     # Catalyst
     with when("+catalyst"):


### PR DESCRIPTION
According to [`adios2` cmake](https://github.com/ornladios/ADIOS2/blob/master/cmake/adios2-config-common.cmake.in#L32-L42), by default it enables components for any enabled language (and MPI).

In `ascent` no components is specified in the `find_package(ADIOS2)` [call](https://github.com/Alpine-DAV/ascent/blob/develop/src/cmake/thirdparty/SetupADIOS2.cmake#L39-L41), so it fallbacks to the defaults.

So, when `ascent+fortran` enables the language, `adios2` cmake will look for `fortran` too, so we have to propagate `fortran` as well.