### PR TITLE
ecp-data-vis-sdk: drop old ascent conflict

### DIFF
--- a/repos/spack_repo/builtin/packages/ecp_data_vis_sdk/package.py
+++ b/repos/spack_repo/builtin/packages/ecp_data_vis_sdk/package.py
@@ -161,9 +161,6 @@ class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
     # Need to explicitly turn off conduit hdf5_compat in order to build
     # hdf5@1.12 which is required for SDK
     depends_on("conduit ~hdf5_compat", when="+ascent +hdf5")
-    # Disable configuring with @develop. This should be removed after ascent
-    # releases 0.8 and ascent can build with conduit@0.8: and vtk-m@1.7:
-    conflicts("^ascent@develop", when="+ascent")
 
     depends_on("py-cinemasci", when="+cinema")
 


### PR DESCRIPTION
I've just ran across the comment and I'm trying to do what it suggests.

Let's see if it works.