### PR TITLE
make mkl 2026.0 the default

### DIFF
--- a/repos/spack_repo/builtin/packages/heffte/package.py
+++ b/repos/spack_repo/builtin/packages/heffte/package.py
@@ -67,8 +67,8 @@ class Heffte(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("fftw@3.3.8:", when="+fftw", type=("build", "run"))
     depends_on("intel-oneapi-mkl", when="+mkl", type=("build", "run"))
-    # mkl rename dfti.hpp to dft.hpp in 2026.0, which breaks heffte@2.4.1 and earlier
-    conflicts("^intel-oneapi-mkl@2026.0:", when="@:2.4.1+mkl")
+    # mkl renamed dfti.hpp to dft.hpp in 2026.0, which breaks heffte@2.4.1 and earlier
+    conflicts("^intel-oneapi-mkl@2026.0:", when="@:2.4.1")
     depends_on("cuda@8.0:", when="+cuda", type=("build", "run"))
     depends_on("hip@3.8.0:", when="+rocm", type=("build", "run"))
     depends_on("rocfft@3.8.0:", when="+rocm", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/heffte/package.py
+++ b/repos/spack_repo/builtin/packages/heffte/package.py
@@ -67,6 +67,8 @@ class Heffte(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("fftw@3.3.8:", when="+fftw", type=("build", "run"))
     depends_on("intel-oneapi-mkl", when="+mkl", type=("build", "run"))
+    # mkl rename dfti.hpp to dft.hpp in 2026.0, which breaks heffte@2.4.1 and earlier
+    conflicts("^intel-oneapi-mkl@2026.0:", when="@:2.4.1+mkl")
     depends_on("cuda@8.0:", when="+cuda", type=("build", "run"))
     depends_on("hip@3.8.0:", when="+rocm", type=("build", "run"))
     depends_on("rocfft@3.8.0:", when="+rocm", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/intel_oneapi_mkl/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_mkl/package.py
@@ -35,7 +35,7 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         sha256="f63fd6ce3a374993caa0482fec0a3b9f2c312beeabff82009ab51fca90c97225",
         expand=False,
     )
-    
+
     version(
         "2025.3.1",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/6a17080f-f0de-41b9-b587-52f92512c59a/intel-onemkl-2025.3.1.11_offline.sh",

--- a/repos/spack_repo/builtin/packages/intel_oneapi_mkl/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_mkl/package.py
@@ -40,7 +40,6 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/6a17080f-f0de-41b9-b587-52f92512c59a/intel-onemkl-2025.3.1.11_offline.sh",
         sha256="89753ce0be82d31669172c08c6b6b863f2e25558d775496349473b3299240a01",
         expand=False,
-        preferred=True,
     )
     version(
         "2025.3.0",

--- a/repos/spack_repo/builtin/packages/intel_oneapi_mkl/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_mkl/package.py
@@ -35,6 +35,7 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         sha256="f63fd6ce3a374993caa0482fec0a3b9f2c312beeabff82009ab51fca90c97225",
         expand=False,
     )
+    
     version(
         "2025.3.1",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/6a17080f-f0de-41b9-b587-52f92512c59a/intel-onemkl-2025.3.1.11_offline.sh",

--- a/repos/spack_repo/builtin/packages/magma/package.py
+++ b/repos/spack_repo/builtin/packages/magma/package.py
@@ -94,6 +94,9 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("cuda_arch=75", when="@:2.5.0", msg="magma: cuda_arch=75 needs a version > 2.5.0")
     conflicts("cuda_arch=80", when="@:2.5.3", msg="magma: cuda_arch=80 needs a version > 2.5.3")
 
+    # MAGMA uses mkl_zcsrmv, which is not available in MKL 2026.0+ 
+    conflicts("^intel-oneapi-mkl@2026.0:", msg="magma: MKL 2026.0+ is not supported")
+
     patch("ibm-xl.patch", when="@2.2:2.5.0%xl")
     patch("ibm-xl.patch", when="@2.2:2.5.0%xl_r")
     patch("magma-2.3.0-gcc-4.8.patch", when="@2.3.0%gcc@:4.8")

--- a/repos/spack_repo/builtin/packages/magma/package.py
+++ b/repos/spack_repo/builtin/packages/magma/package.py
@@ -94,7 +94,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("cuda_arch=75", when="@:2.5.0", msg="magma: cuda_arch=75 needs a version > 2.5.0")
     conflicts("cuda_arch=80", when="@:2.5.3", msg="magma: cuda_arch=80 needs a version > 2.5.3")
 
-    # MAGMA uses mkl_zcsrmv, which is not available in MKL 2026.0+ 
+    # MAGMA uses mkl_zcsrmv, which is not available in MKL 2026.0+
     conflicts("^intel-oneapi-mkl@2026.0:", msg="magma: MKL 2026.0+ is not supported")
 
     patch("ibm-xl.patch", when="@2.2:2.5.0%xl")

--- a/repos/spack_repo/builtin/packages/petsc/package.py
+++ b/repos/spack_repo/builtin/packages/petsc/package.py
@@ -354,8 +354,6 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     depends_on("mumps+mpi~int64+metis+parmetis+openmp", when="+mumps+metis+openmp")
     depends_on("scalapack", when="+mumps")
     depends_on("mkl", when="+mkl-pardiso")
-    # issue with detecting MKL sparse support in configuration
-    conflicts("^intel-oneapi-mkl@2026.0:", msg="PETSc does not support MKL 2026.0 and later")
     depends_on("fftw+mpi", when="+fftw+mpi")
     depends_on("suite-sparse", when="+suite-sparse")
     depends_on("libx11", when="+X")
@@ -653,6 +651,11 @@ class Petsc(Package, CudaPackage, ROCmPackage):
 
         if "+mkl-pardiso" in spec:
             options.append("--with-mkl_pardiso-dir=%s" % spec["mkl"].prefix)
+
+        # See https://github.com/spack/spack-packages/pull/4651
+        if spec.satisfies("^intel-oneapi-mkl@2026.0:"):
+            options.append("--with-mkl_sparse=0")
+            options.append("--with-mkl_sparse_optimize=0")
 
         # For the moment, HPDDM does not work as a dependency
         # using download instead

--- a/repos/spack_repo/builtin/packages/petsc/package.py
+++ b/repos/spack_repo/builtin/packages/petsc/package.py
@@ -354,6 +354,8 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     depends_on("mumps+mpi~int64+metis+parmetis+openmp", when="+mumps+metis+openmp")
     depends_on("scalapack", when="+mumps")
     depends_on("mkl", when="+mkl-pardiso")
+    # issue with detecting MKL sparse support in configuration
+    conflicts("^intel-oneapi-mkl@2026.0:", msg="PETSc does not support MKL 2026.0 and later")
     depends_on("fftw+mpi", when="+fftw+mpi")
     depends_on("suite-sparse", when="+suite-sparse")
     depends_on("libx11", when="+X")


### PR DESCRIPTION
For the oneapi 2026.0 release, several packages were not compatible with mkl 2026. I marked mkl 2025.3 as preferred so I could merge the release and pass testing. https://github.com/spack/spack-packages/pull/4513 

I am resolving the MKL issues here. I disable mkl 2026 for the packages that are not compatible with the hope that upstream will resolve the issues and these workarounds can be removed.
