### PR TITLE
py-pyhdf: bugfix for oneapi 2026 or later (-Wno-error-*)

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pyhdf/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyhdf/package.py
@@ -39,7 +39,7 @@ class PyPyhdf(PythonPackage):
 
     def flag_handler(self, name, flags):
         if name == "cflags":
-            if self.spec.satisfies("%gcc@14:"):
+            if self.spec.satisfies("%gcc@14:") or self.spec.satisfies("%oneapi@2026:"):
                 flags.append("-Wno-error=incompatible-pointer-types")
                 flags.append("-Wno-error=discarded-qualifiers")
         return (flags, None, None)


### PR DESCRIPTION
## Description

`py-pyhdf` doesn't build with the newly released Intel oneAPI 2026.0.0 compilers. It needs the same compiler flags that were recently added for `gcc@14`.

## Testing

Tested on my local machine with `oneapi@2026.0.0`.

