### PR TITLE
openblas: Add patch for gfortran library

### DIFF
--- a/repos/spack_repo/builtin/packages/openblas/package.py
+++ b/repos/spack_repo/builtin/packages/openblas/package.py
@@ -150,6 +150,13 @@ class Openblas(CMakePackage, MakefilePackage):
     depends_on("fortran", when="@:0.3.20", type="build")
     depends_on("perl", when="@:0.3.20", type="build")
 
+    # https://github.com/OpenMathLib/OpenBLAS/pull/5796
+    patch(
+        "https://github.com/OpenMathLib/OpenBLAS/commit/88705a932831c0de1ed136b461c6c239802828b2.diff?full_index=1",
+        when="@0.3.32",
+        sha256="723ddc1553b6d27ff89d96985f7732695935c0d4d8df766987702689bdb750ac",
+    )
+
     # https://github.com/OpenMathLib/OpenBLAS/pull/4879
     patch("openblas-0.3.28-thread-buffer.patch", when="@0.3.28")
 


### PR DESCRIPTION
Add https://github.com/OpenMathLib/OpenBLAS/pull/5796 in openblas `0.3.32` (current version). If merged, future versions would not need the patch.