### PR TITLE
`py-ranger-fm`: dependency update and new version

### DIFF
--- a/repos/spack_repo/builtin/packages/py_ranger_fm/package.py
+++ b/repos/spack_repo/builtin/packages/py_ranger_fm/package.py
@@ -15,5 +15,11 @@ class PyRangerFm(PythonPackage):
 
     version("1.9.2", sha256="0ec62031185ad1f40b9faebd5a2d517c8597019c2eee919e3f1c60ce466d8625")
 
+    # Ranger uses the `imghdr` module from the standard library to determine the type of an image
+    # file, as the first step in determining whether and how to display a preview of the image.
+    # The `imghdr` module was removed from the standard library in Python 3.13, so older versions
+    # crash when run with Pythons newer than that.
+    depends_on("python@:3.12", when="@:1.9.2")
+
     # pip silently replaces distutils with setuptools
     depends_on("py-setuptools", type="build")

--- a/repos/spack_repo/builtin/packages/py_ranger_fm/package.py
+++ b/repos/spack_repo/builtin/packages/py_ranger_fm/package.py
@@ -13,13 +13,14 @@ class PyRangerFm(PythonPackage):
     pypi = "ranger-fm/ranger-fm-1.9.2.tar.gz"
     git = "https://github.com/ranger/ranger.git"
 
+    version("1.9.3", sha256="9476ed1971c641f4ba3dde1b8b80387f0216fcde3507426d06871f9d7189ac5e")
     version("1.9.2", sha256="0ec62031185ad1f40b9faebd5a2d517c8597019c2eee919e3f1c60ce466d8625")
 
     # Ranger uses the `imghdr` module from the standard library to determine the type of an image
     # file, as the first step in determining whether and how to display a preview of the image.
     # The `imghdr` module was removed from the standard library in Python 3.13, so older versions
     # crash when run with Pythons newer than that.
-    depends_on("python@:3.12", when="@:1.9.2")
+    depends_on("python@:3.12", when="@:1.9.3")
 
     # pip silently replaces distutils with setuptools
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
`py-ranger-fm` is a terminal file manager written in Python. One feature it provides is dynamic previews of files -- it attempts to determine the type of a file, then shows it in the file preview window if the system has the right tools installed to display the file in a terminal-friendly way.

In the versions that have so far been released, part of this process relied on the `imghdr` module from the standard library, which was removed in Python 3.13 as part of [PEP 0594](https://peps.python.org/pep-0594/) which cleaned out some of the stdlib's "dead batteries." However, this means that right now, `py-ranger-fm` crashes due to an ImportError when run with Pythons 3.13 or newer. This PR adds a dependency constraint to reflect this.

(For good measure, I also checksummed the latest patch release of `py-ranger-fm` and added it to the package as well; it doesn't fix the dependency on `imghdr`, though.) 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
