### PR TITLE
py-stevedore: fix dependency type

### DIFF
--- a/repos/spack_repo/builtin/packages/py_stevedore/package.py
+++ b/repos/spack_repo/builtin/packages/py_stevedore/package.py
@@ -29,7 +29,7 @@ class PyStevedore(PythonPackage):
     depends_on("python@3.8:", type=("build", "run"), when="@4.0.0:")
 
     depends_on("py-setuptools", type="build")
+    depends_on("py-pbr@2.0.0:", type="build", when="@3.5.0:")
 
     depends_on("py-six@1.10.0:", type=("build", "run"), when="@:3.4")
     depends_on("py-pbr@2.0.0:2.1.0", type=("build", "run"), when="@:3.4")
-    depends_on("py-pbr@2.0.0:", type=("build", "run"), when="@3.5.0:")


### PR DESCRIPTION
`pbr` is listed in `requirements.txt` but is only used by `setup.py`.