### PR TITLE
opendatadetector: Update URLs and versions

### DIFF
--- a/repos/spack_repo/builtin/packages/opendatadetector/package.py
+++ b/repos/spack_repo/builtin/packages/opendatadetector/package.py
@@ -11,8 +11,8 @@ from spack.package import *
 class Opendatadetector(CMakePackage):
     """Open Data Detector for High Energy Physics."""
 
-    homepage = "https://gitlab.cern.ch/acts/OpenDataDetector.git"
-    git = "https://gitlab.cern.ch/acts/OpenDataDetector.git"
+    homepage = "https://github.com/OpenDataDetector/OpenDataDetector.git"
+    git = "https://github.com/OpenDataDetector/OpenDataDetector.git"
 
     maintainers("vvolkl")
 
@@ -21,6 +21,8 @@ class Opendatadetector(CMakePackage):
     license("MPL-2.0-no-copyleft-exception")
 
     version("main", branch="main")
+    version("v6.0.2", tag="v6.0.2", commit="d70556f33b1c36abdf101a07ad8cf57eb56fbdf1")
+    version("v4.0.4", tag="v4.0.4", commit="b0992c148305224899a16d21fcd56406408bd393")
     version("v3.0.0", tag="v3.0.0", commit="e3b1eceae96fd5dddf10223753964c570ee868c9")
     version("v2", tag="v2", commit="7041ae086dff4ee4a8d5b65f5d9559acc6dbec47")
     version("v1", tag="v1", commit="81c43c6511723c13c15327479082d3dcfa1947c7")


### PR DESCRIPTION
Updates the git URL to the new GitHub repo (old tags are available), and adds two versions that are relevant for clients.
