### PR TITLE
pfunit: add v4.18.1

### DIFF
--- a/repos/spack_repo/builtin/packages/pfunit/package.py
+++ b/repos/spack_repo/builtin/packages/pfunit/package.py
@@ -23,6 +23,7 @@ class Pfunit(CMakePackage):
     license("NASA-1.3", checked_by="mathomp4", when="@:4.16")
     license("Apache-2.0", checked_by="mathomp4", when="@4.17:")
 
+    version("4.18.1", sha256="34654ac27c3498333210cac480d6319d3d8c0230057fd0974f3e3c4d656b8cd9")
     version("4.18.0", sha256="e1beb32e95f487423720b85bbb8314f46af5321f3ed0d06cf0122bc479ecb812")
     version("4.17.1", sha256="de3d3a9d097762e41763035b1e8f39edfce7606c7ccda01839ca6331580ef38c")
     # There was a mistake in the 4.16.0 release. Mark as deprecated.


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This adds pFUnit v4.18.1 which has a workaround found needed in testing with GCC 16.1.0 which had a bug now [fixed upstream in GCC](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=125117).

Note: The bug presented only in the pFUnit unit tests. Runs with GEOS had no issues.