### PR TITLE
r-purrr: add v1.2.2

### DIFF
--- a/repos/spack_repo/builtin/packages/r_purrr/package.py
+++ b/repos/spack_repo/builtin/packages/r_purrr/package.py
@@ -16,6 +16,7 @@ class RPurrr(RPackage):
 
     license("MIT")
 
+    version("1.2.2", sha256="ac3bc0fc0e789510042522e6c4294336c71447be8f6921b5ef78b9a9fb86617d")
     version("1.0.2", sha256="2c1bc6bb88433dff0892b41136f2f5c23573b335ff35a4775c72aa57b48bbb63")
     version("1.0.1", sha256="0a7911be3539355a4c40d136f2602befcaaad5a3f7222078500bfb969a6f2ba2")
     version("0.3.5", sha256="a2386cd7e78a043cb9c14703023fff15ab1c879bf648816879d2c0c4a554fcef")
@@ -27,19 +28,22 @@ class RPurrr(RPackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
-    depends_on("r@3.1:", type=("build", "run"))
-    depends_on("r@3.2:", type=("build", "run"), when="@0.3.3:")
-    depends_on("r@3.4.0:", type=("build", "run"), when="@1.0.1:")
-    depends_on("r@3.5.0:", type=("build", "run"), when="@1.0.2:")
-    depends_on("r-vctrs@0.5.0:", type=("build", "run"), when="@1.0.1:")
-    depends_on("r-vctrs@0.6.3:", type=("build", "run"), when="@1.0.2:")
-    depends_on("r-lifecycle@1.0.3:", type=("build", "run"), when="@1.0.1:")
-    depends_on("r-cli@3.4.0:", type=("build", "run"), when="@1.0.1:")
-    depends_on("r-cli@3.6.1:", type=("build", "run"), when="@1.0.2:")
-    depends_on("r-magrittr@1.5:", type=("build", "run"))
-    depends_on("r-magrittr@1.5.0:", type=("build", "run"), when="@1.0.1:")
-    depends_on("r-rlang@0.3.1:", type=("build", "run"))
-    depends_on("r-rlang@0.4.10:", type=("build", "run"), when="@1.0.1:")
-    depends_on("r-rlang@1.1.1:", type=("build", "run"), when="@1.0.2:")
+    with default_args(type=("build", "run")):
+        depends_on("r@4.1:", when="@1.1.0:")
+        depends_on("r@3.5.0:", when="@1.0.2:")
+        depends_on("r@3.4.0:", when="@1.0.1:")
+        depends_on("r@3.2:", when="@0.3.3:")
+        depends_on("r@3.1:")
 
-    depends_on("r-tibble", type=("build", "run"), when="@:0.2.9")
+        depends_on("r-cli@3.6.1:", when="@1.0.2:")
+        depends_on("r-cli@3.4.0:", when="@1.0.1:")
+        depends_on("r-lifecycle@1.0.3:", when="@1.0.1:")
+        depends_on("r-magrittr@1.5:")
+        depends_on("r-rlang@1.1.1:", when="@1.0.2:")
+        depends_on("r-rlang@0.4.10:", when="@1.0.1:")
+        depends_on("r-rlang@0.3.1:")
+        depends_on("r-vctrs@0.6.3:", when="@1.0.2:")
+        depends_on("r-vctrs@0.5.0:", when="@1.0.1:")
+
+        # Historical dependencies
+        depends_on("r-tibble", when="@:0.2.9")


### PR DESCRIPTION
https://cran.r-project.org/package=purrr

removed duplicate dependency on `r-magrittr@1.5:`
```
-    depends_on("r-magrittr@1.5:", type=("build", "run"))
-    depends_on("r-magrittr@1.5.0:", type=("build", "run"), when="@1.0.1:")
```
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
