### PR TITLE
py-typer: fix dependency on py-click

### DIFF
--- a/repos/spack_repo/builtin/packages/py_typer/package.py
+++ b/repos/spack_repo/builtin/packages/py_typer/package.py
@@ -24,8 +24,8 @@ class PyTyper(PythonPackage):
     with when("@0.12.5:"):
         depends_on("python@3.7:", type=("build", "run"))
         depends_on("py-pdm-backend", type="build")
-        depends_on("py-click@8:", type=("build", "run"))
-
+        depends_on("py-click@8:8.1.8", when="@:0.23.2", type=("build", "run"))
+        depends_on("py-click@8.2.1:", when="@0.23.2:", type=("build", "run"))
         depends_on("py-shellingham@1.3:", type=("build", "run"))
         depends_on("py-rich@10.11:", type=("build", "run"))
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This PR forces py-typer to depend on a py-click dependency that's less than 8.2.0. py-click introduced a breaking change to its API in 8.2.0 and py-typer didn't seem to have adapted until their 0.24.0 version. In the meantime, using py-click with a version of py-typer greater or equal to 8.2.0 causes this error:

```
TypeError: Parameter.make_metavar() missing 1 required positional argument: 'ctx'
```

There are many newer versions of py-typer since 0.15.2 but I'll leave adding them to another PR as it will require tracking how each dependencies evolved. I just wanted this PR to fix the compatibility issue.