### PR TITLE
py-torch: patch for GCC-14.2 on aarch64 (abolish ICE)

### DIFF
--- a/repos/spack_repo/builtin/packages/py_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_torch/package.py
@@ -375,7 +375,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
         sha256="91d0470cc05f5f0f775f32b70f174af74f5607162852ba1bcdd81381cd735f24",
         when="@2.9:2.10.0",
     )
-    
+
     # https://github.com/pytorch/pytorch/issues/160092
     patch(
         "https://github.com/pytorch/pytorch/commit/231c72240d80091f099c95e326d3600cba866eee.patch?full_index=1",

--- a/repos/spack_repo/builtin/packages/py_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_torch/package.py
@@ -369,6 +369,13 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
 
     conflicts("%gcc@:9.3", when="@2.2:", msg="C++17 support required")
 
+    # https://github.com/pytorch/pytorch/issues/172630 (GCC-14.2 ICE for aarch64)
+    patch(
+        "https://github.com/pytorch/pytorch/commit/8fd509399e25cb4b265dff663d3f777406001f2e.patch?full_index=1",
+        sha256="91d0470cc05f5f0f775f32b70f174af74f5607162852ba1bcdd81381cd735f24",
+        when="@2.9:2.10.0",
+    )
+    
     # https://github.com/pytorch/pytorch/issues/160092
     patch(
         "https://github.com/pytorch/pytorch/commit/231c72240d80091f099c95e326d3600cba866eee.patch?full_index=1",


### PR DESCRIPTION
This PR adds a patch to `py-torch` to get past an [ICE](https://github.com/eic/containers/actions/runs/25415186561/job/74616049315?pr=266#step:15:9442) when using GCC-14.2 on aarch64. The issue was [introduced](https://github.com/pytorch/pytorch/commit/d6237721c074484ea5e72fc05614587886e57fd6) just before 2.9.0, and [fixed](https://github.com/pytorch/pytorch/commit/8fd509399e25cb4b265dff663d3f777406001f2e) after 2.10.0. A single line in a single file is patched. No when clause is added since this patch is not harmful on other compilers, on other versions of GCC, or on other architectures. Verified that the patch applies cleanly to the git tags of v2.9.0 and v2.10.0.