### PR TITLE
remove codeowners who do not have repo write access

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,7 +24,6 @@
 /stacks/tools-sdk/                            @kwryankrattiger
 /stacks/tutorial/                             @alecbcs @becker33 @tldahlgren @tgamblin
 /stacks/windows-vis/                          @johnwparent @kwryankrattiger @scheibelp
-/stacks/radiuss*/                             @adrienbernede @davidbeckingsale
 
 ###
 # CI Components maintained by Kitware


### PR DESCRIPTION
As discussed in the TSC meeting today. Github does not play nicely with a codeowners file with users who do not have repo write access.