### PR TITLE
trilinos: version-restrict variants for deprecated packages

### DIFF
--- a/repos/spack_repo/builtin/packages/albany/package.py
+++ b/repos/spack_repo/builtin/packages/albany/package.py
@@ -44,7 +44,7 @@ class Albany(CMakePackage):
     depends_on("mpi")
     depends_on(
         "trilinos"
-        "~superlu-dist+isorropia+tempus+rythmos+teko+intrepid+intrepid2"
+        "~superlu-dist+tempus+teko+intrepid2"
         "+minitensor+phalanx+nox+piro+rol+shards+stk"
         "@master"
     )

--- a/repos/spack_repo/builtin/packages/trilinos/package.py
+++ b/repos/spack_repo/builtin/packages/trilinos/package.py
@@ -326,6 +326,15 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         conflicts("~mpi")
         conflicts("~stk")
 
+    # ShyLU_DD/core dependended on these libraries and was included with +shylu up until v17.0
+    with when("@:16 +shylu"):
+        conflicts("~amesos")
+        conflicts("~aztec")
+        conflicts("~belos")
+        conflicts("~epetra")
+        conflicts("~ifpack")
+        conflicts("~isorropia")
+
     # Panzer is not gen-2 library
     with when("+panzer"):
         conflicts("~intrepid2")

--- a/repos/spack_repo/builtin/packages/trilinos/package.py
+++ b/repos/spack_repo/builtin/packages/trilinos/package.py
@@ -149,23 +149,19 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
 
     # Package options (alphabet order)
     variant("adelus", default=False, description="Compile with Adelus")
-    variant("amesos", default=True, description="Compile with Amesos")
     variant("amesos2", default=True, description="Compile with Amesos2")
     variant("anasazi", default=True, description="Compile with Anasazi")
-    variant("aztec", default=True, description="Compile with Aztec")
     variant("belos", default=True, description="Compile with Belos")
     variant("chaco", default=False, description="Compile with Chaco from SEACAS")
-    variant("epetra", default=True, description="Compile with Epetra")
-    variant("epetraext", default=True, description="Compile with EpetraExt")
     variant("exodus", default=False, description="Compile with Exodus from SEACAS")
-    variant("ifpack", default=True, description="Compile with Ifpack")
     variant("ifpack2", default=True, description="Compile with Ifpack2")
-    variant("intrepid", default=False, description="Enable Intrepid")
     variant("intrepid2", default=False, description="Enable Intrepid2")
-    variant("isorropia", default=False, description="Compile with Isorropia")
-    variant("gtest", default=False, description="Build vendored Googletest")
+    variant(
+        "gtest",
+        default=False,
+        description="Build vendored Googletest (uses external Googletest for @17:)",
+    )
     variant("kokkos", default=True, description="Compile with Kokkos")
-    variant("ml", default=True, description="Compile with ML")
     variant("minitensor", default=False, description="Compile with MiniTensor")
     variant("muelu", default=True, description="Compile with Muelu")
     variant("nox", default=False, description="Compile with NOX")
@@ -174,7 +170,6 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     variant("piro", default=False, description="Compile with Piro")
     variant("phalanx", default=False, description="Compile with Phalanx")
     variant("rol", default=False, description="Compile with ROL")
-    variant("rythmos", default=False, description="Compile with Rythmos")
     variant("sacado", default=True, description="Compile with Sacado")
     variant("stk", default=False, description="Compile with STK")
     variant("shards", default=False, description="Compile with Shards")
@@ -192,17 +187,38 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
 
     # Internal package options (alphabetical order)
     variant("basker", default=False, description="Compile with the Basker solver in Amesos2")
-    variant("epetraextbtf", default=False, description="Compile with BTF in EpetraExt")
-    variant(
-        "epetraextexperimental",
-        default=False,
-        description="Compile with experimental in EpetraExt",
-    )
-    variant(
-        "epetraextgraphreorderings",
-        default=False,
-        description="Compile with graph reorderings in EpetraExt",
-    )
+
+    # Deprecated packages as of v17.0.0, remove when no earlier versions are supported
+    with when("@:16"):
+        variant("amesos", default=True, description="Compile with Amesos")
+        variant("aztec", default=True, description="Compile with Aztec")
+        variant("epetra", default=True, description="Compile with Epetra")
+        variant("epetraext", default=True, description="Compile with EpetraExt")
+        variant("ifpack", default=True, description="Compile with Ifpack")
+        variant("intrepid", default=False, description="Enable Intrepid")
+        variant("isorropia", default=False, description="Compile with Isorropia")
+        variant("ml", default=True, description="Compile with ML")
+        variant(
+            "epetraextbtf",
+            default=False,
+            description="Compile with BTF in EpetraExt",
+            when="@:16",
+        )
+        variant(
+            "epetraextexperimental",
+            default=False,
+            description="Compile with experimental in EpetraExt",
+            when="@:16",
+        )
+        variant(
+            "epetraextgraphreorderings",
+            default=False,
+            description="Compile with graph reorderings in EpetraExt",
+            when="@:16",
+        )
+
+    # Deprecated as of v15.0.0, remove when no earlier versions are supported
+    variant("rythmos", default=False, description="Compile with Rythmos", when="@:14")
 
     # External package options
     variant("dtk", default=False, description="Enable DataTransferKit (deprecated)")

--- a/stacks/e4s-cray-sles/spack.yaml
+++ b/stacks/e4s-cray-sles/spack.yaml
@@ -50,12 +50,12 @@ spack:
       require: "@5.11 ~qt ^[virtuals=gl] osmesa"
     trilinos:
       require:
-      - one_of: [+amesos +amesos2 +anasazi +aztec +boost +epetra +epetraext +ifpack
-            +intrepid +intrepid2 +isorropia +kokkos +minitensor +nox +piro +phalanx
-            +rol +rythmos +sacado +stk +shards +stratimikos +tempus +tpetra
+      - one_of: [+amesos2 +anasazi +boost
+            +intrepid2 +kokkos +minitensor +nox +piro +phalanx
+            +rol +sacado +stk +shards +stratimikos +tempus +tpetra
             +trilinoscouplings +zoltan]
       - one_of: [gotype=long_long, gotype=all]
-      - one_of: [~ml ~muelu ~zoltan2 ~teko, +ml +muelu +zoltan2 +teko]
+      - one_of: [~muelu ~zoltan2 ~teko, +muelu +zoltan2 +teko]
     xz:
       variants: +pic
     mesa:

--- a/stacks/e4s-neoverse-v2/spack.yaml
+++ b/stacks/e4s-neoverse-v2/spack.yaml
@@ -30,9 +30,9 @@ spack:
     openblas:
       variants: threads=openmp
     trilinos:
-      variants: +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext
-        +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu
-        +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos
+      variants: +amesos2 +anasazi +belos +boost
+        +ifpack2 +intrepid2 +kokkos +minitensor +muelu
+        +nox +piro +phalanx +rol +sacado +stk +shards +shylu +stokhos +stratimikos
         +teko +tempus +thyra +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
     mpi:
       require: mpich
@@ -148,7 +148,7 @@ spack:
   - sz3
   - tasmanian
   - tau +mpi +python +syscall
-  - trilinos +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
+  - trilinos +amesos2 +anasazi +belos +boost +ifpack2 +intrepid2 +kokkos +minitensor +muelu +nox +piro +phalanx +rol +sacado +stk +shards +shylu +stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
   - turbine
   # - umap
   - umpire

--- a/stacks/e4s-oneapi/spack.yaml
+++ b/stacks/e4s-oneapi/spack.yaml
@@ -37,9 +37,9 @@ spack:
       variants: threads=openmp
       require: 'cppflags="-O1" target=x86_64_v3 %oneapi'
     trilinos:
-      variants: +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext
-        +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu
-        +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos
+      variants: +amesos2 +anasazi +belos +boost
+        +ifpack2 +intrepid2 +kokkos +minitensor +muelu
+        +nox +piro +phalanx +rol +sacado +stk +shards +shylu +stokhos +stratimikos
         +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
     xz:
       variants: +pic
@@ -166,7 +166,7 @@ spack:
   - sz3
   - tasmanian
   - tau +mpi +python +syscall
-  - trilinos +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
+  - trilinos +amesos2 +anasazi +belos +boost +ifpack2 +intrepid2 +kokkos +minitensor +muelu +nox +piro +phalanx +rol +sacado +stk +shards +shylu +stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
   - turbine
   - umap
   - umpire

--- a/stacks/e4s-rocm-external/spack.yaml
+++ b/stacks/e4s-rocm-external/spack.yaml
@@ -253,7 +253,7 @@ spack:
   - sundials +rocm amdgpu_target=gfx90a
   - superlu-dist +rocm amdgpu_target=gfx90a
   - tasmanian ~openmp +rocm amdgpu_target=gfx90a
-  - trilinos +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu ~stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long +rocm amdgpu_target=gfx90a
+  - trilinos +amesos2 +anasazi +belos +boost +ifpack2 +intrepid2 +kokkos +minitensor +muelu +nox +piro +phalanx +rol +sacado +stk +shards +shylu ~stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long +rocm amdgpu_target=gfx90a
   - umpire +rocm amdgpu_target=gfx90a
   - upcxx +rocm amdgpu_target=gfx90a
   - vtk-m ~openmp +rocm amdgpu_target=gfx90a

--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -51,9 +51,9 @@ spack:
       variants: amdgpu_target=gfx90a
     trilinos:
       prefer:
-      - +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext
-        +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu
-        +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos
+      - +amesos2 +anasazi +belos +boost
+        +ifpack2 +intrepid2 +kokkos +minitensor +muelu
+        +nox +piro +phalanx +rol +sacado +stk +shards +shylu +stokhos +stratimikos
         +teko +tempus +thyra +tpetra +trilinoscouplings +zoltan +zoltan2 gotype=long_long
       - target=x86_64_v3
     mpich:
@@ -252,7 +252,7 @@ spack:
   - sz3
   - tasmanian
   - tau +mpi +python +syscall
-  - trilinos +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
+  - trilinos +amesos2 +anasazi +belos +boost +ifpack2 +intrepid2 +kokkos +minitensor +muelu +nox +piro +phalanx +rol +sacado +stk +shards +shylu +stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
   - turbine
   - umap
   - umpire
@@ -403,7 +403,7 @@ spack:
     - sundials
     - superlu-dist
     - tasmanian ~openmp
-    - trilinos +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu ~stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 gotype=long_long
+    - trilinos +amesos2 +anasazi +belos +boost +ifpack2 +intrepid2 +kokkos +minitensor +muelu +nox +piro +phalanx +rol +sacado +stk +shards +shylu ~stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 gotype=long_long
     - umpire
     - upcxx
     # INCLUDED IN ECP DAV ROCM


### PR DESCRIPTION
Fix oversight from https://github.com/spack/spack-packages/pull/3361

Running `spack spec trilinos` yields `trilinos@17.0.0+epetra`, which is really not great because it is inconsistent with what will be built (Trilinos 17.0.0 will certainly not include Epetra even if the configure and build succeed).  Prefer preventing people from even getting that concretization for now-deprecated packages.

This is not exhaustive and there are probably other variants that need to be guarded in this way.

Tested that `spack spec trilinos` and `spack spec trilinos+epetra` both yield the expected results:

```
sebrown@hpws00323:/fgs/sebrown/myenv $ spack spec trilinos
trilinos@17.0.0~adelus~adios2+amesos2+anasazi~basker+belos~boost~chaco~complex~cuda~cuda_constexpr~cuda_rdc~cusparse~debug~dtk~exodus+explicit_template_instantiation~float+fortran~hdf5~hypre+ifpack2~intrepid2~ipo+kokkos~mesquite~minitensor+mpi+muelu~mumps~nox~openmp~pamgen~panzer~phalanx~piro~python~rocm~rocm_rdc~rol+sacado~scorec~shards+shared~shylu~stk~stokhos~stratimikos~strumpack~suite-sparse~superlu-dist~teko~tempus~test~thyra+tpetra~wrapper~x11~zoltan~zoltan2 build_system=cmake build_type=Release cxxstd=20 generator=make gotype=long_long platform=linux os=rhel9 target=sapphirerapids %c,cxx,fortran=gcc@11.5.0
```

```
sebrown@hpws00323:/fgs/sebrown/myenv $ spack spec trilinos+epetra
trilinos@16.2.0~adelus~adios2+amesos+amesos2+anasazi+aztec~basker+belos~boost~chaco~complex~cuda~cuda_constexpr~cuda_rdc~cusparse~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings~exodus+explicit_template_instantiation~float+fortran~gtest~hdf5~hypre+ifpack+ifpack2~intrepid~intrepid2~ipo~isorropia+kokkos~mesquite~minitensor+ml+mpi+muelu~mumps~nox~openmp~pamgen~panzer~phalanx~piro~python~rocm~rocm_rdc~rol~rythmos+sacado~scorec~shards+shared~shylu~stk~stokhos~stratimikos~strumpack~suite-sparse~superlu-dist~teko~tempus~test~thyra+tpetra~trilinoscouplings~wrapper~x11~zoltan~zoltan2 build_system=cmake build_type=Release cxxstd=17 generator=make gotype=long_long platform=linux os=rhel9 target=sapphirerapids %c,cxx,fortran=gcc@11.5.0
 ```