### PR TITLE
`apfelxx`, `epic`, `partons*`, `sfml`: new packages

### DIFF
--- a/repos/spack_repo/builtin/packages/apfelxx/package.py
+++ b/repos/spack_repo/builtin/packages/apfelxx/package.py
@@ -1,0 +1,33 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class Apfelxx(CMakePackage):
+    """APFEL++ is a C++ rewriting of the Fortran 77 code APFEL
+    originally conceived to evolve collinear parton
+    distribution functions (PDFs)."""
+
+    homepage = "https://github.com/vbertone/apfelxx"
+    url = "https://github.com/vbertone/apfelxx/archive/refs/tags/4.8.0.tar.gz"
+    git = "https://github.com/vbertone/apfelxx.git"
+
+    tags = ["hep"]
+
+    maintainers("wdconinc")
+
+    license("GPL-3.0", checked_by="wdconinc")
+
+    version("4.10.0", sha256="bff51f56f36c9fa8a2e9b35a87847e7f061d532ba15c8e7f151ad344e4aa2f3f")
+
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
+    depends_on("cmake@3.10:", type="build")
+
+    depends_on("lhapdf")
+    depends_on("yaml-cpp")
+    depends_on("py-pybind11")

--- a/repos/spack_repo/builtin/packages/cln/package.py
+++ b/repos/spack_repo/builtin/packages/cln/package.py
@@ -18,7 +18,7 @@ class Cln(AutotoolsPackage):
 
     homepage = "https://www.ginac.de/CLN/"
     url = "https://www.ginac.de/CLN/cln-1.3.7.tar.bz2"
-    git = "git://www.ginac.de/cln.git"
+    git = "https://codeberg.org/ginac/cln.git"
     maintainers("prudhomm")
 
     license("GPL-2.0-or-later")

--- a/repos/spack_repo/builtin/packages/cln/package.py
+++ b/repos/spack_repo/builtin/packages/cln/package.py
@@ -42,6 +42,7 @@ class Cln(AutotoolsPackage):
     depends_on("cxx", type="build")  # generated
 
     depends_on("autoconf", type="build")
+    depends_on("autoconf-archive", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
@@ -52,9 +53,9 @@ class Cln(AutotoolsPackage):
     depends_on("gettext", type="build")
 
     def autoreconf(self, spec, prefix):
-        autoreconf_args = ["-i"]
+        autoreconf_args = ["-i", "-f"]
 
-        aclocal_pkg_list = ["gettext"]
+        aclocal_pkg_list = ["gettext", "autoconf-archive"]
         aclocal_path = os.path.join("share", "aclocal")
 
         for pkg in aclocal_pkg_list:

--- a/repos/spack_repo/builtin/packages/epic/package.py
+++ b/repos/spack_repo/builtin/packages/epic/package.py
@@ -1,0 +1,53 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class Epic(CMakePackage):
+    """EpIC is a modern and versatile Monte Carlo generator used in
+    studying exclusive processes. These processes are sensitive to
+    generalised parton distributions (GPDs), which describe the 3D
+    partonic structure of hadrons in the language of quantum
+    chromodynamics (QCD). EpIC has been developed to support the
+    current and future experimental programmes, like Electron-Ion
+    Collider (EIC) to be constructed in Brookhaven National Laboratory."""
+
+    homepage = "https://pawelsznajder.github.io/epic"
+    url = "https://github.com/pawelsznajder/epic/archive/refs/tags/v.1.1.8.tar.gz"
+    git = "https://github.com/pawelsznajder/epic.git"
+
+    tags = ["hep"]
+
+    maintainers("wdconinc")
+
+    license("GPL-3.0", checked_by="wdconinc")
+
+    version("1.1.8", sha256="f2b9add278e614fb012856e7b9df676789cb47d33af66438e7962a849f025339")
+
+    depends_on("cxx", type="build")
+    depends_on("cmake@3.5:", type="build")
+
+    depends_on("partons")
+    depends_on("partons-elementary-utils")
+    depends_on("partons-numa")
+    depends_on("sfml@:2")
+    depends_on("cln")
+    depends_on("gsl")
+    depends_on("apfelxx")
+    depends_on("lhapdf")
+    depends_on("libxml2")
+    depends_on("root")
+    depends_on("hepmc3 +rootio")
+    depends_on("boost")
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install(join_path(self.stage.source_path, "bin", "epic"), prefix.bin)
+        install_tree(
+            join_path(self.stage.source_path, "data"),
+            join_path(prefix.share, "epic", "data"),
+        )

--- a/repos/spack_repo/builtin/packages/partons/package.py
+++ b/repos/spack_repo/builtin/packages/partons/package.py
@@ -10,7 +10,7 @@ from spack.package import *
 class Partons(CMakePackage):
     """PARTONS is a software framework dedicated to the phenomenology
     of 3D hadron structure, in particular Generalized Parton Distributions
-    (GPDs) and Tranverse Momentum Dependent (TMDs) parton distribution
+    (GPDs) and Transverse Momentum Dependent (TMDs) parton distribution
     functions."""
 
     homepage = "https://3d-partons.github.io/partons/"

--- a/repos/spack_repo/builtin/packages/partons/package.py
+++ b/repos/spack_repo/builtin/packages/partons/package.py
@@ -1,0 +1,38 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class Partons(CMakePackage):
+    """PARTONS is a software framework dedicated to the phenomenology
+    of 3D hadron structure, in particular Generalized Parton Distributions
+    (GPDs) and Tranverse Momentum Dependent (TMDs) parton distribution
+    functions."""
+
+    homepage = "https://3d-partons.github.io/partons/"
+    url = "https://github.com/3d-partons/partons/archive/refs/tags/v5.0.0.tar.gz"
+    git = "https://github.com/3d-partons/partons.git"
+
+    tags = ["hep"]
+
+    maintainers("wdconinc")
+
+    license("GPL-3.0", checked_by="wdconinc")
+
+    version("5.0.0", sha256="6ac7b68890ce19a8dfd2515264201d7424d2aa809e4b8c2e714528a1f6234865")
+
+    depends_on("cxx", type="build")
+    depends_on("cmake@3.5:", type="build")
+
+    depends_on("partons-elementary-utils")
+    depends_on("partons-numa")
+    depends_on("sfml@:2")
+    depends_on("cln")
+    depends_on("gsl")
+    depends_on("apfelxx")
+    depends_on("lhapdf")
+    depends_on("libxml2")

--- a/repos/spack_repo/builtin/packages/partons_elementary_utils/package.py
+++ b/repos/spack_repo/builtin/packages/partons_elementary_utils/package.py
@@ -1,0 +1,28 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class PartonsElementaryUtils(CMakePackage):
+    """Utility methods for the PARTONS project."""
+
+    homepage = "https://3d-partons.github.io/partons"
+    url = "https://github.com/3d-partons/elementary-utils/archive/refs/tags/v5.0.0.tar.gz"
+    git = "https://github.com/3d-partons/elementary-utils.git"
+
+    tags = ["hep"]
+
+    maintainers("wdconinc")
+
+    license("GPL-3.0", checked_by="wdconinc")
+
+    version("5.0.0", sha256="0611b0614e3efdc60893080e0f35de408fef08671076d8f42ffdeda4ab4a366f")
+
+    depends_on("cxx", type="build")
+    depends_on("cmake@3.5:", type="build")
+
+    depends_on("sfml@:2")

--- a/repos/spack_repo/builtin/packages/partons_numa/package.py
+++ b/repos/spack_repo/builtin/packages/partons_numa/package.py
@@ -1,0 +1,30 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class PartonsNuma(CMakePackage):
+    """Numerical analysis routinesi for the PARTONS project."""
+
+    homepage = "https://3d-partons.github.io/partons"
+    url = "https://github.com/3d-partons/numa/archive/refs/tags/v5.0.0.tar.gz"
+    git = "https://github.com/3d-partons/numa.git"
+
+    tags = ["hep"]
+
+    maintainers("wdconinc")
+
+    license("GPL-3.0", checked_by="wdconinc")
+
+    version("5.0.0", sha256="1ba38b59cf0b8b32ff418f52a63601c65817503b1bf7823860dc6d09782066b0")
+
+    depends_on("cxx", type="build")
+    depends_on("cmake@3.5:", type="build")
+
+    depends_on("sfml@:2")
+    depends_on("partons-elementary-utils")
+    depends_on("eigen@3")

--- a/repos/spack_repo/builtin/packages/partons_numa/package.py
+++ b/repos/spack_repo/builtin/packages/partons_numa/package.py
@@ -8,7 +8,7 @@ from spack.package import *
 
 
 class PartonsNuma(CMakePackage):
-    """Numerical analysis routinesi for the PARTONS project."""
+    """Numerical analysis routines for the PARTONS project."""
 
     homepage = "https://3d-partons.github.io/partons"
     url = "https://github.com/3d-partons/numa/archive/refs/tags/v5.0.0.tar.gz"

--- a/repos/spack_repo/builtin/packages/sfml/package.py
+++ b/repos/spack_repo/builtin/packages/sfml/package.py
@@ -37,7 +37,9 @@ class Sfml(CMakePackage):
 
     conflicts("+window", msg="The window module requires UDev, which is not in spack")
     conflicts("+graphics", msg="The graphics module requires UDev, which is not in spack")
-    conflicts("+audio", msg="The audio module requires OpenAL, which is not in spack")
+    conflicts(
+        "+audio", msg="The audio module requires OpenAL, Vorbis, FLAC, which are not in spack"
+    )
 
     def cmake_args(self):
         args = [

--- a/repos/spack_repo/builtin/packages/sfml/package.py
+++ b/repos/spack_repo/builtin/packages/sfml/package.py
@@ -1,0 +1,48 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class Sfml(CMakePackage):
+    """SFML is a simple, fast, cross-platform and object-oriented
+    multimedia API. It provides access to windowing, graphics,
+    audio and network. It is written in C++ and has bindings for
+    various languages such as C, .Net, Ruby, Python."""
+
+    homepage = "https://www.sfml-dev.org/"
+    url = "https://github.com/SFML/SFML/archive/refs/tags/3.1.0.tar.gz"
+    git = "https://github.com/SFML/SFML.git"
+
+    maintainers("wdconinc")
+
+    license("Zlib", checked_by="wdconinc")
+
+    version("3.1.0", sha256="91209a112c2bd0bc6f4ce0d5f3e413cfb48b57c0de59f5507dc81f71b1ad7a5c")
+    version("2.6.2", sha256="15ff4d608a018f287c6a885db0a2da86ea389e516d2323629e4d4407a7ce047f")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("cmake@3.7.2:", type="build")
+    depends_on("cmake@3.24:", type="build", when="@3.0.0:")
+    depends_on("cmake@3.28:", type="build", when="@3.1.0:")
+
+    variant("window", default=True, description="Build the window module", when="~graphics")
+    variant("graphics", default=True, description="Build the graphics module")
+    variant("audio", default=True, description="Build the audio module")
+    variant("network", default=True, description="Build the network module")
+
+    conflicts("+window", msg="The window module requires UDev, which is not in spack")
+    conflicts("+graphics", msg="The window module requires UDev, which is not in spack")
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("SFML_BUILD_WINDOW", "window"),
+            self.define_from_variant("SFML_BUILD_GRAPHICS", "graphics"),
+            self.define_from_variant("SFML_BUILD_AUDIO", "audio"),
+            self.define_from_variant("SFML_BUILD_NETWORK", "network"),
+        ]
+        return args

--- a/repos/spack_repo/builtin/packages/sfml/package.py
+++ b/repos/spack_repo/builtin/packages/sfml/package.py
@@ -11,7 +11,7 @@ class Sfml(CMakePackage):
     """SFML is a simple, fast, cross-platform and object-oriented
     multimedia API. It provides access to windowing, graphics,
     audio and network. It is written in C++ and has bindings for
-    various languages such as C, .Net, Ruby, Python."""
+    various languages such as C, .NET, Ruby, Python."""
 
     homepage = "https://www.sfml-dev.org/"
     url = "https://github.com/SFML/SFML/archive/refs/tags/3.1.0.tar.gz"

--- a/repos/spack_repo/builtin/packages/sfml/package.py
+++ b/repos/spack_repo/builtin/packages/sfml/package.py
@@ -36,10 +36,12 @@ class Sfml(CMakePackage):
     variant("network", default=True, description="Build the network module")
 
     conflicts("+window", msg="The window module requires UDev, which is not in spack")
-    conflicts("+graphics", msg="The window module requires UDev, which is not in spack")
+    conflicts("+graphics", msg="The graphics module requires UDev, which is not in spack")
+    conflicts("+audio", msg="The audio module requires OpenAL, which is not in spack")
 
     def cmake_args(self):
         args = [
+            self.define("SFML_USE_SYSTEM_DEPS", True),
             self.define_from_variant("SFML_BUILD_WINDOW", "window"),
             self.define_from_variant("SFML_BUILD_GRAPHICS", "graphics"),
             self.define_from_variant("SFML_BUILD_AUDIO", "audio"),


### PR DESCRIPTION
This PR adds a stack of parton distribution function Monte Carlo packages (and multimedia package that they depend on for the only reason that it provides a Mutex class...).
- EpIC: https://github.com/pawelsznajder/epic
- PARTONS: https://github.com/3d-partons/partons
  - NumA++: https://github.com/3d-partons/numa
  - elementary-utils: https://github.com/3d-partons/elementary-utils
- Apfel++: https://github.com/vbertone/apfelxx
- SFML: https://github.com/SFML/SFML

Test builds (since `epic` and `partons` depends on the others, I hope this is sufficient; the rest is buried in a large environment):
```
-- linux-ubuntu26.04-skylake / %cxx=clang@23.0.0 ----------------
umgqbwq partons@5.0.0~ipo build_system=cmake build_type=Release generator=make
==> 1 installed package
```
and
```
-- linux-ubuntu26.04-skylake / %cxx=clang@23.0.0 ----------------
owxspn6 epic-generator@1.1.8~ipo build_system=cmake build_type=Release generator=make
==> 1 installed package
```
(I have a different local package that has the name `epic`, so I had to map `builtin.epic` onto `epic-generator`.)