### PR TITLE
compiler-wrapper: set `-frandom-seed="$*"` for gcc

### DIFF
--- a/repos/spack_repo/builtin/packages/compiler_wrapper/cc.sh
+++ b/repos/spack_repo/builtin/packages/compiler_wrapper/cc.sh
@@ -365,20 +365,17 @@ if [ -z "$mode" ] || [ "$mode" = ld ]; then
     done
 fi
 
-# Finish setting up the mode.
+# Finish setting up the mode, and check whether -frandom-seed needs to be set.
+eval _set_frandom_seed=\${SPACK_${comp}_HAS_FRANDOM_SEED:-}
 if [ -z "$mode" ]; then
     mode=ccld
     for arg in "$@"; do
-        if [ "$arg" = "-E" ]; then
-            mode=cpp
-            break
-        elif [ "$arg" = "-S" ]; then
-            mode=as
-            break
-        elif [ "$arg" = "-c" ]; then
-            mode=cc
-            break
-        fi
+        case $arg in
+            -E) mode=cpp ;;
+            -S) mode=as ;;
+            -c) mode=cc ;;
+            -frandom-seed=*) _set_frandom_seed= ;;
+        esac
     done
 fi
 
@@ -950,6 +947,15 @@ extend args_list libs_list "-l"
 
 full_command_list="$command"
 extend full_command_list args_list
+
+if [ -n "$_set_frandom_seed" ]; then
+    case "$mode" in
+        cc|ccld)
+            # Make GCC deterministic by setting the random seed to command line arguments
+            append full_command_list "-frandom-seed=$input_command"
+            ;;
+    esac
+fi
 
 # prepend the ccache binary if we're using ccache
 if [ -n "$SPACK_CCACHE_BINARY" ]; then

--- a/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
+++ b/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
@@ -40,7 +40,7 @@ class CompilerWrapper(Package):
     if sys.platform != "win32":
         version(
             "1.0",
-            sha256="c7b816479554fd32f677db15ceec6627b91c86074a5d65498688afcbe2796188",
+            sha256="5ecaeb9bf67538daa492ea95bd18b73dccac9af5bf3e187f013aa413adff3ce4",
             expand=False,
         )
     else:
@@ -174,6 +174,10 @@ class CompilerWrapper(Package):
 
             compiler = getattr(compiler_pkg, attr_name)
             env.set(spack_var_name, compiler)
+
+            # -frandom-seed= is needed for deterministic builds with GCC
+            if compiler_pkg.name == "gcc":
+                env.set(f"SPACK_{wrapper_var_name}_HAS_FRANDOM_SEED", "1")
 
             if language not in compiler_pkg.compiler_wrapper_link_paths:
                 continue


### PR DESCRIPTION
To make builds deterministic with GCC, use [`-frandom-seed`][1] with the
value set to all command line arguments. GCC uses the CRC checksum of
this string to initialize its random number generator.

LLVM is deterministic by default.

One concern could be "Argument list too long", but I think this one extra
flag is typically smaller than all the `-I`, `-L`, `-Wl,` flags we inject.

[1]: https://gcc.gnu.org/onlinedocs/gcc/Developer-Options.html#index-frandom-seed