### PR TITLE
readline: fix non-deterministic configure check

### DIFF
--- a/repos/spack_repo/builtin/packages/readline/package.py
+++ b/repos/spack_repo/builtin/packages/readline/package.py
@@ -77,6 +77,13 @@ class Readline(AutotoolsPackage, GNUMirrorPackage):
             sha256=checksum,
         )
 
+    def configure_args(self):
+        # The wcwidth_broken test is a runtime check that requires an installed en_US.UTF-8 locale.
+        # In minimal environments that's lacking, resulting in a false positive, leading to
+        # non-deterministic builds. The test was meant to work around bugs in ancient libc and is
+        # no longer relevant.
+        return ["bash_cv_wcwidth_broken=no"]
+
     def build(self, spec, prefix):
         make("SHLIB_LIBS=" + spec["ncurses:wide"].libs.ld_flags)
 


### PR DESCRIPTION
Build output depends on whether the `locales` system package is installed. It's not always there in minimal environments.

The issue is that the configure test mistakes "missing locales" for "broken libc", and then
adds a fix for ancient libc. That's redundant nowadays, and it's better to build binaries in a deterministic way. 