### PR TITLE
flecsi: update package requirements

### DIFF
--- a/repos/spack_repo/builtin/packages/flecsi/package.py
+++ b/repos/spack_repo/builtin/packages/flecsi/package.py
@@ -75,7 +75,8 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("kokkos", when="+kokkos @2.3:")
     depends_on("kokkos", when="@2.4:")
     depends_on("kokkos +cuda", when="+kokkos +cuda")
-    requires("^kokkos +cuda_constexpr +cuda_lambda", when="^kokkos +cuda")
+    requires("^kokkos +cuda_lambda", when="^kokkos@:4 +cuda")
+    requires("^kokkos +cuda_constexpr", when="^kokkos +cuda")
     depends_on("kokkos +rocm", when="+kokkos +rocm")
     depends_on("kokkos +openmp", when="+kokkos +openmp")
     requires("+openmp", when="@:2.3 ^kokkos +openmp")
@@ -143,13 +144,15 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
             self.define_from_variant("ENABLE_DOCUMENTATION", "doc"),
         ]
 
-        if self.spec.satisfies("^kokkos +rocm"):
+        if self.spec.satisfies("^kokkos +rocm") and not self.spec.satisfies(
+            "^kokkos %cxx=llvm-amdgpu"
+        ):
             options.append(self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc))
             options.append(self.define("CMAKE_C_COMPILER", self.spec["hip"].hipcc))
             if self.spec.satisfies("backend=legion"):
                 # CMake pulled in via find_package(Legion) won't work without this
                 options.append(self.define("HIP_PATH", "{0}/hip".format(spec["hip"].prefix)))
-        elif self.spec.satisfies("^kokkos"):
+        elif self.spec.satisfies("^kokkos +cuda"):
             options.append(self.define("CMAKE_CXX_COMPILER", self["kokkos"].kokkos_cxx))
 
         return options

--- a/repos/spack_repo/builtin/packages/flecsi/package.py
+++ b/repos/spack_repo/builtin/packages/flecsi/package.py
@@ -96,13 +96,13 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("graphviz@2.49.0:", when="+graphviz @2.3:")
 
     # FleCSI documentation dependencies
-    depends_on("py-sphinx", when="+doc")
-    depends_on("py-sphinx-rtd-theme@:2", when="+doc")
-    depends_on("py-recommonmark", when="@:2.2 +doc")
-    depends_on("doxygen", when="+doc")
-    depends_on("graphviz", when="+doc")
-    depends_on("texlive", when="@2.4.1: +doc")
-    depends_on("pdf2svg", when="@2.4.1: +doc")
+    depends_on("py-sphinx", when="+doc", type="build")
+    depends_on("py-sphinx-rtd-theme@:2", when="+doc", type="build")
+    depends_on("py-recommonmark", when="@:2.2 +doc", type="build")
+    depends_on("doxygen", when="+doc", type="build")
+    depends_on("graphviz", when="+doc", type="build")
+    depends_on("texlive", when="@2.4.1: +doc", type="build")
+    depends_on("pdf2svg", when="@2.4.1: +doc", type="build")
 
     # Propagate cuda_arch requirement to dependencies
     for _flag in CudaPackage.cuda_arch_values:


### PR DESCRIPTION
- allow building with `amdclang++` directly
- allow building with Kokkos 5
- avoid `kokkos_cxx` logic in non-CUDA cases
- mark documentation deps as build-only