### PR TITLE
ghex: Use nanobind instead of pybind11 from 0.6 onwards

### DIFF
--- a/repos/spack_repo/builtin/packages/ghex/package.py
+++ b/repos/spack_repo/builtin/packages/ghex/package.py
@@ -65,7 +65,8 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
         extends("python")
         depends_on("python@3.7:", type=("build", "run"))
         depends_on("py-pip", type="build")
-        depends_on("py-pybind11", type="build")
+        depends_on("py-pybind11", type="build", when="@:0.5")
+        depends_on("py-nanobind", type="build", when="@0.6:")
         depends_on("py-mpi4py", type=("build", "run"))
         depends_on("py-numpy", type=("build", "run"))
 


### PR DESCRIPTION
0.6 is not yet released, but the nanobind change will soon be on master, changing this already now in preparation for merge to master.