### PR TITLE
[TAU package] Remove CUDA version limit

### DIFF
--- a/repos/spack_repo/builtin/packages/tau/package.py
+++ b/repos/spack_repo/builtin/packages/tau/package.py
@@ -192,8 +192,7 @@ class Tau(Package):
     depends_on("libunwind libs=static +pic", when="libunwind=static")
     depends_on("libunwind libs=shared", when="libunwind=shared")
     depends_on("mpi", when="+mpi", type=("build", "run", "link"))
-    # Legacy nvtx is only supported until cuda@12.8, newer cuda only provides nvtx3.
-    depends_on("cuda@:12.8", when="+cuda")
+    depends_on("cuda", when="+cuda")
     depends_on("gasnet", when="+gasnet")
     depends_on("adios2", when="+adios2")
     depends_on("sqlite", when="+sqlite")


### PR DESCRIPTION
CUDA should detect if we are using CUDA 12 or newer and use NVTX3.