### PR TITLE
refactor: python package pypi url

### DIFF
--- a/repos/spack_repo/builtin/build_systems/python.py
+++ b/repos/spack_repo/builtin/build_systems/python.py
@@ -212,7 +212,10 @@ def _homepage(cls: "PythonPackage") -> Optional[str]:
 
 def _url(cls: "PythonPackage") -> Optional[str]:
     if cls.pypi:
-        return f"https://files.pythonhosted.org/packages/source/{cls.pypi[0]}/{cls.pypi}"
+        package_name = cls.pypi.split("/")[0]
+        normalised_pypi = re.sub(r"[-_.]+", "-", package_name).lower()
+        package_extension = cls.pypi.split("-")[-1]
+        return f"https://files.pythonhosted.org/packages/source/{normalised_pypi[0]}/{normalised_pypi}/{normalised_pypi}-{package_extension}"
     return None
 
 

--- a/repos/spack_repo/builtin/packages/py_accessible_pygments/package.py
+++ b/repos/spack_repo/builtin/packages/py_accessible_pygments/package.py
@@ -22,13 +22,3 @@ class PyAccessiblePygments(PythonPackage):
     depends_on("python@3.9:", type=("build", "run"), when="@0.0.5:")
     depends_on("py-pygments@1.5:", type=("build", "run"))
     depends_on("py-setuptools", type=("build"))
-
-    def url_for_version(self, version):
-        url = (
-            "https://pypi.org/packages/source/a/accessible-pygments/accessible{}pygments-{}.tar.gz"
-        )
-        if version < Version("0.0.5"):
-            separator = "-"
-        else:
-            separator = "_"
-        return url.format(separator, version)

--- a/repos/spack_repo/builtin/packages/py_async_lru/package.py
+++ b/repos/spack_repo/builtin/packages/py_async_lru/package.py
@@ -26,11 +26,3 @@ class PyAsyncLru(PythonPackage):
     depends_on("py-setuptools", type="build")
 
     depends_on("py-typing-extensions@4:", when="@2: ^python@:3.10", type=("build", "run"))
-
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/a/{0}/{0}-{1}.tar.gz"
-        if version >= Version("2.0.5") or version <= Version("1.0.2"):
-            name = "async_lru"
-        else:
-            name = "async-lru"
-        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_awkward_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/py_awkward_cpp/package.py
@@ -57,9 +57,3 @@ class PyAwkwardCpp(PythonPackage):
 
     # https://github.com/scikit-hep/awkward/issues/3132#issuecomment-2136042870
     conflicts("%gcc@14:", when="@:33")
-
-    def url_for_version(self, version):
-        if version <= Version("35"):
-            return super().url_for_version(version).replace("_", "-")
-        else:
-            return super().url_for_version(version)

--- a/repos/spack_repo/builtin/packages/py_babel/package.py
+++ b/repos/spack_repo/builtin/packages/py_babel/package.py
@@ -32,10 +32,3 @@ class PyBabel(PythonPackage):
     depends_on("py-setuptools", type=("build", "run"))
     depends_on("py-pytz@2015.7:", when="@2.12: ^python@:3.8", type=("build", "run"))
     depends_on("py-pytz@2015.7:", when="@:2.10", type=("build", "run"))
-
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/B/Babel/{}-{}.tar.gz"
-        name = "Babel"
-        if version >= Version("2.15"):
-            name = name.lower()
-        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_bids_validator/package.py
+++ b/repos/spack_repo/builtin/packages/py_bids_validator/package.py
@@ -31,11 +31,3 @@ class PyBidsValidator(PythonPackage):
     depends_on("py-versioneer+toml", when="@1.14:", type="build")
 
     depends_on("py-bidsschematools@0.10:", when="@1.14.7:", type=("build", "run"))
-
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/b/bids-validator/{}-{}.tar.gz"
-        if version >= Version("1.14.6"):
-            name = "bids_validator"
-        else:
-            name = "bids-validator"
-        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_bottleneck/package.py
+++ b/repos/spack_repo/builtin/packages/py_bottleneck/package.py
@@ -34,11 +34,3 @@ class PyBottleneck(PythonPackage):
     depends_on("py-setuptools", type="build")
     depends_on("py-versioneer", when="@1.3.3:", type="build")
     depends_on("py-numpy", type=("build", "run"))
-
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/b/Bottleneck/{0}-{1}.tar.gz"
-        if version > Version("1.3.8"):
-            name = "bottleneck"
-        else:
-            name = "Bottleneck"
-        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_cachecontrol/package.py
+++ b/repos/spack_repo/builtin/packages/py_cachecontrol/package.py
@@ -35,11 +35,3 @@ class PyCachecontrol(PythonPackage):
     depends_on("py-filelock@3.8.0:", when="@0.13:+filecache", type=("build", "run"))
     depends_on("py-lockfile@0.9:", when="@0.12+filecache", type=("build", "run"))
     depends_on("py-redis@2.10.5:", when="+redis", type=("build", "run"))
-
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/c/cachecontrol/{0}-{1}.tar.gz"
-        if version <= Version("0.13.0"):
-            letter = "CacheControl"
-        else:
-            letter = "cachecontrol"
-        return url.format(letter, version)

--- a/repos/spack_repo/builtin/packages/py_cartopy/package.py
+++ b/repos/spack_repo/builtin/packages/py_cartopy/package.py
@@ -145,14 +145,6 @@ class PyCartopy(PythonPackage):
 
     patch("proj6.patch", when="@0.17.0")
 
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/C/Cartopy/{}-{}.tar.gz"
-        if version >= Version("0.24"):
-            name = "cartopy"
-        else:
-            name = "Cartopy"
-        return url.format(name, version)
-
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         # Needed for `spack install --test=root py-cartopy`
         library_dirs = []

--- a/repos/spack_repo/builtin/packages/py_charset_normalizer/package.py
+++ b/repos/spack_repo/builtin/packages/py_charset_normalizer/package.py
@@ -42,10 +42,3 @@ class PyCharsetNormalizer(PythonPackage):
         depends_on("python@3.6:3.11", when="@2.1:3.0")
         depends_on("python@3.5:3.11", when="@2.0.11:2.0.12")
         depends_on("python@3.5:3.10", when="@1.3.5:2.0.10")
-
-    def url_for_version(self, version):
-        if version >= Version("3.4.0"):
-            url = "https://files.pythonhosted.org/packages/source/c/charset_normalizer/charset_normalizer-{0}.tar.gz"
-        else:
-            url = "https://files.pythonhosted.org/packages/source/c/charset-normalizer/charset-normalizer-{0}.tar.gz"
-        return url.format(version)

--- a/repos/spack_repo/builtin/packages/py_configspace/package.py
+++ b/repos/spack_repo/builtin/packages/py_configspace/package.py
@@ -43,15 +43,3 @@ class PyConfigspace(PythonPackage):
     depends_on("py-scipy", when="@0.4.21:")
     depends_on("py-typing-extensions", when="@0.6.0:")
     depends_on("py-more-itertools", when="@0.6.1:")
-
-    def url_for_version(self, version):
-        new_url = (
-            "https://files.pythonhosted.org/packages/source/c/configspace/configspace-{0}.tar.gz"
-        )
-        old_url = (
-            "https://files.pythonhosted.org/packages/source/C/ConfigSpace/ConfigSpace-{0}.tar.gz"
-        )
-        if version >= Version("1.0.0"):
-            return new_url.format(version)
-        else:
-            return old_url.format(version)

--- a/repos/spack_repo/builtin/packages/py_cwl_utils/package.py
+++ b/repos/spack_repo/builtin/packages/py_cwl_utils/package.py
@@ -37,11 +37,3 @@ class PyCwlUtils(PythonPackage):
     depends_on("py-schema-salad@8.8.20250205075315:8", when="@0.32:", type=("build", "run"))
     depends_on("py-ruamel-yaml@0.17.6:0.18", when="@0.30:", type=("build", "run"))
     depends_on("py-typing-extensions", when="@0.37 ^python@:3.9", type=("build", "run"))
-
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/c/cwl-utils/cwl{}utils-{}.tar.gz"
-        if version >= Version("0.34"):
-            sep = "_"
-        else:
-            sep = "-"
-        return url.format(sep, version)

--- a/repos/spack_repo/builtin/packages/py_cython/package.py
+++ b/repos/spack_repo/builtin/packages/py_cython/package.py
@@ -72,14 +72,6 @@ class PyCython(PythonPackage):
     patch("5307.patch", when="@0.29:0.29.33")
     patch("5712.patch", when="@0.29")
 
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/c/cython/{}-{}.tar.gz"
-        if version >= Version("3.0.11"):
-            name = "cython"
-        else:
-            name = "Cython"
-        return url.format(name, version)
-
     @property
     def command(self):
         """Returns the Cython command"""

--- a/repos/spack_repo/builtin/packages/py_dask_ml/package.py
+++ b/repos/spack_repo/builtin/packages/py_dask_ml/package.py
@@ -76,14 +76,6 @@ class PyDaskMl(PythonPackage):
 
     conflicts("+docs", when="target=aarch64: %gcc")
 
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/d/dask-ml/dask{0}ml-{1}.tar.gz"
-        if version > Version("2024.4.3"):
-            sep = "_"
-        else:
-            sep = "-"
-        return url.format(sep, version)
-
     @run_after("install")
     def install_docs(self):
         if "+docs" in self.spec:

--- a/repos/spack_repo/builtin/packages/py_dm_tree/package.py
+++ b/repos/spack_repo/builtin/packages/py_dm_tree/package.py
@@ -63,12 +63,6 @@ class PyDmTree(PythonPackage):
     def clean(self):
         remove_linked_tree(PyDmTree.tmp_path)
 
-    def url_for_version(self, version):
-        if version <= Version("0.1.8"):
-            return super().url_for_version(version).replace("_", "-")
-        else:
-            return super().url_for_version(version)
-
     def patch(self):
         PyDmTree.tmp_path = tempfile.mkdtemp(prefix="spack")
         env["TEST_TMPDIR"] = PyDmTree.tmp_path

--- a/repos/spack_repo/builtin/packages/py_earthengine_api/package.py
+++ b/repos/spack_repo/builtin/packages/py_earthengine_api/package.py
@@ -30,10 +30,3 @@ class PyEarthengineApi(PythonPackage):
     depends_on("py-requests", type=("build", "run"))
     depends_on("google-cloud-cli", type="run")
 
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/e/earthengine-api/{}-{}.tar.gz"
-        if version >= Version("0.1.399"):
-            name = "earthengine_api"
-        else:
-            name = "earthengine-api"
-        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_fiona/package.py
+++ b/repos/spack_repo/builtin/packages/py_fiona/package.py
@@ -65,11 +65,3 @@ class PyFiona(PythonPackage):
         depends_on("py-setuptools", when="@:1.9.1,1.9.5")
         depends_on("py-six", when="@1.9.4:1.9")
         depends_on("py-six@1.7:", when="@:1.8")
-
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/{0}/{0}iona/{0}iona-{1}.tar.gz"
-        if version >= Version("1.9.5"):
-            letter = "f"
-        else:
-            letter = "F"
-        return url.format(letter, version)

--- a/repos/spack_repo/builtin/packages/py_flufl_lock/package.py
+++ b/repos/spack_repo/builtin/packages/py_flufl_lock/package.py
@@ -28,11 +28,3 @@ class PyFluflLock(PythonPackage):
     depends_on("py-atpublic", type=("build", "run"))
     depends_on("py-psutil", type=("build", "run"))
     depends_on("py-typing-extensions", when="@:5.0.4^python@:3.7", type=("build", "run"))
-
-    def url_for_version(self, version):
-        url = "https://pypi.io/packages/source/f/flufl.lock/{0}-{1}.tar.gz"
-        if version >= Version("8"):
-            filename = "flufl_lock"
-        else:
-            filename = "flufl.lock"
-        return url.format(filename, version)

--- a/repos/spack_repo/builtin/packages/py_globus_sdk/package.py
+++ b/repos/spack_repo/builtin/packages/py_globus_sdk/package.py
@@ -84,9 +84,3 @@ class PyGlobusSdk(PythonPackage):
     depends_on("py-typing-extensions@4:", when="@3.46: ^python@:3.10", type=("build", "run"))
     depends_on("py-typing-extensions@4:", when="@3.25:3.45 ^python@:3.9", type=("build", "run"))
     depends_on("py-importlib-resources@5.12.0:", when="@3.41: ^python@:3.8", type=("build", "run"))
-
-    def url_for_version(self, version):
-        if version <= Version("3.39"):
-            return super().url_for_version(version).replace("_", "-")
-        else:
-            return super().url_for_version(version)

--- a/repos/spack_repo/builtin/packages/py_google_api_core/package.py
+++ b/repos/spack_repo/builtin/packages/py_google_api_core/package.py
@@ -65,11 +65,3 @@ class PyGoogleApiCore(PythonPackage):
             depends_on("py-grpcio@1.33.2:1", when="@1.33:", type="run")
             depends_on("py-grpcio@1.29.0:1", when="@1.19.1", type="run")
             depends_on("py-grpcio@1.8.2:1", type="run")
-
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/g/google-api-core/{}-{}.tar.gz"
-        if version >= Version("2.19.2"):
-            name = "google_api_core"
-        else:
-            name = "google-api-core"
-        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_googleapis_common_protos/package.py
+++ b/repos/spack_repo/builtin/packages/py_googleapis_common_protos/package.py
@@ -42,11 +42,3 @@ class PyGoogleapisCommonProtos(PythonPackage):
     with when("+grpc"), default_args(type="run"):
         depends_on("py-grpcio@1.44:1", when="@1.57:")
         depends_on("py-grpcio@1:")
-
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/g/googleapis-common-protos/{}-{}.tar.gz"
-        if version >= Version("1.64"):
-            name = "googleapis_common_protos"
-        else:
-            name = "googleapis-common-protos"
-        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_grpcio_status/package.py
+++ b/repos/spack_repo/builtin/packages/py_grpcio_status/package.py
@@ -28,11 +28,3 @@ class PyGrpcioStatus(PythonPackage):
         for grpcio in ("1.75.0", "1.62.2", "1.60.1", "1.56.2"):
             depends_on(f"py-grpcio@{grpcio}:", when=f"@{grpcio}")
         depends_on("py-googleapis-common-protos@1.5.5:")
-
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/g/grpcio_status/{}-{}.tar.gz"
-        if version >= Version("63"):
-            name = "grpcio_status"
-        else:
-            name = "grpcio-status"
-        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_jinja2/package.py
+++ b/repos/spack_repo/builtin/packages/py_jinja2/package.py
@@ -49,11 +49,3 @@ class PyJinja2(PythonPackage):
 
     # https://github.com/pallets/jinja/issues/1585
     conflicts("^py-markupsafe@2.1:", when="@:2")
-
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/j/jinja2/"
-        if self.spec.satisfies("@:3.1.3"):
-            url += "Jinja2-{0}.tar.gz"
-        else:
-            url += "jinja2-{0}.tar.gz"
-        return url.format(version)

--- a/repos/spack_repo/builtin/packages/py_jupyter_lsp/package.py
+++ b/repos/spack_repo/builtin/packages/py_jupyter_lsp/package.py
@@ -23,12 +23,3 @@ class PyJupyterLsp(PythonPackage):
 
     depends_on("py-jupyter-server@1.1.2:", type=("build", "run"))
     depends_on("py-importlib-metadata@4.8.3:", when="^python@:3.9", type=("build", "run"))
-
-    def url_for_version(self, version):
-        if version >= Version("2.2.6"):
-            name = "jupyter_lsp"
-        else:
-            name = "jupyter-lsp"
-        return (
-            f"https://files.pythonhosted.org/packages/source/j/jupyter-lsp/{name}-{version}.tar.gz"
-        )

--- a/repos/spack_repo/builtin/packages/py_jupyter_server_proxy/package.py
+++ b/repos/spack_repo/builtin/packages/py_jupyter_server_proxy/package.py
@@ -41,10 +41,3 @@ class PyJupyterServerProxy(PythonPackage):
     # Historical dependencies
     depends_on("py-jupyter-packaging@0.7.9:0.7", type="build", when="@:3")
     depends_on("py-setuptools@40.8.0:", type="build", when="@:3")
-
-    def url_for_version(self, version):
-        if version >= Version("3.2.3"):
-            name = "jupyter_server_proxy"
-        else:
-            name = "jupyter-server-proxy"
-        return f"https://files.pythonhosted.org/packages/source/j/jupyter-server-proxy/{name}-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_keyrings_alt/package.py
+++ b/repos/spack_repo/builtin/packages/py_keyrings_alt/package.py
@@ -30,10 +30,3 @@ class PyKeyringsAlt(PythonPackage):
 
     depends_on("py-jaraco-classes", when="@4.1.2:", type=("build", "run"))
     depends_on("py-jaraco-context", when="@5.0.1:", type=("build", "run"))
-
-    def url_for_version(self, version):
-        if version >= Version("5.0.2"):
-            name = "keyrings_alt"
-        else:
-            name = "keyrings.alt"
-        return f"https://files.pythonhosted.org/packages/source/k/keyrings.alt/{name}-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_lightning_uq_box/package.py
+++ b/repos/spack_repo/builtin/packages/py_lightning_uq_box/package.py
@@ -59,11 +59,3 @@ class PyLightningUqBox(PythonPackage):
             depends_on("py-omegaconf@2.3:")
             depends_on("py-jsonargparse@4.28:+signatures")
             depends_on("py-ruff@0.2:")
-
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/l/lightning-uq-box/{}-{}.tar.gz"
-        if version >= Version("0.2.0"):
-            name = "lightning_uq_box"
-        else:
-            name = "lightning-uq-box"
-        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_lightning_utilities/package.py
+++ b/repos/spack_repo/builtin/packages/py_lightning_utilities/package.py
@@ -42,11 +42,3 @@ class PyLightningUtilities(PythonPackage):
         depends_on("py-fire", when="@0.3.0")
         # https://github.com/Lightning-AI/utilities/pull/473
         depends_on("py-setuptools@:81", when="@:0.15.2")
-
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/l/lightning-utilities/{}-{}.tar.gz"
-        if version >= Version("0.11.3"):
-            name = "lightning_utilities"
-        else:
-            name = "lightning-utilities"
-        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_macs3/package.py
+++ b/repos/spack_repo/builtin/packages/py_macs3/package.py
@@ -20,12 +20,6 @@ class PyMacs3(PythonPackage):
     version("3.0.3", sha256="ee1c892901c4010ff9e201b433c0623cbd747a3058300322386a7185623b1684")
     version("3.0.0b3", sha256="caa794d4cfcd7368447eae15878505315dac44c21546e8fecebb3561e9cee362")
 
-    def url_for_version(self, version):
-        if version < Version("3.0.2"):
-            url_fmt = "https://files.pythonhosted.org/packages/b1/88/df5436ec1510d635e7c41f2aee185da35d6d98ccde9bf1ec5a67ad2bbd62/MACS3-{}.tar.gz"
-            return url_fmt.format(version)
-        return super().url_for_version(version)
-
     depends_on("python@3.9:", type=("build", "run"))
     depends_on("py-setuptools@68.0:", when="@3.0.2:", type="build")
     depends_on("py-setuptools@60.0:", when="@:3.0.1", type="build")

--- a/repos/spack_repo/builtin/packages/py_mako/package.py
+++ b/repos/spack_repo/builtin/packages/py_mako/package.py
@@ -35,10 +35,3 @@ class PyMako(PythonPackage):
 
     # Historical dependencies
     depends_on("py-importlib-metadata", when="@1.2.2: ^python@:3.7", type=("build", "run"))
-
-    def url_for_version(self, version):
-        if version >= Version("1.3.6"):
-            name = "mako"
-        else:
-            name = "Mako"
-        return f"https://files.pythonhosted.org/packages/source/M/Mako/{name}-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_markdown_it_py/package.py
+++ b/repos/spack_repo/builtin/packages/py_markdown_it_py/package.py
@@ -38,11 +38,3 @@ class PyMarkdownItPy(PythonPackage):
     depends_on("py-setuptools", when="@:2.0", type="build")
     depends_on("py-attrs@19:21", when="@:2.0", type=("build", "run"))
     depends_on("py-typing-extensions@3.7.4:", when="@:2 ^python@:3.7", type=("build", "run"))
-
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/m/markdown-it-py/{}-{}.tar.gz"
-        if version >= Version("4"):
-            name = "markdown_it_py"
-        else:
-            name = "markdown-it-py"
-        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_markupsafe/package.py
+++ b/repos/spack_repo/builtin/packages/py_markupsafe/package.py
@@ -43,12 +43,3 @@ class PyMarkupsafe(PythonPackage):
     with default_args(type=("build", "run")):
         depends_on("python@3.9:", when="@3:")
         depends_on("python@3.7:", when="@2:")
-
-    def url_for_version(self, version):
-        if version >= Version("3.0.0"):
-            name = "markupsafe"
-        else:
-            name = "MarkupSafe"
-        return (
-            f"https://files.pythonhosted.org/packages/source/M/MarkupSafe/{name}-{version}.tar.gz"
-        )

--- a/repos/spack_repo/builtin/packages/py_mdanalysis/package.py
+++ b/repos/spack_repo/builtin/packages/py_mdanalysis/package.py
@@ -103,11 +103,3 @@ class PyMdanalysis(PythonPackage):
     depends_on("py-gsd@1.9.3:", when="@:2.5.0", type=("build", "run"))
     depends_on("py-biopython@1.80:", when="@:2.6.1", type=("build", "run"))
     depends_on("py-networkx@2.0:", when="@:2.6.1", type=("build", "run"))
-
-    def url_for_version(self, version):
-        """
-        From version 2.8.0 onwards, the archive named changed
-        to 'mdanalysis-{version}.tar.gz from 'MDAnalysis-{version}.tar.gz
-        """
-        if version >= Version("2.8.0"):
-            return f"https://files.pythonhosted.org/packages/source/m/mdanalysis/mdanalysis-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_mdanalysistests/package.py
+++ b/repos/spack_repo/builtin/packages/py_mdanalysistests/package.py
@@ -49,11 +49,3 @@ class PyMdanalysistests(PythonPackage):
 
     depends_on("py-setuptools@40.9.0:", when="@2.8.0:", type="build")
     depends_on("py-setuptools", type="build")
-
-    def url_for_version(self, version):
-        """
-        From version 2.8.0 onwards, the archive named changed
-        to 'mdanalysistests-{version}.tar.gz from 'MDAnalysistests-{version}.tar.gz
-        """
-        if version >= Version("2.8.0"):
-            return f"https://files.pythonhosted.org/packages/source/m/mdanalysistests/mdanalysistests-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_mdit_py_plugins/package.py
+++ b/repos/spack_repo/builtin/packages/py_mdit_py_plugins/package.py
@@ -23,11 +23,6 @@ class PyMditPyPlugins(PythonPackage):
     version("0.3.1", sha256="3fc13298497d6e04fe96efdd41281bfe7622152f9caa1815ea99b5c893de9441")
     version("0.2.8", sha256="5991cef645502e80a5388ec4fc20885d2313d4871e8b8e320ca2de14ac0c015f")
 
-    def url_for_version(self, version):
-        prefix = self.url.rsplit("/", maxsplit=1)[0]
-        package = "mdit-py-plugins" if version < Version("2.0.0") else "mdit_py_plugins"
-        return f"{prefix}/{package}-{version}.tar.gz"
-
     depends_on("python@3.6:3", when="@:0.2", type=("build", "run"))
     depends_on("python@3.7:3", when="@0.3", type=("build", "run"))
     depends_on("python@3.8:3", when="@0.4:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_metpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_metpy/package.py
@@ -84,10 +84,3 @@ class PyMetpy(PythonPackage):
         depends_on("py-scipy@1.0:", type=("build", "run"))
         depends_on("py-traitlets@4.3.0:", type=("build", "run"))
         depends_on("py-xarray@0.14.1:", type=("build", "run"))
-
-    def url_for_version(self, version):
-        if version > Version("1.6.2"):
-            return super().url_for_version(version)
-
-        url = "https://files.pythonhosted.org/packages/source/m/MetPy/MetPy-{0}.tar.gz"
-        return url.format(version.dotted)

--- a/repos/spack_repo/builtin/packages/py_more_itertools/package.py
+++ b/repos/spack_repo/builtin/packages/py_more_itertools/package.py
@@ -39,10 +39,3 @@ class PyMoreItertools(PythonPackage):
     # Historical dependencies
     depends_on("py-setuptools", when="@:8.12.0", type="build")
     depends_on("py-six@1.0.0:1", when="@:5", type=("build", "run"))
-
-    def url_for_version(self, version):
-        if version >= Version("10.7.0"):
-            name = "more_itertools"
-        else:
-            name = "more-itertools"
-        return f"https://files.pythonhosted.org/packages/source/m/more-itertools/{name}-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_myst_parser/package.py
+++ b/repos/spack_repo/builtin/packages/py_myst_parser/package.py
@@ -64,8 +64,3 @@ class PyMystParser(PythonPackage):
         depends_on("py-sphinx@8:9", when="@5")
 
         depends_on("py-typing-extensions", when="@:1")
-
-    def url_for_version(self, version):
-        prefix = self.url.rsplit("/", maxsplit=1)[0]
-        package = "myst-parser" if version < Version("2.0.0") else "myst_parser"
-        return f"{prefix}/{package}-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_netcdf4/package.py
+++ b/repos/spack_repo/builtin/packages/py_netcdf4/package.py
@@ -81,14 +81,6 @@ class PyNetcdf4(PythonPackage):
         when="@1.6:1.6.5 %gcc@14:",
     )
 
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/n/netCDF4/{}-{}.tar.gz"
-        if version >= Version("1.7"):
-            name = "netcdf4"
-        else:
-            name = "netCDF4"
-        return url.format(name, version)
-
     def flag_handler(self, name, flags):
         if name == "cflags":
             if self.spec.satisfies("%oneapi") or self.spec.satisfies("%apple-clang@15:"):

--- a/repos/spack_repo/builtin/packages/py_nvidia_ml_py/package.py
+++ b/repos/spack_repo/builtin/packages/py_nvidia_ml_py/package.py
@@ -39,13 +39,3 @@ class PyNvidiaMlPy(PythonPackage):
     version("11.450.51", sha256="5aa6dd23a140b1ef2314eee5ca154a45397b03e68fd9ebc4f72005979f511c73")
 
     depends_on("py-setuptools", type="build")
-
-    # pip silently replaces distutils with setuptools
-
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/n/nvidia-ml-py/nvidia{0}ml{0}py-{1}.tar.gz"
-        if version > Version("12.560.30"):
-            sep = "_"
-        else:
-            sep = "-"
-        return url.format(sep, version)

--- a/repos/spack_repo/builtin/packages/py_odc_geo/package.py
+++ b/repos/spack_repo/builtin/packages/py_odc_geo/package.py
@@ -27,11 +27,3 @@ class PyOdcGeo(PythonPackage):
         depends_on("py-pyproj@3:", when="@0.4:")
         depends_on("py-pyproj")
         depends_on("py-shapely")
-
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/o/odc-geo/{}-{}.tar.gz"
-        if version >= Version("0.4.4"):
-            name = "odc_geo"
-        else:
-            name = "odc-geo"
-        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_pathos/package.py
+++ b/repos/spack_repo/builtin/packages/py_pathos/package.py
@@ -56,13 +56,3 @@ class PyPathos(PythonPackage):
     depends_on("py-dill@0.3.5.1:", type=("build", "run"), when="@0.2.9:")
     depends_on("py-dill@0.3.4:", type=("build", "run"), when="@0.2.8:")
     depends_on("py-dill@0.2.9:", type=("build", "run"))
-
-    def url_for_version(self, version):
-        url = self.url.rsplit("/", 1)[0]
-        if Version("0.2.8") > version >= Version("0.2.2"):
-            url += "/pathos-{0}.tar.gz"
-        else:
-            url += "/pathos-{0}.zip"
-
-        url = url.format(version)
-        return url

--- a/repos/spack_repo/builtin/packages/py_poetry_plugin_export/package.py
+++ b/repos/spack_repo/builtin/packages/py_poetry_plugin_export/package.py
@@ -24,13 +24,3 @@ class PyPoetryPluginExport(PythonPackage):
     depends_on("py-poetry-core@1.1:1", when="@1.0", type=("build", "run"))
     # depends_on("py-poetry@1.6:1", when="@1.6", type=("build", "run")) # circular dependency
     # depends_on("py-poetry@1.2:1", type="run") # circular dependency
-
-    def url_for_version(self, version):
-        url = (
-            "https://files.pythonhosted.org/packages/source/p/poetry-plugin-export/{0}-{1}.tar.gz"
-        )
-        if version >= Version("1.6"):
-            letter = "poetry_plugin_export"
-        else:
-            letter = "poetry-plugin-export"
-        return url.format(letter, version)

--- a/repos/spack_repo/builtin/packages/py_psyclone/package.py
+++ b/repos/spack_repo/builtin/packages/py_psyclone/package.py
@@ -71,11 +71,6 @@ class PyPsyclone(PythonPackage):
     depends_on("py-pytest-xdist", type="test")
     depends_on("py-pytest", type="test")
 
-    def url_for_version(self, version):
-        # As of version 3.0.0, the name of the tarball on pypi is all lowercase.
-        name = "psyclone" if version >= Version("3.0.0") else "PSyclone"
-        return f"https://files.pythonhosted.org/packages/source/P/PSyclone/{name}-{version}.tar.gz"
-
     # Test
     @run_after("install")
     @on_package_attributes(run_tests=True)

--- a/repos/spack_repo/builtin/packages/py_pydap/package.py
+++ b/repos/spack_repo/builtin/packages/py_pydap/package.py
@@ -37,8 +37,3 @@ class PyPydap(PythonPackage):
     depends_on("py-docopt", type=("build", "run"), when="@:3.4")
     depends_on("py-six@1.4.0:", type=("build", "run"), when="@:3.4")
 
-    def url_for_version(self, version):
-        if version < Version("3.5"):
-            return f"https://files.pythonhosted.org/packages/source/P/Pydap/Pydap-{version}.tar.gz"
-
-        return super().url_for_version(version)

--- a/repos/spack_repo/builtin/packages/py_pyfftw/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyfftw/package.py
@@ -42,13 +42,5 @@ class PyPyfftw(PythonPackage):
 
     depends_on("fftw@3.3:")
 
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/p/pyfftw/{0}-{1}.tar.gz"
-        if version >= Version("0.14.0"):
-            name = "pyfftw"
-        else:
-            name = "pyFFTW"
-        return url.format(name, version)
-
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         env.append_flags("LDFLAGS", self.spec["fftw"].libs.search_flags)

--- a/repos/spack_repo/builtin/packages/py_pygithub/package.py
+++ b/repos/spack_repo/builtin/packages/py_pygithub/package.py
@@ -49,7 +49,3 @@ class PyPygithub(PythonPackage):
     depends_on("py-typing-extensions@4:", type=("build", "run"), when="@2.1.0:")
     depends_on("py-urllib3@1.26.0:", type=("build", "run"), when="@2.1.0:")
     depends_on("py-deprecated", type=("build", "run"), when="@:2.1.1")
-
-    def url_for_version(self, version):
-        name = "pygithub" if version >= Version("2.4") else "PyGithub"
-        return f"https://files.pythonhosted.org/packages/source/{name[0]}/{name}/{name}-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_pyglet/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyglet/package.py
@@ -32,12 +32,6 @@ class PyPyglet(PythonPackage):
     depends_on("pil", type=("build", "run"), when="@2.0: platform=linux")
     depends_on("pulseaudio", type=("build", "run"), when="@2.0: platform=linux")
 
-    def url_for_version(self, version):
-        if version <= Version("1.4.2"):
-            return (
-                f"https://files.pythonhosted.org/packages/source/p/pyglet/pyglet-{version}.tar.gz"
-            )
-
     @when("@2.0.9:2.0.10")
     def patch(self):
         # 2.0.9 and 2.0.10 had a broken pyproject.toml in their PyPI zipfile

--- a/repos/spack_repo/builtin/packages/py_pygments/package.py
+++ b/repos/spack_repo/builtin/packages/py_pygments/package.py
@@ -55,10 +55,3 @@ class PyPygments(PythonPackage):
     # Historical dependencies
     depends_on("py-setuptools@61:", when="@2.15:2.16", type=("build", "run"))
     depends_on("py-setuptools", when="@:2.14", type=("build", "run"))
-
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/P/Pygments/{}-{}.tar.gz"
-        name = "Pygments"
-        if version >= Version("2.17"):
-            name = name.lower()
-        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_pyopenssl/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyopenssl/package.py
@@ -41,10 +41,3 @@ class PyPyopenssl(PythonPackage):
         depends_on("py-six@1.5.2:", when="@:19")
 
     conflicts("^py-cryptography@40:40.0.1", when="@23.2:")
-
-    def url_for_version(self, version):
-        if self.spec.satisfies("@24.2:"):
-            name = "pyopenssl"
-        else:
-            name = "pyOpenSSL"
-        return f"https://files.pythonhosted.org/packages/source/{name[0]}/{name}/{name}-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_pyproject_metadata/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyproject_metadata/package.py
@@ -29,9 +29,3 @@ class PyPyprojectMetadata(PythonPackage):
     with default_args(type=("build", "run")):
         depends_on("py-packaging@23.2:", when="@0.10:")
         depends_on("py-packaging@19:")
-
-    def url_for_version(self, version):
-        if version >= Version("0.8.0"):
-            return f"https://files.pythonhosted.org/packages/source/p/pyproject_metadata/pyproject_metadata-{version}.tar.gz"
-        else:
-            return f"https://files.pythonhosted.org/packages/source/p/pyproject-metadata/pyproject-metadata-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_pyqt5_sip/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyqt5_sip/package.py
@@ -30,12 +30,3 @@ class PyPyqt5Sip(PythonPackage):
         sha256="82a326749b145b30eda3f0040cd7099c4c06a57a5e9626687b0a983de1ebfc3e",
         when="@12.12:12.13 %gcc@14:",
     )
-
-    def url_for_version(self, version):
-        if version >= Version("12.17.0"):
-            name = "pyqt5-sip"
-        else:
-            name = "PyQt5-sip"
-        return (
-            f"https://files.pythonhosted.org/packages/source/P/PyQt5-sip/{name}-{version}.tar.gz"
-        )

--- a/repos/spack_repo/builtin/packages/py_pyqt6/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyqt6/package.py
@@ -51,13 +51,6 @@ class PyPyqt6(SIPPackage):
     # README
     depends_on("qt-base@6+gui+accessibility")
 
-    def url_for_version(self, version):
-        if version >= Version("6.8.1"):
-            name = "pyqt6"
-        else:
-            name = "PyQt6"
-        return f"https://files.pythonhosted.org/packages/source/P/PyQt6/{name}-{version}.tar.gz"
-
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         # Detected system locale encoding (US-ASCII, locale "C") is not UTF-8.
         # Qt shall use a UTF-8 locale ("UTF-8") instead. If this causes problems,

--- a/repos/spack_repo/builtin/packages/py_pyqt6_sip/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyqt6_sip/package.py
@@ -25,12 +25,3 @@ class PyPyqt6Sip(PythonPackage):
 
     depends_on("py-setuptools@75.8.1:", type="build", when="@13.10.2:")
     depends_on("py-setuptools@30.3:", type="build")
-
-    def url_for_version(self, version):
-        if version >= Version("13.9.1"):
-            name = "pyqt6_sip"
-        else:
-            name = "PyQt6_sip"
-        return (
-            f"https://files.pythonhosted.org/packages/source/P/PyQt6-sip/{name}-{version}.tar.gz"
-        )

--- a/repos/spack_repo/builtin/packages/py_pyqt_builder/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyqt_builder/package.py
@@ -27,10 +27,3 @@ class PyPyqtBuilder(PythonPackage):
     depends_on("py-packaging", type=("build", "run"))
     depends_on("py-sip@6.7:6", when="@1.15:", type=("build", "run"))
     depends_on("py-sip@6.3:6", type=("build", "run"))
-
-    def url_for_version(self, version):
-        if version >= Version("1.16.1"):
-            name = "pyqt_builder"
-        else:
-            name = "PyQt-builder"
-        return f"https://files.pythonhosted.org/packages/source/P/PyQt-builder/{name}-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_pytest_cov/package.py
+++ b/repos/spack_repo/builtin/packages/py_pytest_cov/package.py
@@ -35,10 +35,3 @@ class PyPytestCov(PythonPackage):
 
     # Historical dependencies
     depends_on("py-setuptools", type="build", when="@:4.1")
-
-    def url_for_version(self, version):
-        if self.spec.satisfies("@6.1:"):
-            name = "pytest_cov"
-        else:
-            name = "pytest-cov"
-        return f"https://files.pythonhosted.org/packages/source/p/{name}/{name}-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_pytest_doctestplus/package.py
+++ b/repos/spack_repo/builtin/packages/py_pytest_doctestplus/package.py
@@ -30,11 +30,3 @@ class PyPytestDoctestplus(PythonPackage):
 
     depends_on("py-pytest@4.6:", type=("build", "run"))
     depends_on("py-packaging@17:", when="@0.10:", type=("build", "run"))
-
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/p/{0}/{0}-{1}.tar.gz"
-        if version >= Version("1.3.0"):
-            name = "pytest_doctestplus"
-        else:
-            name = "pytest-doctestplus"
-        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_pytest_fail_slow/package.py
+++ b/repos/spack_repo/builtin/packages/py_pytest_fail_slow/package.py
@@ -28,10 +28,3 @@ class PyPytestFailSlow(PythonPackage):
 
     # Historical dependencies
     depends_on("py-setuptools@46.4:", type="build", when="@:0.4")
-
-    def url_for_version(self, version):
-        if version >= Version("0.5.0"):
-            name = "pytest_fail_slow"
-        else:
-            name = "pytest-fail-slow"
-        return f"https://files.pythonhosted.org/packages/source/p/{name}/{name}-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_pytest_timeout/package.py
+++ b/repos/spack_repo/builtin/packages/py_pytest_timeout/package.py
@@ -26,10 +26,3 @@ class PyPytestTimeout(PythonPackage):
     depends_on("py-pytest@7:", when="@2.3:", type=("build", "run"))
     depends_on("py-pytest@5:", when="@2:", type=("build", "run"))
     depends_on("py-pytest@3.6.0:", type=("build", "run"))
-
-    def url_for_version(self, version):
-        if version >= Version("2.4"):
-            name = "pytest_timeout"
-        else:
-            name = "pytest-timeout"
-        return f"https://files.pythonhosted.org/packages/source/p/pytest-timeout/{name}-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_python_gitlab/package.py
+++ b/repos/spack_repo/builtin/packages/py_python_gitlab/package.py
@@ -48,10 +48,3 @@ class PyPythonGitlab(PythonPackage):
         # Historical dependencies
         depends_on("py-typing-extensions@4:", when="@3.14:3 ^python@:3.7")
         depends_on("py-six", when="@:1")
-
-    def url_for_version(self, version):
-        if self.spec.satisfies("@4.5:"):
-            name = "python_gitlab"
-        else:
-            name = "python-gitlab"
-        return f"https://files.pythonhosted.org/packages/source/p/{name}/{name}-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_python_json_logger/package.py
+++ b/repos/spack_repo/builtin/packages/py_python_json_logger/package.py
@@ -26,10 +26,3 @@ class PyPythonJsonLogger(PythonPackage):
 
     depends_on("py-setuptools", type="build")
     depends_on("py-typing-extensions", type="build", when="@3.1: ^python@:3.9")
-
-    def url_for_version(self, version):
-        if self.spec.satisfies("@3.1:"):
-            name = "python_json_logger"
-        else:
-            name = "python-json-logger"
-        return f"https://files.pythonhosted.org/packages/source/p/{name}/{name}-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_python_lsp_server/package.py
+++ b/repos/spack_repo/builtin/packages/py_python_lsp_server/package.py
@@ -47,11 +47,3 @@ class PyPythonLspServer(PythonPackage):
         depends_on("py-black", when="@1.13: formatter=black")
         depends_on("py-ruff", when="@1.13: formatter=ruff")
         depends_on("py-importlib-metadata@4.8.3:", when="^python@:3.9")
-
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/p/"
-        if self.spec.satisfies("@1.13:"):
-            url += "python_lsp_server/python_lsp_server-{0}.tar.gz"
-        else:
-            url += "python-lsp-server/python-lsp-server-{0}.tar.gz"
-        return url.format(version)

--- a/repos/spack_repo/builtin/packages/py_python_swiftclient/package.py
+++ b/repos/spack_repo/builtin/packages/py_python_swiftclient/package.py
@@ -38,9 +38,3 @@ class PyPythonSwiftclient(PythonPackage):
     depends_on("py-python-keystoneclient@0.7.0:", when="+keystone", type=("build", "run"))
 
     depends_on("py-six@1.9:", type=("build", "run"), when="@:3")
-
-    def url_for_version(self, version):
-        if version < Version("4.7.0"):
-            return f"https://files.pythonhosted.org/packages/source/p/python-swiftclient/python-swiftclient-{version}.tar.gz"
-        else:
-            return f"https://files.pythonhosted.org/packages/source/p/python-swiftclient/python_swiftclient-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_python_xmp_toolkit/package.py
+++ b/repos/spack_repo/builtin/packages/py_python_xmp_toolkit/package.py
@@ -33,10 +33,3 @@ class PyPythonXmpToolkit(PythonPackage):
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         env.prepend_path("LD_LIBRARY_PATH", self.spec["exempi"].prefix.lib)
-
-    def url_for_version(self, version):
-        if self.spec.satisfies("@2.1:"):
-            name = "python_xmp_toolkit"
-        else:
-            name = "python-xmp-toolkit"
-        return f"https://files.pythonhosted.org/packages/source/{name[0]}/{name}/{name}-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_pytorch_lightning/package.py
+++ b/repos/spack_repo/builtin/packages/py_pytorch_lightning/package.py
@@ -130,11 +130,3 @@ class PyPytorchLightning(PythonPackage):
     conflicts("^py-torch~distributed", when="@1.8.0")
     # https://github.com/Lightning-AI/lightning/issues/10348
     conflicts("^py-torch~distributed", when="@1.5.0:1.5.2")
-
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/p/pytorch-lightning/{}-{}.tar.gz"
-        if version >= Version("2.5"):
-            name = "pytorch_lightning"
-        else:
-            name = "pytorch-lightning"
-        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_pywavelets/package.py
+++ b/repos/spack_repo/builtin/packages/py_pywavelets/package.py
@@ -41,12 +41,3 @@ class PyPywavelets(PythonPackage):
 
     # Historical dependencies
     depends_on("py-setuptools@:64", type="build", when="@:1.4")
-
-    def url_for_version(self, version):
-        if version >= Version("1.5"):
-            name = "pywavelets"
-        else:
-            name = "PyWavelets"
-        return (
-            f"https://files.pythonhosted.org/packages/source/P/PyWavelets/{name}-{version}.tar.gz"
-        )

--- a/repos/spack_repo/builtin/packages/py_pyyaml/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyyaml/package.py
@@ -59,14 +59,6 @@ class PyPyyaml(PythonPackage):
     conflicts("^python@3.13:", when="@:6.0.1")
     conflicts("^python@3.14:", when="@:6.0.2")
 
-    # With pyyaml 6.0.2, the tarfile changed from PyYAML-6.0.1.tar.gz to pyyaml-6.0.2.tar.gz
-    def url_for_version(self, version):
-        if version >= Version("6.0.2"):
-            url = "https://pypi.io/packages/source/p/pyyaml/pyyaml-{0}.tar.gz"
-        else:
-            url = "https://pypi.io/packages/source/P/PyYAML/PyYAML-{0}.tar.gz"
-        return url.format(version.dotted)
-
     @property
     def import_modules(self):
         modules = ["yaml"]

--- a/repos/spack_repo/builtin/packages/py_quart/package.py
+++ b/repos/spack_repo/builtin/packages/py_quart/package.py
@@ -41,11 +41,3 @@ class PyQuart(PythonPackage):
 
     # Historical dependencies
     depends_on("py-toml", type=("build", "run"), when="@:0.17")
-
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/q/quart/{}-{}.tar.gz"
-        if self.spec.satisfies("@:0.18.3"):
-            name = "Quart"
-        else:
-            name = "quart"
-        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_requests_unixsocket/package.py
+++ b/repos/spack_repo/builtin/packages/py_requests_unixsocket/package.py
@@ -25,11 +25,3 @@ class PyRequestsUnixsocket(PythonPackage):
     depends_on("python@3.9:", when="@0.4:", type=("build", "run"))
     depends_on("py-requests@1.1:", type=("build", "run"))
     depends_on("py-urllib3@1.8:", when="@:0.2.0", type=("build", "run"))
-
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/r/requests-unixsocket/requests{}unixsocket-{}.tar.gz"
-        if version >= Version("0.3.1"):
-            sep = "_"
-        else:
-            sep = "-"
-        return url.format(sep, version)

--- a/repos/spack_repo/builtin/packages/py_rich_click/package.py
+++ b/repos/spack_repo/builtin/packages/py_rich_click/package.py
@@ -28,11 +28,3 @@ class PyRichClick(PythonPackage):
     depends_on("py-rich@10.7.0:", type=("build", "run"))
     depends_on("py-importlib-metadata", type=("build", "run"), when="^python@:3.7")
     depends_on("py-typing-extensions@4", type=("build", "run"), when="@1.8.0:")
-
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/r/rich-click/{0}-{1}.tar.gz"
-        if version >= Version("1.8.0"):
-            name = "rich_click"
-        else:
-            name = "rich-click"
-        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_rtree/package.py
+++ b/repos/spack_repo/builtin/packages/py_rtree/package.py
@@ -32,13 +32,6 @@ class PyRtree(PythonPackage):
     depends_on("libspatialindex@1.8.5:")
     depends_on("py-numpy", when="@1.4:", type="test")
 
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/R/Rtree/{}-{}.tar.gz"
-        name = "Rtree"
-        if version >= Version("1.3.0"):
-            name = name.lower()
-        return url.format(name, version)
-
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         env.set("SPATIALINDEX_C_LIBRARY", self.spec["libspatialindex"].libs[0])
 

--- a/repos/spack_repo/builtin/packages/py_ruamel_yaml_clib/package.py
+++ b/repos/spack_repo/builtin/packages/py_ruamel_yaml_clib/package.py
@@ -40,11 +40,3 @@ class PyRuamelYamlClib(PythonPackage):
             if self.spec.satisfies("%oneapi") or self.spec.satisfies("%apple-clang@15:"):
                 flags.append("-Wno-error=incompatible-function-pointer-types")
         return (flags, None, None)
-
-    def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/r/ruamel.yaml.clib/{}-{}.tar.gz"
-        if version >= Version("0.2.15"):
-            name = "ruamel_yaml_clib"
-        else:
-            name = "ruamel.yaml.clib"
-        return url.format(name, version)


### PR DESCRIPTION
Remove a lot of `url_for_version` in python packages by refactoring the `_url` method in `PythonPackage`.

Based on https://packaging.python.org/en/latest/specifications/simple-repository-api/#normalized-names.

Verfiying with:
`cat packages.txt | xargs -I {} sh -c "echo {}; spack versions --safe {} | grep -E -v \"==>|[a-z]\" | xargs -I [] sh -c 'echo {}@[]; spack fetch {}@[]'"`