### PR TITLE
intel-pin: remove compiler dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/intel_pin/package.py
+++ b/repos/spack_repo/builtin/packages/intel_pin/package.py
@@ -133,9 +133,6 @@ class IntelPin(Package):
         url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-2.14-71313-gcc.4.4.7-linux.tar.gz",
     )
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-
     def install(self, spec, prefix):
         install_tree(".", prefix)
         mkdir(prefix.bin)


### PR DESCRIPTION
Even though Pin includes source code, nothing requires compilation; the installer just extracts files into a tree.