### PR TITLE
jacamar-ci: correctly rpath-link libseccomp in jacamar-auth

### DIFF
--- a/repos/spack_repo/builtin/packages/jacamar_ci/package.py
+++ b/repos/spack_repo/builtin/packages/jacamar_ci/package.py
@@ -55,7 +55,9 @@ class JacamarCi(GoPackage):
 
     def setup_build_environment(self, env):
         libseccomp = self.spec["libseccomp"]
-        env.append_flags("CGO_LDFLAGS", f"-L{libseccomp.prefix.lib} -Wl,-rpath,{libseccomp.prefix.lib}")
+        env.append_flags(
+            "CGO_LDFLAGS", f"-L{libseccomp.prefix.lib} -Wl,-rpath,{libseccomp.prefix.lib}"
+        )
 
     def build(self, spec, prefix):
         make("VERSION={0}".format(spec.version), "build")

--- a/repos/spack_repo/builtin/packages/jacamar_ci/package.py
+++ b/repos/spack_repo/builtin/packages/jacamar_ci/package.py
@@ -53,6 +53,10 @@ class JacamarCi(GoPackage):
         match = re.search(r"Version:\s*(\S+)", output)
         return match.group(1) if match else None
 
+    def setup_build_environment(self, env):
+        libseccomp = self.spec["libseccomp"]
+        env.append_flags("CGO_LDFLAGS", f"-L{libseccomp.prefix.lib} -Wl,-rpath,{libseccomp.prefix.lib}")
+
     def build(self, spec, prefix):
         make("VERSION={0}".format(spec.version), "build")
 


### PR DESCRIPTION
This PR fixes `jacamar-ci` to use rpath linking for the CGO component that installs the `jacamar-auth` executable. Since the `libseccomp` dependency is type=link, the intent appears to be to have this be resolved to the spack-installed `libseccomp.so` at run time (another option would be to make it a statically linked executable, and type=build would be sufficient). Since CGO bypasses the spack wrappers, we have to inject the rpath flags directly.

This PR injects the rpath flags for `libseccomp`, and results in:
```
[wouter.deconinck@ap43 spack]$ ldd /home/wouter.deconinck/git/spack/opt/spack/linux-zen4/jacamar-ci-develop-j4jdmz3thnwfonupaagusn3ih3e75hyx/bin/jacamar-auth 
        linux-vdso.so.1 (0x00007fffa6793000)
        libseccomp.so.2 => /home/wouter.deconinck/git/spack/opt/spack/linux-zen4/libseccomp-2.6.0-ghww2sbsnvmmmviama3qfjde4yw5x5jc/lib/libseccomp.so.2 (0x00007f303c3e0000)
        libc.so.6 => /lib64/libc.so.6 (0x00007f303c000000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f303c410000)
[wouter.deconinck@ap43 spack]$ readelf -d /home/wouter.deconinck/git/spack/opt/spack/linux-zen4/jacamar-ci-develop-j4jdmz3thnwfonupaagusn3ih3e75hyx/bin/jacamar-auth 

Dynamic section at offset 0xd59a80 contains 28 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libseccomp.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x000000000000000f (RPATH)              Library rpath: [/home/wouter.deconinck/git/spack/opt/spack/linux-zen4/libseccomp-2.6.0-ghww2sbsnvmmmviama3qfjde4yw5x5jc/lib]
```
instead of picking up the system `libseccomp.so`:
```
[wouter.deconinck@ap43 spack]$ ldd /home/wouter.deconinck/git/spack/opt/spack/linux-zen4/jacamar-ci-develop-ia5tttju4nu5rqiw4mdvamwdr6otpkub/bin/jacamar-auth 
        linux-vdso.so.1 (0x00007ffd6e2f4000)
        libseccomp.so.2 => /lib64/libseccomp.so.2 (0x00007fb2f98f7000)
        libc.so.6 => /lib64/libc.so.6 (0x00007fb2f9600000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fb2f9923000)
```