### PR TITLE
geant4: set optional data variants

### DIFF
--- a/repos/spack_repo/builtin/packages/geant4/package.py
+++ b/repos/spack_repo/builtin/packages/geant4/package.py
@@ -341,8 +341,9 @@ class Geant4(CMakePackage):
                 if v in variants:
                     # Inform Geant4 whether this optional dataset is in use
                     # so that it's exported to Geant4_DATASET_DESCRIPTIONS
-                    options.append(self.define("GEANT4_INSTALL_DATASETS_" +
-                                               v.upper(), variants[v].value))
+                    options.append(
+                        self.define("GEANT4_INSTALL_DATASETS_" + v.upper(), variants[v].value)
+                    )
 
         # Vecgeom
         if spec.satisfies("+vecgeom"):

--- a/repos/spack_repo/builtin/packages/geant4/package.py
+++ b/repos/spack_repo/builtin/packages/geant4/package.py
@@ -336,6 +336,13 @@ class Geant4(CMakePackage):
         options.append(self.define("GEANT4_INSTALL_DATA", False))
         if spec.satisfies("+data"):
             options.append(self.define("GEANT4_INSTALL_DATADIR", self.datadir))
+            variants = self.spec["geant4-data"].variants
+            for v in ["tendl", "nudexlib", "urrpt"]:
+                if v in variants:
+                    # Inform Geant4 whether this optional dataset is in use
+                    # so that it's exported to Geant4_DATASET_DESCRIPTIONS
+                    options.append(self.define("GEANT4_INSTALL_DATASETS_" +
+                                               v.upper(), variants[v].value))
 
         # Vecgeom
         if spec.satisfies("+vecgeom"):


### PR DESCRIPTION
Some of the installed datasets aren't exported into the Geant4 config file due to some missing g4 config variables. This makes `spack load geant4-data` consistent with using the `Geant4_DATASET_DESCRIPTIONS` in `Geant4Config.cmake`.