### PR TITLE
expat: 2.8.1 + deprecate vulnerable 2.8.0 (for CVE-2026-45186)

### DIFF
--- a/repos/spack_repo/builtin/packages/expat/package.py
+++ b/repos/spack_repo/builtin/packages/expat/package.py
@@ -18,7 +18,10 @@ class Expat(AutotoolsPackage, CMakePackage):
     url = "https://github.com/libexpat/libexpat/releases/download/R_2_2_9/expat-2.2.9.tar.bz2"
 
     license("MIT")
-    version("2.8.0", sha256="586494499ac3ad46d87f3beda7b1f770c1c8026a9b60e151593f8b29089a52ca")
+    version(
+        "2.8.0",
+        sha256="586494499ac3ad46d87f3beda7b1f770c1c8026a9b60e151593f8b29089a52ca",
+    )
     # deprecate all releases before 2.8.0 because of various security issues
     version(
         "2.7.5",

--- a/repos/spack_repo/builtin/packages/expat/package.py
+++ b/repos/spack_repo/builtin/packages/expat/package.py
@@ -22,11 +22,12 @@ class Expat(AutotoolsPackage, CMakePackage):
         "2.8.1",
         sha256="f5833dd2e1cd7739ec9182804a1a29c4f0cc7c2f26b633d3a2188b7766a88ecb",
     )
+    # deprecate all releases before 2.8.1 because of various security issues
     version(
         "2.8.0",
         sha256="586494499ac3ad46d87f3beda7b1f770c1c8026a9b60e151593f8b29089a52ca",
+        deprecated=True,
     )
-    # deprecate all releases before 2.8.0 because of various security issues
     version(
         "2.7.5",
         sha256="386a423d40580f1e392e8b512b7635cac5083fe0631961e74e036b0a7a830d77",

--- a/repos/spack_repo/builtin/packages/expat/package.py
+++ b/repos/spack_repo/builtin/packages/expat/package.py
@@ -19,6 +19,10 @@ class Expat(AutotoolsPackage, CMakePackage):
 
     license("MIT")
     version(
+        "2.8.1",
+        sha256="f5833dd2e1cd7739ec9182804a1a29c4f0cc7c2f26b633d3a2188b7766a88ecb",
+    )
+    version(
         "2.8.0",
         sha256="586494499ac3ad46d87f3beda7b1f770c1c8026a9b60e151593f8b29089a52ca",
     )


### PR DESCRIPTION
Similar to #4506

Related blog post: https://blog.hartwork.org/posts/expat-2-8-1-released/

CVE-2026-45186

CC @wdconinc