### PR TITLE
pelican: new package, v7.24.3

### DIFF
--- a/repos/spack_repo/builtin/packages/pelican/package.py
+++ b/repos/spack_repo/builtin/packages/pelican/package.py
@@ -1,0 +1,66 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.go import GoPackage
+
+from spack.package import *
+
+
+class Pelican(GoPackage):
+    """The Pelican command line tool allows one to use a Pelican
+    federation as a client and serve datasets through running a
+    Pelican origin service."""
+
+    homepage = "https://pelicanplatform.org/"
+    url = "https://github.com/PelicanPlatform/pelican/archive/refs/tags/v7.24.3.tar.gz"
+    git = "https://github.com/PelicanPlatform/pelican.git"
+
+    maintainers("wdconinc")
+
+    license("Apache-2.0", checked_by="wdconinc")
+
+    version("7.24.3", sha256="fd73d4c9193f3a25d82c696e7269d10f84f4941786e957c8dffa1562d4b605a0")
+
+    variant("server", default=False, description="Also build the pelican-server binary")
+
+    @run_before("build")
+    def create_frontend_placeholder(self):
+        # web_ui/ui.go uses //go:embed frontend/out/*, which requires at least one
+        # file to exist. Releases prior to v7.25 did not commit this placeholder,
+        # so we create it here to satisfy the embed directive without a full frontend
+        # build.
+        out_dir = join_path(self.stage.source_path, "web_ui", "frontend", "out")
+        mkdirp(out_dir)
+        touch(join_path(out_dir, "placeholder"))
+
+    @property
+    def build_directory(self):
+        # The main package entrypoint is in the cmd/ subdirectory
+        return join_path(self.stage.source_path, "cmd")
+
+    @property
+    def build_args(self):
+        # Build only the CLI client binary (no web frontend embedded)
+        args = super().build_args
+        version_ldflag = (
+            f"-X github.com/pelicanplatform/pelican/version.version={self.spec.version}"
+        )
+        if "-ldflags" in args:
+            args[args.index("-ldflags") + 1] += f" {version_ldflag}"
+        else:
+            args.extend(["-ldflags", version_ldflag])
+        args.extend(["-tags", "forceposix,client"])
+        return args
+
+    @run_after("build", when="+server")
+    def build_server(self):
+        args = list(self.build_args)
+        args[args.index("-tags") + 1] = "forceposix,server"
+        args[args.index("-o") + 1] = "pelican-server"
+        with working_dir(self.build_directory):
+            which("go")("build", *args)
+
+    @run_after("install", when="+server")
+    def install_server(self):
+        install(join_path(self.build_directory, "pelican-server"), self.prefix.bin)

--- a/repos/spack_repo/builtin/packages/pelican/package.py
+++ b/repos/spack_repo/builtin/packages/pelican/package.py
@@ -24,6 +24,8 @@ class Pelican(GoPackage):
 
     variant("server", default=False, description="Also build the pelican-server binary")
 
+    depends_on("go@1.25:", type="build")
+
     @run_before("build")
     def create_frontend_placeholder(self):
         # web_ui/ui.go uses //go:embed frontend/out/*, which requires at least one

--- a/repos/spack_repo/builtin/packages/pelican/package.py
+++ b/repos/spack_repo/builtin/packages/pelican/package.py
@@ -61,7 +61,7 @@ class Pelican(GoPackage):
         args[args.index("-tags") + 1] = "forceposix,server"
         args[args.index("-o") + 1] = "pelican-server"
         with working_dir(self.build_directory):
-            which("go")("build", *args)
+            self.module.go("build", *args)
 
     @run_after("install", when="+server")
     def install_server(self):

--- a/repos/spack_repo/builtin/packages/pelican/package.py
+++ b/repos/spack_repo/builtin/packages/pelican/package.py
@@ -26,7 +26,7 @@ class Pelican(GoPackage):
 
     depends_on("go@1.25:", type="build")
 
-    @run_before("build")
+    @run_before("build", when="@:7.24")
     def create_frontend_placeholder(self):
         # web_ui/ui.go uses //go:embed frontend/out/*, which requires at least one
         # file to exist. Releases prior to v7.25 did not commit this placeholder,

--- a/repos/spack_repo/builtin/packages/pelican/package.py
+++ b/repos/spack_repo/builtin/packages/pelican/package.py
@@ -36,10 +36,7 @@ class Pelican(GoPackage):
         mkdirp(out_dir)
         touch(join_path(out_dir, "placeholder"))
 
-    @property
-    def build_directory(self):
-        # The main package entrypoint is in the cmd/ subdirectory
-        return join_path(self.stage.source_path, "cmd")
+    build_directory = "cmd"
 
     @property
     def build_args(self):

--- a/repos/spack_repo/builtin/packages/pelican/package.py
+++ b/repos/spack_repo/builtin/packages/pelican/package.py
@@ -61,7 +61,7 @@ class Pelican(GoPackage):
         args[args.index("-tags") + 1] = "forceposix,server"
         args[args.index("-o") + 1] = "pelican-server"
         with working_dir(self.build_directory):
-            self.module.go("build", *args)
+            go("build", *args)
 
     @run_after("install", when="+server")
     def install_server(self):


### PR DESCRIPTION
This PR adds `pelican`, https://pelicanplatform.org. It's used with the HTC community for data distribution, in particular for the [Open Science Data Federation](https://osg-htc.org/services/osdf.html). This package include the client by default, and installs the server by variant.

Test build:
```
-- linux-ubuntu26.04-skylake / no compilers ---------------------
zliolvk pelican@7.24.3+server build_system=go

-- linux-ubuntu26.04-x86_64 / no compilers ----------------------
2akzz7u go@1.26.0 build_system=generic
==> 2 installed packages
```