### PR TITLE
gettext: disable D language

### DIFF
--- a/repos/spack_repo/builtin/packages/gettext/package.py
+++ b/repos/spack_repo/builtin/packages/gettext/package.py
@@ -123,6 +123,10 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
             "--without-cvs",
         ]
 
+        # Until we know why we need them, do not build D sources:
+        if spec.satisfies("@0.25:"):
+            config_args.append("--disable-d")
+
         config_args.extend(self.enable_or_disable("shared"))
 
         if self.spec["iconv"].name == "libiconv":


### PR DESCRIPTION
Starting version `0.25`, `gettext` contains source files written in D. If a D compiler is found on the system, those source files get compiled. With the old `gdc (Debian 10.2.1-6) 10.2.1 20210110` on my system, the compilation of those files fails:
```console
./gnu/libintl/libintl.d:48:34: error: function gnu.libintl.internal.low.gettext is not accessible from module libintl
   48 |   return to!string(unsafe_gettext(toStringz(msgid)));
```
I chose not to dive deep into this because hardly anyone cares about D. Therefore, this PR simply adds `--disable-d` for the relevant version range.