### PR TITLE
py-snakemake-storage-plugin-pelican: new package v0.1.1 + deps

### DIFF
--- a/repos/spack_repo/builtin/packages/py_aiowebdav2/package.py
+++ b/repos/spack_repo/builtin/packages/py_aiowebdav2/package.py
@@ -1,0 +1,33 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyAiowebdav2(PythonPackage):
+    """Async Python 3 client for WebDAV."""
+
+    homepage = "https://github.com/jpbede/aiowebdav2"
+    pypi = "aiowebdav2/aiowebdav2-0.6.2.tar.gz"
+    git = "https://github.com/jpbede/aiowebdav2.git"
+
+    maintainers("wdconinc")
+
+    license("MIT", checked_by="wdconinc")
+
+    version("0.6.2", sha256="4ac816ec82d2b5ca012e188e066f8d430be663593e908743e1290a4b41964d93")
+
+    depends_on("python@3.11:", type=("build", "run"))
+
+    with default_args(type="build"):
+        depends_on("py-hatchling")
+
+    with default_args(type=("build", "run")):
+        depends_on("py-aiohttp@3.8:")
+        depends_on("py-aiofiles@0.7:")
+        depends_on("py-lxml@5.3:")
+        depends_on("py-python-dateutil@2.9.0.post0:")
+        depends_on("py-yarl@1.18.3:")

--- a/repos/spack_repo/builtin/packages/py_cachetools/package.py
+++ b/repos/spack_repo/builtin/packages/py_cachetools/package.py
@@ -17,12 +17,20 @@ class PyCachetools(PythonPackage):
 
     license("MIT")
 
+    version("7.1.1", sha256="27bdf856d68fd3c71c26c01b5edc312124ed427524d1ddb31aa2b7746fe20d4b")
+    version("6.2.6", sha256="16c33e1f276b9a9c0b49ab5782d901e3ad3de0dd6da9bf9bcd29ac5672f2f9e6")
+    version("5.5.2", sha256="1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4")
     version("5.2.0", sha256="6a94c6402995a99c3970cc7e4884bb60b4a8639938157eeed436098bf9831757")
     version("4.2.4", sha256="89ea6f1b638d5a73a4f9226be57ac5e4f399d22770b92355f92dcb0f7f001693")
     version("4.2.2", sha256="61b5ed1e22a0924aed1d23b478f37e8d52549ff8a961de2909c69bf950020cff")
     version("3.1.1", sha256="8ea2d3ce97850f31e4a08b0e2b5e6c34997d7216a9d2c98e0f3978630d4da69a")
 
-    depends_on("py-setuptools", type="build")
-    depends_on("py-setuptools@46.4.0:", when="@4.2.2:", type="build")
-    depends_on("python@3.5:3", when="@4.2.2", type=("build", "run"))
-    depends_on("python@3.7:3", when="@5.2.0", type=("build", "run"))
+    with default_args(type=("build", "run")):
+        depends_on("python@3.5:3", when="@4.2.2:")
+        depends_on("python@3.7:3", when="@5.2.0:")
+        depends_on("python@3.9:3", when="@6:")
+
+    with default_args(type="build"):
+        depends_on("py-setuptools")
+        depends_on("py-setuptools@46.4.0:", when="@4.2.2:")
+        depends_on("py-setuptools@61.0.0:", when="@6.2.3:")

--- a/repos/spack_repo/builtin/packages/py_frozenlist/package.py
+++ b/repos/spack_repo/builtin/packages/py_frozenlist/package.py
@@ -23,6 +23,7 @@ class PyFrozenlist(PythonPackage):
     version("1.2.0", sha256="68201be60ac56aff972dc18085800b6ee07973c49103a8aba669dee3d71079de")
 
     depends_on("c", type="build")
+    depends_on("cxx", type="build", when="@1.6.0:")
 
     # Based on PyPI wheel availability
     with default_args(type=("build", "run")):

--- a/repos/spack_repo/builtin/packages/py_igwn_auth_utils/package.py
+++ b/repos/spack_repo/builtin/packages/py_igwn_auth_utils/package.py
@@ -28,4 +28,4 @@ class PyIgwnAuthUtils(PythonPackage):
         depends_on("py-cryptography@44.0.1:")
         depends_on("py-requests@2.32:")
         depends_on("py-safe-netrc@1:")
-        depends_on("py-scitokens@1.8")
+        depends_on("py-scitokens@1.8:")

--- a/repos/spack_repo/builtin/packages/py_igwn_auth_utils/package.py
+++ b/repos/spack_repo/builtin/packages/py_igwn_auth_utils/package.py
@@ -1,0 +1,31 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyIgwnAuthUtils(PythonPackage):
+    """Authorisation utilities for IGWN."""
+
+    homepage = "https://git.ligo.org/computing/igwn-auth-utils"
+    pypi = "igwn_auth_utils/igwn_auth_utils-1.4.0.tar.gz"
+    git = "https://git.ligo.org/computing/igwn-auth-utils.git"
+
+    maintainers("wdconinc")
+
+    license("BSD-3-Clause", checked_by="wdconinc")
+
+    version("1.4.0", sha256="8ebd331a1d6de16e843e94cde2dc0a09d07a7fbc089bc525fa0eabddd89ea187")
+
+    with default_args(type="build"):
+        depends_on("py-setuptools@70:")
+        depends_on("py-setuptools-scm@3.4.3:+toml")
+
+    with default_args(type=("build", "run")):
+        depends_on("py-cryptography@44.0.1:")
+        depends_on("py-requests@2.32:")
+        depends_on("py-safe-netrc@1:")
+        depends_on("py-scitokens@1.8")

--- a/repos/spack_repo/builtin/packages/py_pelicanfs/package.py
+++ b/repos/spack_repo/builtin/packages/py_pelicanfs/package.py
@@ -1,0 +1,34 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyPelicanfs(PythonPackage):
+    """An FSSpec Implementation using the Pelican System."""
+
+    homepage = "https://github.com/PelicanPlatform/pelicanfs"
+    pypi = "pelicanfs/pelicanfs-1.3.1.tar.gz"
+    git = "https://github.com/PelicanPlatform/pelicanfs.git"
+
+    maintainers("wdconinc")
+
+    license("Apache-2.0", checked_by="wdconinc")
+
+    version("1.3.1", sha256="fc650efbaf2863eb072aab8624452a63f304dad472934402f862ad05e5b7a958")
+
+    depends_on("python@3.11:", type=("build", "run"))
+
+    with default_args(type="build"):
+        depends_on("py-setuptools@61:")
+
+    with default_args(type=("build", "run")):
+        depends_on("py-aiohttp@3.9.4:3")
+        depends_on("py-aiowebdav2")
+        depends_on("py-cachetools@5.3:5")
+        depends_on("py-fsspec@2024.3.1:")
+        depends_on("py-igwn-auth-utils")
+        depends_on("py-pywinpty", when="platform=windows")

--- a/repos/spack_repo/builtin/packages/py_propcache/package.py
+++ b/repos/spack_repo/builtin/packages/py_propcache/package.py
@@ -15,13 +15,17 @@ class PyPropcache(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.5.2", sha256="01c4fc7480cd0598bb4b57022df55b9ca296da7fc5a8760bd8451a7e63a7d427")
     version("0.4.1", sha256="f48107a8c637e80362555f37ecf49abe20370e557cc4ab374f04ec4423c97c3d")
     version("0.3.2", sha256="20d7d62e4e7ef05f221e0db2856b979540686342e7dd9973b815599c7057e168")
     version("0.3.1", sha256="40d980c33765359098837527e18eddefc9a24cea5b45e078a7f3bb5b032c6ecf")
 
     depends_on("py-setuptools@47:", type="build")
+    depends_on("py-setuptools@82.0.1:", type="build", when="@0.5:")
     depends_on("py-expandvars", type="build")
     depends_on("py-tomli", when="^python@:3.10", type="build")
     depends_on("py-cython", type="build")
 
     depends_on("python@3.9:", when="@0.2.1:", type=("build", "run"))
+    depends_on("python@3.10:", when="@0.5:", type=("build", "run"))
+    depends_on("python@:3.13", when="@:0.4", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_pywinpty/package.py
+++ b/repos/spack_repo/builtin/packages/py_pywinpty/package.py
@@ -20,7 +20,9 @@ class PyPywinpty(PythonPackage):
 
     version("3.0.3", sha256="523441dc34d231fb361b4b00f8c99d3f16de02f5005fd544a0183112bcc22412")
 
-    with default_args(type="build"):
+    requires("platform=windows")
+
+    with default_args(type=("build", "run")):
         depends_on("python@3.9:", type="build")
 
     with default_args(type="build"):

--- a/repos/spack_repo/builtin/packages/py_pywinpty/package.py
+++ b/repos/spack_repo/builtin/packages/py_pywinpty/package.py
@@ -1,0 +1,27 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyPywinpty(PythonPackage):
+    """Pseudoterminals for Windows in Python."""
+
+    homepage = "https://github.com/andfoy/pywinpty"
+    pypi = "pywinpty/pywinpty-3.0.3.tar.gz"
+    git = "https://github.com/andfoy/pywinpty.git"
+
+    maintainers("wdconinc")
+
+    license("MIT", checked_by="wdconinc")
+
+    version("3.0.3", sha256="523441dc34d231fb361b4b00f8c99d3f16de02f5005fd544a0183112bcc22412")
+
+    with default_args(type="build"):
+        depends_on("python@3.9:", type="build")
+
+    with default_args(type="build"):
+        depends_on("py-maturin@1.1:1")

--- a/repos/spack_repo/builtin/packages/py_safe_netrc/package.py
+++ b/repos/spack_repo/builtin/packages/py_safe_netrc/package.py
@@ -1,0 +1,25 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PySafeNetrc(PythonPackage):
+    """Safe netrc file parser."""
+
+    homepage = "https://git.ligo.org/computing/software/safe-netrc"
+    pypi = "safe-netrc/safe-netrc-1.0.1.tar.gz"
+    git = "https://git.ligo.org/computing/software/safe-netrc.git"
+
+    maintainers("wdconinc")
+
+    license("GPL-2.0-or-later", checked_by="wdconinc")
+
+    version("1.0.1", sha256="1dcc7263b4d9ce72e0109d8e2bc9ba89c8056ccc618d26c8c94802c6fd753720")
+
+    with default_args(type="build"):
+        depends_on("py-setuptools@61:")
+        depends_on("py-setuptools-scm@6.2:+toml")

--- a/repos/spack_repo/builtin/packages/py_scitokens/package.py
+++ b/repos/spack_repo/builtin/packages/py_scitokens/package.py
@@ -1,0 +1,29 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyScitokens(PythonPackage):
+    """SciToken reference implementation library."""
+
+    homepage = "https://scitokens.org"
+    pypi = "scitokens/scitokens-1.9.7.tar.gz"
+    git = "https://github.com/scitokens/scitokens.git"
+
+    maintainers("wdconinc")
+
+    license("Apache-2.0", checked_by="wdconinc")
+
+    version("1.9.7", sha256="9aabefbd68859e94a3909f3dc08bd73c0e7a9c08203c16de338c9512ace821e3")
+
+    with default_args(type="build"):
+        depends_on("py-setuptools")
+
+    with default_args(type=("build", "run")):
+        depends_on("py-cryptography")
+        depends_on("py-pyjwt@1.6.1:")
+        depends_on("py-requests")

--- a/repos/spack_repo/builtin/packages/py_snakemake_storage_plugin_pelican/package.py
+++ b/repos/spack_repo/builtin/packages/py_snakemake_storage_plugin_pelican/package.py
@@ -1,0 +1,31 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PySnakemakeStoragePluginPelican(PythonPackage):
+    """A Snakemake Storage Plugin for Pelican Federations."""
+
+    homepage = "https://github.com/PelicanPlatform/snakemake-storage-plugin-pelican"
+    pypi = "snakemake_storage_plugin_pelican/snakemake_storage_plugin_pelican-0.1.1.tar.gz"
+    git = "https://github.com/PelicanPlatform/snakemake-storage-plugin-pelican.git"
+
+    maintainers("wdconinc")
+
+    license("Apache-2.0", checked_by="wdconinc")
+
+    version("0.1.1", sha256="a2b436dedaed0cae1edfb0d2d6c32085239eb0c2ec15bed86419d465b7bb5cb5")
+
+    depends_on("python@3.12:", type=("build", "run"))
+
+    with default_args(type="build"):
+        depends_on("py-poetry-core@2")
+
+    with default_args(type=("build", "run")):
+        depends_on("py-snakemake-interface-common@1.21:1")
+        depends_on("py-snakemake-interface-storage-plugins@4.2.1:4")
+        depends_on("py-pelicanfs@1.2.3:")


### PR DESCRIPTION
This PR adds `py-snakemake-storage-plugin-pelican`, the snakemake plugin to interact with pelican data federations. Also adds the dependencies:
- py-aiowebdav2
- py-cachetools (version upgrades)
- py-igwn-auth-utils
- py-pelicanfs
- py-pywinpty
- py-safe-netrc
- py-scitokens

Test build:
```
-- linux-ubuntu26.04-skylake / no compilers ---------------------
py-snakemake-storage-plugin-pelican@0.1.1
==> 1 installed package
```