### PR TITLE
py-pulp: add version 3.3.1

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pulp/package.py
+++ b/repos/spack_repo/builtin/packages/py_pulp/package.py
@@ -18,7 +18,12 @@ class PyPulp(PythonPackage):
     maintainers("marcusboden")
 
     license("MIT")
-
+    
+    version(                                                                                                                                                                                                     
+        "3.3.1",                                                                                                                                                                                                 
+        sha256="f979a2e08c32279234a802ede4e5e26d493300e8ccf94f9223236d228c3941f5",                                                                                                                               
+        url="https://github.com/coin-or/pulp/archive/refs/tags/3.3.1.tar.gz"                                                                                                                                     
+    )
     version("2.6.0", sha256="4b4f7e1e954453e1b233720be23aea2f10ff068a835ac10c090a93d8e2eb2e8d")
 
     depends_on("python@2.7:2.8,3.4:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_pulp/package.py
+++ b/repos/spack_repo/builtin/packages/py_pulp/package.py
@@ -18,13 +18,14 @@ class PyPulp(PythonPackage):
     maintainers("marcusboden")
 
     license("MIT")
-    
-    version(                                                                                                                                                                                                     
-        "3.3.1",                                                                                                                                                                                                 
-        sha256="f979a2e08c32279234a802ede4e5e26d493300e8ccf94f9223236d228c3941f5",                                                                                                                               
-        url="https://github.com/coin-or/pulp/archive/refs/tags/3.3.1.tar.gz"                                                                                                                                     
+
+    version(
+        "3.3.1",
+        sha256="f979a2e08c32279234a802ede4e5e26d493300e8ccf94f9223236d228c3941f5",
+        url="https://github.com/coin-or/pulp/archive/refs/tags/3.3.1.tar.gz",
     )
     version("2.6.0", sha256="4b4f7e1e954453e1b233720be23aea2f10ff068a835ac10c090a93d8e2eb2e8d")
 
+    depends_on("python@3.9:", type=("build", "run"), when="@3.3.1:")
     depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
Adding a newer version for py-pulp, tested that it's functional:

```py
Python 3.14.3 (main, May  7 2026, 09:34:15) [GCC 12.5.0] on linux                                                                                                                                                
Type "help", "copyright", "credits" or "license" for more information.                                                                                                                                           
>>> from pulp import *                                                                                                                                                                                           
>>> prob = LpProblem("myProblem", LpMinimize)                                                                                                                                                                    
>>> x = prob.add_variable("x", 0, 3)                                                                                                                                                                             
>>> y = prob.add_variable("y", cat="Binary")
>>> prob += x + y <= 2                              
>>> status = prob.solve()         
Welcome to the CBC MILP Solver                 
Version: 2.10.3                   
Build Date: Dec 15 2019                                      
...
```