### PR TITLE
GoPackage: allow packages to define ldflags

### DIFF
--- a/repos/spack_repo/builtin/build_systems/go.py
+++ b/repos/spack_repo/builtin/build_systems/go.py
@@ -85,6 +85,7 @@ class GoBuilder(BuilderWithDefaults):
 
     @property
     def std_ldflags(self) -> List[str]:
+        # Pass ldflags -s = --strip-all and -w = --no-warnings by default
         return ["-s", "-w"]
 
     @property
@@ -94,7 +95,6 @@ class GoBuilder(BuilderWithDefaults):
     @property
     def std_build_args(self):
         """Arguments for ``go build``."""
-        # Pass ldflags -s = --strip-all and -w = --no-warnings by default
         return [
             "-p",
             str(self.pkg.module.make_jobs),

--- a/repos/spack_repo/builtin/build_systems/go.py
+++ b/repos/spack_repo/builtin/build_systems/go.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from typing import List
+
 from spack.package import (
     BuilderWithDefaults,
     EnvironmentModifications,
@@ -64,7 +66,10 @@ class GoBuilder(BuilderWithDefaults):
 
     #: Names associated with package attributes in the old build-system format
     package_attributes = (
+        "std_build_args",
         "build_args",
+        "std_ldflags",
+        "ldflags",
         "check_args",
         "build_directory",
         "install_time_test_callbacks",
@@ -79,21 +84,34 @@ class GoBuilder(BuilderWithDefaults):
         return self.pkg.stage.source_path
 
     @property
-    def build_args(self):
+    def std_ldflags(self) -> List[str]:
+        return ["-s", "-w"]
+
+    @property
+    def ldflags(self) -> List[str]:
+        return []
+
+    @property
+    def std_build_args(self):
         """Arguments for ``go build``."""
         # Pass ldflags -s = --strip-all and -w = --no-warnings by default
         return [
             "-p",
             str(self.pkg.module.make_jobs),
             "-modcacherw",
+            "-trimpath",
             "-ldflags",
-            "-s -w",
+            " ".join([*self.std_ldflags, *self.ldflags]),
             "-o",
             f"{self.pkg.name}",
         ]
 
     @property
-    def check_args(self):
+    def build_args(self) -> List[str]:
+        return []
+
+    @property
+    def check_args(self) -> List[str]:
         """Argument for ``go test`` during check phase"""
         return []
 
@@ -105,7 +123,7 @@ class GoBuilder(BuilderWithDefaults):
     def build(self, pkg: GoPackage, spec: Spec, prefix: Prefix) -> None:
         """Runs ``go build`` in the source directory"""
         with working_dir(self.build_directory):
-            pkg.module.go("build", *self.build_args)
+            pkg.module.go("build", *self.std_build_args, *self.build_args)
 
     def install(self, pkg: GoPackage, spec: Spec, prefix: Prefix) -> None:
         """Install built binaries into prefix bin."""

--- a/repos/spack_repo/builtin/packages/csvtk/package.py
+++ b/repos/spack_repo/builtin/packages/csvtk/package.py
@@ -20,9 +20,7 @@ class Csvtk(GoPackage):
 
     depends_on("go@1.24:", type="build")
 
-    @property
-    def build_directory(self):
-        return f"{join_path(super().build_directory, self.name)}"
+    build_directory = "csvtk"
 
     @run_after("install")
     def install_completions(self):

--- a/repos/spack_repo/builtin/packages/gh/package.py
+++ b/repos/spack_repo/builtin/packages/gh/package.py
@@ -69,11 +69,12 @@ class Gh(GoPackage):
     depends_on("go@1.18:", type="build", when="@2.10:")
     depends_on("go@1.16:", type="build")
 
+    build_directory = "cmd/gh"
+
     @property
-    def build_args(self):
-        args = super().build_args
-        args.extend(["-trimpath", "./cmd/gh"])
-        return args
+    def ldflags(self):
+        version_path = go("list", "../../internal/build", output=str).strip()
+        return [f"-X {version_path}.Version={self.spec.version}"]
 
     @property
     def check_args(self):

--- a/repos/spack_repo/builtin/packages/glab/package.py
+++ b/repos/spack_repo/builtin/packages/glab/package.py
@@ -66,18 +66,8 @@ class Glab(GoPackage):
     # Required to correctly set the version
     # https://gitlab.com/gitlab-org/cli/-/blob/v1.55.0/Makefile?ref_type=tags#L44
     @property
-    def build_args(self):
-        extra_ldflags = [f"-X 'main.version=v{self.version}'"]
-
-        args = super().build_args
-
-        if "-ldflags" in args:
-            ldflags_index = args.index("-ldflags") + 1
-            args[ldflags_index] = args[ldflags_index] + " " + " ".join(extra_ldflags)
-        else:
-            args.extend(["-ldflags", " ".join(extra_ldflags)])
-
-        return args
+    def ldflags(self):
+        return [f"-X main.version=v{self.spec.version}"]
 
     @run_after("install")
     def install_completions(self):

--- a/repos/spack_repo/builtin/packages/glow/package.py
+++ b/repos/spack_repo/builtin/packages/glow/package.py
@@ -43,16 +43,8 @@ class Glow(GoPackage):
     depends_on("go@1.13:")
 
     @property
-    def build_args(self):
-        return [
-            "-p",
-            str(make_jobs),
-            "-modcacherw",
-            "-ldflags",
-            f"-s -w -X main.Version={self.version}",
-            "-o",
-            f"{self.name}",
-        ]
+    def ldflags(self):
+        return [f"-X main.Version={self.spec.version}"]
 
     @run_after("install")
     def install_completions(self):

--- a/repos/spack_repo/builtin/packages/gomplate/package.py
+++ b/repos/spack_repo/builtin/packages/gomplate/package.py
@@ -24,20 +24,9 @@ class Gomplate(GoPackage):
 
     depends_on("go@1.24.5:", type="build")
 
-    def build(self, spec, prefix):
-        # Retrieve the "path" (in Go namespace parlance) to the version object because
-        # we need to set its Version attribute. This is similar to what is done in the
-        # gomplate Makefile.
-        gomplate_version_path = self.module.go("list", "./version", output=str).strip()
-        with working_dir(f"{join_path(self.build_directory, 'cmd', self.name)}"):
-            # When building, set gomplate's version.Version to the value in the version
-            # object for this package
-            self.module.go(
-                "build",
-                "-p",
-                str(make_jobs),
-                "-ldflags",
-                f"-s -w -X {gomplate_version_path}.Version={self.version}",
-                "-o",
-                f"{join_path(self.build_directory, self.name)}",
-            )
+    build_directory = "cmd/gomplate"
+
+    @property
+    def ldflags(self):
+        version_path = go("list", "../../version", output=str).strip()
+        return [f"-X {version_path}.Version={self.spec.version}"]

--- a/repos/spack_repo/builtin/packages/hugo/package.py
+++ b/repos/spack_repo/builtin/packages/hugo/package.py
@@ -63,7 +63,7 @@ class Hugo(GoPackage):
 
     @property
     def build_args(self):
-        args = super().build_args
+        args = []
         if self.spec.satisfies("+extended"):
             args.extend(["--tags", "extended"])
 

--- a/repos/spack_repo/builtin/packages/kubectl/package.py
+++ b/repos/spack_repo/builtin/packages/kubectl/package.py
@@ -58,22 +58,12 @@ class Kubectl(GoPackage):
     # 4. https://github.com/kubernetes/kubernetes/blob/v1.32.2/hack/lib/init.sh#L61
     # 5. https://github.com/kubernetes/kubernetes/blob/v1.32.2/hack/lib/version.sh#L151-L183
     @property
-    def build_args(self):
-        kube_ldflags = [
-            f"-X 'k8s.io/client-go/pkg/version.gitVersion=v{self.version}'",
-            f"-X 'k8s.io/client-go/pkg/version.gitMajor={self.version.up_to(1)}'",
-            f"-X 'k8s.io/client-go/pkg/version.gitMinor={str(self.version).split('.')[1]}'",
-            f"-X 'k8s.io/component-base/version.gitVersion=v{self.version}'",
-            f"-X 'k8s.io/component-base/version.gitMajor={self.version.up_to(1)}'",
-            f"-X 'k8s.io/component-base/version.gitMinor={str(self.version).split('.')[1]}'",
+    def ldflags(self):
+        return [
+            f"-X k8s.io/client-go/pkg/version.gitVersion=v{self.spec.version}",
+            f"-X k8s.io/client-go/pkg/version.gitMajor={self.spec.version.up_to(1)}",
+            f"-X k8s.io/client-go/pkg/version.gitMinor={str(self.spec.version).split('.')[1]}",
+            f"-X k8s.io/component-base/version.gitVersion=v{self.spec.version}",
+            f"-X k8s.io/component-base/version.gitMajor={self.spec.version.up_to(1)}",
+            f"-X k8s.io/component-base/version.gitMinor={str(self.spec.version).split('.')[1]}",
         ]
-
-        args = super().build_args
-
-        if "-ldflags" in args:
-            ldflags_index = args.index("-ldflags") + 1
-            args[ldflags_index] = args[ldflags_index] + " " + " ".join(kube_ldflags)
-        else:
-            args.extend(["-ldflags", " ".join(kube_ldflags)])
-
-        return args

--- a/repos/spack_repo/builtin/packages/oc/package.py
+++ b/repos/spack_repo/builtin/packages/oc/package.py
@@ -35,11 +35,9 @@ class Oc(GoPackage):
 
     @property
     def build_args(self):
-        args = super().build_args
         tags = ["include_gcs", "include_oss", "containers_image_openpgp"]
 
         if self.spec.satisfies("+gssapi"):
             tags.append("gssapi")
 
-        args.extend(["-tags", " ".join(tags)])
-        return args
+        return ["-tags", " ".join(tags)]

--- a/repos/spack_repo/builtin/packages/pprof/package.py
+++ b/repos/spack_repo/builtin/packages/pprof/package.py
@@ -14,14 +14,13 @@ class Pprof(GoPackage):
     git = "https://github.com/google/pprof.git"
 
     maintainers("mcmehrtens")
+
     license("Apache-2.0", checked_by="mcmehrtens")
+
+    sanity_check_is_file = ["bin/pprof"]
 
     # pprof doesn't have tagged releases
     version("main", branch="main", get_full_repo=True)
-
-    # pprof's go.mod requires go 1.24; Go supports the two most recent
-    # major releases, so this will need updating with new Go releases.
-    depends_on("go@1.24:", type="build")
 
     variant(
         "graphviz",
@@ -29,8 +28,8 @@ class Pprof(GoPackage):
         description="Enable graphic visualization of profiles (SVG, PDF, etc.)",
     )
 
-    depends_on("graphviz", type="run", when="+graphviz")
+    # pprof's go.mod requires go 1.24; Go supports the two most recent
+    # major releases, so this will need updating with new Go releases.
+    depends_on("go@1.24:", type="build")
 
-    @property
-    def sanity_check_is_file(self):
-        return [join_path("bin", "pprof")]
+    depends_on("graphviz", type="run", when="+graphviz")

--- a/repos/spack_repo/builtin/packages/rclone/package.py
+++ b/repos/spack_repo/builtin/packages/rclone/package.py
@@ -59,6 +59,11 @@ class Rclone(GoPackage):
     depends_on("go@1.17:", type="build", when="@1.58:")
     depends_on("go@1.14:", type="build")
 
+    @property
+    def ldflags(self):
+        version_path = go("list", "./fs", output=str).strip()
+        return [f"-X {version_path}.Version={self.spec.version}"]
+
     @run_after("install")
     def install_completions(self):
         rclone = Executable(self.prefix.bin.rclone)

--- a/repos/spack_repo/builtin/packages/seqkit/package.py
+++ b/repos/spack_repo/builtin/packages/seqkit/package.py
@@ -2,16 +2,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack_repo.builtin.build_systems import go
 from spack_repo.builtin.build_systems.go import GoPackage
 
 from spack.package import *
-
-
-class GoBuilder(go.GoBuilder):
-    @property
-    def build_directory(self):
-        return join_path(self.pkg.stage.source_path, "seqkit")
 
 
 class Seqkit(GoPackage):
@@ -30,3 +23,5 @@ class Seqkit(GoPackage):
     version("2.4.0", sha256="c319f3d5feb7c99309e654042432959f01bbc5f7e4c71f55dc9854df46c73c7f")
 
     depends_on("go@1.17:", type="build")
+
+    build_directory = "seqkit"

--- a/repos/spack_repo/builtin/packages/trivy/package.py
+++ b/repos/spack_repo/builtin/packages/trivy/package.py
@@ -35,21 +35,10 @@ class Trivy(GoPackage):
 
     build_directory = "cmd/trivy"
 
-    # Required to correctly set the version
-    # https://github.com/aquasecurity/trivy/blob/v0.61.0/goreleaser.yml#L11
     @property
-    def build_args(self):
-        extra_ldflags = [f"-X 'github.com/aquasecurity/trivy/pkg/version/app.ver=v{self.version}'"]
-
-        args = super().build_args
-
-        if "-ldflags" in args:
-            ldflags_index = args.index("-ldflags") + 1
-            args[ldflags_index] = args[ldflags_index] + " " + " ".join(extra_ldflags)
-        else:
-            args.extend(["-ldflags", " ".join(extra_ldflags)])
-
-        return args
+    def ldflags(self):
+        version_path = go("list", "../../pkg/version/app", output=str).strip()
+        return [f"-X {version_path}.ver=v{self.spec.version}"]
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("@0.67.0:"):

--- a/repos/spack_repo/builtin/packages/yamlfmt/package.py
+++ b/repos/spack_repo/builtin/packages/yamlfmt/package.py
@@ -22,15 +22,8 @@ class Yamlfmt(GoPackage):
     depends_on("go@1.22:", type="build", when="@0.21:")
     depends_on("go@1.21:", type="build")
 
+    build_directory = "cmd/yamlfmt"
+
     @property
-    def build_args(self):
-        return [
-            "-p",
-            str(make_jobs),
-            "-modcacherw",
-            "-ldflags",
-            f"-s -w -X main.version={self.version}",
-            "-o",
-            f"{self.name}",
-            f"{join_path(self.build_directory, 'cmd', self.name)}",
-        ]
+    def ldflags(self):
+        return [f"-X main.version={self.spec.version}"]


### PR DESCRIPTION
It is common in the go ecosystem for packages to expect an ldflag to set the package version during the build. This PR adds a new optional property to `GoPackage` allowing maintainers to more easily add additional ldflags to the build without having to overwrite the `std_build_args`. Additionally this PR splits out `std_build_args` and `build_args` to follow more closely with other build systems like Cargo and CMake.
