### PR TITLE
style check is now ruff-format vs. black

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -192,4 +192,4 @@ jobs:
           spack debug report
           spack -d bootstrap now --dev
           source .ci/env
-          spack -d style -b ${SPACK_CHECKOUT_VERSION} -t black
+          spack -d style -b ${SPACK_CHECKOUT_VERSION} -t ruff-format


### PR DESCRIPTION
For current spack checkout version (7e864787bd15a516314d86002ce1cbabde7cbbe9) `spack style --help` reports:

```
-s TOOL, --skip TOOL  specify tools to skip (choose from import, ruff-format, ruff-check, mypy)
```