### PR TITLE
Use ruff format not black

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -192,4 +192,4 @@ jobs:
           spack debug report
           spack -d bootstrap now --dev
           source .ci/env
-          spack -d style -b ${SPACK_CHECKOUT_VERSION} -t black
+          spack -d style -b ${SPACK_CHECKOUT_VERSION} -t ruff-format


### PR DESCRIPTION
Switches the bootstrap check to use `ruff format` instead of `black` as the tool argument