### PR TITLE
cmake: fix application of ignore_crayxc_warnings.patch on macOS

### DIFF
--- a/repos/spack_repo/builtin/packages/cmake/ignore_crayxc_warnings_37.patch
+++ b/repos/spack_repo/builtin/packages/cmake/ignore_crayxc_warnings_37.patch
@@ -1,0 +1,19 @@
+diff --git a/Source/Checks/cm_cxx_features.cmake b/Source/Checks/cm_cxx_features.cmake
+index 80c9f3b7a7..9e8c4dcc68 100644
+--- a/Source/Checks/cm_cxx_features.cmake
++++ b/Source/Checks/cm_cxx_features.cmake
+@@ -9,8 +9,13 @@ function(cm_check_cxx_feature name)
+       CMAKE_FLAGS -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
+       OUTPUT_VARIABLE OUTPUT
+       )
++    set(check_output "${OUTPUT}")
++    # Filter out libhugetlbfs warnings
++    string(REGEX REPLACE "[^\n]*libhugetlbfs [^\n]*: WARNING[^\n]*" "" check_output "${check_output}")
++    # Filter out icpc warnings
++    string(REGEX REPLACE "[^\n]*icpc: command line warning #10121: overriding [^\n]*" "" check_output "${check_output}")
+     # If using the feature causes warnings, treat it as broken/unavailable.
+-    if(OUTPUT MATCHES "warning")
++    if(check_output MATCHES "[Ww]arning")
+       set(CMake_HAVE_CXX_${FEATURE} OFF CACHE INTERNAL "TRY_COMPILE" FORCE)
+     endif()
+     if(CMake_HAVE_CXX_${FEATURE})

--- a/repos/spack_repo/builtin/packages/cmake/ignore_crayxc_warnings_39.patch
+++ b/repos/spack_repo/builtin/packages/cmake/ignore_crayxc_warnings_39.patch
@@ -1,15 +1,15 @@
 diff --git a/Source/Checks/cm_cxx_features.cmake b/Source/Checks/cm_cxx_features.cmake
-index c16286c7fd..fc31371dc1 100644
+index 3b08025798..f80aa4076f 100644
 --- a/Source/Checks/cm_cxx_features.cmake
 +++ b/Source/Checks/cm_cxx_features.cmake
-@@ -21,6 +21,10 @@ function(cm_check_cxx_feature name)
-     set(check_output "${OUTPUT}")
+@@ -16,6 +16,10 @@ function(cm_check_cxx_feature name)
+       )
      # Filter out MSBuild output that looks like a warning.
-     string(REGEX REPLACE " +0 Warning\\(s\\)" "" check_output "${check_output}")
+     string(REGEX REPLACE " +0 Warning\\(s\\)" "" check_output "${OUTPUT}")
 +    # Filter out libhugetlbfs warnings
 +    string(REGEX REPLACE "[^\n]*libhugetlbfs [^\n]*: WARNING[^\n]*" "" check_output "${check_output}")
 +    # Filter out icpc warnings
 +    string(REGEX REPLACE "[^\n]*icpc: command line warning #10121: overriding [^\n]*" "" check_output "${check_output}")
-     # Filter out warnings caused by user flags.
-     string(REGEX REPLACE "[^\n]*warning:[^\n]*-Winvalid-command-line-argument[^\n]*" "" check_output "${check_output}")
-     # Filter out warnings caused by local configuration.
+     # If using the feature causes warnings, treat it as broken/unavailable.
+     if(check_output MATCHES "[Ww]arning")
+       set(CMake_HAVE_CXX_${FEATURE} OFF CACHE INTERNAL "TRY_COMPILE" FORCE)

--- a/repos/spack_repo/builtin/packages/cmake/package.py
+++ b/repos/spack_repo/builtin/packages/cmake/package.py
@@ -211,7 +211,9 @@ class Cmake(Package):
     # Cray libhugetlbfs and icpc warnings failing CXX tests
     # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4698
     # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4681
-    patch("ignore_crayxc_warnings.patch", when="@3.7:3.17.2")
+    patch("ignore_crayxc_warnings_37.patch", when="@3.7:3.8")
+    patch("ignore_crayxc_warnings_39.patch", when="@3.9")
+    patch("ignore_crayxc_warnings.patch", when="@3.10:3.17.2")
 
     # The Fujitsu compiler requires the '--linkfortran' option
     # to combine C++ and Fortran programs.


### PR DESCRIPTION
The original patch didn't apply properly with BSD patch, but also didn't work across all the specified versions.