### PR TITLE
bootstrap ci: run when ci changes are made

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -8,6 +8,10 @@ on:
       - develop
       - releases/**
     paths:
+      # CI
+      - '.ci/**'
+      - '.github/**'
+      # Build Systems
       - 'repos/spack_repo/builtin/build_systems/**'
       # Clingo
       - 'repos/spack_repo/builtin/packages/clingo/**'


### PR DESCRIPTION
We should run the bootstrap CI check when we change CI based components of Spack as they may alter the behavior of bootstrap CI runs in addition to python changes that may do the same. 