### PR TITLE
py-onnxruntime: only run tests when self.run_tests

### DIFF
--- a/repos/spack_repo/builtin/packages/py_onnxruntime/package.py
+++ b/repos/spack_repo/builtin/packages/py_onnxruntime/package.py
@@ -206,6 +206,7 @@ class PyOnnxruntime(CMakePackage, PythonExtension, ROCmPackage, CudaPackage):
         args = [
             define("onnxruntime_ENABLE_PYTHON", True),
             define("onnxruntime_BUILD_SHARED_LIB", True),
+            define("onnxruntime_BUILD_UNIT_TESTS", self.run_tests),
             define_from_variant("onnxruntime_USE_CUDA", "cuda"),
             define("onnxruntime_BUILD_CSHARP", False),
             define("onnxruntime_USE_TVM", False),


### PR DESCRIPTION
This PR ensures that `py-onnxruntime` does not build its unit tests, unless we give the `--test` argument. Unit tests are enabled by default, see https://github.com/microsoft/onnxruntime/blob/19f5d413fc6f2c8ac06c4d1c65e4371fd7bdd8da/cmake/CMakeLists.txt#L97.

After the upgrade from spack 1.1.0 to 1.1.1 this started to fail in our internal builds since the FetchContent of googletest has a certificate error which was previously ignored (the joys of ssl rewrites at DOE NLs). After https://github.com/spack/spack/commit/c4ba02b73b this started to fail hard.