### PR TITLE
Gitlab CI: always upload generate artifacts

### DIFF
--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -116,6 +116,7 @@ default:
       --artifacts-root "${CI_PROJECT_DIR}/jobs_scratch_dir/${SPACK_CI_STACK_NAME}"
       --output-file "${CI_PROJECT_DIR}/jobs_scratch_dir/${SPACK_CI_STACK_NAME}/cloud-ci-pipeline.yml"
   artifacts:
+    when: always
     paths:
       - "${CI_PROJECT_DIR}/jobs_scratch_dir"
       - "${CI_PROJECT_DIR}/jobs_scratch_dir/${SPACK_CI_STACK_NAME}"


### PR DESCRIPTION
Default behavior is to upload generate artifacts on success, uploading on failure is a useful debugging tool and saves devs having to go add it to the gitlab yaml every time they have a generate failure

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
