### PR TITLE
ci: switch to node@24 to test compatibility

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -7,6 +7,9 @@ on:
         required: true
         type: string
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: audit-${{inputs.python_version}}-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
   cancel-in-progress: true

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -36,6 +36,9 @@ on:
     # nightly at 5:16 AM
     - cron: '16 5 * * *'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: bootstrap-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
   cancel-in-progress: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,9 @@ on:
       - releases/**
   merge_group:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: ci-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
   cancel-in-progress: true

--- a/.github/workflows/prechecks.yml
+++ b/.github/workflows/prechecks.yml
@@ -7,6 +7,9 @@ on:
         required: true
         type: string
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: prechecks-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
   cancel-in-progress: true

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -5,6 +5,9 @@ on:
     - cron: '39 2 * * *'
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - develop
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: unit_tests-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
   cancel-in-progress: true

--- a/.github/workflows/update-src-mirror.yml
+++ b/.github/workflows/update-src-mirror.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - develop
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   id-token: write  # Required for AWS OIDC authentication
   contents: read


### PR DESCRIPTION
GitHub is set to update Actions to use Node v24 by default on June 8th. This PR forces the update to test our compatibility with Node v24 so that we won't be surprised if things start failing next month.

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/