### PR TITLE
Disabled Compiler Wrapper Staging

### DIFF
--- a/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
+++ b/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
@@ -61,7 +61,7 @@ class CompilerWrapper(Package):
             )
             return
 
-        cc_script = pathlib.Path(self.stage.source_path) / "cc.sh"
+        cc_script = pathlib.PurePath(__file__).parent / "cc.sh"
         bin_dir = self.bin_dir()
 
         # Copy the script


### PR DESCRIPTION
@omsai as requested :smile: 

For the full explanation behind this see https://spackpm.slack.com/archives/C08Q62S7XEX/p1775163670742649.

In brief it seems that some weird staging of the compiler wrapper keeps the `cc.sh` script from being updated when patched locally.