### PR TITLE
py-libclang: add shared object file

### DIFF
--- a/repos/spack_repo/builtin/packages/py_libclang/package.py
+++ b/repos/spack_repo/builtin/packages/py_libclang/package.py
@@ -35,7 +35,10 @@ class PyLibclang(PythonPackage):
     depends_on("py-setuptools", type="build")
 
     for ver in ["9", "10", "11", "13", "14", "15", "16", "17", "18"]:
-        depends_on("llvm+clang@" + ver, when="@" + ver, type="build")
+        depends_on("llvm+clang@" + ver, when="@" + ver, type=("build", "run", "link"))
+
+    def setup_run_environment(self, env):
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["llvm"].libs.directories[0])
 
     def patch(self):
         if self.version >= Version("14"):


### PR DESCRIPTION
Updated dependencies for llvm+clang to include run and link types. Added setup_run_environment method to configure the library path. This failed to provide the `libclang.so` file needed by other packages unless these changes were added.

Error without this fix when attempting to install another package:

```py
>   OSError: libclang.so: cannot open shared object file: No such file or directory
```