### PR TITLE
fzf: fix FZF_VERSION assignment to use string method

### DIFF
--- a/repos/spack_repo/builtin/packages/fzf/package.py
+++ b/repos/spack_repo/builtin/packages/fzf/package.py
@@ -78,7 +78,7 @@ class Fzf(GoPackage):
         super().setup_build_environment(env)
 
         # Set required environment variables for non-git builds
-        env.set("FZF_VERSION", self.spec.version)
+        env.set("FZF_VERSION", self.spec.version.string)
         env.set("FZF_REVISION", "tarball")
 
     @run_after("install")


### PR DESCRIPTION
```
==> Warning: /capstor/store/cscs/cscs/csstaff/rmeli/spack-packages/repos/spack_repo/builtin/packages/fzf/package.py:81: when setting environment variable FZF_VERSION=0.67.0: value is of type `StandardVersion`, but `str` was expected. This is deprecated and will be an error in Spack v1.0
```