### PR TITLE
plumed: remove libtorch_python

### DIFF
--- a/repos/spack_repo/builtin/packages/plumed/package.py
+++ b/repos/spack_repo/builtin/packages/plumed/package.py
@@ -296,17 +296,18 @@ class Plumed(AutotoolsPackage):
         # Set flags to help with PyTorch
         if enable_libtorch:
             pytorch_path = Path(spec["py-torch"].package.cmake_prefix_paths[0]).parent.parent
+
             extra_ldflags.append(spec["py-torch"].libs.search_flags)
-            extra_libs.append(spec["py-torch"].libs.link_flags)
-            extra_ldflags.append(spec["python"].libs.search_flags)
-            extra_libs.append(spec["python"].libs.link_flags)
+
+            # Do not link libtorch_python
+            extra_libs.append(spec["py-torch"].libs.link_flags.replace("-ltorch_python ", ""))
+
             # Add include paths manually
             # Spack HeaderList.cpp_flags does not support include paths within include paths
             extra_cppflags.extend(
                 [
                     f"-I{pytorch_path / 'include'}",
                     f"-I{pytorch_path / 'include' / 'torch' / 'csrc' / 'api' / 'include'}",
-                    spec["python"].headers.include_flags,
                 ]
             )
         if enable_libmetatomic:

--- a/repos/spack_repo/builtin/packages/plumed/package.py
+++ b/repos/spack_repo/builtin/packages/plumed/package.py
@@ -303,7 +303,8 @@ class Plumed(AutotoolsPackage):
             # Here we manually remove the torch_python library to avoid linking against it
             # Linking against torch_python requires linking against Python as well,
             # which is not needed and can cause issues with some workflows
-            # (e.g. GIL-related when mixing Spack installed-PLUMED with external Python installations)
+            # (e.g. GIL-related when mixing Spack installed-PLUMED with external Python
+            # installations)
             extra_libs.append(spec["py-torch"].libs.link_flags.replace("-ltorch_python ", ""))
 
             # Add include paths manually

--- a/repos/spack_repo/builtin/packages/plumed/package.py
+++ b/repos/spack_repo/builtin/packages/plumed/package.py
@@ -299,7 +299,11 @@ class Plumed(AutotoolsPackage):
 
             extra_ldflags.append(spec["py-torch"].libs.search_flags)
 
-            # Do not link libtorch_python
+            # PLUMED only needs libtorch (PyTorch C++ API)
+            # Here we manually remove the torch_python library to avoid linking against it
+            # Linking against torch_python requires linking against Python as well,
+            # which is not needed and can cause issues with some workflows
+            # (e.g. GIL-related when mixing Spack installed-PLUMED with external Python installations)
             extra_libs.append(spec["py-torch"].libs.link_flags.replace("-ltorch_python ", ""))
 
             # Add include paths manually


### PR DESCRIPTION
Remove `libtorch_python` from PLUMED. This is a bit of a hack, so I'm not convinced it is good idea.