### PR TITLE
Update script for CI style check to point at merge base

### DIFF
--- a/.ci/style_check.sh
+++ b/.ci/style_check.sh
@@ -22,6 +22,10 @@ while [ $# -gt 0 ]; do
   esac
   shift
 done
+
+# Ref should always be the merge-base to avoid picking up extra files
+ref=$(git merge-base $ref HEAD)
+
 if ! python_files > /dev/null; then
   info "skipping style checks: no Python files changed"
   exit 0


### PR DESCRIPTION
In order to limit style to only the changes made in the PR, point at the merge base between the PR HEAD and the target ref.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
