### PR TITLE
py-tensorflow: unvendor protobuf [WIP]

### DIFF
--- a/repos/spack_repo/builtin/packages/py_tensorflow/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow/package.py
@@ -548,6 +548,13 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         when="@2.16.1-rocm-enhanced +rocm",
     )
     patch("set_jit_true.patch", when="@2.18.0-rocm-enhanced: +rocm")
+
+    # Add missing targets to the system protobuf BUILD file so that TF can use
+    # the system protobuf instead of the vendored one (TF issue #60667).
+    # Guarded to @2.18:2.19 because the BUILD file structure was only analysed
+    # for those versions; other versions may require different fixes.
+    patch("system-protobuf-well-known-types.patch", when="@2.18:2.19")
+
     phases = ["configure", "build", "install"]
 
     def flag_handler(self, name, flags):
@@ -570,8 +577,9 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         spec = self.spec
 
-        # Avoid vendoring protobuf
-        env.set("TF_SYSTEM_LIBS", "com_google_protobuf")
+        # Avoid vendoring protobuf; only tested/analysed for @2.18:2.19
+        if spec.satisfies("@2.18:2.19"):
+            env.set("TF_SYSTEM_LIBS", "com_google_protobuf")
 
         # Please specify the location of python
         env.set("PYTHON_BIN_PATH", python.path)
@@ -918,6 +926,16 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
 
         filter_file("build:opt --copt=-march=native", "", ".tf_configure.bazelrc")
         filter_file("build:opt --host_copt=-march=native", "", ".tf_configure.bazelrc")
+
+        # Provide the system protobuf include path for the link_proto_files genrule
+        # in third_party/systemlibs/protobuf.BUILD (used when TF_SYSTEM_LIBS includes
+        # com_google_protobuf). The genrule uses $(PROTOBUF_INCLUDE_PATH) as a Bazel
+        # make-variable set via --define.
+        if spec.satisfies("@2.18:2.19"):
+            with open(".tf_configure.bazelrc", mode="a") as f:
+                f.write(
+                    f"build --define=PROTOBUF_INCLUDE_PATH={spec['protobuf'].prefix.include}\n"
+                )
 
     def build(self, spec, prefix):
         # Bazel needs the directory to exist on install

--- a/repos/spack_repo/builtin/packages/py_tensorflow/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow/package.py
@@ -570,6 +570,9 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         spec = self.spec
 
+        # Avoid vendoring protobuf
+        env.set("TF_SYSTEM_LIBS", "com_google_protobuf")
+
         # Please specify the location of python
         env.set("PYTHON_BIN_PATH", python.path)
 

--- a/repos/spack_repo/builtin/packages/py_tensorflow/system-protobuf-well-known-types.patch
+++ b/repos/spack_repo/builtin/packages/py_tensorflow/system-protobuf-well-known-types.patch
@@ -1,0 +1,37 @@
+diff --git a/third_party/systemlibs/protobuf.BUILD b/third_party/systemlibs/protobuf.BUILD
+--- a/third_party/systemlibs/protobuf.BUILD
++++ b/third_party/systemlibs/protobuf.BUILD
+@@ -108,6 +108,30 @@
+ [proto_library(
+     name = proto[0] + "_proto",
+     srcs = [proto[1][0]],
+     visibility = ["//visibility:public"],
+     deps = [dep + "_proto" for dep in proto[1][1]],
+ ) for proto in WELL_KNOWN_PROTO_MAP.items()]
++
++cc_library(
++    name = "protobuf_lite",
++    linkopts = ["-lprotobuf-lite"],
++    visibility = ["//visibility:public"],
++)
++
++filegroup(
++    name = "well_known_protos",
++    srcs = [":link_proto_files"],
++    visibility = ["//visibility:public"],
++)
++
++cc_library(
++    name = "proto_api",
++    linkopts = ["-lprotobuf"],
++    visibility = ["//visibility:public"],
++)
++
++py_proto_library(
++    name = "well_known_types_py_pb2",
++    srcs = RELATIVE_WELL_KNOWN_PROTOS,
++    include = ".",
++    default_runtime = ":protobuf_python",
++    protoc = ":protoc",
++    visibility = ["//visibility:public"],
++)


### PR DESCRIPTION
This PR aims to unvendor protobuf from py-tensorflow. The mismatch between the vendored version and the dependency leads to issue, both explicitly failing version checks and implicitly in ABI mismatches.

This is a WIP branch for testing in CI and picking up in our container builds.