### PR TITLE
fann: add git attribute and master version

### DIFF
--- a/repos/spack_repo/builtin/packages/fann/package.py
+++ b/repos/spack_repo/builtin/packages/fann/package.py
@@ -23,10 +23,12 @@ class Fann(CMakePackage):
 
     homepage = "https://leenissen.dk/fann/wp/"
     url = "https://github.com/libfann/fann/archive/2.2.0.tar.gz"
+    git = "https://github.com/libfann/fann.git"
 
-    license("LGPL-2.0-or-later")
+    license("LGPL-2.0-or-later", checked_by="wdconinc")
 
+    version("master", branch="master")
     version("2.2.0", sha256="f31c92c1589996f97d855939b37293478ac03d24b4e1c08ff21e0bd093449c3c")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")


### PR DESCRIPTION
This PR adds to `fann` the git attribute and a master version. No changes to dependencies since the last released version ([diff](https://github.com/libfann/fann/compare/2.2.0...master)).
