### PR TITLE
btop: add v1.4.7, fix `+gpu` build

### DIFF
--- a/repos/spack_repo/builtin/packages/btop/gnu-source.patch
+++ b/repos/spack_repo/builtin/packages/btop/gnu-source.patch
@@ -1,0 +1,13 @@
+--- a/src/linux/intel_gpu_top/intel_gpu_top.c
++++ b/src/linux/intel_gpu_top/intel_gpu_top.c
+@@ -23,6 +23,10 @@
+  * DEALINGS IN THE SOFTWARE.
+  */
+
++#ifndef _GNU_SOURCE
++#define _GNU_SOURCE
++#endif
++
+ #include <assert.h>
+ #include <ctype.h>
+ #include <dirent.h>

--- a/repos/spack_repo/builtin/packages/btop/package.py
+++ b/repos/spack_repo/builtin/packages/btop/package.py
@@ -20,13 +20,15 @@ class Btop(MakefilePackage, CMakePackage):
 
     license("Apache-2.0")
 
+    version("1.4.7", sha256="933de2e4d1b2211a638be463eb6e8616891bfba73aef5d38060bd8319baeefc6")
     version("1.4.6", sha256="4beb90172c6acaac08c1b4a5112fb616772e214a7ef992bcbd461453295a58be")
-    version("1.4.4", sha256="98d464041015c888c7b48de14ece5ebc6e410bc00ca7bb7c5a8010fe781f1dd8")
-    version("1.4.3", sha256="81b133e59699a7fd89c5c54806e16452232f6452be9c14b3a634122e3ebed592")
-    version("1.4.0", sha256="ac0d2371bf69d5136de7e9470c6fb286cbee2e16b4c7a6d2cd48a14796e86650")
-    version("1.3.2", sha256="331d18488b1dc7f06cfa12cff909230816a24c57790ba3e8224b117e3f0ae03e")
-    version("1.3.0", sha256="375e078ce2091969f0cd14030620bd1a94987451cf7a73859127a786006a32cf")
-    version("1.2.13", sha256="668dc4782432564c35ad0d32748f972248cc5c5448c9009faeb3445282920e02")
+    with default_args(deprecated=True):
+        version("1.4.4", sha256="98d464041015c888c7b48de14ece5ebc6e410bc00ca7bb7c5a8010fe781f1dd8")
+        version("1.4.3", sha256="81b133e59699a7fd89c5c54806e16452232f6452be9c14b3a634122e3ebed592")
+        version("1.4.0", sha256="ac0d2371bf69d5136de7e9470c6fb286cbee2e16b4c7a6d2cd48a14796e86650")
+        version("1.3.2", sha256="331d18488b1dc7f06cfa12cff909230816a24c57790ba3e8224b117e3f0ae03e")
+        version("1.3.0", sha256="375e078ce2091969f0cd14030620bd1a94987451cf7a73859127a786006a32cf")
+        version("1.2.13", sha256="668dc4782432564c35ad0d32748f972248cc5c5448c9009faeb3445282920e02")
 
     build_system("makefile", conditional("cmake", when="@1.3.0:"), default="cmake")
 
@@ -36,13 +38,16 @@ class Btop(MakefilePackage, CMakePackage):
     depends_on("cxx", type="build")
 
     depends_on("cmake@3.24:", type="build", when="@1.3.0: build_system=cmake")
-    depends_on("cmake@3.25:", type="build", when="@v1.4.1: build_system=cmake")
+    depends_on("cmake@3.25:", type="build", when="@1.4.1: build_system=cmake")
     depends_on("googletest@1.17:", type="test", when="@1.4.6: build_system=cmake")
 
     # Fix linking GPU support, by adding an explicit "target_link_libraries" to ${CMAKE_DL_LIBS}
     patch("link-dl.patch", when="+gpu @:1.4.0")
+    # gcc does not define _GNU_SOURCE by default, making asprintf undeclared in the bundled
+    # intel_gpu_top C code. See https://github.com/aristocratos/btop/issues/1565
+    patch("gnu-source.patch", when="+gpu @1.3.0:")
 
-    requires("%gcc@10:", "%clang@16:", policy="one_of", msg="C++ 20 is required")
+    requires("%gcc@11:", "%clang@16:", policy="one_of", msg="C++ 20 is required")
     requires("%gcc@14:", "%clang@19:", policy="one_of", msg="C++ 23 is required", when="@1.4.6:")
 
 

--- a/repos/spack_repo/builtin/packages/btop/package.py
+++ b/repos/spack_repo/builtin/packages/btop/package.py
@@ -28,7 +28,9 @@ class Btop(MakefilePackage, CMakePackage):
         version("1.4.0", sha256="ac0d2371bf69d5136de7e9470c6fb286cbee2e16b4c7a6d2cd48a14796e86650")
         version("1.3.2", sha256="331d18488b1dc7f06cfa12cff909230816a24c57790ba3e8224b117e3f0ae03e")
         version("1.3.0", sha256="375e078ce2091969f0cd14030620bd1a94987451cf7a73859127a786006a32cf")
-        version("1.2.13", sha256="668dc4782432564c35ad0d32748f972248cc5c5448c9009faeb3445282920e02")
+        version(
+            "1.2.13", sha256="668dc4782432564c35ad0d32748f972248cc5c5448c9009faeb3445282920e02"
+        )
 
     build_system("makefile", conditional("cmake", when="@1.3.0:"), default="cmake")
 


### PR DESCRIPTION
Modifications:
- Add v1.4.7 and deprecate old versions
- Add a patch to define _GNU_SOURCE for the bundled `intel_gpu_top` C code. See https://github.com/aristocratos/btop/issues/1565
- Bump minimum version of required GCC (`<semaphore>` was added in GCC 11)

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
