### PR TITLE
bracken: fix installation

### DIFF
--- a/repos/spack_repo/builtin/packages/bracken/package.py
+++ b/repos/spack_repo/builtin/packages/bracken/package.py
@@ -23,28 +23,46 @@ class Bracken(Package):
     version("2.8", sha256="b0c8a803cc020b7d1cbca47b53e71e874d9688b836911e4a4b71b0e4b826b61a")
     version("2.7", sha256="1795ecd9f9e5582f37549795ba68854780936110a2f6f285c3e626d448cd1532")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
 
     depends_on("python", type="run")
     depends_on("kraken2", type="run")
 
     def install(self, spec, prefix):
-        mkdirp(prefix.bin.src)
-        # installer builds kmer2read_distr in src
+        # Avoid parallel build issues
+        env.pop("MAKEFLAGS", None)
+
+        # Create install directories
+        mkdirp(prefix.bin)
+        mkdirp(join_path(prefix.bin, "src"))
+
+        # Ensure installer is executable
         chmod = which("chmod", required=True)
-        chmod("+x", "./install_bracken.sh")
+        chmod("+x", "install_bracken.sh")
+
+        # Run installer to build kmer2read_distr
         installer = Executable("./install_bracken.sh")
-        installer(self.stage.source_path)
-        # move main scripts to bin
+        installer()
+
+        # Install primary executables
         install("bracken", prefix.bin)
         install("bracken-build", prefix.bin)
+
+        # Install compiled helper binary
         install("./src/kmer2read_distr", prefix.bin)
+
+        # Install analysis helper script
         install("./analysis_scripts/combine_bracken_outputs.py", prefix.bin)
+
         chmod("+x", join_path(prefix.bin, "combine_bracken_outputs.py"))
-        # move scripts to src and create symlinks
-        files = ("est_abundance.py", "generate_kmer_distribution.py")
-        for file in files:
-            filepath = join_path("./src", file)
-            if os.path.isfile(filepath):
-                install(filepath, prefix.bin.src)
-                symlink(join_path(prefix.bin.src, file), join_path(prefix.bin, file))
+
+        # Install Python helper scripts into bin/src
+        helper_scripts = ("est_abundance.py", "generate_kmer_distribution.py")
+
+        for script in helper_scripts:
+            src_path = join_path("src", script)
+
+            if os.path.isfile(src_path):
+                install(src_path, join_path(prefix.bin, "src"))
+
+                symlink(join_path(prefix.bin, "src", script), join_path(prefix.bin, script))

--- a/repos/spack_repo/builtin/packages/bracken/package.py
+++ b/repos/spack_repo/builtin/packages/bracken/package.py
@@ -29,7 +29,7 @@ class Bracken(Package):
     depends_on("kraken2", type="run")
 
     parallel = False
-    
+
     def install(self, spec, prefix):
         # Create install directories
         mkdirp(prefix.bin)

--- a/repos/spack_repo/builtin/packages/bracken/package.py
+++ b/repos/spack_repo/builtin/packages/bracken/package.py
@@ -28,10 +28,9 @@ class Bracken(Package):
     depends_on("python", type="run")
     depends_on("kraken2", type="run")
 
+    parallel = False
+    
     def install(self, spec, prefix):
-        # Avoid parallel build issues
-        env.pop("MAKEFLAGS", None)
-
         # Create install directories
         mkdirp(prefix.bin)
         mkdirp(join_path(prefix.bin, "src"))
@@ -42,7 +41,7 @@ class Bracken(Package):
 
         # Run installer to build kmer2read_distr
         installer = Executable("./install_bracken.sh")
-        installer()
+        installer(self.stage.source_path)
 
         # Install primary executables
         install("bracken", prefix.bin)


### PR DESCRIPTION
Without this fix, I was getting the following error when attempting to install bracken:

```bash
==> No patches needed for bracken    
==> bracken: Executing phase: 'install'
==> [2026-05-14-11:01:09.210554] /usr/bin/chmod +x ./install_bracken.sh
==> [2026-05-14-11:01:09.212286] ./install_bracken.sh /dev/shm/spack.vfk4083/stage/spack-stage-bracken-2.9-4nvwbrobkznzjzgqw7o7qwjd6uqip6mb/spack-src
make: *** internal error: invalid --jobserver-auth string 'fifo:/tmp/tmpgwct33q6/jobserver_fifo'.  Stop.
Traceback (most recent call last):                  
  File "/home/vfk4083/spackng/spack/lib/spack/spack/new_installer.py", line 542, in worker_function
    _install(                           
  File "/home/vfk4083/spackng/spack/lib/spack/spack/new_installer.py", line 772, in _install
    phase.execute()
  File "/home/vfk4083/spackng/spack/lib/spack/spack/builder.py", line 382, in execute
    self.phase_fn(pkg, pkg.spec, pkg.prefix)
  File "/home/vfk4083/spackng/spack/lib/spack/spack/builder.py", line 254, in _adapter
    return phase_fn(spec, prefix)                                                                                                                            
  File "/home/vfk4083/spackng/spack-packages/repos/spack_repo/builtin/packages/bracken/package.py", line 37, in install
    installer(self.stage.source_path)
  File "/home/vfk4083/spackng/spack/lib/spack/spack/util/executable.py", line 322, in __call__
    raise ProcessError(f"Command exited with status {proc.returncode}:", long_msg)
spack.util.executable.ProcessError: Command exited with status 2:
    ./install_bracken.sh /dev/shm/spack.vfk4083/stage/spack-stage-bracken-2.9-4nvwbrobkznzjzgqw7o7qwjd6uqip6mb/spack-src
```


I figured I should try clearing the `MAKEFLAGS` before installing and that did seem to fix it 