### PR TITLE
pin camp sha for RAJA develop

### DIFF
--- a/repos/spack_repo/builtin/packages/raja/package.py
+++ b/repos/spack_repo/builtin/packages/raja/package.py
@@ -281,6 +281,7 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("camp+openmp", when="+openmp")
     depends_on("camp+omptarget", when="+omptarget")
     depends_on("camp+sycl", when="+sycl")
+    # TODO(johnbowen42): Remove the following line after the June 2026 RAJA suite release
     depends_on("camp@main commit=e75ab64c029aa27c80593715cb2a3ccad7453c8c", when="@develop")
     depends_on("camp@2025.12:", when="@2025.12:")
     depends_on("camp@2025.09", when="@2025.09")

--- a/repos/spack_repo/builtin/packages/raja/package.py
+++ b/repos/spack_repo/builtin/packages/raja/package.py
@@ -281,6 +281,7 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("camp+openmp", when="+openmp")
     depends_on("camp+omptarget", when="+omptarget")
     depends_on("camp+sycl", when="+sycl")
+    depends_on("camp@main commit=e75ab64c029aa27c80593715cb2a3ccad7453c8c", when="@develop")
     depends_on("camp@2025.12:", when="@2025.12:")
     depends_on("camp@2025.09", when="@2025.09")
     depends_on("camp@2025.03", when="@2025.03")


### PR DESCRIPTION
RAJA and camp are moving to C++20, and we need to update the version of camp uses in CI for RAJA develop to proceed porting RAJA to C++20