### PR TITLE
axom: run install tests when +example

### DIFF
--- a/repos/spack_repo/builtin/packages/axom/package.py
+++ b/repos/spack_repo/builtin/packages/axom/package.py
@@ -854,7 +854,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
     @on_package_attributes(run_tests=True)
     def test_install_using_make(self):
         if self.spec.satisfies("~examples"):
-            return        
+            return
         """build example with make and run"""
         example_src_dir = join_path(self.prefix.examples.axom, "using-with-make")
         example_stage_dir = "./make"

--- a/repos/spack_repo/builtin/packages/axom/package.py
+++ b/repos/spack_repo/builtin/packages/axom/package.py
@@ -835,6 +835,8 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
     @run_after("install")
     @on_package_attributes(run_tests=True)
     def test_install_using_cmake(self):
+        if self.spec.satisfies("~examples"):
+            return
         """build example with cmake and run"""
         example_src_dir = join_path(self.prefix.examples.axom, "using-with-cmake")
         example_stage_dir = "./cmake"
@@ -851,6 +853,8 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
     @run_after("install")
     @on_package_attributes(run_tests=True)
     def test_install_using_make(self):
+        if self.spec.satisfies("~examples"):
+            return        
         """build example with make and run"""
         example_src_dir = join_path(self.prefix.examples.axom, "using-with-make")
         example_stage_dir = "./make"

--- a/repos/spack_repo/builtin/packages/axom/package.py
+++ b/repos/spack_repo/builtin/packages/axom/package.py
@@ -832,11 +832,9 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
             print("Running Axom Unit Tests...")
             make("test")
 
-    @run_after("install")
+    @run_after("install", when="+examples")
     @on_package_attributes(run_tests=True)
     def test_install_using_cmake(self):
-        if self.spec.satisfies("~examples"):
-            return
         """build example with cmake and run"""
         example_src_dir = join_path(self.prefix.examples.axom, "using-with-cmake")
         example_stage_dir = "./cmake"
@@ -850,11 +848,9 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
             example()
             make("clean")
 
-    @run_after("install")
+    @run_after("install", when="+examples")
     @on_package_attributes(run_tests=True)
     def test_install_using_make(self):
-        if self.spec.satisfies("~examples"):
-            return
         """build example with make and run"""
         example_src_dir = join_path(self.prefix.examples.axom, "using-with-make")
         example_stage_dir = "./make"


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Install tests try to run even if ~examples is specified. The tests then fail because the examples have not been installed.
Modified the testInstall functions to exit if ~examples is specified.