### PR TITLE
e4s ci: update external rocm stack to use rocm 7.2.3

### DIFF
--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -338,7 +338,7 @@ e4s-neoverse-v2-build:
 
 e4s-rocm-external-generate:
   extends: [ ".e4s-rocm-external", ".generate-x86_64"]
-  image: ghcr.io/spack/e4s-rocm-base-x86_64:v7.2.0-1772831027
+  image: ghcr.io/spack/e4s-rocm-base-x86_64:v7.2.3-1778518886
 
 e4s-rocm-external-build:
   extends: [ ".e4s-rocm-external", ".build" ]

--- a/stacks/e4s-rocm-external/spack.yaml
+++ b/stacks/e4s-rocm-external/spack.yaml
@@ -36,7 +36,7 @@ spack:
     llvm-amdgpu:
       buildable: false
       externals:
-      - spec: llvm-amdgpu@7.2.0
+      - spec: llvm-amdgpu@7.2.3
         prefix: /opt/rocm/lib/llvm
         extra_attributes:
           compilers:
@@ -56,179 +56,179 @@ spack:
     amdsmi:
       buildable: false
       externals:
-      - spec: amdsmi@7.2.0
-        prefix: /opt/rocm-7.2.0/
+      - spec: amdsmi@7.2.3
+        prefix: /opt/rocm-7.2.3/
     comgr:
       buildable: false
       externals:
-      - spec: comgr@7.2.0
-        prefix: /opt/rocm-7.2.0/
+      - spec: comgr@7.2.3
+        prefix: /opt/rocm-7.2.3/
     hipblas:
       buildable: false
       externals:
-      - spec: hipblas@7.2.0
-        prefix: /opt/rocm-7.2.0/
+      - spec: hipblas@7.2.3
+        prefix: /opt/rocm-7.2.3/
     hipcub:
       buildable: false
       externals:
-      - spec: hipcub@7.2.0
-        prefix: /opt/rocm-7.2.0/
+      - spec: hipcub@7.2.3
+        prefix: /opt/rocm-7.2.3/
     hipfft:
       buildable: false
       externals:
-      - spec: hipfft@7.2.0
-        prefix: /opt/rocm-7.2.0/
+      - spec: hipfft@7.2.3
+        prefix: /opt/rocm-7.2.3/
     hiprand:
       buildable: false
       externals:
-      - spec: hiprand@7.2.0
-        prefix: /opt/rocm-7.2.0/
+      - spec: hiprand@7.2.3
+        prefix: /opt/rocm-7.2.3/
     hipsparse:
       buildable: false
       externals:
-      - spec: hipsparse@7.2.0
-        prefix: /opt/rocm-7.2.0/
+      - spec: hipsparse@7.2.3
+        prefix: /opt/rocm-7.2.3/
     miopen-hip:
       buildable: false
       externals:
-      - spec: miopen-hip@7.2.0
-        prefix: /opt/rocm-7.2.0/
+      - spec: miopen-hip@7.2.3
+        prefix: /opt/rocm-7.2.3/
     rccl:
       buildable: false
       externals:
-      - spec: rccl@7.2.0
-        prefix: /opt/rocm-7.2.0/
+      - spec: rccl@7.2.3
+        prefix: /opt/rocm-7.2.3/
     rocblas:
       buildable: false
       externals:
-      - spec: rocblas@7.2.0
-        prefix: /opt/rocm-7.2.0/
+      - spec: rocblas@7.2.3
+        prefix: /opt/rocm-7.2.3/
     rocfft:
       buildable: false
       externals:
-      - spec: rocfft@7.2.0
-        prefix: /opt/rocm-7.2.0/
+      - spec: rocfft@7.2.3
+        prefix: /opt/rocm-7.2.3/
     rocm-cmake:
       buildable: false
       externals:
-      - spec: rocm-cmake@7.2.0
-        prefix: /opt/rocm-7.2.0/
+      - spec: rocm-cmake@7.2.3
+        prefix: /opt/rocm-7.2.3/
     rocm-dbgapi:
       buildable: false
       externals:
-      - spec: rocm-dbgapi@7.2.0
-        prefix: /opt/rocm-7.2.0/
+      - spec: rocm-dbgapi@7.2.3
+        prefix: /opt/rocm-7.2.3/
     rocm-debug-agent:
       buildable: false
       externals:
-      - spec: rocm-debug-agent@7.2.0
-        prefix: /opt/rocm-7.2.0/
+      - spec: rocm-debug-agent@7.2.3
+        prefix: /opt/rocm-7.2.3/
     rocm-device-libs:
       buildable: false
       externals:
-      - spec: rocm-device-libs@7.2.0
-        prefix: /opt/rocm-7.2.0/
+      - spec: rocm-device-libs@7.2.3
+        prefix: /opt/rocm-7.2.3/
     rocm-gdb:
       buildable: false
       externals:
-      - spec: rocm-gdb@7.2.0
-        prefix: /opt/rocm-7.2.0/
+      - spec: rocm-gdb@7.2.3
+        prefix: /opt/rocm-7.2.3/
     rocm-opencl:
       buildable: false
       externals:
-      - spec: rocm-opencl@7.2.0
-        prefix: /opt/rocm-7.2.0/opencl
+      - spec: rocm-opencl@7.2.3
+        prefix: /opt/rocm-7.2.3/opencl
     rocm-smi-lib:
       buildable: false
       externals:
-      - spec: rocm-smi-lib@7.2.0
-        prefix: /opt/rocm-7.2.0/
+      - spec: rocm-smi-lib@7.2.3
+        prefix: /opt/rocm-7.2.3/
     rocprofiler-systems:
       buildable: false
       externals:
-      - spec: rocprofiler-systems@7.2.0
-        prefix: /opt/rocm-7.2.0/
+      - spec: rocprofiler-systems@7.2.3
+        prefix: /opt/rocm-7.2.3/
     hip:
       buildable: false
-      require: ["@7.2.0"]
+      require: ["@7.2.3"]
       externals:
-      - spec: hip@7.2.0 %gcc@13.3.0
-        prefix: /opt/rocm-7.2.0
+      - spec: hip@7.2.3 %gcc@13.3.0
+        prefix: /opt/rocm-7.2.3
     hipify-clang:
       buildable: false
       externals:
-      - spec: hipify-clang@7.2.0
-        prefix: /opt/rocm-7.2.0
+      - spec: hipify-clang@7.2.3
+        prefix: /opt/rocm-7.2.3
     hsa-amd-aqlprofile:
       buildable: false
       externals:
-      - spec: hsa-amd-aqlprofile@7.2.0
-        prefix: /opt/rocm-7.2.0/
+      - spec: hsa-amd-aqlprofile@7.2.3
+        prefix: /opt/rocm-7.2.3/
     hsa-rocr-dev:
       buildable: false
       externals:
-      - spec: hsa-rocr-dev@7.2.0
-        prefix: /opt/rocm-7.2.0/
+      - spec: hsa-rocr-dev@7.2.3
+        prefix: /opt/rocm-7.2.3/
     roctracer-dev-api:
       buildable: false
       externals:
-      - spec: roctracer-dev-api@7.2.0
-        prefix: /opt/rocm-7.2.0
+      - spec: roctracer-dev-api@7.2.3
+        prefix: /opt/rocm-7.2.3
     roctracer-dev:
       buildable: false
       externals:
-      - spec: roctracer-dev@7.2.0
-        prefix: /opt/rocm-7.2.0
+      - spec: roctracer-dev@7.2.3
+        prefix: /opt/rocm-7.2.3
     rocprim:
       buildable: false
       externals:
-      - spec: rocprim@7.2.0
-        prefix: /opt/rocm-7.2.0
+      - spec: rocprim@7.2.3
+        prefix: /opt/rocm-7.2.3
     rocrand:
       buildable: false
       externals:
-      - spec: rocrand@7.2.0
-        prefix: /opt/rocm-7.2.0
+      - spec: rocrand@7.2.3
+        prefix: /opt/rocm-7.2.3
     hipsolver:
       buildable: false
       externals:
-      - spec: hipsolver@7.2.0
-        prefix: /opt/rocm-7.2.0
+      - spec: hipsolver@7.2.3
+        prefix: /opt/rocm-7.2.3
     rocsolver:
       buildable: false
       externals:
-      - spec: rocsolver@7.2.0
-        prefix: /opt/rocm-7.2.0
+      - spec: rocsolver@7.2.3
+        prefix: /opt/rocm-7.2.3
     rocsparse:
       buildable: false
       externals:
-      - spec: rocsparse@7.2.0
-        prefix: /opt/rocm-7.2.0
+      - spec: rocsparse@7.2.3
+        prefix: /opt/rocm-7.2.3
     rocthrust:
       buildable: false
       externals:
-      - spec: rocthrust@7.2.0
-        prefix: /opt/rocm-7.2.0
+      - spec: rocthrust@7.2.3
+        prefix: /opt/rocm-7.2.3
     rocprofiler-dev:
       buildable: false
       externals:
-      - spec: rocprofiler-dev@7.2.0
-        prefix: /opt/rocm-7.2.0
+      - spec: rocprofiler-dev@7.2.3
+        prefix: /opt/rocm-7.2.3
     rocprofiler-sdk:
       buildable: false
       externals:
-      - spec: rocprofiler-sdk@7.2.0
-        prefix: /opt/rocm-7.2.0
+      - spec: rocprofiler-sdk@7.2.3
+        prefix: /opt/rocm-7.2.3
     rocm-core:
       buildable: false
       externals:
-      - spec: rocm-core@7.2.0
-        prefix: /opt/rocm-7.2.0
+      - spec: rocm-core@7.2.3
+        prefix: /opt/rocm-7.2.3
     rocm-openmp-extras:
       buildable: false
       externals:
-      - spec: rocm-openmp-extras@7.2.0
-        prefix: /opt/rocm-7.2.0
+      - spec: rocm-openmp-extras@7.2.3
+        prefix: /opt/rocm-7.2.3
 
   specs:
   # ROCM NOARCH
@@ -260,7 +260,7 @@ spack:
 
   # Errors
   # - chapel +rocm amdgpu_target=gfx90a           # rocm version constrained, 7.2 not allowed
-  # - cp2k +mpi +rocm amdgpu_target=gfx90a        # /opt/rocm-7.2.0/include/hip/hip_runtime_api.h:813:29: error: expected unqualified-id before numeric constant
+  # - cp2k +mpi +rocm amdgpu_target=gfx90a        # /opt/rocm-7.2.3/include/hip/hip_runtime_api.h:813:29: error: expected unqualified-id before numeric constant
   # - exago +mpi +python +raja +hiop +rocm amdgpu_target=gfx90a ~ipopt cxxflags="-Wno-error=non-pod-varargs" ^hiop@1.0.0 ~sparse +mpi +raja +rocm amdgpu_target=gfx90a # hiop-1.0.0: hiopVectorHip.hpp:68:10: fatal error: 'hipblas.h' file not found
   # - fftx +rocm amdgpu_target=gfx90a             # examples/rconv/testrconv.cpp:37:14: error: use of undeclared identifier 'strlen'
   # - ginkgo +rocm amdgpu_target=gfx90a           # rocm version constrained, 7.2 not allowed
@@ -276,7 +276,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: ghcr.io/spack/e4s-rocm-base-x86_64:v7.2.0-1772831027
+        image: ghcr.io/spack/e4s-rocm-base-x86_64:v7.2.3-1778518886
     broken-tests-packages:
     - paraview
 


### PR DESCRIPTION
E4S External ROCm CI Stack: Update to ROCm 7.2.3