### PR TITLE
Fix PETSc build against external ROCm

### DIFF
--- a/repos/spack_repo/builtin/packages/petsc/package.py
+++ b/repos/spack_repo/builtin/packages/petsc/package.py
@@ -398,11 +398,11 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     phases = ["configure", "build", "install"]
 
     def patch(self):
-    # ROCm 7.x with minor < 4 (e.g. 7.2) incorrectly falls through to the
-    # ROCm 6.0-6.3 branch due to a broken version comparison in HIP.py.
-    # The condition `version_tuple[0] >= 6 and version_tuple[1] >= 4` was
-    # intended to mean >= 6.4 but fails for 7.2 since 2 < 4.
-    # Fix: use tuple comparison so (7,2) >= (6,4) evaluates correctly.
+        # ROCm 7.x with minor < 4 (e.g. 7.2) incorrectly falls through to the
+        # ROCm 6.0-6.3 branch due to a broken version comparison in HIP.py.
+        # The condition `version_tuple[0] >= 6 and version_tuple[1] >= 4` was
+        # intended to mean >= 6.4 but fails for 7.2 since 2 < 4.
+        # Fix: use tuple comparison so (7,2) >= (6,4) evaluates correctly.
         if "+rocm" in self.spec:
             filter_file(
                 "if self.version_tuple[0] >= 6 and self.version_tuple[1] >= 4:",
@@ -651,7 +651,9 @@ class Petsc(Package, CudaPackage, ROCmPackage):
             for pkg in hip_lpkgs:
                 hip_lib += spec[pkg].libs.joined() + " "
             options.append("HIPPPFLAGS=%s -Wno-unused-command-line-argument" % hip_inc)
-            options.append("--with-hip-lib=%s -L%s -lamdhip64" % (hip_lib.strip(), spec["hip"].prefix.lib))
+            options.append(
+                "--with-hip-lib=%s -L%s -lamdhip64" % (hip_lib.strip(), spec["hip"].prefix.lib)
+            )
         else:
             options.append("--with-hipc=0")
 

--- a/repos/spack_repo/builtin/packages/petsc/package.py
+++ b/repos/spack_repo/builtin/packages/petsc/package.py
@@ -397,6 +397,20 @@ class Petsc(Package, CudaPackage, ROCmPackage):
 
     phases = ["configure", "build", "install"]
 
+    def patch(self):
+    # ROCm 7.x with minor < 4 (e.g. 7.2) incorrectly falls through to the
+    # ROCm 6.0-6.3 branch due to a broken version comparison in HIP.py.
+    # The condition `version_tuple[0] >= 6 and version_tuple[1] >= 4` was
+    # intended to mean >= 6.4 but fails for 7.2 since 2 < 4.
+    # Fix: use tuple comparison so (7,2) >= (6,4) evaluates correctly.
+        if "+rocm" in self.spec:
+            filter_file(
+                "if self.version_tuple[0] >= 6 and self.version_tuple[1] >= 4:",
+                "if (self.version_tuple[0], self.version_tuple[1]) >= (6, 4):",
+                "config/BuildSystem/config/packages/HIP.py",
+                string=True,
+            )
+
     # Using the following tarballs
     # * petsc-3.12 (and older) - includes docs
     # * petsc-lite-3.13, petsc-lite-3.14 (without docs)
@@ -636,8 +650,8 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                 hip_inc += spec[pkg].headers.include_flags + " "
             for pkg in hip_lpkgs:
                 hip_lib += spec[pkg].libs.joined() + " "
-            options.append("HIPPPFLAGS=%s" % hip_inc)
-            options.append("--with-hip-lib=%s -L%s -lamdhip64" % (hip_lib, spec["hip"].prefix.lib))
+            options.append("HIPPPFLAGS=%s -Wno-unused-command-line-argument" % hip_inc)
+            options.append("--with-hip-lib=%s -L%s -lamdhip64" % (hip_lib.strip(), spec["hip"].prefix.lib))
         else:
             options.append("--with-hipc=0")
 


### PR DESCRIPTION
Fixes ROCm version check with patch to HIP.py. Ignores benign warnings (printed to stderr) that were causing PETSc configure to fail despite successful tests. Strips potentially invalid empty string.

PETSc was failing to build against (external) ROCm 7.2.1 These changes fix it for me. The version check patch should probably go into PETSc proper. There may be a more correct way to handle the over-sensitivity to configure test errors but adding -Wno-unused-command-line-argument was the cleanest Spack-level fix I could find for the specific issue I was having.

```
spack find -dvl petsc
==> In environment /e4s/environments/x86_64/gnu/rocm/gfx90a
==> 2 root specs
-- no arch / no compilers ---------------------------------------
[+] 3r5qjzw petsc+rocm amdgpu_target=gfx90a

[+] iflfsmh slepc+rocm amdgpu_target=gfx90a
    [+] 3r5qjzw petsc+rocm amdgpu_target=gfx90a


-- linux-ubuntu24.04-x86_64_v3 / %c,cxx,fortran=gcc@13.3.0 ------
3r5qjzw petsc@3.25.1~X~batch~cgns~complex~cuda~debug+double+examples~exodusii~fftw+fortran+fortran-bindings~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~ml~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123+rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~sycl~tetgen~valgrind~zoltan amdgpu_target:=gfx90a build_system=generic clanguage=C memalign=none
gaqs4ab     compiler-wrapper@1.0 build_system=generic
jv7fosj     diffutils@3.12 build_system=autotools
ckvl7de         libiconv@1.18 build_system=autotools libs:=shared,static
mob5yjf     gcc@13.3.0+binutils+bootstrap~graphite+libsanitizer~mold~nvptx~piclibs~profiled~strip build_system=autotools build_type=RelWithDebInfo languages:='c,c++,fortran'
dwcz77v     gcc-runtime@13.3.0 build_system=generic
jj453jr     glibc@2.39 build_system=autotools
27tbysx     gmake@4.4.1~guile build_system=generic
kvl4hfk     hip@7.2.1~asan~cuda+rocm build_system=cmake build_type=Release generator=make
s4boz2i     hipblas@7.2.1~asan~cuda+rocm amdgpu_target:=auto build_system=cmake build_type=Release generator=make
pe2fdk3     hipblas-common@7.2.1~ipo build_system=cmake build_type=Release generator=make
k3pbdgj         cmake@3.31.11~doc+ncurses+ownlibs~qtgui build_system=generic build_type=Release
lnn2jzl             curl@8.18.0~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs:=shared,static tls:=openssl
f3ioizb                 nghttp2@1.67.1 build_system=autotools
g3gqygu                 openssl@3.6.1~docs+shared build_system=generic certs=mozilla
sghkyxj                     ca-certificates-mozilla@2026-03-19 build_system=generic
gixftjv                     perl@5.42.0+cpanm+opcode+open+shared+threads build_system=generic
halbeor                         berkeley-db@18.1.40+cxx~docs+stl build_system=autotools patches:=26090f4,b231fcc
fdeyzed                         bzip2@1.0.8~debug~pic+shared build_system=generic
ix4abkw                         gdbm@1.26 build_system=autotools
r67tgvx                             readline@8.3 build_system=autotools patches:=21f0a03
3a4iwvp                 pkgconf@2.5.1 build_system=autotools
4zop7nq             ncurses@6.6~symlinks+termlib abi=none build_system=autotools patches:=7a351bc
fp3yliw             zlib-ng@2.3.3+compat+new_strategies+opt+pic+shared build_system=autotools
gbdoshi     hipsolver@7.2.1~asan~cuda+rocm amdgpu_target:=auto build_system=cmake build_type=Release generator=make
kaaxvrc     hipsparse@7.2.1~asan~cuda+rocm amdgpu_target:=auto build_system=cmake build_type=Release generator=make
moqlq3t     hsa-rocr-dev@7.2.1~asan+image+shared build_system=cmake build_type=Release generator=make
hwfn5q2     llvm-amdgpu@7.2.1~link_llvm_dylib~llvm_dylib+rocm-device-libs build_system=cmake build_type=Release generator=ninja
2bzx5cg     mpich@4.3.2~argobots~cuda+fortran~hwloc+hydra~level_zero+libxml2+pci~rocm+romio~slurm~vci~verbs~wrapperrpath~xpmem build_system=autotools datatype-engine=auto device:=ch4 netmod:=ofi pmi=default
dkhrs2e     openblas@0.3.32~bignuma~consistent_fpcsr+dynamic_dispatch+fortran~ilp64+locking+pic+shared~static build_system=makefile symbol_suffix=none threads=openmp
bqfkrxx     python@3.12.12+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~static~tests~tkinter+uuid+zlib build_system=generic
xburyjb     rocblas@7.2.1~asan+hipblaslt+tensile amdgpu_target:=auto build_system=cmake build_type=Release generator=make
tc66gg4     rocm-core@7.2.1~asan build_system=cmake build_type=Release generator=make
hnas4r4     rocprim@7.2.1~asan amdgpu_target:=auto build_system=cmake build_type=Release generator=make
fs5scbl     rocrand@7.2.1~asan amdgpu_target:=auto build_system=cmake build_type=Release generator=make
we4e722     rocsolver@7.2.1~asan+optimal amdgpu_target:=auto build_system=cmake build_type=Release generator=make
zuhxza3     rocsparse@7.2.1~asan~test amdgpu_target:=auto build_system=cmake build_type=Release generator=make
vkw5ydi     rocthrust@7.2.1 amdgpu_target:=auto build_system=cmake build_type=Release generator=make
```

* **Spack:** 1.1.1 (https://github.com/spack/spack/commit/2e2169d5282d166f63e3ee4db8d4446c43cefa8a)
* **Builtin repo:** https://github.com/spack/spack-packages/commit/667b1e7ddfbdbe9e70bafd8326e998d90d2b917f
* **Python:** 3.12.12
* **Platform:** linux-ubuntu24.04-zen4

@eugeneswalker 
@balay

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
