### PR TITLE
rocm-cmake: fix missing rocm-core version dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/rocm_cmake/package.py
+++ b/repos/spack_repo/builtin/packages/rocm_cmake/package.py
@@ -73,6 +73,9 @@ class RocmCmake(CMakePackage):
         "7.0.2",
         "7.1.0",
         "7.1.1",
+        "7.2.0",
+        "7.2.1",
+        "7.2.3",
     ]:
         depends_on(f"rocm-core@{ver}", when=f"@{ver}")
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
