### PR TITLE
shamrock: use CMAKE_INSTALL_PYTHONDIR to install python bindings

### DIFF
--- a/repos/spack_repo/builtin/packages/shamrock/package.py
+++ b/repos/spack_repo/builtin/packages/shamrock/package.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import glob
-
 from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
 
 from spack.package import *
@@ -29,7 +27,7 @@ class Shamrock(CMakePackage):
     depends_on("cxx", type="build")
 
     variant("shared", default=True, description="Enables the build of shared libraries")
-    variant("testing", default=True, description="Enables the build of shared libraries")
+    variant("testing", default=True, description="Enables the build of tests")
     variant("pybindings", default=True, description="Install python bindings")
 
     generator("ninja")
@@ -74,33 +72,13 @@ class Shamrock(CMakePackage):
 
             args += [self.define("ACPP_PATH", self.spec["hipsycl"].prefix)]
 
-        return args
-
-    @run_after("install")
-    def install_python_bindigs(self):
-        """Copy the .so files to the python site-packages directory"""
-
-        spec = self.spec
-        libdir = spec.prefix.lib
-
         if self.spec.satisfies("+pybindings"):
-            # move shamrock python bindings into expected place
-            site_packages = join_path(python_platlib, "shamrock")
-            mkdirp(site_packages)
+            py_libdir = join_path(
+                self.prefix.lib, f"python{spec['python'].version.up_to(2)}", "site-packages"
+            )
+            args.append(self.define("CMAKE_INSTALL_PYTHONDIR", py_libdir))
 
-            # Find all .so files in the build directory
-            so_files = glob.glob(join_path(libdir, "*.so"))
-
-            # Install each .so file to the install directory
-            for _f in so_files:
-                install(_f, site_packages)
-
-            # Python need a __init__.py file to import properly the .so
-            raw_string = "from .shamrock import *\n"
-            filename = "__init__.py"
-            filepath = join_path(site_packages, filename)
-            with open(filepath, "w") as f:
-                f.write(raw_string)
+        return args
 
     def test_install(self):
         """Test the install (executable, python bindings)"""


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR replace the manual installation of the python bindings by one directly handled by Cmake. 
This should yield equivalent results. 
The way to perform the installation was done using the same snippet as ADIOS2 (repos/spack_repo/builtin/packages/adios2/package.py)