### PR TITLE
libssh2: add maintainer

### DIFF
--- a/repos/spack_repo/builtin/packages/libssh2/package.py
+++ b/repos/spack_repo/builtin/packages/libssh2/package.py
@@ -17,7 +17,11 @@ class Libssh2(AutotoolsPackage, CMakePackage):
 
     license("BSD-3-Clause")
 
+    maintainers("CodingYayaToure")
+
     version("1.11.1", sha256="d9ec76cbe34db98eec3539fe2c899d26b0c837cb3eb466a56b0f109cabf658f7")
+    version("1.11.0", sha256="3736161e41e2693324deb38c26cfdc3efe6209d634ba4258db1cecff6a5ad461")
+    version("1.10.0", sha256="2d64e90f3ded394b91d3a2e774ca203a4179f69aebee03003e5a6fa621e41d51")
 
     build_system("autotools", "cmake", default="autotools")
 

--- a/repos/spack_repo/builtin/packages/libssh2/package.py
+++ b/repos/spack_repo/builtin/packages/libssh2/package.py
@@ -20,8 +20,6 @@ class Libssh2(AutotoolsPackage, CMakePackage):
     maintainers("CodingYayaToure")
 
     version("1.11.1", sha256="d9ec76cbe34db98eec3539fe2c899d26b0c837cb3eb466a56b0f109cabf658f7")
-    version("1.11.0", sha256="3736161e41e2693324deb38c26cfdc3efe6209d634ba4258db1cecff6a5ad461")
-    version("1.10.0", sha256="2d64e90f3ded394b91d3a2e774ca203a4179f69aebee03003e5a6fa621e41d51")
 
     build_system("autotools", "cmake", default="autotools")
 


### PR DESCRIPTION
## What this PR does

- Adds `CodingYayaToure` as maintainer for `libssh2`

`libssh2` is a foundational HPC dependency (used by OpenMPI, curl, git)
with no declared maintainer. This PR takes ownership of the package.