### PR TITLE
libevent: add maintainer

### DIFF
--- a/repos/spack_repo/builtin/packages/libevent/package.py
+++ b/repos/spack_repo/builtin/packages/libevent/package.py
@@ -21,6 +21,8 @@ class Libevent(AutotoolsPackage):
 
     license("BSD-3-Clause")
 
+    maintainers("CodingYayaToure")
+
     version("2.1.12", sha256="92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb")
     version("2.1.11", sha256="a65bac6202ea8c5609fd5c7e480e6d25de467ea1917c08290c521752f147283d")
     version("2.1.10", sha256="e864af41a336bb11dab1a23f32993afe963c1f69618bd9292b89ecf6904845b0")


### PR DESCRIPTION
## What this PR does

- Adds `CodingYayaToure` as maintainer for `libevent`

`libevent` is a foundational HPC dependency (used by OpenMPI, tmux, memcached)
with no declared maintainer. This PR takes ownership of the package.
