### PR TITLE
libpciaccess: add v0.18, v0.18.1

### DIFF
--- a/repos/spack_repo/builtin/packages/libpciaccess/package.py
+++ b/repos/spack_repo/builtin/packages/libpciaccess/package.py
@@ -18,12 +18,17 @@ class Libpciaccess(AutotoolsPackage, XorgPackage):
 
     maintainers("CodingYayaToure")
 
-    version("0.18.1", sha256="a395317730e0e8d5e71419d4d1256a89e32c2fa793607b63c4d0fb497ae34602")
-    version("0.18", sha256="724d548c403ca16cdf6e3ea95591361b9746f7e7d1d10de70478d454f5dd1f0f")
+    version("0.18.1", sha256="4af43444b38adb5545d0ed1c2ce46d9608cc47b31c2387fc5181656765a6fa76")
+    version("0.18", sha256="5461b0257d495254346f52a9c329b44b346262663675d3fecdb204a7e7c262a9")
     version("0.17", sha256="bf6985a77d2ecb00e2c79da3edfb26b909178ffca3f2e9d14ed0620259ab733b")
     version("0.16", sha256="84413553994aef0070cf420050aa5c0a51b1956b404920e21b81e96db6a61a27")
     version("0.13.5", sha256="fe26ec788732b4ef60b550f2d3fa51c605d27f646e18ecec878f061807a3526e")
     version("0.13.4", sha256="74d92bda448e6fdb64fee4e0091255f48d625d07146a121653022ed3a0ca1f2f")
+
+    def url_for_version(self, version):
+        if version >= Version("0.18"):
+            return f"https://www.x.org/archive/individual/lib/libpciaccess-{version}.tar.xz"
+        return f"https://www.x.org/archive/individual/lib/libpciaccess-{version}.tar.gz"
 
     depends_on("c", type="build")
 

--- a/repos/spack_repo/builtin/packages/libpciaccess/package.py
+++ b/repos/spack_repo/builtin/packages/libpciaccess/package.py
@@ -16,6 +16,10 @@ class Libpciaccess(AutotoolsPackage, XorgPackage):
 
     license("X11")
 
+    maintainers("CodingYayaToure")
+
+    version("0.18.1", sha256="a395317730e0e8d5e71419d4d1256a89e32c2fa793607b63c4d0fb497ae34602")
+    version("0.18", sha256="724d548c403ca16cdf6e3ea95591361b9746f7e7d1d10de70478d454f5dd1f0f")
     version("0.17", sha256="bf6985a77d2ecb00e2c79da3edfb26b909178ffca3f2e9d14ed0620259ab733b")
     version("0.16", sha256="84413553994aef0070cf420050aa5c0a51b1956b404920e21b81e96db6a61a27")
     version("0.13.5", sha256="fe26ec788732b4ef60b550f2d3fa51c605d27f646e18ecec878f061807a3526e")


### PR DESCRIPTION
## What this PR does

- Adds `CodingYayaToure` as maintainer for `libpciaccess`
- Adds versions 0.18 (Feb 2024) and 0.18.1 (Mar 2024) with verified sha256
- Adds `url_for_version` to handle the switch from .tar.gz to .tar.xz starting at 0.18

## Testing

sha256 verified against official tarballs from xorg.freedesktop.org.