### PR TITLE
clingo-bootstrap: support @develop+optimized

### DIFF
--- a/repos/spack_repo/builtin/packages/clingo/package.py
+++ b/repos/spack_repo/builtin/packages/clingo/package.py
@@ -26,7 +26,7 @@ class Clingo(CMakePackage):
     # Development version for clingo 6
     version("develop", branch="wip-20", submodules=True)
 
-    version("master", branch="master", submodules=True)
+    version("master", branch="master", submodules=True, deprecated=True)
     version("spack", commit="2a025667090d71b2c9dce60fe924feb6bde8f667", submodules=True)
 
     version("5.8.0", sha256="4ddd5975e79d7a0f8d126039f1b923a371b1a43e0e0687e1537a37d6d6d5cc7c")

--- a/repos/spack_repo/builtin/packages/clingo_bootstrap/mimalloc-6.patch
+++ b/repos/spack_repo/builtin/packages/clingo_bootstrap/mimalloc-6.patch
@@ -1,0 +1,40 @@
+Override operator new/delete with mimalloc for the clingo (v6 / wip-20) layout.
+
+This is the equivalent of mimalloc.patch for the rewritten clingo source tree,
+which no longer has libclingo/ but lib/c-api/ instead.
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -109,6 +109,7 @@ endif()
+ endif()
+
+ find_package(RE2C "3.0" REQUIRED)
++find_package(mimalloc REQUIRED)
+
+ add_subdirectory(third_party)
+ add_subdirectory(lib libclingo)
+diff --git a/lib/c-api/CMakeLists.txt b/lib/c-api/CMakeLists.txt
+--- a/lib/c-api/CMakeLists.txt
++++ b/lib/c-api/CMakeLists.txt
+@@ -86,7 +86,7 @@ endif()
+ target_include_directories(clingo PUBLIC
+     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+-target_link_libraries(clingo PRIVATE clingo-control)
++target_link_libraries(clingo PRIVATE mimalloc-static clingo-control)
+ string(TOLOWER "${CMAKE_BUILD_TYPE}" build_type)
+ if(build_type STREQUAL "debug")
+     target_compile_definitions(clingo PRIVATE CLINGO_DEBUG)
+diff --git a/lib/c-api/src/main.cc b/lib/c-api/src/main.cc
+--- a/lib/c-api/src/main.cc
++++ b/lib/c-api/src/main.cc
+@@ -1,6 +1,8 @@
+ #include "control.hh" // IWYU pragma: keep
+ #include "lib.hh"     // IWYU pragma: keep
+ #include "opts.hh"
++
++#include <mimalloc-new-delete.h>
+
+ #include <clingo/app.h>
+

--- a/repos/spack_repo/builtin/packages/clingo_bootstrap/package.py
+++ b/repos/spack_repo/builtin/packages/clingo_bootstrap/package.py
@@ -39,7 +39,8 @@ class ClingoBootstrap(Clingo):
         depends_on("mimalloc +ipo libs=static ~override", type="build")
         conflicts("~static_libstdcpp", msg="Custom allocator requires static libstdc++")
         # Override new/delete with mimalloc.
-        patch("mimalloc.patch", when="@5.5.0:")
+        patch("mimalloc-6.patch", when="@6:")
+        patch("mimalloc.patch", when="@5.5.0:5")
         patch("mimalloc-pre-5.5.0.patch", when="@:5.4")
         # ensure we hide libstdc++ with custom operator new/delete symbols
         patch("version-script.patch", when="@spack,5.5:5.6")
@@ -56,7 +57,7 @@ class ClingoBootstrap(Clingo):
         "https://github.com/haampie/clasp/commit/208972863506ecbd85ed0bd78fac580b5e9c9c90.patch?full_index=1",
         sha256="c569fb439a99b709b6e6ac05253b344e4f3055d52223265baa55946db6d44e8b",
         working_dir="clasp",
-        when="@5.8: +optimized",
+        when="@5.8:5 +optimized",
     )
 
     # CMake at version 3.16.0 or higher has the possibility to force the
@@ -64,6 +65,7 @@ class ClingoBootstrap(Clingo):
     # in environment where more than one interpreter is in the same prefix
     depends_on("cmake@3.16.0:", type="build")
     depends_on("clingo-bootstrap-pgo", type="build", when="+optimized")
+    depends_on("clingo-bootstrap-pgo@1.1:", type="build", when="@6: +optimized")
 
     # On Linux we bootstrap with GCC or clang
     requires(

--- a/repos/spack_repo/builtin/packages/clingo_bootstrap_pgo/package.py
+++ b/repos/spack_repo/builtin/packages/clingo_bootstrap_pgo/package.py
@@ -15,6 +15,7 @@ class ClingoBootstrapPgo(Package):
 
     maintainers("haampie")
 
+    version("1.1.0", commit="207d0c38df87263f1af43b13a8b1a423f7b0c5a8")
     version("1.0.0", commit="64bec625ae06b32b7f5f01bccf9d27d0432a018f")
 
     def install(self, spec, prefix):


### PR DESCRIPTION
Support PGO and mimalloc in clingo-bootstrap v6 (aka wip-20)

The master branch is not useful and only annoying because of `@6:` ranges, which should apply to develop but not master, so deprecate it.