### PR TITLE
cuda: append --allow-unsupported-compilers to CUDAFLAGS

### DIFF
--- a/repos/spack_repo/builtin/packages/cuda/package.py
+++ b/repos/spack_repo/builtin/packages/cuda/package.py
@@ -823,6 +823,12 @@ class Cuda(Package):
         env.set("CUDA_HOME", self.prefix)
         env.set("NVHPC_CUDA_HOME", self.prefix)
 
+        # Append --allow-unsupported-compiler in CMake builds
+        # https://cmake.org/cmake/help/latest/envvar/CUDAFLAGS.html
+        if self.spec.satisfies("+allow-unsupported-compilers"):
+            if dependent_spec.satisfies("+cuda build_system=cmake"):
+                env.append_flags("CUDAFLAGS", "--allow-unsupported-compiler")
+
     @property
     def cmake_prefix_paths(self):
         cmake_prefix_paths = [self.prefix]


### PR DESCRIPTION
This PR propagates the `cuda` variant `allow-unsupported-compilers` to the CMake CUDAFLAGS build environment variable for dependent CMake specs where it is propagated as `--allow-unsupported-compiler` to nvcc calls.

For discussion. The automatic rolling out of this flag to all packages may not be ideal since it opens up the maintainers to receiving build error reports that are due to these unsupported combinations.