### PR TITLE
m4: add maintainer

### DIFF
--- a/repos/spack_repo/builtin/packages/m4/package.py
+++ b/repos/spack_repo/builtin/packages/m4/package.py
@@ -19,6 +19,8 @@ class M4(AutotoolsPackage, GNUMirrorPackage):
 
     license("GPL-3.0-or-later")
 
+    maintainers("CodingYayaToure")
+
     version("1.4.21", sha256="38ae59f7a30bf9c108193cc5c25fbb06014f21e230c7ede2eff614f7b7c37ed8")
     version("1.4.20", sha256="6ac4fc31ce440debe63987c2ebbf9d7b6634e67a7c3279257dc7361de8bdb3ef")
     version("1.4.19", sha256="3be4a26d825ffdfda52a56fc43246456989a3630093cced3fbddf4771ee58a70")


### PR DESCRIPTION
## What this PR does

- Adds `CodingYayaToure` as maintainer for `m4`

`m4` is a foundational GNU build tool dependency with no declared
maintainer. Package is already at latest version (1.4.21).
