### PR TITLE
pkgconf: add maintainer

### DIFF
--- a/repos/spack_repo/builtin/packages/pkgconf/package.py
+++ b/repos/spack_repo/builtin/packages/pkgconf/package.py
@@ -20,6 +20,8 @@ class Pkgconf(AutotoolsPackage):
 
     license("ISC")
 
+    maintainers("CodingYayaToure")
+
     version("2.5.1", sha256="cd05c9589b9f86ecf044c10a2269822bc9eb001eced2582cfffd658b0a50c243")
     version("2.3.0", sha256="3a9080ac51d03615e7c1910a0a2a8df08424892b5f13b0628a204d3fcce0ea8b")
     version("2.2.0", sha256="b06ff63a83536aa8c2f6422fa80ad45e4833f590266feb14eaddfe1d4c853c69")


### PR DESCRIPTION
## What this PR does

- Adds `CodingYayaToure` as maintainer for `pkgconf`

`pkgconf` is a foundational HPC build tool dependency (used by virtually
all autotools and cmake packages) with no declared maintainer.
Package is already at latest stable version (2.5.1).

@spackbot re-run pipeline