### PR TITLE
py-pyrometheus: add main branch version

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pyrometheus/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyrometheus/package.py
@@ -18,6 +18,7 @@ class PyPyrometheus(PythonPackage):
 
     license("MIT")
 
+    version("main", branch="main")
     version("1.0.7", sha256="fd8e1f95868121ea541bbed94657645f5d636a265be5bfd92bebdf38124b5b28")
 
     depends_on("python@3.9:", type=("build", "run"))


### PR DESCRIPTION
Adds a `main` branch version to `py-pyrometheus` so downstream CI can install pyrometheus from the upstream `main` branch via `spack install py-pyrometheus@main` without pinning to a specific release tag.

Motivation: pyrometheus is adding a Spack CI job that installs the current `HEAD` (via `spack develop`). Without a `@main` spec, the workflow has to pin to whatever the recipe's newest release tag is and gets stale every release. A `version("main", branch="main")` entry tracks `main` automatically.

Validated with:

- `ruff format --check repos/spack_repo/builtin/packages/py_pyrometheus/package.py`
- `ruff check repos/spack_repo/builtin/packages/py_pyrometheus/package.py`
- `spack audit packages py-pyrometheus`
- `spack spec py-pyrometheus@main`

Follow-up to #4696.