### PR TITLE
expat: add version 2.8.1

### DIFF
--- a/repos/spack_repo/builtin/packages/expat/package.py
+++ b/repos/spack_repo/builtin/packages/expat/package.py
@@ -18,7 +18,7 @@ class Expat(AutotoolsPackage, CMakePackage):
     url = "https://github.com/libexpat/libexpat/releases/download/R_2_2_9/expat-2.2.9.tar.bz2"
 
     license("MIT")
-    version("2.8.1", sha256="a52eb72108be160e190b5cafa5bba8663f1313f2013e26060d1c18e26e31067b")
+    version("2.8.1", sha256="f5833dd2e1cd7739ec9182804a1a29c4f0cc7c2f26b633d3a2188b7766a88ecb")
     version("2.8.0", sha256="586494499ac3ad46d87f3beda7b1f770c1c8026a9b60e151593f8b29089a52ca")
     # deprecate all releases before 2.8.0 because of various security issues
     version(

--- a/repos/spack_repo/builtin/packages/expat/package.py
+++ b/repos/spack_repo/builtin/packages/expat/package.py
@@ -18,6 +18,7 @@ class Expat(AutotoolsPackage, CMakePackage):
     url = "https://github.com/libexpat/libexpat/releases/download/R_2_2_9/expat-2.2.9.tar.bz2"
 
     license("MIT")
+    version("2.8.1", sha256="a52eb72108be160e190b5cafa5bba8663f1313f2013e26060d1c18e26e31067b")
     version("2.8.0", sha256="586494499ac3ad46d87f3beda7b1f770c1c8026a9b60e151593f8b29089a52ca")
     # deprecate all releases before 2.8.0 because of various security issues
     version(


### PR DESCRIPTION
## What this PR does

- Adds version 2.8.1 of `expat`

`expat` is a widely-used XML parsing library. Version 2.8.1 was released
upstream but was missing from Spack. sha256 verified against the official
tarball from github.com/libexpat/libexpat/releases.