### PR TITLE
libxml2: add versions 2.15.2 and 2.15.3

### DIFF
--- a/repos/spack_repo/builtin/packages/libxml2/package.py
+++ b/repos/spack_repo/builtin/packages/libxml2/package.py
@@ -32,6 +32,8 @@ class Libxml2(AutotoolsPackage, CMakePackage, NMakePackage):
 
     license("MIT")
 
+    version("2.15.3", sha256="78262a6e7ac170d6528ebfe2efccdf220191a5af6a6cd61ea4a9a9a5042c7a07")
+    version("2.15.2", sha256="c8b9bc81f8b590c33af8cc6c336dbff2f53409973588a351c95f1c621b13d09d")
     version("2.15.1", sha256="c008bac08fd5c7b4a87f7b8a71f283fa581d80d80ff8d2efd3b26224c39bc54c")
     version("2.13.9", sha256="a2c9ae7b770da34860050c309f903221c67830c86e4a7e760692b803df95143a")
     version("2.13.5", sha256="74fc163217a3964257d3be39af943e08861263c4231f9ef5b496b6f6d4c7b2b6")

--- a/repos/spack_repo/builtin/packages/libxml2/package.py
+++ b/repos/spack_repo/builtin/packages/libxml2/package.py
@@ -33,7 +33,6 @@ class Libxml2(AutotoolsPackage, CMakePackage, NMakePackage):
     license("MIT")
 
     version("2.15.3", sha256="78262a6e7ac170d6528ebfe2efccdf220191a5af6a6cd61ea4a9a9a5042c7a07")
-    version("2.15.2", sha256="c8b9bc81f8b590c33af8cc6c336dbff2f53409973588a351c95f1c621b13d09d")
     version("2.15.1", sha256="c008bac08fd5c7b4a87f7b8a71f283fa581d80d80ff8d2efd3b26224c39bc54c")
     version("2.13.9", sha256="a2c9ae7b770da34860050c309f903221c67830c86e4a7e760692b803df95143a")
     version("2.13.5", sha256="74fc163217a3964257d3be39af943e08861263c4231f9ef5b496b6f6d4c7b2b6")


### PR DESCRIPTION
## What this PR does

- Adds version 2.15.3 of `libxml2` (latest in the 2.15.x series)

## Links

- Release notes: https://gitlab.gnome.org/GNOME/libxml2/-/blob/v2.15.3/NEWS?ref_type=tags
- Diff with previous version in Spack (2.15.1 → 2.15.3): https://github.com/GNOME/libxml2/compare/v2.15.1...v2.15.3
- Spack binary cache: https://cache.spack.io/?package=libxml2