### PR TITLE
tixi: add v3.3.2

### DIFF
--- a/repos/spack_repo/builtin/packages/tixi/package.py
+++ b/repos/spack_repo/builtin/packages/tixi/package.py
@@ -21,10 +21,11 @@ class Tixi(CMakePackage):
 
     license("Apache-2.0")
 
+    version("3.3.2", sha256="96a6909bb6920e12202545ecab8c9af8250e250cb32d19e36e32bcc0f037f5b8")
     version("3.3.0", sha256="988d79ccd53c815d382cff0c244c0bb8e393986377dfb45385792766adf6f6a9")
-    version("3.2.0", sha256="8df65c4d252d56e98c5ef2657c7aff6086a07b5686716e786891609adaca9d2d")
-    version("3.1.0", sha256="4547133e452f3455b5a39045a8528955dce55faf059afe652a350ecf37d709ba")
-    version("3.0.3", sha256="3584e0cec6ab811d74fb311a9af0663736b1d7f11b81015fcb378efaf5ad3589")
+    version("3.2.0", sha256="8df65c4d252d56e98c5ef2657c7aff6086a07b5686716e786891609adaca9d2d", deprecated=True)
+    version("3.1.0", sha256="4547133e452f3455b5a39045a8528955dce55faf059afe652a350ecf37d709ba", deprecated=True)
+    version("3.0.3", sha256="3584e0cec6ab811d74fb311a9af0663736b1d7f11b81015fcb378efaf5ad3589", deprecated=True)
     version("2.2.4", sha256="9080d2a617b7c411b9b4086de23998ce86e261b88075f38c73d3ce25da94b21c")
 
     variant(

--- a/repos/spack_repo/builtin/packages/tixi/package.py
+++ b/repos/spack_repo/builtin/packages/tixi/package.py
@@ -23,9 +23,21 @@ class Tixi(CMakePackage):
 
     version("3.3.2", sha256="96a6909bb6920e12202545ecab8c9af8250e250cb32d19e36e32bcc0f037f5b8")
     version("3.3.0", sha256="988d79ccd53c815d382cff0c244c0bb8e393986377dfb45385792766adf6f6a9")
-    version("3.2.0", sha256="8df65c4d252d56e98c5ef2657c7aff6086a07b5686716e786891609adaca9d2d", deprecated=True)
-    version("3.1.0", sha256="4547133e452f3455b5a39045a8528955dce55faf059afe652a350ecf37d709ba", deprecated=True)
-    version("3.0.3", sha256="3584e0cec6ab811d74fb311a9af0663736b1d7f11b81015fcb378efaf5ad3589", deprecated=True)
+    version(
+        "3.2.0",
+        sha256="8df65c4d252d56e98c5ef2657c7aff6086a07b5686716e786891609adaca9d2d",
+        deprecated=True,
+    )
+    version(
+        "3.1.0",
+        sha256="4547133e452f3455b5a39045a8528955dce55faf059afe652a350ecf37d709ba",
+        deprecated=True,
+    )
+    version(
+        "3.0.3",
+        sha256="3584e0cec6ab811d74fb311a9af0663736b1d7f11b81015fcb378efaf5ad3589",
+        deprecated=True,
+    )
     version("2.2.4", sha256="9080d2a617b7c411b9b4086de23998ce86e261b88075f38c73d3ce25da94b21c")
 
     variant(


### PR DESCRIPTION
Adds the most recent tixi version and marks older versions with known bugs as deprecated.