### PR TITLE
Qt6: add version 6.11.1 (qt-base, qt-tools, qt-...)

### DIFF
--- a/repos/spack_repo/builtin/packages/qt_5compat/package.py
+++ b/repos/spack_repo/builtin/packages/qt_5compat/package.py
@@ -18,6 +18,7 @@ class Qt5compat(QtPackage):
 
     license("LicenseRef-Qt-Commercial OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only")
 
+    version("6.11.1", sha256="2b21eff89b309819e877f39747494c280fb7b13afea8ce68a6793c364ae289a9")
     version("6.10.2", sha256="3468f5ef429361b427a58830791b34ce4ea826583584b4ba9caaa2923002c78c")
     version("6.10.1", sha256="e936870e435dae57f23793f7d3fd92444f7b98e9aa2931eda458e7e11b3f3571")
     version("6.10.0", sha256="4f0c57c96bd5a04a59cc4fd9a6507392d5a5af886f59e8dc7274f2ccfa6d74f4")

--- a/repos/spack_repo/builtin/packages/qt_base/package.py
+++ b/repos/spack_repo/builtin/packages/qt_base/package.py
@@ -160,6 +160,7 @@ class QtBase(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.11.1", sha256="e20852bd45cdef5da5175f3634e285e03e2be7ca437f3d2b7e1a2af7321bca7a")
     version("6.10.2", sha256="95271bc1f32db239723f597ab1899e624e3b22a16678b88520dee51ad5035faa")
     version("6.10.1", sha256="088c248d7dfbcba1e60fc4fa7a46406c6c638687cd3dbd412cdd13fc21198df9")
     version("6.10.0", sha256="6bc0cab63e70ef9634825de47790409079e00da77bad18d036b7ab83c5618346")

--- a/repos/spack_repo/builtin/packages/qt_declarative/package.py
+++ b/repos/spack_repo/builtin/packages/qt_declarative/package.py
@@ -16,6 +16,7 @@ class QtDeclarative(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.11.1", sha256="3d98c58a8652f7188288832d8bea5529a1bc3906915ad1c9a2974955c8cd5656")
     version("6.10.2", sha256="b3c1fa06ff918cfe5231dd4715438b6cd5b2df3e5affea3472ff303258734567")
     version("6.10.1", sha256="2df250e9245e3af7e72e955948810017adb21911f993c86d78b3e3b6b33e23d4")
     version("6.10.0", sha256="d5dcb10bd3152cfc616afababaa2cd7ea21119bdd03239700d37690c0db8211e")

--- a/repos/spack_repo/builtin/packages/qt_quick3d/package.py
+++ b/repos/spack_repo/builtin/packages/qt_quick3d/package.py
@@ -16,6 +16,7 @@ class QtQuick3d(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.11.1", sha256="fa684e2a86e0de6d128d30d71b8d6155082d2dbfc0b6d4f8f3196dbf106e81ac")
     version("6.10.2", sha256="88082ab6847283c3c2b83c387538099c8d2840eb4b5efe7ab0b6cc8c565ee388")
     version("6.10.1", sha256="993684adddc2825dd9ae1b9c1687e0163960332057df4dfbc3dbe4ea6b900413")
     version("6.10.0", sha256="4a87e5c8f9f187a672af15da8bd1e412fe745d57d71a1df32e4114f340b72ffe")

--- a/repos/spack_repo/builtin/packages/qt_quicktimeline/package.py
+++ b/repos/spack_repo/builtin/packages/qt_quicktimeline/package.py
@@ -16,6 +16,7 @@ class QtQuicktimeline(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.11.1", sha256="8b044f64c96a84282669a76f84fd11b9f7de3e681c025d0b3b595b541153db95")
     version("6.10.2", sha256="e4a1b21a6e1579d1a954b67a22e816aaf23f4e74f156e34aab4ea5ed71d73528")
     version("6.10.1", sha256="cb0db62d8844886eca6387d62be9997c3d25d75503af619690a1cc906d7eb855")
     version("6.10.0", sha256="6af28c87896cf93f1033965323a80a9e5dd7ed004ecfa30826fe8056216f4102")

--- a/repos/spack_repo/builtin/packages/qt_shadertools/package.py
+++ b/repos/spack_repo/builtin/packages/qt_shadertools/package.py
@@ -18,6 +18,7 @@ class QtShadertools(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.11.1", sha256="d4987b5fdf01d33e589cd4e4a8125734fa35fc8c8aa34c3d998571af07a4cfb8")
     version("6.10.2", sha256="dbc29c54631a97778be49d7930367bc9d9ed84014fb735917c9e7658c21eb3d1")
     version("6.10.1", sha256="984857c3ac6b26731e688604be72d3ecfeab13ee1c48b9c924013a6d21989883")
     version("6.10.0", sha256="da7721256607e0074b0d959c61b6e1b422b5b7d0ad2a30b0e409aa9d8afc3d1f")

--- a/repos/spack_repo/builtin/packages/qt_svg/package.py
+++ b/repos/spack_repo/builtin/packages/qt_svg/package.py
@@ -18,6 +18,7 @@ class QtSvg(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.11.1", sha256="06d7cefd2776a072b6906aaf9529a3a17eb51a254fba0cb52f5a35d97c342569")
     version("6.10.2", sha256="70c58c2ad2d99ce1caf7e394e8e6c8a328563b70f97f9428e5c48d28d913a504")
     version("6.10.1", sha256="8c2c82230f6acfb272b48078bd0257628a417b5f6932e10242e14469628bf855")
     version("6.10.0", sha256="bda1574665edc73d08fc5ed0575a65f28e6fa5be2fcdeaae613bebd114a6a982")

--- a/repos/spack_repo/builtin/packages/qt_tools/package.py
+++ b/repos/spack_repo/builtin/packages/qt_tools/package.py
@@ -20,6 +20,7 @@ class QtTools(QtPackage):
     license("BSD-3-Clause")
 
     # src/assistant/qlitehtml is a submodule that is not in the git archive
+    version("6.11.1", commit="947c5f152f4abc06f9e135b411c06a6fbe608aed", submodules=True)
     version("6.10.2", commit="171ae9df0d84ee5133193cd3e27848fd73601c53", submodules=True)
     version("6.10.1", commit="9e0030f889168f7a0ec1bb47a7d7138a497b3c96", submodules=True)
     version("6.10.0", commit="f33c4bb1dee569eec4ffe1333584cb4b75af6c59", submodules=True)


### PR DESCRIPTION
Adds the most recent version of the Qt6 libraries currently installable with spack.
