### PR TITLE
albany/albert/amd_aocl: fix homepage urls

### DIFF
--- a/repos/spack_repo/builtin/packages/albany/package.py
+++ b/repos/spack_repo/builtin/packages/albany/package.py
@@ -15,7 +15,7 @@ class Albany(CMakePackage):
     including fluid mechanics, solid mechanics (elasticity and plasticity),
     ice-sheet flow, quantum device modeling, and many other applications."""
 
-    homepage = "https://gahansen.github.io/Albany"
+    homepage = "https://sandialabs.github.io/Albany/"
     git = "https://github.com/gahansen/Albany.git"
 
     maintainers("gahansen")

--- a/repos/spack_repo/builtin/packages/albert/package.py
+++ b/repos/spack_repo/builtin/packages/albert/package.py
@@ -11,7 +11,7 @@ class Albert(MakefilePackage):
     """Albert is an interactive program to assist the
     specialist in the study of nonassociative algebra."""
 
-    homepage = "https://people.cs.clemson.edu/~dpj/albertstuff/albert.html"
+    homepage = "https://dpj.people.clemson.edu/albertstuff/albert.html"
     url = "https://github.com/kentavv/Albert/archive/v4.0a_opt4.tar.gz"
 
     version("4.0a_opt4", sha256="80b9ee774789c9cd123072523cfb693c443c3624708a58a5af177a51f36b2c79")

--- a/repos/spack_repo/builtin/packages/amd_aocl/package.py
+++ b/repos/spack_repo/builtin/packages/amd_aocl/package.py
@@ -21,7 +21,7 @@ class AmdAocl(BundlePackage):
     https://www.amd.com/en/developer/aocl/eula/aocl-4-1-eula.html
     """
 
-    homepage = "https://developer.amd.com/amd-aocl/"
+    homepage = "https://www.amd.com/en/developer/aocl.html"
 
     maintainers("amd-toolchain-support")
 


### PR DESCRIPTION
Fix some homepage urls based on errors from https://repology.org/repository/spack/problems