### PR TITLE
fix concretization of intel-oneapi-runtime when multiple oneapi compilers are installed

### DIFF
--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
@@ -737,22 +737,6 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
                 description="Add a dependency on 'libifcore' for nodes compiled with "
                 f"{spec.name}@{spec.versions} and using the 'fortran' language",
             )
-        # The version of intel-oneapi-runtime is the same as the %oneapi used to "compile" it
-        pkg("intel-oneapi-runtime").requires(
-            f"@{spec.versions}", when=f"%[deptypes=build] {spec.name}@{spec.versions}"
-        )
-
-        # If the compiler depends on gcc@X.Y, the runtime must depend on gcc-runtime@X.Y
-        if spec.satisfies("%gcc"):
-            try:
-                gcc = spec["gcc"]
-                pkg("intel-oneapi-runtime").requires(
-                    f"@{spec.versions} %gcc-runtime@{gcc.version}",
-                    when=f"%[deptypes=build] {spec.name}/{spec.dag_hash()}",
-                )
-            except (RuntimeError, KeyError):
-                # Externals may not have gcc as a dependency, but still satisfy %gcc
-                pass
 
         # If a node used %intel-oneapi-runtime@X.Y its dependencies must use @:X.Y
         # (technically @:X is broader than ... <= @=X but this should work in practice)

--- a/repos/spack_repo/builtin/packages/intel_oneapi_runtime/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_runtime/package.py
@@ -6,6 +6,7 @@ import os
 from spack_repo.builtin.build_systems.generic import Package
 from spack_repo.builtin.build_systems.oneapi import IntelOneApiPackage
 from spack_repo.builtin.packages.gcc_runtime.package import get_elf_libraries
+from spack_repo.builtin.packages.intel_oneapi_compilers.package import versions as oneapi_versions
 
 from spack.package import *
 
@@ -22,7 +23,15 @@ class IntelOneapiRuntime(Package):
 
     tags = ["runtime"]
 
-    depends_on("intel-oneapi-compilers", type="build")
+    for v in oneapi_versions:
+        version(v["version"])
+
+    for v in oneapi_versions:
+        depends_on(
+            f"intel-oneapi-compilers@={v['version']}",
+            when=f"@={v['version']}",
+            type="build",
+        )
     depends_on("patchelf", when="^intel-oneapi-compilers +fix_rt_linkage", type="build")
     depends_on("gcc-runtime", type="link")
 


### PR DESCRIPTION
Solves: #4749
Closes: spack/spack#52375

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
