### PR TITLE
py-f90wrap: add v0.3.0 with meson-python build

### DIFF
--- a/repos/spack_repo/builtin/packages/py_f90wrap/package.py
+++ b/repos/spack_repo/builtin/packages/py_f90wrap/package.py
@@ -17,6 +17,7 @@ class PyF90wrap(PythonPackage):
 
     license("LGPL-3.0-only")
 
+    version("0.3.0", sha256="9c9f08768fe7e9d60de9e913e30909fa1bdc67828f49dffd7149089703d74836")
     version("0.2.6", sha256="e0748eb5e288be7f47829a272fc230373469fb40afccddf91e9973c56da43dd4")
     version("0.2.3", sha256="5577ea92934c5aad378df21fb0805b5fb433d6f2b8b9c1bf1a9ec1e3bf842cff")
 
@@ -24,6 +25,12 @@ class PyF90wrap(PythonPackage):
     depends_on("fortran", type="build")  # generated
 
     # TODO errors with python 3.6 due to UnicodeDecodeError
-    depends_on("python@3.6:", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
+    depends_on("python@3.6:", when="@:0.2", type=("build", "run"))
+    depends_on("python@3.9:", when="@0.3:", type=("build", "run"))
+
+    depends_on("py-setuptools", when="@:0.2", type="build")
+    depends_on("py-meson-python", when="@0.3:", type="build")
+    depends_on("meson", when="@0.3:", type="build")
+
     depends_on("py-numpy@1.3.0:", type=("build", "run"))
+    depends_on("py-packaging", when="@0.3:", type=("build", "run"))


### PR DESCRIPTION
Update to support v0.3.0 @spackbot fix style
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
