### PR TITLE
Zsh: add build-time dependency on autoconf and add CFLAGS for more recent LLVM

### DIFF
--- a/repos/spack_repo/builtin/packages/zsh/package.py
+++ b/repos/spack_repo/builtin/packages/zsh/package.py
@@ -49,7 +49,11 @@ class Zsh(AutotoolsPackage):
     patch("pointer-types.patch", when="@5.6.2:")
 
     def flag_handler(self, name, flags):
-        if name=="cflags" and self.spec.satisfies('%llvm@10:') or self.spec.satisfies("%apple-clang@12:"):
+        if (
+            name == "cflags"
+            and self.spec.satisfies("%llvm@10:")
+            or self.spec.satisfies("%apple-clang@12:")
+        ):
             flags.append("-Wno-implicit-function-declaration")
             flags.append("-Wno-implicit-int")
         return self.env_flags(name, flags)
@@ -65,7 +69,6 @@ class Zsh(AutotoolsPackage):
             # enable etc dir under install prefix
             mkdirp(self.prefix.etc)
             args.append("--enable-etcdir={0}".format(self.prefix.etc))
-
 
         return args
 

--- a/repos/spack_repo/builtin/packages/zsh/package.py
+++ b/repos/spack_repo/builtin/packages/zsh/package.py
@@ -42,6 +42,7 @@ class Zsh(AutotoolsPackage):
 
     depends_on("pcre")
     depends_on("ncurses")
+    depends_on("autoconf", type="build")
 
     conflicts("+lmod", when="~etcdir", msg="local etc required to setup env for lmod")
 

--- a/repos/spack_repo/builtin/packages/zsh/package.py
+++ b/repos/spack_repo/builtin/packages/zsh/package.py
@@ -48,6 +48,12 @@ class Zsh(AutotoolsPackage):
 
     patch("pointer-types.patch", when="@5.6.2:")
 
+    def flag_handler(self, name, flags):
+        if name=="cflags" and self.spec.satisfies('%llvm@10:') or self.spec.satisfies("%apple-clang@12:"):
+            flags.append("-Wno-implicit-function-declaration")
+            flags.append("-Wno-implicit-int")
+        return self.env_flags(name, flags)
+
     def configure_args(self):
         args = []
 
@@ -59,6 +65,7 @@ class Zsh(AutotoolsPackage):
             # enable etc dir under install prefix
             mkdirp(self.prefix.etc)
             args.append("--enable-etcdir={0}".format(self.prefix.etc))
+
 
         return args
 


### PR DESCRIPTION
This PR fixes two issues with zsh.
1) It seems zsh has a build-time dependency on autoconf. (It looks like it's re-running it later in the process and not finding it when it needs it)

2) Add two compiler flags (`-Wno-implicit-int` and `-Wno-implicit-function-declaration`) when building with newer versions of LLVM. 

Without the latter, the build would complete successfully, but the resulting zsh would lock up and become unresponsive to signals the first time it encounters process substitution. (this issue can be demonstrated by running `timeout 3 zsh -c '$(echo echo success)' || echo failure`.)

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
