### PR TITLE
t8code: add version 4.0.0 (uses CMake now)

### DIFF
--- a/repos/spack_repo/builtin/packages/t8code/package.py
+++ b/repos/spack_repo/builtin/packages/t8code/package.py
@@ -5,27 +5,27 @@
 import os
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
 
 
-class T8code(AutotoolsPackage):
+class T8code(AutotoolsPackage, CMakePackage):
     """t8code is a C/C++ library to manage parallel adaptive meshes with various element types.
     t8code uses a collection (a forest) of multiple connected adaptive space-trees in parallel
     and scales to at least one million MPI ranks and over one Trillion mesh elements."""
 
     homepage = "https://github.com/DLR-AMR/t8code"
-    url = "https://github.com/DLR-AMR/t8code/releases/download/v1.4.1/t8-1.4.1.tar.gz"
+
+    url = "https://github.com/DLR-AMR/t8code/releases/download/v4.0.0/T8CODE-4.0.0-Source.tar.gz"
 
     maintainers("Davknapp", "melven")
 
-    license("GPL-2.0-or-later")
+    license("GPL-2.0-or-later", checked_by="melven")
 
-    version("2.0.0", sha256="b83f6c204cdb663cec7e0c1059406afc4c06df236b71d7b190fb698bec44c1e0")
-    version("1.6.1", sha256="dc96effa7c1ad1d50437fefdd0963f6ef7c943eb10a372a4e8546a5f2970a412")
-    version("1.6.0", sha256="94fb8dd9d9401130867ff18e8f71249cbb0fc34995fd04412a983eb2c93db3d5")
-    version("1.5.0", sha256="22ce6492c0f808c6859a42921352d857639fddd48ecdc9935e419db95c466f28")
-    version("1.4.1", sha256="b0ec0c9b4a182f8ac7e930ba80cd20e6dc5baefc328630e4a9dac8c688749e9a")
+    version("4.0.0", sha256="668536f82730a23fc6fd96ff13e64762b6b0890d04e99a7a38d66341332d5770")
+    version("2.0.0", sha256="b83f6c204cdb663cec7e0c1059406afc4c06df236b71d7b190fb698bec44c1e0", deprecated=True,
+            url = "https://github.com/DLR-AMR/t8code/releases/download/v2.0.0/t8-2.0.0.tar.gz")
 
     variant("mpi", default=True, description="Enable MPI parallel code")
     variant("vtk", default=False, description="Enable vtk-dependent code")
@@ -39,15 +39,17 @@ class T8code(AutotoolsPackage):
     depends_on("mpi", when="+mpi")
     depends_on("vtk@9.1:", when="+vtk")
     # t8code@1.4.1 doesn't build with petsc@3.19.1
-    depends_on("petsc@3.18", when="+petsc")
+    depends_on("petsc@3.18", when="@:2.0.0 +petsc")
     depends_on("netcdf-c~mpi", when="+netcdf~mpi")
     depends_on("netcdf-c+mpi", when="+netcdf+mpi")
     depends_on("metis", when="+metis")
 
+    build_system(conditional("cmake", when="@4:"), conditional("autotools", when="@:2"), default="cmake")
+
     # Per default, t8code uses hardcoded zlib library from vtk package
     # The configure command is overwritten to choose the integrated spack package
     def patch(self):
-        if "+vtk" in self.spec:
+        if "@:2 +vtk" in self.spec:
             filter_file(r"vtkzlib-\$t8_vtk_version", "z", "configure")
 
     def configure_args(self):
@@ -86,5 +88,14 @@ class T8code(AutotoolsPackage):
 
         if "+metis" in spec:
             args.append(f"--with-metis={spec['metis'].prefix}")
+
+        return args
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("T8CODE_ENABLE_MPI", "mpi"),
+            self.define_from_variant("T8CODE_ENABLE_VTK", "vtk"),
+            self.define_from_variant("T8CODE_ENABLE_NETCDF", "netcdf"),
+        ]
 
         return args

--- a/repos/spack_repo/builtin/packages/t8code/package.py
+++ b/repos/spack_repo/builtin/packages/t8code/package.py
@@ -24,8 +24,12 @@ class T8code(AutotoolsPackage, CMakePackage):
     license("GPL-2.0-or-later", checked_by="melven")
 
     version("4.0.0", sha256="668536f82730a23fc6fd96ff13e64762b6b0890d04e99a7a38d66341332d5770")
-    version("2.0.0", sha256="b83f6c204cdb663cec7e0c1059406afc4c06df236b71d7b190fb698bec44c1e0", deprecated=True,
-            url = "https://github.com/DLR-AMR/t8code/releases/download/v2.0.0/t8-2.0.0.tar.gz")
+    version(
+        "2.0.0",
+        sha256="b83f6c204cdb663cec7e0c1059406afc4c06df236b71d7b190fb698bec44c1e0",
+        deprecated=True,
+        url="https://github.com/DLR-AMR/t8code/releases/download/v2.0.0/t8-2.0.0.tar.gz",
+    )
 
     variant("mpi", default=True, description="Enable MPI parallel code")
     variant("vtk", default=False, description="Enable vtk-dependent code")
@@ -44,7 +48,9 @@ class T8code(AutotoolsPackage, CMakePackage):
     depends_on("netcdf-c+mpi", when="+netcdf+mpi")
     depends_on("metis", when="+metis")
 
-    build_system(conditional("cmake", when="@4:"), conditional("autotools", when="@:2"), default="cmake")
+    build_system(
+        conditional("cmake", when="@4:"), conditional("autotools", when="@:2"), default="cmake"
+    )
 
     # Per default, t8code uses hardcoded zlib library from vtk package
     # The configure command is overwritten to choose the integrated spack package

--- a/repos/spack_repo/builtin/packages/t8code/package.py
+++ b/repos/spack_repo/builtin/packages/t8code/package.py
@@ -4,32 +4,37 @@
 
 import os
 
-from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
-from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems import autotools, cmake
 
 from spack.package import *
 
 
-class T8code(AutotoolsPackage, CMakePackage):
+class T8code(autotools.AutotoolsPackage, cmake.CMakePackage):
     """t8code is a C/C++ library to manage parallel adaptive meshes with various element types.
     t8code uses a collection (a forest) of multiple connected adaptive space-trees in parallel
     and scales to at least one million MPI ranks and over one Trillion mesh elements."""
 
     homepage = "https://github.com/DLR-AMR/t8code"
 
-    url = "https://github.com/DLR-AMR/t8code/releases/download/v4.0.0/T8CODE-4.0.0-Source.tar.gz"
+    def url_for_version(self, version):
+        if version < Version("3.0.0"):
+            url = "https://github.com/DLR-AMR/t8code/releases/download/v{0}/t8-{0}.tar.gz"
+        else:
+            url = "https://github.com/DLR-AMR/t8code/releases/download/v{1}/T8CODE-{0}-Source.tar.gz"
+        return url.format(version.up_to(3), version)
 
     maintainers("Davknapp", "melven")
 
     license("GPL-2.0-or-later", checked_by="melven")
 
+    version("4.0.0-26.06", sha256="407281956091ca5b1baaa7d6a00ad27bdb766a5f69423d33a864979f31a350ef")
     version("4.0.0", sha256="668536f82730a23fc6fd96ff13e64762b6b0890d04e99a7a38d66341332d5770")
-    version(
-        "2.0.0",
-        sha256="b83f6c204cdb663cec7e0c1059406afc4c06df236b71d7b190fb698bec44c1e0",
-        deprecated=True,
-        url="https://github.com/DLR-AMR/t8code/releases/download/v2.0.0/t8-2.0.0.tar.gz",
-    )
+    version("3.0.1", sha256="71732ac0f898feed1af8a81c2deac2e5031e37e94384d3e5b10d1b5861be24d0")
+    version("2.0.0", sha256="b83f6c204cdb663cec7e0c1059406afc4c06df236b71d7b190fb698bec44c1e0", deprecated=True)
+    version("1.6.1", sha256="dc96effa7c1ad1d50437fefdd0963f6ef7c943eb10a372a4e8546a5f2970a412", deprecated=True)
+    version("1.6.0", sha256="94fb8dd9d9401130867ff18e8f71249cbb0fc34995fd04412a983eb2c93db3d5", deprecated=True)
+    version("1.5.0", sha256="22ce6492c0f808c6859a42921352d857639fddd48ecdc9935e419db95c466f28", deprecated=True)
+    version("1.4.1", sha256="b0ec0c9b4a182f8ac7e930ba80cd20e6dc5baefc328630e4a9dac8c688749e9a", deprecated=True)
 
     variant("mpi", default=True, description="Enable MPI parallel code")
     variant("vtk", default=False, description="Enable vtk-dependent code")
@@ -48,8 +53,10 @@ class T8code(AutotoolsPackage, CMakePackage):
     depends_on("netcdf-c+mpi", when="+netcdf+mpi")
     depends_on("metis", when="+metis")
 
+    # theoretically, version 3.0.* still support autotools, but it does not work out-of-the box
+    # (missing configure script and .ac files)
     build_system(
-        conditional("cmake", when="@4:"), conditional("autotools", when="@:2"), default="cmake"
+        conditional("cmake", when="@3:"), conditional("autotools", when="@:2"), default="cmake"
     )
 
     # Per default, t8code uses hardcoded zlib library from vtk package
@@ -58,6 +65,8 @@ class T8code(AutotoolsPackage, CMakePackage):
         if "@:2 +vtk" in self.spec:
             filter_file(r"vtkzlib-\$t8_vtk_version", "z", "configure")
 
+
+class AutotoolsBuilder(autotools.AutotoolsBuilder):
     def configure_args(self):
         args = ["CFLAGS=-O3", "CXXFLAGS=-O3"]
         spec = self.spec
@@ -97,6 +106,8 @@ class T8code(AutotoolsPackage, CMakePackage):
 
         return args
 
+
+class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
         args = [
             self.define_from_variant("T8CODE_ENABLE_MPI", "mpi"),

--- a/repos/spack_repo/builtin/packages/t8code/package.py
+++ b/repos/spack_repo/builtin/packages/t8code/package.py
@@ -38,9 +38,9 @@ class T8code(autotools.AutotoolsPackage, cmake.CMakePackage):
 
     variant("mpi", default=True, description="Enable MPI parallel code")
     variant("vtk", default=False, description="Enable vtk-dependent code")
-    variant("petsc", default=False, description="Enable PETSc-dependent code")
+    variant("petsc", when="build_system=autotools", default=False, description="Enable PETSc-dependent code")
     variant("netcdf", default=False, description="Enable NetCDF-dependent code")
-    variant("metis", default=False, description="Enable metis-dependent code")
+    variant("metis", when="build_system=autotools", default=False, description="Enable metis-dependent code")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/t8code/package.py
+++ b/repos/spack_repo/builtin/packages/t8code/package.py
@@ -20,27 +20,61 @@ class T8code(autotools.AutotoolsPackage, cmake.CMakePackage):
         if version < Version("3.0.0"):
             url = "https://github.com/DLR-AMR/t8code/releases/download/v{0}/t8-{0}.tar.gz"
         else:
-            url = "https://github.com/DLR-AMR/t8code/releases/download/v{1}/T8CODE-{0}-Source.tar.gz"
+            url = (
+                "https://github.com/DLR-AMR/t8code/releases/download/v{1}/T8CODE-{0}-Source.tar.gz"
+            )
         return url.format(version.up_to(3), version)
 
     maintainers("Davknapp", "melven")
 
     license("GPL-2.0-or-later", checked_by="melven")
 
-    version("4.0.0-26.06", sha256="407281956091ca5b1baaa7d6a00ad27bdb766a5f69423d33a864979f31a350ef")
+    version(
+        "4.0.0-26.06", sha256="407281956091ca5b1baaa7d6a00ad27bdb766a5f69423d33a864979f31a350ef"
+    )
     version("4.0.0", sha256="668536f82730a23fc6fd96ff13e64762b6b0890d04e99a7a38d66341332d5770")
     version("3.0.1", sha256="71732ac0f898feed1af8a81c2deac2e5031e37e94384d3e5b10d1b5861be24d0")
-    version("2.0.0", sha256="b83f6c204cdb663cec7e0c1059406afc4c06df236b71d7b190fb698bec44c1e0", deprecated=True)
-    version("1.6.1", sha256="dc96effa7c1ad1d50437fefdd0963f6ef7c943eb10a372a4e8546a5f2970a412", deprecated=True)
-    version("1.6.0", sha256="94fb8dd9d9401130867ff18e8f71249cbb0fc34995fd04412a983eb2c93db3d5", deprecated=True)
-    version("1.5.0", sha256="22ce6492c0f808c6859a42921352d857639fddd48ecdc9935e419db95c466f28", deprecated=True)
-    version("1.4.1", sha256="b0ec0c9b4a182f8ac7e930ba80cd20e6dc5baefc328630e4a9dac8c688749e9a", deprecated=True)
+    version(
+        "2.0.0",
+        sha256="b83f6c204cdb663cec7e0c1059406afc4c06df236b71d7b190fb698bec44c1e0",
+        deprecated=True,
+    )
+    version(
+        "1.6.1",
+        sha256="dc96effa7c1ad1d50437fefdd0963f6ef7c943eb10a372a4e8546a5f2970a412",
+        deprecated=True,
+    )
+    version(
+        "1.6.0",
+        sha256="94fb8dd9d9401130867ff18e8f71249cbb0fc34995fd04412a983eb2c93db3d5",
+        deprecated=True,
+    )
+    version(
+        "1.5.0",
+        sha256="22ce6492c0f808c6859a42921352d857639fddd48ecdc9935e419db95c466f28",
+        deprecated=True,
+    )
+    version(
+        "1.4.1",
+        sha256="b0ec0c9b4a182f8ac7e930ba80cd20e6dc5baefc328630e4a9dac8c688749e9a",
+        deprecated=True,
+    )
 
     variant("mpi", default=True, description="Enable MPI parallel code")
     variant("vtk", default=False, description="Enable vtk-dependent code")
-    variant("petsc", when="build_system=autotools", default=False, description="Enable PETSc-dependent code")
+    variant(
+        "petsc",
+        when="build_system=autotools",
+        default=False,
+        description="Enable PETSc-dependent code",
+    )
     variant("netcdf", default=False, description="Enable NetCDF-dependent code")
-    variant("metis", when="build_system=autotools", default=False, description="Enable metis-dependent code")
+    variant(
+        "metis",
+        when="build_system=autotools",
+        default=False,
+        description="Enable metis-dependent code",
+    )
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated


### PR DESCRIPTION
Adds version 4.0.0 from December and switches to CMake.

The old version 2.0.0 with Autotools is still supported but marked as deprecated.

Tested building without MPI and with MPI, VTK and NetCDF.
