### PR TITLE
parallel-netcdf: fix building with ~fortran

### DIFF
--- a/repos/spack_repo/builtin/packages/parallel_netcdf/package.py
+++ b/repos/spack_repo/builtin/packages/parallel_netcdf/package.py
@@ -129,13 +129,15 @@ class ParallelNetcdf(AutotoolsPackage):
         if self.spec.satisfies("+pic"):
             flags["CFLAGS"].append(self.compiler.cc_pic_flag)
             flags["CXXFLAGS"].append(self.compiler.cxx_pic_flag)
-            flags["FFLAGS"].append(self.compiler.f77_pic_flag)
-            flags["FCFLAGS"].append(self.compiler.fc_pic_flag)
+            if self.spec.satisfies("+fortran"):
+                flags["FFLAGS"].append(self.compiler.f77_pic_flag)
+                flags["FCFLAGS"].append(self.compiler.fc_pic_flag)
 
         # https://github.com/Parallel-NetCDF/PnetCDF/issues/61
         if self.spec.satisfies("@:1.12.1%gcc@10:"):
-            flags["FFLAGS"].append("-fallow-argument-mismatch")
-            flags["FCFLAGS"].append("-fallow-argument-mismatch")
+            if self.spec.satisfies("+fortran"):
+                flags["FFLAGS"].append("-fallow-argument-mismatch")
+                flags["FCFLAGS"].append("-fallow-argument-mismatch")
 
         for key, value in sorted(flags.items()):
             if value:

--- a/repos/spack_repo/builtin/packages/parallel_netcdf/package.py
+++ b/repos/spack_repo/builtin/packages/parallel_netcdf/package.py
@@ -61,7 +61,7 @@ class ParallelNetcdf(AutotoolsPackage):
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("fortran", when="+fortran", type="build")
 
     depends_on("mpi")
 


### PR DESCRIPTION
The package.py was using the Fortran compiler spec even if Fortran was disabled, leading to an error when compiling without Fortran.