### PR TITLE
julia: avoid cascading mbedtls in v1.12+

### DIFF
--- a/repos/spack_repo/builtin/packages/julia/package.py
+++ b/repos/spack_repo/builtin/packages/julia/package.py
@@ -254,14 +254,16 @@ class Julia(MakefilePackage):
     depends_on("binutils", type="build")  # for readelf
 
     depends_on("blas")  # note: for now openblas is fixed...
-    depends_on("curl tls=mbedtls +nghttp2 +libssh2")
+    depends_on("curl tls=openssl +nghttp2 +libssh2", when="@1.12:")
+    depends_on("curl tls=mbedtls +nghttp2 +libssh2", when="@:1.11")
     depends_on("dsfmt@2.2.4:")  # apparently 2.2.3->2.2.4 breaks API
     depends_on("gmp")
     depends_on("lapack")  # note: for now openblas is fixed...
     depends_on("libblastrampoline")
     depends_on("libgit2")
-    depends_on("libssh2 crypto=mbedtls")
-    depends_on("mbedtls libs=shared")
+    depends_on("libssh2 crypto=openssl", when="@1.12:")
+    depends_on("libssh2 crypto=mbedtls", when="@:1.11")
+    depends_on("mbedtls libs=shared", when="@:1.11")
     depends_on("mpfr")
     depends_on("nghttp2")
     depends_on("openblas +ilp64 symbol_suffix=64_")


### PR DESCRIPTION
This PR removes the residual dependencies on `mbedtls` in v1.12+. In particular:
- `curl tls={mbedtls => openssl}`
- `libssh2 crypto={mbedtls => openssl}`
- `mbedtls` itself

References: https://github.com/spack/spack-packages/pull/2033, https://github.com/JuliaLang/julia/pull/56708

~~Not built locally yet since it is not part of my usual environment. But I'm picking up this PR for a cloud build and will report here.~~ Build with this commit successful inside our CI environment at https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/7869745#L1. This was previously failing not in the julia build, but downstream since curl with mbedtls cannot handle US DOE MITM/DPI certificate rewrites.