### PR TITLE
`py-accessible-pygments`: Use hatchling for v0.0.5

### DIFF
--- a/repos/spack_repo/builtin/packages/py_accessible_pygments/package.py
+++ b/repos/spack_repo/builtin/packages/py_accessible_pygments/package.py
@@ -21,7 +21,10 @@ class PyAccessiblePygments(PythonPackage):
 
     depends_on("python@3.9:", type=("build", "run"), when="@0.0.5:")
     depends_on("py-pygments@1.5:", type=("build", "run"))
-    depends_on("py-setuptools", type=("build"))
+    depends_on("py-setuptools", type="build", when="@:0.0.4")
+    depends_on("py-hatchling", type="build", when="@0.0.5:")
+    depends_on("py-hatch-fancy-pypi-readme", type="build", when="@0.0.5:")
+    depends_on("py-hatch-vcs", type="build", when="@0.0.5:")
 
     def url_for_version(self, version):
         url = (


### PR DESCRIPTION
The build system for `py-accessible-pygments` changed to hatchling in 0.0.5, so use that instead of setuptools.

This is needed by py-furo which is needed to build the spack docs.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
