### PR TITLE
intel-pin: restrict usage with GCC for v3

### DIFF
--- a/repos/spack_repo/builtin/packages/intel_pin/package.py
+++ b/repos/spack_repo/builtin/packages/intel_pin/package.py
@@ -148,6 +148,8 @@ class IntelPin(Package):
         url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-2.14-71313-gcc.4.4.7-linux.tar.gz",
     )
 
+    conflicts("gcc@15:", when="@:3", msg="Pin v3 does not work with GCC 15 or newer")
+
     def install(self, spec, prefix):
         install_tree(".", prefix)
         mkdir(prefix.bin)


### PR DESCRIPTION
The result of

```
spack install --fresh numaprof %gcc@15 ^intel-pin@:3
```

is

```
                   from /home/eric/data/spack/opt/spack/linux-zen/intel-pin-3.31-4lohc6dmc6nlytdmitkiuzkmagg5pvoe/source/include/pin/pin.H:28,
                   from /tmp/eric/spack-stage/spack-stage-numaprof-1.1.5-qlzaqlycramqqfsg32zmpm6cird3od3f/spack-src/src/integration/pintool/../../lib/core/../portability/Mutex.hpp:14,
                   from /tmp/eric/spack-stage/spack-stage-numaprof-1.1.5-qlzaqlycramqqfsg32zmpm6cird3od3f/spack-src/src/integration/pintool/../../lib/core/PageTable.hpp:13,
                   from /tmp/eric/spack-stage/spack-stage-numaprof-1.1.5-qlzaqlycramqqfsg32zmpm6cird3od3f/spack-src/src/integration/pintool/../../lib/core/MallocTracker.hpp:10,
                   from /tmp/eric/spack-stage/spack-stage-numaprof-1.1.5-qlzaqlycramqqfsg32zmpm6cird3od3f/spack-src/src/integration/pintool/../../lib/core/MallocTracker.cpp:10:
  /home/eric/data/spack/opt/spack/linux-zen/intel-pin-3.31-4lohc6dmc6nlytdmitkiuzkmagg5pvoe/extras/components/include/util/range.hpp: In member function 'bool UTIL::RANGE<ADDRTYPE>::Contains(const UTIL::RANGE<ADDRTYPE>&) const':
> /home/eric/data/spack/opt/spack/linux-zen/intel-pin-3.31-4lohc6dmc6nlytdmitkiuzkmagg5pvoe/extras/components/include/util/range.hpp:102:70: error: 'const class UTIL::RANGE<ADDRTYPE>' has no member named 'm_base'; did you mean '_base'? [-Wtemplate-body]
    102 |     bool Contains(const RANGE& range) const { return (Contains(range.m_base) && !range.Contains(GetEnd())); }
        |                                                                      ^~~~~~
        |                                                                      _base
```

The only other package using Pin is `sst-elements`, and I've confirmed it has the same problem.