### PR TITLE
otf2: compilation requires find utility

### DIFF
--- a/repos/spack_repo/builtin/packages/otf2/package.py
+++ b/repos/spack_repo/builtin/packages/otf2/package.py
@@ -25,6 +25,8 @@ class Otf2(AutotoolsPackage):
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
 
+    depends_on("findutils", type="build")
+
     extends("python")
 
     # `imp` module required


### PR DESCRIPTION
Not having `find` installed (unusual but can happen in fresh containers) leads to cryptic compilation errors; the hint was a substantial amount of `find: command not found` printing during both configure and build.

Attached is the `spack install otf2` output from a new Rocky 8 container.

[spack-stage-otf2-3.1.1-5ug2vedxns3ii3zyyoxlvfjntka3bedy-aokc1_i7.log](https://github.com/user-attachments/files/28075223/spack-stage-otf2-3.1.1-5ug2vedxns3ii3zyyoxlvfjntka3bedy-aokc1_i7.log)
