### PR TITLE
esmf: Make FindESMF.cmake findable via CMAKE_MODULE_PATH

### DIFF
--- a/repos/spack_repo/builtin/packages/esmf/package.py
+++ b/repos/spack_repo/builtin/packages/esmf/package.py
@@ -178,6 +178,8 @@ class Esmf(MakefilePackage, PythonExtension):
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         env.set("ESMFMKFILE", os.path.join(self.prefix.lib, "esmf.mk"))
+        if self.spec.satisfies("@8:"):
+            env.append_path("CMAKE_MODULE_PATH", self.prefix.cmake)
 
 
 class PythonPipBuilder(python.PythonPipBuilder):

--- a/repos/spack_repo/builtin/packages/esmf/package.py
+++ b/repos/spack_repo/builtin/packages/esmf/package.py
@@ -469,7 +469,7 @@ class MakefileBuilder(makefile.MakefileBuilder):
     ) -> None:
         env.set("ESMFMKFILE", os.path.join(self.prefix.lib, "esmf.mk"))
         if self.spec.satisfies("@8:"):
-            env.append_path("CMAKE_PREFIX_PATH", self.prefix.cmake)
+            env.append_path("CMAKE_MODULE_PATH", self.prefix.cmake)
 
     def install(self, pkg, spec, prefix):
         make("install")

--- a/repos/spack_repo/builtin/packages/esmf/package.py
+++ b/repos/spack_repo/builtin/packages/esmf/package.py
@@ -18,9 +18,24 @@ class Esmf(MakefilePackage, PythonExtension):
     related Earth science applications. The ESMF defines an architecture for
     composing complex, coupled modeling systems and includes data structures
     and utilities for developing individual models.
+
     The National Unified Operational Prediction Capability (NUOPC) Layer
     defines a common model architecture to support interoperable ESMF components.
-    The NUOPC Layer is included with the ESMF package."""
+    The NUOPC Layer is included with the ESMF package.
+
+    ESMX (Earth System Modeling eXecutable) extends this infrastructure by
+    providing a unified, runtime executable layer. It simplifies the deployment
+    of NUOPC-compliant components by allowing users to configure, drive, and
+    execute coupled earth system models dynamically via YAML configuration files,
+    reducing the need to write custom top-level application and driver code.
+    ESMX is included with the ESMF package.
+
+    ESMPy is a Python interface to the ESMF gridding engine. It allows for
+    high-performance, parallel regridding of fields between structured grids,
+    unstructured meshes, and observational data streams directly within Python
+    workflows. This bridges native ESMF capabilities with the broader Python
+    data science ecosystem.
+    ESMPy is included with the ESMF package."""
 
     homepage = "https://earthsystemmodeling.org/"
     url = "https://github.com/esmf-org/esmf/archive/v8.4.1.tar.gz"
@@ -453,6 +468,8 @@ class MakefileBuilder(makefile.MakefileBuilder):
         self, env: EnvironmentModifications, dependent_spec: Spec
     ) -> None:
         env.set("ESMFMKFILE", os.path.join(self.prefix.lib, "esmf.mk"))
+        if self.spec.satisfies("@8:"):
+            env.append_path("CMAKE_PREFIX_PATH", self.prefix.cmake)
 
     def install(self, pkg, spec, prefix):
         make("install")


### PR DESCRIPTION
This PR appends to the `CMAKE_MODULE_PATH` to allow dependent packages to find FindESMF.cmake. This follows suggestion by @johnwparent under https://github.com/spack/spack-packages/issues/5045#issuecomment-4479922985

Also cover ESMX and ESMPy in the ESMF package description. Something I noticed was missing.

Resolves https://github.com/spack/spack-packages/issues/5045#issuecomment-4479922985

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
