### PR TITLE
libdeflate: add v1.25

### DIFF
--- a/repos/spack_repo/builtin/packages/libdeflate/package.py
+++ b/repos/spack_repo/builtin/packages/libdeflate/package.py
@@ -19,6 +19,7 @@ class Libdeflate(MakefilePackage, CMakePackage):
 
     license("MIT")
 
+    version("1.25", sha256="d11473c1ad4c57d874695e8026865e38b47116bbcb872bfc622ec8f37a86017d")
     version("1.18", sha256="225d982bcaf553221c76726358d2ea139bb34913180b20823c782cede060affd")
     version("1.14", sha256="89e7df898c37c3427b0f39aadcf733731321a278771d20fc553f92da8d4808ac")
     version("1.10", sha256="5c1f75c285cd87202226f4de49985dcb75732f527eefba2b3ddd70a8865f2533")


### PR DESCRIPTION
Add version v1.25 to the existing libdeflate package. This PR forwards a change from https://gitlab.com/ska-telescope/sdp/ska-sdp-spack/-/merge_requests/356 into the main Spack package repository. That GitLab MR already successfully built the new version in its CI.

