### PR TITLE
py-triton: Add Python versions from release compatibility matrix

### DIFF
--- a/repos/spack_repo/builtin/packages/py_triton/package.py
+++ b/repos/spack_repo/builtin/packages/py_triton/package.py
@@ -24,7 +24,11 @@ class PyTriton(PythonPackage):
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
-
+    depends_on("python@3.9:3.13", when="@3.2.0:")
+    depends_on("python@3.8:3.12", when="@3.0.0:3.1")
+    depends_on("python@3.7:3.12", when="@2.2.0:2")
+    depends_on("python@3.7:3.11", when="@2.1.0:2.1")
+    
     with default_args(type="build"):
         # https://github.com/triton-lang/triton/blob/v3.3.1/python/requirements.txt
         depends_on("cmake@3.18:3")

--- a/repos/spack_repo/builtin/packages/py_triton/package.py
+++ b/repos/spack_repo/builtin/packages/py_triton/package.py
@@ -28,7 +28,7 @@ class PyTriton(PythonPackage):
     depends_on("python@3.8:3.12", when="@3.0.0:3.1")
     depends_on("python@3.7:3.12", when="@2.2.0:2")
     depends_on("python@3.7:3.11", when="@2.1.0:2.1")
-    
+
     with default_args(type="build"):
         # https://github.com/triton-lang/triton/blob/v3.3.1/python/requirements.txt
         depends_on("cmake@3.18:3")

--- a/repos/spack_repo/builtin/packages/py_triton/package.py
+++ b/repos/spack_repo/builtin/packages/py_triton/package.py
@@ -24,10 +24,10 @@ class PyTriton(PythonPackage):
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
-    depends_on("python@3.9:3.13", when="@3.2.0:")
-    depends_on("python@3.8:3.12", when="@3.0.0:3.1")
-    depends_on("python@3.7:3.12", when="@2.2.0:2")
-    depends_on("python@3.7:3.11", when="@2.1.0:2.1")
+    depends_on("python@3.9:3.13", when="@3.2.0:", type=("build", "run"))
+    depends_on("python@3.8:3.12", when="@3.0.0:3.1", type=("build", "run"))
+    depends_on("python@3.7:3.12", when="@2.2.0:2", type=("build", "run"))
+    depends_on("python@3.7:3.11", when="@2.1.0:2.1", type=("build", "run"))
 
     with default_args(type="build"):
         # https://github.com/triton-lang/triton/blob/v3.3.1/python/requirements.txt


### PR DESCRIPTION
https://github.com/triton-lang/triton/blob/main/RELEASE.md

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
