### PR TITLE
neko: pass BLAS/LAPACK as linker flags

### DIFF
--- a/repos/spack_repo/builtin/packages/neko/package.py
+++ b/repos/spack_repo/builtin/packages/neko/package.py
@@ -64,8 +64,8 @@ class Neko(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     def configure_args(self):
         args = []
-        args.append("--with-blas={0}".format(self.spec["blas"].libs.joined(";")))
-        args.append("--with-lapack={0}".format(self.spec["lapack"].libs.joined(";")))
+        args.append("--with-blas={0}".format(self.spec["blas"].libs.ld_flags))
+        args.append("--with-lapack={0}".format(self.spec["lapack"].libs.ld_flags))
         args += self.with_or_without("parmetis", variant="parmetis", activation_value="prefix")
         args += self.with_or_without("metis", variant="parmetis", activation_value="prefix")
         args += self.with_or_without("libxsmm", variant="xsmm")


### PR DESCRIPTION
This fixes BLAS/LAPACK arguments passed to Neko's Autotools configure script.

The current recipe passes `spec["blas"].libs.joined(";")` and `spec["lapack"].libs.joined(";")`, which expands to semicolon-joined library paths. That form is better suited to CMake-style library lists than Autotools linker arguments.

With `neko+shared ^openblas`, this can lead to unstable libtool link ordering: `libneko.so` is built without a `NEEDED` dependency on OpenBLAS, and the final executable link may fail with unresolved BLAS/LAPACK symbols such as `dgemm_` and `dsygv_`.

Using `libs.ld_flags` passes the dependencies as normal linker flags, e.g. `-L... -lopenblas`, which is the form Neko's configure logic expects.