### PR TITLE
py-f90wrap: add v0.2.16, v0.3.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_f90wrap/package.py
+++ b/repos/spack_repo/builtin/packages/py_f90wrap/package.py
@@ -33,3 +33,4 @@ class PyF90wrap(PythonPackage):
     depends_on("py-setuptools", type="build", when="@:0.2.11")
     depends_on("py-numpy@2:", type=("build", "run"), when="@0.3:")
     depends_on("py-numpy@1.3:", type=("build", "run"))
+    depends_on("py-packaging", type=("build", "run"), when="@0.2.14:")

--- a/repos/spack_repo/builtin/packages/py_f90wrap/package.py
+++ b/repos/spack_repo/builtin/packages/py_f90wrap/package.py
@@ -18,6 +18,7 @@ class PyF90wrap(PythonPackage):
     license("LGPL-3.0-only")
 
     version("0.3.0", sha256="9c9f08768fe7e9d60de9e913e30909fa1bdc67828f49dffd7149089703d74836")
+    version("0.2.16", sha256="f085be1eb0dc62512df604e3f5d7535d70ae1837175beb12e3f49466f08776c6")
     version("0.2.6", sha256="e0748eb5e288be7f47829a272fc230373469fb40afccddf91e9973c56da43dd4")
     version("0.2.3", sha256="5577ea92934c5aad378df21fb0805b5fb433d6f2b8b9c1bf1a9ec1e3bf842cff")
 
@@ -26,8 +27,8 @@ class PyF90wrap(PythonPackage):
 
     depends_on("py-meson-python@0.12:", type="build", when="@0.2.12:")
 
-    # TODO errors with python 3.6 due to UnicodeDecodeError
     depends_on("python@3.9:", type=("build", "run"), when="@0.3:")
+    depends_on("python@3.8:", type=("build", "run"), when="@0.2.15:")
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools", type="build", when="@:0.2.11")
     depends_on("py-numpy@2:", type=("build", "run"), when="@0.3:")

--- a/repos/spack_repo/builtin/packages/py_f90wrap/package.py
+++ b/repos/spack_repo/builtin/packages/py_f90wrap/package.py
@@ -29,6 +29,6 @@ class PyF90wrap(PythonPackage):
     # TODO errors with python 3.6 due to UnicodeDecodeError
     depends_on("python@3.9:", type=("build", "run"), when="@0.3:")
     depends_on("python@3.6:", type=("build", "run"))
-    depends_on("py-setuptools", type="build", when="@:0.2")
+    depends_on("py-setuptools", type="build", when="@:0.2.11")
     depends_on("py-numpy@2:", type=("build", "run"), when="@0.3:")
     depends_on("py-numpy@1.3:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_f90wrap/package.py
+++ b/repos/spack_repo/builtin/packages/py_f90wrap/package.py
@@ -30,7 +30,9 @@ class PyF90wrap(PythonPackage):
     depends_on("python@3.9:", type=("build", "run"), when="@0.3:")
     depends_on("python@3.8:", type=("build", "run"), when="@0.2.15:")
     depends_on("python@3.6:", type=("build", "run"))
-    depends_on("py-setuptools", type="build", when="@:0.2.11")
     depends_on("py-numpy@2:", type=("build", "run"), when="@0.3:")
     depends_on("py-numpy@1.3:", type=("build", "run"))
     depends_on("py-packaging", type=("build", "run"), when="@0.2.14:")
+
+    # Historical dependencies
+    depends_on("py-setuptools", type="build", when="@:0.2.11")

--- a/repos/spack_repo/builtin/packages/py_f90wrap/package.py
+++ b/repos/spack_repo/builtin/packages/py_f90wrap/package.py
@@ -24,7 +24,7 @@ class PyF90wrap(PythonPackage):
     depends_on("c", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
-    depends_on("py-meson-python@0.12:", type="build")
+    depends_on("py-meson-python@0.12:", type="build", when="@0.2.12:")
 
     # TODO errors with python 3.6 due to UnicodeDecodeError
     depends_on("python@3.9:", type=("build", "run"), when="@0.3:")

--- a/repos/spack_repo/builtin/packages/py_f90wrap/package.py
+++ b/repos/spack_repo/builtin/packages/py_f90wrap/package.py
@@ -17,13 +17,18 @@ class PyF90wrap(PythonPackage):
 
     license("LGPL-3.0-only")
 
+    version("0.3.0", sha256="9c9f08768fe7e9d60de9e913e30909fa1bdc67828f49dffd7149089703d74836")
     version("0.2.6", sha256="e0748eb5e288be7f47829a272fc230373469fb40afccddf91e9973c56da43dd4")
     version("0.2.3", sha256="5577ea92934c5aad378df21fb0805b5fb433d6f2b8b9c1bf1a9ec1e3bf842cff")
 
     depends_on("c", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
+    depends_on("py-meson-python@0.12:", type="build")
+
     # TODO errors with python 3.6 due to UnicodeDecodeError
+    depends_on("python@3.9:", type=("build", "run"), when="@0.3:")
     depends_on("python@3.6:", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
-    depends_on("py-numpy@1.3.0:", type=("build", "run"))
+    depends_on("py-setuptools", type="build", when="@:0.2")
+    depends_on("py-numpy@2:", type=("build", "run"), when="@0.3:")
+    depends_on("py-numpy@1.3:", type=("build", "run"))


### PR DESCRIPTION
See [pyproject.toml](https://github.com/jameskermode/f90wrap/blob/v0.3.0/pyproject.toml):
- add version 0.3.0
- replace setuptools by meson-python starting from 0.2.12
- make python 3.9 the minimum requirement from 0.3.0 
- make numpy 2 the minimum requirement from 0.3.0