### PR TITLE
mille: add v01-00-03

### DIFF
--- a/repos/spack_repo/builtin/packages/mille/package.py
+++ b/repos/spack_repo/builtin/packages/mille/package.py
@@ -18,6 +18,7 @@ class Mille(CMakePackage):
     license("LGPL-2.0-only", checked_by="paulgessinger")
 
     version("main", branch="main")
+    version("01-00-03", sha256="1953e2a341fed3a1c431c954d6e8f1c823926bc2886bdc209d859d2cb9dac6d8")
     version("01-00-02", sha256="bb232672003a8f13f848635e49a261acb79de26634e4ba76347358f209b5de05")
     version("01-00-00", sha256="ae4bf37de8d835aa8adc2960bb795a2080233a4c8af3d4b55adf395e20df0f3e")
 


### PR DESCRIPTION
Add Mille-01-00-03, supporting Millepede-II 05-01-02 and later.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
