### PR TITLE
python.py: install/.is_develop: Remove cached pip build artifacts when using `spack develop`

### DIFF
--- a/repos/spack_repo/builtin/build_systems/python.py
+++ b/repos/spack_repo/builtin/build_systems/python.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import glob
 import os
 import re
 import shutil
@@ -392,6 +393,19 @@ class PythonPipBuilder(BuilderWithDefaults):
             args.append(pkg.stage.archive_file)
         else:
             args.append(".")
+
+        # For develop packages, remove stale build artifacts that cause pip
+        # to use cached/outdated files instead of rebuilding from source.
+        if spec.is_develop:
+            bd = self.build_directory
+            for artifact in (
+                join_path(bd, "build"),
+                join_path(bd, "dist"),
+                *glob.glob(join_path(bd, "*.egg-info")),
+            ):
+                if os.path.isdir(artifact):
+                    tty.debug(f"Removing stale build artifact: {artifact}")
+                    shutil.rmtree(artifact)
 
         with working_dir(self.build_directory):
             pip(*args)

--- a/repos/spack_repo/builtin/build_systems/python.py
+++ b/repos/spack_repo/builtin/build_systems/python.py
@@ -403,9 +403,12 @@ class PythonPipBuilder(BuilderWithDefaults):
                 join_path(bd, "dist"),
                 *glob.glob(join_path(bd, "*.egg-info")),
             ):
-                if os.path.isdir(artifact):
+                if os.path.isdir(artifact) and not os.path.islink(artifact):
                     tty.debug(f"Removing stale build artifact: {artifact}")
                     shutil.rmtree(artifact)
+                elif os.path.lexists(artifact):
+                    tty.debug(f"Removing stale build artifact: {artifact}")
+                    os.unlink(artifact)
 
         with working_dir(self.build_directory):
             pip(*args)


### PR DESCRIPTION
`pip` generates `build/`, `dist/` and `.egg-info/` build artifacts. These cause `spack develop` to (sometimes) not install the latest version of packages marked as 'develop'. We should make sure that they are deleted before installing again.

This fix along with https://github.com/spack/spack/pull/52371 will make `spack develop` reliable for us.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
