### PR TITLE
gnupg: add v2.5.20, updated dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/gnupg/package.py
+++ b/repos/spack_repo/builtin/packages/gnupg/package.py
@@ -19,12 +19,15 @@ class Gnupg(AutotoolsPackage):
 
     license("GPL-3.0-or-later")
 
-    version("2.5.17", sha256="2c1fbe20e2958fd8fb53cf37d7c38e84a900edc0d561a1c4af4bc3a10888685d")
+    version("2.5.20", sha256="6461266e99c308419a379abe6c356d54c214136c4589bd65951091138989ffc6")
     version("2.4.9", sha256="dd17ab2e9a04fd79d39d853f599cbc852062ddb9ab52a4ddeb4176fd8b302964")
     version("2.3.8", sha256="540b7a40e57da261fb10ef521a282e0021532a80fd023e75fb71757e8a4969ed")
     version("2.2.40", sha256="1164b29a75e8ab93ea15033300149e1872a7ef6bdda3d7c78229a735f8204c28")
 
     with default_args(deprecated=True):
+        version(
+            "2.5.17", sha256="2c1fbe20e2958fd8fb53cf37d7c38e84a900edc0d561a1c4af4bc3a10888685d"
+        )
         version(
             "2.5.16", sha256="05144040fedb828ced2a6bafa2c4a0479ee4cceacf3b6d68ccc75b175ac13b7e"
         )

--- a/repos/spack_repo/builtin/packages/libgcrypt/package.py
+++ b/repos/spack_repo/builtin/packages/libgcrypt/package.py
@@ -17,6 +17,7 @@ class Libgcrypt(AutotoolsPackage):
 
     license("LGPL-2.1-or-later AND GPL-2.0-or-later")
 
+    version("1.12.2", sha256="7ce33c2492221a0436f96a8500215e9f3e3dcb5fd26a757cd415e7a843babd5e")
     version("1.12.0", sha256="0311454e678189bad62a7e9402a9dd793025efff6e7449898616e2fc75e0f4f5")
     version("1.11.2", sha256="6ba59dd192270e8c1d22ddb41a07d95dcdbc1f0fb02d03c4b54b235814330aac")
     version("1.11.1", sha256="24e91c9123a46c54e8371f3a3a2502f1198f2893fbfbf59af95bc1c21499b00e")

--- a/repos/spack_repo/builtin/packages/libgpg_error/package.py
+++ b/repos/spack_repo/builtin/packages/libgpg_error/package.py
@@ -17,6 +17,7 @@ class LibgpgError(AutotoolsPackage):
 
     license("GPL-2.0-or-later AND LGPL-2.1-or-later")
 
+    version("1.61", sha256="7a85413f2bc354f4f8aa832b718af122e48965e9e0eb9012ee659c13c6385c93")
     version("1.58", sha256="f943aea9a830a8bd938e5124b579efaece24a3225ff4c3d27611a80ce1260c27")
     version("1.55", sha256="95b178148863f07d45df0cea67e880a79b9ef71f5d230baddc0071128516ef78")
     version("1.51", sha256="be0f1b2db6b93eed55369cdf79f19f72750c8c7c39fc20b577e724545427e6b2")

--- a/repos/spack_repo/builtin/packages/libksba/package.py
+++ b/repos/spack_repo/builtin/packages/libksba/package.py
@@ -18,6 +18,9 @@ class Libksba(AutotoolsPackage):
 
     license("LGPL-3.0-only AND GPL-2.0-only AND GPL-3.0-only")
 
+    version("1.8.0", sha256="296b9db9095749f2aa104202d7ab7fd09ad10710e00780a709c9754b1a1d9292")
+    version("1.7.0", sha256="e1d3a5745911f5a663fddecf526541c4241052a9e4cafbc92dc7f4096c7efdac")
+    version("1.6.8", sha256="0f4510f1c7a679c3545990a31479f391ad45d84e039176309d42f80cf41743f5")
     version("1.6.7", sha256="cf72510b8ebb4eb6693eef765749d83677a03c79291a311040a5bfd79baab763")
     version("1.6.6", sha256="5dec033d211559338838c0c4957c73dfdc3ee86f73977d6279640c9cd08ce6a4")
     version("1.6.5", sha256="a564628c574c99287998753f98d750babd91a4e9db451f46ad140466ef2a6d16")


### PR DESCRIPTION
- **gnupg**: add v2.5.20, deprecate v2.5.17
- **libgcrypt**: add v1.12.2
- **libgpg_error**: add v1.61
- **libksba**: add v1.8.0, v1.7.0, v1,6,8

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
