### PR TITLE
py-pyyaml, py-arcgis, py-pyomo: fix for older setuptools

### DIFF
--- a/repos/spack_repo/builtin/packages/py_arcgis/package.py
+++ b/repos/spack_repo/builtin/packages/py_arcgis/package.py
@@ -33,7 +33,7 @@ class PyArcgis(PythonPackage):
     depends_on("py-requests-toolbelt", type=("build", "run"))
     depends_on("py-requests-ntlm", type=("build", "run"))
 
-    @when("^py-pip@23.1:")
+    @when("^py-pip@23.1: ^py-setuptools@64:")
     def config_settings(self, spec, prefix):
         return {"--global-option": "--conda-install-mode"}
 

--- a/repos/spack_repo/builtin/packages/py_pyomo/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyomo/package.py
@@ -141,7 +141,7 @@ class PyPyomo(PythonPackage):
     depends_on("py-pandas", when="@6.1:+optional", type=("run"))
     depends_on("py-seaborn", when="@6.1:+optional", type=("run"))
 
-    @when("^py-pip@23.1:")
+    @when("^py-pip@23.1: ^py-setuptools@64:")
     def config_settings(self, spec, prefix):
         if "+cython" in self.spec:
             return {"--global-option": "--with-cython"}

--- a/repos/spack_repo/builtin/packages/py_pyyaml/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyyaml/package.py
@@ -76,7 +76,7 @@ class PyPyyaml(PythonPackage):
 
         return modules
 
-    @when("^py-pip@23.1:")
+    @when("^py-pip@23.1: ^py-setuptools@64:")
     def config_settings(self, spec, prefix):
         if "+libyaml" in self.spec:
             return {"--global-option": "--with-libyaml"}


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Closes #4854

PR #4018 updated these packages to pass flags via `--global-option=...` for `pip` >= 23.1. However, support for `--global-option` was only introduced in setuptools v64.0.0 (Aug 11, 2022). When an older setuptools is resolved (e.g. `py-setuptools@63.4.3`, released the day before), the flag is not recognized and the build fails with:

```
error: option --with-libyaml not recognized
```

The fix narrows the `@when` condition on `config_settings` to require both `^py-pip@23.1:` and `^py-setuptools@64:`. When older setuptools is used with newer pip, neither method fires and pip builds without the extra flags, which seems like the safest thing to do.

Verified locally that:

```
spack install py-pyyaml +libyaml ^py-setuptools@63.4.3 ^py-pip@23.1:
spack install py-pyyaml ~libyaml ^py-setuptools@63.4.3 ^py-pip@23.1:

spack install py-pyyaml +libyaml ^py-setuptools@68: ^py-pip@23.1:
spack install py-pyyaml ~libyaml ^py-setuptools@68: ^py-pip@23.1:
```

now succeed. I didn't try the other ones, but I have to imagine if `py-pyyaml` has this issue, so will `py-arcgis` and `py-pyomo`

