### PR TITLE
Emacs: remove json support @30:

### DIFF
--- a/repos/spack_repo/builtin/packages/emacs/package.py
+++ b/repos/spack_repo/builtin/packages/emacs/package.py
@@ -60,7 +60,7 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
         description="X11 toolkit when gui=x11 (gtk, athena)",
         when="gui=x11",
     )
-    variant("json", default=False, when="@27:", description="Build with json support")
+    variant("json", default=False, when="@27:29", description="Build with json support")
     variant("native", default=False, when="@28:", description="Enable native compilation of elisp")
     variant("sqlite", default=False, when="@29.1:", description="Build with sqlite3 support")
     variant("tls", default=True, description="Build with gnutls support")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Emacs switched from using `jansson` to native json support in Emacs 30. See: https://www.gnu.org/software/emacs/manual/html_node/efaq/New-in-Emacs-30.html. I also confirmed this with `./configure --help`.