### PR TITLE
trng: add v4.28.1

### DIFF
--- a/repos/spack_repo/builtin/packages/trng/package.py
+++ b/repos/spack_repo/builtin/packages/trng/package.py
@@ -15,7 +15,7 @@ class Trng(CMakePackage):
 
     maintainers("chapman39")
 
-    version("4.28", commit="691817a4a0331421776e7f00efa9fbe81554da86", submodules=True)
+    version("4.28.1", commit="cc1b170b050b541ac481415b175394670c2a4e85", submodules=True)
     version("4.24", commit="a22a32b9a285d1293b74b17b34f81af5dcec6311")
     version("4.23.1", commit="610f7836610e9e01788f8461fbe83b67544ded7c")
     version("4.23", commit="22a30c493eff4cb547185fa48275683751df18e0")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Adds patch version of 4.28, with the following fix: https://github.com/rabauke/trng4/issues/35
