### PR TITLE
Windows binary packages: no depends_on c

### DIFF
--- a/repos/spack_repo/builtin/packages/win_file/package.py
+++ b/repos/spack_repo/builtin/packages/win_file/package.py
@@ -24,8 +24,6 @@ class WinFile(Package):
 
     version("5.45", sha256="11b8f3abf647c711bc50ef8451c8d6e955f11c4afd8b0a98f2ac65e9b6e10d5e")
 
-    depends_on("c", type="build")
-
     @classmethod
     def determine_version(cls, exe):
         output = Executable(exe)("--version", output=str, error=str)

--- a/repos/spack_repo/builtin/packages/win_gpg/package.py
+++ b/repos/spack_repo/builtin/packages/win_gpg/package.py
@@ -25,8 +25,6 @@ class WinGpg(Package):
 
     version("2.4.5", sha256="249ab87bd06abea3140054089bad44d9a5d1531413590576da609142db2673ec")
 
-    depends_on("c", type="build")
-
     @classmethod
     def determine_version(cls, exe):
         output = Executable(exe)("--version", output=str, error=str)


### PR DESCRIPTION
Brings in unneeded compiler + compiler wrapper builds/logic for pure binary installs.