### PR TITLE
esmf: Cover ESMX and ESMPy in the ESMF package description.

### DIFF
--- a/repos/spack_repo/builtin/packages/esmf/package.py
+++ b/repos/spack_repo/builtin/packages/esmf/package.py
@@ -18,9 +18,24 @@ class Esmf(MakefilePackage, PythonExtension):
     related Earth science applications. The ESMF defines an architecture for
     composing complex, coupled modeling systems and includes data structures
     and utilities for developing individual models.
+
     The National Unified Operational Prediction Capability (NUOPC) Layer
     defines a common model architecture to support interoperable ESMF components.
-    The NUOPC Layer is included with the ESMF package."""
+    The NUOPC Layer is included with the ESMF package.
+
+    ESMX (Earth System Modeling eXecutable) extends this infrastructure by
+    providing a unified, runtime executable layer. It simplifies the deployment
+    of NUOPC-compliant components by allowing users to configure, drive, and
+    execute coupled earth system models dynamically via YAML configuration files,
+    reducing the need to write custom top-level application and driver code.
+    ESMX is included with the ESMF package.
+
+    ESMPy is a Python interface to the ESMF gridding engine. It allows for
+    high-performance, parallel regridding of fields between structured grids,
+    unstructured meshes, and observational data streams directly within Python
+    workflows. This bridges native ESMF capabilities with the broader Python
+    data science ecosystem.
+    ESMPy is included with the ESMF package."""
 
     homepage = "https://earthsystemmodeling.org/"
     url = "https://github.com/esmf-org/esmf/archive/v8.4.1.tar.gz"


### PR DESCRIPTION
This PR only touches the ESMF package description. It covers ESMX and ESMPy, both layers are shipped with ESMF.


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
