### PR TITLE
sst: add v16.0.0 for core, elements, and macro

### DIFF
--- a/repos/spack_repo/builtin/packages/sst_core/package.py
+++ b/repos/spack_repo/builtin/packages/sst_core/package.py
@@ -106,6 +106,10 @@ class SstCore(AutotoolsPackage):
     with when("@14.0.0"):
         patch("1110-ncurses_detection.patch", level=0)
 
+    with when("^mpi=openmpi"):
+        # < 4 is untested and 5 doesn't pass tests due to reference outputs
+        depends_on("openmpi@4")
+
     # force out-of-source builds
     build_directory = "spack-build"
 

--- a/repos/spack_repo/builtin/packages/sst_core/package.py
+++ b/repos/spack_repo/builtin/packages/sst_core/package.py
@@ -97,7 +97,7 @@ class SstCore(AutotoolsPackage):
     depends_on("ncurses", when="+curses", type=("build", "link"))
 
     with when("@develop,master,14.0.0"):
-        depends_on("autoconf@1.68:", type="build")
+        depends_on("autoconf@2.69:", type="build")
         depends_on("automake@1.11.1:", type="build")
         depends_on("libtool@1.2.4:", type="build")
         depends_on("m4", type="build")

--- a/repos/spack_repo/builtin/packages/sst_core/package.py
+++ b/repos/spack_repo/builtin/packages/sst_core/package.py
@@ -21,6 +21,7 @@ class SstCore(AutotoolsPackage):
 
     license("BSD-3-Clause")
 
+    version("16.0.0", sha256="20733d6334bc80dd8cf5695d1eb3bd32ada80dcf3151695b8dbdbbac28ead616")
     version("15.1.2", sha256="21aabfddb80c7aaf65e562894e0542bdb871bbc630362c3cef579d949c456f33")
     version("15.1.1", sha256="651cf5ee1438a5128aea2ad8b518c5437a1637dce357cbcbdd58681fa749222f")
     version("15.1.0", sha256="ec3d9e733bcf99283b526cfb4a853787d303a8d55b2a42d5102b0f4f4a4feb81")

--- a/repos/spack_repo/builtin/packages/sst_core/package.py
+++ b/repos/spack_repo/builtin/packages/sst_core/package.py
@@ -88,7 +88,7 @@ class SstCore(AutotoolsPackage):
     depends_on("cxx", type="build")  # generated
     depends_on("c", type="build")
 
-    depends_on("python@:3.11", type=("build", "run", "link"))
+    depends_on("python@3.9:", type=("build", "run", "link"))
     depends_on("mpi", when="+pdes_mpi")
     depends_on("zoltan", when="+zoltan")
     depends_on("hdf5 +cxx", when="+hdf5")

--- a/repos/spack_repo/builtin/packages/sst_elements/package.py
+++ b/repos/spack_repo/builtin/packages/sst_elements/package.py
@@ -75,7 +75,7 @@ class SstElements(AutotoolsPackage):
     depends_on("sst-core@develop", when="@develop")
     depends_on("sst-core@master", when="@master")
 
-    depends_on("intel-pin", when="+pin")
+    depends_on("intel-pin@:3", when="+pin")
     depends_on("dramsim2@2:", when="+dramsim2")
     depends_on("dramsim3@master", when="+dramsim3")
     depends_on("sst-dumpi@master", when="+dumpi")

--- a/repos/spack_repo/builtin/packages/sst_elements/package.py
+++ b/repos/spack_repo/builtin/packages/sst_elements/package.py
@@ -95,7 +95,7 @@ class SstElements(AutotoolsPackage):
     depends_on("mpi", when="+ariel_mpi")
 
     for version_name in ("master", "develop"):
-        depends_on("autoconf@1.68:", type="build", when="@{}".format(version_name))
+        depends_on("autoconf@2.69:", type="build", when="@{}".format(version_name))
         depends_on("automake@1.11.1:", type="build", when="@{}".format(version_name))
         depends_on("libtool@1.2.4:", type="build", when="@{}".format(version_name))
         depends_on("m4", type="build", when="@{}".format(version_name))

--- a/repos/spack_repo/builtin/packages/sst_elements/package.py
+++ b/repos/spack_repo/builtin/packages/sst_elements/package.py
@@ -21,6 +21,7 @@ class SstElements(AutotoolsPackage):
 
     license("BSD-3-Clause")
 
+    version("16.0.0", sha256="e0f72777df2d0619bd529334994132d919bd0cdc8f1e84bcbc4200564482258f")
     version("15.1.0", sha256="e7162bb8719341230217dd5ab9d36bb9529ed9ce3d206ca74948044290080c93")
     version("15.0.0", sha256="98f7fbd4bce16f639616edb889fb3c6667b50899273114854e77fcdb26bcddd6")
     version("14.1.0", sha256="433994065810d3afee4e355173e781cd76171043cce8835bbc40887672a33350")

--- a/repos/spack_repo/builtin/packages/sst_elements/package.py
+++ b/repos/spack_repo/builtin/packages/sst_elements/package.py
@@ -66,9 +66,8 @@ class SstElements(AutotoolsPackage):
     variant("otf2", default=False, description="Build with OTF2")
     variant("ariel_mpi", default=False, description="Build Ariel with MPI Support")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("python@3.9:", type=("build", "run"))
     depends_on("sst-core")

--- a/repos/spack_repo/builtin/packages/sst_elements/package.py
+++ b/repos/spack_repo/builtin/packages/sst_elements/package.py
@@ -70,7 +70,7 @@ class SstElements(AutotoolsPackage):
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
-    depends_on("python@:3.11", type=("build", "run"))
+    depends_on("python@3.9:", type=("build", "run"))
     depends_on("sst-core")
     depends_on("sst-core@develop", when="@develop")
     depends_on("sst-core@master", when="@master")

--- a/repos/spack_repo/builtin/packages/sst_elements/package.py
+++ b/repos/spack_repo/builtin/packages/sst_elements/package.py
@@ -114,6 +114,10 @@ class SstElements(AutotoolsPackage):
     )
     requires("+pin", when="+ariel_mpi", msg="Building Ariel requires pin")
 
+    with when("^mpi=openmpi"):
+        # < 4 is untested and 5 doesn't pass tests due to reference outputs
+        depends_on("openmpi@4")
+
     # force out-of-source builds
     build_directory = "spack-build"
 

--- a/repos/spack_repo/builtin/packages/sst_macro/package.py
+++ b/repos/spack_repo/builtin/packages/sst_macro/package.py
@@ -22,6 +22,7 @@ class SstMacro(AutotoolsPackage):
 
     maintainers("berquist", "jmlapre")
 
+    version("16.0.0", sha256="4d8c45b0a103b173d2efc7c692a2aad06bcec19d8bec20bc835261a7aabead3a")
     version("15.1.0", sha256="6ec4e2e79993672329063bb2e4b70f5b0f1317f7bdd46e9898a46d346d8b3a1d")
     version("15.0.0", sha256="ce4bdb28b1500f2fd6875e3ff7a630e24ae381b58c72ae24a5157181d9546d53")
     version("14.1.0", sha256="241f42f5c460b0e7462592a7f412bda9c9de19ad7a4b62c22f35be4093b57014")

--- a/repos/spack_repo/builtin/packages/sst_macro/package.py
+++ b/repos/spack_repo/builtin/packages/sst_macro/package.py
@@ -48,14 +48,15 @@ class SstMacro(AutotoolsPackage):
     version("master", branch="master")
     version("develop", branch="devel")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    # This can go away when the DUMPI package is depended on explicitly.
+    depends_on("fortran", type="build")
 
     for version_name in ("master", "develop"):
         depends_on("autoconf@1.68:", type="build", when="@{}".format(version_name))
         depends_on("automake@1.11.1:", type="build", when="@{}".format(version_name))
-        depends_on("libtool@1.2.4:", type="build", when="@{}".format(version_name))
+        depends_on("libtool@2.2.6:", type="build", when="@{}".format(version_name))
         depends_on("m4", type="build", when="@{}".format(version_name))
 
     depends_on("binutils", type="build")

--- a/repos/spack_repo/builtin/packages/sst_macro/package.py
+++ b/repos/spack_repo/builtin/packages/sst_macro/package.py
@@ -59,6 +59,8 @@ class SstMacro(AutotoolsPackage):
         depends_on("libtool@2.2.6:", type="build", when="@{}".format(version_name))
         depends_on("m4", type="build", when="@{}".format(version_name))
 
+    depends_on("grep", type="build")
+    depends_on("sed", type="build")
     depends_on("binutils", type="build")
     depends_on("zlib-api", type=("build", "link"))
     depends_on("otf2", when="+otf2")

--- a/repos/spack_repo/builtin/packages/sst_macro/package.py
+++ b/repos/spack_repo/builtin/packages/sst_macro/package.py
@@ -67,6 +67,8 @@ class SstMacro(AutotoolsPackage):
     # Allow mismatch between core dependency version and current macro version.
     depends_on("sst-core", when="+core")
     depends_on("gettext")
+    # configure shows this as an optional dependency which is incorrect.
+    depends_on("python@3")
 
     variant("pdes_threads", default=True, description="Enable thread-parallel PDES simulation")
     variant("pdes_mpi", default=False, description="Enable distributed PDES simulation")
@@ -129,5 +131,9 @@ class SstMacro(AutotoolsPackage):
             env["CXX"] = spec["mpi"].mpicxx
             env["F77"] = spec["mpi"].mpif77
             env["FC"] = spec["mpi"].mpifc
+
+        args.append(f"--with-python={spec['python'].command.path}")
+        # Not python-config in order to match search precedence of sst-core
+        args.append(f"--with-python-config={spec['python'].prefix.bin.join('python3-config')}")
 
         return args


### PR DESCRIPTION
Compilation checked on:
- Rocky 8 with GCC 8.5.0
- macOS 26 with Apple Clang 21
all with both Python 3.9 and 3.14