### PR TITLE
pfunit: add v4.18.2, v4.19.0

### DIFF
--- a/repos/spack_repo/builtin/packages/pfunit/package.py
+++ b/repos/spack_repo/builtin/packages/pfunit/package.py
@@ -23,6 +23,8 @@ class Pfunit(CMakePackage):
     license("NASA-1.3", checked_by="mathomp4", when="@:4.16")
     license("Apache-2.0", checked_by="mathomp4", when="@4.17:")
 
+    version("4.19.0", sha256="ec84e2e17d79598d782edc5468e7ebfe392ccf5aff9170a15c10f0b52f9f62b4")
+    version("4.18.2", sha256="d2bdc52372e42d8f0e27d06325c73ce0133b886d207cb5efb6d7fc6f0b536f48")
     version("4.18.1", sha256="34654ac27c3498333210cac480d6319d3d8c0230057fd0974f3e3c4d656b8cd9")
     version("4.18.0", sha256="e1beb32e95f487423720b85bbb8314f46af5321f3ed0d06cf0122bc479ecb812")
     version("4.17.1", sha256="de3d3a9d097762e41763035b1e8f39edfce7606c7ccda01839ca6331580ef38c")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR adds pfunit v4.18.2 and v4.19.0

v4.18.2 has a workaround for parameterised test cases when using flang and the second has improved XML output.