### PR TITLE
py-bids-validator-deno: add v2.4.1

### DIFF
--- a/repos/spack_repo/builtin/packages/py_bids_validator_deno/package.py
+++ b/repos/spack_repo/builtin/packages/py_bids_validator_deno/package.py
@@ -15,6 +15,7 @@ class PyBidsValidatorDeno(PythonPackage):
 
     license("MIT")
 
+    version("2.4.1", sha256="a79b4af2818a200ff5a597715a3c1050ae93be7cb523bcfef54b93af057d8466")
     version("2.4.0", sha256="78cd6bc4d43aa6b17555185181c74b22e2ccaea8c3494175b6524807b467aa94")
     version("2.0.7", sha256="55a46dc9e134c2996ecb077896aad65e5320f3c864b41c47e108011f8fd1e2d1")
 


### PR DESCRIPTION
https://github.com/bids-standard/bids-validator/releases/tag/2.4.1
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
