### PR TITLE
gcc: add `+graphite+bootstrap` conflict and other minor fixes

### DIFF
--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -1026,7 +1026,6 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
 
         self.link_newlib()
 
-        # self.build_directory = 'spack-build-nvptx'
         with working_dir("spack-build-nvptx", create=True):
             options = [
                 "--prefix={0}".format(prefix),
@@ -1161,10 +1160,10 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         Should be use only if self.spec.satisfies("@12: languages=d")
         """
         # Detect GCC package in the directory of the GCC compiler
-        # or in the $PATH if self.compiler.cc is not an absolute path:
+        # or in the $PATH if self["c"].cc is not an absolute path:
         from spack.detection import by_path  # TODO: remove use of private Spack API
 
-        compiler_dir = os.path.dirname(self.compiler.cc)
+        compiler_dir = os.path.dirname(self["c"].cc)
         detected_packages = by_path(
             [self.name], path_hints=([compiler_dir] if os.path.isdir(compiler_dir) else None)
         )
@@ -1180,7 +1179,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
 
         if candidate_specs:
             # We now need to filter specs that match the compiler version:
-            compiler_spec = Spec(repr(self.compiler.spec))
+            compiler_spec = self["c"].spec
 
             # First, try to filter specs that satisfy the compiler spec:
             new_candidate_specs = list(
@@ -1211,7 +1210,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
                     error_nl, self.spec.format("{name}{@version} {variants.languages}")
                 ),
             )
-        elif len(candidate_specs) == 0:
+        elif len(candidate_specs) == 1:
             return candidate_specs[0].extra_attributes["compilers"]["d"]
         else:
             # It is rather unlikely to end up here but let us try to resolve the ambiguity:
@@ -1224,7 +1223,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
             else:
                 raise InstallError(
                     "Cannot resolve ambiguity when detecting GDC that belongs to %{0}".format(
-                        self.compiler.spec
+                        self["c"].spec
                     ),
                     long_msg="The candidates are:{0}{0}{1}{0}".format(
                         error_nl,

--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -1014,14 +1014,6 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         guess = Executable("./config.guess")
         targetguess = guess(output=str).rstrip("\n")
 
-        options = getattr(self, "configure_flag_args", [])
-        options += ["--prefix={0}".format(prefix)]
-
-        options += [
-            "--with-cuda-driver-include={0}".format(spec["cuda"].prefix.include),
-            "--with-cuda-driver-lib={0}".format(spec["cuda"].libs.directories[0]),
-        ]
-
         self.copy_nvptx_tools()
 
         self.link_newlib()

--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -399,6 +399,9 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         # NVPTX build disables bootstrap
         conflicts("+bootstrap")
 
+    # Graphite loop optimizations cause bootstrap comparison failures
+    conflicts("+graphite +bootstrap")
+
     # Binutils can't build ld on macOS
     conflicts("+binutils", when="platform=darwin")
 

--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -1020,13 +1020,13 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
 
         with working_dir("spack-build-nvptx", create=True):
             options = [
-                "--prefix={0}".format(prefix),
-                "--enable-languages={0}".format(",".join(spec.variants["languages"].value)),
-                "--with-mpfr={0}".format(spec["mpfr"].prefix),
-                "--with-gmp={0}".format(spec["gmp"].prefix),
+                f"--prefix={prefix}",
+                f"--enable-languages={','.join(spec.variants['languages'].value)}",
+                f"--with-mpfr={spec['mpfr'].prefix}",
+                f"--with-gmp={spec['gmp'].prefix}",
                 "--target=nvptx-none",
-                "--with-build-time-tools={0}".format(join_path(prefix, "nvptx-none", "bin")),
-                "--enable-as-accelerator-for={0}".format(targetguess),
+                f"--with-build-time-tools={join_path(prefix, 'nvptx-none', 'bin')}",
+                f"--enable-as-accelerator-for={targetguess}",
                 "--disable-sjlj-exceptions",
                 "--enable-newlib-io-long-long",
             ]

--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -15,7 +15,8 @@ from spack.package import *
 
 class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     """The GNU Compiler Collection includes front ends for C, C++, Objective-C,
-    Fortran, Ada, and Go, as well as libraries for these languages."""
+    Fortran, Ada, and Go, as well as libraries for these languages.
+    """
 
     homepage = "https://gcc.gnu.org"
     gnu_mirror_path = "gcc/gcc-9.2.0/gcc-9.2.0.tar.xz"
@@ -64,9 +65,6 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     version("4.6.4", sha256="35af16afa0b67af9b8eb15cafb76d2bc5f568540552522f5dc2c88dd45d977e8")
     version("4.5.4", sha256="eef3f0456db8c3d992cbb51d5d32558190bc14f3bc19383dd93acc27acc6befc")
 
-    # Used in the tutorial
-    version("12.3.0", sha256="949a5d4f99e786421a93b532b22ffab5578de7321369975b91aec97adfda8c3b")
-
     # Deprecated older non-final releases
     with default_args(deprecated=True):
         version(
@@ -85,6 +83,9 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
 
         version(
             "12.4.0", sha256="704f652604ccbccb14bdabf3478c9511c89788b12cb3bbffded37341916a9175"
+        )
+        version(
+            "12.3.0", sha256="949a5d4f99e786421a93b532b22ffab5578de7321369975b91aec97adfda8c3b"
         )
         version(
             "12.2.0", sha256="e549cf9cf3594a00e27b6589d4322d70e0720cdd213f39beb4181e06926230ff"
@@ -205,30 +206,34 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     )
     variant("libsanitizer", default=True, description="Use libsanitizer")
 
+    # See https://gcc.gnu.org/install/prerequisites.html
+
     depends_on("c", type="build")
     depends_on("cxx", type="build")
-
-    depends_on("flex", type="build", when="@master")
-
-    # https://gcc.gnu.org/install/prerequisites.html
-    depends_on("gmp@4.3.2:")
     # mawk is not sufficient for go support
     depends_on("gawk@3.1.5:", type="build")
     depends_on("texinfo@4.7:", type="build")
     depends_on("libtool", type="build")
-    # dependencies required for git versions
-    depends_on("m4@1.4.6:", when="@master", type="build")
-    depends_on("automake@1.15.1:", when="@master", type="build")
-    depends_on("autoconf@2.69:", when="@master", type="build")
 
     depends_on("gmake@3.80:", type="build")
     depends_on("perl@5", type="build")
+    depends_on("diffutils", type="build")
+
+    with when("@master"):
+        depends_on("flex", type="build")
+        # dependencies required for git versions
+        depends_on("m4@1.4.6:", type="build")
+        depends_on("automake@1.15.1:", type="build")
+        depends_on("autoconf@2.69:", type="build")
+
+    depends_on("gmp@4.3.2:")
 
     # GCC 7.3 does not compile with newer releases on some platforms, see
     #   https://github.com/spack/spack/issues/6902#issuecomment-433030376
     depends_on("mpfr@2.4.2:3.1.6", when="@:9.9")
     depends_on("mpfr@3.1.0:", when="@10:")
     depends_on("mpc@1.0.1:", when="@4.5:")
+
     # Already released GCC versions do not support any newer version of ISL
     #   GCC 5.4 https://github.com/spack/spack/issues/6902#issuecomment-433072097
     #   GCC 7.3 https://github.com/spack/spack/issues/6902#issuecomment-433030376
@@ -242,7 +247,6 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
 
     depends_on("zlib-api", when="@6:")
     depends_on("zstd", when="@10:")
-    depends_on("diffutils", type="build")
     depends_on("iconv", when="platform=darwin")
     depends_on("gnat", when="languages=ada")
     depends_on(
@@ -259,11 +263,12 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     # depends_on('cloog')
 
     # https://gcc.gnu.org/install/test.html
-    depends_on("dejagnu@1.4.4", type="test")
-    depends_on("expect", type="test")
-    depends_on("tcl", type="test")
-    depends_on("autogen@5.5.4:", type="test")
-    depends_on("guile@1.4.1:", type="test")
+    with default_args(type="test"):
+        depends_on("dejagnu@1.4.4")
+        depends_on("expect")
+        depends_on("tcl")
+        depends_on("autogen@5.5.4:")
+        depends_on("guile@1.4.1:")
 
     # See https://go.dev/doc/install/gccgo#Releases
     with when("languages=go"):
@@ -1002,30 +1007,22 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
 
     # run configure/make/make(install) for the nvptx-none target
     # before running the host compiler phases
-    @run_before("configure")
+    @run_before("configure", when="+nvptx")
     def nvptx_install(self):
-        spec = self.spec
-        prefix = self.prefix
-
-        if not spec.satisfies("+nvptx"):
-            return
+        self.copy_nvptx_tools()
+        self.link_newlib()
 
         # config.guess returns the host triple, e.g. "x86_64-pc-linux-gnu"
         guess = Executable("./config.guess")
         targetguess = guess(output=str).rstrip("\n")
-
-        self.copy_nvptx_tools()
-
-        self.link_newlib()
-
         with working_dir("spack-build-nvptx", create=True):
             options = [
-                f"--prefix={prefix}",
-                f"--enable-languages={','.join(spec.variants['languages'].value)}",
-                f"--with-mpfr={spec['mpfr'].prefix}",
-                f"--with-gmp={spec['gmp'].prefix}",
+                f"--prefix={self.prefix}",
+                f"--enable-languages={','.join(self.spec.variants['languages'].value)}",
+                f"--with-mpfr={self.spec['mpfr'].prefix}",
+                f"--with-gmp={self.spec['gmp'].prefix}",
                 "--target=nvptx-none",
-                f"--with-build-time-tools={join_path(prefix, 'nvptx-none', 'bin')}",
+                f"--with-build-time-tools={join_path(self.prefix, 'nvptx-none', 'bin')}",
                 f"--enable-as-accelerator-for={targetguess}",
                 "--disable-sjlj-exceptions",
                 "--enable-newlib-io-long-long",

--- a/repos/spack_repo/builtin/packages/gmp/package.py
+++ b/repos/spack_repo/builtin/packages/gmp/package.py
@@ -15,6 +15,8 @@ class Gmp(AutotoolsPackage, GNUMirrorPackage):
     homepage = "https://gmplib.org"
     gnu_mirror_path = "gmp/gmp-6.1.2.tar.bz2"
 
+    maintainers("alalazo")
+
     license("LGPL-3.0-or-later OR GPL-2.0-or-later")
 
     version("6.3.0", sha256="ac28211a7cfb609bae2e2c8d6058d66c8fe96434f740cf6fe2e47b000d1c20cb")

--- a/repos/spack_repo/builtin/packages/isl/package.py
+++ b/repos/spack_repo/builtin/packages/isl/package.py
@@ -14,8 +14,11 @@ class Isl(AutotoolsPackage):
     homepage = "https://libisl.sourceforge.io/"
     url = "https://libisl.sourceforge.io/isl-0.21.tar.bz2"
 
+    maintainers("alalazo")
+
     license("MIT")
 
+    version("0.27", sha256="626335529331f7c89fec493de929e2e92fb3d8cc860fc7af554e0518ee0029ee")
     version("0.26", sha256="5eac8664e9d67be6bd0bee5085d6840b8baf738c06814df47eaf4166d9776436")
     version("0.25", sha256="4305c54d4eebc4bf3ce365af85f04984ef5aa97a52e01128445e26da5b1f467a")
     version("0.24", sha256="fcf78dd9656c10eb8cf9fbd5f59a0b6b01386205fe1934b3b287a0a1898145c0")

--- a/repos/spack_repo/builtin/packages/mpc/package.py
+++ b/repos/spack_repo/builtin/packages/mpc/package.py
@@ -21,6 +21,11 @@ class Mpc(AutotoolsPackage, GNUMirrorPackage):
 
     license("GPL-2.0-or-later")
 
+    version(
+        "1.4.1",
+        sha256="91204cd32f164bd3b7c992d4a6a8ce6519511aadab30f78b6982d0bf8d73e931",
+        url="https://ftp.gnu.org/gnu/mpc/mpc-1.4.1.tar.xz",
+    )
     version("1.3.1", sha256="ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8")
     version("1.2.1", sha256="17503d2c395dfcf106b622dc142683c1199431d095367c6aacba6eec30340459")
     version("1.1.0", sha256="6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e")

--- a/repos/spack_repo/builtin/packages/mpc/package.py
+++ b/repos/spack_repo/builtin/packages/mpc/package.py
@@ -17,6 +17,8 @@ class Mpc(AutotoolsPackage, GNUMirrorPackage):
     gnu_mirror_path = "mpc/mpc-1.1.0.tar.gz"
     list_url = "http://www.multiprecision.org/mpc/download.html"
 
+    maintainers("alalazo")
+
     license("GPL-2.0-or-later")
 
     version("1.3.1", sha256="ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8")

--- a/repos/spack_repo/builtin/packages/mpfr/package.py
+++ b/repos/spack_repo/builtin/packages/mpfr/package.py
@@ -15,7 +15,7 @@ class Mpfr(AutotoolsPackage, GNUMirrorPackage):
     homepage = "https://www.mpfr.org/"
     gnu_mirror_path = "mpfr/mpfr-4.0.2.tar.bz2"
 
-    maintainers("cessenat")
+    maintainers("alalazo", "cessenat")
 
     license("LGPL-3.0-or-later")
 


### PR DESCRIPTION
**gcc:**

- Fix bug in `detect_gdc`: `elif len(candidate_specs) == 0` was dead code and should be `== 1` (single-candidate fast path)
- Replace deprecated `self.compiler` with `self["c"]` (compiler-as-dependency API) in `detect_gdc`
- Remove dead code in `nvptx_install`: options built before the `working_dir` block were overwritten unconditionally (leftover from #40897)
- Convert remaining `.format()` strings to f-strings in `nvptx_install`
- Add `conflicts("+graphite +bootstrap")`: the combination causes reproducible bootstrap comparison failures on GCC 16 (stage 2/3 object files differ) due to the use of hash tables in `isl` keyed by pointer values

**isl:** add v0.27

**mpc:** add v1.4.1
