### PR TITLE
AOCC: add v5.2.0

### DIFF
--- a/repos/spack_repo/builtin/packages/aocc/package.py
+++ b/repos/spack_repo/builtin/packages/aocc/package.py
@@ -36,6 +36,11 @@ class Aocc(Package, LlvmDetection, CompilerPackage):
     maintainers("amd-toolchain-support")
 
     version(
+        ver="5.2.0",
+        sha256="f98af7e2ae8801dd4ba443520653acb739536a86c2a1caf096310c3cfd554ca0",
+        url="https://download.amd.com/developer/eula/aocc/aocc-5-2/aocc-compiler-5.2.0.tar",
+    )
+    version(
         ver="5.1.0",
         sha256="3ccb56e399c66e10d437feb24b73552bc560210f7606d2609c06a7ef35d22c69",
         url="https://download.amd.com/developer/eula/aocc/aocc-5-1/aocc-compiler-5.1.0.tar",


### PR DESCRIPTION
What’s new in AOCC 5.2 (https://www.amd.com/en/developer/aocc.html)

- Based on LLVM 17.0.6 release (llvm.org, Nov 2023)
- Zen5 tuned AOCL-LibM 5.3 ([AMD Math Library](https://www.amd.com/en/developer/aocl/libm.html))
- Bug fixes impacting C, C++, and Fortran applications
- Added DO CONCURRENT parallelization feature in Fortran
- `-finline-aggressive` has been deprecated in AOCC 5.1. Alternatively, use `-mllvm -inline-threshold`
- `-freroll-loops` has been deprecated in AOCC 5.1