### PR TITLE
py-boto3: add v1.43.17, updated dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/py_boto3/package.py
+++ b/repos/spack_repo/builtin/packages/py_boto3/package.py
@@ -15,6 +15,7 @@ class PyBoto3(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.43.17", sha256="8cf48babdd52ff0e2d891dc661143780b361d3776a3be06cd719da0696995074")
     version("1.42.85", sha256="1cd3dcbfaba85c6071ba9397c1804b6a94a1a97031b8f1993fdba27c0c5d6eba")
     version("1.40.64", sha256="b92d6961c352f2bb8710c9892557d4b0e11258b70967d4e740e1c97375bcd779")
     version("1.34.162", sha256="873f8f5d2f6f85f1018cbb0535b03cceddc7b655b61f66a0a56995238804f41f")
@@ -37,7 +38,8 @@ class PyBoto3(PythonPackage):
     version("1.9.253", sha256="d93f1774c4bc66e02acdda2067291acb9e228a035435753cb75f83ad2904cbe3")
     version("1.9.169", sha256="9d8bd0ca309b01265793b7e8d7b88c1df439737d77c8725988f0277bbf58d169")
 
-    depends_on("python@3.9:", when="@1.38:", type=("build", "run"))
+    depends_on("python@3.10:", when="@1.43:", type=("build", "run"))
+    depends_on("python@3.9:", when="@1.38:1.42", type=("build", "run"))
     depends_on("python@3.7:", when="@1.26:", type=("build", "run"))
     depends_on("python@3.6:", when="@1.18:", type=("build", "run"))
     depends_on("python@2.7:2.8,3.6:", when="@1.17:", type=("build", "run"))
@@ -45,6 +47,7 @@ class PyBoto3(PythonPackage):
     depends_on("py-setuptools", type="build")
 
     with default_args(type=("build", "run")):
+        depends_on("py-botocore@1.43.17:1.43", when="@1.43.17")
         depends_on("py-botocore@1.42.85:1.42", when="@1.42.85")
         depends_on("py-botocore@1.40.64:1.40", when="@1.40.64")
         depends_on("py-botocore@1.34.162:1.34", when="@1.34.162")
@@ -65,7 +68,8 @@ class PyBoto3(PythonPackage):
         depends_on("py-jmespath@0.7.1:1")
         depends_on("py-jmespath@0.7.1:0", when="@:1.20")
 
-        depends_on("py-s3transfer@0.16", when="@1.42:")
+        depends_on("py-s3transfer@0.18", when="@1.43:")
+        depends_on("py-s3transfer@0.16", when="@1.42:1.42")
         depends_on("py-s3transfer@0.14", when="@1.40.27:1.41.0")
         depends_on("py-s3transfer@0.10", when="@1.34.6:1.35")
         depends_on("py-s3transfer@0.9", when="@1.34:1.34.5")

--- a/repos/spack_repo/builtin/packages/py_botocore/package.py
+++ b/repos/spack_repo/builtin/packages/py_botocore/package.py
@@ -15,6 +15,7 @@ class PyBotocore(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.43.17", sha256="27f4ecb80cf1e5be70415fc4a4d3db3907d41ef8178c9df822364f275427d375")
     version("1.42.85", sha256="2ee61f80b7724a143e16d0a85408ef5fa20b99dce7a3c8ec5d25cc8dced164c1")
     version("1.40.64", sha256="a13af4009f6912eafe32108f6fa584fb26e24375149836c2bcaaaaec9a7a9e58")
     version("1.34.162", sha256="adc23be4fb99ad31961236342b7cbf3c0bfc62532cd02852196032e8c0d682f3")
@@ -44,7 +45,8 @@ class PyBotocore(PythonPackage):
     version("1.12.253", sha256="3baf129118575602ada9926f5166d82d02273c250d0feb313fc270944b27c48b")
     version("1.12.169", sha256="25b44c3253b5ed1c9093efb57ffca440c5099a2d62fa793e8b6c52e72f54b01e")
 
-    depends_on("python@3.9:", when="@1.38:", type=("build", "run"))
+    depends_on("python@3.10:", when="@1.43:", type=("build", "run"))
+    depends_on("python@3.9:", when="@1.38:1.42", type=("build", "run"))
     depends_on("py-setuptools", type="build")
 
     with default_args(type=("build", "run")):

--- a/repos/spack_repo/builtin/packages/py_python_dateutil/package.py
+++ b/repos/spack_repo/builtin/packages/py_python_dateutil/package.py
@@ -22,14 +22,18 @@ class PyPythonDateutil(PythonPackage):
     version("2.8.1", sha256="73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c")
     version("2.8.0", sha256="c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e")
     version("2.7.5", sha256="88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02")
-    version("2.5.2", sha256="063907ef47f6e187b8fe0728952e4effb587a34f2dc356888646f9b71fbb2e4b")
-    version("2.4.2", sha256="3e95445c1db500a344079a47b171c45ef18f57d188dffdb0e4165c71bea8eb3d")
-    version("2.4.0", sha256="439df33ce47ef1478a4f4765f3390eab0ed3ec4ae10be32f2930000c8d19f417")
-    version("2.2", sha256="eec865307ebe7f329a6a9945c15453265a449cdaaf3710340828a1934d53e468")
+    with default_args(deprecated=True):
+        version("2.5.2", sha256="063907ef47f6e187b8fe0728952e4effb587a34f2dc356888646f9b71fbb2e4b")
+        version("2.4.2", sha256="3e95445c1db500a344079a47b171c45ef18f57d188dffdb0e4165c71bea8eb3d")
+        version("2.4.0", sha256="439df33ce47ef1478a4f4765f3390eab0ed3ec4ae10be32f2930000c8d19f417")
+        version("2.2", sha256="eec865307ebe7f329a6a9945c15453265a449cdaaf3710340828a1934d53e468")
+
+    # parser.py uses collections.Callable, removed in Python 3.10; fixed in 2.7.0
+    depends_on("python@:3.9", when="@:2.6", type=("build", "run"))
 
     with default_args(type="build"):
         depends_on("py-setuptools@24.3:")
-        depends_on("py-setuptools-scm@:7", when="@2.7:")
+        depends_on("py-setuptools-scm", when="@2.7:")
         depends_on("py-wheel", when="@2.8.0:")
 
     with default_args(type=("build", "run")):

--- a/repos/spack_repo/builtin/packages/py_s3transfer/package.py
+++ b/repos/spack_repo/builtin/packages/py_s3transfer/package.py
@@ -15,6 +15,7 @@ class PyS3transfer(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.18.0", sha256="3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd")
     version("0.16.0", sha256="8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920")
     version("0.14.0", sha256="eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125")
     version("0.10.0", sha256="d0c8bbf672d5eebbe4e57945e23b972d963f07d82f661cabf678a5c88831595b")
@@ -29,6 +30,8 @@ class PyS3transfer(PythonPackage):
     version("0.2.1", sha256="6efc926738a3cd576c2a79725fed9afde92378aa5c6a957e3af010cb019fac9d")
 
     depends_on("py-setuptools", type="build")
+
+    depends_on("python@3.10:", when="@0.18:", type=("build", "run"))
 
     depends_on("py-botocore@1.37.4:1", type=("build", "run"), when="@0.11.4:")
     depends_on("py-botocore@1.33.2:1", type=("build", "run"), when="@0.8.1:")


### PR DESCRIPTION
Changes:
* Add `py-boto3@1.43.17`, `py-botocore@1.43.17`, `py-s3transfer@0.18.0`
* `py-python-dateutil`: remove spurious `setuptools-scm@:7` upper bound that caused the concretizer to fall back to 2.5.2 on Python 3.10+
* Add `python@:3.9` upper bound and deprecate `py-python-dateutil@:2.6`

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
