### PR TITLE
fmt: libs property needs to check for libfmtd for debug builds

### DIFF
--- a/repos/spack_repo/builtin/packages/fmt/package.py
+++ b/repos/spack_repo/builtin/packages/fmt/package.py
@@ -157,4 +157,9 @@ class Fmt(CMakePackage):
     @property
     def libs(self):
         # Debug builds provide libfmtd instead of libfmt
-        return find_libraries(["libfmt","libfmtd"], root=self.home, recursive=True, shared=self.spec.satisfies("+shared"))
+        return find_libraries(
+            ["libfmt", "libfmtd"],
+            root=self.home,
+            recursive=True,
+            shared=self.spec.satisfies("+shared"),
+        )

--- a/repos/spack_repo/builtin/packages/fmt/package.py
+++ b/repos/spack_repo/builtin/packages/fmt/package.py
@@ -153,3 +153,8 @@ class Fmt(CMakePackage):
         args.append(self.define("FMT_TEST", self.run_tests))
 
         return args
+
+    @property
+    def libs(self):
+        # Debug builds provide libfmtd instead of libfmt
+        return find_libraries(["libfmt","libfmtd"], root=self.home, recursive=True, shared=self.spec.satisfies("+shared"))


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Debug builds of FMT add a "d" suffix to the library creating `libfmtd` instead of `libfmt`. The default `libs` property does not find the libraries in this case. This PR simply adds a `libs` property that checks for both library names. 

The simplest way I could think of to show the error (I actually hit it with debug builds of an internal package) is to edit `spdlog/package.py` to add the line
```
print(self.spec["fmt"].libs)
```
to `def cmake_args(self):`, then try to install spdlog with a fmt debug build
```
spack install spdlog build_type=Debug ^ fmt build_type=Debug
```
This will fail with
```
Error: NoLibrariesError: Unable to recursively locate fmt libraries in [...]__spack_path_/linux-x86_64_v3/fmt-12.1.0-7imzckjqkc4wcceuldb5sgodw3aafbgg
```
because the library is named `libmftd.a`, not `libfmt.a`. 