### PR TITLE
developer-tools-stacks: drop +json from emacs

### DIFF
--- a/stacks/developer-tools-aarch64-linux-gnu/spack.yaml
+++ b/stacks/developer-tools-aarch64-linux-gnu/spack.yaml
@@ -19,7 +19,7 @@ spack:
   - neovim~no_luajit
   - py-pynvim
   # FIXME (compiler as nodes): recover dependency on gcc as a library when +native
-  - emacs+json~native+treesitter   # note, pulls in gcc
+  - emacs~native+treesitter   # note, pulls in gcc
     # - tree-sitter is a dep, should also have cli but no package
   - nano   # just in case
     # tags and scope search helpers

--- a/stacks/developer-tools-darwin/spack.yaml
+++ b/stacks/developer-tools-darwin/spack.yaml
@@ -14,7 +14,7 @@ spack:
     reuse: false
   specs:
       # editors
-    - emacs+json~native+treesitter   # TODO +native not supported until gcc builds on darwin
+    - emacs~native+treesitter   # TODO +native not supported until gcc builds on darwin
     - nano
     # - neovim
     - py-pynvim

--- a/stacks/developer-tools-x86_64_v3-linux-gnu/spack.yaml
+++ b/stacks/developer-tools-x86_64_v3-linux-gnu/spack.yaml
@@ -22,7 +22,7 @@ spack:
   - neovim~no_luajit
   - py-pynvim
   # FIXME (compiler as nodes): recover dependency on gcc as a library when +native
-  - emacs+json~native+treesitter   # note, pulls in gcc
+  - emacs~native+treesitter   # note, pulls in gcc
     # - tree-sitter is a dep, should also have cli but no package
   - nano   # just in case
     # tags and scope search helpers


### PR DESCRIPTION
Follow up from #4956 to fix the stacks to allow them to build the latest emacs versions.

Once we support deprecating variants this shouldn't be a problem anymore, but since `+json` no longer applies to `emacs@30:` including the variant will make us snap to `emacs@29` instead of the latest version.