### PR TITLE
calculix, spooles, calculix-adapter: new packages

### DIFF
--- a/repos/spack_repo/builtin/packages/calculix/package.py
+++ b/repos/spack_repo/builtin/packages/calculix/package.py
@@ -1,0 +1,104 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
+
+from spack.package import *
+
+
+class Calculix(MakefilePackage):
+    """CalculiX (CCX) is a free finite-element program for three-dimensional
+    structural and thermal analysis. It reads an Abaqus-like input format and
+    relies on the SPOOLES sparse solver and the ARPACK eigensolver."""
+
+    homepage = "http://www.calculix.de/"
+    url = "http://www.dhondt.de/ccx_2.20.src.tar.bz2"
+
+    license("GPL-2.0-or-later")
+
+    maintainers("failed33")
+
+    version("2.20", sha256="63bf6ea09e7edcae93e0145b1bb0579ea7ae82e046f6075a27c8145b72761bcf")
+
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
+
+    depends_on("spooles")
+    # CalculiX is serial/OpenMP and links the serial ARPACK eigensolver; ~mpi
+    # keeps the whole MPI stack out of a standalone CalculiX build.
+    depends_on("arpack-ng~mpi")
+    depends_on("blas")
+    depends_on("lapack")
+
+    # Spack strips the archive's single top-level CalculiX/ dir, so the source
+    # root is already inside it.
+    build_directory = "ccx_2.20/src"
+
+    @property
+    def build_targets(self):
+        spec = self.spec
+        # Legacy C in CalculiX/SPOOLES: keep modern gcc (>= 14) and clang from
+        # promoting int-conversion etc. to hard errors (no-ops on gcc 11).
+        legacy = (
+            "-Wno-error=int-conversion -Wno-error=implicit-function-declaration "
+            "-Wno-error=implicit-int"
+        )
+        cflags = (
+            "-Wall -O2 -fopenmp {1} -I{0} -DARCH=Linux -DSPOOLES -DARPACK "
+            "-DMATRIXSTORAGE -DNETWORKOUT".format(spec["spooles"].prefix.include, legacy)
+        )
+        fflags = "-Wall -O2 -fopenmp"
+        if spec.satisfies("%gcc@10:"):
+            # gfortran 10+ rejects CalculiX's legacy argument-mismatch patterns.
+            fflags += " -fallow-argument-mismatch"
+        libs = "{0} {1} {2} -lpthread -lm -lc".format(
+            spec["arpack-ng"].libs.ld_flags,
+            spec["lapack"].libs.ld_flags,
+            spec["blas"].libs.ld_flags,
+        )
+        return [
+            "CC=" + spack_cc,
+            "FC=" + spack_fc,
+            "CFLAGS=" + cflags,
+            "FFLAGS=" + fflags,
+            "LIBS=" + libs,
+        ]
+
+    def edit(self, spec, prefix):
+        spooles_a = join_path(spec["spooles"].prefix.lib, "libspooles.a")
+
+        # An overridden edit()/install() runs from the stage root, not the
+        # build_directory, so patch the Makefile inside the CalculiX source dir.
+        with working_dir(self.build_directory):
+            # $(LIBS) is overridden on the make command line to ARPACK/LAPACK/BLAS
+            # linker flags; drop it from the ccx_2.20 prerequisites so Make does
+            # not try to build "-lpthread" and friends as files.
+            # NB: no trailing \s* — filter_file is line-based with the newline
+            # included, so \s*$ would eat it and fuse this line into its recipe.
+            filter_file(
+                r"^ccx_2\.20:.*\$\(LIBS\)$",
+                "ccx_2.20: $(OCCXMAIN) ccx_2.20.a",
+                "Makefile",
+            )
+
+            # SPOOLES is no longer carried in $(LIBS); link its static archive
+            # explicitly, wrapping the archives in --start-group so the cyclic
+            # C/Fortran symbol references between them resolve.
+            filter_file(
+                "$(OCCXMAIN) ccx_2.20.a $(LIBS) -fopenmp",
+                "$(OCCXMAIN) -Wl,--start-group ccx_2.20.a {0} -Wl,--end-group "
+                "$(LIBS) -fopenmp".format(spooles_a),
+                "Makefile",
+                string=True,
+            )
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        with working_dir(self.build_directory):
+            install("ccx_2.20", join_path(prefix.bin, "ccx"))
+
+            # Publish the CalculiX sources, headers and Makefile.inc so that the
+            # calculix-adapter package can compile ccx_preCICE against them
+            # ($(CCX) in the adapter Makefile points here).
+            install_tree(".", join_path(prefix, "share", "CalculiX", "ccx_2.20", "src"))

--- a/repos/spack_repo/builtin/packages/calculix_adapter/package.py
+++ b/repos/spack_repo/builtin/packages/calculix_adapter/package.py
@@ -1,0 +1,104 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
+
+from spack.package import *
+
+
+class CalculixAdapter(MakefilePackage):
+    """The preCICE adapter for the CalculiX finite-element solver. It builds the
+    ccx_preCICE executable, which couples CalculiX to other solvers (e.g. an
+    OpenFOAM fluid solver) through the preCICE coupling library for
+    fluid-structure interaction."""
+
+    homepage = "https://precice.org/adapter-calculix-overview.html"
+    url = "https://github.com/precice/calculix-adapter/archive/refs/tags/v2.20.1.tar.gz"
+
+    license("GPL-3.0-or-later")
+
+    maintainers("failed33")
+
+    version("2.20.1", sha256="3372e0d66321c2173899e1db4841c6c4f3c16ffb99067c36dba04e8a34e35d39")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
+    depends_on("pkgconfig", type="build")
+
+    # The adapter version tracks the CalculiX release it wraps.
+    depends_on("calculix@2.20", when="@2.20.1")
+    depends_on("spooles")
+    depends_on("yaml-cpp")
+    # Serial ARPACK (as CalculiX uses it); MPI here comes from preCICE, not ARPACK.
+    depends_on("arpack-ng~mpi")
+    depends_on("blas")
+    depends_on("lapack")
+    depends_on("mpi")
+
+    # The adapter resolves preCICE through pkg-config (libprecice >= 1.4).
+    # NOTE: preCICE participants must share a preCICE version to couple over
+    # sockets, so a coupled FSI deployment pins this to match the partner solver
+    # (e.g. `spack install calculix-adapter ^precice@3.1.2` to match an OpenFOAM
+    # adapter that links preCICE 3.1.2). See README for the version-match trap.
+    depends_on("precice@2:")
+
+    build_directory = "."
+
+    @property
+    def build_targets(self):
+        spec = self.spec
+        spooles = spec["spooles"].prefix
+        ccx_src = join_path(spec["calculix"].prefix, "share", "CalculiX", "ccx_2.20", "src")
+
+        fflags = "-fallow-argument-mismatch" if spec.satisfies("%gcc@10:") else ""
+
+        # The final link is done by the MPI Fortran wrapper, which (unlike the
+        # Spack compiler wrapper) injects no rpaths, and preCICE arrives via
+        # pkg-config which emits none either. rpath the shared dependencies so
+        # ccx_preCICE runs without a module load / LD_LIBRARY_PATH.
+        rpaths = " ".join(
+            "-Wl,-rpath,{0}".format(d)
+            for d in [
+                spec["precice"].libs.directories[0],
+                spec["yaml-cpp"].libs.directories[0],
+                spec["arpack-ng"].libs.directories[0],
+                spec["lapack"].libs.directories[0],
+                spec["blas"].libs.directories[0],
+            ]
+        )
+        arpack_libs = "{0} {1} {2}".format(
+            spec["arpack-ng"].libs.ld_flags,
+            spec["lapack"].libs.ld_flags,
+            spec["blas"].libs.ld_flags,
+        )
+        return [
+            # CalculiX/preCICE link against MPI (via libprecice); use the MPI
+            # compiler wrappers, matching the adapter Makefile defaults. The
+            # adapter has no ADDITIONAL_CFLAGS hook, so embed the legacy-C
+            # down-grade flags in CC (it compiles CalculiX's 1999-era C too).
+            "CC={0} -Wno-error=int-conversion "
+            "-Wno-error=implicit-function-declaration -Wno-error=implicit-int".format(
+                spec["mpi"].mpicc
+            ),
+            "FC=" + spec["mpi"].mpifc,
+            "CCX=" + ccx_src,
+            "SPOOLES_INCLUDE=-I" + spooles.include,
+            "SPOOLES_LIBS=-Wl,--start-group {0} -Wl,--end-group".format(
+                join_path(spooles.lib, "libspooles.a")
+            ),
+            "ARPACK_LIBS={0} {1}".format(arpack_libs, rpaths),
+            "YAML_INCLUDE=-I" + spec["yaml-cpp"].prefix.include,
+            "YAML_LIBS=" + spec["yaml-cpp"].libs.ld_flags,
+            "ADDITIONAL_FFLAGS=" + fflags,
+        ]
+
+    def edit(self, spec, prefix):
+        # Upstream uses -DARCH="Linux"; the embedded quotes mangle the
+        # preprocessor token, so normalise it (matches our validated build).
+        filter_file('-DARCH="Linux"', "-DARCH=Linux", "Makefile", string=True)
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install(join_path("bin", "ccx_preCICE"), prefix.bin)

--- a/repos/spack_repo/builtin/packages/spooles/package.py
+++ b/repos/spack_repo/builtin/packages/spooles/package.py
@@ -1,0 +1,79 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
+
+from spack.package import *
+
+
+class Spooles(MakefilePackage):
+    """SPOOLES is a library for solving sparse real and complex linear systems
+    of equations, written in C and using object-oriented design. It is a build
+    dependency of the CalculiX finite-element solver and its preCICE adapter."""
+
+    homepage = "https://www.netlib.org/linalg/spooles/spooles.2.2.html"
+    url = "https://www.netlib.org/linalg/spooles/spooles.2.2.tgz"
+
+    # SPOOLES is distributed under its own permissive, BSD-like terms (see the
+    # "Internet Public License" notice shipped in the archive). It has no SPDX
+    # identifier, so no license() directive is declared here.
+
+    maintainers("failed33")
+
+    version("2.2", sha256="a84559a0e987a1e423055ef4fdf3035d55b65bbe4bf915efaa1a35bef7f8c5dd")
+
+    depends_on("c", type="build")
+
+    # The 2.2 archive expands into the current directory (no top-level folder);
+    # Make.inc and the top-level "makefile" therefore sit at the source root.
+    build_directory = "."
+
+    # The global archive build (`make global`) drives sequential sub-makes and
+    # is not safe under `make -j`.
+    parallel = False
+
+    build_targets = ["global"]
+
+    def edit(self, spec, prefix):
+        # Point the bundled Make.inc at the active compiler, force -fPIC (the
+        # static archive is linked into CalculiX and the preCICE adapter), and
+        # restore ranlib (upstream ships the no-op "RANLIB = echo").
+        makeinc = FileFilter("Make.inc")
+        makeinc.filter(r"^\s*CC\s*=.*$", "  CC = " + spack_cc)
+        # SPOOLES is 1999-era C: modern gcc (>= 14) and clang promote
+        # int-conversion / implicit-function / implicit-int to hard errors, so
+        # downgrade them to warnings (no-ops on the gcc 11 we validated with).
+        makeinc.filter(
+            r"^\s*CFLAGS\s*=.*$",
+            "  CFLAGS = -O2 -fPIC -D_DEFAULT_SOURCE -Wno-error=int-conversion "
+            "-Wno-error=implicit-function-declaration -Wno-error=implicit-int",
+        )
+        makeinc.filter(r"^\s*RANLIB\s*=.*$", "  RANLIB = ranlib")
+
+        # Build the multithreaded (MT) objects into the global archive: the
+        # preCICE adapter compiles CalculiX with -DUSE_MT and needs those
+        # symbols. Upstream comments the MT entry out of the `global` target.
+        filter_file(r"^#cd MT/src", "\tcd MT/src", "makefile")
+
+        # Tree/src/makeGlobalLib references a stale "drawTree.c"; the real source
+        # in the 2.2 tarball is "draw.c".
+        filter_file("drawTree.c", "draw.c", join_path("Tree", "src", "makeGlobalLib"))
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.lib)
+        install("spooles.a", join_path(prefix.lib, "libspooles.a"))
+
+        # Install every header, preserving SPOOLES' in-tree layout, so that a
+        # downstream "-I<prefix.include>" resolves both the entry-point includes
+        # (e.g. "FrontMtx/FrontMtx.h") and the relative cross-includes between
+        # SPOOLES modules.
+        for root, _dirs, files in os.walk("."):
+            for name in files:
+                if name.endswith(".h"):
+                    src = join_path(root, name)
+                    dst = join_path(prefix.include, os.path.relpath(src, "."))
+                    mkdirp(os.path.dirname(dst))
+                    install(src, dst)


### PR DESCRIPTION
Adds three new packages that together build the [preCICE CalculiX adapter](https://precice.org/adapter-calculix-overview.html) (`ccx_preCICE`) for fluid–structure interaction:

- **`spooles`** — SPOOLES 2.2, the sparse direct solver CalculiX links against (static archive + headers).
- **`calculix`** — CalculiX CCX 2.20; installs `ccx` and its source tree so the adapter can compile against it.
- **`calculix-adapter`** — preCICE CalculiX adapter v2.20.1; version-locks `calculix@2.20`, pulls `spooles`/`arpack-ng`/`openblas`/`yaml-cpp`, and resolves preCICE via `pkg-config` (`requires precice@2:`).

Existing `precice`, `arpack-ng`, `openblas` and `yaml-cpp` packages are reused unchanged. No `calculix`/`spooles`/`calculix-adapter` packages existed before this PR.

### Notes for reviewers

- **Legacy C.** SPOOLES (1999) and CalculiX use pre-C99 idioms that gcc ≥ 14 and clang now reject by default. The recipes downgrade `int-conversion`, `implicit-function-declaration` and `implicit-int` from errors back to warnings so the sources build across toolchains.
- **No upstream install targets.** SPOOLES and CalculiX have no `make install`; the recipes hand-roll `install()` (SPOOLES installs `libspooles.a` + its header tree with layout preserved; `calculix` installs `ccx` plus its source tree for the adapter's `CCX=` to point at).
- **preCICE version.** The recipe only requires `precice@2:`. preCICE participants must share a preCICE version to couple, so a real FSI deployment pins it to match the partner solver (e.g. `spack install calculix-adapter ^precice@3.1.2` to match an OpenFOAM adapter that links preCICE 3.1.2) — a deployment choice, not a recipe constraint.

### Testing

- `spack spec calculix-adapter ^precice@3.1.2` concretizes the full DAG (calculix 2.20 + spooles 2.2 + precice 3.1.2 + arpack-ng + openblas + openmpi + yaml-cpp + pkgconf).
- `spack install spooles` builds clean (verified locally on clang): `libspooles.a` + 115 headers.
- `spack audit packages spooles calculix calculix-adapter` and `spack style` pass.
- The coupled `ccx_preCICE` binary is independently proven on a Linux/gcc 11.5 + OpenMPI 4.1 HPC stack via the equivalent hand build and runs a perpendicular-flap FSI case against an OpenFOAM fluid participant.

Marked as **draft** pending a full native `spack install calculix-adapter` build in CI (the standalone `spooles` build and the out-of-Spack coupled build are confirmed; the in-Spack `calculix`/`calculix-adapter` builds have not yet been exercised end-to-end here). Happy to adjust the maintainer handle, split into per-package PRs, or address any conventions.
