### PR TITLE
Kokkos: fix spurious cmake option

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -153,7 +153,6 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         "debug": [False, None, "Activate extra debug features - may increase compiletimes"],
         "debug_bounds_check": [False, None, "Use bounds checking - will increase runtime"],
         "debug_dualview_modify_check": [False, "@:4", "Debug check on dual views"],
-        "deprecated_code": [False, "@:4", "Whether to enable deprecated code"],
         "hpx_async_dispatch": [False, "@:4", "Whether HPX supports asynchronous dispath"],
         "tuning": [False, None, "Create bindings for tuning tools"],
         "tests": [False, None, "Build for tests"],
@@ -342,7 +341,6 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     variant(
         "deprecated_code",
         default=True,
-        when="@5:",
         description="Whether to enable deprecated code",
     )
 
@@ -457,16 +455,14 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
             from_variant("Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE", "cmake_lang"),
         ]
 
-        # TODO new major: update this
-        if spec.satisfies("@5:"):
-            if spec.version == Version("develop"):
-                highest = max(v for v in self.versions if not v.isdevelop())
-                major_version = int(str(highest.up_to(1)))
-            else:
-                major_version = int(str(spec.version.up_to(1)))
-            options.append(
-                from_variant(f"Kokkos_ENABLE_DEPRECATED_CODE_{major_version}", "deprecated_code")
-            )
+        if spec.version == Version("develop"):
+            highest = max(v for v in self.versions if not v.isdevelop())
+            major_version = int(str(highest.up_to(1)))
+        else:
+            major_version = int(str(spec.version.up_to(1)))
+        options.append(
+            from_variant(f"Kokkos_ENABLE_DEPRECATED_CODE_{major_version}", "deprecated_code")
+        )
 
         spack_microarches = []
         if spec.satisfies("+cuda"):

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -347,7 +347,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     variant(
         "deprecated_code",
         default=True,
-        description="Whether to enable deprecated code",
+        description="Whether to enable code deprecated in the major version",
     )
 
     variant("pic", default=False, description="Build position independent code")
@@ -455,9 +455,9 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
             from_variant("Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE", "cmake_lang"),
         ]
 
+        # TODO new major: update this
         if spec.version == Version("develop"):
-            highest = max(v for v in self.versions if not v.isdevelop())
-            major_version = int(str(highest.up_to(1)))
+            major_version = 5
         else:
             major_version = int(str(spec.version.up_to(1)))
         options.append(

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -154,7 +154,6 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         "debug": [False, None, "Activate extra debug features - may increase compiletimes"],
         "debug_bounds_check": [False, None, "Use bounds checking - will increase runtime"],
         "debug_dualview_modify_check": [False, "@:4", "Debug check on dual views"],
-        "deprecated_code": [False, "@:4", "Whether to enable deprecated code"],
         "hpx_async_dispatch": [False, "@:4", "Whether HPX supports asynchronous dispath"],
         "tuning": [False, None, "Create bindings for tuning tools"],
         "tests": [False, None, "Build for tests"],
@@ -348,7 +347,6 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     variant(
         "deprecated_code",
         default=True,
-        when="@5:",
         description="Whether to enable deprecated code",
     )
 
@@ -457,16 +455,14 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
             from_variant("Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE", "cmake_lang"),
         ]
 
-        # TODO new major: update this
-        if spec.satisfies("@5:"):
-            if spec.version == Version("develop"):
-                highest = max(v for v in self.versions if not v.isdevelop())
-                major_version = int(str(highest.up_to(1)))
-            else:
-                major_version = int(str(spec.version.up_to(1)))
-            options.append(
-                from_variant(f"Kokkos_ENABLE_DEPRECATED_CODE_{major_version}", "deprecated_code")
-            )
+        if spec.version == Version("develop"):
+            highest = max(v for v in self.versions if not v.isdevelop())
+            major_version = int(str(highest.up_to(1)))
+        else:
+            major_version = int(str(spec.version.up_to(1)))
+        options.append(
+            from_variant(f"Kokkos_ENABLE_DEPRECATED_CODE_{major_version}", "deprecated_code")
+        )
 
         spack_microarches = []
         if spec.satisfies("+cuda"):

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -346,7 +346,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     # FIXME regroup variants and conflicts
     variant(
         "deprecated_code",
-        default=False,
+        default=True,
         description="Whether to enable code deprecated in the major version",
     )
 

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -346,7 +346,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     # FIXME regroup variants and conflicts
     variant(
         "deprecated_code",
-        default=True,
+        default=False,
         description="Whether to enable code deprecated in the major version",
     )
 


### PR DESCRIPTION
This PR fixes the spurious cmake option `-DKokkos_ENABLE_DEPRECATED_CODE=ON` for `kokkos@5:`.

We also:
- fix the deprecated variant for `kokkos@:4`, this changes its default value
- set the major version to 5 for the develop branch.

The current implementation of `deprecated_code` is: to enable code deprecated in the concretized major version.