### PR TITLE
ghex: Fix gpu type for nvidia gpus

### DIFF
--- a/repos/spack_repo/builtin/packages/ghex/package.py
+++ b/repos/spack_repo/builtin/packages/ghex/package.py
@@ -94,7 +94,7 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
             arch_str = ";".join(spec.variants["cuda_arch"].value)
             args.append(self.define("CMAKE_CUDA_ARCHITECTURES", arch_str))
             args.append(self.define("GHEX_USE_GPU", True))
-            args.append(self.define("GHEX_GPU_TYPE", "CUDA"))
+            args.append(self.define("GHEX_GPU_TYPE", "NVIDIA"))
         elif spec.satisfies("+rocm"):
             arch_str = ";".join(spec.variants["amdgpu_target"].value)
             args.append(self.define("CMAKE_HIP_ARCHITECTURES", arch_str))


### PR DESCRIPTION
The `GHEX_GPU_TYPE` was incorrectly set by me from the start and should be `NVIDIA` instead of `CUDA`.