### PR TITLE
gitlab-ci: fix shallow globs that skipped all PR jobs

### DIFF
--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -49,9 +49,9 @@ default:
 .package_on_change: &package_on_change
     paths:
       - .ci/env
-      - .ci/gitlab/*
-      - repos/spack_repo/*
-      - stacks/$SPACK_CI_STACK_NAME/*
+      - .ci/gitlab/**/*
+      - repos/spack_repo/**/*
+      - stacks/$SPACK_CI_STACK_NAME/**/*
     compare_to: HEAD~1
 
   ########################################

--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -48,8 +48,6 @@ default:
 
 .package_on_change: &package_on_change
     paths:
-      - .ci/env
-      - .ci/gitlab/**/*
       - repos/spack_repo/**/*
       - stacks/$SPACK_CI_STACK_NAME/**/*
     compare_to: HEAD~1

--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -48,6 +48,8 @@ default:
 
 .package_on_change: &package_on_change
     paths:
+      - .ci/env
+      - .ci/gitlab/**/*
       - repos/spack_repo/**/*
       - stacks/$SPACK_CI_STACK_NAME/**/*
     compare_to: HEAD~1

--- a/repos/spack_repo/builtin/packages/cmake/package.py
+++ b/repos/spack_repo/builtin/packages/cmake/package.py
@@ -32,7 +32,6 @@ class Cmake(Package):
 
     version("master", branch="master")
     version("4.3.3", sha256="cba4bb7a44edf2877bb6f059932896383babe435b3a8c3b5df48b4aa41c9bb85")
-    version("4.3.2", sha256="b0231eb39b3c3cabdc568c619df78208a7bd95ea10c9b2236d61218bac1b367d")
     version("4.2.3", sha256="7efaccde8c5a6b2968bad6ce0fe60e19b6e10701a12fce948c2bf79bac8a11e9")
     version("4.1.5", sha256="50ce77215cf266630fa5de97c360f4c313bb79f94b35236b63c1216de3196356")
     version("4.0.6", sha256="9ebe11be8d304336d62a3e71ca36c18f0a4e40036b97c533d63cf730364b6528")

--- a/repos/spack_repo/builtin/packages/cmake/package.py
+++ b/repos/spack_repo/builtin/packages/cmake/package.py
@@ -32,6 +32,7 @@ class Cmake(Package):
 
     version("master", branch="master")
     version("4.3.3", sha256="cba4bb7a44edf2877bb6f059932896383babe435b3a8c3b5df48b4aa41c9bb85")
+    version("4.3.2", sha256="b0231eb39b3c3cabdc568c619df78208a7bd95ea10c9b2236d61218bac1b367d")
     version("4.2.3", sha256="7efaccde8c5a6b2968bad6ce0fe60e19b6e10701a12fce948c2bf79bac8a11e9")
     version("4.1.5", sha256="50ce77215cf266630fa5de97c360f4c313bb79f94b35236b63c1216de3196356")
     version("4.0.6", sha256="9ebe11be8d304336d62a3e71ca36c18f0a4e40036b97c533d63cf730364b6528")


### PR DESCRIPTION
hotfix for #4615

GitLab CI's `changes.paths` does not allow * to cross directory separators, as a direct consequence of using Ruby's `fnmatch` with the `File::FNM_PATHNAME` flag. See https://docs.gitlab.com/ci/yaml/#ruleschanges

This means that `repos/spack_repo/*` will never match package files nested under `builtin/packages/`.

Here we switch to `**/*` for recursive matching.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
