### PR TITLE
paraview: fix check in catalyst

### DIFF
--- a/repos/spack_repo/builtin/packages/paraview/vtk-consolidate-viskores-wrapping-pv61.patch
+++ b/repos/spack_repo/builtin/packages/paraview/vtk-consolidate-viskores-wrapping-pv61.patch
@@ -19,10 +19,9 @@ flags.
  Accelerators/Vtkm/DataModel/CMakeLists.txt    | 29 +----------------
  .../Vtkm/DataModel/Testing/Cxx/CMakeLists.txt | 28 ----------------
  Accelerators/Vtkm/Filters/CMakeLists.txt      | 26 +--------------
- .../Vtkm/Filters/Testing/Cxx/CMakeLists.txt   | 25 ---------------
  IO/CatalystConduit/CMakeLists.txt             | 19 ++---------
  ThirdParty/viskores/CMakeLists.txt            | 17 +++++++++-
- 9 files changed, 21 insertions(+), 186 deletions(-)
+ 8 files changed, 21 insertions(+), 186 deletions(-)
 
 diff --git a/Accelerators/Vtkm/Core/CMakeLists.txt b/Accelerators/Vtkm/Core/CMakeLists.txt
 index 0501715be03..3e863bc7b4c 100644
@@ -241,48 +240,11 @@ index 4eb9989da51..c24edd94be7 100644
  
  if (MSVC)
    set(msvc_warning_flags
-diff --git a/Accelerators/Vtkm/Filters/Testing/Cxx/CMakeLists.txt b/Accelerators/Vtkm/Filters/Testing/Cxx/CMakeLists.txt
-index d72f0bd7ffe..6f6ec073cb7 100644
---- a/Accelerators/Vtkm/Filters/Testing/Cxx/CMakeLists.txt
-+++ b/Accelerators/Vtkm/Filters/Testing/Cxx/CMakeLists.txt
-@@ -28,32 +28,7 @@ vtk_add_test_cxx(vtkAcceleratorsVTKmFiltersCxxTests tests
-   TestVTKMWarpVector.cxx,NO_SERDES
-   )
- 
--if (TARGET VTK::vtkviskores_cuda)
--  foreach(src IN LISTS tests)
--    string(REPLACE "," ";" src ${src})
--    list(GET src 0 src)
--
--    set_source_files_properties(${src} PROPERTIES LANGUAGE CUDA)
--  endforeach()
--
--  #the tests aren't scoped as a child directory of vtkAcceleratorsVTKmFilters
--  #so we need to redo this logic
--  viskores_get_cuda_flags(CMAKE_CUDA_FLAGS)
--
--  # Temporarily suppress "has address taken but no possible call to it" warnings,
--  # until we figure out its implications.
--  # We are disabling all warnings as nvlink has no known way to suppress
--  # individual warning types.
--  string(APPEND CMAKE_CUDA_FLAGS " -Xnvlink -w")
--
--endif()
--
- 
- vtk_test_cxx_executable(vtkAcceleratorsVTKmFiltersCxxTests tests
-   RENDERING_FACTORY
-   )
--
--if (TARGET VTK::vtkviskores_cuda)
--  set_target_properties(vtkAcceleratorsVTKmFiltersCxxTests PROPERTIES
--    CUDA_ARCHITECTURES OFF)
--endif()
 diff --git a/IO/CatalystConduit/CMakeLists.txt b/IO/CatalystConduit/CMakeLists.txt
 index 91d60f1638c..d1d6049279a 100644
 --- a/IO/CatalystConduit/CMakeLists.txt
 +++ b/IO/CatalystConduit/CMakeLists.txt
-@@ -16,23 +16,8 @@ vtk_module_add_module(VTK::IOCatalystConduit
+@@ -16,23 +16,10 @@ vtk_module_add_module(VTK::IOCatalystConduit
    CLASSES ${classes}
    PRIVATE_CLASSES ${private_classes})
  
@@ -304,7 +266,9 @@ index 91d60f1638c..d1d6049279a 100644
 -endif ()
 -
 +_vtk_module_real_target(vtkm_accel_target VTK::IOCatalystConduit)
-+vtk_add_viskores_device_target_information(${vtkm_accel_target})
++if (TARGET VTK::vtkviskores)
++  vtk_add_viskores_device_target_information(${vtkm_accel_target})
++endif()
  
  vtk_add_test_mangling(VTK::IOCatalystConduit)
  add_subdirectory(Catalyst)


### PR DESCRIPTION
The patch for https://gitlab.kitware.com/vtk/vtk/-/merge_requests/13127 was missing a check for the existance of the CMake function vtk_add_viskores_device_target_information. This has been added to the patch.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
