### PR TITLE
kokkos: remove Kokkos' test

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -599,29 +599,3 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         ]
         cmake(*cmake_args)
         cache_extra_test_sources(self, cmake_out_path)
-
-    def test_run(self):
-        """Test if kokkos builds and runs"""
-        cmake_path = join_path(
-            self.test_suite.current_test_cache_dir, self.test_script_relative_path, "out"
-        )
-
-        if not os.path.exists(cmake_path):
-            raise SkipTest(f"{cmake_path} is missing")
-
-        cmake = self.spec["cmake"].command
-        cmake_args = []
-        if self.spec.satisfies("+rocm"):
-            prefix_paths = ";".join(get_cmake_prefix_path(self))
-            cmake_args.append(self.define("CMAKE_PREFIX_PATH", prefix_paths))
-
-        if self.spec.satisfies("+wrapper"):
-            cmake_args.append(
-                self.define("CMAKE_CXX_COMPILER", self["kokkos-nvcc-wrapper"].kokkos_cxx)
-            )
-        else:
-            cmake_args.append(self.define("CMAKE_CXX_COMPILER", self["cxx"].cxx))
-
-        cmake(cmake_path, *cmake_args)
-        cmake("--build", ".")
-        cmake("--build", ".", "--target", "test")


### PR DESCRIPTION
The relevant discussion is in https://github.com/spack/spack-packages/pull/5017.
TL;DR we do not think the test is actually helping (see discussion), but it would need changes to be useful (we tried to use it in Kokkos' CI). So instead of fixing it, we just remove it and find a better way to test the spack builds in our CI

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
