### PR TITLE
charmpp: remove @8: conflict with aocc

### DIFF
--- a/repos/spack_repo/builtin/packages/charmpp/package.py
+++ b/repos/spack_repo/builtin/packages/charmpp/package.py
@@ -127,6 +127,12 @@ class Charmpp(Package):
     # Fix was suggested in https://github.com/charmplusplus/charm/pull/3646 and the same has
     # been implemented in v8.0.0
     conflicts("%fortran=intel-oneapi-compilers", when="@8: +fortran")
+    conflicts(
+        "%fortran=aocc@:4.2",
+        when="@8: +fortran",
+        msg="Charm++ 8.x +fortran fails to build with AOCC 4.2.0 and earlier; "
+        "use AOCC 5.0+ or charmpp@8: ~fortran",
+    )
 
     # Versions 7.0.0+ use CMake by default when it's available. It's more
     # robust.

--- a/repos/spack_repo/builtin/packages/charmpp/package.py
+++ b/repos/spack_repo/builtin/packages/charmpp/package.py
@@ -127,7 +127,6 @@ class Charmpp(Package):
     # Fix was suggested in https://github.com/charmplusplus/charm/pull/3646 and the same has
     # been implemented in v8.0.0
     conflicts("%fortran=intel-oneapi-compilers", when="@8: +fortran")
-    conflicts("%fortran=aocc", when="@8: +fortran")
 
     # Versions 7.0.0+ use CMake by default when it's available. It's more
     # robust.


### PR DESCRIPTION
This PR removes the below conflict in charmpp package, that is no more required:
`conflicts("%fortran=aocc", when="@8: +fortran")`

This helps in picking up latest `chanrmpp@8.0.0` by deafult while building with `%aocc`, I feel that similar change should be made for the conflict with `%oneapi`.

Originally this conflict was introduced with https://github.com/spack/spack-packages/pull/90 to avoid building of `charmpp@8` with default variant `+fortran`, I don't see any issue with that now. I am able to build `namd@3.0.2` with `charmpp@8.0.0 +fortran` using `aocc@5.2.0`.

Below is the tested spec:
<img width="1222" height="572" alt="image" src="https://github.com/user-attachments/assets/663e7334-2554-44e3-8b7d-1f5bb1fcd7ad" />
