### PR TITLE
amdlibflame: add dual-build support for for shared and static libraries

### DIFF
--- a/repos/spack_repo/builtin/packages/amdlibflame/package.py
+++ b/repos/spack_repo/builtin/packages/amdlibflame/package.py
@@ -9,6 +9,7 @@ from spack_repo.builtin.packages.libflame.package import LibflameBase
 
 from spack.package import *
 
+import os
 
 class Amdlibflame(CMakePackage, LibflameBase):
     """libFLAME (AMD Optimized version) is a portable library for
@@ -73,6 +74,10 @@ class Amdlibflame(CMakePackage, LibflameBase):
     variant("logging", default="False", description="Enable AOCL DTL Logging")
     variant("tracing", default="False", description="Enable AOCL DTL Tracing")
 
+    # Override the 'static' variant defined in LibflameBase: for CMake builds of amdlibflame,
+    # default this variant to False so that only shared libraries are built unless explicitly requested.
+    variant("static", default=False, when="@4.2:", description="Build static library")
+
     # Build system
     build_system(
         conditional("cmake", when="@4.2:"), conditional("autotools", when="@:4.1"), default="cmake"
@@ -87,6 +92,7 @@ class Amdlibflame(CMakePackage, LibflameBase):
     conflicts("threads=pthreads", msg="pthread is not supported")
     conflicts("threads=openmp", when="@:3", msg="openmp is not supported by amdlibflame < 4.0")
     requires("target=x86_64:", msg="AMD libflame available only on x86_64")
+    conflicts("~shared~static", msg="At least one library type (shared or static) must be built")
 
     patch("aocc-2.2.0.patch", when="@:2", level=1)
     patch("cray-compiler-wrapper.patch", when="@:3.0.0", level=1)
@@ -112,15 +118,21 @@ class Amdlibflame(CMakePackage, LibflameBase):
     @property
     def lapack_libs(self):
         """find lapack_libs function"""
+        # When both shared and static are built, prefer shared libraries.
+        # When only one type is built, return that type.
+        shared = self.spec.satisfies("+shared")
         return find_libraries(
-            "libflame", root=self.prefix, shared="+shared" in self.spec, recursive=True
+            "libflame", root=self.prefix, shared=shared, recursive=True
         )
 
     @property
     def libs(self):
         """find libflame libs function"""
+        # When both shared and static are built, prefer shared libraries.
+        # When only one type is built, return that type.
+        shared = self.spec.satisfies("+shared")
         return find_libraries(
-            "libflame", root=self.prefix, shared="+shared" in self.spec, recursive=True
+            "libflame", root=self.prefix, shared=shared, recursive=True
         )
 
     def flag_handler(self, name, flags):
@@ -175,9 +187,59 @@ class CMakeBuilder(cmake.CMakeBuilder):
         else:
             args.append(self.define("LF_ISA_CONFIG", spec.variants["vectorization"].value))
 
+        # Note: When both +shared +static are requested, we use a two-pass build strategy.
+        # The first build is for shared libraries (handled here), and the second build
+        # (for static libraries) is handled in a separate build directory in the install() method.
         args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
 
         return args
+
+    def install(self, pkg, spec, prefix):
+        """Install method with support for building both shared and static libraries.
+
+        When both +shared and +static variants are enabled, this performs a two-pass build:
+        1. First pass: Build and install shared libraries (using the standard build directory)
+        2. Second pass: Build and install static libraries in a separate build directory
+
+        Both builds install to the same prefix. The static build happens after the shared
+        build to ensure no conflicts, as static libraries (.a) and shared libraries (.so)
+        have different file extensions and can coexist in the same directory.
+        """
+        # First build/install: shared libraries (if +shared) or static (if only +static)
+        super().install(pkg, spec, prefix)
+
+        # Second build/install: static libraries (only if both +shared and +static)
+        if spec.satisfies("+shared +static"):
+            # Build static libraries in a separate build directory
+            build_dir_parent = os.path.dirname(self.build_directory)
+            build_dir_name = os.path.basename(self.build_directory)
+            static_build_dir = os.path.join(build_dir_parent, build_dir_name + "-static")
+
+            with working_dir(static_build_dir, create=True):
+                # Configure for static libraries
+                static_args = self.cmake_args()
+                # Replace BUILD_SHARED_LIBS setting to build static libraries
+                static_args = [arg for arg in static_args if "BUILD_SHARED_LIBS" not in arg]
+                static_args.append(self.define("BUILD_SHARED_LIBS", False))
+
+                # Combine standard cmake args with static-specific args
+                options = self.std_cmake_args + static_args
+                options.append(os.path.abspath(self.root_cmakelists_dir))
+
+                # Run cmake configuration
+                pkg.module.cmake(*options)
+
+                # Build static libraries
+                if self.generator == "Unix Makefiles":
+                    pkg.module.make(*self.build_targets)
+                elif self.generator == "Ninja":
+                    pkg.module.ninja(*self.build_targets)
+
+                # Install static libraries to the same prefix
+                if self.generator == "Unix Makefiles":
+                    pkg.module.make(*self.install_targets)
+                elif self.generator == "Ninja":
+                    pkg.module.ninja(*self.install_targets)
 
 
 class AutotoolsBuilder(autotools.AutotoolsBuilder):

--- a/repos/spack_repo/builtin/packages/amdlibflame/package.py
+++ b/repos/spack_repo/builtin/packages/amdlibflame/package.py
@@ -76,7 +76,8 @@ class Amdlibflame(CMakePackage, LibflameBase):
     variant("tracing", default="False", description="Enable AOCL DTL Tracing")
 
     # Override the 'static' variant defined in LibflameBase: for CMake builds of amdlibflame,
-    # default this variant to False so that only shared libraries are built unless explicitly requested.
+    # default this variant to False so that only shared libraries are built unless explicitly
+    # requested.
     variant("static", default=False, when="@4.2:", description="Build static library")
 
     # Build system

--- a/repos/spack_repo/builtin/packages/amdlibflame/package.py
+++ b/repos/spack_repo/builtin/packages/amdlibflame/package.py
@@ -3,13 +3,14 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 # ----------------------------------------------------------------------------\
 
+import os
+
 from spack_repo.builtin.build_systems import autotools, cmake
 from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
 from spack_repo.builtin.packages.libflame.package import LibflameBase
 
 from spack.package import *
 
-import os
 
 class Amdlibflame(CMakePackage, LibflameBase):
     """libFLAME (AMD Optimized version) is a portable library for
@@ -121,9 +122,7 @@ class Amdlibflame(CMakePackage, LibflameBase):
         # When both shared and static are built, prefer shared libraries.
         # When only one type is built, return that type.
         shared = self.spec.satisfies("+shared")
-        return find_libraries(
-            "libflame", root=self.prefix, shared=shared, recursive=True
-        )
+        return find_libraries("libflame", root=self.prefix, shared=shared, recursive=True)
 
     @property
     def libs(self):
@@ -131,9 +130,7 @@ class Amdlibflame(CMakePackage, LibflameBase):
         # When both shared and static are built, prefer shared libraries.
         # When only one type is built, return that type.
         shared = self.spec.satisfies("+shared")
-        return find_libraries(
-            "libflame", root=self.prefix, shared=shared, recursive=True
-        )
+        return find_libraries("libflame", root=self.prefix, shared=shared, recursive=True)
 
     def flag_handler(self, name, flags):
         if name == "cflags":


### PR DESCRIPTION
## Description

Enables building both shared and static libraries simultaneously for amdlibflame CMake builds (@4.2:), addressing the need for dual-library installations to address https://github.com/spack/spack-packages/issues/382.

## Changes

**Variant Configuration:**
- Override `static` variant from `LibflameBase`: `default=False` for CMake builds (@4.2:), making shared-only the default
- Explicitly document that this overrides the base class variant definition
- Add conflict `~shared~static` to require at least one library type
- Fix `logging`/`tracing` variants: boolean `False` instead of string `"False"`

**Dual-Build Strategy:**
- Implement two-pass build in `CMakeBuilder.install()` when both `+shared +static` requested
- First pass: shared libraries in standard build directory
- Second pass: static libraries in separate `build-static` directory
- Both install to same prefix (`.so` and `.a` coexist without conflict)

**Library Discovery:**
- Update `libs` and `lapack_libs` properties with clarified behavior documentation
- When only one type is built: returns that type (e.g., `~shared +static` returns static libraries)
- When both types are built: prefers shared libraries
- Maintains deterministic behavior for dependent packages

## Usage

```bash
# Default: shared only
spack install amdlibflame

# Both library types
spack install amdlibflame +shared +static

# Static only
spack install amdlibflame ~shared +static
```