### PR TITLE
libunwind: disable outdated conflict for aarch64

### DIFF
--- a/repos/spack_repo/builtin/packages/libunwind/package.py
+++ b/repos/spack_repo/builtin/packages/libunwind/package.py
@@ -102,9 +102,6 @@ class Libunwind(AutotoolsPackage):
     conflicts("target=ppc64:", when="@1.8")
     conflicts("target=ppc64le:", when="@1.8")
 
-    # historically it might have failed, 1.8.1+ work
-    conflicts("target=aarch64:", when="@:1.8")
-
     # https://github.com/libunwind/libunwind/issues/672
     conflicts("%gcc@14:", when="@1.7.2")
 

--- a/repos/spack_repo/builtin/packages/libunwind/package.py
+++ b/repos/spack_repo/builtin/packages/libunwind/package.py
@@ -102,7 +102,8 @@ class Libunwind(AutotoolsPackage):
     conflicts("target=ppc64:", when="@1.8")
     conflicts("target=ppc64le:", when="@1.8")
 
-    conflicts("target=aarch64:", when="@1.8:")
+    # historically it might have failed, 1.8.1+ work
+    conflicts("target=aarch64:", when="@:1.8")
 
     # https://github.com/libunwind/libunwind/issues/672
     conflicts("%gcc@14:", when="@1.7.2")


### PR DESCRIPTION
Successfully built 1.8.1, 1.8.2, and 1.8.3 on Grace Hopper (aarch64) with GCC 14.3.0.

Should go in after https://github.com/spack/spack-packages/pull/5089 and https://github.com/spack/spack-packages/pull/5090