### PR TITLE
adios2: depend on latest mgard

### DIFF
--- a/repos/spack_repo/builtin/packages/adios2/package.py
+++ b/repos/spack_repo/builtin/packages/adios2/package.py
@@ -202,8 +202,11 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("zfp@0.5.1:0.5", when="+zfp")
     depends_on("sz@2.0.2.0:", when="+sz")
     depends_on("sz3", when="+sz3")
-    depends_on("mgard@compat-2022-11-18:", when="+mgard")
-    depends_on("mgard@compat-2023-01-10:", when="@2.9: +mgard")
+
+    with when("+mgard"):
+        depends_on("mgard@1.6.0:", when="@2.10:")
+        depends_on("mgard@compat-2023-01-10:", when="@2.9")
+        depends_on("mgard@compat-2022-11-18:", when="@:2.8")
 
     extends("python", when="+python")
     depends_on("python", when="+python", type=("build", "run"))


### PR DESCRIPTION
I have tested this with adios2 `2.{8,9,10,11,12}`