### PR TITLE
pelican, go-sh: update to use GoPackage ldflags

### DIFF
--- a/repos/spack_repo/builtin/packages/go_sh/package.py
+++ b/repos/spack_repo/builtin/packages/go_sh/package.py
@@ -48,20 +48,25 @@ class GoSh(GoPackage):
             files.append(join_path("bin", "gosh"))
         return files
 
+    @property
+    def ldflags(self):
+        # v3.12 uses ldflags to set version; v3.13+ uses Go's VCS stamping
+        if self.spec.satisfies("@:3.12"):
+            return [f"-X main.version={self.spec.version}"]
+        return []
+
     def build(self, spec: Spec, prefix: Prefix) -> None:
         """Runs ``go build`` in the source directory for the specified
         variants."""
-        # v3.12 uses ldflags to set version; v3.13+ uses Go's VCS stamping
-        if spec.satisfies("@:3.12"):
-            ldflags = f"-s -w -X main.version={spec.version}"
-        else:
-            ldflags = "-s -w"
-        common_flags = ("-p", str(make_jobs), "-modcacherw", "-ldflags", ldflags)
         with working_dir(self.build_directory):
             if spec.satisfies("+shfmt"):
-                go("build", "-o", "shfmt", *common_flags, "./cmd/shfmt")
+                args = list(self.std_build_args)
+                args[args.index("-o") + 1] = "shfmt"
+                go("build", *args, "./cmd/shfmt")
             if spec.satisfies("+gosh"):
-                go("build", "-o", "gosh", *common_flags, "./cmd/gosh")
+                args = list(self.std_build_args)
+                args[args.index("-o") + 1] = "gosh"
+                go("build", *args, "./cmd/gosh")
 
     def install(self, spec: Spec, prefix: Prefix) -> None:
         """Install built binaries into prefix bin."""

--- a/repos/spack_repo/builtin/packages/pelican/package.py
+++ b/repos/spack_repo/builtin/packages/pelican/package.py
@@ -26,6 +26,8 @@ class Pelican(GoPackage):
 
     depends_on("go@1.25:", type="build")
 
+    build_directory = "cmd"
+
     @run_before("build", when="@:7.24")
     def create_frontend_placeholder(self):
         # web_ui/ui.go uses //go:embed frontend/out/*, which requires at least one
@@ -36,26 +38,18 @@ class Pelican(GoPackage):
         mkdirp(out_dir)
         touch(join_path(out_dir, "placeholder"))
 
-    build_directory = "cmd"
+    @property
+    def ldflags(self):
+        return [f"-X github.com/pelicanplatform/pelican/version.version={self.spec.version}"]
 
     @property
     def build_args(self):
         # Build only the CLI client binary (no web frontend embedded)
-        args = super().build_args
-        version_ldflag = (
-            f"-X github.com/pelicanplatform/pelican/version.version={self.spec.version}"
-        )
-        if "-ldflags" in args:
-            args[args.index("-ldflags") + 1] += f" {version_ldflag}"
-        else:
-            args.extend(["-ldflags", version_ldflag])
-        args.extend(["-tags", "forceposix,client"])
-        return args
+        return ["-tags", "forceposix,client"]
 
     @run_after("build", when="+server")
     def build_server(self):
-        args = list(self.build_args)
-        args[args.index("-tags") + 1] = "forceposix,server"
+        args = [*self.std_build_args, "-tags", "forceposix,server"]
         args[args.index("-o") + 1] = "pelican-server"
         with working_dir(self.build_directory):
             go("build", *args)


### PR DESCRIPTION
Now that `GoPackage` supports user set `ldflags` we can simplify both of these packages.