### PR TITLE
openmpi: Use `--with-libevent-libdir=spec['libevent'].libs.directories[0]`

### DIFF
--- a/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -1218,6 +1218,7 @@ with '-Wl,-commons,use_dylibs' and without
             config_args.append("--with-libevent=internal")
         elif spec.satisfies("%libevent"):
             config_args.append(f"--with-libevent={spec['libevent'].prefix}")
+            config_args.append(f"--with-libevent-libdir={spec['libevent'].libs.directories[0]}")
 
         # PMIx/PRRTE support
         if spec.satisfies("+internal-pmix"):

--- a/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -1236,6 +1236,7 @@ with '-Wl,-commons,use_dylibs' and without
             config_args.append("--with-libevent=internal")
         elif spec.satisfies("%libevent"):
             config_args.append(f"--with-libevent={spec['libevent'].prefix}")
+            config_args.append(f"--with-libevent-libdir={spec['libevent'].libs.directories[0]}")
 
         # PMIx/PRRTE support
         if spec.satisfies("+internal-pmix"):


### PR DESCRIPTION
On some Systems (e.g. Ubuntu), `libevent` is not found under `/usr/lib` but `/usr/lib/aarch64-linux-gnu/` or similar. Using `/usr` as the prefix does therefore not work. So this commit provides autotools with the actual location of `libevent`.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
