### PR TITLE
Revert "cuda: add v13.1.2, v13.2.0, v13.2.1 and v13.3.0"

### DIFF
--- a/repos/spack_repo/builtin/build_systems/cuda.py
+++ b/repos/spack_repo/builtin/build_systems/cuda.py
@@ -211,7 +211,8 @@ class CudaPackage(PackageBase):
         conflicts("%gcc@13:", when="%cuda@:12.3")
         conflicts("%gcc@14:", when="%cuda@:12.6")
         conflicts("%gcc@15:", when="%cuda@:12.9")
-        conflicts("%gcc@16:", when="%cuda@:13.3")
+        conflicts("%gcc@16:", when="%cuda@:13.1")
+        conflicts("%gcc@15:", when="%cuda@13.1:")
         conflicts("%clang@12:", when="%cuda@:11.4.0")
         conflicts("%clang@13:", when="%cuda@:11.5")
         conflicts("%clang@14:", when="%cuda@:11.7")
@@ -221,8 +222,8 @@ class CudaPackage(PackageBase):
         conflicts("%clang@18:", when="%cuda@:12.5")
         conflicts("%clang@19:", when="%cuda@:12.6")
         conflicts("%clang@20:", when="%cuda@:12.9")
-        conflicts("%clang@21:", when="%cuda@:13.0")
-        conflicts("%clang@22:", when="%cuda@:13.3")
+        conflicts("%clang@21:", when="%cuda@:13.1")
+        conflicts("%clang@20:", when="%cuda@13.1:")
 
         # https://gist.github.com/ax3l/9489132#gistcomment-3860114
         conflicts("%gcc@10", when="%cuda@:11.4.0")

--- a/repos/spack_repo/builtin/packages/cuda/package.py
+++ b/repos/spack_repo/builtin/packages/cuda/package.py
@@ -23,46 +23,6 @@ from spack.package import *
 #    format returned by platform.system() and 'arch' by platform.machine()
 
 _versions = {
-    "13.3.0": {
-        "Linux-aarch64": (
-            "94ec4572197b65532dcf3d327460417c6527fa42ded9d5010e06ddb89e878d4c",
-            "https://developer.download.nvidia.com/compute/cuda/13.3.0/local_installers/cuda_13.3.0_610.43.02_linux_sbsa.run",
-        ),
-        "Linux-x86_64": (
-            "5f79488b57fe6936bc95a56f9b7e2838ab2f2ee3313b1008942206eebe06352d",
-            "https://developer.download.nvidia.com/compute/cuda/13.3.0/local_installers/cuda_13.3.0_610.43.02_linux.run",
-        ),
-    },
-    "13.2.1": {
-        "Linux-aarch64": (
-            "38560e0c48eba793c883ea1ada6ad4c37b744cb5284034d16fd7ee57f95dda04",
-            "https://developer.download.nvidia.com/compute/cuda/13.2.1/local_installers/cuda_13.2.1_595.58.03_linux_sbsa.run",
-        ),
-        "Linux-x86_64": (
-            "5514a3fe7bcea92b25073c7c100c3e64e7961a7e1dbad6955adb8b59806053f0",
-            "https://developer.download.nvidia.com/compute/cuda/13.2.1/local_installers/cuda_13.2.1_595.58.03_linux.run",
-        ),
-    },
-    "13.2.0": {
-        "Linux-aarch64": (
-            "9684ebc64988f71ef1c70846cc9d158fb27950c1355bf37c8795c346346b6a72",
-            "https://developer.download.nvidia.com/compute/cuda/13.2.0/local_installers/cuda_13.2.0_595.45.04_linux_sbsa.run",
-        ),
-        "Linux-x86_64": (
-            "c599b651582c8f345ebde7bcf089b7dcfcd8afd7d3ea7f50525698c563a239d7",
-            "https://developer.download.nvidia.com/compute/cuda/13.2.0/local_installers/cuda_13.2.0_595.45.04_linux.run",
-        ),
-    },
-    "13.1.2": {
-        "Linux-aarch64": (
-            "9d3963ce2d0d73e2175530ccb90f604821ab91b45b41dca85a96aeb6d96978c8",
-            "https://developer.download.nvidia.com/compute/cuda/13.1.2/local_installers/cuda_13.1.2_590.48.01_linux_sbsa.run",
-        ),
-        "Linux-x86_64": (
-            "ad7d50d49898ea1a24518bb9c0c154f73eef3a1b3de22a05b5e3c907dbac4c1b",
-            "https://developer.download.nvidia.com/compute/cuda/13.1.2/local_installers/cuda_13.1.2_590.48.01_linux.run",
-        ),
-    },
     "13.1.1": {
         "Linux-aarch64": (
             "8adcd5d4b3e1e70f7420959b97514c0c97ec729da248d54902174c4d229bfd2c",

--- a/repos/spack_repo/builtin/packages/ginkgo/package.py
+++ b/repos/spack_repo/builtin/packages/ginkgo/package.py
@@ -127,9 +127,6 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
     # https://github.com/ginkgo-project/ginkgo/pull/1926
     conflicts("^cuda@13:", when="@:1.10.0 +cuda")
 
-    # https://github.com/ginkgo-project/ginkgo/pull/2002
-    conflicts("^cuda@13.2:", when="@1.11.0 +cuda")
-
     # error due to change in warpSize constant definition in ROCm 7.0 prior to v.1.11.0
     # https://github.com/ginkgo-project/ginkgo/pull/1954
     conflicts("^hip@7:", when="@:1.10.0 +rocm")

--- a/repos/spack_repo/builtin/packages/hypre/package.py
+++ b/repos/spack_repo/builtin/packages/hypre/package.py
@@ -216,8 +216,6 @@ class Hypre(CMakePackage, AutotoolsPackage, CudaPackage, ROCmPackage):
         conflicts("cxxstd=14", when="^cuda@13:")
         depends_on("cuda@:11", when="@:2.28.0")
         conflicts("^cuda@13:", when="@:2")
-        # https://github.com/hypre-space/hypre/pull/1487
-        conflicts("^cuda@13.2:", when="@:3.1.0")
         for pkg, sm_ in product(gpu_pkgs, CudaPackage.cuda_arch_values):
             requires(f"^{pkg} cuda_arch={sm_}", when=f"+{pkg} cuda_arch={sm_}")
 


### PR DESCRIPTION
Reverts spack/spack-packages#4897 : downstream packages including strumpack seem to fail with it; they weren't tested on gitlab CI due to an error introduced by https://github.com/spack/spack-packages/pull/4615 and fixed in #5046.

Draft to test whether the pipeline passes with the reversion.