### PR TITLE
minisign: add v0.12

### DIFF
--- a/repos/spack_repo/builtin/packages/libsodium/package.py
+++ b/repos/spack_repo/builtin/packages/libsodium/package.py
@@ -19,21 +19,25 @@ class Libsodium(AutotoolsPackage):
 
     license("ISC")
 
+    maintainers("alalazo")
+
     version("master", branch="master")
     version("stable", branch="stable")
 
+    version("1.0.22", sha256="adbdd8f16149e81ac6078a03aca6fc03b592b89ef7b5ed83841c086191be3349")
     version("1.0.20", sha256="ebb65ef6ca439333c2bb41a0c1990587288da07f6c7fd07cb3a18cc18d30ce19")
-    version("1.0.19", sha256="018d79fe0a045cca07331d37bd0cb57b2e838c51bc48fd837a1472e50068bbea")
-    version("1.0.18", sha256="6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5452b46be121e46636c1")
-    version("1.0.17", sha256="0cc3dae33e642cc187b5ceb467e0ad0e1b51dcba577de1190e9ffa17766ac2b1")
-    version("1.0.16", sha256="eeadc7e1e1bcef09680fb4837d448fbdf57224978f865ac1c16745868fbd0533")
-    version("1.0.15", sha256="fb6a9e879a2f674592e4328c5d9f79f082405ee4bb05cb6e679b90afe9e178f4")
-    version("1.0.13", sha256="9c13accb1a9e59ab3affde0e60ef9a2149ed4d6e8f99c93c7a5b97499ee323fd")
-    version("1.0.3", sha256="cbcfc63cc90c05d18a20f229a62c7e7054a73731d0aa858c0517152c549b1288")
-    version("1.0.2", sha256="961d8f10047f545ae658bcc73b8ab0bf2c312ac945968dd579d87c768e5baa19")
-    version("1.0.1", sha256="c3090887a4ef9e2d63af1c1e77f5d5a0656fadb5105ebb9fb66a302210cb3af5")
-    version("1.0.0", sha256="ced1fe3d2066953fea94f307a92f8ae41bf0643739a44309cbe43aa881dbc9a5")
-    version("0.7.1", sha256="ef46bbb5bac263ef6d3fc00ccc11d4690aea83643412919fe15369b9870280a7")
+    with default_args(deprecated=True):
+        version("1.0.19", sha256="018d79fe0a045cca07331d37bd0cb57b2e838c51bc48fd837a1472e50068bbea")
+        version("1.0.18", sha256="6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5452b46be121e46636c1")
+        version("1.0.17", sha256="0cc3dae33e642cc187b5ceb467e0ad0e1b51dcba577de1190e9ffa17766ac2b1")
+        version("1.0.16", sha256="eeadc7e1e1bcef09680fb4837d448fbdf57224978f865ac1c16745868fbd0533")
+        version("1.0.15", sha256="fb6a9e879a2f674592e4328c5d9f79f082405ee4bb05cb6e679b90afe9e178f4")
+        version("1.0.13", sha256="9c13accb1a9e59ab3affde0e60ef9a2149ed4d6e8f99c93c7a5b97499ee323fd")
+        version("1.0.3", sha256="cbcfc63cc90c05d18a20f229a62c7e7054a73731d0aa858c0517152c549b1288")
+        version("1.0.2", sha256="961d8f10047f545ae658bcc73b8ab0bf2c312ac945968dd579d87c768e5baa19")
+        version("1.0.1", sha256="c3090887a4ef9e2d63af1c1e77f5d5a0656fadb5105ebb9fb66a302210cb3af5")
+        version("1.0.0", sha256="ced1fe3d2066953fea94f307a92f8ae41bf0643739a44309cbe43aa881dbc9a5")
+        version("0.7.1", sha256="ef46bbb5bac263ef6d3fc00ccc11d4690aea83643412919fe15369b9870280a7")
 
     depends_on("c", type="build")
 

--- a/repos/spack_repo/builtin/packages/libsodium/package.py
+++ b/repos/spack_repo/builtin/packages/libsodium/package.py
@@ -27,12 +27,24 @@ class Libsodium(AutotoolsPackage):
     version("1.0.22", sha256="adbdd8f16149e81ac6078a03aca6fc03b592b89ef7b5ed83841c086191be3349")
     version("1.0.20", sha256="ebb65ef6ca439333c2bb41a0c1990587288da07f6c7fd07cb3a18cc18d30ce19")
     with default_args(deprecated=True):
-        version("1.0.19", sha256="018d79fe0a045cca07331d37bd0cb57b2e838c51bc48fd837a1472e50068bbea")
-        version("1.0.18", sha256="6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5452b46be121e46636c1")
-        version("1.0.17", sha256="0cc3dae33e642cc187b5ceb467e0ad0e1b51dcba577de1190e9ffa17766ac2b1")
-        version("1.0.16", sha256="eeadc7e1e1bcef09680fb4837d448fbdf57224978f865ac1c16745868fbd0533")
-        version("1.0.15", sha256="fb6a9e879a2f674592e4328c5d9f79f082405ee4bb05cb6e679b90afe9e178f4")
-        version("1.0.13", sha256="9c13accb1a9e59ab3affde0e60ef9a2149ed4d6e8f99c93c7a5b97499ee323fd")
+        version(
+            "1.0.19", sha256="018d79fe0a045cca07331d37bd0cb57b2e838c51bc48fd837a1472e50068bbea"
+        )
+        version(
+            "1.0.18", sha256="6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5452b46be121e46636c1"
+        )
+        version(
+            "1.0.17", sha256="0cc3dae33e642cc187b5ceb467e0ad0e1b51dcba577de1190e9ffa17766ac2b1"
+        )
+        version(
+            "1.0.16", sha256="eeadc7e1e1bcef09680fb4837d448fbdf57224978f865ac1c16745868fbd0533"
+        )
+        version(
+            "1.0.15", sha256="fb6a9e879a2f674592e4328c5d9f79f082405ee4bb05cb6e679b90afe9e178f4"
+        )
+        version(
+            "1.0.13", sha256="9c13accb1a9e59ab3affde0e60ef9a2149ed4d6e8f99c93c7a5b97499ee323fd"
+        )
         version("1.0.3", sha256="cbcfc63cc90c05d18a20f229a62c7e7054a73731d0aa858c0517152c549b1288")
         version("1.0.2", sha256="961d8f10047f545ae658bcc73b8ab0bf2c312ac945968dd579d87c768e5baa19")
         version("1.0.1", sha256="c3090887a4ef9e2d63af1c1e77f5d5a0656fadb5105ebb9fb66a302210cb3af5")

--- a/repos/spack_repo/builtin/packages/minisign/package.py
+++ b/repos/spack_repo/builtin/packages/minisign/package.py
@@ -16,14 +16,20 @@ class Minisign(CMakePackage):
 
     license("ISC")
 
-    version("0.11", sha256="74c2c78a1cd51a43a6c98f46a4eabefbc8668074ca9aa14115544276b663fc55")
-    version("0.9", sha256="caa4b3dd314e065c6f387b2713f7603673e39a8a0b1a76f96ef6c9a5b845da0f")
-    version("0.8", sha256="130eb5246076bc7ec42f13495a601382e566bb6733430d40a68de5e43a7f1082")
-    version("0.7", sha256="0c9f25ae647b6ba38cf7e6aea1da4e8fb20e1bc64ef0c679da737a38c8ad43ef")
+    version(
+        "0.12",
+        sha256="677e3dd52f559992c72be932d958587b5f731a1a295bcee37be878ed3f585926",
+        url="https://github.com/jedisct1/minisign/releases/download/0.12/minisign-0.12.tar.gz",
+    )
+    with default_args(deprecated=True):
+        version("0.11", sha256="74c2c78a1cd51a43a6c98f46a4eabefbc8668074ca9aa14115544276b663fc55")
+        version("0.9", sha256="caa4b3dd314e065c6f387b2713f7603673e39a8a0b1a76f96ef6c9a5b845da0f")
+        version("0.8", sha256="130eb5246076bc7ec42f13495a601382e566bb6733430d40a68de5e43a7f1082")
+        version("0.7", sha256="0c9f25ae647b6ba38cf7e6aea1da4e8fb20e1bc64ef0c679da737a38c8ad43ef")
 
     variant("static", default=True, description="builds a static version of the executable")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     depends_on("libsodium")
 


### PR DESCRIPTION
Modifications:
- Also add libsodium v1.0.22
- Deprecated old versions of both packages.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
