### PR TITLE
ecflow, yaml_cpp: deprecate old versions

### DIFF
--- a/repos/spack_repo/builtin/packages/ecflow/package.py
+++ b/repos/spack_repo/builtin/packages/ecflow/package.py
@@ -27,9 +27,16 @@ class Ecflow(CMakePackage):
     version("5.11.4", sha256="4836a876277c9a65a47a3dc87cae116c3009699f8a25bab4e3afabf160bcf212")
     version("5.8.4", sha256="bc628556f8458c269a309e4c3b8d5a807fae7dfd415e27416fe9a3f544f88951")
     version("5.8.3", sha256="1d890008414017da578dbd5a95cb1b4d599f01d5a3bb3e0297fe94a87fbd81a6")
-    version("4.13.0", sha256="c743896e0ec1d705edd2abf2ee5a47f4b6f7b1818d8c159b521bdff50a403e39")
-    version("4.12.0", sha256="566b797e8d78e3eb93946b923ef540ac61f50d4a17c9203d263c4fd5c39ab1d1")
-    version("4.11.1", sha256="b3bcc1255939f87b9ba18d802940e08c0cf6379ca6aeec1fef7bd169b0085d6c")
+    with default_args(deprecated=True):
+        version(
+            "4.13.0", sha256="c743896e0ec1d705edd2abf2ee5a47f4b6f7b1818d8c159b521bdff50a403e39"
+        )
+        version(
+            "4.12.0", sha256="566b797e8d78e3eb93946b923ef540ac61f50d4a17c9203d263c4fd5c39ab1d1"
+        )
+        version(
+            "4.11.1", sha256="b3bcc1255939f87b9ba18d802940e08c0cf6379ca6aeec1fef7bd169b0085d6c"
+        )
 
     variant("ssl", default=True, description="Enable SSL")
     variant(

--- a/repos/spack_repo/builtin/packages/yaml_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/yaml_cpp/package.py
@@ -25,8 +25,12 @@ class YamlCpp(CMakePackage):
     version("0.7.0", sha256="43e6a9fcb146ad871515f0d0873947e5d497a1c9c60c58cb102a97b47208b7c3")
     version("0.6.3", sha256="77ea1b90b3718aa0c324207cb29418f5bced2354c2e483a9523d98c3460af1ed")
     version("0.6.2", sha256="e4d8560e163c3d875fd5d9e5542b5fd5bec810febdcba61481fe5fc4e6b1fd05")
-    version("0.5.3", sha256="decc5beabb86e8ed9ebeb04358d5363a5c4f72d458b2c788cb2f3ac9c19467b2")
-    version("0.3.0", sha256="ab8d0e07aa14f10224ed6682065569761f363ec44bc36fcdb2946f6d38fe5a89")
+    with default_args(deprecated=True):
+        version(
+            "0.5.3",
+            sha256="decc5beabb86e8ed9ebeb04358d5363a5c4f72d458b2c788cb2f3ac9c19467b2",
+        )
+        version("0.3.0", sha256="ab8d0e07aa14f10224ed6682065569761f363ec44bc36fcdb2946f6d38fe5a89")
 
     variant("shared", default=True, description="Build shared instead of static libraries")
     variant("pic", default=True, description="Build with position independent code")


### PR DESCRIPTION
extracted from #2508

Modifications:
* ecflow: deprecate `@:4`
* yaml_cpp: deprecate `@:5`

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
