### PR TITLE
starship: add v1.25.1

### DIFF
--- a/repos/spack_repo/builtin/packages/starship/package.py
+++ b/repos/spack_repo/builtin/packages/starship/package.py
@@ -15,14 +15,14 @@ class Starship(CargoPackage):
 
     maintainers("ebagrenrut")
 
-    license("ISC")
+    license("ISC", checked_by="mcmehrtens", when="@0.2.0:")
 
+    version("1.25.1", sha256="521306b14066ee7e332d998ef5b5b6455fdc6085c52e86b6316a7cdc37bae1d8")
     version("1.25.0", sha256="e77f3c23683eb544f6dae7171e3c80676aefc66329225bdcd58e40846bb6445f")
     version("1.24.2", sha256="b7ab0ef364f527395b46d2fb7f59f9592766b999844325e35f62c8fa4d528795")
     version("1.24.1", sha256="4f2ac4181c3dea66f84bf8c97a3cb39dd218c27c8e4ade4de149d3834a87c428")
 
     depends_on("c", type="build")
-    depends_on("cmake", type="build")
     depends_on("rust@1.90:", type="build", when="@1.24.2:")
     depends_on("rust@1.89:", type="build")
 


### PR DESCRIPTION
- Add v1.25.1
- Drops the `cmake` requirement since it is not needed for any of the checksummed versions
- Added more info to license. License hasn't changed since the first tagged release, v0.2.0.

Confirmed all four versions build successfully.

Maintainers: @ebagrenrut