### PR TITLE
Deprecate all the `cbtf` packages and dependents

### DIFF
--- a/repos/spack_repo/builtin/packages/cbtf/package.py
+++ b/repos/spack_repo/builtin/packages/cbtf/package.py
@@ -22,10 +22,11 @@ class Cbtf(CMakePackage):
 
     license("GPL-2.0-only")
 
-    version("develop", branch="master")
-    version("1.9.4.1", branch="1.9.4.1")
-    version("1.9.4", branch="1.9.4")
-    version("1.9.3", branch="1.9.3")
+    with default_args(deprecated=True):
+        version("develop", branch="master")
+        version("1.9.4.1", branch="1.9.4.1")
+        version("1.9.4", branch="1.9.4")
+        version("1.9.3", branch="1.9.3")
 
     variant(
         "runtime", default=False, description="build only the runtime libraries and collectors."

--- a/repos/spack_repo/builtin/packages/cbtf_argonavis/package.py
+++ b/repos/spack_repo/builtin/packages/cbtf_argonavis/package.py
@@ -18,10 +18,11 @@ class CbtfArgonavis(CMakePackage):
 
     maintainers("jgalarowicz")
 
-    version("develop", branch="master")
-    version("1.9.4.1", branch="1.9.4.1")
-    version("1.9.4", branch="1.9.4")
-    version("1.9.3", branch="1.9.3")
+    with default_args(deprecated=True):
+        version("develop", branch="master")
+        version("1.9.4.1", branch="1.9.4.1")
+        version("1.9.4", branch="1.9.4")
+        version("1.9.3", branch="1.9.3")
 
     variant(
         "crayfe",

--- a/repos/spack_repo/builtin/packages/cbtf_argonavis_gui/package.py
+++ b/repos/spack_repo/builtin/packages/cbtf_argonavis_gui/package.py
@@ -20,8 +20,9 @@ class CbtfArgonavisGui(QMakePackage):
 
     maintainers("jgalarowicz")
 
-    version("develop", branch="master")
-    version("1.3.0.0", branch="1.3.0.0")
+    with default_args(deprecated=True):
+        version("develop", branch="master")
+        version("1.3.0.0", branch="1.3.0.0")
 
     depends_on("cxx", type="build")  # generated
 

--- a/repos/spack_repo/builtin/packages/cbtf_krell/package.py
+++ b/repos/spack_repo/builtin/packages/cbtf_krell/package.py
@@ -19,10 +19,11 @@ class CbtfKrell(CMakePackage):
 
     maintainers("jgalarowicz")
 
-    version("develop", branch="master")
-    version("1.9.4.1", branch="1.9.4.1")
-    version("1.9.4", branch="1.9.4")
-    version("1.9.3", branch="1.9.3")
+    with default_args(deprecated=True):
+        version("develop", branch="master")
+        version("1.9.4.1", branch="1.9.4.1")
+        version("1.9.4", branch="1.9.4")
+        version("1.9.3", branch="1.9.3")
 
     # MPI variants
     variant(

--- a/repos/spack_repo/builtin/packages/cbtf_lanl/package.py
+++ b/repos/spack_repo/builtin/packages/cbtf_lanl/package.py
@@ -16,10 +16,11 @@ class CbtfLanl(CMakePackage):
 
     maintainers("jgalarowicz")
 
-    version("develop", branch="master")
-    version("1.9.4.1", branch="1.9.4.1")
-    version("1.9.4", branch="1.9.4")
-    version("1.9.3", branch="1.9.3")
+    with default_args(deprecated=True):
+        version("develop", branch="master")
+        version("1.9.4.1", branch="1.9.4.1")
+        version("1.9.4", branch="1.9.4")
+        version("1.9.3", branch="1.9.3")
 
     variant(
         "build_type",


### PR DESCRIPTION
After an analysis of packages depending on old boost versions it seems these packages are unmaintained, and upstream development stopped around 2018. `openspeedshop` in particular seems to be tied to very old versions of `binutils` and possibly needing Python 2.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
