### PR TITLE
rclone: add v1.74.3

### DIFF
--- a/repos/spack_repo/builtin/packages/rclone/package.py
+++ b/repos/spack_repo/builtin/packages/rclone/package.py
@@ -18,6 +18,7 @@ class Rclone(GoPackage):
 
     license("MIT")
 
+    version("1.74.3", sha256="c51062f24bb8e6d05c252c9c9fb527adc831715e0dd936ca0c9fb8d07e49d66a")
     version("1.73.5", sha256="19c929ce2f54bd22af2db4dd9d2a289499b02274f9f7d3c6639090761adfab1f")
     version("1.73.3", sha256="608dde134e02a429b95ae566d638e514a9a658d0d69c35812069cf1c1b8f24af")
     version("1.70.2", sha256="982b1f09239855e7e55fb6a3b6a8146fe2ef93c8ba6e015a9c5d6ada5297ea30")


### PR DESCRIPTION
Release notes: https://rclone.org/changelog/#v1-74-3-2026-06-05
Diff: https://github.com/rclone/rclone/compare/v1.73.5...v1.74.3