### PR TITLE
py-trove-classifiers: add v2026.6.1.19

### DIFF
--- a/repos/spack_repo/builtin/packages/py_trove_classifiers/package.py
+++ b/repos/spack_repo/builtin/packages/py_trove_classifiers/package.py
@@ -17,6 +17,9 @@ class PyTroveClassifiers(PythonPackage):
     license("Apache-2.0")
 
     version(
+        "2026.6.1.19", sha256="c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745"
+    )
+    version(
         "2026.4.28.13", sha256="c85bb8a53c3de7330d1699b844ed9fb809a602a09ac15dc79ad6d1a509be0676"
     )
     version(


### PR DESCRIPTION
Release notes: https://github.com/pypa/trove-classifiers/releases
Diff: https://github.com/pypa/trove-classifiers/compare/2026.4.28.13...2026.6.1.19