### PR TITLE
Disable smoke test of visit in CI pipelines

### DIFF
--- a/.ci/gitlab/configs/ci.yaml
+++ b/.ci/gitlab/configs/ci.yaml
@@ -4,6 +4,7 @@ ci:
   broken-tests-packages:
     - superlu-dist    # srun -n 4 hangs
     - papyrus
+    - visit # times out
 
   pipeline-gen:
   - build-job:


### PR DESCRIPTION
VisIt CI jobs started timing out after #95 was merged. Disable the smoke test added in that PR to unblock our CI pipelines.