### PR TITLE
py-astropy: constrain upper numpy :2.3 for versions 7.0, 7.1

### DIFF
--- a/repos/spack_repo/builtin/packages/py_astropy/package.py
+++ b/repos/spack_repo/builtin/packages/py_astropy/package.py
@@ -64,7 +64,7 @@ class PyAstropy(PythonPackage):
     depends_on("py-astropy-iers-data@0.2025.4.28.0.37.27:", when="@7.1.0:", type=("build", "run"))
     depends_on("py-astropy-iers-data", when="@6:", type=("build", "run"))
     depends_on("py-numpy@1.24:", when="@7.2.0:", type=("build", "run"))
-    depends_on("py-numpy@1.23.2:", when="@7.0.1:", type=("build", "run"))
+    depends_on("py-numpy@1.23.2:2.3", when="@7.0.1:", type=("build", "run"))
     depends_on("py-numpy@1.23:", when="@6.1:", type=("build", "run"))
     depends_on("py-numpy@1.18:", when="@5.1:", type=("build", "run"))
     depends_on("py-numpy@1.16:", when="@4.0:", type=("build", "run"))


### PR DESCRIPTION
Cause is function in1d that was removed in numpy@2.4 https://numpy.org/doc/2.3/reference/generated/numpy.in1d.html

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
