### PR TITLE
autotools: relax the nixos requirement to patch configure files

### DIFF
--- a/repos/spack_repo/builtin/build_systems/autotools.py
+++ b/repos/spack_repo/builtin/build_systems/autotools.py
@@ -314,15 +314,11 @@ To resolve this problem, please try the following:
 
     @run_before("configure")
     def _patch_usr_bin_file(self) -> None:
-        """On NixOS file is not available in /usr/bin/file. Patch configure
-        scripts to use file from path."""
-
-        if self.spec.os.startswith("nixos"):
-            x = FileFilter(
-                *filter(is_exe, find(self.build_directory, "configure", recursive=True))
-            )
-            with keep_modification_time(*x.filenames):
-                x.filter(regex="/usr/bin/file", repl="file", string=True)
+        """Patch configure scripts to use file from PATH instead of the
+        hardcoded /usr/bin/file baked in by libtool's AC_PATH_PROG."""
+        x = FileFilter(*filter(is_exe, find(self.build_directory, "configure", recursive=True)))
+        with keep_modification_time(*x.filenames):
+            x.filter(regex="/usr/bin/file", repl="file", string=True)
 
     @run_before("configure")
     def _set_autotools_environment_variables(self) -> None:

--- a/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -698,6 +698,7 @@ with '-Wl,-commons,use_dylibs' and without
 
     depends_on("perl", type="build")
     depends_on("pkgconfig", type="build")
+    depends_on("file", type="build")
     # Based on https://docs.open-mpi.org/en/v5.0.x/developers/prerequisites.html#flex
     depends_on("flex@2.5.4:", type="build", when="@main")
 


### PR DESCRIPTION
Let `autotools` patch configure file to use `file` from the PATH and not just `/usr/bin/file`. Previously this was done only for `nixos`.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
