### PR TITLE
AOCL: add v5.3 support for AOCL component packages

### DIFF
--- a/repos/spack_repo/builtin/packages/amd_aocl/package.py
+++ b/repos/spack_repo/builtin/packages/amd_aocl/package.py
@@ -25,6 +25,7 @@ class AmdAocl(BundlePackage):
 
     maintainers("amd-toolchain-support")
 
+    version("5.3")
     version("5.2")
     version("5.1")
     version("5.0")
@@ -65,7 +66,7 @@ class AmdAocl(BundlePackage):
         depends_on("aocl-da ~openmp")
         depends_on("aocl-compression ~openmp")
 
-    for vers in ["2.2", "3.0", "3.1", "3.2", "4.0", "4.1", "4.2", "5.0", "5.1", "5.2"]:
+    for vers in ["2.2", "3.0", "3.1", "3.2", "4.0", "4.1", "4.2", "5.0", "5.1", "5.2", "5.3"]:
         with when(f"@={vers}"):
             depends_on(f"amdblis@={vers}")
             depends_on(f"amdfftw@={vers}")

--- a/repos/spack_repo/builtin/packages/amdblis/package.py
+++ b/repos/spack_repo/builtin/packages/amdblis/package.py
@@ -4,7 +4,7 @@
 
 import os
 
-from spack_repo.builtin.packages.blis.package import BlisBase
+from spack_repo.builtin.packages.blis.package import BlisBase, _targets as blis_targets
 
 from spack.package import *
 
@@ -36,6 +36,7 @@ class Amdblis(BlisBase):
 
     license("BSD-3-Clause")
 
+    version("5.3", sha256="0d456548174a5a71df1225b5648d802d53d0351187ae2f829ecf5122f3aeab9e")
     version("5.2", sha256="c553bd543eedc87920df9b82634ae4c02662145ed737f51fdf4c9bca5e588028")
     version("5.1", sha256="4ab210cea8753f4be9646a3ad8e6b42c7d19380084a66312497c97278b8c76a4")
     version("5.0", sha256="5abb34972b88b2839709d0af8785662bc651c7806ccfa41d386d93c900169bc2")
@@ -103,6 +104,24 @@ class Amdblis(BlisBase):
 
         return args
 
+    def _targets_for_spec(self):
+        amd = {}
+        if self.spec.satisfies("@5.0:"):
+            amd["zen5"] = None
+        if self.spec.satisfies("@4.0:"):
+            amd["zen4"] = None
+        return {**amd, **blis_targets}
+
+    def edit(self, spec, prefix):
+        target = "auto"
+        for spack_target, blis_target in self._targets_for_spec().items():
+            if self.spec.satisfies(f"target={spack_target}:"):
+                target = blis_target or spack_target
+                break
+        # To ensure the target should always be the last argument for base and derived class
+        config_args = self.configure_args() + [target]
+        configure("--prefix={0}".format(prefix), *config_args)
+
     @run_after("install")
     def create_symlink(self):
         with working_dir(self.prefix.lib):
@@ -110,6 +129,14 @@ class Amdblis(BlisBase):
                 symlink("libblis-mt.a", "libblis.a")
             if os.path.isfile("libblis-mt.so"):
                 symlink("libblis-mt.so", "libblis.so")
+
+        # Since AOCL 5.1, OpenMP builds install blis-mt.pc instead of blis.pc.
+        # Create a compatibility symlink because some consumers (e.g. py-scipy)
+        # expect to discover BLIS via blis.pc.
+        if self.spec.satisfies("@5.1: threads=openmp"):
+            with working_dir(self.prefix.share.pkgconfig):
+                if os.path.isfile("blis-mt.pc") and not os.path.exists("blis.pc"):
+                    symlink("blis-mt.pc", "blis.pc")
 
     @property
     def libs(self):

--- a/repos/spack_repo/builtin/packages/amdblis/package.py
+++ b/repos/spack_repo/builtin/packages/amdblis/package.py
@@ -4,7 +4,8 @@
 
 import os
 
-from spack_repo.builtin.packages.blis.package import BlisBase, _targets as blis_targets
+from spack_repo.builtin.packages.blis.package import BlisBase
+from spack_repo.builtin.packages.blis.package import _targets as blis_targets
 
 from spack.package import *
 

--- a/repos/spack_repo/builtin/packages/amdfftw/package.py
+++ b/repos/spack_repo/builtin/packages/amdfftw/package.py
@@ -39,6 +39,7 @@ class Amdfftw(FftwBase):
 
     license("GPL-2.0-only")
 
+    version("5.3", sha256="175a426dbbe9ba332416adeead59af364177016c7c3057c597a26c0159c83c43")
     version("5.2", sha256="143c7a936fd197a94551aa1c67d7ae7cbf7d96338947aa21d3007df7aea46c78")
     version("5.1", sha256="4cc0d6985afc5ce14cafc195ad46d9876ac4f35b959861b41a3b681385d7320d")
     version("5.0", sha256="bead6c08309a206f8a6258971272affcca07f11eb57b5ecd8496e2e7e3ead877")
@@ -159,6 +160,10 @@ class Amdfftw(FftwBase):
         if name == "cflags":
             if self.spec.satisfies("%gcc@14:"):
                 flags.append("-Wno-incompatible-pointer-types")
+            if "avx512" in self.spec.target:
+                flags.append("-mprefer-vector-width=512")
+            else:
+                flags.append("-mprefer-vector-width=256")
         return (flags, None, None)
 
     def configure(self, spec, prefix):
@@ -200,11 +205,6 @@ class Amdfftw(FftwBase):
 
         if not self.compiler.f77 or not self.compiler.fc:
             options.append("--disable-fortran")
-
-        if "avx512" in spec.target:
-            options.append("CFLAGS=-mprefer-vector-width=512")
-        else:
-            options.append("CFLAGS=-mprefer-vector-width=256")
 
         # Specific SIMD support.
         # float and double precisions are supported

--- a/repos/spack_repo/builtin/packages/amdfftw/package.py
+++ b/repos/spack_repo/builtin/packages/amdfftw/package.py
@@ -173,7 +173,6 @@ class Amdfftw(FftwBase):
 
         # Dynamic dispatcher builds a single portable optimized library
         # that can execute on different x86 CPU architectures.
-        # It is supported for GCC compiler and Linux based systems only.
         if spec.satisfies("+amd-dynamic-dispatcher"):
             options.append("--enable-dynamic-dispatcher")
 

--- a/repos/spack_repo/builtin/packages/amdlibflame/package.py
+++ b/repos/spack_repo/builtin/packages/amdlibflame/package.py
@@ -114,7 +114,7 @@ class Amdlibflame(CMakePackage, LibflameBase):
     depends_on("python+pythoncmd", type="build")
     depends_on("gmake@4:", when="@3.0.1,3.1:", type="build")
 
-    for vers in ["4.1", "4.2", "5.0", "5.1", "5.2","5.3"]:
+    for vers in ["4.1", "4.2", "5.0", "5.1", "5.2", "5.3"]:
         with when(f"@{vers}"):
             depends_on(f"aocl-utils@{vers}")
 

--- a/repos/spack_repo/builtin/packages/amdlibflame/package.py
+++ b/repos/spack_repo/builtin/packages/amdlibflame/package.py
@@ -50,6 +50,7 @@ class Amdlibflame(CMakePackage, LibflameBase):
 
     license("BSD-3-Clause")
 
+    version("5.3", sha256="ecb74c879b4d6bb33e159300304a9b48206d2c2b546dceb7d097b339eb127b9c")
     version("5.2", sha256="fb5fe5128f718050c9911443fcf7ed91b60538a40d57084ed0124bb91afabb9b")
     version("5.1", sha256="25524ba78b5952303369fa0859d217e44071144fd122a9dc3f72ed0bd73e3b2d")
     version("5.0", sha256="3bee3712459a8c5bd728a521d8a4c8f46735730bf35d48c878d2fc45fc000918")
@@ -113,7 +114,7 @@ class Amdlibflame(CMakePackage, LibflameBase):
     depends_on("python+pythoncmd", type="build")
     depends_on("gmake@4:", when="@3.0.1,3.1:", type="build")
 
-    for vers in ["4.1", "4.2", "5.0", "5.1", "5.2"]:
+    for vers in ["4.1", "4.2", "5.0", "5.1", "5.2","5.3"]:
         with when(f"@{vers}"):
             depends_on(f"aocl-utils@{vers}")
 

--- a/repos/spack_repo/builtin/packages/amdlibm/package.py
+++ b/repos/spack_repo/builtin/packages/amdlibm/package.py
@@ -47,10 +47,10 @@ class Amdlibm(SConsPackage, CMakePackage):
     variant("verbose", default=False, description="Building with verbosity", when="@:4.1")
 
     # Build system
-    # - For version 5.2: both 'cmake' and 'scons' are supported, with 'cmake' as default.
+    # - For version 5.2+: both 'cmake' and 'scons' are supported, with 'cmake' as default.
     # - For version 5.1: both 'scons' and 'cmake' are supported, with 'scons' as default.
     # - For versions below 5.1: only 'scons' is supported.
-    with when("@5.2"):
+    with when("@5.2:"):
         build_system("cmake", "scons", default="cmake")
 
     with when("@:5.1"):

--- a/repos/spack_repo/builtin/packages/amdlibm/package.py
+++ b/repos/spack_repo/builtin/packages/amdlibm/package.py
@@ -32,6 +32,7 @@ class Amdlibm(SConsPackage, CMakePackage):
 
     license("BSD-3-Clause")
 
+    version("5.3", sha256="bbd97cbb3745afbeb203f6cdddadb410ea32f2fbcac807bcd0c27e6b7d1133e4")
     version("5.2", sha256="5cec8d30dc1083923c332c80808eda637ebd385b02a0cebf65ce72b5c8cbc029")
     version("5.1", sha256="7acf2c98469353b60a59fad167a98e1ae689055a3faf8352a254832145c9d59e")
     version("5.0", sha256="ba1d50c068938c9a927e37e5630f683b6149d7d5a95efffeb76e7c9a8bcb2b5e")
@@ -63,7 +64,7 @@ class Amdlibm(SConsPackage, CMakePackage):
     depends_on("scons@3.1.2:4.8.1", type=("build"))
     depends_on("cmake@3.26:3.30.6", type="build", when="build_system=cmake")
     depends_on("mpfr", type=("link"))
-    for vers in ["4.1", "4.2", "5.0", "5.1", "5.2"]:
+    for vers in ["4.1", "4.2", "5.0", "5.1", "5.2","5.3"]:
         with when(f"@{vers}"):
             depends_on(f"aocl-utils@{vers}")
 

--- a/repos/spack_repo/builtin/packages/amdlibm/package.py
+++ b/repos/spack_repo/builtin/packages/amdlibm/package.py
@@ -64,7 +64,7 @@ class Amdlibm(SConsPackage, CMakePackage):
     depends_on("scons@3.1.2:4.8.1", type=("build"))
     depends_on("cmake@3.26:3.30.6", type="build", when="build_system=cmake")
     depends_on("mpfr", type=("link"))
-    for vers in ["4.1", "4.2", "5.0", "5.1", "5.2","5.3"]:
+    for vers in ["4.1", "4.2", "5.0", "5.1", "5.2", "5.3"]:
         with when(f"@{vers}"):
             depends_on(f"aocl-utils@{vers}")
 

--- a/repos/spack_repo/builtin/packages/amdscalapack/package.py
+++ b/repos/spack_repo/builtin/packages/amdscalapack/package.py
@@ -34,6 +34,7 @@ class Amdscalapack(ScalapackBase):
 
     license("BSD-3-Clause-Open-MPI")
 
+    version("5.3", sha256="2bd0ef1d8bbd9990a8bc7b33ad7c32db788f39b9730b110d15737837111eacff")
     version("5.2", sha256="ff01f0f39c9e6d44fa493e1c68d9862d2600f425e9caaec1fe5179c10debf1d9")
     version("5.1", sha256="92f6f6b2081e27731c8b9e96c742203777cc7f2a848b96ca7511f4d259142b37")
     version("5.0", sha256="a33cf16c51cfd65c7acb5fbdb8884a5c147cdefea73931b07863c56d54f812cc")

--- a/repos/spack_repo/builtin/packages/aocl_compression/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_compression/package.py
@@ -3,12 +3,13 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 # ----------------------------------------------------------------------------
-from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems.cmake import CMakeBuilder, CMakePackage
+from spack_repo.builtin.build_systems.makefile import MakefileBuilder, MakefilePackage
 
 from spack.package import *
 
 
-class AoclCompression(CMakePackage):
+class AoclCompression(CMakePackage, MakefilePackage):
     """
     AOCL-Compression is a software framework of various lossless compression
     and decompression methods tuned and optimized for AMD Zen based CPUs.
@@ -44,6 +45,7 @@ class AoclCompression(CMakePackage):
 
     maintainers("amd-toolchain-support")
 
+    version("5.3", sha256="fdc58c1f42933290b8c127102c28d8a8f93102eab251046d8ed01a69a0abdbcb")
     version("5.2", sha256="93a4eddd0a70e6d8701ecf2c55a06ab341d987ccd2e87c50a5c7e1efb37e033e")
     version("5.1", sha256="9462c6898350d66a5d9ce0236c432c94b4c9393b638ddf6511628b784eb02720")
     version("5.0", sha256="50bfb2c4a4738b96ed6d45627062b17bb9d0e1787c7d83ead2841da520327fa4")
@@ -74,36 +76,78 @@ class AoclCompression(CMakePackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    depends_on("cmake@3.22:", when="@:5.0", type="build")
-    depends_on("cmake@3.26:", when="@5.1:", type="build")
+    depends_on("cmake@3.22:", when="build_system=cmake @:5.0", type="build")
+    depends_on("cmake@3.26:", when="build_system=cmake @5.1:5.2", type="build")
 
-    def cmake_args(self):
-        """Runs ``cmake`` in the build directory"""
-        spec = self.spec
-        args = []
+    build_system(
+        conditional("cmake", when="@:5.2"),
+        conditional("makefile", when="@5.3:"),
+        default="cmake",
+    )
 
-        args = [
-            self.define_from_variant("AOCL_ENABLE_THREADS", "openmp"),
-            self.define_from_variant("ENABLE_FAST_MATH", "enable_fast_math"),
-            "-DLZ4_FRAME_FORMAT_SUPPORT=ON",
-            "-DAOCL_LZ4HC_DISABLE_PATTERN_ANALYSIS=ON",
-        ]
-        if spec.satisfies("~shared"):
-            args.append("-DBUILD_STATIC_LIBS=ON")
-        if spec.satisfies("~zlib"):
-            args.append("-DAOCL_EXCLUDE_ZLIB=ON")
-        if spec.satisfies("~bzip2"):
-            args.append("-DAOCL_EXCLUDE_BZIP2=ON")
-        if spec.satisfies("~snappy"):
-            args.append("-DAOCL_EXCLUDE_SNAPPY=ON")
-        if spec.satisfies("~zstd"):
-            args.append("-DAOCL_EXCLUDE_ZSTD=ON")
-        if spec.satisfies("~lzma"):
-            args.append("-DAOCL_EXCLUDE_LZMA=ON")
-        if spec.satisfies("~lz4"):
-            args.append("-DAOCL_EXCLUDE_LZ4=ON")
-        if spec.satisfies("~lz4hc"):
-            args.append("-DAOCL_EXCLUDE_LZ4HC=ON")
+    class CMakeBuilder(CMakeBuilder):
+        def cmake_args(self):
+            spec = self.spec
+            args = [
+                self.define_from_variant("AOCL_ENABLE_THREADS", "openmp"),
+                self.define_from_variant("ENABLE_FAST_MATH", "enable_fast_math"),
+                "-DLZ4_FRAME_FORMAT_SUPPORT=ON",
+                "-DAOCL_LZ4HC_DISABLE_PATTERN_ANALYSIS=ON",
+            ]
+            if spec.satisfies("~shared"):
+                args.append("-DBUILD_STATIC_LIBS=ON")
+            if spec.satisfies("~zlib"):
+                args.append("-DAOCL_EXCLUDE_ZLIB=ON")
+            if spec.satisfies("~bzip2"):
+                args.append("-DAOCL_EXCLUDE_BZIP2=ON")
+            if spec.satisfies("~snappy"):
+                args.append("-DAOCL_EXCLUDE_SNAPPY=ON")
+            if spec.satisfies("~zstd"):
+                args.append("-DAOCL_EXCLUDE_ZSTD=ON")
+            if spec.satisfies("~lzma"):
+                args.append("-DAOCL_EXCLUDE_LZMA=ON")
+            if spec.satisfies("~lz4"):
+                args.append("-DAOCL_EXCLUDE_LZ4=ON")
+            if spec.satisfies("~lz4hc"):
+                args.append("-DAOCL_EXCLUDE_LZ4HC=ON")
 
-        args.append("-DAOCL_DECOMPRESS_FAST={}".format(spec.variants["decompress_fast"].value))
-        return args
+            args.append(
+                "-DAOCL_DECOMPRESS_FAST={}".format(spec.variants["decompress_fast"].value)
+            )
+            return args
+
+    class MakefileBuilder(MakefileBuilder):
+        def _make_options(self, spec):
+            """Shared Make variable list used by both build and install phases."""
+            options = [
+                "LZ4_FRAME_FORMAT_SUPPORT=1",
+                "AOCL_LZ4HC_DISABLE_PATTERN_ANALYSIS=1",
+                "AOCL_ENABLE_THREADS={0}".format("1" if spec.satisfies("+openmp") else "0"),
+                "ENABLE_FAST_MATH={0}".format("1" if spec.satisfies("+enable_fast_math") else "0"),
+            ]
+            if spec.satisfies("~shared"):
+                options.append("BUILD_STATIC_LIBS=1")
+            if spec.satisfies("~zlib"):
+                options.append("AOCL_EXCLUDE_ZLIB=1")
+            if spec.satisfies("~bzip2"):
+                options.append("AOCL_EXCLUDE_BZIP2=1")
+            if spec.satisfies("~snappy"):
+                options.append("AOCL_EXCLUDE_SNAPPY=1")
+            if spec.satisfies("~zstd"):
+                options.append("AOCL_EXCLUDE_ZSTD=1")
+            if spec.satisfies("~lzma"):
+                options.append("AOCL_EXCLUDE_LZMA=1")
+            if spec.satisfies("~lz4"):
+                options.append("AOCL_EXCLUDE_LZ4=1")
+            if spec.satisfies("~lz4hc"):
+                options.append("AOCL_EXCLUDE_LZ4HC=1")
+            decompress_fast = spec.variants["decompress_fast"].value
+            if decompress_fast != "OFF":
+                options.append("AOCL_DECOMPRESS_FAST={0}".format(decompress_fast))
+            return options
+
+        def build(self, pkg, spec, prefix):
+            make(*self._make_options(spec))
+
+        def install(self, pkg, spec, prefix):
+            make("install", "PREFIX={0}".format(prefix), *self._make_options(spec))

--- a/repos/spack_repo/builtin/packages/aocl_compression/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_compression/package.py
@@ -51,6 +51,8 @@ class AoclCompression(CMakePackage, MakefilePackage):
     version("5.0", sha256="50bfb2c4a4738b96ed6d45627062b17bb9d0e1787c7d83ead2841da520327fa4")
     version("4.2", sha256="a18b3e7f64a8105c1500dda7b4c343e974b5e26bfe3dd838a1c1acf82a969c6f")
 
+    build_system("cmake", conditional("makefile", when="@5.3:"), default="cmake")
+
     variant("shared", default=True, description="Build shared library")
     variant("zlib", default=True, description="Build zlib library")
     variant("bzip2", default=True, description="Build bzip2 library")
@@ -79,37 +81,10 @@ class AoclCompression(CMakePackage, MakefilePackage):
     depends_on("cmake@3.22:", when="build_system=cmake @:5.0", type="build")
     depends_on("cmake@3.26:", when="build_system=cmake @5.1:5.2", type="build")
 
-    build_system(
-        conditional("cmake", when="@:5.2"),
-        conditional("makefile", when="@5.3:"),
-        default="cmake",
-    )
-
     class CMakeBuilder(CMakeBuilder):
         def cmake_args(self):
+            """Runs ``cmake`` in the build directory"""
             spec = self.spec
-            args = [
-                self.define_from_variant("AOCL_ENABLE_THREADS", "openmp"),
-                self.define_from_variant("ENABLE_FAST_MATH", "enable_fast_math"),
-                "-DLZ4_FRAME_FORMAT_SUPPORT=ON",
-                "-DAOCL_LZ4HC_DISABLE_PATTERN_ANALYSIS=ON",
-            ]
-            if spec.satisfies("~shared"):
-                args.append("-DBUILD_STATIC_LIBS=ON")
-            if spec.satisfies("~zlib"):
-                args.append("-DAOCL_EXCLUDE_ZLIB=ON")
-            if spec.satisfies("~bzip2"):
-                args.append("-DAOCL_EXCLUDE_BZIP2=ON")
-            if spec.satisfies("~snappy"):
-                args.append("-DAOCL_EXCLUDE_SNAPPY=ON")
-            if spec.satisfies("~zstd"):
-                args.append("-DAOCL_EXCLUDE_ZSTD=ON")
-            if spec.satisfies("~lzma"):
-                args.append("-DAOCL_EXCLUDE_LZMA=ON")
-            if spec.satisfies("~lz4"):
-                args.append("-DAOCL_EXCLUDE_LZ4=ON")
-            if spec.satisfies("~lz4hc"):
-                args.append("-DAOCL_EXCLUDE_LZ4HC=ON")
 
             args.append("-DAOCL_DECOMPRESS_FAST={}".format(spec.variants["decompress_fast"].value))
             return args

--- a/repos/spack_repo/builtin/packages/aocl_compression/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_compression/package.py
@@ -81,6 +81,7 @@ class AoclCompression(CMakePackage, MakefilePackage):
     depends_on("cmake@3.22:", when="build_system=cmake @:5.0", type="build")
     depends_on("cmake@3.26:", when="build_system=cmake @5.1:5.2", type="build")
 
+
 class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):
         """Runs ``cmake`` in the build directory"""
@@ -110,9 +111,9 @@ class CMakeBuilder(CMakeBuilder):
         if spec.satisfies("~lz4hc"):
             args.append("-DAOCL_EXCLUDE_LZ4HC=ON")
 
-
         args.append("-DAOCL_DECOMPRESS_FAST={}".format(spec.variants["decompress_fast"].value))
         return args
+
 
 class MakefileBuilder(MakefileBuilder):
     def _make_options(self, spec):

--- a/repos/spack_repo/builtin/packages/aocl_compression/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_compression/package.py
@@ -111,9 +111,7 @@ class AoclCompression(CMakePackage, MakefilePackage):
             if spec.satisfies("~lz4hc"):
                 args.append("-DAOCL_EXCLUDE_LZ4HC=ON")
 
-            args.append(
-                "-DAOCL_DECOMPRESS_FAST={}".format(spec.variants["decompress_fast"].value)
-            )
+            args.append("-DAOCL_DECOMPRESS_FAST={}".format(spec.variants["decompress_fast"].value))
             return args
 
     class MakefileBuilder(MakefileBuilder):

--- a/repos/spack_repo/builtin/packages/aocl_compression/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_compression/package.py
@@ -81,46 +81,71 @@ class AoclCompression(CMakePackage, MakefilePackage):
     depends_on("cmake@3.22:", when="build_system=cmake @:5.0", type="build")
     depends_on("cmake@3.26:", when="build_system=cmake @5.1:5.2", type="build")
 
-    class CMakeBuilder(CMakeBuilder):
-        def cmake_args(self):
-            """Runs ``cmake`` in the build directory"""
-            spec = self.spec
+class CMakeBuilder(CMakeBuilder):
+    def cmake_args(self):
+        """Runs ``cmake`` in the build directory"""
+        spec = self.spec
+        args = []
 
-            args.append("-DAOCL_DECOMPRESS_FAST={}".format(spec.variants["decompress_fast"].value))
-            return args
+        args = [
+            self.define_from_variant("AOCL_ENABLE_THREADS", "openmp"),
+            self.define_from_variant("ENABLE_FAST_MATH", "enable_fast_math"),
+            "-DLZ4_FRAME_FORMAT_SUPPORT=ON",
+            "-DAOCL_LZ4HC_DISABLE_PATTERN_ANALYSIS=ON",
+        ]
+        if spec.satisfies("~shared"):
+            args.append("-DBUILD_STATIC_LIBS=ON")
+        if spec.satisfies("~zlib"):
+            args.append("-DAOCL_EXCLUDE_ZLIB=ON")
+        if spec.satisfies("~bzip2"):
+            args.append("-DAOCL_EXCLUDE_BZIP2=ON")
+        if spec.satisfies("~snappy"):
+            args.append("-DAOCL_EXCLUDE_SNAPPY=ON")
+        if spec.satisfies("~zstd"):
+            args.append("-DAOCL_EXCLUDE_ZSTD=ON")
+        if spec.satisfies("~lzma"):
+            args.append("-DAOCL_EXCLUDE_LZMA=ON")
+        if spec.satisfies("~lz4"):
+            args.append("-DAOCL_EXCLUDE_LZ4=ON")
+        if spec.satisfies("~lz4hc"):
+            args.append("-DAOCL_EXCLUDE_LZ4HC=ON")
 
-    class MakefileBuilder(MakefileBuilder):
-        def _make_options(self, spec):
-            """Shared Make variable list used by both build and install phases."""
-            options = [
-                "LZ4_FRAME_FORMAT_SUPPORT=1",
-                "AOCL_LZ4HC_DISABLE_PATTERN_ANALYSIS=1",
-                "AOCL_ENABLE_THREADS={0}".format("1" if spec.satisfies("+openmp") else "0"),
-                "ENABLE_FAST_MATH={0}".format("1" if spec.satisfies("+enable_fast_math") else "0"),
-            ]
-            if spec.satisfies("~shared"):
-                options.append("BUILD_STATIC_LIBS=1")
-            if spec.satisfies("~zlib"):
-                options.append("AOCL_EXCLUDE_ZLIB=1")
-            if spec.satisfies("~bzip2"):
-                options.append("AOCL_EXCLUDE_BZIP2=1")
-            if spec.satisfies("~snappy"):
-                options.append("AOCL_EXCLUDE_SNAPPY=1")
-            if spec.satisfies("~zstd"):
-                options.append("AOCL_EXCLUDE_ZSTD=1")
-            if spec.satisfies("~lzma"):
-                options.append("AOCL_EXCLUDE_LZMA=1")
-            if spec.satisfies("~lz4"):
-                options.append("AOCL_EXCLUDE_LZ4=1")
-            if spec.satisfies("~lz4hc"):
-                options.append("AOCL_EXCLUDE_LZ4HC=1")
-            decompress_fast = spec.variants["decompress_fast"].value
-            if decompress_fast != "OFF":
-                options.append("AOCL_DECOMPRESS_FAST={0}".format(decompress_fast))
-            return options
 
-        def build(self, pkg, spec, prefix):
-            make(*self._make_options(spec))
+        args.append("-DAOCL_DECOMPRESS_FAST={}".format(spec.variants["decompress_fast"].value))
+        return args
 
-        def install(self, pkg, spec, prefix):
-            make("install", "PREFIX={0}".format(prefix), *self._make_options(spec))
+class MakefileBuilder(MakefileBuilder):
+    def _make_options(self, spec):
+        """Shared Make variable list used by both build and install phases."""
+        options = [
+            "LZ4_FRAME_FORMAT_SUPPORT=1",
+            "AOCL_LZ4HC_DISABLE_PATTERN_ANALYSIS=1",
+            "AOCL_ENABLE_THREADS={0}".format("1" if spec.satisfies("+openmp") else "0"),
+            "ENABLE_FAST_MATH={0}".format("1" if spec.satisfies("+enable_fast_math") else "0"),
+        ]
+        if spec.satisfies("~shared"):
+            options.append("BUILD_STATIC_LIBS=1")
+        if spec.satisfies("~zlib"):
+            options.append("AOCL_EXCLUDE_ZLIB=1")
+        if spec.satisfies("~bzip2"):
+            options.append("AOCL_EXCLUDE_BZIP2=1")
+        if spec.satisfies("~snappy"):
+            options.append("AOCL_EXCLUDE_SNAPPY=1")
+        if spec.satisfies("~zstd"):
+            options.append("AOCL_EXCLUDE_ZSTD=1")
+        if spec.satisfies("~lzma"):
+            options.append("AOCL_EXCLUDE_LZMA=1")
+        if spec.satisfies("~lz4"):
+            options.append("AOCL_EXCLUDE_LZ4=1")
+        if spec.satisfies("~lz4hc"):
+            options.append("AOCL_EXCLUDE_LZ4HC=1")
+        decompress_fast = spec.variants["decompress_fast"].value
+        if decompress_fast != "OFF":
+            options.append("AOCL_DECOMPRESS_FAST={0}".format(decompress_fast))
+        return options
+
+    def build(self, pkg, spec, prefix):
+        make(*self._make_options(spec))
+
+    def install(self, pkg, spec, prefix):
+        make("install", "PREFIX={0}".format(prefix), *self._make_options(spec))

--- a/repos/spack_repo/builtin/packages/aocl_crypto/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_crypto/package.py
@@ -38,6 +38,7 @@ class AoclCrypto(CMakePackage):
 
     maintainers("amd-toolchain-support")
 
+    version("5.3", sha256="8f7fa806879aac399c73e044048fc507c06fd099642cd7fece9e6ba9945d968e")
     version("5.2", sha256="a08da78287a05b6e48fc2870ef15053bb67d539ba83cf233ad8dcdc65f892d89")
     version("5.1", sha256="a2f768b7d37516c5c29cca0034aba90b91d02e477c762f2fa0fe4b1c30613973")
     version("5.0", sha256="b15e609943f9977e13f2d5839195bb7411c843839a09f0ad47f78f57e8821c23")
@@ -60,7 +61,7 @@ class AoclCrypto(CMakePackage):
     depends_on("openssl@3.1.5:")
     depends_on("intel-oneapi-ippcp@2021.12.0:", when="+ipp")
     depends_on("p7zip", type="build")
-    for vers in ["4.2", "5.0", "5.1", "5.2"]:
+    for vers in ["4.2", "5.0", "5.1", "5.2","5.3"]:
         with when(f"@={vers}"):
             depends_on(f"aocl-utils@={vers}")
 

--- a/repos/spack_repo/builtin/packages/aocl_crypto/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_crypto/package.py
@@ -61,7 +61,7 @@ class AoclCrypto(CMakePackage):
     depends_on("openssl@3.1.5:")
     depends_on("intel-oneapi-ippcp@2021.12.0:", when="+ipp")
     depends_on("p7zip", type="build")
-    for vers in ["4.2", "5.0", "5.1", "5.2","5.3"]:
+    for vers in ["4.2", "5.0", "5.1", "5.2", "5.3"]:
         with when(f"@={vers}"):
             depends_on(f"aocl-utils@={vers}")
 

--- a/repos/spack_repo/builtin/packages/aocl_da/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_da/package.py
@@ -34,6 +34,7 @@ class AoclDa(CMakePackage):
 
     maintainers("amd-toolchain-support")
 
+    version("5.3", sha256="d74a51017f2a22238f972e1b4432e63a8a09488ee95228a817e44437437ae049")
     version("5.2", sha256="faaa250de44d0b7d15a75b26121d457ac895b5cddd87ae1d81882a685ca81eb9")
     version("5.1", sha256="93cdb789c948bf750e531f95618bae4370d53eddc88960744ff02c9acbfe9ef5")
     version("5.0", sha256="3458adc7be39c78a08232c887f32838633149df0a69ccea024327c3edc5a5c1d")

--- a/repos/spack_repo/builtin/packages/aocl_dlp/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_dlp/package.py
@@ -21,6 +21,7 @@ class AoclDlp(CMakePackage):
 
     maintainers("amd-toolchain-support")
 
+    version("5.3", sha256="103607ba75a84f623d8ad1a2164ea100a0ce925f75c9dfdb65933cf3982ecb29")
     version("5.2", sha256="1eec26eeaf427cb2377ec21415ddce6e1bc62d4eab8ec51630a9c02711019c1c")
 
     # Feature toggles mapping directly to AOCL-DLP CMake options

--- a/repos/spack_repo/builtin/packages/aocl_libmem/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_libmem/package.py
@@ -34,6 +34,7 @@ class AoclLibmem(CMakePackage):
 
     maintainers("amd-toolchain-support")
 
+    version("5.3", sha256="15ca49e5874d84a039f680dfc0cef849c983cbc982c321161ce8b2c4fd359be6")
     version("5.2", sha256="06b56596fe32a4528a93d18a827bd5cbd814115d16390c6f2ae93d6b5715d41d")
     version("5.1", sha256="e03bc712a576b3e14ae433a696558e121dc67aac7fc1b4dca9b727605784e994")
     version("5.0", sha256="d3148db1a57fec4f3468332c775cade356e8133bf88385991964edd7534b7e22")

--- a/repos/spack_repo/builtin/packages/aocl_sparse/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_sparse/package.py
@@ -31,6 +31,7 @@ class AoclSparse(CMakePackage):
 
     license("MIT")
 
+    version("5.3", sha256="54121bef989f14f5ffb95470bbd697c7f71c836f2f92be3983ce6e6ecda5b26f")
     version("5.2", sha256="7de4ccb22b9bdf4733e621b44ebde1951dae5333841b02148fae382a8859f550")
     version("5.1", sha256="a5fff94f9144cb5e5e0f4702cc0d48a20215ccccd06cbed915e566e5d901fa0a")
     version("5.0", sha256="7528970f41ae60563df9fe1f8cc74a435be1566c01868a603ab894e9956c3c94")

--- a/repos/spack_repo/builtin/packages/aocl_utils/package.py
+++ b/repos/spack_repo/builtin/packages/aocl_utils/package.py
@@ -36,6 +36,7 @@ class AoclUtils(CMakePackage):
 
     license("BSD-3-Clause")
 
+    version("5.3", sha256="0e29afbbda3b81528380d2dbf7dae1ed6825d8c69e0abfcce53cc6cf90430e69")
     version("5.2", sha256="db0d807170a6eb73fcccd720a65a3e3aa8a787ae656c46479f7d9b4e1f9ed08a")
     version("5.1", sha256="68d75e04013abe90ea8308a9bc99b99532233b6c7f937f35381563f4124c20a5")
     version("5.0", sha256="ee2e5d47f33a3f673b3b6fcb88a7ef1a28648f407485ad07b6e9bf1b86159c59")


### PR DESCRIPTION
- Add `AOCL5.3` support across core AOCL component packages (`amdblis, amdfftw, amdlibflame, amdlibm, aocl-compression, aocl-crypto, aocl-da, aocl-dlp, aocl-libmem, aocl-sparse, aocl-utils, `and the` amd-aocl` bundle).

- Update `amdblis` with `zen4/zen5` target selection and adding a compatibility link for pkgconfig file with an `OpenMP` build of  `amdblis@5.1:` 

- Update `amdfftw` to apply vector-width compiler flags via `flag_handler`.

- Update `aocl-compression` to use the makefile build system for `@5.3:` in addition to existing `cmake`  build system support