### PR TITLE
HDF5: fix compilation of tests for static build

### DIFF
--- a/repos/spack_repo/builtin/packages/hdf5/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5/package.py
@@ -775,7 +775,14 @@ int main(int argc, char **argv) {{
 
             cc = Executable(os.environ["CC"])
             cc(*(["-c", "check.c"] + spec["hdf5"].headers.cpp_flags.split()))
-            cc(*(["-o", "check", "check.o"] + spec["hdf5"].libs.ld_flags.split()))
+            ld_flags = spec["hdf5"].libs.ld_flags.split()
+            if spec.satisfies("~shared"):
+                # Static builds require explicit linking
+                ld_flags += spec["zlib-api"].libs.ld_flags.split()
+                if spec.satisfies("+mpi"):
+                    ld_flags += spec["mpi"].libs.ld_flags.split()
+                ld_flags += ["-lm"]
+            cc(*(["-o", "check", "check.o"] + ld_flags))
             try:
                 check = Executable("./check")
                 output = check(output=str)

--- a/repos/spack_repo/builtin/packages/hdf5/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5/package.py
@@ -781,7 +781,14 @@ int main(int argc, char **argv) {{
 
             cc = Executable(os.environ["CC"])
             cc(*(["-c", "check.c"] + spec["hdf5"].headers.cpp_flags.split()))
-            cc(*(["-o", "check", "check.o"] + spec["hdf5"].libs.ld_flags.split()))
+            ld_flags = spec["hdf5"].libs.ld_flags.split()
+            if spec.satisfies("~shared"):
+                # Static builds require explicit linking
+                ld_flags += spec["zlib-api"].libs.ld_flags.split()
+                if spec.satisfies("+mpi"):
+                    ld_flags += spec["mpi"].libs.ld_flags.split()
+                ld_flags += ["-lm"]
+            cc(*(["-o", "check", "check.o"] + ld_flags))
             try:
                 check = Executable("./check")
                 output = check(output=str)


### PR DESCRIPTION
Fixes https://github.com/spack/spack-packages/issues/2714

Although this fixes compilation for static builds, one of the tests still fails (`t_2Gio`) for me when compiled with `~shared+mpi`. For `~shared~mpi` everything is fine. However, that is a separate issue.