### PR TITLE
p3dfft3: add missing releases up to latest

### DIFF
--- a/repos/spack_repo/builtin/packages/p3dfft3/package.py
+++ b/repos/spack_repo/builtin/packages/p3dfft3/package.py
@@ -15,10 +15,22 @@ class P3dfft3(AutotoolsPackage):
     of use cases."""
 
     homepage = "https://www.p3dfft.net"
-    url = "https://github.com/sdsc/p3dfft.3/archive/v3.0.0.tar.gz"
+    url = "https://github.com/sdsc/p3dfft.3/archive/refs/tags/v3.0.0.tar.gz"
     git = "https://github.com/sdsc/p3dfft.3.git"
 
     version("develop", branch="master")
+    version(
+        "3.1.2",
+        sha256="c487393eab301ca0ad0c6f69ddaade59f3eed437222fb7f85ed7b23ce5eea5f1",
+        url="https://github.com/sdsc/p3dfft.3/archive/refs/tags/v.3.1.2.tar.gz",
+    )
+    version(
+        "3.1.1",
+        sha256="85becdd05bb0ba84802cd1932f34ad44299487f83f92f08c58ad15a2615a3797",
+        url="https://github.com/sdsc/p3dfft.3/archive/refs/tags/v.3.1.1.tar.gz",
+    )
+    version("3.1.0", sha256="39c8d60083a6c9cd7e043135544057bdff5fe41475d44afc11c3b9c9a397b5d4")
+    version("3.0.1", sha256="65791f6385d80d99f7ec164f53f491acd64f7819862a4b0fba22bd7c198f0b50")
     version("3.0.0", sha256="1c549e78097d1545d18552b039be0d11cdb96be46efe99a16b65fd5d546dbfa7")
 
     variant("fftw", default=True, description="Builds with FFTW library")


### PR DESCRIPTION
The current package only includes the initial release v3.0.0 and the current master branch. This PR adds the missing releases up to v3.1.2.