### PR TITLE
setuptools: conflicts vendored deps

### DIFF
--- a/repos/spack_repo/builtin/packages/py_setuptools/package.py
+++ b/repos/spack_repo/builtin/packages/py_setuptools/package.py
@@ -77,9 +77,89 @@ class PySetuptools(Package, PythonExtension):
 
     depends_on("py-pip", type="build")
 
+    # https://github.com/pypa/setuptools/blob/v71.0.0/NEWS.rst
+    #
+    # Now setuptools declares its own dependencies in the core extra.
+    # Dependencies are still vendored for bootstrapping purposes,
+    # but setuptools will prefer installed dependencies if present.
+
+    # wheel>=0.43.0 v71.0.0 +
+    conflicts("py-wheel@:0.42", when="@71:")
+
+    # tomli>=2.0.1; python_version < '3.11' v71.1.0 +
+    # tomli>=2.0.1                          v71.1.0 -
+    conflicts("py-tomli@:2.0.0", when="@71.1: ^python@:3.10")
+    # tomli>=2.0.1                          v71.0.0 +
+    conflicts("py-tomli@:2.0.0", when="@71.0")
+
+    # platformdirs >= 4.2.2 v82.0.1 -
+    # platformdirs >= 4.2.2 v75.3.0 +
+    # platformdirs >= 2.6.2 v75.3.0 -
+    conflicts("py-platformdirs@:4.2.1", when="@75.3:82.0.0")
+    # platformdirs >= 2.6.2 v71.0.0 +
+    conflicts("py-platformdirs@:2.6.1", when="@71:75.2")
+
+    # packaging       v77.0.3 -
+    # packaging       v75.4.0 +
+    # packaging>=24.2 v75.3.4 +
+    # packaging       v75.3.4 -
+    # packaging>=24   v75.3.4 -
+    conflicts("py-packaging@:24.1", when="@75.3.4:")
+    # packaging>=24   v75.3.3 +
+    # packaging>=24.2 v75.3.3 -
+    conflicts("py-packaging@:23", when="@75.3.3")
+    # packaging>=24.2 v75.3.2 +
+    # packaging>=24   v75.3.2 -
+    conflicts("py-packaging@:24.1", when="@75.3.2")
+    # packaging       v75.0.0 +
+    # packaging>=24   v71.0.0 +
+    conflicts("py-packaging@:23", when="@71:")
+
+    # ordered-set>=3.1.1 v73.0.0 -
+    # ordered-set>=3.1.1 v71.0.0 +
+    conflicts("py-ordered-set@:3.1.0", when="@71:72")
+
+    # more_itertools      v75.0.0 +
+    # more_itertools>=8.8 v71.0.0 +
+    conflicts("py-more_itertools@:8.7", when="@71:")
+
+    # jaraco.text>=3.7      v71.0.0 +
+    # does not exist in spack (2026-07-07)
+
+    # jaraco.functools >= 4 v75.3.4 +
+    # jaraco.functools      v75.3.4 -
+    conflicts("py-jaraco-functools@:3", when="@75.3.4:")
+    # jaraco.functools      v75.3.3 +
+    # jaraco.functools >= 4 v75.3.3 -
+    # jaraco.functools >= 4 v75.3.2 +
+    # jaraco.functools      v75.3.2 -
+    conflicts("py-jaraco-functools@:3", when="@75.3.2")
+    # jaraco.functools      v75.0.0 +
+
+    # jaraco.collections    v77.0.2 -
+    # jaraco.collections    v75.4.0 +
+    # jaraco.collections    v75.3.4 -
+    # jaraco.collections    v75.0.0 +
+
+    # importlib_resources>=5.10.2; python_version < '3.9' v75.3.4 -
+    # importlib_resources>=5.10.2; python_version < '3.9' v75.3.3 +
+    conflicts("py-importlib-resources@:5.10.1", when="@75.3.3 ^python@:3.8")
+    # importlib_resources>=5.10.2; python_version < '3.9' v75.3.2 -
+    # importlib_resources>=5.10.2; python_version < '3.9' v71.1.0 +
+    conflicts("py-importlib-resources@:5.10.1", when="@71.1:75.3.1 ^python@:3.8")
+    # importlib_resources>=5.10.2                         v71.1.0 -
+    # importlib_resources>=5.10.2                         v71.0.0 +
+    conflicts("py-importlib-resources@:5.10.1", when="@71.0")
+
+    # importlib_metadata>=6; python_version < '3.10' v71.1.0 +
+    # importlib_metadata>=6                          v71.1.0 -
+    conflicts("py-importlib-metadata@:5", when="@71.1: ^python@:3.9")
+    # importlib_metadata>=6                          v71.0.0 +
+    conflicts("py-importlib-metadata@:5", when="@71.0")
+
     conflicts(
-        "^python@:3.9 ^py-pip@25:",
-        when="@:75.1.0",
+        "^py-pip@25:",
+        when="@:75.1.0 ^python@:3.9",
         msg="py-pip@25: vendors pyproject-hooks@1.2. "
         "The combination pyproject-hooks@1.2, python@:3.9, and py-setuptools@:75.1.0 is broken. "
         "See https://github.com/pypa/pyproject-hooks/issues/206 for details.",

--- a/repos/spack_repo/builtin/packages/py_setuptools/package.py
+++ b/repos/spack_repo/builtin/packages/py_setuptools/package.py
@@ -82,80 +82,41 @@ class PySetuptools(Package, PythonExtension):
     # Now setuptools declares its own dependencies in the core extra.
     # Dependencies are still vendored for bootstrapping purposes,
     # but setuptools will prefer installed dependencies if present.
+    conflicts("py-importlib-metadata@:5", when="@71.1: ^python@:3.9")
+    conflicts("py-importlib-metadata@:5", when="@71.0")
 
-    # wheel>=0.43.0 v71.0.0 +
-    conflicts("py-wheel@:0.42", when="@71:")
+    conflicts("py-importlib-resources@:5.10.1", when="@75.3.3 ^python@:3.8")
+    conflicts("py-importlib-resources@:5.10.1", when="@71.1:75.3.1 ^python@:3.8")
+    conflicts("py-importlib-resources@:5.10.1", when="@71.0")
 
-    # tomli>=2.0.1; python_version < '3.11' v71.1.0 +
-    # tomli>=2.0.1                          v71.1.0 -
-    conflicts("py-tomli@:2.0.0", when="@71.1: ^python@:3.10")
-    # tomli>=2.0.1                          v71.0.0 +
-    conflicts("py-tomli@:2.0.0", when="@71.0")
-
-    # platformdirs >= 4.2.2 v82.0.1 -
-    # platformdirs >= 4.2.2 v75.3.0 +
-    # platformdirs >= 2.6.2 v75.3.0 -
-    conflicts("py-platformdirs@:4.2.1", when="@75.3:82.0.0")
-    # platformdirs >= 2.6.2 v71.0.0 +
-    conflicts("py-platformdirs@:2.6.1", when="@71:75.2")
-
-    # packaging       v77.0.3 -
-    # packaging       v75.4.0 +
-    # packaging>=24.2 v75.3.4 +
-    # packaging       v75.3.4 -
-    # packaging>=24   v75.3.4 -
-    conflicts("py-packaging@:24.1", when="@75.3.4:")
-    # packaging>=24   v75.3.3 +
-    # packaging>=24.2 v75.3.3 -
-    conflicts("py-packaging@:23", when="@75.3.3")
-    # packaging>=24.2 v75.3.2 +
-    # packaging>=24   v75.3.2 -
-    conflicts("py-packaging@:24.1", when="@75.3.2")
-    # packaging       v75.0.0 +
-    # packaging>=24   v71.0.0 +
-    conflicts("py-packaging@:23", when="@71:")
-
-    # ordered-set>=3.1.1 v73.0.0 -
-    # ordered-set>=3.1.1 v71.0.0 +
-    conflicts("py-ordered-set@:3.1.0", when="@71:72")
-
-    # more_itertools      v75.0.0 +
-    # more_itertools>=8.8 v71.0.0 +
-    conflicts("py-more_itertools@:8.7", when="@71:")
-
-    # jaraco.text>=3.7      v71.0.0 +
     # does not exist in spack (2026-07-07)
-
-    # jaraco.functools >= 4 v75.3.4 +
-    # jaraco.functools      v75.3.4 -
-    conflicts("py-jaraco-functools@:3", when="@75.3.4:")
-    # jaraco.functools      v75.3.3 +
-    # jaraco.functools >= 4 v75.3.3 -
-    # jaraco.functools >= 4 v75.3.2 +
-    # jaraco.functools      v75.3.2 -
-    conflicts("py-jaraco-functools@:3", when="@75.3.2")
-    # jaraco.functools      v75.0.0 +
-
     # jaraco.collections    v77.0.2 -
     # jaraco.collections    v75.4.0 +
     # jaraco.collections    v75.3.4 -
     # jaraco.collections    v75.0.0 +
 
-    # importlib_resources>=5.10.2; python_version < '3.9' v75.3.4 -
-    # importlib_resources>=5.10.2; python_version < '3.9' v75.3.3 +
-    conflicts("py-importlib-resources@:5.10.1", when="@75.3.3 ^python@:3.8")
-    # importlib_resources>=5.10.2; python_version < '3.9' v75.3.2 -
-    # importlib_resources>=5.10.2; python_version < '3.9' v71.1.0 +
-    conflicts("py-importlib-resources@:5.10.1", when="@71.1:75.3.1 ^python@:3.8")
-    # importlib_resources>=5.10.2                         v71.1.0 -
-    # importlib_resources>=5.10.2                         v71.0.0 +
-    conflicts("py-importlib-resources@:5.10.1", when="@71.0")
+    conflicts("py-jaraco-functools@:3", when="@75.3.4:")
+    conflicts("py-jaraco-functools@:3", when="@75.3.2")
 
-    # importlib_metadata>=6; python_version < '3.10' v71.1.0 +
-    # importlib_metadata>=6                          v71.1.0 -
-    conflicts("py-importlib-metadata@:5", when="@71.1: ^python@:3.9")
-    # importlib_metadata>=6                          v71.0.0 +
-    conflicts("py-importlib-metadata@:5", when="@71.0")
+    # does not exist in spack (2026-07-07)
+    # jaraco.text>=3.7      v71.0.0 +
+
+    conflicts("py-more_itertools@:8.7", when="@71:")
+
+    conflicts("py-ordered-set@:3.1.0", when="@71:72")
+
+    conflicts("py-packaging@:24.1", when="@75.3.4:")
+    conflicts("py-packaging@:23", when="@75.3.3")
+    conflicts("py-packaging@:24.1", when="@75.3.2")
+    conflicts("py-packaging@:23", when="@71:")
+
+    conflicts("py-platformdirs@:4.2.1", when="@75.3:82.0.0")
+    conflicts("py-platformdirs@:2.6.1", when="@71:75.2")
+
+    conflicts("py-tomli@:2.0.0", when="@71.1: ^python@:3.10")
+    conflicts("py-tomli@:2.0.0", when="@71.0")
+
+    conflicts("py-wheel@:0.42", when="@71:")
 
     conflicts(
         "^py-pip@25:",


### PR DESCRIPTION
Added conflicts for all vendored dependencies, because they are used when present instead of the vendored versions which leads to conflicts.

https://github.com/pypa/setuptools/blob/v71.0.0/NEWS.rst

>   Now setuptools declares its own dependencies in the core extra.
>   Dependencies are still vendored for bootstrapping purposes,
>   but setuptools will prefer installed dependencies if present.