### PR TITLE
Kokkos: make installation error into a constraint

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -331,6 +331,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("kokkos-nvcc-wrapper@develop", when="@develop+wrapper")
     conflicts("+wrapper", when="~cuda")
     conflicts("+wrapper", when="+cmake_lang")
+    requires("%clang", "%cce", "+cmake_lang", policy="any_of", when="~wrapper+cuda")
 
     # TODO new major: update c++ std
     with default_args(multi=False, description="C++ standard"):
@@ -442,13 +443,6 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     def cmake_args(self):
         spec = self.spec
         from_variant = self.define_from_variant
-
-        if spec.satisfies("~wrapper+cuda") and not (
-            spec.satisfies("%clang") or spec.satisfies("%cce") or spec.satisfies("+cmake_lang")
-        ):
-            raise InstallError(
-                "Kokkos requires +wrapper when using +cuda without %clang, %cce or +cmake_lang"
-            )
 
         options = [
             from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),


### PR DESCRIPTION
Before, installation error:
```
spack install kokkos +cuda cuda_arch=80 ~wrapper ~cmake_lang target=x86_64 %gcc
...
==> No binary for kokkos-5.0.2-6jmjl5ow6nviaiwzselltkjdwfk5hded found: installing from source
==> Installing kokkos-5.0.2-6jmjl5ow6nviaiwzselltkjdwfk5hded [16/16]
==> Using cached archive: /local/home/tpadiole/spack-1.1.1/var/spack/cache/_source-cache/archive/18/188817bb452ca805ee8701f1c5adbbb4fb83dc8d1c50624566a18a719ba0fa5e.tar.gz
==> No patches needed for kokkos
==> kokkos: Executing phase: 'cmake'
==> Error: InstallError: Kokkos requires +wrapper when using +cuda without %clang, %cce or +cmake_lang

/local/home/tpadiole/.spack/package_repos/fncqgg4/repos/spack_repo/builtin/packages/kokkos/package.py:405, in cmake_args:
        402        if spec.satisfies("~wrapper+cuda") and not (
        403            spec.satisfies("%clang") or spec.satisfies("%cce") or spec.satisfies("+cmake_lang")
        404        ):
  >>    405            raise InstallError(
        406                "Kokkos requires +wrapper when using +cuda without %clang, %cce or +cmake_lang"
        407            )
        408

See build log for details:
  /local/home/tpadiole/tmp_spack/spack-stage/spack-stage-kokkos-5.0.2-6jmjl5ow6nviaiwzselltkjdwfk5hded/spack-build-out.txt
```

After, concretization error:
```
spack install kokkos +cuda cuda_arch=80 ~wrapper ~cmake_lang target=x86_64 %gcc
==> Error: failed to concretize `kokkos~cmake_lang+cuda~wrapper cuda_arch=80 target=x86_64 %gcc` for the following reasons:
     1. 'kokkos' requires conflicting variant values '~cmake_lang' and '+cmake_lang'
     2. 'kokkos' requires conflicting variant values '~cmake_lang' and '+cmake_lang'
        required because kokkos~cmake_lang+cuda~wrapper cuda_arch=80 target=x86_64 %gcc requested explicitly 
        required because +cmake_lang is a requirement for package kokkos when +cuda~wrapper 
          required because kokkos~cmake_lang+cuda~wrapper cuda_arch=80 target=x86_64 %gcc requested explicitly 
```