### PR TITLE
toml11: add C compiler dependency for @3:

### DIFF
--- a/repos/spack_repo/builtin/packages/toml11/package.py
+++ b/repos/spack_repo/builtin/packages/toml11/package.py
@@ -42,6 +42,7 @@ class Toml11(CMakePackage):
         "cxx_std", default="11", description="C++ standard", values=("11", "14", "17"), multi=False
     )
 
+    depends_on("c", type="build", when="@:3")
     depends_on("cxx", type="build")  # generated
 
     @when("@3.8.0:")


### PR DESCRIPTION
Since Toml11 4.0.0, the language in the CMakeLists.txt file has been set to CXX. As a result, CMake now requires only a C++ compiler. Previously, no language was specified, and the CMakeLists.txt file for Toml 3.8.1 and earlier versions also requires a C compiler.

CMakeLists.txt 3.8.1:
https://github.com/ToruNiina/toml11/blob/v3.8.1/CMakeLists.txt CMakeLists.txt 4.0.0:
https://github.com/ToruNiina/toml11/blob/v4.0.0/CMakeLists.txt

Fix: #3955

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
