### PR TITLE
py-tomopy: fix py-tomopy's dependency on py-setuptools

### DIFF
--- a/repos/spack_repo/builtin/packages/py_tomopy/package.py
+++ b/repos/spack_repo/builtin/packages/py_tomopy/package.py
@@ -41,7 +41,7 @@ class PyTomopy(PythonPackage):
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-pyfftw", type=("build", "run"), when="@1.0:1.9")
     depends_on("py-scipy", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools", type=("build", "run"))
     depends_on("py-h5py", type=("build", "run"))
     depends_on("py-six", type=("build", "run"))
     depends_on("py-pywavelets", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_tomopy/package.py
+++ b/repos/spack_repo/builtin/packages/py_tomopy/package.py
@@ -41,7 +41,7 @@ class PyTomopy(PythonPackage):
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-pyfftw", type=("build", "run"), when="@1.0:1.9")
     depends_on("py-scipy", type=("build", "run"))
-    depends_on("py-setuptools", type=("build", "run"))
+    depends_on("py-setuptools@:80.9.0", type=("build", "run"))
     depends_on("py-h5py", type=("build", "run"))
     depends_on("py-six", type=("build", "run"))
     depends_on("py-pywavelets", type=("build", "run"))


### PR DESCRIPTION
py-tomopy imports `pkg_resources` at run time, this is a module provided by py-setuptools, and which was removed after version 80.9.0. This PR hence makes py-tomopy depend on py-setuptools@:80.9.0.