### PR TITLE
py-elecsolver: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/py_elecsolver/package.py
+++ b/repos/spack_repo/builtin/packages/py_elecsolver/package.py
@@ -1,0 +1,31 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyElecsolver(PythonPackage):
+    """Formalizes electric systems as linear problems for temporal and frequency-domain studies."""
+
+    homepage = "https://github.com/williampiat3/ElecSolver"
+    pypi = "ElecSolver/elecsolver-2.0.1.tar.gz"
+
+    maintainers = ["williampiat3"]
+
+    version("2.0.1", sha256="126b02e90e01405109ddd52255a43015d5e0e634945c46baa13c6d41d0e4e05e")
+
+    with default_args(type="build"):
+        depends_on("py-setuptools")
+    # Python dependencies
+    with default_args(type=("run")):
+        depends_on("python@3.9:")
+        depends_on("py-numpy")
+        depends_on("py-scipy")
+        depends_on("py-networkx")
+
+    # Optional/test deps
+    depends_on("py-pytest", type="test")
+    depends_on("py-python-mumps", type="test")

--- a/repos/spack_repo/builtin/packages/py_elecsolver/package.py
+++ b/repos/spack_repo/builtin/packages/py_elecsolver/package.py
@@ -28,3 +28,9 @@ class PyElecsolver(PythonPackage):
     # Optional/test deps
     depends_on("py-pytest", type="test")
     depends_on("py-python-mumps", type="test")
+
+    @run_after("install")
+    @on_package_attributes(run_tests=True)
+    def install_test(self):
+        with working_dir(self.stage.source_path):
+            python("-m", "pytest", "tests")

--- a/repos/spack_repo/builtin/packages/py_elecsolver/package.py
+++ b/repos/spack_repo/builtin/packages/py_elecsolver/package.py
@@ -18,8 +18,7 @@ class PyElecsolver(PythonPackage):
     version("2.1.0", sha256="17a33dd4d6f8551904baa55c840d561cff00dc046b4bf7e11bad7e69722c4faa")
     version("2.0.1", sha256="126b02e90e01405109ddd52255a43015d5e0e634945c46baa13c6d41d0e4e05e")
 
-    with default_args(type="build"):
-        depends_on("py-setuptools@80:")
+    depends_on("py-setuptools@80:", type="build")
     # Python dependencies
     with default_args(type=("run")):
         depends_on("python@3.9:")

--- a/repos/spack_repo/builtin/packages/py_elecsolver/package.py
+++ b/repos/spack_repo/builtin/packages/py_elecsolver/package.py
@@ -13,7 +13,7 @@ class PyElecsolver(PythonPackage):
     homepage = "https://github.com/williampiat3/ElecSolver"
     pypi = "ElecSolver/elecsolver-2.0.1.tar.gz"
 
-    maintainers = ["williampiat3"]
+    maintainers("williampiat3")
 
     version("2.1.0", sha256="17a33dd4d6f8551904baa55c840d561cff00dc046b4bf7e11bad7e69722c4faa")
     version("2.0.1", sha256="126b02e90e01405109ddd52255a43015d5e0e634945c46baa13c6d41d0e4e05e")

--- a/repos/spack_repo/builtin/packages/py_elecsolver/package.py
+++ b/repos/spack_repo/builtin/packages/py_elecsolver/package.py
@@ -14,7 +14,8 @@ class PyElecsolver(PythonPackage):
     pypi = "ElecSolver/elecsolver-2.0.1.tar.gz"
 
     maintainers = ["williampiat3"]
-
+    
+    version("2.1.0", sha256="17a33dd4d6f8551904baa55c840d561cff00dc046b4bf7e11bad7e69722c4faa")
     version("2.0.1", sha256="126b02e90e01405109ddd52255a43015d5e0e634945c46baa13c6d41d0e4e05e")
 
     with default_args(type="build"):

--- a/repos/spack_repo/builtin/packages/py_elecsolver/package.py
+++ b/repos/spack_repo/builtin/packages/py_elecsolver/package.py
@@ -14,7 +14,7 @@ class PyElecsolver(PythonPackage):
     pypi = "ElecSolver/elecsolver-2.0.1.tar.gz"
 
     maintainers = ["williampiat3"]
-    
+
     version("2.1.0", sha256="17a33dd4d6f8551904baa55c840d561cff00dc046b4bf7e11bad7e69722c4faa")
     version("2.0.1", sha256="126b02e90e01405109ddd52255a43015d5e0e634945c46baa13c6d41d0e4e05e")
 

--- a/repos/spack_repo/builtin/packages/py_elecsolver/package.py
+++ b/repos/spack_repo/builtin/packages/py_elecsolver/package.py
@@ -19,7 +19,7 @@ class PyElecsolver(PythonPackage):
     version("2.0.1", sha256="126b02e90e01405109ddd52255a43015d5e0e634945c46baa13c6d41d0e4e05e")
 
     with default_args(type="build"):
-        depends_on("py-setuptools")
+        depends_on("py-setuptools@:80")
     # Python dependencies
     with default_args(type=("run")):
         depends_on("python@3.9:")

--- a/repos/spack_repo/builtin/packages/py_elecsolver/package.py
+++ b/repos/spack_repo/builtin/packages/py_elecsolver/package.py
@@ -19,8 +19,7 @@ class PyElecsolver(PythonPackage):
     version("2.0.1", sha256="126b02e90e01405109ddd52255a43015d5e0e634945c46baa13c6d41d0e4e05e")
 
     depends_on("py-setuptools@80:", type="build")
-    # Python dependencies
-    with default_args(type=("run")):
+    with default_args(type=("build", "run")):
         depends_on("python@3.9:")
         depends_on("py-numpy")
         depends_on("py-scipy")

--- a/repos/spack_repo/builtin/packages/py_elecsolver/package.py
+++ b/repos/spack_repo/builtin/packages/py_elecsolver/package.py
@@ -19,7 +19,7 @@ class PyElecsolver(PythonPackage):
     version("2.0.1", sha256="126b02e90e01405109ddd52255a43015d5e0e634945c46baa13c6d41d0e4e05e")
 
     with default_args(type="build"):
-        depends_on("py-setuptools@:80")
+        depends_on("py-setuptools@80:")
     # Python dependencies
     with default_args(type=("run")):
         depends_on("python@3.9:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Small no-arch python package that I would like to have in spack to avoid having to resort to pypi after installing a spack env
