### PR TITLE
cmake: add v3.31.12

### DIFF
--- a/repos/spack_repo/builtin/packages/cmake/package.py
+++ b/repos/spack_repo/builtin/packages/cmake/package.py
@@ -36,10 +36,11 @@ class Cmake(Package):
     version("4.1.5", sha256="50ce77215cf266630fa5de97c360f4c313bb79f94b35236b63c1216de3196356")
     version("4.0.6", sha256="9ebe11be8d304336d62a3e71ca36c18f0a4e40036b97c533d63cf730364b6528")
     version(
-        "3.31.11",
-        sha256="c0a3b3f2912b2166f522d5010ffb6029d8454ee635f5ad7a3247e0be7f9a15c9",
+        "3.31.12",
+        sha256="5f3fd5a54dfa65602bdbed64f981a72673cc19f2d304cc2955cf0dfa0cfd8272",
         preferred=True,
     )
+    version("3.31.11", sha256="c0a3b3f2912b2166f522d5010ffb6029d8454ee635f5ad7a3247e0be7f9a15c9")
     version("3.30.9", sha256="65f765bb87c8019316cabe67cbe5e8f45ede334eeb5afd161ca6874d17994e0d")
     version("3.29.6", sha256="1391313003b83d48e2ab115a8b525a557f78d8c1544618b48d1d90184a10f0af")
     version("3.28.6", sha256="c39c733900affc4eb0e9688b4d1a45435a732105d9bf9cc1e75dd2b9b81a36bb")


### PR DESCRIPTION
### Testing

```
[root@6527e7659012 /]# spack install cmake@3.31.12
...
==> Installing cmake-3.31.12-pjqgyyf2qi5ifkvgizqv2blbfa4xsuhb [16/16]
==> Fetching https://github.com/Kitware/CMake/releases/download/v3.31.12/cmake-3.31.12.tar.gz
    [100%]   11.72 MB @   32.6 MB/s
==> Ran patch() for cmake
==> cmake: Executing phase: 'bootstrap'
==> cmake: Executing phase: 'build'
==> cmake: Executing phase: 'install'
==> cmake: Successfully installed cmake-3.31.12-pjqgyyf2qi5ifkvgizqv2blbfa4xsuhb
  Stage: 2.20s.  Bootstrap: 57.69s.  Build: 1m 8.13s.  Install: 1.18s.  Post-install: 0.36s.  Total: 2m 9.62s
```