### PR TITLE
erf: add v26.05 and v26.06

### DIFF
--- a/repos/spack_repo/builtin/packages/erf/package.py
+++ b/repos/spack_repo/builtin/packages/erf/package.py
@@ -31,6 +31,8 @@ class Erf(CMakePackage, CudaPackage):
 
     license("BSD-3-Clause", checked_by="larenspear")
 
+    version("26.06", tag="26.06", submodules=submodules)
+    version("26.05", tag="26.05", submodules=submodules)
     version("26.04", tag="26.04", submodules=submodules)
     version("26.03", tag="26.03", submodules=submodules)
     version("26.02", tag="26.02", submodules=submodules)


### PR DESCRIPTION
Add ERF versions 26.05 and 26.06.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
