### PR TITLE
mt-metis: additional variants for 64-bit indices and position independent code

### DIFF
--- a/repos/spack_repo/builtin/packages/mt_metis/package.py
+++ b/repos/spack_repo/builtin/packages/mt_metis/package.py
@@ -26,6 +26,7 @@ class MtMetis(CMakePackage):
     variant("shared", default=True, description="Enable build of shared libraries")
 
     variant("int64",default=False,description="Use index type of 64 bit")
+    variant("pic",default=False,description="Build with position-independent-code")
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
@@ -39,6 +40,7 @@ class MtMetis(CMakePackage):
             self.define_from_variant("BIGVERTICES","64bit"),
             self.define_from_variant("BIGWEIGHTS","64bit"),
             self.define_from_variant("BIGPARTITIONS","64bit"),
+            self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic")
         ]
         return cmake_args
 

--- a/repos/spack_repo/builtin/packages/mt_metis/package.py
+++ b/repos/spack_repo/builtin/packages/mt_metis/package.py
@@ -25,6 +25,7 @@ class MtMetis(CMakePackage):
 
     variant("shared", default=True, description="Enable build of shared libraries")
 
+    variant("int64",default=False,description="Use index type of 64 bit")
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
@@ -34,6 +35,10 @@ class MtMetis(CMakePackage):
             self.define("WILDRIVER_PATH", "wildriver"),
             self.define("METIS_PATH", "metis"),
             self.define_from_variant("SHARED", "shared"),
+            self.define_from_variant("BIGEDGES","64bit"),
+            self.define_from_variant("BIGVERTICES","64bit"),
+            self.define_from_variant("BIGWEIGHTS","64bit"),
+            self.define_from_variant("BIGPARTITIONS","64bit"),
         ]
         return cmake_args
 

--- a/repos/spack_repo/builtin/packages/mt_metis/package.py
+++ b/repos/spack_repo/builtin/packages/mt_metis/package.py
@@ -26,6 +26,7 @@ class MtMetis(CMakePackage):
     variant("shared", default=True, description="Enable build of shared libraries")
 
     variant("int64",default=False,description="Use index type of 64 bit")
+    variant("pic",default=False,description="Build with position-independent-code")
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
@@ -35,10 +36,11 @@ class MtMetis(CMakePackage):
             self.define("WILDRIVER_PATH", "wildriver"),
             self.define("METIS_PATH", "metis"),
             self.define_from_variant("SHARED", "shared"),
-            self.define_from_variant("BIGEDGES","64bit"),
-            self.define_from_variant("BIGVERTICES","64bit"),
-            self.define_from_variant("BIGWEIGHTS","64bit"),
-            self.define_from_variant("BIGPARTITIONS","64bit"),
+            self.define_from_variant("BIGEDGES", "int64"),
+            self.define_from_variant("BIGVERTICES", "int64"),
+            self.define_from_variant("BIGWEIGHTS", "int64"),
+            self.define_from_variant("BIGPARTITIONS", "int64"),
+            self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic")
         ]
         return cmake_args
 


### PR DESCRIPTION
This adds the variants `int64` and `pic` to the multithreaded metis build.
Since both are set to false by default this should not affect existing builds.