### PR TITLE
WarpX, pyAMReX 26.05

### DIFF
--- a/repos/spack_repo/builtin/packages/py_amrex/package.py
+++ b/repos/spack_repo/builtin/packages/py_amrex/package.py
@@ -14,7 +14,7 @@ class PyAmrex(CMakePackage, PythonExtension, CudaPackage, ROCmPackage):
     """AMReX Python Bindings with pybind11"""
 
     homepage = "https://amrex-codes.github.io/amrex/"
-    url = "https://github.com/AMReX-Codes/pyamrex/archive/refs/tags/26.04.tar.gz"
+    url = "https://github.com/AMReX-Codes/pyamrex/archive/refs/tags/26.05.tar.gz"
     git = "https://github.com/AMReX-Codes/pyamrex.git"
 
     maintainers("ax3l", "EZoni", "atmyers", "sayerhs", "WeiqunZhang")
@@ -24,6 +24,7 @@ class PyAmrex(CMakePackage, PythonExtension, CudaPackage, ROCmPackage):
     license("BSD-3-Clause-LBNL")
 
     version("develop", branch="development")
+    version("26.05", sha256="f61a4384b46feeffd095d56b1e636f49410aa74a5fbdbfec10a3f568aa1b0e24")
     version("26.04", sha256="0d17f27ca7463b9983a987629ea2c18e06a8e4d98b2b8c6affb7aacfe340690d")
     version("26.03", sha256="d6490ba75d3b9c71bbb73a15417d3238a0c0408e8ce63e3987c08ca85402c44b")
     version("26.02", sha256="a31cfe3fcd1ab4d80e7997fd888fb290c571050d22281eaa9b349c2ed74ec7bb")
@@ -32,7 +33,17 @@ class PyAmrex(CMakePackage, PythonExtension, CudaPackage, ROCmPackage):
     version("25.11", sha256="87de39f435ba6d03bc69adb9cbcc7679da65ef0e4d6dcd60ab654a68220cbc1f")
     version("25.04", sha256="2c765d581f21170ea26a5eb50bdd2c9151d2dbed9f1002dc25e62f38ed6220c0")
 
-    for v in ["25.04", "25.11", "25.12", "26.01", "26.02", "26.03", "26.04", "develop"]:
+    for v in [
+        "develop",
+        "26.05",
+        "26.04",
+        "26.03",
+        "26.02",
+        "26.01",
+        "25.12",
+        "25.11",
+        "25.04",
+    ]:
         depends_on(f"amrex@{v}", when=f"@{v}", type=("build", "link"))
 
     variant(

--- a/repos/spack_repo/builtin/packages/warpx/package.py
+++ b/repos/spack_repo/builtin/packages/warpx/package.py
@@ -17,7 +17,7 @@ class Warpx(CMakePackage, PythonExtension):
     """
 
     homepage = "https://ecp-warpx.github.io"
-    url = "https://github.com/BLAST-WarpX/warpx/archive/refs/tags/26.04.tar.gz"
+    url = "https://github.com/BLAST-WarpX/warpx/archive/refs/tags/26.05.tar.gz"
     git = "https://github.com/BLAST-WarpX/warpx.git"
 
     maintainers("ax3l", "dpgrote", "EZoni", "RemiLehe")
@@ -26,6 +26,7 @@ class Warpx(CMakePackage, PythonExtension):
     license("BSD-3-Clause-LBNL")
 
     version("develop", branch="development")
+    version("26.05", sha256="4cbbbaa444b96252b9f7e2cacd6329ac5b287595f8aa34052f6dc5c16ac34595")
     version("26.04", sha256="484175b83b7752c2de1d947b181f2e1406d27dda95b4f51dbf7fcbc78c5a4bc4")
     version("26.03", sha256="7f857a2189dc9bf428825f2c17e74c6404d73e616a59d2f94d8d3692acb5d26d")
     version("26.01", sha256="c3b34a93e350e068c07e3107784885562cfa5c93ce3fd65fed002e5a6353d63d")
@@ -34,7 +35,16 @@ class Warpx(CMakePackage, PythonExtension):
     version("25.04", sha256="374136fbf566d65307dfe95ae12686ccaf3e649d2f66a79cd856585986c94ac7")
 
     depends_on("amrex build_system=cmake +linear_solvers +pic +particles +shared +tiny_profile")
-    for v in ["develop", "26.04", "26.03", "26.01", "25.12", "25.11", "25.04"]:
+    for v in [
+        "develop",
+        "26.05",
+        "26.04",
+        "26.03",
+        "26.01",
+        "25.12",
+        "25.11",
+        "25.04",
+    ]:
         depends_on(f"amrex@{v}", when=f"@{v}")
         depends_on(f"py-amrex@{v}", when=f"@{v} +python", type=("build", "run"))
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

## Overview

- [x] Update WarpX package from 26.04 to 26.05.
- [x] Update pyAMReX package from 26.04 to 26.05.
- [x] Change style of `for` loop to have both ordered in the same way.

## To do

- [x] Run `@spackbot fix style` to check style issues.