### PR TITLE
ucc: fix bad quoting in configure line when +cuda

### DIFF
--- a/repos/spack_repo/builtin/packages/ucc/package.py
+++ b/repos/spack_repo/builtin/packages/ucc/package.py
@@ -67,7 +67,7 @@ class Ucc(AutotoolsPackage, CudaPackage, ROCmPackage):
         if "+cuda" in self.spec:
             if self.spec.variants["cuda_arch"].values != ("none",):
                 gencode_args = self.cuda_flags(self.spec.variants["cuda_arch"].values)
-                args.append(f"--with-nvcc-gencode='{' '.join(gencode_args)}'")
+                args.append(f"--with-nvcc-gencode={' '.join(gencode_args)}")
 
         if self.spec.satisfies("+rocm"):
             cppflags = " ".join(


### PR DESCRIPTION
Without this change, quotes will be escaped and make it all the way into configure, which then fails with:
```
  nvcc fatal   : Unknown option '--generate-code arch=compute_70,code=sm_70 --generate-code arch=compute_70,code=compute_70'
```