### PR TITLE
Kokkos-FFT: update dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos_fft/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_fft/package.py
@@ -39,7 +39,9 @@ class KokkosFft(CMakePackage):
     variant("tests", default=False, description="Enable tests")
 
     depends_on("cxx", type="build")
-    depends_on("cmake@3.22:3", type="build")
+    depends_on("cmake@3.22:", type="build")
+    depends_on("cmake@:4", type="build", when="@:1")
+    depends_on("cmake@:3", type="build", when="@:0")
 
     depends_on("kokkos +complex_align")
     depends_on("kokkos@4.7:", when="@1.1:")
@@ -59,7 +61,10 @@ class KokkosFft(CMakePackage):
     depends_on("fftw@3.3:3 ~mpi precision=float,double")
     requires("^fftw +openmp", when="host_backend=fftw-openmp")
     depends_on("cuda@11:12", when="device_backend=cufft")
-    depends_on("hipfft@5.3:6", when="device_backend=hipfft")
+    with when("device_backend=hipfft"):
+        depends_on("hipfft@5.3:")
+        depends_on("hipfft@:7", when="@:1")
+        depends_on("hipfft@:6", when="@:0")
     depends_on("intel-oneapi-mkl@2023:2025", when="device_backend=onemkl")
 
     def cmake_args(self):

--- a/stacks/e4s-rocm-external/spack.yaml
+++ b/stacks/e4s-rocm-external/spack.yaml
@@ -244,6 +244,7 @@ spack:
   - gasnet +rocm amdgpu_target=gfx90a
   - heffte +rocm amdgpu_target=gfx90a
   - kokkos +rocm amdgpu_target=gfx90a
+  - kokkos-fft device_backend=hipfft +tests ^kokkos +rocm amdgpu_target=gfx90a
   - legion +rocm amdgpu_target=gfx90a %c,cxx=gcc
   - libceed +rocm amdgpu_target=gfx90a
   - mfem +rocm amdgpu_target=gfx90a


### PR DESCRIPTION
This PR updates some dependencies:
- hipfft support up to 7
- cmake support up to 4

We also reintroduce Kokkos-fft in the E4S stack with the hipfft backend.