### PR TITLE
recola-sm: Add compiler depends.

### DIFF
--- a/repos/spack_repo/builtin/packages/recola_sm/package.py
+++ b/repos/spack_repo/builtin/packages/recola_sm/package.py
@@ -22,6 +22,8 @@ class RecolaSm(CMakePackage):
 
     version("2.2.3", sha256="9ebdc4fd8ca48789de0b6bbb2ab7e4845c92d19dfe0c3f67866cbf114d6242a5")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
     depends_on("fortran", type="build")  # generated
 
     depends_on("collier")


### PR DESCRIPTION
The `recola-sm` Spack package seems to require C/CXX compiler dependencies. Not sure why, given that the package is only Fortran files. Perhaps CMake tries to check those compilers by default?

In any case, the install works after adding the `depends_on()` lines.
