### PR TITLE
WarpX, pyAMReX: add 26.06

### DIFF
--- a/repos/spack_repo/builtin/packages/py_amrex/package.py
+++ b/repos/spack_repo/builtin/packages/py_amrex/package.py
@@ -14,7 +14,7 @@ class PyAmrex(CMakePackage, PythonExtension, CudaPackage, ROCmPackage):
     """AMReX Python Bindings with pybind11"""
 
     homepage = "https://amrex-codes.github.io/amrex/"
-    url = "https://github.com/AMReX-Codes/pyamrex/archive/refs/tags/26.05.tar.gz"
+    url = "https://github.com/AMReX-Codes/pyamrex/archive/refs/tags/26.06.tar.gz"
     git = "https://github.com/AMReX-Codes/pyamrex.git"
 
     maintainers("ax3l", "EZoni", "atmyers", "sayerhs", "WeiqunZhang")
@@ -24,6 +24,7 @@ class PyAmrex(CMakePackage, PythonExtension, CudaPackage, ROCmPackage):
     license("BSD-3-Clause-LBNL")
 
     version("develop", branch="development")
+    version("26.06", sha256="990526a64378066bf9a53a6268731c03cc4e12cf59804a1695447d9336e251d5")
     version("26.05", sha256="f61a4384b46feeffd095d56b1e636f49410aa74a5fbdbfec10a3f568aa1b0e24")
     version("26.04", sha256="0d17f27ca7463b9983a987629ea2c18e06a8e4d98b2b8c6affb7aacfe340690d")
     version("26.03", sha256="d6490ba75d3b9c71bbb73a15417d3238a0c0408e8ce63e3987c08ca85402c44b")
@@ -35,6 +36,7 @@ class PyAmrex(CMakePackage, PythonExtension, CudaPackage, ROCmPackage):
 
     for v in [
         "develop",
+        "26.06",
         "26.05",
         "26.04",
         "26.03",

--- a/repos/spack_repo/builtin/packages/warpx/package.py
+++ b/repos/spack_repo/builtin/packages/warpx/package.py
@@ -17,7 +17,7 @@ class Warpx(CMakePackage, PythonExtension):
     """
 
     homepage = "https://ecp-warpx.github.io"
-    url = "https://github.com/BLAST-WarpX/warpx/archive/refs/tags/26.05.tar.gz"
+    url = "https://github.com/BLAST-WarpX/warpx/archive/refs/tags/26.06.tar.gz"
     git = "https://github.com/BLAST-WarpX/warpx.git"
 
     maintainers("ax3l", "dpgrote", "EZoni", "RemiLehe")
@@ -26,6 +26,7 @@ class Warpx(CMakePackage, PythonExtension):
     license("BSD-3-Clause-LBNL")
 
     version("develop", branch="development")
+    version("26.06", sha256="260869743fa5995fcdce964ebb3996efe5fd4126da753c6bdc645e2f9722364e")
     version("26.05", sha256="4cbbbaa444b96252b9f7e2cacd6329ac5b287595f8aa34052f6dc5c16ac34595")
     version("26.04", sha256="484175b83b7752c2de1d947b181f2e1406d27dda95b4f51dbf7fcbc78c5a4bc4")
     version("26.03", sha256="7f857a2189dc9bf428825f2c17e74c6404d73e616a59d2f94d8d3692acb5d26d")
@@ -37,6 +38,7 @@ class Warpx(CMakePackage, PythonExtension):
     depends_on("amrex build_system=cmake +linear_solvers +pic +particles +shared +tiny_profile")
     for v in [
         "develop",
+        "26.06",
         "26.05",
         "26.04",
         "26.03",


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

## Overview

- [x] Update WarpX package from 26.05 to 26.06.
- [x] Update pyAMReX package from 26.05 to 26.06.