### PR TITLE
slurm: add v25.05, v25.11, and v26.05

### DIFF
--- a/repos/spack_repo/builtin/packages/libyogrt/package.py
+++ b/repos/spack_repo/builtin/packages/libyogrt/package.py
@@ -17,6 +17,7 @@ class Libyogrt(AutotoolsPackage):
 
     license("LGPL-2.1-or-later")
 
+    version("1.36", sha256="2615cf0ad6cd2938e953c13c42bc6b79e79fb35be20bd30cc4e073e2dc8caa6a")
     version("1.35", sha256="a03b3d24da49af626351aaca9ab3eaff102ed41d5171f1bcb2ff26a561bd0cd6")
     version("1.33", sha256="797d20c49cdc4f6beae8660b4f41ba7ac13f7e93a0344b47f0bdc64f780d1398")
     version("1.27", sha256="c57ce60770b61aa20bc83fe34ff52b5e444964338df3786f282d0d9bcdd26138")
@@ -52,7 +53,7 @@ class Libyogrt(AutotoolsPackage):
 
     depends_on("flux-core@0.21.0:", when="scheduler=flux")
     depends_on("lsf", when="scheduler=lsf")
-    depends_on("slurm", when="scheduler=slurm")
+    depends_on("slurm@:25", when="scheduler=slurm")
 
     # support for flux added in libyogrt 1.27
     conflicts("scheduler=flux", when="@:1.26")

--- a/repos/spack_repo/builtin/packages/slurm/package.py
+++ b/repos/spack_repo/builtin/packages/slurm/package.py
@@ -31,6 +31,9 @@ class Slurm(AutotoolsPackage):
 
     license("GPL-2.0-or-later")
 
+    version("26-05-1-1", sha256="432362d3ced66476a8edb61b6c06b6f0c0c1b3bbbf40589fae94de0664c803b5")
+    version("25-11-6-1", sha256="2e305a5cc051d08ded4d710e349636b6a054da2c371bbce85797744b693ca790")
+    version("25-05-8-1", sha256="3f77fa80fdcec1e8a47f146bf0b34a6a6c2435f13dad26aea758a7a0f8c82954")
     version("25-05-1-1", sha256="b568c761a6c9d72358addb3bb585456e73e80a02214ce375d2de8534f9ddb585")
     version("24-11-6-1", sha256="282708483326f381eb001a14852a1a82e65e18f37b62b7a5f4936c0ed443b600")
     version(


### PR DESCRIPTION
I added 3 of the latest versions of slurm from 25.05, 25.08, and 26.05.

@w8jcik is the current maintainer of the Slurm package.

Comments, questions, concerns?