### PR TITLE
Libheif

### DIFF
--- a/repos/spack_repo/builtin/packages/crunch/package.py
+++ b/repos/spack_repo/builtin/packages/crunch/package.py
@@ -22,7 +22,8 @@ class Crunch(CMakePackage):
     # No stable releases since 2012
     version("master", branch="build_fixes")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("cmake@3.5:", type="build")
 

--- a/repos/spack_repo/builtin/packages/libheif/package.py
+++ b/repos/spack_repo/builtin/packages/libheif/package.py
@@ -15,9 +15,22 @@ class Libheif(CMakePackage):
 
     license("LGPL-3.0-or-later")
 
+    version("1.21.2", sha256="79996de959d28ca82ef070c382304683f5cdaf04cbe2953a74587160a3710a36")
     version("1.12.0", sha256="086145b0d990182a033b0011caadb1b642da84f39ab83aa66d005610650b3c65")
+
+    variant("gdk-plugin", default=True, description="Build gdk-pixbuf plugin")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
     depends_on("cmake@3.13:", type="build")
+    depends_on("gdk-pixbuf", when="+gdk-plugin")
+    depends_on("jpeg")
+    depends_on("libpng")
+
+    def cmake_args(self):
+        args = [
+                self.define_from_variant("WITH_GDK_PIXBUF", "gdk-plugin")
+        ]
+
+        return args


### PR DESCRIPTION
    Added version 1.21.2 of libheif
    
    Added gdk-plugin boolean variant to control whether to build the
    gdk-pixbuf plugin.  Default is true (which is what the libheif Cmake
    infrastructure defaults to) so as to mimic old behavior if omitted.
    
    Add dependencies:
            gdk-pixbuf when +gdk-plugin
            jpeg
            libpng
    
    as the package depends on such (and was finding and linking against system
    versions of these libraries w/out the explicit spack dependencies).
    This should fix #4322
    
    @spackbot fix style
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
