### PR TITLE
CI: Don't clone the allocation configs for build

### DIFF
--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 stages: [ "generate", "build" ]
 
 variables:
+  SPACK_CI_GENERATE: "generate"
   SPACK_DISABLE_LOCAL_CONFIG: "1"
   SPACK_USER_CACHE_PATH: "${CI_PROJECT_DIR}/tmp/_user_cache/"
   # PR_MIRROR_FETCH_DOMAIN: "https://binaries-prs.spack.io"

--- a/.ci/gitlab/include.yaml
+++ b/.ci/gitlab/include.yaml
@@ -42,7 +42,7 @@ include:
     when: platform == "linux"
 
   # === Per-package resource requests (Only used for Linux on Kubernetes) ===
-  - when: platform == "linux"
+  - when: 'platform == "linux" and env.get("SPACK_CI_GENERATE")'
     git: https://gitlab.spack.io/spack/resource-requests
     branch: main
     paths:


### PR DESCRIPTION
The allocation configs are only required during the generate job. Exclude them from the configs loaded during build to avoid spurious failures.
