### PR TITLE
ci: define SPACK_CI_GENERATE in .generate-common

### DIFF
--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -1,7 +1,6 @@
 stages: [ "generate", "build" ]
 
 variables:
-  SPACK_CI_GENERATE: "generate"
   SPACK_DISABLE_LOCAL_CONFIG: "1"
   SPACK_USER_CACHE_PATH: "${CI_PROJECT_DIR}/tmp/_user_cache/"
   # PR_MIRROR_FETCH_DOMAIN: "https://binaries-prs.spack.io"
@@ -134,6 +133,7 @@ default:
       - "${CI_PROJECT_DIR}/tmp/_user_cache/cache/providers"
       - "${CI_PROJECT_DIR}/tmp/_user_cache/cache/tags"
   variables:
+    SPACK_CI_GENERATE: "generate"
     SPACK_CONCRETIZE_JOBS: 8
     KUBERNETES_CPU_REQUEST: 8000m
     KUBERNETES_MEMORY_REQUEST: 16G


### PR DESCRIPTION
Follow-up fix for #5263