### PR TITLE
Fix gettext 1.0:

### DIFF
--- a/repos/spack_repo/builtin/packages/gettext/package.py
+++ b/repos/spack_repo/builtin/packages/gettext/package.py
@@ -116,12 +116,17 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
             "--disable-java",
             "--disable-csharp",
             "--with-included-glib",
-            "--with-included-gettext",
             "--with-included-libcroco",
             "--without-emacs",
             "--with-lispdir=%s/emacs/site-lisp/gettext" % self.prefix.share,
             "--without-cvs",
         ]
+
+        # The name of the option to include libintl changed in 1.0
+        if spec.satisfies("@1.0:"):
+            config_args.append("--with-included-libintl")
+        else:
+            config_args.append("--with-included-gettext")
 
         # Until we know why we need them, do not build D sources:
         if spec.satisfies("@0.25:"):


### PR DESCRIPTION
In `gettext` prior to 1.0, the name of the configure option to include `libintl` was confusingly named `--with-included-gettext`. With `gettext` 1.0, the option was renamed `--with-included-libintl`. This PR reflects that change.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

@michaelkuhn Please review