### PR TITLE
opencascade: add v8.0.0, v8.0.0.p1

### DIFF
--- a/repos/spack_repo/builtin/packages/opencascade/package.py
+++ b/repos/spack_repo/builtin/packages/opencascade/package.py
@@ -24,7 +24,13 @@ class Opencascade(CMakePackage):
 
     license("LGPL-2.1-only")
 
-    version("7.9.3", sha256="5ecf094ec6b12d5413dfb851d8c3590c354058aee556e32e408bdfbf8c357d57")
+    version("8.0.0.p1", sha256="ad794cba1f377274b40050b098c106e02409def7e23b0763fae4b0aea95ac3a7")
+    version("8.0.0", sha256="118398ff8a010c2cb693450d7e5e2690533c88208fc25bd2730451ec4fab0a0f")
+    version(
+        "7.9.3",
+        sha256="5ecf094ec6b12d5413dfb851d8c3590c354058aee556e32e408bdfbf8c357d57",
+        preferred=True
+    )
     version("7.9.2", sha256="3cd080d3fc33ba0c6c157e110afe3e015859524c4694dbb09812ec9d61595639")
     version("7.9.1", sha256="de442298cd8860f5580b01007f67f0ecd0b8900cfa4da467fa3c823c2d1a45df")
     version("7.9.0", sha256="151b7a522ba8220aed3009e440246abbaf2ffec42672c37e9390096f7f2c098d")
@@ -96,8 +102,8 @@ class Opencascade(CMakePackage):
     variant("freetype", default=False, description="Build with freetype")
     variant("rapidjson", default=False, description="Build with rapidjson")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("tbb", when="+tbb")
     depends_on("intel-tbb@2021.5: build_type=Release", when="@7.7 +tbb")

--- a/repos/spack_repo/builtin/packages/opencascade/package.py
+++ b/repos/spack_repo/builtin/packages/opencascade/package.py
@@ -29,7 +29,7 @@ class Opencascade(CMakePackage):
     version(
         "7.9.3",
         sha256="5ecf094ec6b12d5413dfb851d8c3590c354058aee556e32e408bdfbf8c357d57",
-        preferred=True
+        preferred=True,
     )
     version("7.9.2", sha256="3cd080d3fc33ba0c6c157e110afe3e015859524c4694dbb09812ec9d61595639")
     version("7.9.1", sha256="de442298cd8860f5580b01007f67f0ecd0b8900cfa4da467fa3c823c2d1a45df")


### PR DESCRIPTION
This PR adds `opencascade`, v8.0.0 and v8.0.0.p1. Major release, minor changes. https://dev.opencascade.org/doc/overview/html/occt__upgrade.html#upgrade_occt800 and https://github.com/Open-Cascade-SAS/OCCT/compare/V7_9_3...V8_0_0. Nothing actually affects the spack package but marked 7.9.3 as preferred for now due to api changes.

Test build:
```
-- linux-ubuntu26.04-skylake / %c,cxx=clang@23.0.0 --------------
opencascade@8.0.0.p1
==> 1 installed package
```