### PR TITLE
WIP: Release tools

### DIFF
--- a/.release/CHANGELOG.header.template
+++ b/.release/CHANGELOG.header.template
@@ -1,0 +1,36 @@
+# Spack packages {{current_version}}.0
+
+The {{current_version}}.0 release of the spack packages along with version {{spack_cur_version_major}}.{{spack_cur_version_minor}} of
+the Spack tool. This release brings new packages and package version updates
+and deprecations that are not made available via backports to previous releases.
+
+## Spack version compatibility
+
+This release continues to use the v{{package_api}} Package API. This is the Package API
+version used by the Spack v{{spack_min_version}} release. Any Spack version {{spack_min_version}} or newer
+is compatible with this release of the packages repo.
+
+This release was tested against Spack v{{spack_cur_version}} ({{spack_cur_commit}})
+and the environments used to generate the binary caches use new features 
+that will be part of the Spack {{spack_cur_version_major}}.{{spack_cur_version_minor}} release. The binary caches themselves are
+compatible with any Spack v{{spack_min_version}} or newer (any Spack that supports the v{{bc_layout_version}}
+URL build cache layout), but the environments used to generate them
+cannot be reconcretized with any existing Spack release, and require the
+`develop` branch.
+
+See the [Package API
+Documentation](https://spack.readthedocs.io/en/latest/package_api.html)
+for full details on package versioning and compatibility.
+
+## Package statistics
+
+There are now {{count_packages}} packages in the spack-packages builtin repo. This
+is up from {{count_packages_prev}} in the previous release.
+
+## New and removed packages
+
+This release contains a number of deprecations to address CVEs in a number
+of projects.
+
+In addition to new deprecations, all package versions deprecated prior to
+the {{prev_version}} release have been removed with a few exceptions.

--- a/.release/branch.sh
+++ b/.release/branch.sh
@@ -1,0 +1,9 @@
+# Fetch and checkout the latest passing develop
+release_ref=${1-:snapshots/develop-latest}
+git fetch origin "$release_ref"
+git checkout "$release_ref"
+
+# Create and push the branch
+branch="releases/v$(date +%Y.%m)"
+git checkout -b "$branch"
+git push origin "$branch"

--- a/.release/create_release_note.sh
+++ b/.release/create_release_note.sh
@@ -1,0 +1,73 @@
+#!/bin/zsh
+
+prev_release=$1
+current_release="v$(date +%Y.%m)"
+
+extract_package_names() {
+  sed 's/^.*packages\/\([^\/]\+\)\/package\.py$/*  \1/g' $1 > .tmp$1
+  sed 's/_/-/g' .tmp$1 >> CHANGELOG.$current_release
+}
+
+format_header() {
+  current_version="$current_release"
+  prev_version="$prev_release"
+  spack_min_version="1.0.0" # TODO denote this for the build cache and the Package API seperately
+  package_api="2.2" # TODO Extract from repo.yaml
+  bc_layout_version="3"
+  spack_cur_version="1.2.0"
+  spack_cur_version_major="1"
+  spack_cur_version_minor="2"
+  spack_cur_version_patch="0"
+  spack_cur_commit="63943396d634faa92cb59474df3558ec9b9b2425"
+  count_packages=$(find ./repos -name package.py | wc -l)
+  count_packages_prev="8752" # TODO compute this
+
+
+  cp CHANGELOG.header.template CHANGELOG.header.$current_release
+  sed -i "s/{{count_packages_prev}}/$count_packages_prev/g" CHANGELOG.header.$current_release
+  sed -i "s/{{current_version}}/$current_version/g" CHANGELOG.header.$current_release
+  sed -i "s/{{prev_version}}/$prev_version/g" CHANGELOG.header.$current_release
+  sed -i "s/{{spack_min_version}}/$spack_min_version/g" CHANGELOG.header.$current_release
+  sed -i "s/{{package_api}}/$package_api/g" CHANGELOG.header.$current_release
+  sed -i "s/{{bc_layout_version}}/$bc_layout_version/g" CHANGELOG.header.$current_release
+  sed -i "s/{{spack_cur_version}}/$spack_cur_version/g" CHANGELOG.header.$current_release
+  sed -i "s/{{spack_cur_version_major}}/$spack_cur_version_major/g" CHANGELOG.header.$current_release
+  sed -i "s/{{spack_cur_version_minor}}/$spack_cur_version_minor/g" CHANGELOG.header.$current_release
+  sed -i "s/{{spack_cur_version_patch}}/$spack_cur_version_patch/g" CHANGELOG.header.$current_release
+  sed -i "s/{{spack_cur_commit}}/$spack_cur_commit/g" CHANGELOG.header.$current_release
+  sed -i "s/{{count_packages}}/$count_packages/g" CHANGELOG.header.$current_release
+  sed -i "s/{{count_packages_prev}}/$count_packages_prev/g" CHANGELOG.header.$current_release
+}
+
+format_header
+cat CHANGELOG.header.$current_release > CHANGELOG.$current_release
+
+git diff --name-status "releases/$prev_release".."releases/$current_release" | grep "package.py" > .rel-files.txt
+
+grep "^A" .rel-files.txt > .rel-new-packages.txt
+echo "
+### New packages
+" >> CHANGELOG.$current_release
+extract_package_names .rel-new-packages.txt >> CHANGELOG.$current_release
+
+grep "^D" .rel-files.txt > .rel-del-packages.txt
+echo "
+### Removed packages
+" >> CHANGELOG.$current_release
+extract_package_names .rel-del-packages.txt >> CHANGELOG.$current_release
+
+git log --name-only -S "\+.*deprecated=True" "releases/$prev_release".."releases/$current_release" | grep "package.py" > .rel-deprecated.txt
+extract_package_names .rel-deprecated.txt >> CHANGELOG.$current_release
+
+# Add a newline to the end of the changelog
+echo >> CHANGELOG.$current_release
+
+cat CHANGELOG.$current_release
+
+if read -q "choice?Commit? [Yn] "; then
+  cat CHANGELOG.$current_release CHANGELOG.md > CHANGELOG.md.tmp
+  mv CHANGELOG.md.tmp CHANGELOG.md
+else
+  echo
+  echo "goodbye"
+fi


### PR DESCRIPTION
A couple simple tools to help make the release process easier.

`.release/branch.sh` - Create a release branch from the latest snapshot or a commit
`.release/create_release_note.sh` - Derive the release notes from the repo
`.release/CHANGELOG.header.template` - Template for filling out the header with the important information related to the release
