### PR TITLE
New version for py-nanobind + switch to pypi for released versions

### DIFF
--- a/repos/spack_repo/builtin/packages/py_nanobind/package.py
+++ b/repos/spack_repo/builtin/packages/py_nanobind/package.py
@@ -81,48 +81,37 @@ class PyNanobind(PythonPackage):
         sha256="53fa7a6227bddecaa4a0710e0b8dc18fad4c8ded7a0a31d6eddcf68009eadc03",
     )
     version(
-        "2.1.0",
-        sha256="a613a2ce750fee63f03dc8a36593be2bdc2929cb4cea56b38fafeb74b85c3a5f",
+        "2.1.0", tag="v2.1.0", commit="9641bb7151f04120013b812789b3ebdfa7e7324f", submodules=True
     )
     version(
-        "2.0.0",
-        sha256="9e4f4383ad83a72ce46ba5e9395dc67fadb8d53e5230aecdfc90ffdcd08d1a70",
+        "2.0.0", tag="v2.0.0", commit="8d7f1ee0621c17fa370b704b2100ffa0243d5bfb", submodules=True
     )
     version(
-        "1.9.2",
-        sha256="137ba9e75cc6b2e5d92c2acb9810beaa079b9c8e5d68c581b4f90d626d79358c",
+        "1.9.2", tag="v1.9.2", commit="80a30c8efb093b14f0e744bc7f6a9ef34beb3f7f", submodules=True
     )
     version(
-        "1.8.0",
-        sha256="c9b069f408660124b12565ca026834d146154a3965efcd2bcf749eefb99b4873",
+        "1.8.0", tag="v1.8.0", commit="1a309ba444a47e081dc6213d72345a2fbbd20795", submodules=True
     )
     version(
-        "1.7.0",
-        sha256="a368b8121d3c1ec384a2dab0cb2b556924ceafc84ed80b0d1e211e3997576dae",
+        "1.7.0", tag="v1.7.0", commit="555ec7595c89c60ce7cf53e803bc226dc4899abb", submodules=True
     )
     version(
-        "1.6.2",
-        sha256="27b62eae0134cd60563a4026e5f347d88fcae6d6357b11683b470eb4c51efe9f",
+        "1.6.2", tag="v1.6.2", commit="cc5ac7e61def198db2a8b65c6d630343987a9f1d", submodules=True
     )
     version(
-        "1.5.2",
-        sha256="34515bf2c0675d6d1c7be17ae8c7a1361439cb0a98dcde15899f23a63ef1b55f",
+        "1.5.2", tag="v1.5.2", commit="b0e24d5b0ab0d518317d6b263a257ae72d4d29a2", submodules=True
     )
     version(
-        "1.5.1",
-        sha256="e408ca6bcd424cb4555c6217cf7624d334862a6d497c549b01b9bc509e25b21e",
+        "1.5.1", tag="v1.5.1", commit="ec6168d06dbf2ab94c31858223bd1d7617222706", submodules=True
     )
     version(
-        "1.5.0",
-        sha256="0e2343bdc7246c332eb4bd477b89b53482490457a12d7b084a9b410f122770b8",
+        "1.5.0", tag="v1.5.0", commit="e85a51049db500383808aaa4a77306ff37d96131", submodules=True
     )
     version(
-        "1.4.0",
-        sha256="0eeded0d1868e2b575714dc620e85631ffe03eb719f8d629101abb2c09668d8f",
+        "1.4.0", tag="v1.4.0", commit="05cba0ef85ba2bb68aa115af4b74c30aa2aa7bec", submodules=True
     )
     version(
-        "1.2.0",
-        sha256="949332ba8653a7dedf1ebb2485a4479116e7774478240213a00493db3c49e9d5",
+        "1.2.0", tag="v1.2.0", commit="ec9350b805d2fe568f65746fd69225eedc5e37ae", submodules=True
     )
 
     depends_on("cxx", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_nanobind/package.py
+++ b/repos/spack_repo/builtin/packages/py_nanobind/package.py
@@ -16,7 +16,7 @@ class PyNanobind(PythonPackage):
     """
 
     homepage = "https://nanobind.readthedocs.io"
-    url = "https://github.com/wjakob/nanobind/archive/refs/tags/v1.2.0.tar.gz"
+    pypi = "nanobind/nanobind-2.13.0.tar.gz"
     git = "https://github.com/wjakob/nanobind.git"
 
     maintainers("chrisrichardson", "garth-wells")
@@ -25,58 +25,104 @@ class PyNanobind(PythonPackage):
 
     version("master", branch="master", submodules=True)
     version(
-        "2.12.0", tag="v2.12.0", commit="2a61ad2494d09fecb2e13322c1383342c299900d", submodules=True
+        "2.13.0",
+        sha256="c7b04d6a6a4cd57985571e605539399b51331ae455d7fce576a5e2fcb89b1dcf",
     )
     version(
-        "2.8.0", tag="v2.8.0", commit="0e7aa61a75052034453cd2b906a79fe222792697", submodules=True
+        "2.12.0",
+        sha256="0ae77c1a88f27153fa57045e00f7b0a7b06b1cd3df942e95a34b38c5d0a5bee",
     )
     version(
-        "2.7.0", tag="v2.7.0", commit="44ad9a9e5729abda24ef8dc9d76233d801e651e9", submodules=True
+        "2.11.0",
+        sha256="6d98d063c1dbbd05a2d903e59be398bfcff9d59c54fbbc9d4488960485d40d0",
     )
     version(
-        "2.6.1", tag="v2.6.1", commit="9b3afa9dbdc23641daf26fadef7743e7127ff92f", submodules=True
+        "2.10.2",
+        sha256="08509910ce6d1fadeed69cb0880d4d4fcb77739c6af9bd8fb4419391a3ca4c6b",
     )
     version(
-        "2.5.0", tag="v2.5.0", commit="4ccbe6e005fc017652312305f280742da49d3dd5", submodules=True
+        "2.10.1",
+        sha256="66d2c6fea9541401551b0ca6df674758bb769cf4939b11c1bcd73774cdcc760",
     )
     version(
-        "2.4.0", tag="v2.4.0", commit="0f9ce749b257fdfe701edb3cf6f7027ba029434a", submodules=True
+        "2.9.2",
+        sha256="7608472de99d375759814cab3e2c94aba3f9ec80e62cfef8ced495ca5c27d6e",
     )
     version(
-        "2.2.0", tag="v2.2.0", commit="784efa2a0358a4dc5432c74f5685ee026e20f2b6", submodules=True
+        "2.9.1",
+        sha256="8e0f084176bfc4904159475b92d4b6552b781ed7b66f21708f4b4715be01895",
     )
     version(
-        "2.1.0", tag="v2.1.0", commit="9641bb7151f04120013b812789b3ebdfa7e7324f", submodules=True
+        "2.9.0",
+        sha256="c8d5154c4f44a52cccbc18fdb824c69ce55ee97a2f52e80116b65ef7ca34fd8",
     )
     version(
-        "2.0.0", tag="v2.0.0", commit="8d7f1ee0621c17fa370b704b2100ffa0243d5bfb", submodules=True
+        "2.8.0",
+        sha256="94e7b6aa1d7dff9566eddc15252aba94fdadbf67a99a169bfab34b708427cd8",
     )
     version(
-        "1.9.2", tag="v1.9.2", commit="80a30c8efb093b14f0e744bc7f6a9ef34beb3f7f", submodules=True
+        "2.7.0",
+        sha256="f9f1b160580c50dcf37b6495a0fd5ec61dc0d95dae5f8004f87dd9ad7eb4b34",
     )
     version(
-        "1.8.0", tag="v1.8.0", commit="1a309ba444a47e081dc6213d72345a2fbbd20795", submodules=True
+        "2.6.1",
+        sha256="e05c6816a844aa699e46408add3bff8c743f9fd3d38eafa307a73633fddf94e",
     )
     version(
-        "1.7.0", tag="v1.7.0", commit="555ec7595c89c60ce7cf53e803bc226dc4899abb", submodules=True
+        "2.5.0",
+        sha256="cc8412e94acffa20a369191382bcdbbfbfb302e475e87cacff9516d51023a15",
     )
     version(
-        "1.6.2", tag="v1.6.2", commit="cc5ac7e61def198db2a8b65c6d630343987a9f1d", submodules=True
+        "2.4.0",
+        sha256="a0392de5f58881085b2ac8bfe8e53f74285aa4868b1472bfaf76cfb414e1c96",
     )
     version(
-        "1.5.2", tag="v1.5.2", commit="b0e24d5b0ab0d518317d6b263a257ae72d4d29a2", submodules=True
+        "2.2.0",
+        sha256="53fa7a6227bddecaa4a0710e0b8dc18fad4c8ded7a0a31d6eddcf68009eadc03",
     )
     version(
-        "1.5.1", tag="v1.5.1", commit="ec6168d06dbf2ab94c31858223bd1d7617222706", submodules=True
+        "2.1.0",
+        sha256="a613a2ce750fee63f03dc8a36593be2bdc2929cb4cea56b38fafeb74b85c3a5f",
     )
     version(
-        "1.5.0", tag="v1.5.0", commit="e85a51049db500383808aaa4a77306ff37d96131", submodules=True
+        "2.0.0",
+        sha256="9e4f4383ad83a72ce46ba5e9395dc67fadb8d53e5230aecdfc90ffdcd08d1a70",
     )
     version(
-        "1.4.0", tag="v1.4.0", commit="05cba0ef85ba2bb68aa115af4b74c30aa2aa7bec", submodules=True
+        "1.9.2",
+        sha256="137ba9e75cc6b2e5d92c2acb9810beaa079b9c8e5d68c581b4f90d626d79358c",
     )
     version(
-        "1.2.0", tag="v1.2.0", commit="ec9350b805d2fe568f65746fd69225eedc5e37ae", submodules=True
+        "1.8.0",
+        sha256="c9b069f408660124b12565ca026834d146154a3965efcd2bcf749eefb99b4873",
+    )
+    version(
+        "1.7.0",
+        sha256="a368b8121d3c1ec384a2dab0cb2b556924ceafc84ed80b0d1e211e3997576dae",
+    )
+    version(
+        "1.6.2",
+        sha256="27b62eae0134cd60563a4026e5f347d88fcae6d6357b11683b470eb4c51efe9f",
+    )
+    version(
+        "1.5.2",
+        sha256="34515bf2c0675d6d1c7be17ae8c7a1361439cb0a98dcde15899f23a63ef1b55f",
+    )
+    version(
+        "1.5.1",
+        sha256="e408ca6bcd424cb4555c6217cf7624d334862a6d497c549b01b9bc509e25b21e",
+    )
+    version(
+        "1.5.0",
+        sha256="0e2343bdc7246c332eb4bd477b89b53482490457a12d7b084a9b410f122770b8",
+    )
+    version(
+        "1.4.0",
+        sha256="0eeded0d1868e2b575714dc620e85631ffe03eb719f8d629101abb2c09668d8f",
+    )
+    version(
+        "1.2.0",
+        sha256="949332ba8653a7dedf1ebb2485a4479116e7774478240213a00493db3c49e9d5",
     )
 
     depends_on("cxx", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_nanobind/package.py
+++ b/repos/spack_repo/builtin/packages/py_nanobind/package.py
@@ -30,15 +30,15 @@ class PyNanobind(PythonPackage):
     )
     version(
         "2.12.0",
-        sha256="0ae77c1a88f27153fa57045e00f7b0a7b06b1cd3df942e95a34b38c5d0a5bee",
+        sha256="0ae77c1a88f27153fa57045ee00f7b0a7b06b1cd3df942e95a34b38c5d0a5bee",
     )
     version(
         "2.11.0",
-        sha256="6d98d063c1dbbd05a2d903e59be398bfcff9d59c54fbbc9d4488960485d40d0",
+        sha256="6d98d063c61dbbd05a2d903e59be398bfcff9d59c54fbbc9d4488960485d40d0",
     )
     version(
         "2.10.2",
-        sha256="08509910ce6d1fadeed69cb0880d4d4fcb77739c6af9bd8fb4419391a3ca4c6b",
+        sha256="66d2c6fea9541401551b0ca6df674758bb769cf4939b11c1bcd73774c1dcc760",
     )
     version(
         "2.10.1",
@@ -46,39 +46,39 @@ class PyNanobind(PythonPackage):
     )
     version(
         "2.9.2",
-        sha256="7608472de99d375759814cab3e2c94aba3f9ec80e62cfef8ced495ca5c27d6e",
+        sha256="e7608472de99d375759814cab3e2c94aba3f9ec80e62cfef8ced495ca5c27d6e",
     )
     version(
         "2.9.1",
-        sha256="8e0f084176bfc4904159475b92d4b6552b781ed7b66f21708f4b4715be01895",
+        sha256="8e0f084176bfc4904159475b92d4b6552b781ed7b66f21708f4b471c5be01895",
     )
     version(
         "2.9.0",
-        sha256="c8d5154c4f44a52cccbc18fdb824c69ce55ee97a2f52e80116b65ef7ca34fd8",
+        sha256="c8d5154c4f44a52cccbc18fdb824c6e9ce55ee97a2f52e80116b65ef7ca34fd8",
     )
     version(
         "2.8.0",
-        sha256="94e7b6aa1d7dff9566eddc15252aba94fdadbf67a99a169bfab34b708427cd8",
+        sha256="94e7bf6aa1d7dff9566eddc15252aba94fdadbf67a99a169bfab34b708427cd8",
     )
     version(
         "2.7.0",
-        sha256="f9f1b160580c50dcf37b6495a0fd5ec61dc0d95dae5f8004f87dd9ad7eb4b34",
+        sha256="f9f1b160580c50dcf37b6495a0fd5ec61dc0d95dae5f8004f87dd9ad7eb46b34",
     )
     version(
         "2.6.1",
-        sha256="e05c6816a844aa699e46408add3bff8c743f9fd3d38eafa307a73633fddf94e",
+        sha256="e05c6816a844aa699e46408add3bff8c743af9fd3d38eafa307a73633fddf94e",
     )
     version(
         "2.5.0",
-        sha256="cc8412e94acffa20a369191382bcdbbfbfb302e475e87cacff9516d51023a15",
+        sha256="cc8412e94acffa20a369191382bcdbb6fbfb302e475e87cacff9516d51023a15",
     )
     version(
         "2.4.0",
-        sha256="a0392de5f58881085b2ac8bfe8e53f74285aa4868b1472bfaf76cfb414e1c96",
+        sha256="a0392dee5f58881085b2ac8bfe8e53f74285aa4868b1472bfaf76cfb414e1c96",
     )
     version(
         "2.2.0",
-        sha256="53fa7a6227bddecaa4a0710e0b8dc18fad4c8ded7a0a31d6eddcf68009eadc03",
+        sha256="53fa7a6227bddecaa4a0710e0b8dc18fad4c8ded7a0a31d6eddcf68009ead603",
     )
     version(
         "2.1.0", tag="v2.1.0", commit="9641bb7151f04120013b812789b3ebdfa7e7324f", submodules=True

--- a/repos/spack_repo/builtin/packages/py_nanobind/package.py
+++ b/repos/spack_repo/builtin/packages/py_nanobind/package.py
@@ -38,11 +38,11 @@ class PyNanobind(PythonPackage):
     )
     version(
         "2.10.2",
-        sha256="66d2c6fea9541401551b0ca6df674758bb769cf4939b11c1bcd73774c1dcc760",
+        sha256="08509910ce6d1fadeed69cb0880d4d4fcb77739c6af9bd8fb4419391a3ca4c6b",
     )
     version(
         "2.10.1",
-        sha256="66d2c6fea9541401551b0ca6df674758bb769cf4939b11c1bcd73774cdcc760",
+        sha256="66d2c6fea9541401551b0ca6df674758bb769cf4939b11c1bcd73774c1dcc760",
     )
     version(
         "2.9.2",


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
New (and old) versions for py-nanobind
Also I changed the released version to fetch source on pypi, it is prefered as stated in the documentation: https://spack.readthedocs.io/en/latest/build_systems/pythonpackage.html#downloading
It is also more convenient for air-gapped systems not to rely on a github commit with submodules.