### PR TITLE
just: add v1.53.0

### DIFF
--- a/repos/spack_repo/builtin/packages/just/package.py
+++ b/repos/spack_repo/builtin/packages/just/package.py
@@ -19,6 +19,7 @@ class Just(CargoPackage):
     license("CC0-1.0", checked_by="Dando18")
 
     version("master", branch="master")
+    version("1.53.0", sha256="9742f15ea4e6afd4bf9b8fecd0c5ef61904d3d187f24675601fdfbace885a4c3")
     version("1.52.0", sha256="cd869b45801f1434d26c05df7ca999b7b56c7d1d57fb1211cdfd2526ec28f130")
     version("1.50.0", sha256="cca015e07739a1c26c6fc459f7d46e1e36ce0f7613114eddedd8cd3af55a10b7")
     version("1.49.0", sha256="442406ee14eb9a59414525cf262354fe2e752b22c224ce2a5e42b2c493226e09")


### PR DESCRIPTION
This PR adds 1.53.0 of just. I tested the build locally.

Ref: [casey/just@1.53.0 (release)](https://github.com/casey/just/releases/tag/1.53.0)