### PR TITLE
just: add v1.54.0

### DIFF
--- a/repos/spack_repo/builtin/packages/just/package.py
+++ b/repos/spack_repo/builtin/packages/just/package.py
@@ -19,6 +19,7 @@ class Just(CargoPackage):
     license("CC0-1.0", checked_by="Dando18")
 
     version("master", branch="master")
+    version("1.54.0", sha256="53d288296054876d4d9fb76b0f947c3f2a805969bfa19ec79108da44e70cd93e")
     version("1.53.0", sha256="9742f15ea4e6afd4bf9b8fecd0c5ef61904d3d187f24675601fdfbace885a4c3")
     version("1.52.0", sha256="cd869b45801f1434d26c05df7ca999b7b56c7d1d57fb1211cdfd2526ec28f130")
     version("1.50.0", sha256="cca015e07739a1c26c6fc459f7d46e1e36ce0f7613114eddedd8cd3af55a10b7")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Sorry for the PR churn. I just opened a PR for 1.53.0 yesterday, only to find out a new version was released today.

---

This PR adds 1.54.0 of just. I tested the build locally.

Ref: [casey/just@1.54.0 (release)](https://github.com/casey/just/releases/tag/1.54.0)