### PR TITLE
nnpack and qnnpack: Support air-gapped build

### DIFF
--- a/repos/spack_repo/builtin/packages/nnpack/package.py
+++ b/repos/spack_repo/builtin/packages/nnpack/package.py
@@ -46,42 +46,42 @@ class Nnpack(CMakePackage):
     resource(
         name="peachpy",
         git="https://github.com/Maratyszcza/PeachPy.git",
-        branch="master",
+        commit="349e8f836142b2ed0efeb6bb99b1b715d87202e9",
         destination="deps",
         placement="peachpy",
     )
     resource(
         name="cpuinfo",
-        git="https://github.com/Maratyszcza/cpuinfo.git",
-        branch="master",
+        git="https://github.com/pytorch/cpuinfo.git",
+        commit="315d03cacc51bfabe316057b0d3466e13bce88a0",
         destination="deps",
         placement="cpuinfo",
     )
     resource(
         name="fp16",
         git="https://github.com/Maratyszcza/FP16.git",
-        branch="master",
+        commit="782eea126dc5c755827be751a099eb01826175cf",
         destination="deps",
         placement="fp16",
     )
     resource(
         name="fxdiv",
         git="https://github.com/Maratyszcza/FXdiv.git",
-        branch="master",
+        commit="63058eff77e11aa15bf531df5dd34395ec3017c8",
         destination="deps",
         placement="fxdiv",
     )
     resource(
         name="psimd",
         git="https://github.com/Maratyszcza/psimd.git",
-        branch="master",
+        commit="072586a71b55b7f8c584153d223e95687148a900",
         destination="deps",
         placement="psimd",
     )
     resource(
         name="pthreadpool",
         git="https://github.com/Maratyszcza/pthreadpool.git",
-        branch="master",
+        commit="560c60d342a76076f0557a3946924c6478470044",
         destination="deps",
         placement="pthreadpool",
     )

--- a/repos/spack_repo/builtin/packages/nnpack/package.py
+++ b/repos/spack_repo/builtin/packages/nnpack/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
 
@@ -87,7 +86,6 @@ class Nnpack(CMakePackage):
         destination="deps",
         placement="googletest",
     )
-
 
     def cmake_args(self):
         return [

--- a/repos/spack_repo/builtin/packages/nnpack/package.py
+++ b/repos/spack_repo/builtin/packages/nnpack/package.py
@@ -2,10 +2,12 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
 
 from spack.package import *
-import os
+
 
 class Nnpack(CMakePackage):
     """Acceleration package for neural networks on multi-core CPUs."""
@@ -28,8 +30,8 @@ class Nnpack(CMakePackage):
     depends_on("cmake@2.8.12:", type="build")
     depends_on("python", type="build")
     depends_on("py-setuptools", type="build")
-    depends_on("py-wheel",type="build")
-    depends_on("py-pip",type="build")
+    depends_on("py-wheel", type="build")
+    depends_on("py-pip", type="build")
 
     resource(
         name="six",
@@ -46,12 +48,12 @@ class Nnpack(CMakePackage):
         placement="opcodes",
     )
     resource(
-    name="peachpy",
-    git="https://github.com/malfet/PeachPy.git",
-    commit="f45429b087dd7d5bc78bb40dc7cf06425c252d67",
-    destination="deps",
-    placement="peachpy",
-)
+        name="peachpy",
+        git="https://github.com/malfet/PeachPy.git",
+        commit="f45429b087dd7d5bc78bb40dc7cf06425c252d67",
+        destination="deps",
+        placement="peachpy",
+    )
 
     resource(
         name="cpuinfo",
@@ -61,12 +63,12 @@ class Nnpack(CMakePackage):
         placement="cpuinfo",
     )
     resource(
-    name="fp16",
-    git="https://github.com/Maratyszcza/FP16.git",
-    commit="4987f20d48c22694d84bbffa839168596ea027ae",
-    destination="deps",
-    placement="fp16",
-)
+        name="fp16",
+        git="https://github.com/Maratyszcza/FP16.git",
+        commit="4987f20d48c22694d84bbffa839168596ea027ae",
+        destination="deps",
+        placement="fp16",
+    )
     resource(
         name="fxdiv",
         git="https://github.com/Maratyszcza/FXdiv.git",
@@ -100,16 +102,16 @@ class Nnpack(CMakePackage):
     def generate_peachpy(self):
         deps_dir = join_path(self.stage.source_path, "deps")
         pythonpath = ":".join(
-        [
-            join_path(deps_dir, "six"),
-            join_path(deps_dir, "opcodes"),
-        ]
-    )
+            [
+                join_path(deps_dir, "six"),
+                join_path(deps_dir, "opcodes"),
+            ]
+        )
 
         old_pythonpath = os.environ.get("PYTHONPATH")
         os.environ["PYTHONPATH"] = (
-        f"{pythonpath}:{old_pythonpath}" if old_pythonpath else pythonpath
-    )
+            f"{pythonpath}:{old_pythonpath}" if old_pythonpath else pythonpath
+        )
         try:
             with working_dir(join_path(deps_dir, "peachpy")):
                 python("setup.py", "generate")
@@ -140,5 +142,7 @@ class Nnpack(CMakePackage):
             self.define("NNPACK_BUILD_TESTS", self.run_tests),
             self.define("NNPACK_BUILD_BENCHMARKS", False),
             self.define("NNPACK_LIBRARY_TYPE", "static"),
-            self.define("PYTHON_OPCODES_SOURCE_DIR", join_path(self.stage.source_path, "deps", "opcodes"))
+            self.define(
+                "PYTHON_OPCODES_SOURCE_DIR", join_path(self.stage.source_path, "deps", "opcodes")
+            ),
         ]

--- a/repos/spack_repo/builtin/packages/nnpack/package.py
+++ b/repos/spack_repo/builtin/packages/nnpack/package.py
@@ -5,7 +5,7 @@
 from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
 
 from spack.package import *
-
+import os
 
 class Nnpack(CMakePackage):
     """Acceleration package for neural networks on multi-core CPUs."""
@@ -28,6 +28,8 @@ class Nnpack(CMakePackage):
     depends_on("cmake@2.8.12:", type="build")
     depends_on("python", type="build")
     depends_on("py-setuptools", type="build")
+    depends_on("py-wheel",type="build")
+    depends_on("py-pip",type="build")
 
     resource(
         name="six",
@@ -44,12 +46,13 @@ class Nnpack(CMakePackage):
         placement="opcodes",
     )
     resource(
-        name="peachpy",
-        git="https://github.com/Maratyszcza/PeachPy.git",
-        commit="349e8f836142b2ed0efeb6bb99b1b715d87202e9",
-        destination="deps",
-        placement="peachpy",
-    )
+    name="peachpy",
+    git="https://github.com/malfet/PeachPy.git",
+    commit="f45429b087dd7d5bc78bb40dc7cf06425c252d67",
+    destination="deps",
+    placement="peachpy",
+)
+
     resource(
         name="cpuinfo",
         git="https://github.com/pytorch/cpuinfo.git",
@@ -58,12 +61,12 @@ class Nnpack(CMakePackage):
         placement="cpuinfo",
     )
     resource(
-        name="fp16",
-        git="https://github.com/Maratyszcza/FP16.git",
-        commit="782eea126dc5c755827be751a099eb01826175cf",
-        destination="deps",
-        placement="fp16",
-    )
+    name="fp16",
+    git="https://github.com/Maratyszcza/FP16.git",
+    commit="4987f20d48c22694d84bbffa839168596ea027ae",
+    destination="deps",
+    placement="fp16",
+)
     resource(
         name="fxdiv",
         git="https://github.com/Maratyszcza/FXdiv.git",
@@ -95,9 +98,26 @@ class Nnpack(CMakePackage):
 
     @run_before("cmake")
     def generate_peachpy(self):
-        # https://github.com/Maratyszcza/NNPACK/issues/203
-        with working_dir(join_path(self.stage.source_path, "deps", "peachpy")):
-            python("setup.py", "generate")
+        deps_dir = join_path(self.stage.source_path, "deps")
+        pythonpath = ":".join(
+        [
+            join_path(deps_dir, "six"),
+            join_path(deps_dir, "opcodes"),
+        ]
+    )
+
+        old_pythonpath = os.environ.get("PYTHONPATH")
+        os.environ["PYTHONPATH"] = (
+        f"{pythonpath}:{old_pythonpath}" if old_pythonpath else pythonpath
+    )
+        try:
+            with working_dir(join_path(deps_dir, "peachpy")):
+                python("setup.py", "generate")
+        finally:
+            if old_pythonpath is None:
+                del os.environ["PYTHONPATH"]
+            else:
+                os.environ["PYTHONPATH"] = old_pythonpath
 
     def cmake_args(self):
         return [
@@ -118,4 +138,7 @@ class Nnpack(CMakePackage):
                 "GOOGLETEST_SOURCE_DIR", join_path(self.stage.source_path, "deps", "googletest")
             ),
             self.define("NNPACK_BUILD_TESTS", self.run_tests),
+            self.define("NNPACK_BUILD_BENCHMARKS", False),
+            self.define("NNPACK_LIBRARY_TYPE", "static"),
+            self.define("PYTHON_OPCODES_SOURCE_DIR", join_path(self.stage.source_path, "deps", "opcodes"))
         ]

--- a/repos/spack_repo/builtin/packages/nnpack/package.py
+++ b/repos/spack_repo/builtin/packages/nnpack/package.py
@@ -29,9 +29,6 @@ class Nnpack(CMakePackage):
     generator("ninja")
     depends_on("cmake@2.8.12:", type="build")
     depends_on("python", type="build")
-    depends_on("py-setuptools", type="build")
-    depends_on("py-wheel", type="build")
-    depends_on("py-pip", type="build")
 
     resource(
         name="six",
@@ -39,13 +36,6 @@ class Nnpack(CMakePackage):
         sha256="70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
         destination="deps",
         placement="six",
-    )
-    resource(
-        name="opcodes",
-        url="https://files.pythonhosted.org/packages/source/o/opcodes/opcodes-0.3.13.tar.gz",
-        sha256="1859c23143fe20daa4110be87a947cbf3eefa048da71dde642290213f251590c",
-        destination="deps",
-        placement="opcodes",
     )
     resource(
         name="peachpy",
@@ -98,28 +88,6 @@ class Nnpack(CMakePackage):
         placement="googletest",
     )
 
-    @run_before("cmake")
-    def generate_peachpy(self):
-        deps_dir = join_path(self.stage.source_path, "deps")
-        pythonpath = ":".join(
-            [
-                join_path(deps_dir, "six"),
-                join_path(deps_dir, "opcodes"),
-            ]
-        )
-
-        old_pythonpath = os.environ.get("PYTHONPATH")
-        os.environ["PYTHONPATH"] = (
-            f"{pythonpath}:{old_pythonpath}" if old_pythonpath else pythonpath
-        )
-        try:
-            with working_dir(join_path(deps_dir, "peachpy")):
-                python("setup.py", "generate")
-        finally:
-            if old_pythonpath is None:
-                del os.environ["PYTHONPATH"]
-            else:
-                os.environ["PYTHONPATH"] = old_pythonpath
 
     def cmake_args(self):
         return [
@@ -140,9 +108,5 @@ class Nnpack(CMakePackage):
                 "GOOGLETEST_SOURCE_DIR", join_path(self.stage.source_path, "deps", "googletest")
             ),
             self.define("NNPACK_BUILD_TESTS", self.run_tests),
-            self.define("NNPACK_BUILD_BENCHMARKS", False),
             self.define("NNPACK_LIBRARY_TYPE", "static"),
-            self.define(
-                "PYTHON_OPCODES_SOURCE_DIR", join_path(self.stage.source_path, "deps", "opcodes")
-            ),
         ]

--- a/repos/spack_repo/builtin/packages/qnnpack/package.py
+++ b/repos/spack_repo/builtin/packages/qnnpack/package.py
@@ -32,19 +32,22 @@ class Qnnpack(CMakePackage):
 
     resource(
         name="cpuinfo",
-        git="https://github.com/Maratyszcza/cpuinfo.git",
+        git="https://github.com/pytorch/cpuinfo.git",
+        commit="315d03cacc51bfabe316057b0d3466e13bce88a0",
         destination="deps",
         placement="cpuinfo",
     )
     resource(
         name="fp16",
         git="https://github.com/Maratyszcza/FP16.git",
+        commit="782eea126dc5c755827be751a099eb01826175cf",
         destination="deps",
         placement="fp16",
     )
     resource(
         name="fxdiv",
         git="https://github.com/Maratyszcza/FXdiv.git",
+        commit="63058eff77e11aa15bf531df5dd34395ec3017c8",
         destination="deps",
         placement="fxdiv",
     )
@@ -65,12 +68,14 @@ class Qnnpack(CMakePackage):
     resource(
         name="psimd",
         git="https://github.com/Maratyszcza/psimd.git",
+        commit="072586a71b55b7f8c584153d223e95687148a900",
         destination="deps",
         placement="psimd",
     )
     resource(
         name="pthreadpool",
         git="https://github.com/Maratyszcza/pthreadpool.git",
+        commit="560c60d342a76076f0557a3946924c6478470044",
         destination="deps",
         placement="pthreadpool",
     )


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This updates NNPACK and QNNPACK to work in air-gapped systems
