### PR TITLE
py-uv-build: add missing dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/py_uv_build/package.py
+++ b/repos/spack_repo/builtin/packages/py_uv_build/package.py
@@ -22,3 +22,5 @@ class PyUvBuild(PythonPackage):
 
     depends_on("python@3.8:", type=("build", "run"))
     depends_on("py-maturin@1", type="build")
+
+    depends("bzip2")

--- a/repos/spack_repo/builtin/packages/py_uv_build/package.py
+++ b/repos/spack_repo/builtin/packages/py_uv_build/package.py
@@ -23,4 +23,4 @@ class PyUvBuild(PythonPackage):
     depends_on("python@3.8:", type=("build", "run"))
     depends_on("py-maturin@1", type="build")
 
-    depends("bzip2")
+    depends_on("bzip2")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This fixes the following error:

```
/mnt/storage/opt/spack/linux-x86_64/py-uv-build-0.8.2-dchpcvtibzryhw76o4eoxffkc275ukhw/bin/uv-build: error while loading shared libraries: libbz2.so.1.0: cannot open shared object file: No such file or direct
ory  
    error: subprocess-exited-with-error                                                                   
      
    × Preparing metadata (pyproject.toml) did not run successfully.     
    │ exit code: 127                                                                                      
    ╰─> No available output.
```