### PR TITLE
py-lxml@5: flags to compile with gcc@14 / oneapi@2026

### DIFF
--- a/repos/spack_repo/builtin/packages/py_lxml/package.py
+++ b/repos/spack_repo/builtin/packages/py_lxml/package.py
@@ -64,3 +64,10 @@ class PyLxml(PythonPackage):
     depends_on("py-cython@3.0.9:", type="build", when="@5.1.1:")
     depends_on("py-cython@3.0.8:", type="build", when="@5:")
     depends_on("py-cython@0.29.7:", type="build")
+
+    def flag_handler(self, name, flags):
+        if name == "cflags":
+            if self.spec.satisfies("@:5") and (self.spec.satisfies("%gcc@14:") or self.spec.satisfies("%oneapi@2026:")):
+                flags.append("-Wno-error=incompatible-pointer-types")
+        return (flags, None, None)
+

--- a/repos/spack_repo/builtin/packages/py_lxml/package.py
+++ b/repos/spack_repo/builtin/packages/py_lxml/package.py
@@ -67,7 +67,8 @@ class PyLxml(PythonPackage):
 
     def flag_handler(self, name, flags):
         if name == "cflags":
-            if self.spec.satisfies("@:5") and (self.spec.satisfies("%gcc@14:") or self.spec.satisfies("%oneapi@2026:")):
+            if self.spec.satisfies("@:5") and (
+                self.spec.satisfies("%gcc@14:") or self.spec.satisfies("%oneapi@2026:")
+            ):
                 flags.append("-Wno-error=incompatible-pointer-types")
         return (flags, None, None)
-


### PR DESCRIPTION
## Description

`repos/spack_repo/builtin/packages/py_lxml/package.py`: add flags for version 5 (required by some downstream packages) to compile with `gcc@14:` and `oneapi@2026:`

