### PR TITLE
Correct dependencies when amdgpu_target=auto for rocsolver and rocsparse

### DIFF
--- a/repos/spack_repo/builtin/packages/rocsolver/package.py
+++ b/repos/spack_repo/builtin/packages/rocsolver/package.py
@@ -115,7 +115,7 @@ class Rocsolver(CMakePackage):
     ]:
         depends_on(f"hip@{ver}", when=f"@{ver}")
         depends_on(f"rocm-cmake@{ver}:", type="build", when=f"@{ver}")
-        for tgt in ROCmPackage.amdgpu_targets:
+        for tgt in ROCmPackage.amdgpu_targets + ["auto"]:
             depends_on(f"rocsparse@{ver} amdgpu_target={tgt}", when=f"@{ver} amdgpu_target={tgt}")
             depends_on(f"rocblas@{ver} amdgpu_target={tgt}", when=f"@{ver} amdgpu_target={tgt}")
 

--- a/repos/spack_repo/builtin/packages/rocsolver/package.py
+++ b/repos/spack_repo/builtin/packages/rocsolver/package.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import itertools
 import re
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
@@ -115,7 +116,7 @@ class Rocsolver(CMakePackage):
     ]:
         depends_on(f"hip@{ver}", when=f"@{ver}")
         depends_on(f"rocm-cmake@{ver}:", type="build", when=f"@{ver}")
-        for tgt in ROCmPackage.amdgpu_targets + ["auto"]:
+        for tgt in itertools.chain(["auto"], ROCmPackage.amdgpu_targets):
             depends_on(f"rocsparse@{ver} amdgpu_target={tgt}", when=f"@{ver} amdgpu_target={tgt}")
             depends_on(f"rocblas@{ver} amdgpu_target={tgt}", when=f"@{ver} amdgpu_target={tgt}")
 

--- a/repos/spack_repo/builtin/packages/rocsparse/package.py
+++ b/repos/spack_repo/builtin/packages/rocsparse/package.py
@@ -106,13 +106,12 @@ class Rocsparse(CMakePackage):
         "7.2.1",
         "7.2.3",
     ]:
-        depends_on(f"hip@{ver}", when=f"@{ver}")
-        for tgt in ROCmPackage.amdgpu_targets:
+        for tgt in ROCmPackage.amdgpu_targets + ["auto"]:
             depends_on(f"rocprim@{ver} amdgpu_target={tgt}", when=f"@{ver} amdgpu_target={tgt}")
         depends_on(f"rocm-cmake@{ver}:", type="build", when=f"@{ver}")
 
     for ver in ["7.2.0", "7.2.1", "7.2.3"]:
-        for tgt in ROCmPackage.amdgpu_targets:
+        for tgt in ROCmPackage.amdgpu_targets + ["auto"]:
             depends_on(f"rocblas@{ver} amdgpu_target={tgt}", when=f"@{ver} amdgpu_target={tgt}")
 
     depends_on("googletest@1.11.0:", when="+test")

--- a/repos/spack_repo/builtin/packages/rocsparse/package.py
+++ b/repos/spack_repo/builtin/packages/rocsparse/package.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import itertools
 import re
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
@@ -106,12 +107,12 @@ class Rocsparse(CMakePackage):
         "7.2.1",
         "7.2.3",
     ]:
-        for tgt in ROCmPackage.amdgpu_targets + ["auto"]:
+        for tgt in itertools.chain(["auto"], ROCmPackage.amdgpu_targets):
             depends_on(f"rocprim@{ver} amdgpu_target={tgt}", when=f"@{ver} amdgpu_target={tgt}")
         depends_on(f"rocm-cmake@{ver}:", type="build", when=f"@{ver}")
 
     for ver in ["7.2.0", "7.2.1", "7.2.3"]:
-        for tgt in ROCmPackage.amdgpu_targets + ["auto"]:
+        for tgt in itertools.chain(["auto"], ROCmPackage.amdgpu_targets):
             depends_on(f"rocblas@{ver} amdgpu_target={tgt}", when=f"@{ver} amdgpu_target={tgt}")
 
     depends_on("googletest@1.11.0:", when="+test")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Adding amdgpu_target=auto to rocmsparse deps (rocprim and rocblas) and rocsolver deps (rocsparse and rocblas): previously having amggpu_target=auto made those deps disapear from the dependency graph