### PR TITLE
CP2K: update recipe for DeepMD

### DIFF
--- a/repos/spack_repo/builtin/packages/cp2k/package.py
+++ b/repos/spack_repo/builtin/packages/cp2k/package.py
@@ -197,8 +197,6 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     variant("nlcg", default=False, description="Enable nlcg support in sirius", when="+sirius")
     variant("vcsqnm", default=False, description="Enable VCSQNM support in sirius", when="+sirius")
 
-    conflicts("+deepmd", msg="DeepMD-kit is not yet available in Spack")
-
     with when("+cuda"):
         variant(
             "cuda_arch_35_k20x",
@@ -246,6 +244,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     depends_on("lapack")
     depends_on("fftw-api@3")
     depends_on("greenx", when="+greenx")
+    depends_on("deepmdkit", when="+deepmd")
     depends_on("hdf5+hl+fortran", when="+hdf5")
     depends_on("trexio", when="+trexio")
 

--- a/repos/spack_repo/builtin/packages/cp2k/package.py
+++ b/repos/spack_repo/builtin/packages/cp2k/package.py
@@ -244,9 +244,15 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     depends_on("lapack")
     depends_on("fftw-api@3")
     depends_on("greenx", when="+greenx")
-    depends_on("deepmdkit", when="+deepmd")
     depends_on("hdf5+hl+fortran", when="+hdf5")
     depends_on("trexio", when="+trexio")
+
+    conflicts(
+        "+deepmd",
+        when="build_system=makefile",
+        msg="DeepMD only is only available with CMake",
+    )
+    depends_on("deepmdkit", when="+deepmd")
 
     depends_on("tblite build_system=cmake", when="+tblite")
     # Force openmp propagation on some providers of blas / fftw-api

--- a/repos/spack_repo/builtin/packages/cp2k/package.py
+++ b/repos/spack_repo/builtin/packages/cp2k/package.py
@@ -250,7 +250,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     conflicts(
         "+deepmd",
         when="build_system=makefile",
-        msg="DeepMD only is only available with CMake",
+        msg="DeepMD is only available with CMake (in Spack)",
     )
     depends_on("deepmdkit", when="+deepmd")
 

--- a/repos/spack_repo/builtin/packages/cp2k/package.py
+++ b/repos/spack_repo/builtin/packages/cp2k/package.py
@@ -190,9 +190,14 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         description="Enable green X support",
         when="@2025.2: build_system=cmake",
     )
+    variant(
+        "deepmd",
+        default=False,
+        description="Enable DeepMD-kit support",
+        when="@2024.2: build_system=cmake",
+    )
 
     variant("vdwxc", default=False, description="Enable VDW support in SIRIUS.", when="+sirius")
-    variant("deepmd", default=False, description="Enable DeepMD-kit support")
     variant("tblite", default=False, description="Enable tblite support", when="@2025.2:")
     variant("nlcg", default=False, description="Enable nlcg support in sirius", when="+sirius")
     variant("vcsqnm", default=False, description="Enable VCSQNM support in sirius", when="+sirius")
@@ -246,12 +251,6 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     depends_on("greenx", when="+greenx")
     depends_on("hdf5+hl+fortran", when="+hdf5")
     depends_on("trexio", when="+trexio")
-
-    conflicts(
-        "+deepmd",
-        when="build_system=makefile",
-        msg="DeepMD is only available with CMake (in Spack)",
-    )
     depends_on("deepmdkit", when="+deepmd")
 
     depends_on("tblite build_system=cmake", when="+tblite")


### PR DESCRIPTION
DeepMD-kit is now available in spack. Provided a successful build of `deepmd`, `cp2k+deepmd` works out of the box.