### PR TITLE
nanobind: add gmake build dependency to resolve internal error

### DIFF
--- a/repos/spack_repo/builtin/packages/py_nanobind/package.py
+++ b/repos/spack_repo/builtin/packages/py_nanobind/package.py
@@ -86,6 +86,8 @@ class PyNanobind(PythonPackage):
     depends_on("py-setuptools@42:", when="@:2.0", type="build")
     depends_on("py-scikit-build", when="@:2.0", type="build")
     depends_on("py-typing-extensions", when="@2.0", type="build")
+
+    depends_on("gmake", type="build")
     depends_on("ninja", when="@2.0", type="build")
     depends_on("cmake@3.17:", when="@:2.0", type="build")
 


### PR DESCRIPTION
This PR:
- Adds `gmake` as a dependency to the nanobind recipe to resolve gmake-related error.
- Fix is based on comment https://github.com/spack/spack-packages/issues/5106#issuecomment-4679593276 and PR #4298 

Error snippet:
```
Building wheels for collected packages: nanobind
  Destination directory: /tmp/han12/pip-ephem-wheel-cache-1swor6ya/wheels/71/68/f9/dd8aac4d10859113aa5ae6fca9cf62f41961f0577c4fb7b5c0/tmplkm8dao5
  Building wheel for nanobind (pyproject.toml): started
  Running command Building wheel for nanobind (pyproject.toml)
  *** scikit-build-core 0.12.2 using CMake 3.26.5 (wheel)
  *** Configuring CMake...
  loading initial cache file /var/tmp/han12/tmpvza8jlmc/build/CMakeInit.txt
  -- Configuring done (0.0s)
  -- Generating done (0.0s)
  -- Build files have been written to: /var/tmp/han12/tmpvza8jlmc/build
  *** Building project with Unix Makefiles...
  gmake: *** internal error: invalid --jobserver-auth string 'fifo:/var/tmp/han12/tmpvcslq5gh/jobserver_fifo'.  Stop.
 
  *** CMake build failed
  error: subprocess-exited-with-error
 
  × Building wheel for nanobind (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> No available output.
```