### PR TITLE
SEACAS: fix legacy app runtimes by setting ACCESS

### DIFF
--- a/repos/spack_repo/builtin/packages/seacas/package.py
+++ b/repos/spack_repo/builtin/packages/seacas/package.py
@@ -296,6 +296,8 @@ class Seacas(CMakePackage):
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         env.prepend_path("PYTHONPATH", self.prefix.lib)
+        if self.spec.satisfies("+legacy"):
+            env.set("ACCESS", self.prefix)
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
Package update to fix SEACAS runtime when legacy X11 package blot is enabled.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
