### PR TITLE
boost: don't double-quote cxxflags

### DIFF
--- a/repos/spack_repo/builtin/packages/boost/package.py
+++ b/repos/spack_repo/builtin/packages/boost/package.py
@@ -748,7 +748,7 @@ class Boost(Package):
             cxxflags.append("-DBOOST_STACKTRACE_LIBCXX_RUNTIME_MAY_CAUSE_MEMORY_LEAK")
 
         if cxxflags:
-            options.append('cxxflags="{0}"'.format(" ".join(cxxflags)))
+            options.append("cxxflags={0}".format(" ".join(cxxflags)))
 
         # Visibility was added in 1.69.0.
         if spec.satisfies("@1.69.0:"):


### PR DESCRIPTION
b2 already quotes them, so passing multiple values causes them to be passed to the compiler as a quoted string like '-fFoo -fBar'.

Fixes #5323