### PR TITLE
eccodes: enforce libaec version & set static/shared lib correctly

### DIFF
--- a/repos/spack_repo/builtin/packages/eccodes/package.py
+++ b/repos/spack_repo/builtin/packages/eccodes/package.py
@@ -371,9 +371,11 @@ class Eccodes(CMakePackage):
         if self.spec.satisfies("+aec"):
             # Prevent overriding by environment variables AEC_DIR and AEC_PATH:
             args.append(self.define("AEC_DIR", self.spec["libaec"].prefix))
-            # eccodes 2.46+ defaults ENABLE_USE_SHARED_LIB_AEC=ON; set based on whether libaec has shared libs
+            # set ENABLE_USE_SHARED_LIB_AEC based on libaec's specs; used since eccodes 2.46
             if self.spec.satisfies("@2.46:"):
-                args.append(self.define("ENABLE_USE_SHARED_LIB_AEC", "+shared" in self.spec["libaec"]))
+                args.append(
+                    self.define("ENABLE_USE_SHARED_LIB_AEC", "+shared" in self.spec["libaec"])
+                )
 
         return args
 

--- a/repos/spack_repo/builtin/packages/eccodes/package.py
+++ b/repos/spack_repo/builtin/packages/eccodes/package.py
@@ -125,6 +125,7 @@ class Eccodes(CMakePackage):
 
     depends_on("libpng", when="+png")
     depends_on("libaec", when="+aec")
+    depends_on("libaec@1.1.4:", when="@2.47: +aec")
     # Can be built with Python 2 or Python 3.
     depends_on("python", when="+memfs", type="build")
 
@@ -370,6 +371,9 @@ class Eccodes(CMakePackage):
         if self.spec.satisfies("+aec"):
             # Prevent overriding by environment variables AEC_DIR and AEC_PATH:
             args.append(self.define("AEC_DIR", self.spec["libaec"].prefix))
+            # eccodes 2.46+ defaults ENABLE_USE_SHARED_LIB_AEC=ON; set based on whether libaec has shared libs
+            if self.spec.satisfies("@2.46:"):
+                args.append(self.define("ENABLE_USE_SHARED_LIB_AEC", "+shared" in self.spec["libaec"]))
 
         return args
 


### PR DESCRIPTION
- starting with eccodes 2.47.0, the minimum required libaec version is 1.1.4: https://confluence.ecmwf.int/spaces/ECC/pages/656639695/ecCodes+version+2.47.0+released
- since eccodes 2.46.0, CMakeLists.txt uses ENABLE_USE_SHARED_LIB_AEC; set this in package.py based on libaec's specs instead of using the default: https://github.com/ecmwf/eccodes/blob/c10e8be0c3e27dd2be36a909b06d5d3be6889708/CMakeLists.txt#L158-L166