### PR TITLE
Imod: Fix qt dependency, spack csh use and compiler selection

### DIFF
--- a/repos/spack_repo/builtin/packages/imod/package.py
+++ b/repos/spack_repo/builtin/packages/imod/package.py
@@ -42,6 +42,10 @@ class Imod(MakefilePackage, CudaPackage):
     depends_on("python", type=("run"))
 
     def edit(self, spec, prefix):
+        # Ensure that Spack-provided tcsh is used
+        csh = join_path(spec["tcsh"].prefix.bin, "csh")
+        filter_file("#!/bin/csh", f"#!{csh}", "setup", "manpages/convert", "packMacApps")
+
         configure = Executable("./setup")
         configure_args = ["-inst", prefix]  # Set up prefix
         configure(*configure_args)

--- a/repos/spack_repo/builtin/packages/imod/package.py
+++ b/repos/spack_repo/builtin/packages/imod/package.py
@@ -31,7 +31,7 @@ class Imod(MakefilePackage, CudaPackage):
     depends_on("fortran", type="build")
     depends_on("java@17:")
 
-    depends_on("qt@5.12:")  # Can do with 4.6:, but they themselves recommend 5.12+
+    depends_on("qt+opengl@5.12:")  # Can do with 4.6:, but they themselves recommend 5.12+
     depends_on("cuda", when="+cuda")
     depends_on("libtiff@4:")
     depends_on("fftw@3:", when="+fftw")

--- a/repos/spack_repo/builtin/packages/imod/package.py
+++ b/repos/spack_repo/builtin/packages/imod/package.py
@@ -48,6 +48,11 @@ class Imod(MakefilePackage, CudaPackage):
 
         configure = Executable("./setup")
         configure_args = ["-inst", prefix]  # Set up prefix
+        # Try to help the setup script pick the desired compiler
+        if spec.satisfies("%gcc"):
+            configure_args.extend(["-compiler", "gnu"])
+        elif spec.satisfies("%intel"):
+            configure_args.extend(["-compiler", "intel"])
         configure(*configure_args)
 
         if self.spec.satisfies("+cuda"):


### PR DESCRIPTION
### Summary from the commit messages of the 3 commits:

- Fix depends_on() for `qt`: Depend on `qt+opengl`
- Ensure that Spack-provided tcsh is used, otherwise running the csh
  scripts will either use the system csh or fail if none is available.
- Try to help the setup script pick the desired compiler, otherwise
  IMOD's internal checks seem to fail as the setup script tries to
  use Intel compilers when trying to compile with GNU compilers.