### PR TITLE
osg-ca-certs: avoid StandardVersion -> str warning

### DIFF
--- a/repos/spack_repo/builtin/packages/osg_ca_certs/package.py
+++ b/repos/spack_repo/builtin/packages/osg_ca_certs/package.py
@@ -56,9 +56,9 @@ class OsgCaCerts(Package):
     depends_on("openssl")
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        env.set("OSG_CERTS_VERSION", self.version[:2])
+        env.set("OSG_CERTS_VERSION", str(self.version[:2]))
         env.set("OUR_CERTS_VERSION", str(self.version[:2]) + "NEW")
-        env.set("IGTF_CERTS_VERSION", self.version[3:])
+        env.set("IGTF_CERTS_VERSION", str(self.version[3:]))
         env.set("CADIST", join_path(self.stage.source_path, "certificates"))
         env.set("PKG_NAME", self.spec.name)
 

--- a/repos/spack_repo/builtin/packages/osg_ca_certs/package.py
+++ b/repos/spack_repo/builtin/packages/osg_ca_certs/package.py
@@ -59,9 +59,9 @@ class OsgCaCerts(Package):
     depends_on("openssl")
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        env.set("OSG_CERTS_VERSION", self.version[:2])
+        env.set("OSG_CERTS_VERSION", str(self.version[:2]))
         env.set("OUR_CERTS_VERSION", str(self.version[:2]) + "NEW")
-        env.set("IGTF_CERTS_VERSION", self.version[3:])
+        env.set("IGTF_CERTS_VERSION", str(self.version[3:]))
         env.set("CADIST", join_path(self.stage.source_path, "certificates"))
         env.set("PKG_NAME", self.spec.name)
 


### PR DESCRIPTION
This PR fixes `osg-ca-certs` to avoid the following warning:
```
#29 230.9 > ==> Warning: /opt/spack-packages/repos/spack_repo/builtin/packages/osg_ca_certs/package.py:59: when setting environment variable OSG_CERTS_VERSION=1.141: value is of type `StandardVersion`, but `str` was expected. This is deprecated and will be an error in Spack v1.0
#29 230.9 > ==> Warning: /opt/spack-packages/repos/spack_repo/builtin/packages/osg_ca_certs/package.py:61: when setting environment variable IGTF_CERTS_VERSION=1.141: value is of type `StandardVersion`, but `str` was expected. This is deprecated and will be an error in Spack v1.0
```