### PR TITLE
expat: 2.8.2 + deprecate vulnerable 2.8.1

### DIFF
--- a/repos/spack_repo/builtin/packages/expat/package.py
+++ b/repos/spack_repo/builtin/packages/expat/package.py
@@ -19,6 +19,10 @@ class Expat(AutotoolsPackage, CMakePackage):
 
     license("MIT")
     version(
+        "2.8.2",
+        sha256="69e7f52417d85b1c2b7fe855e176eec55d0b2d7d92d691372d833a1c7df7923b",
+    )
+    version(
         "2.8.1",
         sha256="f5833dd2e1cd7739ec9182804a1a29c4f0cc7c2f26b633d3a2188b7766a88ecb",
     )

--- a/repos/spack_repo/builtin/packages/expat/package.py
+++ b/repos/spack_repo/builtin/packages/expat/package.py
@@ -22,11 +22,12 @@ class Expat(AutotoolsPackage, CMakePackage):
         "2.8.2",
         sha256="69e7f52417d85b1c2b7fe855e176eec55d0b2d7d92d691372d833a1c7df7923b",
     )
+    # deprecate all releases before 2.8.2 because of various security issues
     version(
         "2.8.1",
         sha256="f5833dd2e1cd7739ec9182804a1a29c4f0cc7c2f26b633d3a2188b7766a88ecb",
+        deprecated=True,
     )
-    # deprecate all releases before 2.8.1 because of various security issues
     version(
         "2.8.0",
         sha256="586494499ac3ad46d87f3beda7b1f770c1c8026a9b60e151593f8b29089a52ca",


### PR DESCRIPTION
Similar to #4784

Related blog post: https://blog.hartwork.org/posts/expat-2-8-2-released/


- CVE-2026-50219
- CVE-2026-56131
- CVE-2026-56132
- CVE-2026-56403
- CVE-2026-56404
- CVE-2026-56405
- CVE-2026-56406
- CVE-2026-56407
- CVE-2026-56408
- CVE-2026-56409
- CVE-2026-56410
- CVE-2026-56411
- CVE-2026-56412

CC @wdconinc