### PR TITLE
acts: cleanup the last remaining dep for the removed versions

### DIFF
--- a/repos/spack_repo/builtin/packages/acts/package.py
+++ b/repos/spack_repo/builtin/packages/acts/package.py
@@ -206,7 +206,6 @@ class Acts(CMakePackage, CudaPackage):
     depends_on("geant4", when="+geant4")
     depends_on("geomodel @6.3.0: +geomodelg4", when="+geomodel")
     depends_on("geomodel @6.8.0:", when="@43.1: +geomodel ")
-    depends_on("git-lfs", when="@12.0.0:")
     depends_on("gperftools", when="+profilecpu")
     depends_on("gperftools", when="+profilemem")
     depends_on("hepmc3 @3.2.1:", when="+hepmc3")


### PR DESCRIPTION
The initial version of this PR was opened by @wdconinc as #2333:

This PR removes the `acts` dependency on `git-lfs` entirely. The `git-lfs` dependency was originally added for versions 12–13, but support for those deprecated versions (all below `38.x.x`) has since been removed from the recipe. With no remaining versions that require `git-lfs`, the dependency is no longer needed.