### PR TITLE
Add packages needed for spack docs to build with Spack

### DIFF
--- a/repos/spack_repo/builtin/packages/py_furo/package.py
+++ b/repos/spack_repo/builtin/packages/py_furo/package.py
@@ -28,8 +28,8 @@ class PyFuro(PythonPackage):
     depends_on("py-sphinx-theme-builder@0.2.0a10:", type="build")
 
     depends_on("py-beautifulsoup4", type=("build", "run"))
-    depends_on("py-sphinx@6:7", type=("build", "run"))
-    depends_on("py-sphinx@7:10", type=("build", "run"), when="@2025.12.19:")
+    depends_on("py-sphinx@6:7", type=("build", "run"), when="@:2024.7.18")
+    depends_on("py-sphinx@7:9", type=("build", "run"), when="@2025.12.19:")
     depends_on("py-sphinx-basic-ng@1.0.0b2:", type=("build", "run"))
     depends_on("py-pygments@2.7:", type=("build", "run"))
     depends_on("py-accessible-pygments@0.0.5:", type=("build", "run"), when="@2025.07.19:")

--- a/repos/spack_repo/builtin/packages/py_sphinx_last_updated_by_git/package.py
+++ b/repos/spack_repo/builtin/packages/py_sphinx_last_updated_by_git/package.py
@@ -1,0 +1,22 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PySphinxLastUpdatedByGit(PythonPackage):
+    """Get the "last updated" time for each Sphinx page from Git."""
+
+    homepage = "https://github.com/mgeier/sphinx-last-updated-by-git/"
+    pypi = "sphinx-last-updated-by-git/sphinx_last_updated_by_git-0.3.8.tar.gz"
+
+    license("BSD-2-Clause")
+
+    version("0.3.8", sha256="c145011f4609d841805b69a9300099fc02fed8f5bb9e5bcef77d97aea97b7761")
+
+    depends_on("python@3.7:", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+    depends_on("py-sphinx@1.8:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_sphinx_sitemap/package.py
+++ b/repos/spack_repo/builtin/packages/py_sphinx_sitemap/package.py
@@ -1,0 +1,24 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PySphinxSitemap(PythonPackage):
+    """A Sphinx extension to generate multiversion and multilanguage
+    sitemaps.org compliant sitemaps for the HTML version of your Sphinx
+    documentation."""
+
+    homepage = "https://github.com/jdillard/sphinx-sitemap"
+    pypi = "sphinx-sitemap/sphinx_sitemap-2.9.0.tar.gz"
+
+    license("MIT")
+
+    version("2.9.0", sha256="70f97bcdf444e3d68e118355cf82a1f54c4d3c03d651cd17fe87398b26e25e21")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-sphinx@1.2:", type=("build", "run"))
+    depends_on("py-sphinx-last-updated-by-git", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_sphinxcontrib_svg2pdfconverter/package.py
+++ b/repos/spack_repo/builtin/packages/py_sphinxcontrib_svg2pdfconverter/package.py
@@ -1,0 +1,30 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PySphinxcontribSvg2pdfconverter(PythonPackage):
+    """Sphinx SVG to PDF or PNG converter extension.
+
+    Provides the ``sphinxcontrib.rsvgconverter`` (using rsvg-convert) and
+    ``sphinxcontrib.inkscapeconverter`` (using Inkscape) extensions, which
+    convert SVG images to PDF or PNG when building non-HTML documentation.
+    The corresponding converter binary (rsvg-convert or inkscape) must be
+    available on the PATH at run time."""
+
+    homepage = "https://github.com/missinglinkelectronics/sphinxcontrib-svg2pdfconverter"
+    pypi = "sphinxcontrib-svg2pdfconverter/sphinxcontrib_svg2pdfconverter-2.1.0.tar.gz"
+
+    license("BSD-2-Clause")
+
+    version("2.1.0", sha256="9756e82d5f3bf11629ffcbafb1f8a1092d3bb4789e33494032cdce9a9c8459d3")
+    version("2.0.0", sha256="ab9c8f1080391e231812d20abf2657a69ee35574563b1014414f953964a95fa3")
+
+    depends_on("python@3.6:", when="@2:", type=("build", "run"))
+    depends_on("py-setuptools@61:", when="@2:", type="build")
+    depends_on("py-setuptools", type="build")
+    depends_on("py-sphinx@1.6.3:", type=("build", "run"))


### PR DESCRIPTION
Add packages needed to build the Spack docs. I'm able to build the docs locally without a requirement for Inkscape using these packages.

* py-sphinx-sitemap: new package
* py-sphinxcontrib-svg2pdfconverter: new package; its sphinxcontrib.rsvgconverter extension converts SVG->PDF using rsvg-convert (from librsvg), so no external tools like inkscape are required
* py-sphinx-last-updated-by-git: new package

Also fix py-furo: the unconditional py-sphinx@6:7 dependency intersected with the @7:10 bound for 2025.12.19, pinning the latest furo to Sphinx 7. Scope the old bound to @:2024.7.18 and tighten the new one to @7:9, matching furo 2025.12.19's requirement of sphinx>=7,<10.
