### PR TITLE
py-cwl-utils: add v0.42

### DIFF
--- a/repos/spack_repo/builtin/packages/py_cwl_utils/package.py
+++ b/repos/spack_repo/builtin/packages/py_cwl_utils/package.py
@@ -18,13 +18,16 @@ class PyCwlUtils(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.42", sha256="94e585dcc3082416c657ae446804b5e60f6363045743cbd64814ed85402e3f87")
     version("0.37", sha256="7b69c948f8593fdf44b44852bd8ef94c666736ce0ac12cf6e66e2a72ad16a773")
     version("0.21", sha256="583f05010f7572f3a69310325472ccb6efc2db7f43dc6428d03552e0ffcbaaf9")
     version("0.16", sha256="38182e6dd12b039601ac2f72911b3d93ca4e37efca3b0165ffe162abab3edf7b")
 
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("python@3.8:", when="@0.29:", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
+    depends_on("python@3.10:", when="@0.42:", type=("build", "run"))
+    depends_on("py-setuptools", when="@:0.41", type="build")
+    depends_on("py-hatchling", when="@0.42:", type="build")
 
     depends_on("py-cwl-upgrader@1.2.3:", type=("build", "run"))
     depends_on("py-packaging", type=("build", "run"))
@@ -36,7 +39,9 @@ class PyCwlUtils(PythonPackage):
     # requirement
     depends_on("py-schema-salad@8.8.20250205075315:8", when="@0.32:", type=("build", "run"))
     depends_on("py-ruamel-yaml@0.17.6:0.18", when="@0.30:", type=("build", "run"))
+    depends_on("py-ruamel-yaml@0.17.6:0.19", when="@0.42:", type=("build", "run"))
     depends_on("py-typing-extensions", when="@0.37 ^python@:3.9", type=("build", "run"))
+    depends_on("py-typing-extensions@4.10.0:", when="@0.42:", type=("build", "run"))
 
     def url_for_version(self, version):
         url = "https://files.pythonhosted.org/packages/source/c/cwl-utils/cwl{}utils-{}.tar.gz"


### PR DESCRIPTION
Tested that this builds and imports
```py
Python 3.13.13 (main, Jun 25 2026, 13:36:39) [GCC 12.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import cwl_utils
>>> exit()
```
