### PR TITLE
ci: update retry conditions for generate jobs

### DIFF
--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -152,6 +152,8 @@ default:
       - runner_unsupported
       - stale_schedule
       - job_execution_timeout
+      - server_timeout_running
+      - server_timeout_canceling
       - archived_failure
       - unmet_prerequisites
       - scheduler_failure


### PR DESCRIPTION
We've recently noticed failed generate jobs not being retried when expected. After querying the GitLab API, we noticed that these jobs are now being categorized as `server_timeout_running` rather than `job_execution_timeout`.

Update the list of retry conditions for generate jobs to include everything but `script_failure`, matching the intention when this list was originally added.