### PR TITLE
set `SPACK_PREFIX_MAP_ARGS` for `-ffile-prefix-map=<stage>=.`  and `SPACK_BUILD_ID_ARGS` for  `--build-id` injection at compiler-wrapper level (companion to spack/compiler-wrapper#19)

### DIFF
--- a/repos/spack_repo/builtin/build_systems/compiler.py
+++ b/repos/spack_repo/builtin/build_systems/compiler.py
@@ -167,7 +167,11 @@ class CompilerPackage(PackageBase):
     verbose_flags: str = "-v"
     #: Flag to activate OpenMP support
     openmp_flag: str = "-fopenmp"
-
+    #: Format string for the compiler's file-prefix-remapping flag, taking
+    #: {0}=old prefix, {1}=new prefix, e.g. "-ffile-prefix-map={0}={1}".
+    #: None if the compiler has no equivalent capability.
+    file_prefix_map_arg: Optional[str] = None
+    
     implicit_rpath_libs: List[str] = []
 
     def standard_flag(self, *, language: str, standard: str) -> str:

--- a/repos/spack_repo/builtin/packages/aocc/package.py
+++ b/repos/spack_repo/builtin/packages/aocc/package.py
@@ -167,6 +167,12 @@ class Aocc(Package, LlvmDetection, CompilerPackage):
     def _fortran_path(self):
         return os.path.join(self.spec.prefix.bin, "flang")
 
+    def setup_dependent_build_environment(
+        self, env: EnvironmentModifications, dependent_spec: Spec
+    ) -> None:
+        if self.spec.satisfies("platform=linux"):
+            env.set("SPACK_BUILD_ID_ARGS", "--build-id")
+    
     compiler_version_regex = r"AOCC_(\d+[._]\d+[._]\d+)"
     fortran_names = ["flang"]
 
@@ -183,6 +189,13 @@ class Aocc(Package, LlvmDetection, CompilerPackage):
 
     opt_flags = ["-O0", "-O1", "-O2", "-O3", "-Ofast", "-Os", "-Oz", "-Og", "-O", "-O4"]
 
+    # AOCC is a Clang derivative; -ffile-prefix-map is supported across all
+    # packaged versions here (@3.2.0: is based on LLVM 13.0, well past the
+    # LLVM 10 introduction of this flag). If an older AOCC version is added
+    # to this package in the future, verify -ffile-prefix-map support before
+    # assuming it applies, earlier AOCC releases (2.x, LLVM <10) may not.
+    file_prefix_map_arg = "-ffile-prefix-map={0}={1}"
+    
     compiler_wrapper_link_paths = {
         "c": os.path.join("aocc", "clang"),
         "cxx": os.path.join("aocc", "clang++"),

--- a/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
+++ b/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
@@ -229,6 +229,16 @@ class CompilerWrapper(Package):
             extra_rpaths = dedupe(extra_rpaths)
             env.set("SPACK_COMPILER_EXTRA_RPATHS", ":".join(extra_rpaths))
 
+        # Set SPACK_DEBUG_PREFIX_MAP to the staging path
+        # Develop packages are excluded
+        if not dependent_spec.variants.get("dev_path"):
+            try:
+                staging_src = dependent_spec.package.stage.source_path
+                env.set("SPACK_DEBUG_PREFIX_MAP", staging_src)
+            except Exception:
+                # Stage not yet set up
+                pass
+
         env.set("SPACK_ENABLE_NEW_DTAGS", self.enable_new_dtags)
         env.set("SPACK_DISABLE_NEW_DTAGS", self.disable_new_dtags)
 

--- a/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
+++ b/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
@@ -1,12 +1,14 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
 import pathlib
 import shutil
 import sys
 
 from spack_repo.builtin.build_systems.generic import Package
 
+import spack.builder
 from spack.package import *
 
 
@@ -229,11 +231,22 @@ class CompilerWrapper(Package):
             extra_rpaths = dedupe(extra_rpaths)
             env.set("SPACK_COMPILER_EXTRA_RPATHS", ":".join(extra_rpaths))
 
-        # Set SPACK_DEBUG_PREFIX_MAP to the staging path
-        # Develop packages are excluded
-        if not dependent_spec.variants.get("dev_path"):
-            staging_src = dependent_spec.package.stage.source_path
-            env.set("SPACK_DEBUG_PREFIX_MAP", staging_src)
+        # Set SPACK_PREFIX_MAP and SPACK_BUILD_PREFIX_MAP, so
+        # the source tree and and the out-of-source build directory
+        # are remapped to . and ./build respectively
+        staging_src = dependent_spec.package.stage.source_path
+        env.set("SPACK_PREFIX_MAP", staging_src)
+
+        try:
+            builder = spack.builder.create(dependent_spec.package)
+            build_dir = getattr(builder, "build_directory", None)
+        except Exception:
+            build_dir = None
+
+        if build_dir and os.path.isabs(build_dir):
+            env.set("SPACK_BUILD_PREFIX_MAP", build_dir)
+        else:
+            env.set("SPACK_BUILD_PREFIX_MAP", staging_src)
 
         env.set("SPACK_ENABLE_NEW_DTAGS", self.enable_new_dtags)
         env.set("SPACK_DISABLE_NEW_DTAGS", self.disable_new_dtags)

--- a/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
+++ b/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
@@ -232,12 +232,8 @@ class CompilerWrapper(Package):
         # Set SPACK_DEBUG_PREFIX_MAP to the staging path
         # Develop packages are excluded
         if not dependent_spec.variants.get("dev_path"):
-            try:
-                staging_src = dependent_spec.package.stage.source_path
-                env.set("SPACK_DEBUG_PREFIX_MAP", staging_src)
-            except Exception:
-                # Stage not yet set up
-                pass
+            staging_src = dependent_spec.package.stage.source_path
+            env.set("SPACK_DEBUG_PREFIX_MAP", staging_src)
 
         env.set("SPACK_ENABLE_NEW_DTAGS", self.enable_new_dtags)
         env.set("SPACK_DISABLE_NEW_DTAGS", self.disable_new_dtags)

--- a/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
+++ b/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
@@ -166,6 +166,7 @@ class CompilerWrapper(Package):
         bin_dir = self.bin_dir()
         implicit_rpaths, env_paths = [], []
         extra_rpaths = []
+        prefix_map_arg = None
         for language, attr_name, wrapper_var_name, spack_var_name in _var_list:
             compiler_pkg = dependent_spec[language].package
             if not hasattr(compiler_pkg, attr_name):

--- a/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
+++ b/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
@@ -255,6 +255,9 @@ class CompilerWrapper(Package):
                     "SPACK_BUILD_PREFIX_MAP_ARGS", prefix_map_arg.format(build_dir, "./build")
                     )
 
+        env.set("SPACK_ENABLE_NEW_DTAGS", self.enable_new_dtags)
+        env.set("SPACK_DISABLE_NEW_DTAGS", self.disable_new_dtags)
+                
         for item in env_paths:
             env.prepend_path("SPACK_COMPILER_WRAPPER_PATH", item)
 

--- a/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
+++ b/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
@@ -178,6 +178,9 @@ class CompilerWrapper(Package):
             if compiler_pkg.name == "gcc" and self.spec.satisfies("@1.1:"):
                 env.set(f"SPACK_{wrapper_var_name}_HAS_FRANDOM_SEED", "1")
 
+            if getattr(compiler_pkg, "file_prefix_map_arg", None):
+                prefix_map_arg = compiler_pkg.file_prefix_map_arg
+                
             if language not in compiler_pkg.compiler_wrapper_link_paths:
                 continue
 
@@ -231,25 +234,25 @@ class CompilerWrapper(Package):
             extra_rpaths = dedupe(extra_rpaths)
             env.set("SPACK_COMPILER_EXTRA_RPATHS", ":".join(extra_rpaths))
 
-        # Set SPACK_PREFIX_MAP and SPACK_BUILD_PREFIX_MAP, so
-        # the source tree and and the out-of-source build directory
-        # are remapped to . and ./build respectively
-        staging_src = dependent_spec.package.stage.source_path
-        env.set("SPACK_PREFIX_MAP", staging_src)
+        # If (at least one of) the compiler(s) used for this build supports a
+        # file-prefix-remapping flag, emit the full flag(s) so the source tree
+        # and the out-of-source build directory are remapped to . and ./build
+        # respectively. Compilers without this capability (file_prefix_map_arg
+        # is None) get no flag at all, rather than a broken/rejected one.
+        if prefix_map_arg:
+            staging_src = dependent_spec.package.stage.source_path
+            env.set("SPACK_PREFIX_MAP_ARGS", prefix_map_arg.format(staging_src, "."))
 
-        try:
-            builder = spack.builder.create(dependent_spec.package)
-            build_dir = getattr(builder, "build_directory", None)
-        except Exception:
-            build_dir = None
+            try:
+                builder = spack.builder.create(dependent_spec.package)
+                build_dir = getattr(builder, "build_directory", None)
+            except Exception:
+                build_dir = None
 
-        if build_dir and os.path.isabs(build_dir):
-            env.set("SPACK_BUILD_PREFIX_MAP", build_dir)
-        else:
-            env.set("SPACK_BUILD_PREFIX_MAP", staging_src)
-
-        env.set("SPACK_ENABLE_NEW_DTAGS", self.enable_new_dtags)
-        env.set("SPACK_DISABLE_NEW_DTAGS", self.disable_new_dtags)
+            if build_dir and os.path.isabs(build_dir) and build_dir != staging_src:
+                env.set(
+                    "SPACK_BUILD_PREFIX_MAP_ARGS", prefix_map_arg.format(build_dir, "./build")
+                    )
 
         for item in env_paths:
             env.prepend_path("SPACK_COMPILER_WRAPPER_PATH", item)

--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -1149,6 +1149,15 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
             env.set("FC", self.fortran)
             env.set("F77", self.fortran)
 
+    def setup_dependent_build_environment(
+        self, env: EnvironmentModifications, dependent_spec: Spec
+    ) -> None:
+        # Enable GNU build-id notes for debuginfo auto-discovery (ELF platforms
+        # only; not supported by Darwin's linker).
+        print(f">>> GCC setup_dependent_build_environment CALLED for {dependent_spec.name}")
+        if self.spec.satisfies("platform=linux"):
+            env.set("SPACK_BUILD_ID_ARGS", "--build-id")
+            
     def detect_gdc(self):
         """Detect and return the path to GDC that belongs to the same instance of GCC that is used
         by self.compiler.

--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -1154,7 +1154,6 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     ) -> None:
         # Enable GNU build-id notes for debuginfo auto-discovery (ELF platforms
         # only; not supported by Darwin's linker).
-        print(f">>> GCC setup_dependent_build_environment CALLED for {dependent_spec.name}")
         if self.spec.satisfies("platform=linux"):
             env.set("SPACK_BUILD_ID_ARGS", "--build-id")
             

--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -1055,6 +1055,12 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         spec_dir = glob.glob(f"{self.prefix.lib}/gcc/*/*")
         return spec_dir[0] if spec_dir else None
 
+    @property
+    def file_prefix_map_arg(self):
+        if self.spec.satisfies("@8:"):
+            return "-ffile-prefix-map={0}={1}"
+        return None
+
     @run_after("install")
     def write_specs_file(self):
         """(1) inject an rpath to its runtime library dir, (2) add a default programs search path

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
@@ -539,6 +539,10 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
         self, env: EnvironmentModifications, dependent_spec: Spec
     ) -> None:
         super().setup_dependent_build_environment(env, dependent_spec)
+
+        if self.spec.satisfies("platform=linux"):
+            env.set("SPACK_BUILD_ID_ARGS", "--build-id")
+
         # workaround bug in icpx driver where it requires sycl-post-link is on the PATH
         # It is located in the same directory as the driver. Error message:
         #   clang++: error: unable to execute command:

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
@@ -404,6 +404,8 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
 
     openmp_flag = "-fiopenmp"
 
+    file_prefix_map_arg = "-ffile-prefix-map={0}={1}"
+
     compiler_wrapper_link_paths = {
         "c": os.path.join("oneapi", "icx"),
         "cxx": os.path.join("oneapi", "icpx"),

--- a/repos/spack_repo/builtin/packages/llvm/package.py
+++ b/repos/spack_repo/builtin/packages/llvm/package.py
@@ -704,6 +704,12 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
             languages.append("fortran")
         return languages
 
+    @property
+    def file_prefix_map_arg(self):
+        if self.spec.satisfies("@10: +clang"):
+            return "-ffile-prefix-map={0}={1}"
+        return None
+
     @classproperty
     def executables(cls):
         return super().executables + [r"^ld\.lld(-\d+)?$", r"^lldb(-\d+)?$"]

--- a/repos/spack_repo/builtin/packages/llvm/package.py
+++ b/repos/spack_repo/builtin/packages/llvm/package.py
@@ -921,6 +921,12 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
             env.set("FC", join_path(self.spec.prefix.bin, "flang"))
             env.set("F77", join_path(self.spec.prefix.bin, "flang"))
 
+    def setup_dependent_build_environment(
+        self, env: EnvironmentModifications, dependent_spec: Spec
+     ) -> None:
+        if self.spec.satisfies("platform=linux"):
+            env.set("SPACK_BUILD_ID_ARGS", "--build-id")
+
     root_cmakelists_dir = "llvm"
 
     def cmake_args(self):

--- a/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
+++ b/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
@@ -38,6 +38,8 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
 
     stdcxx_libs = ("-lstdc++",)
 
+    file_prefix_map_arg = "-ffile-prefix-map={0}={1}"
+
     generator("ninja")
 
     maintainers("srekolam", "renjithravindrankannath", "haampie", "afzpatel")
@@ -484,6 +486,9 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
     def setup_dependent_build_environment(
         self, env: EnvironmentModifications, dependent_spec: Spec
     ) -> None:
+        if self.spec.satisfies("platform=linux"):
+            env.set("SPACK_BUILD_ID_ARGS", "--build-id")
+
         for root, _, files in os.walk(self.prefix):
             if "libclang_rt.asan-x86_64.so" in files:
                 env.prepend_path("LD_LIBRARY_PATH", root)


### PR DESCRIPTION
This PR sets `SPACK_DEBUG_PREFIX_MAP` in `setup_dependent_build_environment` (in `repos/spack_repo/builtin/packages/compiler_wrapper/package.py`) to the staging source path of the package being compiled. `cc.sh` in `compiler-wrapper` repo reads this variable and injects `-ffile-prefix-map=<staging>=.`,  normalizing DWARF paths for build reproducibility.  `develop`-based packages are excluded.

This PR is a companion to https://github.com/spack/compiler-wrapper/pull/19