### PR TITLE
ants: add v2.6.5

### DIFF
--- a/repos/spack_repo/builtin/packages/ants/package.py
+++ b/repos/spack_repo/builtin/packages/ants/package.py
@@ -21,6 +21,7 @@ class Ants(CMakePackage):
     url = "https://github.com/ANTsX/ANTs/archive/v2.2.0.tar.gz"
 
     version("master", branch="master")
+    version("2.6.5", sha256="c089cb8deac83cad51605299f38c418fdf2023c2e4d924cf4ccbe1a6f376740f")
     version("2.5.1", sha256="8e3a7c0d3dab05883cba466aff262d78d832f679491318b94ce49b606565cebe")
     version("2.4.3", sha256="13ba78917aca0b20e69f4c43da607f8fe8c810edba23b6f5fd64fbd81b70a79a")
     version("2.4.0", sha256="a8ff78f4d2b16e495f340c9b0647f56c92cc4fc40b6ae04a60b941e5e239f9be")


### PR DESCRIPTION
Adds ANTs 2.6.5 (released 2026-01-14).

- sha256 verified against the upstream tag tarball (`https://github.com/ANTsX/ANTs/archive/v2.6.5.tar.gz`).
- Builds and installs from source locally (the bundled ITK superbuild + ANTs); the installed `antsRegistration --version` reports `ANTs Version: 2.6.5`.
- No other recipe changes required — nothing in the recipe is version-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
