### PR TITLE
py-pycparser: more recent setuptools is needed

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pycparser/package.py
+++ b/repos/spack_repo/builtin/packages/py_pycparser/package.py
@@ -27,7 +27,7 @@ class PyPycparser(PythonPackage):
     with default_args(type="build"):
         depends_on("c")
 
-        depends_on("py-setuptools@69:", when="@3:")
+        depends_on("py-setuptools@77:", when="@3:")
         depends_on("py-setuptools")
 
     with default_args(type=("build", "run")):

--- a/repos/spack_repo/builtin/packages/py_pycparser/package.py
+++ b/repos/spack_repo/builtin/packages/py_pycparser/package.py
@@ -27,6 +27,9 @@ class PyPycparser(PythonPackage):
     with default_args(type="build"):
         depends_on("c")
 
+        # Upstream repo indicates py-setuptools@69, but a newer version
+        # is required to compile this package.
+        # See: https://github.com/spack/spack-packages/pull/5356
         depends_on("py-setuptools@77:", when="@3:")
         depends_on("py-setuptools")
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Anything below `setuptools@:76` gives the following error for me:

```

tbouvier@login02:/path$ spack install py-pycparser ^py-setuptools@76
[+] yhlpoux py-setuptools@76.1.0 /path/spack/opt/spack/linux-icelake/py-setuptools-76.1.0-yhlpouxdoqqrn4zxcx3ospxkn2jxbnau (6s)
[x] oyvvalh py-pycparser@3.0 failed: /scratch_local/tbouvier/spack-stage/spack-stage-py-pycparser-3.0-oyvvalhbptdwcayxxzufzmnvdl65ae4j-qbv_j35e.log (2s)
-- lines 116 to 128 --
    ╰─> No available output.
  
    note: This error originates from a subprocess, and is likely not a problem with pip.
    full command: /path/spack/opt/spack/linux-icelake/python-venv-1.0-a4rlqmn6faaj7fh54gtcp44je5khnswd/bin/python3 /path/spack/opt/spack/linux-icelake/py-pip-26.1.2-efdnmxipcxu6twcpxwnk3xlnieamgcbs/lib/python3.13/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py prepare_metadata_for_build_wheel /scratch_local/tmp13r0pdvy
    cwd: /scratch_local/tbouvier/spack-stage/spack-stage-py-pycparser-3.0-oyvvalhbptdwcayxxzufzmnvdl65ae4j/spack-src
    Preparing metadata (pyproject.toml): finished with status 'error'
> error: metadata-generation-failed
  
  × Encountered error while generating package metadata.
  ╰─> from file:///scratch_local/tbouvier/spack-stage/spack-stage-py-pycparser-3.0-oyvvalhbptdwcayxxzufzmnvdl65ae4j/spack-src
  
  note: This is an issue with the package mentioned above, not pip.
  hint: See above for details.
-- lines 252 to 271 --
      self.req.prepare_metadata()
      ~~~~~~~~~~~~~~~~~~~~~~~~~^^
    File "/path/spack/opt/spack/linux-icelake/py-pip-26.1.2-efdnmxipcxu6twcpxwnk3xlnieamgcbs/lib/python3.13/site-packages/pip/_internal/req/req_install.py", line 540, in prepare_metadata
      self.metadata_directory = generate_metadata(
                                ~~~~~~~~~~~~~~~~~^
          build_env=self.build_env,
          ^^^^^^^^^^^^^^^^^^^^^^^^^
          backend=self.pep517_backend,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          details=details,
          ^^^^^^^^^^^^^^^^
      )
      ^
    File "/path/spack/opt/spack/linux-icelake/py-pip-26.1.2-efdnmxipcxu6twcpxwnk3xlnieamgcbs/lib/python3.13/site-packages/pip/_internal/operations/build/metadata.py", line 36, in generate_metadata
      raise MetadataGenerationFailed(package_details=details) from error
  pip._internal.exceptions.MetadataGenerationFailed: metadata generation failed
  Removed file:///scratch_local/tbouvier/spack-stage/spack-stage-py-pycparser-3.0-oyvvalhbptdwcayxxzufzmnvdl65ae4j/spack-src from build tracker '/scratch_local/pip-build-tracker-m0889uw2'
  Removed build tracker: '/scratch_local/pip-build-tracker-m0889uw2'
  Command exited with status 1:
      /path/spack/opt/spack/linux-icelake/python-venv-1.0-a4rlqmn6faaj7fh54gtcp44je5khnswd/bin/python3 -m pip -vvv --no-input --no-cache-dir --disable-pip-version-check install --no-deps --ignore-installed --no-build-isolation --no-warn-script-location --no-index --prefix=/path/spack/opt/spack/linux-icelake/py-pycparser-3.0-oyvvalhbptdwcayxxzufzmnvdl65ae4j .
==> Error: The following packages failed to install:
```

Installation is successful with `setuptools@77:` on my system:

```
tbouvier@login02:/path$ spack install py-pycparser ^py-setuptools@77
[+] ylbsids py-setuptools@77.0.3 /path/spack/opt/spack/linux-icelake/py-setuptools-77.0.3-ylbsidsklreirlchjr2b32sekvjiribr (6s)
[+] wpwp3od py-pycparser@3.0 /path/spack/opt/spack/linux-icelake/py-pycparser-3.0-wpwp3odwzyzzd4k7wgsl5xlloiszzcz6 (3s)
```