### PR TITLE
osg-ca-certs: depends on gmake and perl, type build

### DIFF
--- a/repos/spack_repo/builtin/packages/osg_ca_certs/package.py
+++ b/repos/spack_repo/builtin/packages/osg_ca_certs/package.py
@@ -53,6 +53,9 @@ class OsgCaCerts(Package):
         destination="letsencrypt-certificates-master",
     )
 
+    depends_on("gmake", type="build")
+    depends_on("perl", type="build")
+
     depends_on("openssl")
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:


### PR DESCRIPTION
This adds to `osg-ca-certs` the build dependencies `gmake` and `perl`, which are needed by the build script, https://github.com/opensciencegrid/osg-certificates/blob/master/build-certificates-dir.sh.
