### PR TITLE
py-pynacl: depends on gmake, type build

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pynacl/package.py
+++ b/repos/spack_repo/builtin/packages/py_pynacl/package.py
@@ -17,7 +17,8 @@ class PyPynacl(PythonPackage):
     version("1.5.0", sha256="8ac7448f09ab85811607bdd21ec2464495ac8b7c66d146bf545b0f08fb9220ba")
     version("1.4.0", sha256="54e9a2c849c742006516ad56a88f5c74bf2ce92c9f67435187c3c5953b346505")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("gmake", type="build")
 
     depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
     depends_on("python@3.6:", type=("build", "run"), when="@1.5.0:")


### PR DESCRIPTION
This PR adds to `py-pynacl`, the build dependency on `gmake`, as called from python in https://github.com/pyca/pynacl/blob/main/setup.py#L122 and used for libsodium in https://github.com/pyca/pynacl/blob/main/src/libsodium/Makefile.in. Fixes #5106.