### PR TITLE
admixtools: fix makefile.filter call to use literal matching

### DIFF
--- a/repos/spack_repo/builtin/packages/admixtools/package.py
+++ b/repos/spack_repo/builtin/packages/admixtools/package.py
@@ -38,7 +38,7 @@ class Admixtools(MakefilePackage):
 
         makefile.filter(
             "override LDLIBS += -lgsl -lopenblas -lm -lnick",
-            "override LDLIBS += -lgsl -lm -lnick " + lapackflags,
+            "override LDLIBS += -lgsl -lm -lnick " + lapackflags, string=True
         )
 
         makefile.filter("TOP=../bin", "TOP=./bin")

--- a/repos/spack_repo/builtin/packages/admixtools/package.py
+++ b/repos/spack_repo/builtin/packages/admixtools/package.py
@@ -50,7 +50,7 @@ class Admixtools(MakefilePackage):
 
         makefile.filter(
             "override LDLIBS += -lgsl -lopenblas -lm -lnick",
-            "override LDLIBS += -lgsl -lm -lnick " + lapackflags,
+            "override LDLIBS += -lgsl -lm -lnick " + lapackflags, string=True
         )
 
         makefile.filter("HOMEL=$(PWD)", "HOMEL=$(CURDIR)", string=True)

--- a/repos/spack_repo/builtin/packages/admixtools/package.py
+++ b/repos/spack_repo/builtin/packages/admixtools/package.py
@@ -50,7 +50,8 @@ class Admixtools(MakefilePackage):
 
         makefile.filter(
             "override LDLIBS += -lgsl -lopenblas -lm -lnick",
-            "override LDLIBS += -lgsl -lm -lnick " + lapackflags, string=True
+            "override LDLIBS += -lgsl -lm -lnick " + lapackflags,
+            string=True,
         )
 
         makefile.filter("HOMEL=$(PWD)", "HOMEL=$(CURDIR)", string=True)


### PR DESCRIPTION
`admixtools` Makefile hardcodes `-lopenblas`. Presently, the recipe already tries to fix this by calling
```python
        lapackflags = spec["lapack"].libs.ld_flags

        makefile.filter(
            "override LDLIBS += -lgsl -lopenblas -lm -lnick",
            "override LDLIBS += -lgsl -lm -lnick " + lapackflags
        )
```
in `edit`. Yet this alone does not work:
```sh
$ spack install admixtools "^[virtuals=lapack] intel-oneapi-mkl"
```
still fails with multiple `/usr/bin/ld: cannot find -lopenblas: No such file or directory`.

The string that the filter attempts to match is a literal string rather than a regex: ` +=` must match literally rather than as "at least one space then `=`".

The fix in this PR allows the aforementioned command to run successfully.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
