### PR TITLE
py-wrapt: more recent setuptools is needed

### DIFF
--- a/repos/spack_repo/builtin/packages/py_wrapt/package.py
+++ b/repos/spack_repo/builtin/packages/py_wrapt/package.py
@@ -28,7 +28,7 @@ class PyWrapt(PythonPackage):
     with default_args(type="build"):
         depends_on("c")
 
-        depends_on("py-setuptools@62:", when="@2.1:")
+        depends_on("py-setuptools@77:", when="@2.1:")
         depends_on("py-setuptools@38.3:")
 
     with default_args(type=("build", "run")):

--- a/repos/spack_repo/builtin/packages/py_wrapt/package.py
+++ b/repos/spack_repo/builtin/packages/py_wrapt/package.py
@@ -28,6 +28,9 @@ class PyWrapt(PythonPackage):
     with default_args(type="build"):
         depends_on("c")
 
+        # Upstream repo indicates py-setuptools@62, but a newer version
+        # is required to compile this package.
+        # See: https://github.com/spack/spack-packages/pull/5365
         depends_on("py-setuptools@77:", when="@2.1:")
         depends_on("py-setuptools@38.3:")
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Similarly to https://github.com/spack/spack-packages/pull/5356, anything below setuptools@:76 gives the following error for me:

```
tbouvier@login02:/path$ spack install py-wrapt ^py-setuptools@76
[x] slrtaig py-wrapt@2.1.2 failed: /scratch_local/tbouvier/spack-stage/spack-stage-py-wrapt-2.1.2-slrtaig4jyfrjqgz5ahsogqrwglbsvy6-3e3adzgx.log (11s)
-- lines 116 to 128 --
    ╰─> No available output.
  
    note: This error originates from a subprocess, and is likely not a problem with pip.
    full command: /path/spack/opt/spack/linux-icelake/python-venv-1.0-a4rlqmn6faaj7fh54gtcp44je5khnswd/bin/python3 /path/spack/opt/spack/linux-icelake/py-pip-26.1.2-efdnmxipcxu6twcpxwnk3xlnieamgcbs/lib/python3.13/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py prepare_metadata_for_build_wheel /scratch_local/tmpq9tlb7dr
    cwd: /scratch_local/tbouvier/spack-stage/spack-stage-py-wrapt-2.1.2-slrtaig4jyfrjqgz5ahsogqrwglbsvy6/spack-src
    Preparing metadata (pyproject.toml): finished with status 'error'
> error: metadata-generation-failed
  
  × Encountered error while generating package metadata.
  ╰─> from file:///scratch_local/tbouvier/spack-stage/spack-stage-py-wrapt-2.1.2-slrtaig4jyfrjqgz5ahsogqrwglbsvy6/spack-src
  
  note: This is an issue with the package mentioned above, not pip.
  hint: See above for details.
-- lines 252 to 271 --
      self.req.prepare_metadata()
      ~~~~~~~~~~~~~~~~~~~~~~~~~^^
    File "/path/spack/opt/spack/linux-icelake/py-pip-26.1.2-efdnmxipcxu6twcpxwnk3xlnieamgcbs/lib/python3.13/site-packages/pip/_internal/req/req_install.py", line 540, in prepare_metadata
      self.metadata_directory = generate_metadata(
                                ~~~~~~~~~~~~~~~~~^
          build_env=self.build_env,
          ^^^^^^^^^^^^^^^^^^^^^^^^^
          backend=self.pep517_backend,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          details=details,
          ^^^^^^^^^^^^^^^^
      )
      ^
    File "/path/spack/opt/spack/linux-icelake/py-pip-26.1.2-efdnmxipcxu6twcpxwnk3xlnieamgcbs/lib/python3.13/site-packages/pip/_internal/operations/build/metadata.py", line 36, in generate_metadata
      raise MetadataGenerationFailed(package_details=details) from error
  pip._internal.exceptions.MetadataGenerationFailed: metadata generation failed
  Removed file:///scratch_local/tbouvier/spack-stage/spack-stage-py-wrapt-2.1.2-slrtaig4jyfrjqgz5ahsogqrwglbsvy6/spack-src from build tracker '/scratch_local/pip-build-tracker-oepi9vz6'
  Removed build tracker: '/scratch_local/pip-build-tracker-oepi9vz6'
  Command exited with status 1:
      /path/spack/opt/spack/linux-icelake/python-venv-1.0-a4rlqmn6faaj7fh54gtcp44je5khnswd/bin/python3 -m pip -vvv --no-input --no-cache-dir --disable-pip-version-check install --no-deps --ignore-installed --no-build-isolation --no-warn-script-location --no-index --prefix=/path/spack/opt/spack/linux-icelake/py-wrapt-2.1.2-slrtaig4jyfrjqgz5ahsogqrwglbsvy6 .
==> Error: The following packages failed to install:
py-wrapt@2.1.2/slrtaig4jyfrjqgz5ahsogqrwglbsvy6: /scratch_local/tbouvier/spack-stage/spack-stage-py-wrapt-2.1.2-slrtaig4jyfrjqgz5ahsogqrwglbsvy6-3e3adzgx.log
```

Installation is successful with `setuptools@77:` on my system:

```
tbouvier@login02:/path$ spack install py-wrapt ^py-setuptools@77
[+] 2cjwopx py-wrapt@2.1.2 /path/spack/opt/spack/linux-icelake/py-wrapt-2.1.2-2cjwopxdbhazvdz6gizic2rijfj7ejqm
```