### PR TITLE
Vecgeom: new version v2.1.0

### DIFF
--- a/repos/spack_repo/builtin/packages/veccore/package.py
+++ b/repos/spack_repo/builtin/packages/veccore/package.py
@@ -24,17 +24,61 @@ class Veccore(CMakePackage):
 
     version("master", branch="master")
     version("0.8.2", sha256="1268bca92acf00acd9775f1e79a2da7b1d902733d17e283e0dd5e02c41ac9666")
-    version("0.8.1", sha256="7d7983947c2c6faa55c908b3a968f19f96f4d5c909447c536de30c34b439e008")
-    version("0.8.0", sha256="2f8e49f2b609bf15a776026fbec899b3d5d4ba30f033d4fdac4b07a5220a4fd3")
-    version("0.7.0", sha256="61d9fc4be815c5c98088c2796763d3ed82ba4bad5a69b7892c1c2e7e1e53d311")
-    version("0.6.0", sha256="db404d745906efec2a76175995e847af9174df5a8da1e5ccdb241c773d7c8df9")
-    version("0.5.2", sha256="6c8740342bfa1d9c6ef55a19f57b95674a94e5f9ea156e9b329635718b0b4049")
-    version("0.5.1", sha256="20f4ab8f599b9d12becc3e27e8dbb0f4ec0aa2de958053eb550020a9c95a6d62")
-    version("0.5.0", sha256="5b52205c1213574fa43d6362b60b0e16239035cf64106f8841d7beb7e32bdd03")
-    version("0.4.2", sha256="79f418e466c211d0a5ff1d9127a82d84bceefe5321878cd37e77f50bc91f4cc2")
-    version("0.4.1", sha256="59ffe668c061acde89afb33749f4eb8bab35dd5f6e51f632758794c1a745aabf")
-    version("0.4.0", sha256="0a38b958c92647c30b5709d17edaf39d241b92b988f1040c0fbe24932b42927e")
-    version("0.3.2", sha256="d72b03df00f5e94b2d07f78ab3af6d9d956c19e9a1fae07267b48f6fc8d7713f")
+    version(
+        "0.8.1",
+        sha256="7d7983947c2c6faa55c908b3a968f19f96f4d5c909447c536de30c34b439e008",
+        deprecated=True,
+    )
+    version(
+        "0.8.0",
+        sha256="2f8e49f2b609bf15a776026fbec899b3d5d4ba30f033d4fdac4b07a5220a4fd3",
+        deprecated=True,
+    )
+    version(
+        "0.7.0",
+        sha256="61d9fc4be815c5c98088c2796763d3ed82ba4bad5a69b7892c1c2e7e1e53d311",
+        deprecated=True,
+    )
+    version(
+        "0.6.0",
+        sha256="db404d745906efec2a76175995e847af9174df5a8da1e5ccdb241c773d7c8df9",
+        deprecated=True,
+    )
+    version(
+        "0.5.2",
+        sha256="6c8740342bfa1d9c6ef55a19f57b95674a94e5f9ea156e9b329635718b0b4049",
+        deprecated=True,
+    )
+    version(
+        "0.5.1",
+        sha256="20f4ab8f599b9d12becc3e27e8dbb0f4ec0aa2de958053eb550020a9c95a6d62",
+        deprecated=True,
+    )
+    version(
+        "0.5.0",
+        sha256="5b52205c1213574fa43d6362b60b0e16239035cf64106f8841d7beb7e32bdd03",
+        deprecated=True,
+    )
+    version(
+        "0.4.2",
+        sha256="79f418e466c211d0a5ff1d9127a82d84bceefe5321878cd37e77f50bc91f4cc2",
+        deprecated=True,
+    )
+    version(
+        "0.4.1",
+        sha256="59ffe668c061acde89afb33749f4eb8bab35dd5f6e51f632758794c1a745aabf",
+        deprecated=True,
+    )
+    version(
+        "0.4.0",
+        sha256="0a38b958c92647c30b5709d17edaf39d241b92b988f1040c0fbe24932b42927e",
+        deprecated=True,
+    )
+    version(
+        "0.3.2",
+        sha256="d72b03df00f5e94b2d07f78ab3af6d9d956c19e9a1fae07267b48f6fc8d7713f",
+        deprecated=True,
+    )
 
     variant("vc", default=False, description="Enable Vc backend")
 

--- a/repos/spack_repo/builtin/packages/vecgeom/package.py
+++ b/repos/spack_repo/builtin/packages/vecgeom/package.py
@@ -32,6 +32,11 @@ class Vecgeom(CMakePackage, CudaPackage):
 
     version("master", branch="master", get_full_repo=True)
     version(
+        "2.1.0",
+        url="https://gitlab.cern.ch/-/project/981/uploads/d62c7f4aa01ad0cec96ed939fd2fc4ce/VecGeom-v2.1.0.tar.gz",
+        sha256="d23335472562cd97a61f21f5bde2361acda8cf50951c1b384981511ad43c99c9",
+    )
+    version(
         "2.0.0",
         url="https://gitlab.cern.ch/-/project/981/uploads/d2ae816669e324d5828c16857b307372/VecGeom-v2.0.0.tar.gz",
         sha256="f5fb455b2a2a5f386e171a621d0e95908ab6269803c4b186861849e8c88e8350",

--- a/repos/spack_repo/builtin/packages/vecgeom/package.py
+++ b/repos/spack_repo/builtin/packages/vecgeom/package.py
@@ -57,7 +57,6 @@ class Vecgeom(CMakePackage, CudaPackage):
         "1.2.11",
         url="https://gitlab.cern.ch/-/project/981/uploads/f2a483a4a073fac560714280e0e223ec/VecGeom-v1.2.11.tar.gz",
         sha256="0e251b0c6d79401e49cd2137a32b499ce3857045683d1fc8b6cd3b527247a3ef",
-        preferred=True,
     )
     version(
         "1.2.10",


### PR DESCRIPTION
- [release notes](https://gitlab.cern.ch/VecGeom/VecGeom/-/releases/v2.1.0)
- deprecated ancient veccore versions (v0.8.2. has been preferred for a long time by vecgeom)
- unmark 1.x as preferred