### PR TITLE
petsc, py-petsc4py: add v3.25.3

### DIFF
--- a/repos/spack_repo/builtin/packages/petsc/package.py
+++ b/repos/spack_repo/builtin/packages/petsc/package.py
@@ -24,6 +24,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     tags = ["e4s"]
 
     version("main", branch="main")
+    version("3.25.3", sha256="95ce60df2c7f9c5044d6a544c41e996a512557f91df1a60bdb690b332904ebb5")
     version("3.25.2", sha256="03fbcfb72e28dbd92eac042faf7a4ba7e75e602fd1c9af0676f78e0a762412ec")
     version("3.25.1", sha256="d9d9518110aea1f8f5444985cc1a95273ab140cdbcd2c2038c6309a3b611abb4")
     version("3.25.0", sha256="dc1c018c16bd9dcf40596959875725edb4ba8b854a0b67bbce62a0d4be1bd3be")

--- a/repos/spack_repo/builtin/packages/py_petsc4py/package.py
+++ b/repos/spack_repo/builtin/packages/py_petsc4py/package.py
@@ -21,6 +21,7 @@ class PyPetsc4py(PythonPackage):
     license("BSD-2-Clause")
 
     version("main", branch="main")
+    version("3.25.3", sha256="4bed8d503e223e1be2ec8c298dfbe7d8262c41c2e95d920ce756a57979bb9963")
     version("3.25.2", sha256="dc1bcd7ccb367e9f76dcf6dd83a9c74426049003d3debc5a748618816b3d27bb")
     version("3.25.1", sha256="2cddfe810dd975988e350f821a15e657e88b7fc796c091b54040921ba2f6dce3")
     version("3.25.0", sha256="8eafd133adbb22a6b7cd963f5eb03f86d959b832c7e5843704caba29b79c5659")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
