### PR TITLE
rsync: add v3.4.4

### DIFF
--- a/repos/spack_repo/builtin/packages/rsync/package.py
+++ b/repos/spack_repo/builtin/packages/rsync/package.py
@@ -19,6 +19,7 @@ class Rsync(AutotoolsPackage):
 
     executables = ["^rsync$"]
 
+    version("3.4.4", sha256="bd88cf82fa653da32314fb229136407c5c90f80d1758d8f4b091767877d8fa96")
     version("3.4.3", sha256="c72e63ca3021cbc80ba86ec30102773f4c5631fbc492b52e773b3958f82a53d3")
     version("3.4.2", sha256="ff10aa2c151cd4b2dbbe6135126dbc854046113d2dfb49572a348233267eb315")
     version("3.4.1", sha256="2924bcb3a1ed8b551fc101f740b9f0fe0a202b115027647cf69850d65fd88c52")


### PR DESCRIPTION
Adding rsync v3.4.4, the latest patch release.