### PR TITLE
oomph, ghex: add nccl variant

### DIFF
--- a/repos/spack_repo/builtin/packages/ghex/package.py
+++ b/repos/spack_repo/builtin/packages/ghex/package.py
@@ -51,7 +51,7 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("oomph")
     for backend in backends:
         depends_on(f"oomph backend={backend}", when=f"backend={backend}")
-    requires("@0.7:", when="backend=nccl")
+    requires("@0.8:", when="backend=nccl")
     depends_on("oomph+cuda", when="+cuda")
     depends_on("oomph+rocm", when="+rocm")
     depends_on("oomph~rocm~cuda", when="~rocm~cuda")

--- a/repos/spack_repo/builtin/packages/ghex/package.py
+++ b/repos/spack_repo/builtin/packages/ghex/package.py
@@ -34,7 +34,7 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("ninja", type="build")
 
-    backends = ("mpi", "ucx", "libfabric")
+    backends = ("mpi", "ucx", "libfabric", "nccl")
     variant(
         "backend", default="mpi", description="Transport backend", values=backends, multi=False
     )
@@ -51,6 +51,7 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("oomph")
     for backend in backends:
         depends_on(f"oomph backend={backend}", when=f"backend={backend}")
+    requires("@0.7:", when="backend=nccl")
     depends_on("oomph+cuda", when="+cuda")
     depends_on("oomph+rocm", when="+rocm")
     depends_on("oomph~rocm~cuda", when="~rocm~cuda")

--- a/repos/spack_repo/builtin/packages/oomph/package.py
+++ b/repos/spack_repo/builtin/packages/oomph/package.py
@@ -35,7 +35,7 @@ class Oomph(CMakePackage):
     variant("cuda", default=False, description="Enable CUDA support")
     variant("rocm", default=False, description="Enable ROCm support")
 
-    backends = ("mpi", "ucx", "libfabric")
+    backends = ("mpi", "ucx", "libfabric", "nccl")
     variant(
         "backend", default="mpi", description="Transport backend", values=backends, multi=False
     )
@@ -87,6 +87,9 @@ class Oomph(CMakePackage):
         )
         for provider in libfabric_providers:
             depends_on(f"libfabric fabrics={provider}", when=f"libfabric-provider={provider}")
+
+    requires("@0.6:", when="backend=nccl")
+    depends_on("nccl", when="backend=nccl")
 
     depends_on("mpi")
     depends_on("boost+thread")


### PR DESCRIPTION
Adds a `nccl` option to the `backend` variants of oomph and ghex. Similar to #4754, adding this for the next, currently unreleased, versions of ghex and oomph so that I can use this PR on the PRs that add NCCL support and make the new releases.