### PR TITLE
py-throttler: add v1.2.3

### DIFF
--- a/repos/spack_repo/builtin/packages/py_throttler/package.py
+++ b/repos/spack_repo/builtin/packages/py_throttler/package.py
@@ -17,6 +17,9 @@ class PyThrottler(PythonPackage):
 
     license("MIT")
 
+    version("1.2.3", sha256="d2f5b0b499d62f1fc984dcac8043450b606549b0097753a9c8a707f7427c27e1")
     version("1.2.2", sha256="d54db406d98e1b54d18a9ba2b31ab9f093ac64a0a59d730c1cf7bb1cdfc94a58")
 
-    depends_on("py-setuptools@:81", type="build")
+    dpeends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@61:", type="build", when="@1.2.3:")
+    depends_on("py-setuptools@:81", type="build", when="@:1.2.2")

--- a/repos/spack_repo/builtin/packages/py_throttler/package.py
+++ b/repos/spack_repo/builtin/packages/py_throttler/package.py
@@ -20,6 +20,6 @@ class PyThrottler(PythonPackage):
     version("1.2.3", sha256="d2f5b0b499d62f1fc984dcac8043450b606549b0097753a9c8a707f7427c27e1")
     version("1.2.2", sha256="d54db406d98e1b54d18a9ba2b31ab9f093ac64a0a59d730c1cf7bb1cdfc94a58")
 
-    dpeends_on("py-setuptools", type="build")
+    depends_on("py-setuptools", type="build")
     depends_on("py-setuptools@61:", type="build", when="@1.2.3:")
     depends_on("py-setuptools@:81", type="build", when="@:1.2.2")


### PR DESCRIPTION
This PR adds `py-throttler`, v1.2.3([release notes](https://github.com/uburuntu/throttler/releases/tag/v1.2.3), [diff](https://github.com/uburuntu/throttler/compare/v1.2.2...v1.2.3)), which does not use setuptools pkg_resources anymore and therefore doesn't require the setuptools upper limit.

Test  build:
```
-- linux-ubuntu26.04-skylake / no compilers ---------------------
5jpkzox py-throttler@1.2.3 build_system=python_pip
```