### PR TITLE
xxhash: add pic variant

### DIFF
--- a/repos/spack_repo/builtin/packages/xxhash/package.py
+++ b/repos/spack_repo/builtin/packages/xxhash/package.py
@@ -37,6 +37,13 @@ class Xxhash(MakefilePackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
+    variant("pic", default=True, description="Enable position-independent code (PIC)")
+
+    def flag_handler(self, name, flags):
+        if name == "cflags" and self.spec.satisfies("+pic"):
+            flags.append(self.compiler.cc_pic_flag)
+        return (flags, None, None)
+
     @property
     def build_targets(self):
         targets = []


### PR DESCRIPTION
`xxhash` builds a static `libxxhash.a` alongside the shared library, but the static archive is compiled **without** position-independent code.