### PR TITLE
`admixtools` incompatible with C23

### DIFF
--- a/repos/spack_repo/builtin/packages/admixtools/package.py
+++ b/repos/spack_repo/builtin/packages/admixtools/package.py
@@ -31,6 +31,17 @@ class Admixtools(MakefilePackage):
 
     build_directory = "src"
 
+    def flag_handler(self, name, flags):
+        # AdmixTools is old C that relies on the pre-C23 meaning of an
+        # empty parameter list: `void setgtime ();` is a vague declaration,
+        # not a claim of "no arguments". GCC 15 defaults to C23, where ()
+        # means (void), so it conflicts with the header's
+        # `void setgtime(double *time);`. Pin the C17 dialect this code
+        # was written against.
+        if name == "cflags":
+            flags.append("-std=gnu17")
+        return (flags, None, None)
+
     def edit(self, spec, prefix):
         makefile = FileFilter("src/Makefile")
 


### PR DESCRIPTION
# Issue

`admixtools` fail to install with `gcc@15.1.0`

## Symptom
```
$ spack install admixtools@7.0.2 %gcc@15.1.0 %openblas
[+] / (external glibc-2.38-tfghf6luj545o6gwct3qgiitlwtre7wm)
[+] /mpcdf/soft/SLE_15/packages/x86_64/gcc/15.1.0 (external gcc-15.1.0-z2ocq66gwhxbnnfbf73byerconyeiera)
[+] /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/compiler-wrapper-1.1.0-rm6a2ekkxuodgply3j5kbgt4jnmqpthx
[+] /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/gcc-runtime-15.1.0-kvnkocgm6ylhy7obgn46i37iolv2vmem
[+] /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/gsl-2.8-r6r6tcwdymd3dnaeucahctmgkuc3qbsh
[+] /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/openblas-0.3.33-vpvdjamkrvifsx3nqd4mw3m36viimg3f
[+] /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/gmake-4.4.1-5nc7rdlb6yzh3zdpu6f26thwgwyuhv2w
==> No binary for admixtools-7.0.2-bhq6wtlslfjbrt33bu3yp5sq232epgme found: installing from source
==> Installing admixtools-7.0.2-bhq6wtlslfjbrt33bu3yp5sq232epgme [8/8]
==> Using cached archive: /geany/fs/scratch/resib/spack/var/spack/cache/_source-cache/archive/d1/d1dc1963e01017f40e05e28009008e14388a14a3facc75cff46653da585bd91e.tar.gz
==> No patches needed for admixtools
==> admixtools: Executing phase: 'edit'
==> admixtools: Executing phase: 'build'
==> Error: ProcessError: Command exited with status 2:
    '/geany/fs/scratch/resib/spack/opt/spack/linux-zen4/gmake-4.4.1-5nc7rdlb6yzh3zdpu6f26thwgwyuhv2w/bin/make' '-j16'

2 errors found in build log:
     69    cc -c -g -p -pg -Wimplicit -I./ -I./nicksrc   -c -o rolloff.o rolloff.c
     70    ranlib libnick.a
     71    make[1]: Leaving directory '/tmp/resib/spack-stage/spack-stage-admixtools-7.0.2-bhq6wtlslfjbrt33bu3yp5sq232epgme/spack-src/src/nicksrc'
     72    cc -c -g -p -pg -Wimplicit -I./ -I./nicksrc   -c -o rolloffp.o rolloffp.c
     73    cc -c -g -p -pg -Wimplicit -I./ -I./nicksrc   -c -o convertf.o convertf.c
     74    cc -c -g -p -pg -Wimplicit -I./ -I./nicksrc   -c -o h2d.o h2d.c
  >> 75    qpgsubs.c:125:6: error: conflicting types for 'setgtime'; have 'void(void)'
     76      125 | void setgtime ();
     77          |      ^~~~~~~~
     78    In file included from qpgsubs.c:12:
     79    qpsubs.h:52:6: note: previous declaration of 'setgtime' with type 'void(double *)'
     80       52 | void setgtime(double *time) ;
     81          |      ^~~~~~~~
     82    cc -c -g -p -pg -Wimplicit -I./ -I./nicksrc   -c -o exclude.o exclude.c
     83    cc -c -g -p -pg -Wimplicit -I./ -I./nicksrc   -c -o mergeit.o mergeit.c
  >> 84    make: *** [<builtin>: qpgsubs.o] Error 1
     85    make: *** Waiting for unfinished jobs....
```

<details>

  <summary>FYI <code>$ spack spec admixtools@7.0.2 gcc@15.1.0 %openblas</code></summary>

  ```
   -   admixtools@7.0.2 build_system=makefile platform=linux os=sles15 target=zen4 %c=gcc@15.1.0
  [+]      ^compiler-wrapper@1.1.0 build_system=generic platform=linux os=sles15 target=zen4 
  [e]      ^gcc@15.1.0+binutils+bootstrap~graphite+libsanitizer~mold~nvptx~piclibs~profiled~strip build_system=autotools build_type=RelWithDebInfo languages:='c,c++,fortran' platform=linux os=sles15 target=x86_64 
  [+]      ^gcc-runtime@15.1.0 build_system=generic platform=linux os=sles15 target=zen4 
  [e]      ^glibc@2.38 build_system=autotools platform=linux os=sles15 target=x86_64 
  [+]      ^gmake@4.4.1~guile build_system=generic platform=linux os=sles15 target=zen4 %c=gcc@15.1.0
  [+]      ^gsl@2.8~external-cblas+pic+shared build_system=autotools platform=linux os=sles15 target=zen4 %c=gcc@15.1.0
  [+]      ^openblas@0.3.33~bignuma~consistent_fpcsr+dynamic_dispatch+fortran~ilp64+locking+pic+shared~static build_system=makefile patches:=723ddc1 symbol_suffix=none threads=none platform=linux os=sles15 target=zen4 %c,cxx,fortran=gcc@15.1.0
  ```

</details>

For completeness, it works fine with older versions of GCC, e.g. `gcc@14.1.0`.

## Reason
`setgtime` has incompatible signatures in the source code. C23 changed the interpretation of `void setgtime ();`. What was permitted as a vague promise, is a conflict of declaration/definition under the new standard. GCC, in turn, changed the default standard in v15.

Worth noting that these incompatibilities [have been fixed](https://github.com/DReichLab/AdmixTools/commit/f3c076ab48b98cac283822925928ddfa628de170) on [master](https://github.com/DReichLab/AdmixTools/blob/683c89db5ae2d1dc819f45e52d912ed774c83687/src/qpgsubs.c#L128) by now, but have not yet been released.

# Fix

Passing `cflags='-std=gnu17'` fixes the issue:

<details>

  <summary>`$ spack install admixtools@7.0.2 cflags='-std=gnu17' %gcc@15.1.0 %openblas` runs fine</summary>

  ```
  [+] / (external glibc-2.38-tfghf6luj545o6gwct3qgiitlwtre7wm)
  [+] /mpcdf/soft/SLE_15/packages/x86_64/gcc/15.1.0 (external gcc-15.1.0-z2ocq66gwhxbnnfbf73byerconyeiera)
  [+] /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/compiler-wrapper-1.1.0-rm6a2ekkxuodgply3j5kbgt4jnmqpthx
  [+] /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/gcc-runtime-15.1.0-kvnkocgm6ylhy7obgn46i37iolv2vmem
  [+] /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/gsl-2.8-r6r6tcwdymd3dnaeucahctmgkuc3qbsh
  [+] /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/openblas-0.3.33-vpvdjamkrvifsx3nqd4mw3m36viimg3f
  [+] /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/gmake-4.4.1-5nc7rdlb6yzh3zdpu6f26thwgwyuhv2w
  ==> No binary for admixtools-7.0.2-pcuzrovvcxdm553y2my7dv6vqetjfsag found: installing from source
  ==> Installing admixtools-7.0.2-pcuzrovvcxdm553y2my7dv6vqetjfsag [8/8]
  ==> Using cached archive: /geany/fs/scratch/resib/spack/var/spack/cache/_source-cache/archive/d1/d1dc1963e01017f40e05e28009008e14388a14a3facc75cff46653da585bd91e.tar.gz
  ==> No patches needed for admixtools
  ==> admixtools: Executing phase: 'edit'
  ==> admixtools: Executing phase: 'build'
  ==> admixtools: Executing phase: 'install'
  ==> admixtools: Successfully installed admixtools-7.0.2-pcuzrovvcxdm553y2my7dv6vqetjfsag
    Stage: 0.06s.  Edit: 0.01s.  Build: 1.17s.  Install: 0.11s.  Post-install: 0.13s.  Total: 1.55s
  [+] /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/admixtools-7.0.2-pcuzrovvcxdm553y2my7dv6vqetjfsag
  ```

</details>

This PR patches the recipe to inject this flag.

```python
class Admixtools(MakefilePackage):
    # ... everything unchanged above ...

    build_directory = "src"

    def flag_handler(self, name, flags):
        # AdmixTools is old C that relies on the pre-C23 meaning of an
        # empty parameter list: `void setgtime ();` is a vague declaration,
        # not a claim of "no arguments". GCC 15 defaults to C23, where ()
        # means (void), so it conflicts with the header's
        # `void setgtime(double *time);`. Pin the C17 dialect this code
        # was written against.
        if name == "cflags":
            flags.append("-std=gnu17")
        return (flags, None, None)

    def edit(self, spec, prefix):
        # ... unchanged ...
```

This allows `$ spack install admixtools@7.0.2 %gcc@15.1.0 %openblas` to run successfully.
