### PR TITLE
`admixtools` installation escapes build directory

### DIFF
--- a/repos/spack_repo/builtin/packages/admixtools/package.py
+++ b/repos/spack_repo/builtin/packages/admixtools/package.py
@@ -41,6 +41,7 @@ class Admixtools(MakefilePackage):
             "override LDLIBS += -lgsl -lm -lnick " + lapackflags,
         )
 
+        makefile.filter("HOMEL=$(PWD)", "HOMEL=$(CURDIR)", string=True)
         makefile.filter("TOP=../bin", "TOP=./bin")
 
     def install(self, spec, prefix):


### PR DESCRIPTION
# Issue
Parts of the installation process use the current working directory, where the user ran `spack install admixtools`:

## Symptoms
1. build artefacts (`admixtables/`) are left in the current directory 

    <details> 

    <summary> Building in <code>~/</code> </summary>

    ```
    $ cd ~/
    $ ls admixtables/
    ls: cannot access 'admixtables/': No such file or directory
    $ spack install admixtools@7.0.2 %gcc@14.1.0 %openblas
    [+] / (external glibc-2.38-tfghf6luj545o6gwct3qgiitlwtre7wm)
    [+] /mpcdf/soft/SLE_15/packages/x86_64/gcc/14.1.0 (external gcc-14.1.0-aleiywcnxoqwjfdqz2xq6z4vi76wuh66)
    [+] /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/compiler-wrapper-1.1.0-rm6a2ekkxuodgply3j5kbgt4jnmqpthx
    [+] /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/gcc-runtime-14.1.0-zeve346kgkr5tzt4xddedgx44ctiajxm
    [+] /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/openblas-0.3.33-eqc27nyuza6gubsnx72l7akvqwlacu4b
    [+] /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/gmake-4.4.1-ymcpt75lijc324xrz2td4lp2saqhz6gh
    [+] /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/gsl-2.8-7fthp53pmaw7rrqgyit2ykyenzi33jlu
    ==> No binary for admixtools-7.0.2-bpdeyvz2t4dzip7osehsjhporlk7dj65 found: installing from source
    ==> Installing admixtools-7.0.2-bpdeyvz2t4dzip7osehsjhporlk7dj65 [8/8]
    ==> Using cached archive: /geany/fs/scratch/resib/spack/var/spack/cache/_source-cache/archive/d1/d1dc1963e01017f40e05e28009008e14388a14a3facc75cff46653da585bd91e.tar.gz
    ==> No patches needed for admixtools
    ==> admixtools: Executing phase: 'edit'
    ==> admixtools: Executing phase: 'build'
    ==> admixtools: Executing phase: 'install'
    ==> admixtools: Successfully installed admixtools-7.0.2-bpdeyvz2t4dzip7osehsjhporlk7dj65
        Stage: 0.06s.  Edit: 0.00s.  Build: 1.16s.  Install: 0.13s.  Post-install: 0.13s.  Total: 1.58s
    [+] /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/admixtools-7.0.2-bpdeyvz2t4dzip7osehsjhporlk7dj65
    $ ls admixtables/
    twtable
    ```

    </details>

2. if the current directory is not writable, the installation fails

    <details> 

    <summary> Building in <code>/</code> </summary>

    ```
    $ cd /
    $ spack install admixtools@7.0.2 %gcc@14.1.0 %openblas
    [+] / (external glibc-2.38-tfghf6luj545o6gwct3qgiitlwtre7wm)
    [+] /mpcdf/soft/SLE_15/packages/x86_64/gcc/14.1.0 (external gcc-14.1.0-aleiywcnxoqwjfdqz2xq6z4vi76wuh66)
    [+] /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/compiler-wrapper-1.1.0-rm6a2ekkxuodgply3j5kbgt4jnmqpthx
    [+] /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/gcc-runtime-14.1.0-zeve346kgkr5tzt4xddedgx44ctiajxm
    [+] /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/gmake-4.4.1-ymcpt75lijc324xrz2td4lp2saqhz6gh
    [+] /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/gsl-2.8-7fthp53pmaw7rrqgyit2ykyenzi33jlu
    [+] /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/openblas-0.3.33-eqc27nyuza6gubsnx72l7akvqwlacu4b
    ==> No binary for admixtools-7.0.2-bpdeyvz2t4dzip7osehsjhporlk7dj65 found: installing from source
    ==> Installing admixtools-7.0.2-bpdeyvz2t4dzip7osehsjhporlk7dj65 [8/8]
    ==> Using cached archive: /geany/fs/scratch/resib/spack/var/spack/cache/_source-cache/archive/d1/d1dc1963e01017f40e05e28009008e14388a14a3facc75cff46653da585bd91e.tar.gz
    ==> No patches needed for admixtools
    ==> admixtools: Executing phase: 'edit'
    ==> admixtools: Executing phase: 'build'
    ==> admixtools: Executing phase: 'install'
    ==> Error: ProcessError: Command exited with status 2:
        '/geany/fs/scratch/resib/spack/opt/spack/linux-zen4/gmake-4.4.1-ymcpt75lijc324xrz2td4lp2saqhz6gh/bin/make' '-j16' 'install'

    4 errors found in build log:
            104    cc -g  -L./nicksrc  gcount.o qpsubs.o mcio.o ldsubs.o admutils.o egsubs.o regsubs.o  -lgsl -lopenblas -lm -lnick -o gcount
            105    cc -g  -L./nicksrc  kimf.o gslkim.o qpgsubs.o qpsubs.o mcio.o ldsubs.o admutils.o egsubs.o regsubs.o  -lgsl -lopenblas -lm -lnick -o kimf
            106    ==> admixtools: Executing phase: 'install'
            107    ==> [2026-07-01-14:36:13.366507] '/geany/fs/scratch/resib/spack/opt/spack/linux-zen4/gmake-4.4.1-ymcpt75lijc324xrz2td4lp2saqhz6gh/bin/make' '-j16' 'install'
            108    mkdir -p  //admixtables
            109    echo "tables made"  > tables
        >> 110    mkdir: cannot create directory '//admixtables': Permission denied
        >> 111    make: *** [Makefile:115: dirs] Error 1
            112    make: *** Waiting for unfinished jobs....
            113    cp twtable  //admixtables
        >> 114    cp: cannot create regular file '//admixtables': Permission denied
        >> 115    make: *** [Makefile:112: tables] Error 1
    ```

    </details>

## Reason

`Makefile` of `admixtools` uses `$PWD` to define the target to place the artefacts in the `install` target.

For spack this means that 
1. ✅ `MakefileBuilder.build` runs `make` correctly in `build_stage`, e.g. `$tempdir/$user/spack-stage`.
2. During the `install` step:
 - ❌ [`make("install")`](https://github.com/spack/spack-packages/blob/e0c91d5c94bccda7ee63eb346957278a93807cce/repos/spack_repo/builtin/packages/admixtools/package.py#L48) follows the `install` target, resolves `$PWD` to the directory where the user ran `spack install admixtools`, creates folders there and copies the executable there ❌
 - `install_tree` then copies the artefacts to `prefix.bin` in spack's store.

# Fix

During the `edit` stage, substitute `PWD` with `CURDIR`, which will resolve to the correct working directory.

```python
        makefile.filter(
            "override LDLIBS += -lgsl -lopenblas -lm -lnick",
            "override LDLIBS += -lgsl -lm -lnick " + lapackflags,
        )

        # PWD does not respond to python changing directories, CURDIR does
        makefile.filter("HOMEL=$(PWD)", "HOMEL=$(CURDIR)", string=True)
        makefile.filter("TOP=../bin", "TOP=./bin")
```

This yields:
```
$ cd /
$ spack install -v admixtools@7.0.2 %gcc@14.1.0 %openblas
...  # manually truncated
make[1]: Entering directory '/tmp/resib/spack-stage/spack-stage-admixtools-7.0.2-fcbppwlgfqfwd4i4ubqcewrbltcw6syn/spack-src/src/nicksrc'
... # manually truncated
==> admixtools: Executing phase: 'install'
==> [2026-07-01-14:38:37.146284] '/geany/fs/scratch/resib/spack/opt/spack/linux-zen4/gmake-4.4.1-ymcpt75lijc324xrz2td4lp2saqhz6gh/bin/make' '-j16' 'install'
mkdir -p  /tmp/resib/spack-stage/spack-stage-admixtools-7.0.2-fcbppwlgfqfwd4i4ubqcewrbltcw6syn/spack-src/src/admixtables
echo "tables made"  > tables
cp twtable  /tmp/resib/spack-stage/spack-stage-admixtools-7.0.2-fcbppwlgfqfwd4i4ubqcewrbltcw6syn/spack-src/src/admixtables
mkdir -p ./bin
cp qp3Pop qpDstat qpF4ratio qpAdm qpWave qp4diff qpdslow dowtjack expfit.sh  qpBound qpGraph qpreroot qpff3base qpDpart qpfstats qpfmv qpmix ./bin
cp rexpfit.r  wtjack.pl  ./bin
cp rolloff rolloffp convertf mergeit simpjack2 grabpars kimf gcount  ./bin
cp ../perlsrc/* ./bin 
==> [2026-07-01-14:38:37.200097] Installing bin to /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/admixtools-7.0.2-fcbppwlgfqfwd4i4ubqcewrbltcw6syn/bin
==> [2026-07-01-14:38:37.251691] Installing twtable to /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/admixtools-7.0.2-fcbppwlgfqfwd4i4ubqcewrbltcw6syn/bin
==> admixtools: Successfully installed admixtools-7.0.2-fcbppwlgfqfwd4i4ubqcewrbltcw6syn
  Stage: 0.06s.  Edit: 0.01s.  Build: 1.10s.  Install: 0.11s.  Post-install: 0.12s.  Total: 1.48s
[+] /geany/fs/scratch/resib/spack/opt/spack/linux-zen4/admixtools-7.0.2-fcbppwlgfqfwd4i4ubqcewrbltcw6syn
```
