### PR TITLE
admixtools: add v8.0.2

### DIFF
--- a/repos/spack_repo/builtin/packages/admixtools/package.py
+++ b/repos/spack_repo/builtin/packages/admixtools/package.py
@@ -15,6 +15,9 @@ class Admixtools(MakefilePackage):
     homepage = "https://github.com/DReichLab/AdmixTools"
     url = "https://github.com/DReichLab/AdmixTools/archive/v7.0.2.tar.gz"
 
+    version("8.0.2", sha256="fea3eaabc5c47aa85dbc4346b6be0c377249064ccba087c246cbc7bec4b18777")
+    version("8.0.1", sha256="fb9347542cf847f8f6e0cf5abc62e2ff615de4a53c20fa8d0b7d9e4bc4216f12")
+    version("8.0.0", sha256="8779dd94c923dfaf2e6449f008dd45671c121158262fdaa0925b87b4f91650c1")
     version("7.0.2", sha256="d1dc1963e01017f40e05e28009008e14388a14a3facc75cff46653da585bd91e")
     version("7.0.1", sha256="182dd6f55109e9a1569b47843b0d1aa89fe4cf4a05f9292519b9811faea67a20")
     version("7.0", sha256="c00faab626f02bbf9c25c6d2dcf661db225776e9ed61251f164e5edeb5a448e5")
@@ -42,6 +45,8 @@ class Admixtools(MakefilePackage):
         )
 
         makefile.filter("TOP=../bin", "TOP=./bin")
+        makefile.filter("cp fxtract $(BIN)", "cp fxtract $(TOP)", string=True)
+        makefile.filter("cp -r script $(BIN)", "cp -r script $(TOP)", string=True)
 
     def install(self, spec, prefix):
         with working_dir("src"):

--- a/repos/spack_repo/builtin/packages/admixtools/package.py
+++ b/repos/spack_repo/builtin/packages/admixtools/package.py
@@ -16,8 +16,6 @@ class Admixtools(MakefilePackage):
     url = "https://github.com/DReichLab/AdmixTools/archive/v7.0.2.tar.gz"
 
     version("8.0.2", sha256="fea3eaabc5c47aa85dbc4346b6be0c377249064ccba087c246cbc7bec4b18777")
-    version("8.0.1", sha256="fb9347542cf847f8f6e0cf5abc62e2ff615de4a53c20fa8d0b7d9e4bc4216f12")
-    version("8.0.0", sha256="8779dd94c923dfaf2e6449f008dd45671c121158262fdaa0925b87b4f91650c1")
     version("7.0.2", sha256="d1dc1963e01017f40e05e28009008e14388a14a3facc75cff46653da585bd91e")
     version("7.0.1", sha256="182dd6f55109e9a1569b47843b0d1aa89fe4cf4a05f9292519b9811faea67a20")
     version("7.0", sha256="c00faab626f02bbf9c25c6d2dcf661db225776e9ed61251f164e5edeb5a448e5")


### PR DESCRIPTION
The last three releases are not compatible with the recipe as it is. 


Bits of the Makefile for context:
```makefile
HOMEL=$(PWD)
TOP=../bin
BIN=$(HOMEL)/../bin
```
and 
```makefile
install:	all dirs tables
	mkdir -p $(TOP)
	cp $(PROGS) $(TOP)
	cp $(PROGS2) $(TOP)
	cp $(PROGS3) $(TOP)
	cp $(PROGS3) $(TOP)
	cp ../perlsrc/* $(TOP) 
	cp fxtract $(BIN)
	cp -r script $(BIN) 
```

the last 3 lines of `install` target were introduced in v8.0.0 and the two of them use $BIN instead of $TOP.
[Normally](https://github.com/DReichLab/AdmixTools/blob/683c89db5ae2d1dc819f45e52d912ed774c83687/README.INSTALL#L9)  `$BIN` and `$TOP` evaluate to the same folder (and I don't quite understand why the two of them).
However, because Makefile so far uses `PWD` and not `CURWD`, `$BIN != $TOP` under `spack install` (see #5415). Yet, Makefile never `mkdir $(BIN)`, only `mkdir -p $(TOP)`and this, in turn, means that `cp fxtract $(BIN)` *creates* `$BIN` to be an executable file (a copy of `fxtract`) and not a folder. This means that the next call, fails with
`cp: cannot overwrite non-directory '...' with directory 'script'`.
IMHO, easiest fix is to change $(BIN) to $(TOP), consistently with the rest of `install` target, which this PR does.
<details>

<summary>Once #5415 lands, it can be simplified </summary>

```diff
@@ -56,12 +56,9 @@ class Admixtools(MakefilePackage):
         )
 
         makefile.filter("HOMEL=$(PWD)", "HOMEL=$(CURDIR)", string=True)
-        makefile.filter("TOP=../bin", "TOP=./bin")
-        makefile.filter("cp fxtract $(BIN)", "cp fxtract $(TOP)", string=True)
-        makefile.filter("cp -r script $(BIN)", "cp -r script $(TOP)", string=True)
 
     def install(self, spec, prefix):
         with working_dir("src"):
             make("install")
-            install_tree("bin", prefix.bin)
+            install_tree("../bin", prefix.bin)
             install("twtable", prefix.bin)
```
</details>
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
