### PR TITLE
wftools: Add python dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/swftools/package.py
+++ b/repos/spack_repo/builtin/packages/swftools/package.py
@@ -25,6 +25,8 @@ class Swftools(AutotoolsPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
+    depends_on("python@:3.8")
+
     patch("configure.patch")
     patch("swfs_Makefile.in.patch")
     patch(


### PR DESCRIPTION
Should fix #5418

swftools seems to depend on python, and in particular on python@:3.8 (as it uses tp_print which was removed from PyTypeObject starting python@3.9)

@spackbot fix style
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
