### PR TITLE
ncbi-toolkit: add v29_10_0, v30_4_0

### DIFF
--- a/repos/spack_repo/builtin/packages/ncbi_toolkit/package.py
+++ b/repos/spack_repo/builtin/packages/ncbi_toolkit/package.py
@@ -18,6 +18,16 @@ class NcbiToolkit(AutotoolsPackage):
     # Per https://ncbi.github.io/cxx-toolkit/pages/ch_getcode_svn#ch_getcode_svn.external
     # New versions are released on github
     version(
+        "30_4_0",
+        sha256="d9937d0a0b495c63b46c94918d4538e32039c9076fe956c606e6659fecd6b4a2",
+        url="https://github.com/ncbi/ncbi-cxx-toolkit-public/archive/refs/tags/release/30.4.0.tar.gz",
+    )
+    version(
+        "29_10_0",
+        sha256="08b460edcc0de32d176bcf2b6134e3e4ded5df1dce15ff1111c44cd355358bca",
+        url="https://github.com/ncbi/ncbi-cxx-toolkit-public/archive/refs/tags/release/29.10.0.tar.gz",
+    )
+    version(
         "28_0_12",
         sha256="db8a21ca242480badce126a6cad6ed5a2a8bcf40427fe6ea0dfd1ce6e8755a33",
         url="https://github.com/ncbi/ncbi-cxx-toolkit-public/archive/refs/tags/release-28.0.12.tar.gz",
@@ -70,6 +80,11 @@ class NcbiToolkit(AutotoolsPackage):
     depends_on("samtools")
     depends_on("bamtools")
     depends_on("berkeley-db")
+
+    # GCC 13.2, Clang 16, ICC (20)24 required for C++20 support
+    conflicts("%gcc@:13.1", when="@30:")
+    conflicts("%llvm@:15", when="@30:")
+    conflicts("%intel-oneapi-compilers@:2023", when="@30:")
 
     # boost 1.87 removes dummy_cond(). ncbi-toolset 29.5.0 fixes this.
     conflicts("boost@1.87:", when="@:29_4")


### PR DESCRIPTION
Added the 2 latest versions from the 29 and 30 branches.

They unfortunately dont post per-update release notes, but as of the time of writing the latest version (30) mentions using specific compiler versions GCC 13.2, Clang 16, ICC (20)24 [1].

Version 29 compiled without issue using gcc@8.5.0, though version 30 failed due to missing C++20 support.

[1]  https://ncbi.github.io/cxx-toolkit/pages/release_notes