### PR TITLE
libxs: Sync with CP2k recipe

### DIFF
--- a/repos/spack_repo/builtin/packages/libxs/package.py
+++ b/repos/spack_repo/builtin/packages/libxs/package.py
@@ -11,37 +11,35 @@ class Libxs(CMakePackage):
     """LIBXS is a portable C library providing building blocks for memory
     operations, numerics, synchronization, and more -- with a focus on
     performance and minimal dependencies. Targets x86-64, AArch64, and RISC-V;
-    requires only a C89 compiler. Originally developed as part of LIBXSMM.
-    """
+    requires only a C89 compiler. Originally developed as part of LIBXSMM."""
+
+    homepage = "https://libxs.readthedocs.io/en/latest"
+    git = "https://github.com/hfp/libxs.git"
+    url = "https://github.com/hfp/libxs/releases/download/1.0.0/libxs-1.0.0.tar.gz"
 
     maintainers("hfp", "mkrack", "mtaillefumier")
-
-    homepage = "hhttps://libxs.readthedocs.io/en/latest"
-    url = "https://github.com/hfp/libxs/archive/refs/tags/1.0.tar.gz"
-    git = "https://github.com/hfp/libxs.git"
 
     license("BSD-3-Clause", checked_by="mkrack")
 
     version("main", branch="main")
-    version("1.0.0", sha256="b26654a9d7d41e7281a785d3674626c2484c92e7fc698e166639c8e78b2b18ee")
+    version("1.0.0", sha256="de26f50cb986a2f0e4f92c0eb489d40a44f7e4c5acd22751a6cfa2829dabd04d")
 
-    variant("fortran", default=True, description="Build Fortran module interface")
+    variant("fortran", default=False, description="Build Fortran module interface")
     variant("pic", default=True, description="Build position independent code")
     variant("shared", default=False, description="Build shared libraries (otherwise static)")
-    variant("libxsmm", default=False, description="Enable libxsmm dependency")
+    variant("tests", default=False, description="Build unit testsi (requires BLAS)")
 
     depends_on("cmake@3.13:", type="build")
     depends_on("c", type="build")
-    depends_on("cxx", type="build")
     depends_on("fortran", type="build", when="+fortran")
 
-    depends_on("libxsmm")
+    depends_on("blas", when="+tests")
 
     def cmake_args(self):
         args = [
             self.define_from_variant("LIBXS_FORTRAN", "fortran"),
             self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
-            self.define_from_variant("LIBXS_SHARED", "shared"),
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define_from_variant("BUILD_TESTING", "tests"),
         ]
         return args


### PR DESCRIPTION
The following changes are proposed:
- Fix typo in homepage url
- Prefer release url over auto-generated archive url for download
- Set default for variant fortran to false as in CMakeLists.txt
- Remove the not existing libxsmm option and the corresponding dependency
- Add variant tests and add dependence on BLAS for +tests
- Remove redundant shared variant LIBXS_SHARED from the CMake args

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
