### PR TITLE
hpctoolkit: add support for jemalloc

### DIFF
--- a/repos/spack_repo/builtin/packages/hpctoolkit/package.py
+++ b/repos/spack_repo/builtin/packages/hpctoolkit/package.py
@@ -23,7 +23,7 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
 
     homepage = "https://hpctoolkit.org"
     git = "https://gitlab.com/hpctoolkit/hpctoolkit.git"
-    maintainers("mwkrentel")
+    maintainers("blue42u")
 
     tags = ["e4s"]
 
@@ -196,6 +196,7 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
     depends_on("xz+pic libs=static", type="link", when="@:2023.08")
     depends_on("yaml-cpp@0.7.0: +shared", when="@2022.10:")
     depends_on("googletest@1.8.1: +gmock", type="test", when="@2025:")
+    depends_on("jemalloc", when="@develop: ^dyninst@master:")
 
     depends_on("zlib-api")
     depends_on("zlib+shared", when="^[virtuals=zlib-api] zlib")
@@ -479,6 +480,11 @@ class MesonBuilder(meson.MesonBuilder):
 
         if spec.satisfies("@:2024.01"):
             args.append(f"--native-file={self.gen_prefix_file()}")
+
+        # Dyninst before master June 2026 pulls in tbbmalloc_proxy,
+        # and we don't really want to run both.
+        if spec.satisfies("@develop:"):
+            args.append("-Djemalloc=" + ("enabled" if spec.satisfies("^dyninst@master:") else "disabled"))
 
         return args
 

--- a/repos/spack_repo/builtin/packages/hpctoolkit/package.py
+++ b/repos/spack_repo/builtin/packages/hpctoolkit/package.py
@@ -196,7 +196,7 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
     depends_on("xz+pic libs=static", type="link", when="@:2023.08")
     depends_on("yaml-cpp@0.7.0: +shared", when="@2022.10:")
     depends_on("googletest@1.8.1: +gmock", type="test", when="@2025:")
-    depends_on("jemalloc", when="@develop: ^dyninst@master:")
+    depends_on("jemalloc", when="@2026.1: ^dyninst@14:")
 
     depends_on("zlib-api")
     depends_on("zlib+shared", when="^[virtuals=zlib-api] zlib")
@@ -483,9 +483,9 @@ class MesonBuilder(meson.MesonBuilder):
 
         # Dyninst before master June 2026 pulls in tbbmalloc_proxy,
         # and we don't really want to run both.
-        if spec.satisfies("@develop:"):
+        if spec.satisfies("@2026.1:"):
             args.append(
-                "-Djemalloc=" + ("enabled" if spec.satisfies("^dyninst@master:") else "disabled")
+                "-Djemalloc=" + ("enabled" if spec.satisfies("^dyninst@14:") else "disabled")
             )
 
         return args

--- a/repos/spack_repo/builtin/packages/hpctoolkit/package.py
+++ b/repos/spack_repo/builtin/packages/hpctoolkit/package.py
@@ -484,7 +484,9 @@ class MesonBuilder(meson.MesonBuilder):
         # Dyninst before master June 2026 pulls in tbbmalloc_proxy,
         # and we don't really want to run both.
         if spec.satisfies("@develop:"):
-            args.append("-Djemalloc=" + ("enabled" if spec.satisfies("^dyninst@master:") else "disabled"))
+            args.append(
+                "-Djemalloc=" + ("enabled" if spec.satisfies("^dyninst@master:") else "disabled")
+            )
 
         return args
 


### PR DESCRIPTION
HPCToolkit and Dyninst switched from using TBB malloc_proxy to jemalloc. This patch adds the spack support for that when both packages allow it. We don't want to run both, so disable jemalloc for older Dyninst.

Switch hpctoolkit package maintainer to blue42u (I'm retired).

ping @blue42u @hainest 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
