### PR TITLE
geant4: add examples variant

### DIFF
--- a/repos/spack_repo/builtin/packages/geant4/package.py
+++ b/repos/spack_repo/builtin/packages/geant4/package.py
@@ -83,6 +83,7 @@ class Geant4(CMakePackage):
     variant("tbb", default=False, description="Use TBB as a tasking backend", when="@11:")
     variant("timemory", default=False, description="Use TiMemory for profiling", when="@9.5:11.2")
     variant("vtk", default=False, description="Enable VTK support", when="@11:")
+    variant("examples", default=True, description="Install examples")
 
     # For most users, obtaining the Geant4 data via Spack will be useful; the
     # sticky, default-enabled `+data` variant ensures that this happens.
@@ -368,6 +369,7 @@ class Geant4(CMakePackage):
         options.append(self.define_from_variant("GEANT4_USE_HDF5", "hdf5"))
         options.append(self.define_from_variant("GEANT4_USE_VTK", "vtk"))
         options.append(self.define_from_variant("GEANT4_USE_PYTHON", "python"))
+        options.append(self.define_from_variant("GEANT4_INSTALL_EXAMPLES", "examples"))
 
         return options
 


### PR DESCRIPTION
This PR adds a variant to geant4 to allow a build without examples.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
