### PR TITLE
gnupg: add v2.5.21

### DIFF
--- a/repos/spack_repo/builtin/packages/gnupg/package.py
+++ b/repos/spack_repo/builtin/packages/gnupg/package.py
@@ -19,12 +19,15 @@ class Gnupg(AutotoolsPackage):
 
     license("GPL-3.0-or-later")
 
-    version("2.5.20", sha256="6461266e99c308419a379abe6c356d54c214136c4589bd65951091138989ffc6")
+    version("2.5.21", sha256="e3af2c8caa46a66a9329fa7c6880af260451914d819595beabc2c26597b31352")
     version("2.4.9", sha256="dd17ab2e9a04fd79d39d853f599cbc852062ddb9ab52a4ddeb4176fd8b302964")
     version("2.3.8", sha256="540b7a40e57da261fb10ef521a282e0021532a80fd023e75fb71757e8a4969ed")
     version("2.2.40", sha256="1164b29a75e8ab93ea15033300149e1872a7ef6bdda3d7c78229a735f8204c28")
 
     with default_args(deprecated=True):
+        version(
+            "2.5.20", sha256="6461266e99c308419a379abe6c356d54c214136c4589bd65951091138989ffc6"
+        )
         version(
             "2.5.17", sha256="2c1fbe20e2958fd8fb53cf37d7c38e84a900edc0d561a1c4af4bc3a10888685d"
         )

--- a/repos/spack_repo/builtin/packages/pinentry/package.py
+++ b/repos/spack_repo/builtin/packages/pinentry/package.py
@@ -22,6 +22,7 @@ class Pinentry(AutotoolsPackage):
 
     license("GPL-2.0-or-later")
 
+    version("1.3.3", sha256="c2970f16d6afb66ecddfca767d743936c86239bff936eed7fd7597a678414b63")
     version("1.3.2", sha256="8e986ed88561b4da6e9efe0c54fa4ca8923035c99264df0b0464497c5fb94e9e")
     version("1.3.1", sha256="bc72ee27c7239007ab1896c3c2fae53b076e2c9bd2483dc2769a16902bce8c04")
     version("1.3.0", sha256="9b3cd5226e7597f2fded399a3bc659923351536559e9db0826981bca316494de")


### PR DESCRIPTION
Also adds pinentry v1.3.3

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
