### PR TITLE
r-languageserver, r-lintr, r-collections and r-xmlparsedata: new packages

### DIFF
--- a/repos/spack_repo/builtin/packages/r_collections/package.py
+++ b/repos/spack_repo/builtin/packages/r_collections/package.py
@@ -1,0 +1,20 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.r import RPackage
+
+from spack.package import *
+
+
+class RCollections(RPackage):
+    """Provides high performance container data types such as queues, stacks, deques, dicts
+    and ordered dicts."""
+
+    cran = "collections"
+
+    license("MIT")
+
+    version("0.3.12", sha256="60e63ee65bc1889e54a008410f53cb5b643f2fffdb926c3ed12316094709c60d")
+
+    depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/r_languageserver/package.py
+++ b/repos/spack_repo/builtin/packages/r_languageserver/package.py
@@ -1,0 +1,40 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.r import RPackage
+
+from spack.package import *
+
+
+class RLanguageserver(RPackage):
+    """An implementation of the Language Server Protocol for R."""
+
+    cran = "languageserver"
+
+    license("MIT")
+
+    version("0.3.18", sha256="747fdeaa4474e9424189544ce84622d146ab0cc09eaf6667000d3c8d88f079d9")
+
+    depends_on("c", type="build")
+
+    with default_args(type=("build", "run")):
+        depends_on("r@3.4:")
+
+        depends_on("curl")
+        depends_on("openssl")
+        depends_on("libxml2")
+        depends_on("libuv")
+
+        depends_on("r-callr@3:")
+        depends_on("r-collections@0.3:")
+        depends_on("r-digest@0.3:")
+        depends_on("r-fs@1.3.1:")
+        depends_on("r-jsonlite@1.6:")
+        depends_on("r-lintr@3:")
+        depends_on("r-r6@2.4.1:")
+        depends_on("r-roxygen2@7:")
+        depends_on("r-stringi@1.1.7:")
+        depends_on("r-styler@1.5.1:")
+        depends_on("r-xml2@1.2.2:")
+        depends_on("r-xmlparsedata@1.0.3:")

--- a/repos/spack_repo/builtin/packages/r_lintr/package.py
+++ b/repos/spack_repo/builtin/packages/r_lintr/package.py
@@ -1,0 +1,33 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.r import RPackage
+
+from spack.package import *
+
+
+class RLintr(RPackage):
+    """A 'Linter' for R Code
+
+    Checks adherence to a given style, syntax errors and possible semantic issues."""
+
+    cran = "lintr"
+
+    license("MIT")
+
+    version("3.3.0-1", sha256="b12964c46fcd77d235e98af10586e103e50a4109affa9ede547c9ee75cffca06")
+
+    with default_args(type=("build", "run")):
+        depends_on("r@4:")
+
+        depends_on("r-backports@1.5:")
+        depends_on("r-cli@3.4:")
+        depends_on("r-codetools")
+        depends_on("r-digest")
+        depends_on("r-glue")
+        depends_on("r-knitr")
+        depends_on("r-rex")
+        depends_on("r-xfun")
+        depends_on("r-xml2@1:")
+        depends_on("r-xmlparsedata@1.0.5:")

--- a/repos/spack_repo/builtin/packages/r_xmlparsedata/package.py
+++ b/repos/spack_repo/builtin/packages/r_xmlparsedata/package.py
@@ -1,0 +1,23 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.r import RPackage
+
+from spack.package import *
+
+
+class RXmlparsedata(RPackage):
+    """Convert the output of 'utils::getParseData()' to an 'XML' tree, that one can search via
+    'XPath', and easier to manipulate in general."""
+
+    cran = "xmlparsedata"
+
+    license("MIT")
+
+    version("1.0.5", sha256="766034ab5e9728609bd240c9954d23ca0cdb881a98a31b9d3e1c8767c7b7cbb0")
+
+    depends_on("c", type="build")
+
+    with default_args(type=("build", "run")):
+        depends_on("r@3:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Installation of `r-languageserver` offers R language support in VSCode and other LSP-enabled editors. The other three packages are the dependencies of `r-languageserver` that were missing from `spack-packages`.