### PR TITLE
(py-)xgboost: add v2.1.4

### DIFF
--- a/repos/spack_repo/builtin/packages/py_xgboost/package.py
+++ b/repos/spack_repo/builtin/packages/py_xgboost/package.py
@@ -20,6 +20,7 @@ class PyXgboost(PythonPackage):
     license("Apache-2.0")
     maintainers("adamjstewart")
 
+    version("2.1.4", sha256="ab84c4bbedd7fae1a26f61e9dd7897421d5b08454b51c6eb072abc1d346d08d7")
     version("2.1.1", sha256="4b1729837f9f1ba88a32ef1be3f8efb860fee6454a68719b196dc88032c23d97")
     version("2.1.0", sha256="7144980923e76ce741c7b03a14d3bd7514db6de5c7cabe96ba95b229d274f5ca")
     version("1.7.6", sha256="1c527554a400445e0c38186039ba1a00425dcdb4e40b37eed0e74cb39a159c47")
@@ -35,10 +36,11 @@ class PyXgboost(PythonPackage):
     variant("dask", default=False, description="Enables Dask extensions for distributed training.")
     variant("plotting", default=False, description="Enables tree and importance plotting.")
 
-    for ver in ["1.3.3", "1.5.2", "1.6.1", "1.6.2", "1.7.6", "2.1.0", "2.1.1"]:
+    for ver in ["1.3.3", "1.5.2", "1.6.1", "1.6.2", "1.7.6", "2.1.0", "2.1.1", "2.1.4"]:
         depends_on("xgboost@" + ver, when="@" + ver)
 
     with default_args(type="build"):
+        depends_on("py-packaging@21.3:", type="build", when="@2.1.2:")
         depends_on("py-hatchling@1.12.1:", type="build", when="@2:")
         # Required to use --config-settings
         depends_on("py-pip@22.1:", when="@2:")

--- a/repos/spack_repo/builtin/packages/xgboost/package.py
+++ b/repos/spack_repo/builtin/packages/xgboost/package.py
@@ -26,6 +26,7 @@ class Xgboost(CMakePackage, CudaPackage):
     maintainers("adamjstewart")
 
     version("master", branch="master")
+    version("2.1.4", tag="v2.1.4", commit="62e7923619352c4079b24303b367134486b1c84f")
     version("2.1.1", tag="v2.1.1", commit="9c9db1259240bffe9040ed7ca6e3fb2c1bda80e4")
     version("2.1.0", tag="v2.1.0", commit="213ebf7796b757448dfa2cfba532074696fa1524")
     version("1.7.6", tag="v1.7.6", commit="36eb41c960483c8b52b44082663c99e6a0de440a")
@@ -55,7 +56,7 @@ class Xgboost(CMakePackage, CudaPackage):
         # thrust 2.3.1 tuple issues
         depends_on("cuda@:12.3", when="@:1.7")
         # https://github.com/dmlc/xgboost/issues/10555
-        depends_on("cuda@:12.4", when="@:2.1")
+        depends_on("cuda@:12.4", when="@:2.1.3")
 
     depends_on("nccl", when="+nccl")
     depends_on("llvm-openmp@19:", when="+openmp %apple-clang")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

The latest 2.x release supports newer CUDA and newer GPUs  
https://github.com/dmlc/xgboost/releases/tag/v2.1.4