### PR TITLE
Update oneAPI packages to 2026.1.0

### DIFF
--- a/repos/spack_repo/builtin/packages/intel_oneapi_ccl/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_ccl/package.py
@@ -29,6 +29,12 @@ class IntelOneapiCcl(IntelOneApiLibraryPackage):
     depends_on("intel-oneapi-mpi")
 
     version(
+        "2022.1.0",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/bc26d315-1c3c-4270-92e1-6b67c130cc06/intel-oneccl-2022.1.0.145_offline.sh",
+        sha256="cc0933af9ae933764989b113f2bbf22b7fd12cd89514b4df8db8da28f1ea2512",
+        expand=False,
+    )
+    version(
         "2021.16.1",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/66ce2615-4f44-42d5-9b4b-69ca25df01fc/intel-oneccl-2021.16.1.10_offline.sh",
         sha256="e8a48c828d7f0d274ff8af7089a42fbe88664beef810b659be4aedc39830206e",

--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
@@ -14,6 +14,17 @@ from spack.package import *
 
 versions = [
     {
+        "version": "2026.1.0",
+        "cpp": {
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/eb43fd3f-7cff-46a4-ab14-a2d3b60c4899/intel-dpcpp-cpp-compiler-2026.1.0.118_offline.sh",
+            "sha256": "65d81ec1f249fb2cb7267fc787b21cf618b4f553c06b9e19d0981b30f25ae227",
+        },
+        "ftn": {
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/87bd1c07-e474-4f38-9492-e44e15ea7a52/intel-fortran-compiler-2026.1.0.104_offline.sh",
+            "sha256": "3779081508ebc099e99717eccd9de615c57fde292dc4f93e18955a103835f58d",
+        },
+    },
+    {
         "version": "2025.2.1",
         "cpp": {
             "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/04c5fd98-57e6-4a4b-be4d-e84de3aea45a/intel-dpcpp-cpp-compiler-2025.2.1.7_offline.sh",

--- a/repos/spack_repo/builtin/packages/intel_oneapi_dnn/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_dnn/package.py
@@ -28,6 +28,12 @@ class IntelOneapiDnn(IntelOneApiLibraryPackage):
     )
 
     version(
+        "2026.0.1",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/0451dc19-00a2-4236-bace-dc0b4aec0680/intel-onednn-2026.0.1.64_offline.sh",
+        sha256="838feeccb8332934bb3a801603ccdf617c8dce3a9728f5e2e3809dc379fd2142",
+        expand=False,
+    )
+    version(
         "2025.2.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/6b523cc0-3241-4b80-bfba-ebe6c67599f6/intel-onednn-2025.2.0.562_offline.sh",
         sha256="eabb2ef5de48b01a5fe2c3c5b6d332515ee812c9ebeb712064b4c1cba118f108",

--- a/repos/spack_repo/builtin/packages/intel_oneapi_dpl/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_dpl/package.py
@@ -24,6 +24,12 @@ class IntelOneapiDpl(IntelOneApiLibraryPackage):
     homepage = "https://github.com/oneapi-src/oneDPL"
 
     version(
+        "2022.13.0",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2703adb2-b977-4b87-9dc9-acf686f1bea4/intel-onedpl-2022.13.0.111_offline.sh",
+        sha256="378a672b15bab02b08c65ff04f4f7e8d5f184127d1d97a5b948f760206cfbccb",
+        expand=False,
+    )
+    version(
         "2022.9.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/4f06fa3c-add6-4e58-9505-36942ba90315/intel-onedpl-2022.9.0.378_offline.sh",
         sha256="e76c50d698583d90baef78c583812352e20859cc923d3312afaa6467571796e4",

--- a/repos/spack_repo/builtin/packages/intel_oneapi_ipp/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_ipp/package.py
@@ -29,6 +29,12 @@ class IntelOneapiIpp(IntelOneApiLibraryPackage):
     )
 
     version(
+        "2026.0.1",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/1bf493cd-8dd6-4168-be51-a0c7fe171f70/intel-ipp-2026.0.1.62_offline.sh",
+        sha256="e4ce172388068b1efcf66af71e7d4791c3a088336fafbb160cd5dbeb194d1b59",
+        expand=False,
+    )
+    version(
         "2022.2.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/d9649232-67ed-489e-8cd8-2c4c54b06135/intel-ipp-2022.2.0.583_offline.sh",
         sha256="624985c649f34b54004f7865a2df23389b9ca6d410f785e9f08ab0d56ddc84b9",

--- a/repos/spack_repo/builtin/packages/intel_oneapi_ippcp/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_ippcp/package.py
@@ -30,6 +30,12 @@ class IntelOneapiIppcp(IntelOneApiLibraryPackage):
     )
 
     version(
+        "2026.0.1",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/bdaa109d-f2ae-4b10-a8ad-a6ef8663abda/intel-cryptography-primitives-library-2026.0.1.11_offline.sh",
+        sha256="c890e961fe60367ce2ec7ce79edddebe3a91b7ccfe97379fb3e587a2afce327f",
+        expand=False,
+    )
+    version(
         "2025.2.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/60f39c8f-1f9a-4d58-80d1-452381eeed1a/intel-cryptography-primitives-library-2025.2.0.448_offline.sh",
         sha256="fa18943ecb6446ece3ea37804a93a402f7062adbc959c1804e5cb5b31251aa06",

--- a/repos/spack_repo/builtin/packages/intel_oneapi_mkl/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_mkl/package.py
@@ -30,6 +30,12 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
     )
 
     version(
+        "2026.1.0",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17f37e16-768e-40d2-bcf8-c252dc6c5499/intel-onemkl-2026.1.0.237_offline.sh",
+        sha256="854deea4c4eec21d23cfb895b0c76ac02b5a76e3a9581a39b4c69fb7ffc69146",
+        expand=False,
+    )
+    version(
         "2025.2.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/47c7d946-fca1-441a-b0df-b094e3f045ea/intel-onemkl-2025.2.0.629_offline.sh",
         sha256="7bfdde1379a9cd3c2784af4352931a0527a5c483c9da71e851a3f06e055af7c7",

--- a/repos/spack_repo/builtin/packages/intel_oneapi_mpi/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_mpi/package.py
@@ -23,6 +23,12 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
     homepage = "https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/mpi-library.html"
 
     version(
+        "2021.18.0",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/f62e2cfe-82a9-480f-b6ca-51ad7cc799fc/intel-mpi-2021.18.0.749_offline.sh",
+        sha256="a2afb95b3b9f85b9ddd32171e940a7b7cc02d7bbd6dca9d77a7bd405f3d62b73",
+        expand=False,
+    )
+    version(
         "2021.16.1",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/203edae7-5269-4124-a1ed-09ad924f8b47/intel-mpi-2021.16.1.804_offline.sh",
         sha256="4165717608e90ae6123397ebf2a9b87a0b070842ce7d13378d1446a08966eb6e",

--- a/repos/spack_repo/builtin/packages/intel_oneapi_tbb/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_tbb/package.py
@@ -24,6 +24,12 @@ class IntelOneapiTbb(IntelOneApiLibraryPackage):
     )
 
     version(
+        "2023.1.0",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/d93b2767-7739-4b1c-8cfc-084b52f31447/intel-onetbb-2023.1.0.157_offline.sh",
+        sha256="ca12a1dcfebd119bd5f832a39d560e8740d441949e87a11213d82a84ef4df324",
+        expand=False,
+    )
+    version(
         "2022.2.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/7516db94-4877-4ffe-8dde-37e9a46e69a2/intel-onetbb-2022.2.0.508_offline.sh",
         sha256="b8da6678bf4fdd4bf780436c21d191fe13a5ec71db21c8af9e10e3c6209d258e",

--- a/repos/spack_repo/builtin/packages/intel_oneapi_vtune/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_vtune/package.py
@@ -30,6 +30,12 @@ class IntelOneapiVtune(IntelOneApiLibraryPackageWithSdk):
     homepage = "https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/vtune-profiler.html"
 
     version(
+        "2026.2.0",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ba4cd139-536d-4887-baa6-b60a86b874d4/intel-vtune-2026.2.0.228_offline.sh",
+        sha256="2fb9fcb17ee9dcb5249b380c9ac707a5d07789c0697c28a7811a5700d57b9e68",
+        expand=False,
+    )
+    version(
         "2025.5.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2775669e-5be4-4982-96de-d0ca5444859a/intel-vtune-2025.5.0.40_offline.sh",
         sha256="dc75067a48dc04a58b15b5944f1d8e951f3340ef7e2652030cab082ff53c6a87",


### PR DESCRIPTION
This PR updates oneAPI packages to 2026.1.0.

@rscohn2