### PR TITLE
Metis: Support Windows Builds

### DIFF
--- a/repos/spack_repo/builtin/packages/metis/package.py
+++ b/repos/spack_repo/builtin/packages/metis/package.py
@@ -45,6 +45,7 @@ class Metis(CMakePackage, MakefilePackage):
     build_system(
         conditional("cmake", when="@5:"), conditional("makefile", when="@:4"), default="cmake"
     )
+    requires("build_system=cmake", when="platform=windows")
     variant("shared", default=True, description="Build shared libraries")
     with when("build_system=cmake"):
         variant("gdb", default=False, description="Enable gdb support")
@@ -57,6 +58,20 @@ class Metis(CMakePackage, MakefilePackage):
         patch("install_gklib_defs_rename.patch")
         # Disable the "misleading indentation" warning when compiling
         patch("gklib_nomisleadingindentation_warning.patch", when="%gcc@6:")
+        # Fix the MSVC/Windows CMake build: enable `install()` (upstream
+        # disables it entirely under MSVC), link the "programs" (gpmetis,
+        # ndmetis, ...) against a private static copy of libmetis instead of
+        # the shared metis.dll (they call internal GKlib/libmetis symbols
+        # that are never part of the public, dllexport'd METIS_API), and
+        # install metis.dll to bin/ instead of lib/ so Spack's automatic
+        # Windows DLL-linkage (which only scans dependents' bin/) can find it.
+        patch("windows_msvc_build.patch")
+        # GKlib's MSVC fallback for INFINITY (#define INFINITY FLT_MAX) isn't
+        # guarded for modern MSVC/UCRT, where <math.h> already defines a real
+        # INFINITY; shadowing it breaks <corecrt_math.h>'s own later use of
+        # the macro (error C2059). Only fall back on MSVC versions that
+        # actually lack INFINITY/rint().
+        patch("windows_msvc_infinity_rint.patch")
 
     with when("build_system=makefile"):
         variant("debug", default=False, description="Compile in debug mode")

--- a/repos/spack_repo/builtin/packages/metis/windows_msvc_build.patch
+++ b/repos/spack_repo/builtin/packages/metis/windows_msvc_build.patch
@@ -1,0 +1,88 @@
+Fix the CMake build under MSVC: enable install(), and stop the
+"programs" (gpmetis, ndmetis, mpmetis, m2gmetis, graphchk, cmpfillin)
+from failing to link against a shared metis.dll.
+
+Upstream's CMakeLists.txt disables install() entirely when the
+compiler is MSVC. It also builds the "programs" against whichever
+metis library target was requested (static or shared); but those
+programs call directly into GKlib and internal libmetis__-prefixed
+symbols that are never part of the public METIS_API (see the
+METIS_API() dllexport macro in include/metis.h), so when SHARED is
+requested on Windows those internal symbols are never exported from
+metis.dll and the programs fail to link with LNK2019 unresolved
+external errors. Some of those internal symbols (gk_optarg/gk_optind)
+are global *data*, which additionally can't be transparently imported
+across a DLL boundary without every consumer declaring them
+__declspec(dllimport) -- which upstream's plain `extern` declarations
+in GKlib do not do.
+
+Rather than patch dllexport/dllimport annotations into every internal
+GKlib/libmetis symbol, give the "programs" a private static copy of
+the library to link against on Windows when SHARED is requested, so
+they never depend on DLL export/import semantics for symbols that were
+never meant to be part of the public interface. The installed
+metis.dll's public surface (METIS_API) is unaffected.
+
+Also install the DLL itself to bin/ instead of lib/: on Windows the
+runtime artifact of a shared library needs to be discoverable next to
+its consumers (and by Spack's automatic Windows DLL-linkage, which
+only scans dependents' bin/ directories), whereas import libraries
+belong in lib/. This has no effect on Unix, where RUNTIME DESTINATION
+is meaningless for a library target (LIBRARY/ARCHIVE DESTINATION lib
+already governs .so/.a placement there).
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -4,11 +4,7 @@
+ set(GKLIB_PATH "${CMAKE_SOURCE_DIR}/GKlib" CACHE PATH "path to GKlib")
+ set(SHARED FALSE CACHE BOOL "build a shared library")
+
+-if(MSVC)
+-  set(METIS_INSTALL FALSE)
+-else()
+-  set(METIS_INSTALL TRUE)
+-endif()
++set(METIS_INSTALL TRUE)
+
+ # Configure libmetis library.
+ if(SHARED)
+--- a/libmetis/CMakeLists.txt
++++ b/libmetis/CMakeLists.txt
+@@ -8,10 +8,20 @@
+   target_link_libraries(metis m)
+ endif()
+
++# The "programs" (gpmetis, ndmetis, ...) call directly into internal
++# GKlib/libmetis symbols that are not part of the public METIS_API and are
++# therefore never exported from a shared metis.dll on Windows. Give them a
++# private static copy of the library to link against instead, so they never
++# depend on Windows DLL export/import semantics for internal symbols.
++if(WIN32 AND METIS_LIBRARY_TYPE STREQUAL "SHARED")
++  add_library(metis_internal STATIC ${GKlib_sources} ${metis_sources})
++  set_target_properties(metis_internal PROPERTIES EXCLUDE_FROM_ALL TRUE)
++endif()
++
+ if(METIS_INSTALL)
+   install(TARGETS metis
+     LIBRARY DESTINATION lib
+-    RUNTIME DESTINATION lib
++    RUNTIME DESTINATION bin
+     ARCHIVE DESTINATION lib)
+   install(FILES gklib_defs.h DESTINATION include)
+   install(FILES gklib_rename.h DESTINATION include)
+--- a/programs/CMakeLists.txt
++++ b/programs/CMakeLists.txt
+@@ -8,8 +8,13 @@
+ add_executable(m2gmetis m2gmetis.c cmdline_m2gmetis.c io.c)
+ add_executable(graphchk graphchk.c io.c)
+ add_executable(cmpfillin cmpfillin.c io.c smbfactor.c)
++if(TARGET metis_internal)
++  set(METIS_PROGRAMS_LIBRARY metis_internal)
++else()
++  set(METIS_PROGRAMS_LIBRARY metis)
++endif()
+ foreach(prog gpmetis ndmetis mpmetis m2gmetis graphchk cmpfillin)
+-  target_link_libraries(${prog} metis)
++  target_link_libraries(${prog} ${METIS_PROGRAMS_LIBRARY})
+ #  target_link_libraries(${prog} metis profiler)
+ endforeach(prog)

--- a/repos/spack_repo/builtin/packages/metis/windows_msvc_infinity_rint.patch
+++ b/repos/spack_repo/builtin/packages/metis/windows_msvc_infinity_rint.patch
@@ -1,0 +1,48 @@
+Fix GKlib's MSVC fallback definitions of rint() and INFINITY so they
+don't clobber the real ones on modern (Visual Studio 2015+/UCRT) MSVC.
+
+GKlib unconditionally defines `INFINITY` (as `FLT_MAX`, guarded only by
+`#ifndef INFINITY`) and `rint()` whenever `__MSC__` is defined, to make
+up for MSVC versions that lacked them. On current MSVC/UCRT toolchains
+(_MSC_VER >= 1900), <math.h> already defines a proper INFINITY, but
+since gk_arch.h is typically included before <math.h>/<corecrt_math.h>
+pull that definition in, GKlib's `#ifndef INFINITY` fires first and
+shadows it with FLT_MAX (a finite value). When <corecrt_math.h> is
+included later in the same translation unit, its own use of the
+(now-wrong) INFINITY token expands incorrectly and produces a hard
+compile error:
+
+  corecrt_math.h(94): warning C4005: 'INFINITY': macro redefinition
+  corecrt_math.h(566): error C2059: syntax error: '('
+
+Guard both fallbacks behind `_MSC_VER < 1900` so they only kick in on
+the old MSVC versions that actually need them.
+
+--- a/GKlib/gk_arch.h
++++ b/GKlib/gk_arch.h
+@@ -58,14 +58,18 @@
+ #define PTRDIFF_MAX  INT64_MAX
+ #endif
+ 
+-#ifdef __MSC__
+-/* MSC does not have rint() function */
+-#define rint(x) ((int)((x)+0.5))  
++#ifdef _MSC_VER
++  /* MSVC versions before Visual Studio 2015 (UCRT) lacked standard rint() */
++  #if (_MSC_VER < 1900)
++    #define rint(x) ((idx_t)((x)+0.5))
++  #endif
+ 
+-/* MSC does not have INFINITY defined */
+-#ifndef INFINITY
+-#define INFINITY FLT_MAX
+-#endif
++  /* MSVC versions before Visual Studio 2015 lacked the INFINITY macro */
++  #ifndef INFINITY
++    #if (_MSC_VER < 1900)
++      #define INFINITY FLT_MAX
++    #endif
++  #endif
+ #endif
+ 
+ #endif


### PR DESCRIPTION
Support building Metis on Windows

* Adds a patch correctly exporting the expected public API, and linking programs to private gklib api
* Adds a patch ensuring the bundled gklib handles Windows preprocessor definitions properly with never versions of MSVC

Allows for building, linking, and running metis on Windows with MSVC