### PR TITLE
Umpire FMT fix for 2025 release

### DIFF
--- a/repos/spack_repo/builtin/packages/umpire/package.py
+++ b/repos/spack_repo/builtin/packages/umpire/package.py
@@ -295,7 +295,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("mpi", when="+mpi")
 
     depends_on("fmt@12.1.0", when="@2026:")
-    depends_on("fmt@9.1:11.0", when="@2024.02.0:2025")
+    depends_on("fmt@9.1:12.1.0", when="@2024.02.0:2025")
     # We need c++ 17 only with intel
     depends_on("fmt@9.1:11.0 cxxstd=17", when="@2024.02.0: %intel@19.1")
 


### PR DESCRIPTION
Expanded allowed values of `fmt` dependency for the 2024-2025 releases. This fixes compile errors when `umpire` is included in a project being built with `rocm/7.2.1`.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
