### PR TITLE
mapl: add v2.70.0

### DIFF
--- a/repos/spack_repo/builtin/packages/mapl/package.py
+++ b/repos/spack_repo/builtin/packages/mapl/package.py
@@ -41,12 +41,6 @@ class Mapl(CMakePackage):
 
     # Remember if there is a new ESMA_cmake, to update the resources too
     version(
-        "3.0.0-alpha.2", sha256="59a1a0af335b9774cafabe71296f227990dcff5edf6c35624c57d6023376779b"
-    )
-    version(
-        "3.0.0-alpha.0", sha256="85e991c29638ec2930e5b9186315f16da85504d00d5e0a2dd7e2631c38d0de89"
-    )
-    version(
         "2.70.0",
         sha256="c31a390f39260ef25620c9d0367dc111e354d1f3e83157209ee2aca03249d804",
         preferred=True,

--- a/repos/spack_repo/builtin/packages/mapl/package.py
+++ b/repos/spack_repo/builtin/packages/mapl/package.py
@@ -173,9 +173,17 @@ class Mapl(CMakePackage):
     resource(
         name="esma_cmake",
         git="https://github.com/GEOS-ESM/ESMA_cmake.git",
+        tag="v4.40.0",
+        commit="bfea7ae9482f508f66f7964cf98908c7a6c63ce8",
+        when="@2.70:",
+        placement="ESMA_cmake",
+    )
+    resource(
+        name="esma_cmake",
+        git="https://github.com/GEOS-ESM/ESMA_cmake.git",
         tag="v4.37.0",
         commit="267dc7326176c27d90cb40a6dab0419655a385ad",
-        when="@2.69:",
+        when="@2.69",
         placement="ESMA_cmake",
     )
     resource(

--- a/repos/spack_repo/builtin/packages/mapl/package.py
+++ b/repos/spack_repo/builtin/packages/mapl/package.py
@@ -41,7 +41,15 @@ class Mapl(CMakePackage):
 
     # Remember if there is a new ESMA_cmake, to update the resources too
     version(
+        "3.0.0-alpha.2", sha256="59a1a0af335b9774cafabe71296f227990dcff5edf6c35624c57d6023376779b"
+    )
+    version(
         "3.0.0-alpha.0", sha256="85e991c29638ec2930e5b9186315f16da85504d00d5e0a2dd7e2631c38d0de89"
+    )
+    version(
+        "2.70.0",
+        sha256="c31a390f39260ef25620c9d0367dc111e354d1f3e83157209ee2aca03249d804",
+        preferred=True,
     )
     version(
         "2.69.1",

--- a/repos/spack_repo/builtin/packages/mapl/package.py
+++ b/repos/spack_repo/builtin/packages/mapl/package.py
@@ -51,11 +51,7 @@ class Mapl(CMakePackage):
         sha256="c31a390f39260ef25620c9d0367dc111e354d1f3e83157209ee2aca03249d804",
         preferred=True,
     )
-    version(
-        "2.69.1",
-        sha256="d34ba656c06a1ab0f306e22a8615a694f87c24626fc4cc8da3fe6f19fcbf3a4d",
-        preferred=True,
-    )
+    version("2.69.1", sha256="d34ba656c06a1ab0f306e22a8615a694f87c24626fc4cc8da3fe6f19fcbf3a4d")
     version("2.69.0", sha256="ba5d08dbcfd6765955b19d944748d93506df649c59781e7307c14ca2ef613d92")
     version("2.68.0", sha256="ccba8339569d4a8f64fd2435bcde1b09a41c6a54aae798eb8d4cc44a30e2a495")
     version("2.67.0", sha256="fb8899c13fdf5145f16745a8ca6f88807c7a39423e17f745663d719348fc05e5")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This adds MAPL v2.70.0 and the latest v3 alpha