### PR TITLE
awscli: add v1.45.40 and required dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/awscli/package.py
+++ b/repos/spack_repo/builtin/packages/awscli/package.py
@@ -14,6 +14,7 @@ class Awscli(PythonPackage):
 
     pypi = "awscli/awscli-1.16.308.tar.gz"
 
+    version("1.45.40", sha256="d1555eed16b08cf3948eda040598f5f4c3c17bd6b7760cea5ba2ce63128cc8e6")
     version("1.29.41", sha256="c029edd2c0bd72fb49cefe1a8f83ce2b46ba31ab45769677f7ba0771461078cb")
     version("1.27.84", sha256="a27a7d1f3efa9dd2acf9d8bd72b939337d53da4ac71721cde6d5dff94aa446f7")
     version("1.27.56", sha256="58fd7122547db71646c053c914bd4f9b673356dd8c9520ae6d35560a8aec208b")
@@ -21,27 +22,36 @@ class Awscli(PythonPackage):
     version("1.16.179", sha256="6a87114d1325358d000abe22b2103baae7b91f053ff245b9fde33cb0affb5e4f")
 
     depends_on("py-setuptools", type="build")
-    depends_on("python@3.7:", when="@1.25:", type=("build", "run"))
 
-    # py-botocore is pinned to the patch version number
-    depends_on("py-botocore@1.31.41", when="@1.29.41", type=("build", "run"))
-    depends_on("py-botocore@1.29.84", when="@1.27.84", type=("build", "run"))
-    depends_on("py-botocore@1.29.56", when="@1.27.56", type=("build", "run"))
-    depends_on("py-botocore@1.13.44", when="@1.16.308", type=("build", "run"))
-    depends_on("py-botocore@1.12.169", when="@1.16.179", type=("build", "run"))
+    with default_args(type=("build", "run")):
+        depends_on("python@3.7:", when="@1.25:")
+        depends_on("python@3.8:", when="@1.32:")
+        depends_on("python@3.9:", when="@1.39:")
+        depends_on("python@3.10:", when="@1.45:")
 
-    depends_on("py-colorama@0.2.5:0.4.4", when="@1.27:", type=("build", "run"))
-    depends_on("py-colorama@0.2.5:0.3.9", when="@1.16", type=("build", "run"))
+        # py-botocore is pinned to the patch version number
+        depends_on("py-botocore@1.43.40", when="@1.45.40")
+        depends_on("py-botocore@1.31.41", when="@1.29.41")
+        depends_on("py-botocore@1.29.84", when="@1.27.84")
+        depends_on("py-botocore@1.29.56", when="@1.27.56")
+        depends_on("py-botocore@1.13.44", when="@1.16.308")
+        depends_on("py-botocore@1.12.169", when="@1.16.179")
 
-    depends_on("py-docutils@0.10:0.16", when="@1.27:", type=("build", "run"))
-    depends_on("py-docutils@0.10:0.15", when="@1.16", type=("build", "run"))
+        depends_on("py-colorama@0.2.5:0.4.6", when="@1.32.93:")
+        depends_on("py-colorama@0.2.5:0.4.4", when="@1.27:1.32.92")
+        depends_on("py-colorama@0.2.5:0.3.9", when="@1.16")
 
-    depends_on("py-pyyaml@3.10:6.0", when="@1.29", type=("build", "run"))
-    depends_on("py-pyyaml@3.10:5.4", when="@1.27", type=("build", "run"))
-    depends_on("py-pyyaml@3.10:5.2", when="@1.16", type=("build", "run"))
+        depends_on("py-docutils@0.18.1:0.19", when="@1.39:")
+        depends_on("py-docutils@0.10:0.16", when="@1.27:1.38")
+        depends_on("py-docutils@0.10:0.15", when="@1.16")
 
-    depends_on("py-rsa@3.1.2:4.7", when="@1.27:", type=("build", "run"))
-    depends_on("py-rsa@3.1.2:3.5.0", when="@1.16", type=("build", "run"))
+        depends_on("py-pyyaml@3.10:6.0", when="@1.29.4:")
+        depends_on("py-pyyaml@3.10:5.4", when="@1.27:1.29.3")
+        depends_on("py-pyyaml@3.10:5.2", when="@1.16")
 
-    depends_on("py-s3transfer@0.6", when="@1.27:", type=("build", "run"))
-    depends_on("py-s3transfer@0.2", when="@1.16", type=("build", "run"))
+        depends_on("py-rsa@3.1.2:4.7", when="@1.27:")
+        depends_on("py-rsa@3.1.2:3.5.0", when="@1.16")
+
+        depends_on("py-s3transfer@0.19", when="@1.45.40:")
+        depends_on("py-s3transfer@0.6", when="@1.27:1.29")
+        depends_on("py-s3transfer@0.2", when="@1.16")

--- a/repos/spack_repo/builtin/packages/py_botocore/package.py
+++ b/repos/spack_repo/builtin/packages/py_botocore/package.py
@@ -15,6 +15,7 @@ class PyBotocore(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.43.40", sha256="2085a4314cfd2c8bc1d08ab8039f76c92e99278db0d2a0e2437010526d5d5d70")
     version("1.43.17", sha256="27f4ecb80cf1e5be70415fc4a4d3db3907d41ef8178c9df822364f275427d375")
     version("1.42.85", sha256="2ee61f80b7724a143e16d0a85408ef5fa20b99dce7a3c8ec5d25cc8dced164c1")
     version("1.40.64", sha256="a13af4009f6912eafe32108f6fa584fb26e24375149836c2bcaaaaec9a7a9e58")

--- a/repos/spack_repo/builtin/packages/py_s3transfer/package.py
+++ b/repos/spack_repo/builtin/packages/py_s3transfer/package.py
@@ -15,6 +15,7 @@ class PyS3transfer(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.19.0", sha256="ce436931687addc4c1712d52d40b32f53e88315723f107ffa20ba82b05a0f685")
     version("0.18.0", sha256="3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd")
     version("0.16.0", sha256="8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920")
     version("0.14.0", sha256="eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125")


### PR DESCRIPTION
After deprecating old versions of urllib in https://github.com/spack/spack-packages/pull/4811 the awscli package failed to concretize. This PR adds a newer version of the cli and bumps the required dependencies to safe versions not caught by the CVE deprecations. 