### PR TITLE
py-torch: ensure setuptools is not unnecessarily constrained for 2.10:

### DIFF
--- a/repos/spack_repo/builtin/packages/py_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_torch/package.py
@@ -207,7 +207,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
 
         # pyproject.toml
         depends_on("py-setuptools@70.1:81", when="@2.10:")
-        depends_on("py-setuptools@70.1:79", when="@2.9:")
+        depends_on("py-setuptools@70.1:79", when="@2.9")
         depends_on("py-setuptools@62.3:79", when="@2.8")
         depends_on("py-setuptools@:79", when="@:2.7")
         depends_on("py-numpy")


### PR DESCRIPTION
This PR fixes what (I think) is a typo in `py-torch` introduced with the addition of v2.10. Currently, for v2.10 and later, setuptools is still constrained to at most v79.