### PR TITLE
ci: disable concretization cache

### DIFF
--- a/.ci/gitlab/configs/concretizer.yaml
+++ b/.ci/gitlab/configs/concretizer.yaml
@@ -1,3 +1,5 @@
 concretizer:
   reuse: false
   unify: false
+  concretization_cache:
+    enable: false


### PR DESCRIPTION
Addresses an issue where concretization cache takes O(paths) time, noticeable
in big specs.

