### PR TITLE
3dtk: fix homepage url

### DIFF
--- a/repos/spack_repo/builtin/packages/_3dtk/package.py
+++ b/repos/spack_repo/builtin/packages/_3dtk/package.py
@@ -16,7 +16,7 @@ class _3dtk(CMakePackage):
     plane extraction software, etc. Several file formats for the point clouds
     are natively supported, new formats can be implemented easily."""
 
-    homepage = "https://slam6d.sourceforge.net/"
+    homepage = "https://slam6d.sourceforge.io/"
     # Repo seems to be in the process of switching to git:
     # https://github.com/3DTK/3DTK
 


### PR DESCRIPTION
Triggered by https://repology.org/repository/spack/problems

> Homepage link https://slam6d.sourceforge.net/ is [dead](https://repology.org/link/https://slam6d.sourceforge.net/) (timeout) for more than a month and should be replaced by alive link (see other packages for hints, or link to [archive.org](https://archive.org/) as a last resort).