### PR TITLE
7zip: fix sourceforge_mirror_path

### DIFF
--- a/repos/spack_repo/builtin/packages/_7zip/package.py
+++ b/repos/spack_repo/builtin/packages/_7zip/package.py
@@ -18,7 +18,7 @@ class _7zip(SourceforgePackage, Package):
     """7-Zip is a file archiver for Windows"""
 
     homepage = "https://sourceforge.net/projects/sevenzip/"
-    sourceforge_mirror_path = "sevenzip/files/7z2107-src.tar.xz"
+    sourceforge_mirror_path = "project/sevenzip/7-Zip/21.07/7z2107-src.tar.xz"
     tags = ["windows"]
 
     executables = ["7z"]


### PR DESCRIPTION
Triggered by https://repology.org/repository/spack/problems

> Download link https://prdownloads.sourceforge.net/sevenzip/files/7z2107-src.tar.xz is [dead](https://repology.org/link/https://prdownloads.sourceforge.net/sevenzip/files/7z2107-src.tar.xz) (timeout) for more than a month and should be replaced by alive link (see other packages for hints).

Determined new url by following the url trail below:

- https://www.7-zip.org/links.html
- https://sourceforge.net/projects/sevenzip/
- https://sourceforge.net/projects/sevenzip/files/7-Zip/21.07/7z2107-src.tar.xz/download.

Following redirects till we hit a dl.sourceforge.net
- https://downloads.sourceforge.net/project/sevenzip/7-Zip/21.07/7z2107-src.tar.xz
- https://master.dl.sourceforge.net/project/sevenzip/7-Zip/21.07/7z2107-src.tar.xz