### PR TITLE
pflare: ensure that the petsc dependency has the +metis variant

### DIFF
--- a/repos/spack_repo/builtin/packages/pflare/package.py
+++ b/repos/spack_repo/builtin/packages/pflare/package.py
@@ -46,6 +46,7 @@ class Pflare(MakefilePackage):
     depends_on("lapack")
     depends_on("metis")
     depends_on("parmetis")
+    depends_on("petsc+metis")
 
     # PETSc version dependencies
     depends_on("petsc@main", when="@main")


### PR DESCRIPTION
Ensures petsc is built with metis support