### PR TITLE
openblas: fix dylib install name for cmake build on macOS

### DIFF
--- a/repos/spack_repo/builtin/packages/openblas/package.py
+++ b/repos/spack_repo/builtin/packages/openblas/package.py
@@ -558,10 +558,7 @@ class MakefileBuilder(makefile.MakefileBuilder):
         if self.spec.satisfies("target=m1:"):
             # Use custom simplified target for macOS ARM procesors:
             # GENERIC target results in SIGILL
-            make_defs += [
-                "TARGET=VORTEX",
-                "NO_SVE=1",
-            ]
+            make_defs += ["TARGET=VORTEX", "NO_SVE=1"]
         else:
             # Try to intelligently add target and architecture flags
             make_defs += self._microarch_target_args()
@@ -690,6 +687,13 @@ class CMakeBuilder(cmake.CMakeBuilder):
             # ensure MACOSX_RPATH is set
             self.define("CMAKE_POLICY_DEFAULT_CMP0042", "NEW"),
         ]
+
+        # On macOS the cmake build sets the dylib install name to the build-stage
+        # path instead of the install prefix, causing downstream packages (e.g.
+        # py-numpy) to embed a broken rpath.  Setting CMAKE_INSTALL_NAME_DIR fixes
+        # the install name to the real installed lib directory.
+        if self.spec.satisfies("platform=darwin"):
+            cmake_defs += [self.define("CMAKE_INSTALL_NAME_DIR", self.spec.prefix.lib)]
 
         if self.spec.satisfies("+dynamic_dispatch"):
             cmake_defs += [self.define("DYNAMIC_ARCH", "ON")]


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

When building with `build_system=cmake` on macOS, the install name of `libopenblas.dylib` was set to the build-stage path rather than the install prefix. This caused all downstream packages (e.g. `py-numpy`) to fail at import time with "Library not loaded: <build_stage_path>".

Add `CMAKE_INSTALL_NAME_DIR` set to `spec.prefix.lib` when `platform=darwin` so the dylib embeds the correct install-time path.

The makefile build system handles this correctly and is the default on macOS, which is why this has not been caught upstream.

---

I had help finding this fix with Claude Sonnet 4.6