### PR TITLE
fortran: disable F77/FC if no fortran virtual, hdf5-blosc: Dedicated plugin dir and use libtool for installs

### DIFF
--- a/repos/spack_repo/builtin/packages/hdf5_blosc/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5_blosc/package.py
@@ -10,22 +10,6 @@ from spack_repo.builtin.build_systems.generic import Package
 from spack.package import *
 
 
-def _install_shlib(name, src, dst):
-    """Install a shared library from directory src to directory dst"""
-    if sys.platform == "darwin":
-        shlib0 = name + ".0.dylib"
-        shlib = name + ".dylib"
-        install(join_path(src, shlib0), join_path(dst, shlib0))
-        symlink(shlib0, join_path(dst, shlib))
-    else:
-        shlib000 = name + ".so.0.0.0"
-        shlib0 = name + ".so.0"
-        shlib = name + ".dylib"
-        install(join_path(src, shlib000), join_path(dst, shlib000))
-        symlink(shlib000, join_path(dst, shlib0))
-        symlink(shlib0, join_path(dst, shlib))
-
-
 class Hdf5Blosc(Package):
     """Blosc filter for HDF5"""
 
@@ -52,6 +36,8 @@ class Hdf5Blosc(Package):
         # make("install")
         # if sys.platform == "darwin":
         #     fix_darwin_install_name(prefix.lib)
+        plugins_dir = prefix.lib.hdf5_plugins
+        mkdirp(plugins_dir)
 
         libtool = spec["libtool"].command
 
@@ -63,7 +49,6 @@ class Hdf5Blosc(Package):
         # shlibext = "so" if sys.platform != "darwin" else "dylib"
 
         mkdirp(prefix.include)
-        mkdirp(prefix.lib)
 
         # Build and install filter
         with working_dir("src"):
@@ -75,7 +60,7 @@ class Hdf5Blosc(Package):
                 "-g",
                 "-O",
                 "-rpath",
-                prefix.lib,
+                plugins_dir,
                 "-o",
                 "libblosc_filter.la",
                 "blosc_filter.lo",
@@ -84,7 +69,7 @@ class Hdf5Blosc(Package):
                 "-L%s" % spec["hdf5"].prefix.lib,
                 "-lhdf5",
             )
-            _install_shlib("libblosc_filter", ".libs", prefix.lib)
+            libtool("--mode=install", "cp", "libblosc_filter.la", plugins_dir)
 
             # Build and install plugin
             # The plugin requires at least HDF5 1.8.11:
@@ -97,18 +82,18 @@ class Hdf5Blosc(Package):
                     "-g",
                     "-O",
                     "-rpath",
-                    prefix.lib,
+                    plugins_dir,
                     "-o",
                     "libblosc_plugin.la",
                     "blosc_plugin.lo",
-                    "-L%s" % prefix.lib,
+                    "-L%s" % plugins_dir,
                     "-lblosc_filter",
                     "-L%s" % spec["c-blosc"].prefix.lib,
                     "-lblosc",
                     "-L%s" % spec["hdf5"].prefix.lib,
                     "-lhdf5",
                 )
-                _install_shlib("libblosc_plugin", ".libs", prefix.lib)
+                libtool("--mode=install", "cp", "libblosc_plugin.la", plugins_dir)
 
         if self.run_tests:
             self.check_install(spec)
@@ -203,17 +188,17 @@ Done.
         shutil.rmtree(checkdir)
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        env.append_path("HDF5_PLUGIN_PATH", self.spec.prefix.lib)
+        env.append_path("HDF5_PLUGIN_PATH", self.spec.prefix.lib.hdf5_plugins)
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
-        env.append_path("HDF5_PLUGIN_PATH", self.spec.prefix.lib)
+        env.append_path("HDF5_PLUGIN_PATH", self.spec.prefix.lib.hdf5_plugins)
 
     def setup_dependent_build_environment(
         self, env: EnvironmentModifications, dependent_spec: Spec
     ) -> None:
-        env.append_path("HDF5_PLUGIN_PATH", self.spec.prefix.lib)
+        env.append_path("HDF5_PLUGIN_PATH", self.spec.prefix.lib.hdf5_plugins)
 
     def setup_dependent_run_environment(
         self, env: EnvironmentModifications, dependent_spec: Spec
     ) -> None:
-        env.append_path("HDF5_PLUGIN_PATH", self.spec.prefix.lib)
+        env.append_path("HDF5_PLUGIN_PATH", self.spec.prefix.lib.hdf5_plugins)

--- a/repos/spack_repo/builtin/packages/hdf5_blosc/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5_blosc/package.py
@@ -68,7 +68,12 @@ class Hdf5Blosc(Package):
                 "-L%s" % spec["hdf5"].prefix.lib,
                 "-lhdf5",
             )
-            libtool("--mode=install", "cp", "libblosc_filter.la", join_path(plugins_dir, "libblosc_filter.la"))
+            libtool(
+                "--mode=install",
+                "cp",
+                "libblosc_filter.la",
+                join_path(plugins_dir, "libblosc_filter.la"),
+            )
 
             # Build and install plugin
             # The plugin requires at least HDF5 1.8.11:
@@ -92,7 +97,12 @@ class Hdf5Blosc(Package):
                     "-L%s" % spec["hdf5"].prefix.lib,
                     "-lhdf5",
                 )
-                libtool("--mode=install", "cp", "libblosc_plugin.la", join_path(plugins_dir, "libblosc_plugin.la"))
+                libtool(
+                    "--mode=install",
+                    "cp",
+                    "libblosc_plugin.la",
+                    join_path(plugins_dir, "libblosc_plugin.la"),
+                )
 
         if self.run_tests:
             self.check_install(spec)

--- a/repos/spack_repo/builtin/packages/hdf5_blosc/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5_blosc/package.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import shutil
-import sys
 
 from spack_repo.builtin.build_systems.generic import Package
 

--- a/repos/spack_repo/builtin/packages/hdf5_blosc/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5_blosc/package.py
@@ -68,7 +68,7 @@ class Hdf5Blosc(Package):
                 "-L%s" % spec["hdf5"].prefix.lib,
                 "-lhdf5",
             )
-            libtool("--mode=install", "cp", "libblosc_filter.la", plugins_dir)
+            libtool("--mode=install", "cp", "libblosc_filter.la", join_path(plugins_dir, "libblosc_filter.la"))
 
             # Build and install plugin
             # The plugin requires at least HDF5 1.8.11:
@@ -92,7 +92,7 @@ class Hdf5Blosc(Package):
                     "-L%s" % spec["hdf5"].prefix.lib,
                     "-lhdf5",
                 )
-                libtool("--mode=install", "cp", "libblosc_plugin.la", plugins_dir)
+                libtool("--mode=install", "cp", "libblosc_plugin.la", join_path(plugins_dir, "libblosc_plugin.la"))
 
         if self.run_tests:
             self.check_install(spec)

--- a/repos/spack_repo/builtin/packages/libtool/package.py
+++ b/repos/spack_repo/builtin/packages/libtool/package.py
@@ -111,17 +111,27 @@ class Libtool(AutotoolsPackage, GNUMirrorPackage):
             join_path(self.prefix.bin, "libtoolize"), join_path(self.prefix.bin, "glibtoolize")
         )
 
-    def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        """Wrapper until spack has a real implementation of setup_test_environment()"""
-        if self.run_tests:
-            self.setup_test_environment(env)
-
-    def setup_test_environment(self, env: EnvironmentModifications):
-        """When Fortran is not provided, a few tests need to be skipped"""
-        if self.compiler.f77 is None:
+    def _disable_fortran_if_absent(self, env: EnvironmentModifications) -> None:
+        # When no Fortran compiler is available, Spack unsets F77/FC, but
+        # libtool's configure then finds the compiler-wrapper's f77/f95 stubs
+        # (always on PATH, dispatching to a nonexistent Fortran compiler) and
+        # tries to configure a Fortran tag anyway. That failing probe disables
+        # shared-library support in the *default* section of the installed
+        # standalone `libtool` (build_libtool_libs=no), which silently breaks
+        # every package that uses it to build shared libraries
+        # Setting the "no" sentinel makes libtool's configure skip
+        # the F77/FC tags entirely, so the C toolchain's shared-library support
+        # is preserved.
+        if not self.spec.dependencies(virtuals=("fortran",)):
             env.set("F77", "no")
-        if self.compiler.fc is None:
             env.set("FC", "no")
+
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        self._disable_fortran_if_absent(env)
+
+    def setup_test_environment(self, env: EnvironmentModifications) -> None:
+        """When Fortran is not provided, a few tests need to be skipped"""
+        self._disable_fortran_if_absent(env)
 
     @when("@2.4.6")
     def check(self):

--- a/repos/spack_repo/builtin/packages/libtool/package.py
+++ b/repos/spack_repo/builtin/packages/libtool/package.py
@@ -112,13 +112,6 @@ class Libtool(AutotoolsPackage, GNUMirrorPackage):
         )
 
     def _disable_fortran_if_absent(self, env: EnvironmentModifications) -> None:
-        # When no Fortran compiler is available, Spack unsets F77/FC, but
-        # libtool's configure then finds the compiler-wrapper's f77/f95 stubs
-        # (always on PATH, dispatching to a nonexistent Fortran compiler) and
-        # tries to configure a Fortran tag anyway. That failing probe disables
-        # shared-library support in the *default* section of the installed
-        # standalone `libtool` (build_libtool_libs=no), which silently breaks
-        # every package that uses it to build shared libraries
         # Setting the "no" sentinel makes libtool's configure skip
         # the F77/FC tags entirely, so the C toolchain's shared-library support
         # is preserved.


### PR DESCRIPTION
- Isolate plugin installation to `prefix.lib.hdf5_plugins`
- Use `libtool --mode=install` to install instead of a custom copy script that leaked some rpath information from the build dir.

Example below where the first entry is still pointing to the stage directory:
``` shell
  $ readelf -d $store/hdf5-blosc-master-<hash>/lib/libblosc_plugin.so.0.0.0 | grep RPATH
  (RPATH)  Library rpath: [$stage/spack-stage-hdf5-blosc-master-<hash>/spack-src/src/.libs:
                           $store/hdf5-blosc-master-<hash>/lib:
                           $store/gcc-runtime-14.2.0-<hash>/lib:
                           $store/zstd-1.5.2-<hash>/lib: ...]
```
`libtool --mode=install` is designed to update the rpath. It also makes sense to install via `libtool` since we are building with it as well.

Diagnosis and fixes in this PR were AI assisted.

Todo:
- [ ] Test on Darwin

Closes #5507 
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
