### PR TITLE
wrf: interpret csh script with `-f`

### DIFF
--- a/repos/spack_repo/builtin/packages/wrf/package.py
+++ b/repos/spack_repo/builtin/packages/wrf/package.py
@@ -500,6 +500,7 @@ class Wrf(Package):
         # and the custom compile script will always return zero regardless of
         # success or failure
         result_buf = csh(
+            "-f",
             "./compile",
             "-j",
             num_jobs,


### PR DESCRIPTION
WRF's `compile` [has](https://github.com/wrf-model/WRF/blob/06d4240ae989cc3e50af412bb472df3d9048783c/compile#L1) `-f` in its shebang: `#!/bin/csh -f`. 
Spack invokes the interpreter explicitly (`csh ./compile …`) rather than executing the script directly, the shebang is never consulted, so the `-f` it requests is silently dropped. Passing `-f` on the command line restores it.

`-f` prevents user's environment from affecting the script execution. In an HPC environment a global `cshrc` can `set noclobber`. In combination with this recipie's
```python
        if not result:
            tty.warn("Compilation failed first time (WRF idiosyncrasies?) - trying again...")
            result = self.run_compile_script()
```
`noclobber` means that the second compilation pass (i.e. the invocation of the same `csh ./compile`) will fail with `File exists.`. If the user cannot change the offending system `cshrc`, this recipe in its present form cannot be built.

Verified that WRF 4.7.1 builds successfully with `-f`.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
