### PR TITLE
autotools: remove macos deployment target

### DIFF
--- a/repos/spack_repo/builtin/build_systems/autotools.py
+++ b/repos/spack_repo/builtin/build_systems/autotools.py
@@ -8,7 +8,6 @@ from typing import Callable, List, Optional, Set, Tuple, Union
 
 from spack.package import (
     BuilderWithDefaults,
-    EnvironmentModifications,
     Executable,
     FileFilter,
     InstallError,
@@ -16,7 +15,6 @@ from spack.package import (
     PackageBase,
     Prefix,
     Spec,
-    Version,
     apply_macos_rpath_fixups,
     build_system,
     compiler_spec,
@@ -29,7 +27,6 @@ from spack.package import (
     force_remove,
     is_exe,
     keep_modification_time,
-    macos_version,
     mkdirp,
     register_builder,
     run_after,

--- a/repos/spack_repo/builtin/build_systems/autotools.py
+++ b/repos/spack_repo/builtin/build_systems/autotools.py
@@ -841,12 +841,6 @@ To resolve this problem, please try the following:
             with open(self._removed_la_files_log, mode="w", encoding="utf-8") as f:
                 f.write("\n".join(libtool_files))
 
-    def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        if self.spec.platform == "darwin" and macos_version() >= Version("11"):
-            # Many configure files rely on matching '10.*' for macOS version
-            # detection and fail to add flags if it shows as version 11.
-            env.set("MACOSX_DEPLOYMENT_TARGET", "10.16")
-
     # On macOS, force rpaths for shared library IDs and remove duplicate rpaths
     run_after("install", when="platform=darwin")(apply_macos_rpath_fixups)
 


### PR DESCRIPTION
When macOS jumped from 10.16 to 11, we patched the autotools build system to hardcode the deployment target at 10.16, since many autotools scripts at the time assumed a 10.xx macOS version and broke otherwise.

This workaround is now instead causing build failures on macOS 26/27. The latest apple-clang@21 emits a warning whenever the deployment target is now set below 11 (since Apple Silicon is required for new macOS releases you'll no longer be able to compile for an SDK before M-series support). In several packages (like ruby) this warning crashes the test program in configure, causing the build to fail outright.

Since the original compatibility issue is now several years old, I removed the environment hardcode and rebuilt 100+ autotools-based packages (bash, coreutils, aspell, sed, etc.) to check for regressions. All of them built successfully.

As such, I think it's finally time we remove this from the autotools builder to fix compatibility with newer MacOS versions.