### PR TITLE
rust: add v1.97.0

### DIFF
--- a/repos/spack_repo/builtin/packages/rust/package.py
+++ b/repos/spack_repo/builtin/packages/rust/package.py
@@ -17,11 +17,13 @@ class Rust(Package):
     url = "https://static.rust-lang.org/dist/rustc-1.42.0-src.tar.gz"
     git = "https://github.com/rust-lang/rust.git"
 
+    supplier = "Organization: Rust Foundation"
+
     tags = ["build-tools"]
 
-    maintainers("alecbcs")
+    maintainers("alecbcs", "mcmehrtens")
 
-    license("Apache-2.0 OR MIT")
+    license("Apache-2.0 OR MIT", checked_by="mcmehrtens")
 
     # When adding a version of Rust you may need to add an additional version
     # to rust-bootstrap as the minimum bootstrapping requirements increase.
@@ -38,6 +40,7 @@ class Rust(Package):
     version("nightly")
 
     # Stable versions.
+    version("1.97.0", sha256="de002ee301c1b7422b0a7b09d7c4cb4924cd3224e6cfb24f065dad786dd3ed12")
     version("1.96.1", sha256="77a6ff3003a4ad0cb00697b043c879e3e1a15d945b1a1f63818903bfc3fa8b98")
     version("1.96.0", sha256="b99ce16cdf0ecfc761b585ac84d131b46733465a02f8ecd0ff2de9713c62ee09")
     version("1.92.0", sha256="9e0d2ca75c7e275fdc758255bf4b03afb3d65d1543602746907c933b6901c3b8")
@@ -94,6 +97,7 @@ class Rust(Package):
     depends_on("rust-bootstrap@nightly", type="build", when="@nightly")
 
     # Stable version dependencies
+    depends_on("rust-bootstrap@1.96:1.97", type="build", when="@1.97")
     depends_on("rust-bootstrap@1.95:1.96", type="build", when="@1.96")
     depends_on("rust-bootstrap@1.91:1.92", type="build", when="@1.92")
     depends_on("rust-bootstrap@1.90:1.91", type="build", when="@1.91")

--- a/repos/spack_repo/builtin/packages/rust_bootstrap/package.py
+++ b/repos/spack_repo/builtin/packages/rust_bootstrap/package.py
@@ -15,7 +15,7 @@ class RustBootstrap(Package):
     homepage = "https://www.rust-lang.org"
     url = "https://static.rust-lang.org/dist/rust-1.65.0-aarch64-apple-darwin.tar.gz"
 
-    maintainers("alecbcs")
+    maintainers("alecbcs", "mcmehrtens")
 
     skip_version_audit = ["platform=windows"]
 


### PR DESCRIPTION
- add [Rust v1.97.0](https://doc.rust-lang.org/stable/releases.html#version-1970-2026-07-09)
- add supplier field
- add @mcmehrtens to maintainers for `rust` and `rust-bootstrap`