### PR TITLE
labels: automatically tag build-systems, fix maintainers

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -14,6 +14,12 @@ tests:
   filename: '^tests/.*$'
 
 #------------------------------------------------------------------------
+# Build Systems
+#------------------------------------------------------------------------
+build-systems:
+  filename: '^repos/spack_repo/builtin/build_systems/.*$'
+
+#------------------------------------------------------------------------
 # Package Types
 #------------------------------------------------------------------------
 intel:
@@ -51,31 +57,34 @@ remove-package:
 # Package Properties
 #------------------------------------------------------------------------
 maintainers:
-  patch: '[+-] +maintainers +='
+  patch: '[+-] +maintainers\('
+
+licenses:
+  patch: '[+-] +license\('
 
 new-version:
   patch: '\+ +version\('
 
-conflicts:
-  patch: '\+ +conflicts\('
-
-dependencies:
-  patch: '\+ +depends_on\('
-
-extends:
-  patch: '\+ +extends\('
-
-virtual-dependencies:
-  patch: '\+ +provides\('
-
-patch:
-  patch: '\+ +patch\('
-
 new-variant:
   patch: '\+ +variant\('
 
+conflicts:
+  patch: '[+-] +conflicts\('
+
+dependencies:
+  patch: '[+-] +depends_on\('
+
+extends:
+  patch: '[+-] +extends\('
+
+virtual-dependencies:
+  patch: '[+-] +provides\('
+
+patch:
+  patch: '[+-] +patch\('
+
 resources:
-  patch: '\+ +resource\('
+  patch: '[+-] +resource\('
 
 external-packages:
   patch: '[+-] +def determine_spec_details\('


### PR DESCRIPTION
- automatically tag build system changes with existing `build-systems` label
- automatically tag license changes with existing `licenses` label
- fix maintainers regex to look for `maintainers()` directive and not list
- make labels that are not `new-*` also trigger on deleted lines
