### PR TITLE
py-ase: add v3.29.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_ase/package.py
+++ b/repos/spack_repo/builtin/packages/py_ase/package.py
@@ -19,6 +19,7 @@ class PyAse(PythonPackage):
 
     maintainers("alikhamze")
 
+    version("3.29.0", sha256="7b9dd103f007810339c24acfee2f6b677c0c48443b21d3c98e52959246cf4ebf")
     version("3.28.0", sha256="74fe77ca38bf78070e24cd283f5d25be129bad6503fd26619008548518144732")
     version("3.27.0", sha256="92ada752d6866a61d2d27e0e6a4fd5b8cd86f59ca79a58f1d2fe29d7099153dc")
     version("3.26.0", sha256="a071a355775b0a8062d23e9266e9d811b19d9f6d9ec5215e8032f7d93dc65075")
@@ -44,6 +45,8 @@ class PyAse(PythonPackage):
         depends_on("py-scipy@1.8.1:", type=("build", "run"))
         depends_on("py-matplotlib@3.5.2:", type=("build", "run"))
         depends_on("py-setuptools@77.0.3:", type="build")
+        with when("@3.29.0:"):
+            depends_on("py-typing-extensions@4.13.1:", type=("build", "run"))
 
     with when("@3.24.0:3.26.0"):
         depends_on("python@3.9:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_ase/package.py
+++ b/repos/spack_repo/builtin/packages/py_ase/package.py
@@ -19,7 +19,7 @@ class PyAse(PythonPackage):
 
     maintainers("alikhamze")
 
-    version("3.29.0", sha256="7b9dd103f007810339c24acfee2f6b677c0c48443b21d3c98e52959246cf4ebf")
+    version("3.29.0", sha256="ef4e2caa38169e3fbbc4164764a060d1877a6692519a4bed82521328eeb0d9aa")
     version("3.28.0", sha256="74fe77ca38bf78070e24cd283f5d25be129bad6503fd26619008548518144732")
     version("3.27.0", sha256="92ada752d6866a61d2d27e0e6a4fd5b8cd86f59ca79a58f1d2fe29d7099153dc")
     version("3.26.0", sha256="a071a355775b0a8062d23e9266e9d811b19d9f6d9ec5215e8032f7d93dc65075")


### PR DESCRIPTION
Add `py-ase@3.29.0`.

Only one new dependency for this version relative to `@3.27.0:`, so I nested it under the dependencies for that version.
Hash from [https://pypi.org/project/ase/#ase-3.29.0-py3-none-any.whl](https://pypi.org/project/ase/#ase-3.29.0-py3-none-any.whl).