### PR TITLE
Python: Correct impossible virtual

### DIFF
--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -220,7 +220,7 @@ class Python(Package):
         depends_on("pkgconfig", type="build")
         depends_on("gettext +libxml2", when="+libxml2")
         depends_on("iconv", when="~libxml2")
-        depends_on("gettext ~libxml2", when="~libxml2 ^[virtuals=iconv]gettext")
+        depends_on("gettext ~libxml2", when="~libxml2 ^[virtuals=iconv] libiconv")
 
         # Optional dependencies
         # See detect_modules() in setup.py for details


### PR DESCRIPTION
`gettext` depends on `iconv` and therefore can't be a provider of `iconv`.

The providers of `iconv` are `libiconv`, `musl` and `glibc`. Of these, `libiconv` is the only one where we want to require `gettext`. `gettext` (provides `libintl`) is an optional dependency of `python` and python is configured to build without it.
If `gettext` is detected then `python` will use it, otherwise it builds without it.

Links:
https://github.com/python/cpython/issues/61428
https://github.com/astral-sh/python-build-standalone/blob/main/docs/technotes.rst#gettext--locale-module

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
