### PR TITLE
node-js: embed certs from openssl dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/node_js/package.py
+++ b/repos/spack_repo/builtin/packages/node_js/package.py
@@ -258,6 +258,11 @@ class NodeJs(Package):
                     "--shared-openssl",
                     "--shared-openssl-includes={0}".format(self.spec["openssl"].prefix.include),
                     "--shared-openssl-libpath={0}".format(self.spec["openssl"].prefix.lib),
+                    # Always prefer the CA store from our OpenSSL dependency
+                    # over the bundled Mozilla snapshot.  The OPENSSLDIR baked
+                    # into the shared library already points to the right certs
+                    # (mozilla, system, or none) as chosen by the openssl spec.
+                    "--openssl-use-def-ca-store",
                 ]
             )
 


### PR DESCRIPTION
By default NodeJS uses a vendored cert bundle in the source code, this changes it so that we instead use the cert bundle from our openssl dependency instead which allows us to capture self-signed system certificates.