### PR TITLE
multichase: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/multichase/package.py
+++ b/repos/spack_repo/builtin/packages/multichase/package.py
@@ -1,0 +1,37 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
+
+from spack.package import *
+
+
+class Multichase(MakefilePackage):
+    """Multichase pointer chaser benchmark."""
+
+    homepage = "https://github.com/google/multichase"
+    git = "https://github.com/google/multichase.git"
+
+    license("Apache-2.0")
+
+    # There are no releases or tags in the repo
+    version("master", branch="master")
+
+    # glibc-static is not available in most environments
+    variant("static", default=False, description="Link statically (requires glibc-static)")
+
+    depends_on("c", type="build")
+
+    def build(self, spec, prefix):
+        make_args = []
+        if "+static" not in spec:
+            make_args.append("LDFLAGS=-g -O3 -pthread")
+        make(*make_args)
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install("multichase", prefix.bin)
+        install("multiload", prefix.bin)
+        install("pingpong", prefix.bin)
+        install("fairness", prefix.bin)


### PR DESCRIPTION
Add multichase package, which contains a suite of benchmarks covering memory latency and bandwidth tests.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
