### PR TITLE
geant4: add version 11.4.2

### DIFF
--- a/repos/spack_repo/builtin/packages/geant4/package.py
+++ b/repos/spack_repo/builtin/packages/geant4/package.py
@@ -26,6 +26,7 @@ class Geant4(CMakePackage):
 
     maintainers("drbenmorgan", "sethrj")
 
+    version("11.4.2", sha256="f9d5c7d108ae6be644d12997e0289e23e5d2da18df1cab9aaacd9b76412dfec6")
     version("11.4.1", sha256="99dcf5f9d4f806fb8c4fde85cb2674a42e4ca19833143464ff7efa55c1852140")
     version("11.4.0", sha256="a6d78cf70ba46902cb74ff65d09dc2d1e46b4ab9325862f84e439f0d4ec329fb")
     version("11.3.2", sha256="077edca6aa3b3940f351cf9a948457cad3fb117f215b88c52cce315e1a07fd7a")


### PR DESCRIPTION
This PR adds the Geant4 11.4.2 release to the package recipe and updates the source checksum accordingly. No dependency
or variant changes were needed for this bump.
