### PR TITLE
RFC on llvm: Add libclang variant with external detection

### DIFF
--- a/repos/spack_repo/builtin/packages/llvm/detection_test.yaml
+++ b/repos/spack_repo/builtin/packages/llvm/detection_test.yaml
@@ -4,17 +4,182 @@ paths:
     - "bin/clang-3.9"
     - "bin/clang++-3.9"
     script: |
+      for arg in "$@"; do
+        case "$arg" in
+          -o*)
+            output="${arg#-o}"
+            printf '#!/bin/bash\necho "OK: mock libclang"\n' > "$output"
+            chmod +x "$output"
+            exit 0
+            ;;
+        esac
+      done
       echo "clang version 3.9.1-19ubuntu1 (tags/RELEASE_391/rc2)"
       echo "Target: x86_64-pc-linux-gnu"
       echo "Thread model: posix"
       echo "InstalledDir: /usr/bin"
+  - executables:
+    - "bin/llvm-config-3.9"
+    script: |
+      case "$1" in
+        --version) echo "3.9.1" ;;
+        --includedir|--libdir) echo "/tmp" ;;
+        --bindir) dirname "$0" ;;
+      esac
   platforms: ["darwin", "linux"]
   results:
-  - spec: 'llvm@3.9.1 +clang~flang~lld~lldb'
+  - spec: 'llvm@3.9.1 +clang+libclang~flang~lld~lldb'
     extra_attributes:
       compilers:
         c: ".*/bin/clang-3.9$"
         cxx: ".*/bin/clang[+][+]-3.9$"
+
+# clang compiler detection without libclang build usability
+- layout:
+  - executables:
+    - "bin/clang-18"
+    - "bin/clang++-18"
+    script: |
+      for arg in "$@"; do
+        case "$arg" in
+          -o*)
+            output="${arg#-o}"
+            printf '#!/bin/bash\necho "intentional libclang probe run failure"\nexit 1\n' > "$output"
+            chmod +x "$output"
+            exit 0
+            ;;
+        esac
+      done
+      echo "clang version 18.1.3 (1ubuntu1)"
+      echo "Target: x86_64-pc-linux-gnu"
+      echo "Thread model: posix"
+      echo "InstalledDir: /usr/bin"
+  - executables:
+    - "bin/llvm-config-18"
+    script: |
+      case "$1" in
+        --version) echo "18.1.3" ;;
+        --includedir|--libdir) echo "/tmp" ;;
+        --bindir) dirname "$0" ;;
+      esac
+  platforms: ["darwin", "linux"]
+  results:
+  - spec: 'llvm@18.1.3 +clang~flang~libclang~lld~lldb'
+    extra_attributes:
+      compilers:
+        c: ".*/bin/clang-18$"
+        cxx: ".*/bin/clang[+][+]-18$"
+
+# libclang detection when the mock clang compile fails
+- layout:
+  - executables:
+    - "bin/clang-17"
+    - "bin/clang++-17"
+    script: |
+      for arg in "$@"; do
+        case "$arg" in
+          -o*)
+            echo "intentional libclang probe compile failure" >&2
+            exit 1
+            ;;
+        esac
+      done
+      echo "clang version 17.0.6"
+      echo "Target: x86_64-pc-linux-gnu"
+      echo "Thread model: posix"
+      echo "InstalledDir: /usr/bin"
+  - executables:
+    - "bin/llvm-config-17"
+    script: |
+      case "$1" in
+        --version) echo "17.0.6" ;;
+        --includedir|--libdir) echo "/tmp" ;;
+        --bindir) dirname "$0" ;;
+      esac
+  platforms: ["darwin", "linux"]
+  results:
+  - spec: 'llvm@17.0.6 +clang~flang~libclang~lld~lldb'
+    extra_attributes:
+      compilers:
+        c: ".*/bin/clang-17$"
+        cxx: ".*/bin/clang[+][+]-17$"
+
+# libclang detection when the clang executable derived from llvm-config is absent
+- layout:
+  - executables:
+    - "bin/clang-16"
+    - "bin/clang++-16"
+    script: |
+      echo "clang version 16.0.6"
+      echo "Target: x86_64-pc-linux-gnu"
+      echo "Thread model: posix"
+      echo "InstalledDir: /usr/bin"
+  - executables:
+    - "bin/llvm-config-16.0"
+    script: |
+      case "$1" in
+        --version) echo "16.0.6" ;;
+        --includedir|--libdir) echo "/tmp" ;;
+        --bindir) dirname "$0" ;;
+      esac
+  platforms: ["darwin", "linux"]
+  results:
+  - spec: 'llvm@16.0.6 +clang~flang~libclang~lld~lldb'
+    extra_attributes:
+      compilers:
+        c: ".*/bin/clang-16$"
+        cxx: ".*/bin/clang[+][+]-16$"
+
+# libclang detection when llvm-config reports a bindir without the derived clang
+- layout:
+  - executables:
+    - "bin/clang-15"
+    - "bin/clang++-15"
+    script: |
+      echo "clang version 15.0.7"
+      echo "Target: x86_64-pc-linux-gnu"
+      echo "Thread model: posix"
+      echo "InstalledDir: /usr/bin"
+  - executables:
+    - "bin/llvm-config-15"
+    script: |
+      case "$1" in
+        --version) echo "15.0.7" ;;
+        --includedir|--libdir) echo "/tmp" ;;
+        --bindir) echo "/does/not/exist" ;;
+      esac
+  platforms: ["darwin", "linux"]
+  results:
+  - spec: 'llvm@15.0.7 +clang~flang~libclang~lld~lldb'
+    extra_attributes:
+      compilers:
+        c: ".*/bin/clang-15$"
+        cxx: ".*/bin/clang[+][+]-15$"
+
+# libclang detection when llvm-config itself fails during probing
+- layout:
+  - executables:
+    - "bin/clang-14"
+    - "bin/clang++-14"
+    script: |
+      echo "clang version 14.0.6"
+      echo "Target: x86_64-pc-linux-gnu"
+      echo "Thread model: posix"
+      echo "InstalledDir: /usr/bin"
+  - executables:
+    - "bin/llvm-config-14"
+    script: |
+      case "$1" in
+        --version) echo "14.0.6" ;;
+        *) echo "intentional llvm-config libclang probe failure" >&2; exit 1 ;;
+      esac
+  platforms: ["darwin", "linux"]
+  results:
+  - spec: 'llvm@14.0.6 +clang~flang~libclang~lld~lldb'
+    extra_attributes:
+      compilers:
+        c: ".*/bin/clang-14$"
+        cxx: ".*/bin/clang[+][+]-14$"
 
 # flang-new detection: flang-new generates slightly-different output than clang
 - layout:
@@ -22,10 +187,28 @@ paths:
     - "bin/clang"
     - "bin/clang++"
     script: |
+      for arg in "$@"; do
+        case "$arg" in
+          -o*)
+            output="${arg#-o}"
+            printf '#!/bin/bash\necho "OK: mock libclang"\n' > "$output"
+            chmod +x "$output"
+            exit 0
+            ;;
+        esac
+      done
       echo "clang version 19.1.6 (https://github.com/spack/spack.git 8d3a733b7798b6e33c371518b6dec298c3ebd8b1)"
       echo "Target: x86_64-unknown-linux-gnu"
       echo "Thread model: posix"
       echo "InstalledDir: /path/to/spack/install/llvm/bin"
+  - executables:
+    - "bin/llvm-config"
+    script: |
+      case "$1" in
+        --version) echo "19.1.6" ;;
+        --includedir|--libdir) echo "/tmp" ;;
+        --bindir) dirname "$0" ;;
+      esac
   - executables:
     - "bin/flang-new"
     script: |
@@ -35,7 +218,7 @@ paths:
       echo "InstalledDir: /path/to/spack/install/llvm/bin"
   platforms: ["darwin", "linux"]
   results:
-  - spec: 'llvm@19.1.6 +flang+clang~lld~lldb'
+  - spec: 'llvm@19.1.6 +flang+clang+libclang~lld~lldb'
     extra_attributes:
       compilers:
         c: ".*/bin/clang"
@@ -48,10 +231,28 @@ paths:
     - "bin/clang"
     - "bin/clang++"
     script: |
+      for arg in "$@"; do
+        case "$arg" in
+          -o*)
+            output="${arg#-o}"
+            printf '#!/bin/bash\necho "OK: mock libclang"\n' > "$output"
+            chmod +x "$output"
+            exit 0
+            ;;
+        esac
+      done
       echo "clang version 20.1.0-rc1 (https://github.com/llvm/llvm-project af7f483a9d801252247b6c72e3763c1f55c5a506)"
       echo "Target: x86_64-unknown-linux-gnu"
       echo "Thread model: posix"
       echo "InstalledDir: /tmp/clang/LLVM-20.1.0-rc1-Linux-X64/bin"
+  - executables:
+    - "bin/llvm-config"
+    script: |
+      case "$1" in
+        --version) echo "20.1.0" ;;
+        --includedir|--libdir) echo "/tmp" ;;
+        --bindir) dirname "$0" ;;
+      esac
   - executables:
     - "bin/flang"
     script: |
@@ -61,7 +262,7 @@ paths:
       echo "InstalledDir: /tmp/clang/LLVM-20.1.0-rc1-Linux-X64/bin"
   platforms: ["darwin", "linux"]
   results:
-  - spec: 'llvm@20.1.0 +flang+clang~lld~lldb'
+  - spec: 'llvm@20.1.0 +flang+clang+libclang~lld~lldb'
     extra_attributes:
       compilers:
         c: ".*/bin/clang"
@@ -74,10 +275,28 @@ paths:
     - "bin/clang"
     - "bin/clang++"
     script: |
+      for arg in "$@"; do
+        case "$arg" in
+          -o*)
+            output="${arg#-o}"
+            printf '#!/bin/bash\necho "OK: mock libclang"\n' > "$output"
+            chmod +x "$output"
+            exit 0
+            ;;
+        esac
+      done
       echo "clang version 20.1.0-rc1 (https://github.com/llvm/llvm-project af7f483a9d801252247b6c72e3763c1f55c5a506)"
       echo "Target: x86_64-unknown-linux-gnu"
       echo "Thread model: posix"
       echo "InstalledDir: /tmp/clang/LLVM-20.1.0-rc1-Linux-X64/bin"
+  - executables:
+    - "bin/llvm-config"
+    script: |
+      case "$1" in
+        --version) echo "20.1.0" ;;
+        --includedir|--libdir) echo "/tmp" ;;
+        --bindir) dirname "$0" ;;
+      esac
   - executables:
     - "bin/flang"
     - "bin/flang-new"
@@ -88,7 +307,7 @@ paths:
       echo "InstalledDir: /tmp/clang/LLVM-20.1.0-rc1-Linux-X64/bin"
   platforms: ["darwin", "linux"]
   results:
-  - spec: 'llvm@20.1.0 +flang+clang~lld~lldb'
+  - spec: 'llvm@20.1.0 +flang+clang+libclang~lld~lldb'
     extra_attributes:
       compilers:
         c: ".*/bin/clang"
@@ -102,14 +321,32 @@ paths:
     - "bin/clang-6.0"
     - "bin/clang++-6.0"
     script: |
+        for arg in "$@"; do
+          case "$arg" in
+            -o*)
+              output="${arg#-o}"
+              printf '#!/bin/bash\necho "OK: mock libclang"\n' > "$output"
+              chmod +x "$output"
+              exit 0
+              ;;
+          esac
+        done
         echo "clang version 6.0.1-svn334776-1~exp1~20181018152737.116 (branches/release_60)"
         echo "Target: x86_64-pc-linux-gnu"
         echo "Thread model: posix"
         echo "InstalledDir: /usr/bin",
+  - executables:
+    - "bin/llvm-config-6.0"
+    script: |
+        case "$1" in
+          --version) echo "6.0.1" ;;
+          --includedir|--libdir) echo "/tmp" ;;
+          --bindir) dirname "$0" ;;
+        esac
 
   platforms: ["darwin", "linux"]
   results:
-  - spec: 'llvm@6.0.1 +clang~flang~lld~lldb'
+  - spec: 'llvm@6.0.1 +clang+libclang~flang~lld~lldb'
     extra_attributes:
       compilers:
         c: ".*/bin/clang-6.0$"
@@ -119,14 +356,32 @@ paths:
     - "bin/clang-9.0"
     - "bin/clang++-9.0"
     script: |      
+        for arg in "$@"; do
+          case "$arg" in
+            -o*)
+              output="${arg#-o}"
+              printf '#!/bin/bash\necho "OK: mock libclang"\n' > "$output"
+              chmod +x "$output"
+              exit 0
+              ;;
+          esac
+        done
         echo "clang version 9.0.1-+201911131414230800840845a1eea-1~exp1~20191113231141.78"
         echo "Target: x86_64-pc-linux-gnu"
         echo "Thread model: posix"
         echo "InstalledDir: /usr/bin"
+  - executables:
+    - "bin/llvm-config-9.0"
+    script: |
+        case "$1" in
+          --version) echo "9.0.1" ;;
+          --includedir|--libdir) echo "/tmp" ;;
+          --bindir) dirname "$0" ;;
+        esac
 
   platforms: ["darwin", "linux"]
   results:
-  - spec: 'llvm@9.0.1 +clang~flang~lld~lldb'
+  - spec: 'llvm@9.0.1 +clang+libclang~flang~lld~lldb'
     extra_attributes:
       compilers:
         c: ".*/bin/clang-9.0$"
@@ -138,10 +393,28 @@ paths:
     - "bin/clang-8"
     - "bin/clang++-8"
     script: |
+      for arg in "$@"; do
+        case "$arg" in
+          -o*)
+            output="${arg#-o}"
+            printf '#!/bin/bash\necho "OK: mock libclang"\n' > "$output"
+            chmod +x "$output"
+            exit 0
+            ;;
+        esac
+      done
       echo "clang version 8.0.0-3~ubuntu18.04.2 (tags/RELEASE_800/final)"
       echo "Target: x86_64-pc-linux-gnu"
       echo "Thread model: posix"
       echo "InstalledDir: /usr/bin"
+  - executables:
+    - "bin/llvm-config-8"
+    script: |
+      case "$1" in
+        --version) echo "8.0.0" ;;
+        --includedir|--libdir) echo "/tmp" ;;
+        --bindir) dirname "$0" ;;
+      esac
   - executables:
     - "bin/ld.lld-8"
     script: 'echo "LLD 8.0.0 (compatible with GNU linkers)"'
@@ -152,19 +425,37 @@ paths:
     - "bin/clang-3.9"
     - "bin/clang++-3.9"
     script: |
+      for arg in "$@"; do
+        case "$arg" in
+          -o*)
+            output="${arg#-o}"
+            printf '#!/bin/bash\necho "OK: mock libclang"\n' > "$output"
+            chmod +x "$output"
+            exit 0
+            ;;
+        esac
+      done
       echo "clang version 3.9.1-19ubuntu1 (tags/RELEASE_391/rc2)"
       echo "Target: x86_64-pc-linux-gnu"
       echo "Thread model: posix"
       echo "InstalledDir: /usr/bin"
+  - executables:
+    - "bin/llvm-config-3.9"
+    script: |
+      case "$1" in
+        --version) echo "3.9.1" ;;
+        --includedir|--libdir) echo "/tmp" ;;
+        --bindir) dirname "$0" ;;
+      esac
   platforms: ["darwin", "linux"]
   results:
-  - spec: 'llvm@8.0.0+clang~flang+lld+lldb'
+  - spec: 'llvm@8.0.0+clang+libclang~flang+lld+lldb'
     extra_attributes:
       compilers:
         c: ".*/bin/clang-8$"
         cxx: ".*/bin/clang[+][+]-8$"
 
-  - spec: 'llvm@3.9.1+clang~flang~lld~lldb'
+  - spec: 'llvm@3.9.1+clang+libclang~flang~lld~lldb'
     extra_attributes:
       compilers:
         c: ".*/bin/clang-3.9$"

--- a/repos/spack_repo/builtin/packages/llvm/package.py
+++ b/repos/spack_repo/builtin/packages/llvm/package.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 import re
+import tempfile
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
 from spack_repo.builtin.build_systems.compiler import CompilerPackage
@@ -22,12 +23,14 @@ class LlvmDetection(PackageBase):
     def filter_detected_exes(cls, prefix, exes_in_prefix):
         # Executables like lldb-vscode-X are daemon listening on some port and would hang Spack
         # during detection. clang-cl, clang-cpp, etc. are dev tools that we don't need to test
+        # and can be filtered out. Only apply it to the file names not the full path to avoid
+        # filtering out directories with these names which would break some environments.
         reject = re.compile(
             r"-(vscode|cpp|cl|ocl|gpu|tidy|rename|scan-deps|format|refactor|offload|"
             r"check|query|doc|move|extdef|apply|reorder|change-namespace|"
             r"include-fixer|import-test|dap|server|PerfectShuffle)"
         )
-        return [x for x in exes_in_prefix if not reject.search(x)]
+        return [x for x in exes_in_prefix if not reject.search(os.path.basename(x))]
 
 
 class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
@@ -106,6 +109,8 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
     variant(
         "clang", default=True, description="Build the LLVM C/C++/Objective-C compiler frontend"
     )
+    variant("libclang", default=True, description="Provide the libclang development interface")
+    conflicts("+libclang", when="~clang")
 
     variant("flang", default=False, description="Build the LLVM Fortran compiler frontend ")
 
@@ -709,13 +714,19 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
 
     @classproperty
     def executables(cls):
-        return super().executables + [r"^ld\.lld(-\d+)?$", r"^lldb(-\d+)?$"]
+        return super().executables + [
+            r"^ld\.lld(-\d+)?$",
+            r"^lldb(-\d+)?$",
+            r"^llvm-config(-\d+(\.\d+)*)?$",
+        ]
 
     @classmethod
     def determine_version(cls, exe):
         try:
             compiler = Executable(exe)
             output = compiler(cls.compiler_version_argument, output=str, error=str)
+            if compiler.name.startswith("llvm-config"):
+                return output.strip()
             if "Apple" in output:
                 return None
             if "AMD" in output:
@@ -733,6 +744,63 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
         return None
 
     @classmethod
+    def determine_libclang_variant(cls, exe_path) -> bool:
+        """Determine if the given executable support the libclang variant.
+
+        Compiles and runs a test program that uses the libclang API.
+        """
+        llvm_config = Executable(exe_path)
+        try:
+            inc = llvm_config("--includedir", output=str, error=str).strip()
+            lib = llvm_config("--libdir", output=str, error=str).strip()
+            bin = llvm_config("--bindir", output=str, error=str).strip()
+        except ProcessError:
+            tty.debug(f"Failed to query llvm-config for {exe_path}")
+            return False
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = os.path.join(tmpdir, "test.cpp")
+            with open(test_file, "w") as f:
+                f.write("""#include <stdio.h>
+                    #include <clang-c/Index.h>
+                    int main(void) {
+                        CXString s = clang_getClangVersion();
+                        const char *v = clang_getCString(s);
+                        if (!v) return 2;
+                        printf("OK: %s", v);
+                        return 0;
+                    }""")
+            clang = os.path.join(bin, os.path.basename(exe_path).replace("llvm-config", "clang"))
+            try:
+                # TODO: If cmake is available, get llvm-config --cmakedir.
+                # Or check the cmake modules directory for LLVMConfig.cmake and
+                # and read the LLVMConfig.cmake file to get the libraries it
+                # requires.
+                # Use it to get the correct flags for compiling the test program.
+                # This is needed for LLVM 15+ where zstd support is enabled by
+                # default, and the test program wants to link with zstd.
+                Executable(clang)(
+                    test_file,
+                    "-o" + os.path.join(tmpdir, "test"),
+                    "-I" + inc,
+                    "-L" + lib,
+                    "-lclang",
+                    # LLVMConfig.cmake enables LLVM zstd support by default, so we need to test it
+                    "-lzstd",
+                    error=str,
+                )
+            except ProcessError:
+                tty.debug(f"Failed to compile libclang test program for {exe_path}")
+                return False
+
+            try:
+                if "OK:" in Executable(os.path.join(tmpdir, "test"))(output=str):
+                    return True
+            except ProcessError:
+                tty.debug(f"Failed to run libclang test program for {exe_path}")
+        return False
+
+    @classmethod
     def determine_variants(cls, exes, version_str):
         # Do not need to reuse more general logic from CompilerPackage
         # because LLVM has kindly named compilers
@@ -745,6 +813,7 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
             ("flang", "flang", "fortran"),
             ("ld.lld", "lld", None),
             ("lldb", "lldb", None),
+            ("llvm-config", "libclang", None),
         ]
 
         variants = set()
@@ -753,11 +822,15 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
         # Prefer shorter pathnames by sorting with len and using setdefault
         for exe_path in sorted(exes, key=len):
             name = os.path.basename(exe_path)
-            for exe, var, lang in exe_variant_lang:
+            for exe, variant, lang in exe_variant_lang:
                 # NOTE: since "amdclang++" is "clang", we use `in` rather than `startswith`
                 if exe in name:
                     compilers.setdefault(lang, exe_path)
-                    variants.add(var)
+                    if variant == "libclang":
+                        if cls.determine_libclang_variant(exe_path):
+                            variants.add(variant)
+                    elif variant:
+                        variants.add(variant)
                     break
 
         # Remove executables that aren't compilers
@@ -1178,6 +1251,13 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
     def post_install(self):
         spec = self.spec
         define = self.define
+
+        if spec.satisfies("~libclang"):
+            clang_c_headers = join_path(self.prefix.include, "clang-c")
+            if os.path.exists(clang_c_headers):
+                remove_linked_tree(clang_c_headers)
+            if os.path.isdir(self.prefix.lib):
+                force_remove(*find(self.prefix.lib, "libclang.*", recursive=False))
 
         # unnecessary if we build openmp via LLVM_ENABLE_RUNTIMES
         if self.spec.satisfies("+cuda openmp=project"):


### PR DESCRIPTION
Add a libclang variant and detect whether an external LLVM installation provides usable libclang development support during compiler discovery.

When Spack discovers a system clang compiler or registers an external LLVM package, detection uses llvm-config to query include, library, and binary paths, then compiles, links, and runs a minimal clang-c program against libclang.

This lets detected externals distinguish between a usable clang compiler and a usable libclang development installation. Common distro installs can provide clang while still lacking libclang headers, link-time libraries, or transitive development dependencies such as zstd.

In those cases the external is still detected, but with ~libclang so dependents that need libclang can fall back to a Spack-built LLVM.

The detection tests model both positive and negative libclang probe behavior. Positive fixtures provide llvm-config scripts with matching --version, include, library, and bindir responses, and mock clang executables create runnable probe binaries.

Negative fixtures cover explicit ~libclang detection for:

- a generated probe executable that fails when run,
- a mock clang compile step that fails,
- a derived clang executable that does not exist,
- an llvm-config --bindir result that points to a missing directory, and
- an llvm-config failure while querying probe paths.

Also updated the filter for Executables like lldb-vscode-X: Only apply it to the file names not the full path to avoid filtering out directories with these names which would break some environments.

Tested with `spack -d audit externals`
