### PR TITLE
motif: fix build with GCC 14 and GCC 15

### DIFF
--- a/repos/spack_repo/builtin/packages/motif/package.py
+++ b/repos/spack_repo/builtin/packages/motif/package.py
@@ -46,6 +46,18 @@ class Motif(AutotoolsPackage):
     # ensure tools/wml/wmluiltok.c has a main function
     patch("add_wmluiltok_option_main.patch")
 
+    def flag_handler(self, name, flags):
+        if name == "cflags":
+            if self.spec.satisfies("%gcc@14:"):
+                # Implicit function declarations became a hard error in GCC 14;
+                # e.g. lib/Xm/XpmI.h only includes <string.h> on SysV platforms.
+                flags.append("-Wno-error=implicit-function-declaration")
+            if self.spec.satisfies("%gcc@15:"):
+                # GCC 15 defaults to gnu23 where empty () means no arguments, breaking
+                # legacy K&R function pointer declarations in config/util/makestrs.c.
+                flags.append("-std=gnu17")
+        return (flags, None, None)
+
     def patch(self):
         # fix linking the simple_app demo program
         # https://bugs.launchpad.net/ubuntu/+source/openmotif/+bug/705294


### PR DESCRIPTION
## Summary

Motif 2.3.8 is unmaintained and its sources predate modern C strictness, so it fails to build with recent GCC. This adds a `flag_handler` to work around two separate toolchain-driven failures:

- **GCC 14** makes implicit function declarations a hard error. `lib/Xm/XpmI.h` only includes `<string.h>` on SysV-style platforms and falls back to `<strings.h>` elsewhere, so `strcpy()` and friends are never declared on glibc:
  ```
  XpmCrBufFrI.c:155:5: error: implicit declaration of function 'strcpy' [-Wimplicit-function-declaration]
  ```
- **GCC 15** defaults to `-std=gnu23`, where an empty `()` parameter list means "no arguments". `config/util/makestrs.c` relies on the old K&R meaning for its `headerproc[]`/`sourceproc[]` function-pointer arrays:
  ```
  makestrs.c:241:39: error: initialization of 'void (*)(void)' from incompatible pointer type 'void (*)(FILE *, File *)' [-Wincompatible-pointer-types]
  ```

The fix appends `-Wno-error=implicit-function-declaration` for `%gcc@14:` and `-std=gnu17` for `%gcc@15:`. This mirrors the approach taken by Gentoo (https://bugs.gentoo.org/944107) and by existing Spack packages such as `termcap`.

## Test plan (to be checked by a human, updated by @bernhardkaindl )

- [ ] `spack install xnedit` (which pulls in `motif`) builds successfully with `%gcc@14`
- [ ] `spack install xnedit` (which pulls in `motif`) builds successfully with `%gcc@15`

Made with [Cursor](https://cursor.com)