### PR TITLE
libgpiod: add v2.2.4-v2.3.1, support meson build, fix snapshot urls

### DIFF
--- a/repos/spack_repo/builtin/packages/libgpiod/package.py
+++ b/repos/spack_repo/builtin/packages/libgpiod/package.py
@@ -3,12 +3,14 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+from spack_repo.builtin.build_systems import autotools, meson
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.build_systems.meson import MesonPackage
 
 from spack.package import *
 
 
-class Libgpiod(AutotoolsPackage):
+class Libgpiod(AutotoolsPackage, MesonPackage):
     """C library and tools for interacting with the linux GPIO character device
     (gpiod stands for GPIO device)"""
 
@@ -19,36 +21,63 @@ class Libgpiod(AutotoolsPackage):
 
     license("LGPL-2.1-or-later")
 
+    # libgpiod switched from autotools to meson in the 2.3 release series
+    build_system(
+        conditional("autotools", when="@:2.2"),
+        conditional("meson", when="@2.3:"),
+        default="meson",
+    )
+
     version("master", branch="master")
+    version("2.3.1", sha256="33ae7069ba1558b4b0f5385479c2a357a05f70998535c19d170079597ff7d09c")
+    version("2.3.0", sha256="aff97f550327a03b2200da4460ca629fce5b110ad3ae1ba3820689a78f90f9c2")
+    version("2.2.5", sha256="f4eb223c6f56df930d335def9609103773a028d71716d350a196c867af707e34")
+    version("2.2.4", sha256="fc8294633f1579648c77dac2afc9c05d6db05285c62ecd3d0ccbab34b4d538ce")
     version("2.2.3", sha256="70de4639856620571f99d851cf1acd48f6462b62ccba929f1a0235ec76b4e4dc")
     version("2.2.2", sha256="02794831a65adab942620dd3e8f038ff881c3c127d7d26841d94caa8caea793f")
     version("2.2.1", sha256="c6054a64a12681beeb0ce5200867754843bb68465b06c543f132ad984aee3f83")
-    version("2.2.0", sha256="ae35329db7027c740e90c883baf27c26311f0614e6a7b115771b28188b992aec")
-    version("2.1.3", sha256="8d80ea022ae78122aa525308e7423b83064bff278fcd9cd045b94b4f81f8057d")
-    version("2.1.2", sha256="b1bdf1e3f75238695f93e442062bafc069170f2bf4f0cd4b8e049ca67131a1f0")
-    version("2.1.1", sha256="0af43a6089d69f9d075cf67ca2ae5972b9081e38e6b3d46cea37d67e2df6fb9b")
-    version("2.1.0", sha256="fd6ed4b2c674fe6cc3b481880f6cde1eea79e296e95a139b85401eaaea6de3fc")
-    version("2.0.2", sha256="3532e1dbaffdc2c5965a761a0750f2691ee49aad273ddbbd93acf6a727b1b65c")
-    version("2.0.1", sha256="b6eda55356160a8e73906e3d48e959ef81296787d764975b10f257e9660668e9")
-    version("2.0.0", sha256="62071ac22872d9b936408e4a067d15edcdd61dce864ace8725eacdaefe23b898")
-    version("1.6.5", sha256="1473d3035b506065393a4569763cf6b5c98e59c8f865326374ebadffa2578f3a")
-    version("1.6.4", sha256="829d4ac268df07853609d67cfc7f476e9aa736cb2a68a630be99e8fad197be0a")
-    version("1.6.3", sha256="eb446070be1444fd7d32d32bbca53c2f3bbb0a21193db86198cf6050b7a28441")
+    version("2.2.0", sha256="9af73e884b06f63ee777938999a6f563a02dd9afdb785a5a7479e94ac2d99f75")
+    version("2.1.3", sha256="aa1bd204982862cf991eb827a244867969f7d6f5361d56514f599d9724a33974")
+    version("2.1.2", sha256="87b093d07d34f2180df5cd7425209cff5e77b79343485e5dda1c27108bda1dbd")
+    version("2.1.1", sha256="2ca57a484d4d5d4005778b032c06156a09d0536160eb8de7713ed3346b873d40")
+    version("2.1.0", sha256="00eed92b31dd15fc995a41650dbf705b227958c444866fd082b415c1b2a53b95")
+    version("2.0.2", sha256="dc2d13ff73d42bba1bad80a67745f97e5594c84d087534a0d0b710b2c090d8a3")
+    version("2.0.1", sha256="cf0d4db1d94cc99281de142063d0e28f42760c4d918d6b8854e1b27811517c34")
+    version("2.0.0", sha256="a0f835c4ca4a2a3ca021090b574235ba58bb9fd612d8a6051fb1350054e04fdd")
+    version("1.6.5", sha256="7715458859333fe111f900d23baac459a5e0629881e6490779de79fce49373fb")
+    version("1.6.4", sha256="9f920260c46b155f65cba8796dcf159e4ba56950b85742af357d75a1af709e68")
+    version("1.6.3", sha256="b4b8d4ffc13777ce7540532e47458924df475dd3eb7d4fb4afcca7fe3fe03595")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    depends_on("autoconf", type="build")
-    depends_on("autoconf-archive", type="build")
-    depends_on("automake", type="build")
     depends_on("pkgconfig", type="build")
-    depends_on("libtool", type="build")
 
-    def autoreconf(self, spec, prefix):
-        Executable("./autogen.sh")()
+    with when("build_system=autotools"):
+        depends_on("autoconf", type="build")
+        depends_on("autoconf-archive", type="build")
+        depends_on("automake", type="build")
+        depends_on("libtool", type="build")
 
     def url_for_version(self, version):
+        # Patch-0 releases are tagged without the trailing ".0" (e.g. v2.3, not v2.3.0)
         if version[2] == 0:
-            return f"https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-v{version.up_to(1)}.tar.gz"
+            return f"https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-v{version.up_to(2)}.tar.gz"
         else:
             return f"https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-v{version}.tar.gz"
+
+
+class AutotoolsBuilder(autotools.AutotoolsBuilder):
+    def autoreconf(self, pkg, spec, prefix):
+        Executable("./autogen.sh")()
+
+
+class MesonBuilder(meson.MesonBuilder):
+    def meson_args(self):
+        return [
+            "-Dtools=enabled",
+            "-Dtests=disabled",
+            "-Dexamples=disabled",
+            "-Dbindings-cxx=disabled",
+            "-Dgpioset-interactive=disabled",
+        ]

--- a/repos/spack_repo/builtin/packages/libgpiod/package.py
+++ b/repos/spack_repo/builtin/packages/libgpiod/package.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack_repo.builtin.build_systems import autotools, meson
+from spack_repo.builtin.build_systems import meson
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack_repo.builtin.build_systems.meson import MesonPackage
 
@@ -15,6 +15,7 @@ class Libgpiod(AutotoolsPackage, MesonPackage):
     (gpiod stands for GPIO device)"""
 
     homepage = "https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/about/"
+    url = "https://mirrors.edge.kernel.org/pub/software/libs/libgpiod/libgpiod-2.3.1.tar.xz"
     git = "https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod"
 
     maintainers("davekeeshan")
@@ -23,53 +24,40 @@ class Libgpiod(AutotoolsPackage, MesonPackage):
 
     # libgpiod switched from autotools to meson in the 2.3 release series
     build_system(
-        conditional("autotools", when="@:2.2"),
-        conditional("meson", when="@2.3:"),
-        default="meson",
+        conditional("autotools", when="@:2.2"), conditional("meson", when="@2.3:"), default="meson"
     )
 
     version("master", branch="master")
-    version("2.3.1", sha256="33ae7069ba1558b4b0f5385479c2a357a05f70998535c19d170079597ff7d09c")
-    version("2.3.0", sha256="aff97f550327a03b2200da4460ca629fce5b110ad3ae1ba3820689a78f90f9c2")
-    version("2.2.5", sha256="f4eb223c6f56df930d335def9609103773a028d71716d350a196c867af707e34")
-    version("2.2.4", sha256="fc8294633f1579648c77dac2afc9c05d6db05285c62ecd3d0ccbab34b4d538ce")
-    version("2.2.3", sha256="70de4639856620571f99d851cf1acd48f6462b62ccba929f1a0235ec76b4e4dc")
-    version("2.2.2", sha256="02794831a65adab942620dd3e8f038ff881c3c127d7d26841d94caa8caea793f")
-    version("2.2.1", sha256="c6054a64a12681beeb0ce5200867754843bb68465b06c543f132ad984aee3f83")
-    version("2.2.0", sha256="9af73e884b06f63ee777938999a6f563a02dd9afdb785a5a7479e94ac2d99f75")
-    version("2.1.3", sha256="aa1bd204982862cf991eb827a244867969f7d6f5361d56514f599d9724a33974")
-    version("2.1.2", sha256="87b093d07d34f2180df5cd7425209cff5e77b79343485e5dda1c27108bda1dbd")
-    version("2.1.1", sha256="2ca57a484d4d5d4005778b032c06156a09d0536160eb8de7713ed3346b873d40")
-    version("2.1.0", sha256="00eed92b31dd15fc995a41650dbf705b227958c444866fd082b415c1b2a53b95")
-    version("2.0.2", sha256="dc2d13ff73d42bba1bad80a67745f97e5594c84d087534a0d0b710b2c090d8a3")
-    version("2.0.1", sha256="cf0d4db1d94cc99281de142063d0e28f42760c4d918d6b8854e1b27811517c34")
-    version("2.0.0", sha256="a0f835c4ca4a2a3ca021090b574235ba58bb9fd612d8a6051fb1350054e04fdd")
-    version("1.6.5", sha256="7715458859333fe111f900d23baac459a5e0629881e6490779de79fce49373fb")
-    version("1.6.4", sha256="9f920260c46b155f65cba8796dcf159e4ba56950b85742af357d75a1af709e68")
-    version("1.6.3", sha256="b4b8d4ffc13777ce7540532e47458924df475dd3eb7d4fb4afcca7fe3fe03595")
+    version("2.3.1", sha256="e3a358a90a9204ff16f92b6f4028ed91460b1926f10589eb54b3566484650a30")
+    version("2.3.0", sha256="cb71db463aec2604ac520c95bf04eff1839d86bdc9a2dfd67ef879fbb10426ea")
+    version("2.2.5", sha256="0df1bb2be89d9091a167b9f702f8f31d89863e8d84997aad09ee4aba12fe78c5")
+    version("2.2.4", sha256="13207176b0eb9b3e0f02552d5f49f5a6a449343ce47416158bb484d9d3019592")
+    version("2.2.3", sha256="70012b0262e4b90f140431efa841ca89643b02ea6c09f507e23cec664a51b71a")
+    version("2.2.2", sha256="7e3bff0209d75fbca2e9fcff1fd5f07cc58b543e129e08b6d4bb1e4a56cfec0d")
+    version("2.2.1", sha256="0e948049c309b87c220fb24ee0d605d7cd5b72f22376e608470903fffa2d4b18")
+    version("2.2.0", sha256="ee29735890eb1cc0e4b494001da5163d1a9c4735343201d22485db313601ca07")
+    version("2.1.3", sha256="2be4c0b03e995d236c0e476e14aeb475d7b431dd1439609b6d65c540f91eaf58")
+    version("2.1.2", sha256="7a148a5a7d1c97a1abb40474b9a392b6edd7a42fe077dfd7ff42cfba24308548")
+    version("2.1.1", sha256="b21913f469d3135680d5516f00fdf9f81d5e564e19ffb690927ea7f1d7e312cb")
+    version("2.1.0", sha256="fa4024a080121c958502f9a46a5bda44bea85e7a4dd7fcb3dead463b6fc4261c")
+    version("2.0.2", sha256="c3c923dc63b7b1b02639c9179c81e3d9febf0887bbaa59775990229cdbedb88b")
+    version("2.0.1", sha256="b5367d28d045b36007a4ffd42cceda4c358737ef4f2ce22b0c1d05ec57a38392")
+    version("2.0.0", sha256="f74cbf82038b3cb98ebeb25bce55ee2553be28194002d2a9889b9268cce2dd07")
+    version("1.6.5", sha256="ae280f697bf035a1fb780c9972e5c81d0d2712b7ab6124fb3fba24619daa72bc")
+    version("1.6.4", sha256="7b146e12f28fbca3df7557f176eb778c5ccf952ca464698dba8a61b2e1e3f9b5")
+    version("1.6.3", sha256="841be9d788f00bab08ef22c4be5c39866f0e46cb100a3ae49ed816ac9c5dddc7")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
     depends_on("pkgconfig", type="build")
 
-    with when("build_system=autotools"):
-        depends_on("autoconf", type="build")
-        depends_on("autoconf-archive", type="build")
-        depends_on("automake", type="build")
-        depends_on("libtool", type="build")
-
     def url_for_version(self, version):
-        # Patch-0 releases are tagged without the trailing ".0" (e.g. v2.3, not v2.3.0)
+        # Release tarballs for x.y.0 drop the trailing ".0" (e.g. 2.3, not 2.3.0)
+        base = "https://mirrors.edge.kernel.org/pub/software/libs/libgpiod"
         if version[2] == 0:
-            return f"https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-v{version.up_to(2)}.tar.gz"
-        else:
-            return f"https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-v{version}.tar.gz"
-
-
-class AutotoolsBuilder(autotools.AutotoolsBuilder):
-    def autoreconf(self, pkg, spec, prefix):
-        Executable("./autogen.sh")()
+            return f"{base}/libgpiod-{version.up_to(2)}.tar.xz"
+        return f"{base}/libgpiod-{version}.tar.xz"
 
 
 class MesonBuilder(meson.MesonBuilder):


### PR DESCRIPTION
## Summary
- libgpiod switched from autotools to meson starting with the 2.3 release
  series. The package now selects the build system per version via
  `build_system()` and provides both an `AutotoolsBuilder` (`@:2.2`) and a
  `MesonBuilder` (`@2.3:`, default).
- Add versions 2.2.4, 2.2.5, 2.3.0 and 2.3.1.
- Fix `url_for_version` for `x.y.0` releases: kernel.org tags these without the
  trailing ".0" (e.g. `v2.3`), so use `up_to(2)` instead of `up_to(1)`, which
  previously generated a non-existent `libgpiod-v2` URL.
- Refresh the sha256 checksums for older cgit snapshots (`<= 2.2.0` and `1.6.x`)
  that no longer matched the tarballs currently served by kernel.org.

All 18 versions from 1.6.3 through 2.3.1 had their recorded sha256 verified
against the official kernel.org release tarballs. Builds were validated across
both paths — meson for 2.3+ (2.3.1, 2.3.0) and autotools for <= 2.2 (2.2.5,
2.0.0, 1.6.3).