### PR TITLE
trilinos: remove `cxx20` conflict, obsoleted by LLVM fix in `hip@7:`

### DIFF
--- a/repos/spack_repo/builtin/packages/trilinos/package.py
+++ b/repos/spack_repo/builtin/packages/trilinos/package.py
@@ -373,10 +373,6 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
 
     conflicts("+rocm~rocm_rdc", when="@:16 +stk")
     conflicts("+rocm~rocm_rdc", when="@17: +stk ^hip@:6.2")
-    # rocm@7 conflicts with cxxstd=20 per https://github.com/llvm/llvm-project/issues/184856
-    # this conflict can be updated once https://github.com/llvm/llvm-project/pull/184894
-    # makes it into hip
-    conflicts("cxxstd=20", when="+rocm ^hip@7:")
 
     # TRIbits dependencies only relied on by testing are invoked regardless,
     # whether +test or ~test. see https://github.com/TriBITSPub/TriBITS/issues/56


### PR DESCRIPTION
Remove constraint from trilinos package.py on cxx20 and hip 7+. The referenced llvm issue/MR has now been merged. 

> rocm@7 conflicts with cxxstd=20 per https://github.com/llvm/llvm-project/issues/184856
> this conflict can be updated once https://github.com/llvm/llvm-project/pull/184894
> makes it into hip

Removes: `conflicts("cxxstd=20", when="+rocm ^hip@7:")`
