### PR TITLE
vtk: depends on `nlohmann-json+multiple_headers`

### DIFF
--- a/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/repos/spack_repo/builtin/packages/vtk/package.py
@@ -222,7 +222,7 @@ class Vtk(CMakePackage):
         depends_on("seacas@2022-10-14", when="@9.2:9.3")
         depends_on("seacas@2024-06-27", when="@9.4:")
 
-    depends_on("nlohmann-json", when="@9.2:")
+    depends_on("nlohmann-json+multiple_headers", when="@9.2:")
 
     # Freetype@2.10.3 no longer exports FT_CALLBACK_DEF, this
     # patch replaces FT_CALLBACK_DEF with simple extern "C"


### PR DESCRIPTION
Do not rely on `multiple_headers` variant being enabled by default.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
