### PR TITLE
nvbench: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/nvbench/package.py
+++ b/repos/spack_repo/builtin/packages/nvbench/package.py
@@ -27,8 +27,8 @@ class Nvbench(CudaPackage, CMakePackage):
     variant("cuda", default=True, description="Build with CUDA")
 
     depends_on("cmake@4:", type="build")
-    depends_on("cxx")
-    depends_on("cuda@12")
+    depends_on("cxx", type="build")
+    depends_on("cuda@12:", type=("build", "link"))
 
     requires("+cuda")
     requires("%gcc@7:", when="%gcc")

--- a/repos/spack_repo/builtin/packages/nvbench/package.py
+++ b/repos/spack_repo/builtin/packages/nvbench/package.py
@@ -3,11 +3,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems.cuda import CudaPackage
 
 from spack.package import *
 
 
-class Nvbench(CMakePackage):
+class Nvbench(CudaPackage, CMakePackage):
     """NVBench is a C++17 library designed to simplify CUDA kernel benchmarking.
     It solves challenges inherent to CUDA kernel benchmarking."""
 
@@ -22,4 +23,13 @@ class Nvbench(CMakePackage):
     license("Apache-2.0 WITH LLVM-exception", checked_by="gusser93")
 
     version("main", branch="main")
+
+    variant("cuda", default=True, description="Build with CUDA")
+
     depends_on("cmake@4:", type="build")
+    depends_on("cxx")
+    depends_on("cuda@12")
+
+    requires("+cuda")
+    requires("%gcc@7:", when="%gcc")
+    requires("%clang@14:", when="%clang")

--- a/repos/spack_repo/builtin/packages/nvbench/package.py
+++ b/repos/spack_repo/builtin/packages/nvbench/package.py
@@ -1,0 +1,25 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class Nvbench(CMakePackage):
+    """NVBench is a C++17 library designed to simplify CUDA kernel benchmarking.
+    It solves challenges inherent to CUDA kernel benchmarking."""
+
+    homepage = "https://github.com/NVIDIA/nvbench"
+    url = "https://github.com/NVIDIA/nvbench"
+    git = "https://github.com/NVIDIA/nvbench"
+
+    supplier = "NVIDIA"
+
+    maintainers("gusser93")
+
+    license("Apache-2.0 WITH LLVM-exception", checked_by="gusser93")
+
+    version("main", branch="main")
+    depends_on("cmake@4:", type="build")


### PR DESCRIPTION
nvbench is a library to write performance benchmarks for CUDA kernel.

I tested the package locally without problems. I plan to include variants in the future after more testing.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
