### PR TITLE
py-uv: add v0.11.29

### DIFF
--- a/repos/spack_repo/builtin/packages/py_uv/package.py
+++ b/repos/spack_repo/builtin/packages/py_uv/package.py
@@ -24,6 +24,7 @@ class PyUv(PythonPackage, CargoPackage):
 
     executables = ["^uv$"]
 
+    version("0.11.29", sha256="a4ca34dc3b247740e511ca7c718181d5300e7899bbef755db45bb6c993610a64")
     version("0.11.28", sha256="df86cfd135542a833e9f84708b3b8dbaa987a3b9db85b267062db49ab639d242")
     version("0.11.27", sha256="3469204521869f0e6bdea17b02c1d86db2d0150820895653a6152cab206fb00b")
     version("0.11.26", sha256="2a433ece2ace088dd572d8abb0e6bd9a4ecb0e10bc9856447bbb37545f384f29")
@@ -90,6 +91,7 @@ class PyUv(PythonPackage, CargoPackage):
         depends_on("gmake")
 
         # Minimum Rust toolchain, from Cargo.toml
+        depends_on("rust@1.95:", when="@0.11.29:")
         depends_on("rust@1.94:", when="@0.11.18:")
         depends_on("rust@1.93:", when="@0.11.8:")
         depends_on("rust@1.92:", when="@0.10.10:")


### PR DESCRIPTION
- add [uv v0.11.29](https://github.com/astral-sh/uv/releases/tag/0.11.29)
- bump required Rust version to `@1.95:` per [`cargo.toml`](https://github.com/astral-sh/uv/blob/0.11.29/Cargo.toml#L12).