### PR TITLE
r-fs: add missing ^libuv

### DIFF
--- a/repos/spack_repo/builtin/packages/r_fs/package.py
+++ b/repos/spack_repo/builtin/packages/r_fs/package.py
@@ -35,5 +35,7 @@ class RFs(RPackage):
         depends_on("r@3.4:", when="@1.6.2:")
         depends_on("r@3.1:")
 
+        depends_on("libuv", when="@2.1.0:")
+
         # Historical dependencies
         depends_on("r-rcpp", when="@:1.3.1")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

# Fixes

```log
1 error found in build log:
-- lines 249 to 259 --
   * deb: libuv1-dev (Debian, Ubuntu, etc)
   * rpm: libuv-devel (Fedora, EPEL)
   * brew: libuv (OSX)
  Alternatively set environment variable USE_BUNDLED_LIBUV=1 to build a static
  version of libuv that is included with this package.
  -------------------------- [ERROR MESSAGE] ---------------------------
> <stdin>:1:10: fatal error: uv.h: No such file or directory
  compilation terminated.
  --------------------------------------------------------------------
  ERROR: configuration failed for package 'fs'
```

# Build grid

```
tiamat r-fs -d r@4.5.3,4.5.0,4.4.3,4.4.0,4.3.3
```

## Before

<img width="271" height="209" alt="image" src="https://github.com/user-attachments/assets/a43f29ba-2a67-4d69-b477-82bcb14aa58e" />

## After

<img width="271" height="209" alt="image" src="https://github.com/user-attachments/assets/d8877462-7e86-4c32-89ca-136aa5053c36" />