### PR TITLE
r-affy: older versions need older R

### DIFF
--- a/repos/spack_repo/builtin/packages/r_affy/package.py
+++ b/repos/spack_repo/builtin/packages/r_affy/package.py
@@ -26,6 +26,8 @@ class RAffy(RPackage):
 
     depends_on("c", type="build")
 
+    depends_on("r@:4.4", type=("build", "run"), when="@:1.83.0")
+
     depends_on("r-biocgenerics@0.1.12:", type=("build", "run"))
     depends_on("r-biobase@2.5.5:", type=("build", "run"))
     depends_on("r-affyio@1.13.3:", type=("build", "run"))


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

# Fixes

```log
  rma_common.c: In function 'median':
  rma_common.c:62:20: warning: implicit declaration of function 'Calloc'; did you mean 'calloc'? [-Wimplicit-function-declaration]
     62 |   double *buffer = Calloc(length,double);
        |                    ^~~~~~
        |                    calloc
  chipbackground.c: In function 'compute_weights_individual':
> rma_common.c:62:34: error: expected expression before 'double'
     62 |   double *buffer = Calloc(length,double);
        |                                  ^~~~~~
> chipbackground.c:181:48: error: expected expression before 'double'
    181 |   double *distance = (double *)Calloc(grid_dim,double);
        |                                                ^~~~~~
  rma_common.c:84:3: warning: implicit declaration of function 'Free'; did you mean 'free'? [-Wimplicit-function-declaration]
     84 |   Free(buffer);
        |   ^~~~
        |   free
```

(and similar)

# Build grid

```sh
tiamat r-affy@1.82:1.84 -d r@4.5.3,4.5.0,4.4.3,4.4.0,4.3.3,4.3.0
```

## Before

<img width="174" height="252" alt="image" src="https://github.com/user-attachments/assets/04033bf3-c8db-4013-92f2-2c3b537bbc6f" />

## After

<img width="174" height="252" alt="image" src="https://github.com/user-attachments/assets/d8b60cda-8157-464f-85b6-a58dd2cfcf12" />

```sh
tiamat r-affy -d r@4.5.3,4.5.0,4.4.3,4.4.0,4.3.3,4.3.0
```

<img width="309" height="252" alt="image" src="https://github.com/user-attachments/assets/99720f80-5767-4b65-9452-8025ab0f0c57" />