### PR TITLE
MVAPICH: add new dependencies for minimal envs

### DIFF
--- a/repos/spack_repo/builtin/packages/mvapich/package.py
+++ b/repos/spack_repo/builtin/packages/mvapich/package.py
@@ -102,7 +102,7 @@ class Mvapich(MpichEnvironmentModifications, AutotoolsPackage):
     depends_on("ucx", when="netmod=ucx")
     depends_on("json-c")
     depends_on("libnl", when="netmod=ofi")
- 
+
     filter_compiler_wrappers("mpicc", "mpicxx", "mpif77", "mpif90", "mpifort", relative_root="bin")
 
     @classmethod

--- a/repos/spack_repo/builtin/packages/mvapich/package.py
+++ b/repos/spack_repo/builtin/packages/mvapich/package.py
@@ -100,7 +100,9 @@ class Mvapich(MpichEnvironmentModifications, AutotoolsPackage):
     depends_on("libfabric", when="netmod=ofi")
     depends_on("slurm", when="process_managers=slurm")
     depends_on("ucx", when="netmod=ucx")
-
+    depends_on("json-c")
+    depends_on("libnl", when="netmod=ofi")
+ 
     filter_compiler_wrappers("mpicc", "mpicxx", "mpif77", "mpif90", "mpifort", relative_root="bin")
 
     @classmethod


### PR DESCRIPTION
Adds a few dependencies for minimal environments
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
