### PR TITLE
upp: patch for Intel oneAPI support

### DIFF
--- a/repos/spack_repo/builtin/packages/upp/package.py
+++ b/repos/spack_repo/builtin/packages/upp/package.py
@@ -80,6 +80,6 @@ class Upp(CMakePackage):
         return args
 
     def patch(self):
-        if spec.satisfies("^[virtuals=fortran] intel-oneapi-compilers"):
+        if self.spec.satisfies("^[virtuals=fortran] intel-oneapi-compilers"):
             filter_file("Intel", "Intel|IntelLLVM", "CMakeLists.txt")
             filter_file("Intel", "Intel|IntelLLVM", "sorc/ncep_post.fd/CMakeLists.txt")

--- a/repos/spack_repo/builtin/packages/upp/package.py
+++ b/repos/spack_repo/builtin/packages/upp/package.py
@@ -78,3 +78,8 @@ class Upp(CMakePackage):
         ]
 
         return args
+
+    def patch(self):
+        if spec.satisfies("^[virtuals=fortran] intel-oneapi-compilers"):
+            filter_file("Intel", "Intel|IntelLLVM", "CMakeLists.txt")
+            filter_file("Intel", "Intel|IntelLLVM", "sorc/ncep_post.fd/CMakeLists.txt")


### PR DESCRIPTION
This PR adds patching to enable Intel oneAPI support for the UPP package. Intel oneAPI support is in UPP develop but not any releases yet.