### PR TITLE
llvm-amdgpu: prevent OCaml build errors

### DIFF
--- a/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
+++ b/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
@@ -286,6 +286,7 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
         args = [
             self.define("LLVM_ENABLE_Z3_SOLVER", "OFF"),
             self.define("LLVM_ENABLE_ZLIB", "ON"),
+            self.define("LLVM_ENABLE_BINDINGS", "OFF"),  # prevent OCaml build errors
             self.define("CLANG_DEFAULT_LINKER", "lld"),
             self.define("LIBCXXABI_INSTALL_STATIC_LIBRARY", "OFF"),
             self.define("LLVM_ENABLE_RTTI", "ON"),


### PR DESCRIPTION
When OCaml tools are installed, the LLVM-AMDGPU build detects them and enables building OCaml bindings and documentation.

This is not a decision by the spack solver but by the package which makes it less predictable and it can cause that the build fail if some part of the OCaml stack does not behave like the build of LLVM-AMDGPU expects.

For a reliable build, forcibly disable building the OCaml bindings for LLVM-AMDGPU (unless/until OCaml support is properly enabled in the spack recipe):
```diff
--- a/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
+++ b/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
@@ -271,6 +271,7 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
         args = [
             self.define("LLVM_ENABLE_Z3_SOLVER", "OFF"),
             self.define("LLVM_ENABLE_ZLIB", "ON"),
+            self.define("LLVM_ENABLE_BINDINGS", "OFF"),  # prevent OCaml build errors
             self.define("CLANG_DEFAULT_LINKER", "lld"),
             self.define("LIBCXXABI_INSTALL_STATIC_LIBRARY", "OFF"),
             self.define("LLVM_ENABLE_RTTI", "ON"),
```