### PR TITLE
python packages: standardize url_for_version() methods

### DIFF
--- a/repos/spack_repo/builtin/packages/py_accessible_pygments/package.py
+++ b/repos/spack_repo/builtin/packages/py_accessible_pygments/package.py
@@ -27,11 +27,9 @@ class PyAccessiblePygments(PythonPackage):
     depends_on("py-hatch-vcs", type="build", when="@0.0.5:")
 
     def url_for_version(self, version):
-        url = (
-            "https://pypi.org/packages/source/a/accessible-pygments/accessible{}pygments-{}.tar.gz"
-        )
+        url = "https://pypi.org/packages/source/a/{0}/{0}-{1}.tar.gz"
         if version < Version("0.0.5"):
-            separator = "-"
+            name = "accessible-pygments"
         else:
-            separator = "_"
-        return url.format(separator, version)
+            name = "accessible_pygments"
+        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_bids_validator/package.py
+++ b/repos/spack_repo/builtin/packages/py_bids_validator/package.py
@@ -33,7 +33,7 @@ class PyBidsValidator(PythonPackage):
     depends_on("py-bidsschematools@0.10:", when="@1.14.7:", type=("build", "run"))
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/b/bids-validator/{}-{}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/b/{0}/{0}-{1}.tar.gz"
         if version >= Version("1.14.6"):
             name = "bids_validator"
         else:

--- a/repos/spack_repo/builtin/packages/py_cwl_utils/package.py
+++ b/repos/spack_repo/builtin/packages/py_cwl_utils/package.py
@@ -44,9 +44,9 @@ class PyCwlUtils(PythonPackage):
     depends_on("py-typing-extensions@4.10.0:", when="@0.42:", type=("build", "run"))
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/c/cwl-utils/cwl{}utils-{}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/c/{0}/{0}-{1}.tar.gz"
         if version >= Version("0.34"):
-            sep = "_"
+            name = "cwl_utils"
         else:
-            sep = "-"
-        return url.format(sep, version)
+            name = "cwl-utils"
+        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_cylc_flow/package.py
+++ b/repos/spack_repo/builtin/packages/py_cylc_flow/package.py
@@ -66,7 +66,7 @@ class PyCylcFlow(PythonPackage):
     depends_on("py-typing-extensions", type="run", when="@8.4")
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/c/cylc-flow/{0}-{1}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/c/{0}/{0}-{1}.tar.gz"
         if version >= Version("8.3"):
             prefix = "cylc_flow"
         else:

--- a/repos/spack_repo/builtin/packages/py_cylc_rose/package.py
+++ b/repos/spack_repo/builtin/packages/py_cylc_rose/package.py
@@ -42,7 +42,7 @@ class PyCylcRose(PythonPackage):
         depends_on("py-ansimarkup", type=("build", "run"))
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/c/cylc-rose/{0}-{1}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/c/{0}/{0}-{1}.tar.gz"
         if version >= Version("1.4"):
             prefix = "cylc_rose"
         else:

--- a/repos/spack_repo/builtin/packages/py_dask_ml/package.py
+++ b/repos/spack_repo/builtin/packages/py_dask_ml/package.py
@@ -77,12 +77,12 @@ class PyDaskMl(PythonPackage):
     conflicts("+docs", when="target=aarch64: %gcc")
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/d/dask-ml/dask{0}ml-{1}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/d/{0}/{0}-{1}.tar.gz"
         if version > Version("2024.4.3"):
-            sep = "_"
+            name = "dask_ml"
         else:
-            sep = "-"
-        return url.format(sep, version)
+            name = "dask-ml"
+        return url.format(name, version)
 
     @run_after("install")
     def install_docs(self):

--- a/repos/spack_repo/builtin/packages/py_earthengine_api/package.py
+++ b/repos/spack_repo/builtin/packages/py_earthengine_api/package.py
@@ -31,7 +31,7 @@ class PyEarthengineApi(PythonPackage):
     depends_on("google-cloud-cli", type="run")
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/e/earthengine-api/{}-{}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/e/{0}/{0}-{1}.tar.gz"
         if version >= Version("0.1.399"):
             name = "earthengine_api"
         else:

--- a/repos/spack_repo/builtin/packages/py_google_api_core/package.py
+++ b/repos/spack_repo/builtin/packages/py_google_api_core/package.py
@@ -67,7 +67,7 @@ class PyGoogleApiCore(PythonPackage):
             depends_on("py-grpcio@1.8.2:1", type="run")
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/g/google-api-core/{}-{}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/g/{0}/{0}-{1}.tar.gz"
         if version >= Version("2.19.2"):
             name = "google_api_core"
         else:

--- a/repos/spack_repo/builtin/packages/py_google_crc32c/package.py
+++ b/repos/spack_repo/builtin/packages/py_google_crc32c/package.py
@@ -28,12 +28,12 @@ class PyGoogleCrc32c(PythonPackage):
     depends_on("google-crc32c", type=("build", "run"))
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/g/google-crc32c/google{0}crc32c-{1}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/g/{0}/{0}-{1}.tar.gz"
         if version > Version("1.5.0"):
-            sep = "_"
+            name = "google_crc32c"
         else:
-            sep = "-"
-        return url.format(sep, version)
+            name = "google-crc32c"
+        return url.format(name, version)
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         env.set("CRC32C_INSTALL_PREFIX", self.spec["google-crc32c"].prefix)

--- a/repos/spack_repo/builtin/packages/py_googleapis_common_protos/package.py
+++ b/repos/spack_repo/builtin/packages/py_googleapis_common_protos/package.py
@@ -44,7 +44,7 @@ class PyGoogleapisCommonProtos(PythonPackage):
         depends_on("py-grpcio@1:")
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/g/googleapis-common-protos/{}-{}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/g/{0}/{0}-{1}.tar.gz"
         if version >= Version("1.64"):
             name = "googleapis_common_protos"
         else:

--- a/repos/spack_repo/builtin/packages/py_graphql_core/package.py
+++ b/repos/spack_repo/builtin/packages/py_graphql_core/package.py
@@ -36,7 +36,7 @@ class PyGraphqlCore(PythonPackage):
     depends_on("py-rx@1.6:1", type=("build", "run"), when="@2.3.2")
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/g/graphql-core/{0}-{1}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/g/{0}/{0}-{1}.tar.gz"
         if version >= Version("3.2.5"):
             prefix = "graphql_core"
         else:

--- a/repos/spack_repo/builtin/packages/py_grpcio_status/package.py
+++ b/repos/spack_repo/builtin/packages/py_grpcio_status/package.py
@@ -30,7 +30,7 @@ class PyGrpcioStatus(PythonPackage):
         depends_on("py-googleapis-common-protos@1.5.5:")
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/g/grpcio_status/{}-{}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/g/{0}/{0}-{1}.tar.gz"
         if version >= Version("63"):
             name = "grpcio_status"
         else:

--- a/repos/spack_repo/builtin/packages/py_jupyter_lsp/package.py
+++ b/repos/spack_repo/builtin/packages/py_jupyter_lsp/package.py
@@ -29,6 +29,4 @@ class PyJupyterLsp(PythonPackage):
             name = "jupyter_lsp"
         else:
             name = "jupyter-lsp"
-        return (
-            f"https://files.pythonhosted.org/packages/source/j/jupyter-lsp/{name}-{version}.tar.gz"
-        )
+        return f"https://files.pythonhosted.org/packages/source/j/{name}/{name}-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_jupyter_server_proxy/package.py
+++ b/repos/spack_repo/builtin/packages/py_jupyter_server_proxy/package.py
@@ -47,4 +47,4 @@ class PyJupyterServerProxy(PythonPackage):
             name = "jupyter_server_proxy"
         else:
             name = "jupyter-server-proxy"
-        return f"https://files.pythonhosted.org/packages/source/j/jupyter-server-proxy/{name}-{version}.tar.gz"
+        return f"https://files.pythonhosted.org/packages/source/j/{name}/{name}-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_lightning_uq_box/package.py
+++ b/repos/spack_repo/builtin/packages/py_lightning_uq_box/package.py
@@ -61,7 +61,7 @@ class PyLightningUqBox(PythonPackage):
             depends_on("py-ruff@0.2:")
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/l/lightning-uq-box/{}-{}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/l/{0}/{0}-{1}.tar.gz"
         if version >= Version("0.2.0"):
             name = "lightning_uq_box"
         else:

--- a/repos/spack_repo/builtin/packages/py_lightning_utilities/package.py
+++ b/repos/spack_repo/builtin/packages/py_lightning_utilities/package.py
@@ -44,7 +44,7 @@ class PyLightningUtilities(PythonPackage):
         depends_on("py-setuptools@:81", when="@:0.15.2")
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/l/lightning-utilities/{}-{}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/l/{0}/{0}-{1}.tar.gz"
         if version >= Version("0.11.3"):
             name = "lightning_utilities"
         else:

--- a/repos/spack_repo/builtin/packages/py_markdown_it_py/package.py
+++ b/repos/spack_repo/builtin/packages/py_markdown_it_py/package.py
@@ -40,7 +40,7 @@ class PyMarkdownItPy(PythonPackage):
     depends_on("py-typing-extensions@3.7.4:", when="@:2 ^python@:3.7", type=("build", "run"))
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/m/markdown-it-py/{}-{}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/m/{0}/{0}-{1}.tar.gz"
         if version >= Version("4"):
             name = "markdown_it_py"
         else:

--- a/repos/spack_repo/builtin/packages/py_more_itertools/package.py
+++ b/repos/spack_repo/builtin/packages/py_more_itertools/package.py
@@ -45,4 +45,4 @@ class PyMoreItertools(PythonPackage):
             name = "more_itertools"
         else:
             name = "more-itertools"
-        return f"https://files.pythonhosted.org/packages/source/m/more-itertools/{name}-{version}.tar.gz"
+        return f"https://files.pythonhosted.org/packages/source/m/{name}/{name}-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_nvidia_ml_py/package.py
+++ b/repos/spack_repo/builtin/packages/py_nvidia_ml_py/package.py
@@ -43,9 +43,9 @@ class PyNvidiaMlPy(PythonPackage):
     # pip silently replaces distutils with setuptools
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/n/nvidia-ml-py/nvidia{0}ml{0}py-{1}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/n/{0}/{0}-{1}.tar.gz"
         if version > Version("12.560.30"):
-            sep = "_"
+            name = "nvidia_ml_py"
         else:
-            sep = "-"
-        return url.format(sep, version)
+            name = "nvidia-ml-py"
+        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_odc_geo/package.py
+++ b/repos/spack_repo/builtin/packages/py_odc_geo/package.py
@@ -29,7 +29,7 @@ class PyOdcGeo(PythonPackage):
         depends_on("py-shapely")
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/o/odc-geo/{}-{}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/o/{0}/{0}-{1}.tar.gz"
         if version >= Version("0.4.4"):
             name = "odc_geo"
         else:

--- a/repos/spack_repo/builtin/packages/py_poetry_core/package.py
+++ b/repos/spack_repo/builtin/packages/py_poetry_core/package.py
@@ -39,7 +39,7 @@ class PyPoetryCore(PythonPackage):
         depends_on("py-importlib-metadata@1.7:1", when="@:1.0 ^python@:3.7")
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/p/poetry-core/{0}-{1}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/p/{0}/{0}-{1}.tar.gz"
         if version >= Version("1.4"):
             letter = "poetry_core"
         else:

--- a/repos/spack_repo/builtin/packages/py_poetry_plugin_export/package.py
+++ b/repos/spack_repo/builtin/packages/py_poetry_plugin_export/package.py
@@ -26,9 +26,7 @@ class PyPoetryPluginExport(PythonPackage):
     # depends_on("py-poetry@1.2:1", type="run") # circular dependency
 
     def url_for_version(self, version):
-        url = (
-            "https://files.pythonhosted.org/packages/source/p/poetry-plugin-export/{0}-{1}.tar.gz"
-        )
+        url = "https://files.pythonhosted.org/packages/source/p/{0}/{0}-{1}.tar.gz"
         if version >= Version("1.6"):
             letter = "poetry_plugin_export"
         else:

--- a/repos/spack_repo/builtin/packages/py_pytest_timeout/package.py
+++ b/repos/spack_repo/builtin/packages/py_pytest_timeout/package.py
@@ -32,4 +32,4 @@ class PyPytestTimeout(PythonPackage):
             name = "pytest_timeout"
         else:
             name = "pytest-timeout"
-        return f"https://files.pythonhosted.org/packages/source/p/pytest-timeout/{name}-{version}.tar.gz"
+        return f"https://files.pythonhosted.org/packages/source/p/{name}/{name}-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_python_lsp_server/package.py
+++ b/repos/spack_repo/builtin/packages/py_python_lsp_server/package.py
@@ -54,7 +54,7 @@ class PyPythonLspServer(PythonPackage):
         depends_on("py-ruff", when="@1.13: formatter=ruff")
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/p/python-lsp-server/{}-{}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/p/{0}/{0}-{1}.tar.gz"
         if version >= Version("1.13"):
             name = "python_lsp_server"
         else:

--- a/repos/spack_repo/builtin/packages/py_pytorch_lightning/package.py
+++ b/repos/spack_repo/builtin/packages/py_pytorch_lightning/package.py
@@ -132,7 +132,7 @@ class PyPytorchLightning(PythonPackage):
     conflicts("^py-torch~distributed", when="@1.5.0:1.5.2")
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/p/pytorch-lightning/{}-{}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/p/{0}/{0}-{1}.tar.gz"
         if version >= Version("2.5"):
             name = "pytorch_lightning"
         else:

--- a/repos/spack_repo/builtin/packages/py_requests_unixsocket/package.py
+++ b/repos/spack_repo/builtin/packages/py_requests_unixsocket/package.py
@@ -27,9 +27,9 @@ class PyRequestsUnixsocket(PythonPackage):
     depends_on("py-urllib3@1.8:", when="@:0.2.0", type=("build", "run"))
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/r/requests-unixsocket/requests{}unixsocket-{}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/r/{0}/{0}-{1}.tar.gz"
         if version >= Version("0.3.1"):
-            sep = "_"
+            name = "requests_unixsocket"
         else:
-            sep = "-"
-        return url.format(sep, version)
+            name = "requests-unixsocket"
+        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_rich_click/package.py
+++ b/repos/spack_repo/builtin/packages/py_rich_click/package.py
@@ -30,7 +30,7 @@ class PyRichClick(PythonPackage):
     depends_on("py-typing-extensions@4", type=("build", "run"), when="@1.8.0:")
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/r/rich-click/{0}-{1}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/r/{0}/{0}-{1}.tar.gz"
         if version >= Version("1.8.0"):
             name = "rich_click"
         else:

--- a/repos/spack_repo/builtin/packages/py_schema_salad/package.py
+++ b/repos/spack_repo/builtin/packages/py_schema_salad/package.py
@@ -64,11 +64,9 @@ class PySchemaSalad(PythonPackage):
     depends_on("py-types-setuptools", type="build")
 
     def url_for_version(self, version):
-        url = (
-            "https://files.pythonhosted.org/packages/source/s/schema-salad/schema{}salad-{}.tar.gz"
-        )
+        url = "https://files.pythonhosted.org/packages/source/s/{0}/{0}-{1}.tar.gz"
         if version >= Version("8.5.20240503091721"):
-            sep = "_"
+            name = "schema_salad"
         else:
-            sep = "-"
-        return url.format(sep, version)
+            name = "schema-salad"
+        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_scikit_build/package.py
+++ b/repos/spack_repo/builtin/packages/py_scikit_build/package.py
@@ -58,11 +58,9 @@ class PyScikitBuild(PythonPackage):
     depends_on("py-setuptools-scm+toml", when="@0.15", type="build")
 
     def url_for_version(self, version):
-        url = (
-            "https://files.pythonhosted.org/packages/source/s/scikit-build/scikit{}build-{}.tar.gz"
-        )
+        url = "https://files.pythonhosted.org/packages/source/s/{0}/{0}-{1}.tar.gz"
         if version >= Version("0.17"):
-            separator = "_"
+            name = "scikit_build"
         else:
-            separator = "-"
-        return url.format(separator, version)
+            name = "scikit-build"
+        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_scikit_image/package.py
+++ b/repos/spack_repo/builtin/packages/py_scikit_image/package.py
@@ -138,11 +138,9 @@ class PyScikitImage(PythonPackage):
     conflicts("py-imageio@2.35.0")
 
     def url_for_version(self, version):
-        url = (
-            "https://files.pythonhosted.org/packages/source/s/scikit-image/scikit{}image-{}.tar.gz"
-        )
+        url = "https://files.pythonhosted.org/packages/source/s/{0}/{0}-{1}.tar.gz"
         if version >= Version("0.20"):
-            sep = "_"
+            name = "scikit_image"
         else:
-            sep = "-"
-        return url.format(sep, version)
+            name = "scikit-image"
+        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_scikit_learn/package.py
+++ b/repos/spack_repo/builtin/packages/py_scikit_learn/package.py
@@ -124,7 +124,7 @@ class PyScikitLearn(PythonPackage):
         depends_on("py-setuptools@:59", when="@:1.2.1")
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/s/scikit-learn/{}-{}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/s/{0}/{0}-{1}.tar.gz"
         if version >= Version("1.5"):
             name = "scikit_learn"
         else:

--- a/repos/spack_repo/builtin/packages/py_scikit_optimize/package.py
+++ b/repos/spack_repo/builtin/packages/py_scikit_optimize/package.py
@@ -47,9 +47,9 @@ class PyScikitOptimize(PythonPackage):
     depends_on("py-matplotlib@2:", when="@0.9:+plots")
 
     def url_for_version(self, version):
-        url = "https://pypi.org/packages/source/s/scikit-optimize/scikit{}optimize-{}.tar.gz"
+        url = "https://pypi.org/packages/source/s/{0}/{0}-{1}.tar.gz"
         if version < Version("0.10.2"):
-            separator = "-"
+            name = "scikit-optimize"
         else:
-            separator = "_"
-        return url.format(separator, version)
+            name = "scikit_optimize"
+        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_sentry_sdk/package.py
+++ b/repos/spack_repo/builtin/packages/py_sentry_sdk/package.py
@@ -61,9 +61,9 @@ class PySentrySdk(PythonPackage):
     depends_on("py-httpx@0.16.0:", type=("build", "run"), when="+httpx")
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/s/sentry-sdk/sentry{0}sdk-{1}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/s/{0}/{0}-{1}.tar.gz"
         if version >= Version("1.45.1"):
-            dash = "_"
+            name = "sentry_sdk"
         else:
-            dash = "-"
-        return url.format(dash, version)
+            name = "sentry-sdk"
+        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_setuptools_rust/package.py
+++ b/repos/spack_repo/builtin/packages/py_setuptools_rust/package.py
@@ -46,4 +46,4 @@ class PySetuptoolsRust(PythonPackage):
             name = "setuptools_rust"
         else:
             name = "setuptools-rust"
-        return f"https://files.pythonhosted.org/packages/source/s/setuptools-rust/{name}-{version}.tar.gz"
+        return f"https://files.pythonhosted.org/packages/source/s/{name}/{name}-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_sphinx_theme_builder/package.py
+++ b/repos/spack_repo/builtin/packages/py_sphinx_theme_builder/package.py
@@ -39,7 +39,7 @@ class PySphinxThemeBuilder(PythonPackage):
         depends_on("py-diagnostic@2:", when="@0.3:")
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/s/sphinx-theme-builder/{}-{}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/s/{0}/{0}-{1}.tar.gz"
         if version == Version("0.2.0b2"):
             name = "sphinx-theme-builder"
         else:

--- a/repos/spack_repo/builtin/packages/py_sphinxcontrib_applehelp/package.py
+++ b/repos/spack_repo/builtin/packages/py_sphinxcontrib_applehelp/package.py
@@ -32,9 +32,7 @@ class PySphinxcontribApplehelp(PythonPackage):
     depends_on("py-setuptools", when="@:1.0.3", type="build")
 
     def url_for_version(self, version):
-        url = (
-            "https://files.pythonhosted.org/packages/source/s/sphinxcontrib-applehelp/{}-{}.tar.gz"
-        )
+        url = "https://files.pythonhosted.org/packages/source/s/{0}/{0}-{1}.tar.gz"
         if version >= Version("1.0.5"):
             name = "sphinxcontrib_applehelp"
         else:

--- a/repos/spack_repo/builtin/packages/py_sphinxcontrib_bibtex/package.py
+++ b/repos/spack_repo/builtin/packages/py_sphinxcontrib_bibtex/package.py
@@ -45,9 +45,9 @@ class PySphinxcontribBibtex(PythonPackage):
     conflicts("^py-docutils@0.18:0.19", when="@2.6.5")
 
     def url_for_version(self, version):
-        url = "https://pypi.org/packages/source/s/sphinxcontrib-bibtex/sphinxcontrib{}bibtex-{}.tar.gz"
+        url = "https://pypi.org/packages/source/s/{0}/{0}-{1}.tar.gz"
         if version < Version("2.6.3"):
-            separator = "-"
+            name = "sphinxcontrib-bibtex"
         else:
-            separator = "_"
-        return url.format(separator, version)
+            name = "sphinxcontrib_bibtex"
+        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_sphinxcontrib_devhelp/package.py
+++ b/repos/spack_repo/builtin/packages/py_sphinxcontrib_devhelp/package.py
@@ -30,7 +30,7 @@ class PySphinxcontribDevhelp(PythonPackage):
     depends_on("py-setuptools", when="@:1.0.2", type="build")
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/s/sphinxcontrib-devhelp/{}-{}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/s/{0}/{0}-{1}.tar.gz"
         if version >= Version("1.0.3"):
             name = "sphinxcontrib_devhelp"
         else:

--- a/repos/spack_repo/builtin/packages/py_sphinxcontrib_htmlhelp/package.py
+++ b/repos/spack_repo/builtin/packages/py_sphinxcontrib_htmlhelp/package.py
@@ -32,9 +32,7 @@ class PySphinxcontribHtmlhelp(PythonPackage):
     depends_on("py-setuptools", when="@:2.0.0", type="build")
 
     def url_for_version(self, version):
-        url = (
-            "https://files.pythonhosted.org/packages/source/s/sphinxcontrib-htmlhelp/{}-{}.tar.gz"
-        )
+        url = "https://files.pythonhosted.org/packages/source/s/{0}/{0}-{1}.tar.gz"
         if version >= Version("2.0.2"):
             name = "sphinxcontrib_htmlhelp"
         else:

--- a/repos/spack_repo/builtin/packages/py_sphinxcontrib_qthelp/package.py
+++ b/repos/spack_repo/builtin/packages/py_sphinxcontrib_qthelp/package.py
@@ -29,7 +29,7 @@ class PySphinxcontribQthelp(PythonPackage):
     depends_on("py-setuptools", when="@:1.0.3", type="build")
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/s/sphinxcontrib-qthelp/{}-{}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/s/{0}/{0}-{1}.tar.gz"
         if version >= Version("1.0.4"):
             name = "sphinxcontrib_qthelp"
         else:

--- a/repos/spack_repo/builtin/packages/py_sphinxcontrib_serializinghtml/package.py
+++ b/repos/spack_repo/builtin/packages/py_sphinxcontrib_serializinghtml/package.py
@@ -36,9 +36,9 @@ class PySphinxcontribSerializinghtml(PythonPackage):
     depends_on("py-setuptools", when="@:1.1.5", type="build")
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/s/sphinxcontrib-serializinghtml/sphinxcontrib{}serializinghtml-{}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/s/{0}/{0}-{1}.tar.gz"
         if version >= Version("1.1.6"):
-            separator = "_"
+            name = "sphinxcontrib_serializinghtml"
         else:
-            separator = "-"
-        return url.format(separator, version)
+            name = "sphinxcontrib-serializinghtml"
+        return url.format(name, version)

--- a/repos/spack_repo/builtin/packages/py_trame_client/package.py
+++ b/repos/spack_repo/builtin/packages/py_trame_client/package.py
@@ -26,5 +26,5 @@ class PyTrameClient(PythonPackage):
     depends_on("py-trame-common@0.2:", type=("build", "run"), when="@3.11.2")
 
     def url_for_version(self, version):
-        sep = "_" if version >= Version("3.5.1") else "-"
-        return f"https://files.pythonhosted.org/packages/source/t/trame{sep}client/trame{sep}client-{version}.tar.gz"
+        name = "trame_client" if version >= Version("3.5.1") else "trame-client"
+        return f"https://files.pythonhosted.org/packages/source/t/{name}/{name}-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_trove_classifiers/package.py
+++ b/repos/spack_repo/builtin/packages/py_trove_classifiers/package.py
@@ -42,8 +42,8 @@ class PyTroveClassifiers(PythonPackage):
 
     def url_for_version(self, version):
         if version >= Version("2024.5.17"):
-            sep = "_"
+            name = "trove_classifiers"
         else:
-            sep = "-"
+            name = "trove-classifiers"
 
-        return f"https://files.pythonhosted.org/packages/source/t/trove{sep}classifiers/trove{sep}classifiers-{version}.tar.gz"
+        return f"https://files.pythonhosted.org/packages/source/t/{name}/{name}-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/py_types_setuptools/package.py
+++ b/repos/spack_repo/builtin/packages/py_types_setuptools/package.py
@@ -40,7 +40,7 @@ class PyTypesSetuptools(PythonPackage):
         depends_on("python@3.9:", when="@75.8.0.20250210:")
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/t/types-setuptools/{}-{}.tar.gz"
+        url = "https://files.pythonhosted.org/packages/source/t/{0}/{0}-{1}.tar.gz"
         if version >= Version("75.5.0.20241121"):
             name = "types_setuptools"
         else:


### PR DESCRIPTION
I noticed we had a couple different competing `url_for_version()` method formats over the python ecosystem.

This PR attempts to standardize the methods so that it's easier to users to pull examples from the existing packages when updating other packages.

@adamjstewart I'm not sure if you would be interested in taking a look at these.