### PR TITLE
bufr: Add meson dependency for newer python

### DIFF
--- a/repos/spack_repo/builtin/packages/bufr/package.py
+++ b/repos/spack_repo/builtin/packages/bufr/package.py
@@ -55,6 +55,8 @@ class Bufr(CMakePackage):
     depends_on("python@3:", type=("build", "run"), when="+python")
     depends_on("python@:3.11", type=("build", "run"), when="@:12.0 +python")
     depends_on("py-setuptools", type="build", when="+python")
+    # f2py uses Meson as its build backend with Python 3.12 and newer.
+    depends_on("meson", type="build", when="+python ^python@3.12:")
     depends_on("py-numpy", type=("build", "run"), when="+python")
     depends_on("py-pip", type="build", when="+python")
     depends_on("py-wheel", type="build", when="+python")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

In trying to build `bufr` with Python 3.13, it was found it now needs to depend on `meson` due to use of `f2py`