### PR TITLE
ecflow: add v5.18.0

### DIFF
--- a/repos/spack_repo/builtin/packages/ecflow/package.py
+++ b/repos/spack_repo/builtin/packages/ecflow/package.py
@@ -24,6 +24,7 @@ class Ecflow(CMakePackage):
 
     maintainers("climbfuji", "AlexanderRichert-NOAA")
 
+    version("5.18.0", sha256="f01826a442671575a5079bc8c57abaf079317e5c14fe45bdc5acbfe24b8bc4b5")
     version("5.11.4", sha256="4836a876277c9a65a47a3dc87cae116c3009699f8a25bab4e3afabf160bcf212")
     version("5.8.4", sha256="bc628556f8458c269a309e4c3b8d5a807fae7dfd415e27416fe9a3f544f88951")
     version("5.8.3", sha256="1d890008414017da578dbd5a95cb1b4d599f01d5a3bb3e0297fe94a87fbd81a6")
@@ -55,6 +56,8 @@ class Ecflow(CMakePackage):
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy", type="build")
     depends_on("py-pip", type="build")
+    # ecFlow 5.18+ configures its Python bindings with pybind11.
+    depends_on("py-pybind11@2.10.3:", type=("build", "link"), when="@5.18:")
 
     # v4: Boost-1.7X release not working well on serialization
     depends_on("boost@1.53:1.69+python", when="@:4")
@@ -78,8 +81,10 @@ class Ecflow(CMakePackage):
     depends_on("openssl@1:", when="@5:")
     depends_on("pkgconfig", type="build", when="+ssl ^openssl ~shared")
     depends_on("qt@5: +gui", when="+ui")
-    # Requirement to use the Python3_EXECUTABLE variable
+    # Requirement to use the Python3_EXECUTABLE variable.
     depends_on("cmake@3.16:", type="build")
+    # ecFlow through 5.11.4 sets CMP0046 to OLD, which CMake 4 no longer permits.
+    depends_on("cmake@3.16:3", type="build", when="@:5.11.4")
 
     # https://github.com/JCSDA/spack-stack/issues/1001
     # https://github.com/JCSDA/spack-stack/issues/1009


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This adds `ecflow` 5.18.0 which was found needed in my tests with spack-stack and Python 3.13