### PR TITLE
py-awscrt: add 0.35.0, awscli-v2: add 2.35.16

### DIFF
--- a/repos/spack_repo/builtin/packages/awscli_v2/package.py
+++ b/repos/spack_repo/builtin/packages/awscli_v2/package.py
@@ -17,6 +17,7 @@ class AwscliV2(PythonPackage):
     license("Apache-2.0")
     maintainers("climbfuji", "teaguesterling")
 
+    version("2.35.16", sha256="55754646274f224b19b0daeb9f01e4232a3e6e46665f3c1fdb425b2f026ade7d")
     version("2.24.24", sha256="d7b135ef02c96d50d81c0b5eb2723cf474cfda8e1758cccabbcaa6c14f281419")
     version("2.22.4", sha256="56c6170f3be830afef2dea60fc3fd7ed14cf2ca2efba055c085fe6a7c4de358e")
     version("2.15.53", sha256="a4f5fd4e09b8f2fb3d2049d0610c7b0993f9aafaf427f299439f05643b25eb4b")
@@ -44,13 +45,19 @@ class AwscliV2(PythonPackage):
         depends_on("py-ruamel-yaml-clib@0.2:0.2.7", when="@:2.15")
         depends_on("py-prompt-toolkit@3.0.24:3.0.38")
         depends_on("py-distro@1.5:1.8")
-        depends_on("py-awscrt@0.19.18:0.22.0", when="@2.22:")
+        depends_on("py-awscrt@0.35.0", when="@2.35.16")
+        depends_on("py-awscrt@0.19.18:0.22.0", when="@2.22:2.35.15")
         depends_on("py-awscrt@0.19.18:0.19.19", when="@2.15")
         depends_on("py-awscrt@0.16.4:0.16.16", when="@2.13")
         depends_on("py-python-dateutil@2.1:2.9.0", when="@2.22:")
         depends_on("py-python-dateutil@2.1:2.8.2", when="@:2.15")
         depends_on("py-jmespath@0.7.1:1.0")
-        depends_on("py-urllib3@1.25.4:1.26")
+
+        # For Python 3.10 and newer, support urllib3 v1 and v2
+        depends_on("py-urllib3@1.25.4:2.99", when="^python@3.10:")
+
+        # For legacy Python versions, stick to the 1.x branch
+        depends_on("py-urllib3@1.25.4:1.26", when="^python@:3.9")
 
     variant("examples", default=True, description="Install code examples")
 

--- a/repos/spack_repo/builtin/packages/awscli_v2/package.py
+++ b/repos/spack_repo/builtin/packages/awscli_v2/package.py
@@ -23,6 +23,10 @@ class AwscliV2(PythonPackage):
     version("2.15.53", sha256="a4f5fd4e09b8f2fb3d2049d0610c7b0993f9aafaf427f299439f05643b25eb4b")
     version("2.13.22", sha256="dd731a2ba5973f3219f24c8b332a223a29d959493c8a8e93746d65877d02afc1")
 
+    # The patch makes completion-index generation optional for environments
+    # where importing the full CLI command set during the wheel build hangs.
+    patch("skip-autocomplete-index.patch", when="@2.35.16")
+
     with default_args(type="build"):
         depends_on("py-flit-core@3.7.1:", when="@2.22:")
         # Upper bound relaxed for Python 3.14 support
@@ -60,6 +64,11 @@ class AwscliV2(PythonPackage):
         depends_on("py-urllib3@1.25.4:1.26", when="^python@:3.9")
 
     variant("examples", default=True, description="Install code examples")
+    variant("autocomplete", default=True, description="Build the AWS CLI shell-completion index")
+
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        if "~autocomplete" in self.spec:
+            env.set("AWSCLI_SKIP_AUTOCOMPLETE_INDEX", "1")
 
     @run_after("install", when="~examples")
     def post_install(self):

--- a/repos/spack_repo/builtin/packages/awscli_v2/skip-autocomplete-index.patch
+++ b/repos/spack_repo/builtin/packages/awscli_v2/skip-autocomplete-index.patch
@@ -1,0 +1,11 @@
+--- a/backends/pep517.py
++++ b/backends/pep517.py
+@@ -183,7 +183,6 @@ def _rewrite_shebang(path):
+ 
+def _inject_wheel_extras(whl_path):
+    with _extracted_wheel_dir(whl_path) as extracted_wheel_dir:
+        if os.environ.get("AWSCLI_SKIP_AUTOCOMPLETE_INDEX") != "1":
+            _build_and_inject_ac_index(BUILD_DIR, extracted_wheel_dir)
+        _inject_scripts(extracted_wheel_dir)
+ 
+ 

--- a/repos/spack_repo/builtin/packages/awscli_v2/skip-autocomplete-index.patch
+++ b/repos/spack_repo/builtin/packages/awscli_v2/skip-autocomplete-index.patch
@@ -1,11 +1,11 @@
 --- a/backends/pep517.py
 +++ b/backends/pep517.py
-@@ -183,7 +183,6 @@ def _rewrite_shebang(path):
+@@ -188,6 +188,7 @@ def _rewrite_shebang(path):
  
-def _inject_wheel_extras(whl_path):
-    with _extracted_wheel_dir(whl_path) as extracted_wheel_dir:
-        if os.environ.get("AWSCLI_SKIP_AUTOCOMPLETE_INDEX") != "1":
-            _build_and_inject_ac_index(BUILD_DIR, extracted_wheel_dir)
-        _inject_scripts(extracted_wheel_dir)
- 
+ def _inject_wheel_extras(whl_path):
+     with _extracted_wheel_dir(whl_path) as extracted_wheel_dir:
+-        _build_and_inject_ac_index(BUILD_DIR, extracted_wheel_dir)
++        if os.environ.get("AWSCLI_SKIP_AUTOCOMPLETE_INDEX") != "1":
++            _build_and_inject_ac_index(BUILD_DIR, extracted_wheel_dir)
+         _inject_scripts(extracted_wheel_dir)
  

--- a/repos/spack_repo/builtin/packages/py_awscrt/package.py
+++ b/repos/spack_repo/builtin/packages/py_awscrt/package.py
@@ -17,6 +17,7 @@ class PyAwscrt(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.35.0", sha256="761ae0dda17fd9dfaff4bbb2a376e28e44dfd77dc6410b7bc408297a1fd5600e")
     version("0.31.2", sha256="552555de1beff02d72a1f6d384cd49c5a7c283418310eae29d21bcb749c65792")
     version("0.29.2", sha256="c78d81b1308d42fda1eb21d27fcf26579137b821043e528550f2cfc6c09ab9ff")
     version("0.20.9", sha256="243785ac9ee64945e0479c2384325545f29597575743ce84c371556d1014e63e")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR adds `awscli-v2` 2.35.16 and `py-awscrt` 0.35.0.

`awscli-v2` 2.35.16 requires `awscrt==0.35.0`. We also allow for py-urllib3 v2 for newer python

This also adds a new `autocomplete` variant. In my builds on the discover cluster, the building of the AWS CLI shell-completion was causing a "halt" or "disk uninterruptible" state. With the help of GPT 5.6 Terra we came up with this change which allows me to turn it off on that machine.