### PR TITLE
py-h5py: add hdf2 support

### DIFF
--- a/repos/spack_repo/builtin/packages/py_h5py/package.py
+++ b/repos/spack_repo/builtin/packages/py_h5py/package.py
@@ -92,7 +92,8 @@ class PyH5py(PythonPackage):
     # Link dependencies (py-h5py v2 cannot build against HDF5 1.12 regardless
     # of API setting)
     # version constraints from https://github.com/h5py/h5py/tree/master/docs/whatsnew
-    depends_on("hdf5@1.10.7:1.14 +hl", when="@3.15:")
+    depends_on("hdf5@1.10.7: +hl", when="@3.16:")
+    depends_on("hdf5@1.10.7:1.14 +hl", when="@3.15")
     depends_on("hdf5@1.10.6:1.14 +hl", when="@3.12:3.14")
     depends_on("hdf5@1.10.4:1.14 +hl", when="@3.10:3.11")
     depends_on("hdf5@1.8.4:1.14 +hl", when="@3.8:3.9")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

In testing a spack stack with hdf5 2.0, I found `py-h5py` could use it with version 3.16.

This adds that ability.
