### PR TITLE
supergateway: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/supergateway/package.py
+++ b/repos/spack_repo/builtin/packages/supergateway/package.py
@@ -1,0 +1,29 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.generic import Package
+
+from spack.package import *
+
+
+class Supergateway(Package):
+    """Run MCP stdio servers over SSE and Streamable HTTP, and vice versa."""
+
+    homepage = "https://github.com/supercorp-ai/supergateway"
+    url = "https://registry.npmjs.org/supergateway/-/supergateway-3.4.3.tgz"
+
+    maintainers("aprozo")
+
+    license("MIT", checked_by="aprozo")
+
+    # The npm registry tarball ships a prebuilt dist/, so no TypeScript build
+    # is needed; install with --ignore-scripts to skip the (dev-only) prepare.
+    version("3.4.3", sha256="d26391996026bb5967a77e877474cdffa9431ed59c65186d557064de98f5ab84")
+
+    depends_on("node-js@20:", type=("build", "run"))
+    depends_on("npm@10:", type="build")
+
+    def install(self, spec, prefix):
+        npm = which("npm", required=True)
+        npm("install", "--global", "--ignore-scripts", f"--prefix={prefix}", ".")


### PR DESCRIPTION
Adds [supergateway](https://github.com/supercorp-ai/supergateway): bridges MCP (Model Context Protocol) stdio servers to SSE / streamable HTTP and vice versa. The npm registry tarball ships a prebuilt `dist/`, so the install uses `npm install --global --ignore-scripts` (same npm pattern as `claude-code`).

Companion to #5637 (py-mcp) — used to expose the MCP servers packaged for the EIC's eic-shell ([eic/eic-spack#986](https://github.com/eic/eic-spack/pull/986)) as local HTTP services, but general-purpose for any MCP deployment. Verified: builds and serves streamable-HTTP MCP sessions in that stack.