### PR TITLE
opencode, bun: new packages

### DIFF
--- a/repos/spack_repo/builtin/packages/bun/package.py
+++ b/repos/spack_repo/builtin/packages/bun/package.py
@@ -1,0 +1,64 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import platform
+
+from spack_repo.builtin.build_systems.generic import Package
+
+from spack.package import *
+
+
+class Bun(Package):
+    """Bun is an all-in-one JavaScript runtime, bundler, transpiler and package manager."""
+
+    homepage = "https://bun.com/"
+    url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-x64.zip"
+    supplier = "Organization: Oven"
+
+    maintainers("aprozo")
+
+    license("MIT AND LGPL-2.1-only", checked_by="aprozo")
+
+    skip_version_audit = ["platform=windows"]
+
+    sanity_check_is_file = ["bin/bun"]
+
+    bun_versions = {
+        "1.3.14": {
+            "linux": {
+                "x86_64": "951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f",
+                "aarch64": "a27ffb63a8310375836e0d6f668ae17fa8d8d18b88c37c821c65331973a19a3b",
+            },
+            "darwin": {
+                "x86_64": "4183df3374623e5bab315c547cfa0974533cd457d86b73b639f7a87974cd6633",
+                "arm64": "d8b96221828ad6f97ac7ac0ab7e95872341af763001e8803e8267652c2652620",
+            },
+        }
+    }
+
+    zip_name = {
+        "linux": {"x86_64": "linux-x64", "aarch64": "linux-aarch64"},
+        "darwin": {"x86_64": "darwin-x64", "arm64": "darwin-aarch64"},
+    }
+
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+
+    for ver in bun_versions:
+        if system in bun_versions[ver] and machine in bun_versions[ver][system]:
+            version(ver, sha256=bun_versions[ver][system][machine])
+
+    def url_for_version(self, version):
+        target = self.zip_name.get(self.system, {}).get(self.machine)
+
+        if target is None:
+            return None
+
+        return f"https://github.com/oven-sh/bun/releases/download/bun-v{version}/bun-{target}.zip"
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install("bun", prefix.bin)
+        set_executable(prefix.bin.bun)
+        symlink("bun", join_path(prefix.bin, "bunx"))

--- a/repos/spack_repo/builtin/packages/opencode/package.py
+++ b/repos/spack_repo/builtin/packages/opencode/package.py
@@ -1,0 +1,76 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import glob
+
+from spack_repo.builtin.build_systems.generic import Package
+
+from spack.package import *
+
+
+class Opencode(Package):
+    """
+    opencode is an open-source AI coding agent for the terminal, running as a TUI or as a
+    headless CLI against MCP servers and LLM providers.
+    """
+
+    homepage = "https://opencode.ai"
+    url = "https://github.com/anomalyco/opencode/archive/refs/tags/v1.18.3.tar.gz"
+    supplier = "Organization: Anomaly Innovations"
+
+    maintainers("aprozo")
+
+    license("MIT", checked_by="aprozo")
+
+    sanity_check_is_file = ["bin/opencode"]
+
+    version("1.18.3", sha256="494041aedd7407079f91fd694de355f4ff022ba6bf876e09ff30983bbdc70ae1")
+
+    depends_on("bun@1.3.14:1", type="build")
+    depends_on("node-js@22.12:", type="build")
+    depends_on("ripgrep", type="run")
+
+    phases = ["build", "install"]
+
+    def setup_build_environment(self, env):
+        # the build scripts read both from git, which a release archive has not
+        env.set("OPENCODE_VERSION", self.spec.version.string)
+        env.set("OPENCODE_CHANNEL", "stable")
+        env.set("HOME", self.stage.path)
+        env.set("BUN_INSTALL_CACHE_DIR", join_path(self.stage.path, "bun-cache"))
+
+    def build(self, spec, prefix):
+        bun = which("bun", required=True)
+
+        bun(
+            "install",
+            "--cpu=*",
+            "--os=*",
+            "--frozen-lockfile",
+            "--ignore-scripts",
+            "--no-progress",
+            "--filter",
+            "./",
+            "--filter",
+            "./packages/app",
+            "--filter",
+            "./packages/desktop",
+            "--filter",
+            "./packages/opencode",
+            "--filter",
+            "./packages/shared",
+        )
+
+        with working_dir(join_path("packages", "opencode")):
+            bun("--bun", "./script/build.ts", "--single", "--skip-install")
+
+    def install(self, spec, prefix):
+        (binary,) = glob.glob(join_path("packages", "opencode", "dist", "*", "bin", "opencode"))
+
+        mkdirp(prefix.bin)
+        install(binary, prefix.bin)
+        set_executable(join_path(prefix.bin, "opencode"))
+
+    def setup_run_environment(self, env):
+        env.set("OPENCODE_DISABLE_AUTOUPDATE", "true")


### PR DESCRIPTION
Adds [opencode](https://opencode.ai) ([anomalyco/opencode](https://github.com/anomalyco/opencode)), an open-source AI coding agent CLI — useful on headless systems (farm nodes, CI debugging) where a graphical client is not available — together with the `bun` package it needs to build.

Built from the tagged source archive. opencode is a bun workspace: the lockfile is `bun.lock`, dependencies use bun's `catalog:` / `workspace:` protocols plus `patchedDependencies`, and the build is `Bun.build({ compile: ... })`, which links the sources against the bun runtime into a single executable — so npm cannot drive it. The build steps follow the nixpkgs derivation: `bun install` over the workspaces the CLI pulls in, then `bun --bun ./script/build.ts --single --skip-install` in `packages/opencode`.

`bun` itself is installed from the upstream release archives, in the same shape as the existing `deno` package: bun is Zig plus a patched JavaScriptCore and needs an existing bun to bootstrap. It is a separate commit and can be split into its own PR if preferred.

Dependencies, each confirmed by shimming the tool out of `PATH` and re-running the build: `bun` and `node-js` at build time (the embedded web UI is built with vite, which runs on node), `ripgrep` at run time (otherwise opencode downloads an `rg` binary into the user cache at first use). `git` and `npm` are not needed.

Verified on linux-x86_64: clean `spack install opencode` → `bin/opencode`, `opencode --version` reports `1.18.3`. Companion to #5637; also exercised in the EIC eic-shell stack ([eic/eic-spack#986](https://github.com/eic/eic-spack/pull/986)).
