### PR TITLE
py-pandas-datareader: add 0.11.0, 0.11.1

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pandas_datareader/package.py
+++ b/repos/spack_repo/builtin/packages/py_pandas_datareader/package.py
@@ -11,30 +11,36 @@ class PyPandasDatareader(PythonPackage):
     """Up-to-date remote data access for pandas. Works for multiple versions of pandas"""
 
     homepage = "https://pypi.org/project/pandas-datareader"
-    pypi = "pandas-datareader/pandas-datareader-0.10.0.tar.gz"
+    pypi = "pandas-datareader/pandas_datareader-0.11.1.tar.gz"
     git = "https://github.com/pydata/pandas-datareader.git"
 
     maintainers("climbfuji")
 
     license("BSD-3-Clause", checked_by="climbfuji")
 
-    version(
-        "0.11.1",
-        url="https://files.pythonhosted.org/packages/58/86/288382815ce0b52585e8fbcdd8167cdbc056e2d750dea84fcc2ba5c36748/pandas_datareader-0.11.1.tar.gz",
-        sha256="e1eadb6d2ccaa4b7a876a1c81b6ff0307fa7a08b56f7799862a50207c2e65a05",
-    )
+    version("0.11.1", sha256="e1eadb6d2ccaa4b7a876a1c81b6ff0307fa7a08b56f7799862a50207c2e65a05")
+    version("0.11.0", sha256="6c86360127f0b4c4451495574e162da058cf6154a185503310df70c417e0e266")
     version("0.10.0", sha256="9fc3c63d39bc0c10c2683f1c6d503ff625020383e38f6cbe14134826b454d5a6")
+
+    def url_for_version(self, version):
+        if isinstance(version, str):
+            version = Version(version)
+
+        if version < Version("0.11.0"):
+            return f"https://files.pythonhosted.org/packages/source/p/pandas-datareader/pandas-datareader-{version}.tar.gz"
+
+        return super().url_for_version(version)
 
     # Versioneer bundled with 0.10.0 uses APIs removed in Python 3.12.
     patch("py312-versioneer.patch", when="@0.10.0 ^python@3.12:")
 
     depends_on("python@3.8:", type=("build", "run"))
-    depends_on("python@3.11:", when="@0.11.1:", type=("build", "run"))
+    depends_on("python@3.11:", when="@0.11.0:", type=("build", "run"))
     depends_on("py-setuptools@0.64:", type="build")
     depends_on("py-setuptools-scm@8", type="build")
 
     depends_on("py-lxml", type="run")
     depends_on("py-pandas@1.5.3:", when="@0.10.0", type="run")
-    depends_on("py-pandas@2.1.4:", when="@0.11.1:", type="run")
+    depends_on("py-pandas@2.1.4:", when="@0.11.0:", type="run")
     depends_on("py-statsmodels@0.12:", when="@0.10.0", type="run")
     depends_on("py-requests@2.19:", type="run")

--- a/repos/spack_repo/builtin/packages/py_pandas_datareader/package.py
+++ b/repos/spack_repo/builtin/packages/py_pandas_datareader/package.py
@@ -18,13 +18,23 @@ class PyPandasDatareader(PythonPackage):
 
     license("BSD-3-Clause", checked_by="climbfuji")
 
+    version(
+        "0.11.1",
+        url="https://files.pythonhosted.org/packages/58/86/288382815ce0b52585e8fbcdd8167cdbc056e2d750dea84fcc2ba5c36748/pandas_datareader-0.11.1.tar.gz",
+        sha256="e1eadb6d2ccaa4b7a876a1c81b6ff0307fa7a08b56f7799862a50207c2e65a05",
+    )
     version("0.10.0", sha256="9fc3c63d39bc0c10c2683f1c6d503ff625020383e38f6cbe14134826b454d5a6")
 
+    # Versioneer bundled with 0.10.0 uses APIs removed in Python 3.12.
+    patch("py312-versioneer.patch", when="@0.10.0 ^python@3.12:")
+
     depends_on("python@3.8:", type=("build", "run"))
+    depends_on("python@3.11:", when="@0.11.1:", type=("build", "run"))
     depends_on("py-setuptools@0.64:", type="build")
     depends_on("py-setuptools-scm@8", type="build")
 
     depends_on("py-lxml", type="run")
-    depends_on("py-pandas@1.5.3:", type="run")
-    depends_on("py-statsmodels@0.12:", type="run")
+    depends_on("py-pandas@1.5.3:", when="@0.10.0", type="run")
+    depends_on("py-pandas@2.1.4:", when="@0.11.1:", type="run")
+    depends_on("py-statsmodels@0.12:", when="@0.10.0", type="run")
     depends_on("py-requests@2.19:", type="run")

--- a/repos/spack_repo/builtin/packages/py_pandas_datareader/py312-versioneer.patch
+++ b/repos/spack_repo/builtin/packages/py_pandas_datareader/py312-versioneer.patch
@@ -1,0 +1,13 @@
+--- a/versioneer.py
++++ b/versioneer.py
+@@ -344,9 +344,9 @@ def get_config_from_root(root):
+     # the top of versioneer.py for instructions on writing your setup.cfg .
+     setup_cfg = os.path.join(root, "setup.cfg")
+-    parser = configparser.SafeConfigParser()
++    parser = configparser.ConfigParser()
+     with open(setup_cfg, "r") as f:
+-        parser.readfp(f)
++        parser.read_file(f)
+     VCS = parser.get("versioneer", "VCS")  # mandatory
+ 
+     def get(parser, name):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

More in my series of building things with Python 3.13, this adds py-pandas-datareader 0.11.0. I also added a patch 0.10.0 in case that version is explicitly needed.

Also clean up the PyPI source URL handling for `py-pandas-datareader`.

PyPI changed the sdist filename from `pandas-datareader-...tar.gz` to `pandas_datareader-...tar.gz` in `0.11.x`, which meant `spack checksum py-pandas-datareader` would not discover the new releases correctly from the default package URL.

This update switches the package's default PyPI template to the current `0.11.x` naming scheme and adds a `url_for_version()` override for older releases, so both interactive `spack checksum py-pandas-datareader` and targeted checksums for `0.11.0` / `0.11.1` work cleanly.