### PR TITLE
cargo-c: depends_on pkgconfig

### DIFF
--- a/repos/spack_repo/builtin/packages/cargo_c/package.py
+++ b/repos/spack_repo/builtin/packages/cargo_c/package.py
@@ -22,5 +22,6 @@ class CargoC(CargoPackage):
     depends_on("c", type="build")
 
     depends_on("openssl")
+    depends_on("pkgconfig", type="build")
     depends_on("rust@1.89:", type="build", when="@0.10.17:")
     depends_on("rust@1.88:", type="build", when="@0.10.16:")


### PR DESCRIPTION
This PR updates `cargo-c` to depend on `pkgconfig`, type build, per https://github.com/lu-zero/cargo-c/blob/master/README.md#installation.

This should fix https://github.com/eic/containers/actions/runs/29587192045/job/87908377211?pr=359#step:15:3218