### PR TITLE
professor: cast version to str

### DIFF
--- a/repos/spack_repo/builtin/packages/professor/package.py
+++ b/repos/spack_repo/builtin/packages/professor/package.py
@@ -38,7 +38,7 @@ class Professor(Package):
     extends("python")
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        env.set("PROF_VERSION", self.spec.version)
+        env.set("PROF_VERSION", str(self.spec.version))
 
     def install(self, spec, prefix):
         make()


### PR DESCRIPTION
This PR fixes a warnings in `professor`, by casting version to string explicitly. Fixes warning at https://github.com/eic/containers/actions/runs/29644898727/job/88081877592?pr=359#step:15:3161.