### PR TITLE
cusolvermp: mark source and binary artifacts non-redistributable

### DIFF
--- a/repos/spack_repo/builtin/packages/cusolvermp/package.py
+++ b/repos/spack_repo/builtin/packages/cusolvermp/package.py
@@ -44,6 +44,8 @@ class Cusolvermp(Package, CudaPackage):
 
     maintainers("albestro")
 
+    redistribute(source=False, binary=False)
+
     # https://docs.nvidia.com/cuda/cusolvermp/license.html
     license("NVIDIA Software License Agreement")
 


### PR DESCRIPTION
## Summary

Mark cuSOLVERMp source archives and installed binaries as non-redistributable.

## Rationale

The cuSOLVERMp package downloads NVIDIA redist archives under the NVIDIA Software License Agreement. The bundled license describes binary and header distribution when they are incorporated into an application that satisfies its conditions; it does not clearly authorize publishing the standalone source archives or installed package artifacts through public Spack mirrors or buildcaches. This change therefore sets `redistribute(source=False, binary=False)` so Spack does not publish those artifacts by default.

This follows the existing metadata used by the related NVIDIA packages `nvpl_common`, `nvpl_blas`, `nvpl_lapack`, `nvpl_fft`, `nvpl_scalapack`, `nvhpc`, and `nvidia_nsight_systems`.

## Validation

- `./.ci/style_check.sh upstream/develop`
- `python -m compileall -q repos/spack_repo/builtin/packages/cusolvermp/package.py`
- `git diff --check upstream/develop...HEAD`
