### PR TITLE
py-wxpython: add v4.2.5

### DIFF
--- a/repos/spack_repo/builtin/packages/py_wxpython/package.py
+++ b/repos/spack_repo/builtin/packages/py_wxpython/package.py
@@ -11,8 +11,11 @@ class PyWxpython(PythonPackage):
     """Cross platform GUI toolkit for Python."""
 
     homepage = "https://www.wxpython.org/"
-    pypi = "wxPython/wxPython-4.0.6.tar.gz"
+    pypi = "wxpython/wxpython-4.0.6.tar.gz"
+    git = "https://github.com/wxWidgets/Phoenix.git"
 
+    version("4.2.5", sha256="44e836d1bccd99c38790bb034b6ecf70d9060f6734320560f7c4b0d006144793")
+    version("4.2.4", sha256="2eb123979c87bcb329e8a2452269d60ff8f9f651e9bf25c67579e53c4ebbae3c")
     version("4.2.3", sha256="20d6e0c927e27ced85643719bd63e9f7fd501df6e9a8aab1489b039897fd7c01")
     version("4.2.2", sha256="5dbcb0650f67fdc2c5965795a255ffaa3d7b09fb149aa8da2d0d9aa44e38e2ba")
     version("4.1.1", sha256="00e5e3180ac7f2852f342ad341d57c44e7e4326de0b550b9a5c4a8361b6c3528")
@@ -23,10 +26,15 @@ class PyWxpython(PythonPackage):
 
     # Versions before 4.2.3 require distutils which is removed in python 3.12
     depends_on("python@:3.11", when="@:4.2.2")
+    # Pre-generated Cython C files fail to build with free-threaded Python
+    # https://github.com/wxWidgets/Phoenix/issues/2707
+    conflicts("^python+freethreading", when="@:4.2.3")
 
     depends_on("wxwidgets +gui")
     depends_on("wxwidgets@3.2.6 +gui", when="@4.2.2")
     depends_on("wxwidgets@3.2.7 +gui", when="@4.2.3")
+    depends_on("wxwidgets@3.2.8.1 +gui", when="@4.2.4")
+    depends_on("wxwidgets@3.2.9 +gui", when="@4.2.5")
 
     # Needed by the buildtools/config.py script
     depends_on("pkgconfig", type="build")
@@ -40,6 +48,12 @@ class PyWxpython(PythonPackage):
     depends_on("py-numpy", type=("build", "run"))
     depends_on("pil", type=("build", "run"))
     depends_on("py-six", type=("build", "run"))
+
+    def url_for_version(self, version):
+        url = "https://files.pythonhosted.org/packages/source/w/wxPython/wxPython-{0}.tar.gz"
+        if version >= Version("4.2.3"):
+            url = url.lower()
+        return url.format(version)
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         # By default wxWdigets is built as well instead of using spack provided version,

--- a/repos/spack_repo/builtin/packages/py_wxpython/package.py
+++ b/repos/spack_repo/builtin/packages/py_wxpython/package.py
@@ -59,6 +59,6 @@ class PyWxpython(PythonPackage):
         return url.format(version)
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        # By default wxWdigets is built as well instead of using spack provided version,
+        # By default wxWidgets is built as well instead of using spack provided version,
         # this tells it to just build the python extensions
         env.set("WXPYTHON_BUILD_ARGS", "build_py --use_syswx")

--- a/repos/spack_repo/builtin/packages/py_wxpython/package.py
+++ b/repos/spack_repo/builtin/packages/py_wxpython/package.py
@@ -41,6 +41,9 @@ class PyWxpython(PythonPackage):
     # Needed for the build.py script
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools@:75", type="build", when="@:4.1")  # deprecated license-file
+    # As of 4.2.4, sdists no longer ship wx/svg/_nanosvg.c
+    # https://github.com/wxWidgets/Phoenix/issues/2843
+    depends_on("py-cython", type="build", when="@4.2.4:")
     depends_on("py-pathlib2", type="build")
     depends_on("py-requests", type="build")
 

--- a/repos/spack_repo/builtin/packages/wxwidgets/package.py
+++ b/repos/spack_repo/builtin/packages/wxwidgets/package.py
@@ -24,6 +24,8 @@ class Wxwidgets(AutotoolsPackage):
     git = "https://github.com/wxWidgets/wxWidgets.git"
 
     version("develop", branch="master")
+    version("3.2.9", sha256="fb90f9538bffd6a02edbf80037a0c14c2baf9f509feac8f76ab2a5e4321f112b")
+    version("3.2.8.1", sha256="ad0cf6c18815dcf1a6a89ad3c3d21a306cd7b5d99a602f77372ef1d92cb7d756")
     version("3.2.7", sha256="69a1722f874d91cd1c9e742b72df49e0fab02890782cf794791c3104cee868c6")
     version("3.2.6", sha256="939e5b77ddc5b6092d1d7d29491fe67010a2433cf9b9c0d841ee4d04acb9dce7")
     version("3.2.5", sha256="0ad86a3ad3e2e519b6a705248fc9226e3a09bbf069c6c692a02acf7c2d1c6b51")


### PR DESCRIPTION
This PR upgrades and fixes `py-wxpython` to v4.2.4 and v4.2.5. Since `py-wxpython` pins a specific version of `wxwidgets` we add the necessary versions. These new versions add support for free-threaded python (i.e. it now compiles on those pythons). URL on PyPI changed.

Test build (against free-threaded python, fast due to ccache):
```
[+] exwg3lw py-wxpython@4.2.5 /opt/software/linux-skylake/py-wxpython-4.2.5-exwg3lwwqy7ae7tohqnmvertb73pojzh (4m01s)
``` 