### PR TITLE
professor: add v2.5.6

### DIFF
--- a/repos/spack_repo/builtin/packages/professor/package.py
+++ b/repos/spack_repo/builtin/packages/professor/package.py
@@ -19,8 +19,6 @@ class Professor(Package):
     maintainers("mjk655")
 
     version("2.5.6", sha256="7537f23078bd56f00e67e1f96c7a24026b255cc26907ad5d5234b8371e49b3c7")
-    version("2.4.2", sha256="d1a602f2301dac5a165d8cb5baf31d8a1a3d92f30a7069cda66b98c595a4fa21")
-    version("2.3.4", sha256="2c293479342d3a74a6261e7139677bf3580ec34c7bc6a389854fc26497c65ad8")
     version("2.3.3", sha256="60c5ba00894c809e2c31018bccf22935a9e1f51c0184468efbdd5d27b211009f")
 
     variant(

--- a/repos/spack_repo/builtin/packages/professor/package.py
+++ b/repos/spack_repo/builtin/packages/professor/package.py
@@ -13,9 +13,14 @@ class Professor(Package):
 
     homepage = "https://professor.hepforge.org/"
     url = "https://professor.hepforge.org/downloads/?f=Professor-2.3.3.tar.gz"
+    git = "https://gitlab.com/hepcedar/professor"
+    list_url = "https://professor.hepforge.org/downloads/"
 
     maintainers("mjk655")
 
+    version("2.5.6", sha256="7537f23078bd56f00e67e1f96c7a24026b255cc26907ad5d5234b8371e49b3c7")
+    version("2.4.2", sha256="d1a602f2301dac5a165d8cb5baf31d8a1a3d92f30a7069cda66b98c595a4fa21")
+    version("2.3.4", sha256="2c293479342d3a74a6261e7139677bf3580ec34c7bc6a389854fc26497c65ad8")
     version("2.3.3", sha256="60c5ba00894c809e2c31018bccf22935a9e1f51c0184468efbdd5d27b211009f")
 
     variant(
@@ -25,6 +30,8 @@ class Professor(Package):
     )
 
     depends_on("cxx", type="build")  # generated
+    depends_on("gmake", type="build")
+    depends_on("py-pip", type="build")
 
     depends_on("yoda")
     depends_on("eigen")
@@ -33,15 +40,20 @@ class Professor(Package):
     depends_on("py-matplotlib")
     depends_on("py-matplotlib backend=wx", when="+interactive")
     depends_on("root")
-    depends_on("gmake", type="build")
 
     extends("python")
+
+    def patch(self):
+        filter_file("PROF_ROOT=$(PWD)", "PROF_ROOT=$(CURDIR)", "Makefile", string=True)
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         env.set("PROF_VERSION", str(self.spec.version))
 
     def install(self, spec, prefix):
-        make()
-        make("PREFIX={0}".format(prefix), "install")
+        with working_dir(self.stage.source_path):
+            configure = Executable("./configure")
+            configure("--prefix={0}".format(prefix), "--with-eigen={0}".format(spec["eigen"].prefix))
+            make()
+            make("PREFIX={0}".format(prefix), "install")
         if self.spec.satisfies("~interactive"):
             os.remove(join_path(prefix.bin, "prof2-I"))

--- a/repos/spack_repo/builtin/packages/professor/package.py
+++ b/repos/spack_repo/builtin/packages/professor/package.py
@@ -48,7 +48,7 @@ class Professor(Package):
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         env.set("PROF_VERSION", str(self.spec.version))
 
-    @when("@2.5.0:")
+    @run_before("install", when="@2.5.0:")
     def configure(self, spec, prefix):
         with working_dir(self.stage.source_path):
             configure = Executable("configure")

--- a/repos/spack_repo/builtin/packages/professor/package.py
+++ b/repos/spack_repo/builtin/packages/professor/package.py
@@ -35,6 +35,7 @@ class Professor(Package):
     depends_on("eigen")
     depends_on("py-cython")
     depends_on("py-iminuit")
+    depends_on("py-iminuit@2:", when="@2.4:")
     depends_on("py-matplotlib")
     depends_on("py-matplotlib backend=wx", when="+interactive")
     depends_on("root")
@@ -47,12 +48,14 @@ class Professor(Package):
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         env.set("PROF_VERSION", str(self.spec.version))
 
+    @when("@2.5.0:")
+    def configure(self, spec, prefix):
+        with working_dir(self.stage.source_path):
+            configure = Executable("configure")
+            configure(f"--prefix={prefix}", f"--with-eigen={self.spec['eigen'].prefix}")
+
     def install(self, spec, prefix):
         with working_dir(self.stage.source_path):
-            configure = Executable("./configure")
-            configure(
-                "--prefix={0}".format(prefix), "--with-eigen={0}".format(spec["eigen"].prefix)
-            )
             make()
             make("PREFIX={0}".format(prefix), "install")
         if self.spec.satisfies("~interactive"):

--- a/repos/spack_repo/builtin/packages/professor/package.py
+++ b/repos/spack_repo/builtin/packages/professor/package.py
@@ -47,6 +47,8 @@ class Professor(Package):
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         env.set("PROF_VERSION", str(self.spec.version))
+        if self.spec["eigen"].satisfies("@5:"):
+            env.set("CXXSTD", "c++14")
 
     @run_before("install", when="@2.5.0:")
     def configure(self):

--- a/repos/spack_repo/builtin/packages/professor/package.py
+++ b/repos/spack_repo/builtin/packages/professor/package.py
@@ -52,7 +52,9 @@ class Professor(Package):
     def install(self, spec, prefix):
         with working_dir(self.stage.source_path):
             configure = Executable("./configure")
-            configure("--prefix={0}".format(prefix), "--with-eigen={0}".format(spec["eigen"].prefix))
+            configure(
+                "--prefix={0}".format(prefix), "--with-eigen={0}".format(spec["eigen"].prefix)
+            )
             make()
             make("PREFIX={0}".format(prefix), "install")
         if self.spec.satisfies("~interactive"):

--- a/repos/spack_repo/builtin/packages/professor/package.py
+++ b/repos/spack_repo/builtin/packages/professor/package.py
@@ -51,7 +51,7 @@ class Professor(Package):
     @run_before("install", when="@2.5.0:")
     def configure(self):
         with working_dir(self.stage.source_path):
-            configure = Executable("configure")
+            configure = Executable("./configure")
             configure(f"--prefix={self.prefix}", f"--with-eigen={self.spec['eigen'].prefix}")
 
     def install(self, spec, prefix):

--- a/repos/spack_repo/builtin/packages/professor/package.py
+++ b/repos/spack_repo/builtin/packages/professor/package.py
@@ -49,10 +49,10 @@ class Professor(Package):
         env.set("PROF_VERSION", str(self.spec.version))
 
     @run_before("install", when="@2.5.0:")
-    def configure(self, spec, prefix):
+    def configure(self):
         with working_dir(self.stage.source_path):
             configure = Executable("configure")
-            configure(f"--prefix={prefix}", f"--with-eigen={self.spec['eigen'].prefix}")
+            configure(f"--prefix={self.prefix}", f"--with-eigen={self.spec['eigen'].prefix}")
 
     def install(self, spec, prefix):
         with working_dir(self.stage.source_path):

--- a/stacks/hep/spack.yaml
+++ b/stacks/hep/spack.yaml
@@ -118,7 +118,7 @@ spack:
   - pandorasdk
   - photos +hepmc3
   - podio +rntuple +sio
-  #- professor
+  - professor
   - py-awkward
   - py-boost-histogram
   - py-dask-awkward ~io


### PR DESCRIPTION
This PR adds to `professor` the newer version v2.5.6. This also fixes a few issues which likely explain why I could never get professor to build in the HEP stack: the Makefile seems to pick up the `$PWD` where you issue the spack command, unless we add a working_dir and/or replace the use of explicit `$(PWD)` with `$(CURDIR)` (https://stackoverflow.com/questions/52437728/what-is-the-difference-between-pwd-and-curdir). This now also explicitly calls the `./configure` script (home-grown, not autotools).

Test build (`dev_path` with a fake 2.5.1, but it was a clean clone):
```
t7tqfkn professor@2.5.1+interactive build_system=generic dev_path=/home/wdconinc/git/professor
```