### PR TITLE
boost: missing upper version limit for cobalt library variant

### DIFF
--- a/repos/spack_repo/builtin/packages/boost/package.py
+++ b/repos/spack_repo/builtin/packages/boost/package.py
@@ -166,7 +166,7 @@ class Boost(Package):
         "openmethod": {"when": "@1.90:"},
         "mqtt5": {"when": "@1.88:"},
         "charconv": {"when": "@1.85:"},
-        "cobalt": {"when": "@1.84"},
+        "cobalt": {"when": "@1.84:"},
         "url": {"when": "@1.81:"},
         "json": {"when": "@1.75:"},
         "nowide": {"when": "@1.73:"},


### PR DESCRIPTION
`cobalt` variant can be enabled starting from 1.84 version, but in the recipe is missing the `:` to indicate all higher versions.
The typo was not present in older versions of the recipe, and was introduced with the merge of this [pull request](https://github.com/spack/spack-packages/pull/4016) that added version restrinctions for other variants.



