### PR TITLE
libxsmm: scope binutils+gas dependency to @:1.16

### DIFF
--- a/repos/spack_repo/builtin/packages/libxsmm/package.py
+++ b/repos/spack_repo/builtin/packages/libxsmm/package.py
@@ -122,7 +122,7 @@ class Libxsmm(CMakePackage, MakefilePackage):
         # A recent `as` is needed to compile libxsmm until version 1.17
         # (<https://github.com/spack/spack/issues/28404>), but not afterwards
         # (<https://github.com/spack/spack/pull/21671#issuecomment-779882282>).
-        depends_on("binutils+ld+gas@2.33:", type="build")
+        depends_on("binutils+ld+gas@2.33:", type="build", when="@:1.16")
 
     # Although it predates CMake support, this snapshot starts with the
     # infinity-version component "main" and therefore satisfies "@2:".


### PR DESCRIPTION
The package comment already notes that a recent `as` (from binutils +gas) is only needed to build libxsmm before version 1.17, not afterwards. The dependency was nevertheless unconditional.
