### PR TITLE
hdf: fix for GCC 15+ build

### DIFF
--- a/repos/spack_repo/builtin/packages/hdf/package.py
+++ b/repos/spack_repo/builtin/packages/hdf/package.py
@@ -172,7 +172,7 @@ class Hdf(AutotoolsPackage):
             ):
                 flags.append("-Wno-error=implicit-int")
 
-            if (self.spec.satisfies("%gcc@15:")):
+            if self.spec.satisfies("%gcc@15:"):
                 flags.append("-std=gnu17")
 
         return flags, None, None

--- a/repos/spack_repo/builtin/packages/hdf/package.py
+++ b/repos/spack_repo/builtin/packages/hdf/package.py
@@ -172,6 +172,9 @@ class Hdf(AutotoolsPackage):
             ):
                 flags.append("-Wno-error=implicit-int")
 
+            if (self.spec.satisfies("%gcc@15:")):
+                flags.append("-std=gnu17")
+
         return flags, None, None
 
     def configure_args(self):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR sets `-std=gnu17` when building with GCC 15+ as they now default to `gnu23` and `hdf` raises errors. (This has been done to many other packages, see https://github.com/spack/spack-packages/pull/5656 for example.) 