### PR TITLE
ncview: fix for GCC 15+ build

### DIFF
--- a/repos/spack_repo/builtin/packages/ncview/package.py
+++ b/repos/spack_repo/builtin/packages/ncview/package.py
@@ -25,6 +25,13 @@ class Ncview(AutotoolsPackage):
     depends_on("libpng")
     depends_on("libxaw")
 
+    def flag_handler(self, name, flags):
+        # The package does not build with C dialects newer than gnu17, so set gnu17
+        # for GCC 15 and newer which default to gnu23
+        if name == "cflags" and self.spec.satisfies("%gcc@15:"):
+            flags.append("-std=gnu17")
+        return (flags, None, None)
+
     def patch(self):
         # Disable the netcdf-c compiler check, save and restore the
         # modification timestamp of the file to prevent autoreconf.


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR sets `-std=gnu17` when building with GCC 15+ as they now default to `gnu23` and `ncview` raises errors. (This has been done to many other packages, see https://github.com/spack/spack-packages/pull/5656 for example.) 