### PR TITLE
btllib: add v1.7.6, 1.7.7, 1.7.8

### DIFF
--- a/repos/spack_repo/builtin/packages/btllib/package.py
+++ b/repos/spack_repo/builtin/packages/btllib/package.py
@@ -16,6 +16,9 @@ class Btllib(MesonPackage):
 
     license("GPL-3.0-or-later")
 
+    version("1.7.8", sha256="cd213d20a971ae3441551dd61b0e46a08559e3d9da19cb59ee8dc3397807f121")
+    version("1.7.7", sha256="9e81a509f60d5bf7f19d5e5d052248a92425fec5809d0d31368537660336247a")
+    version("1.7.6", sha256="36eea386e42033b8e099232ca19827cd6c70b8f92bdfe4f6ed51fc6ad976486b")
     version("1.7.5", sha256="118a9f8d6445a618178bfbec40d121bbe03014e767261522148f642686090c76")
     version("1.7.4", sha256="8c046340b9db4d580521297bfd9cb55af6877a34b48cf6a053266703ebc17837")
 
@@ -23,6 +26,8 @@ class Btllib(MesonPackage):
     depends_on("cxx", type="build")
 
     depends_on("gettext")
+
+    conflicts("python@3.14:", when="@:1.7.6")
 
     with default_args(type="build"):
         depends_on("cmake")


### PR DESCRIPTION
Added 3 latest versions for btllib. Also added a conflict for python@3.14: for versions @:1.7.6 due to the version of SWIG used in btllib causing errors during compilation.

No maintainers for btllib.