### PR TITLE
py-uv: add v0.11.30, v0.11.31

### DIFF
--- a/repos/spack_repo/builtin/packages/py_uv/package.py
+++ b/repos/spack_repo/builtin/packages/py_uv/package.py
@@ -24,6 +24,7 @@ class PyUv(PythonPackage, CargoPackage):
 
     executables = ["^uv$"]
 
+    version("0.11.31", sha256="763609d59721af5b8522e16deac6cffe8055f82bb837740c708917506f305185")
     version("0.11.30", sha256="06f4b824c6123df1cd00a68367f970870e7252b0b11a4d03a06b2b4b433afcda")
     version("0.11.29", sha256="a4ca34dc3b247740e511ca7c718181d5300e7899bbef755db45bb6c993610a64")
     version("0.11.28", sha256="df86cfd135542a833e9f84708b3b8dbaa987a3b9db85b267062db49ab639d242")

--- a/repos/spack_repo/builtin/packages/py_uv/package.py
+++ b/repos/spack_repo/builtin/packages/py_uv/package.py
@@ -24,6 +24,7 @@ class PyUv(PythonPackage, CargoPackage):
 
     executables = ["^uv$"]
 
+    version("0.11.30", sha256="06f4b824c6123df1cd00a68367f970870e7252b0b11a4d03a06b2b4b433afcda")
     version("0.11.29", sha256="a4ca34dc3b247740e511ca7c718181d5300e7899bbef755db45bb6c993610a64")
     version("0.11.28", sha256="df86cfd135542a833e9f84708b3b8dbaa987a3b9db85b267062db49ab639d242")
     version("0.11.27", sha256="3469204521869f0e6bdea17b02c1d86db2d0150820895653a6152cab206fb00b")


### PR DESCRIPTION
- add [uv v0.11.30](https://github.com/astral-sh/uv/releases/tag/0.11.30)
- add [uv v0.11.31](https://github.com/astral-sh/uv/releases/tag/0.11.31)

```
❯ spack find -v py-uv@0.11.30
-- darwin-tahoe-m1 / %c=apple-clang@17.0.0 ----------------------
py-uv@0.11.30 build_system=cargo  py-uv@0.11.30 build_system=python_pip
==> 2 installed packages)
```

```
❯ spack find -v py-uv@0.11.31
-- darwin-tahoe-m1 / %c=apple-clang@21.0.0 ----------------------
py-uv@0.11.31 build_system=cargo  py-uv@0.11.31 build_system=python_pip
==> 2 installed packages
```