### PR TITLE
ncview: version bump, fixed versions URL

### DIFF
--- a/repos/spack_repo/builtin/packages/ncview/package.py
+++ b/repos/spack_repo/builtin/packages/ncview/package.py
@@ -41,6 +41,6 @@ class Ncview(AutotoolsPackage):
 
     def url_for_version(self, version):
         if version >= Version("2.1.9"):
-            return F"https://cirrus.ucsd.edu/~pierce/ncview/ncview-{version}.tar.gz"
+            return f"https://cirrus.ucsd.edu/~pierce/ncview/ncview-{version}.tar.gz"
         else:
-            return F"ftp://cirrus.ucsd.edu/pub/ncview/ncview-{version}.tar.gz"
+            return f"ftp://cirrus.ucsd.edu/pub/ncview/ncview-{version}.tar.gz"

--- a/repos/spack_repo/builtin/packages/ncview/package.py
+++ b/repos/spack_repo/builtin/packages/ncview/package.py
@@ -14,6 +14,8 @@ class Ncview(AutotoolsPackage):
 
     license("GPL-3.0-only")
 
+    version("2.1.11", sha256="597cfddf9c2d7993e9b0b86bca1b73839567ee9116ee33f6d750a449b5033d91")
+    version("2.1.10", sha256="08d9cefb58a25b41316296074dccfe24147c3b7ea1af071cbfe785eff9f0dc65")
     version("2.1.9", sha256="e2317ac094af62f0adcf68421d70658209436aae344640959ec8975a645891af")
     version("2.1.8", sha256="e8badc507b9b774801288d1c2d59eb79ab31b004df4858d0674ed0d87dfc91be")
     version("2.1.7", sha256="a14c2dddac0fc78dad9e4e7e35e2119562589738f4ded55ff6e0eca04d682c82")
@@ -39,6 +41,6 @@ class Ncview(AutotoolsPackage):
 
     def url_for_version(self, version):
         if version >= Version("2.1.9"):
-            return "https://cirrus.ucsd.edu/~pierce/ncview/ncview-2.1.9.tar.gz"
+            return F"https://cirrus.ucsd.edu/~pierce/ncview/ncview-{version}.tar.gz"
         else:
-            return "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
+            return F"ftp://cirrus.ucsd.edu/pub/ncview/ncview-{version}.tar.gz"


### PR DESCRIPTION
Bumps the versions of ncview, also fixes the `url_for_version` function as from first glace it wouldn't have ever worked for version 2.1.8...

No maintainer for ncview.