### PR TITLE
cernlib: add variant for external Xbae + fix build with GCC16

### DIFF
--- a/repos/spack_repo/builtin/packages/cernlib/fix_build_with_gcc16.patch
+++ b/repos/spack_repo/builtin/packages/cernlib/fix_build_with_gcc16.patch
@@ -1,0 +1,78 @@
+--- lapack/SRC/second.f	2026-07-21 12:39:38.694282918 +0200
++++ lapack/SRC/second.f	2026-07-21 12:40:56.671997850 +0200
+@@ -19,10 +19,6 @@
+ *     .. Local Arrays ..
+       REAL               TARRAY( 2 )
+ *     ..
+-*     .. External Functions ..
+-      REAL               ETIME
+-      EXTERNAL           ETIME
+-*     ..
+ *     .. Executable Statements ..
+ *
+       T1 = ETIME( TARRAY )
+--- lapack/SRC/dsecnd.f	2026-07-21 12:39:57.595939285 +0200
++++ lapack/SRC/dsecnd.f	2026-07-21 12:41:12.168032327 +0200
+@@ -19,10 +19,6 @@
+ *     .. Local Arrays ..
+       REAL               TARRAY( 2 )
+ *     ..
+-*     .. External Functions ..
+-      REAL               ETIME
+-      EXTERNAL           ETIME
+-*     ..
+ *     .. Executable Statements ..
+ *
+       T1 = ETIME( TARRAY )
+--- lapack/INSTALL/second.f	2026-07-21 12:39:38.694282918 +0200
++++ lapack/INSTALL/second.f	2026-07-21 12:41:26.347063875 +0200
+@@ -19,10 +19,6 @@
+ *     .. Local Arrays ..
+       REAL               TARRAY( 2 )
+ *     ..
+-*     .. External Functions ..
+-      REAL               ETIME
+-      EXTERNAL           ETIME
+-*     ..
+ *     .. Executable Statements ..
+ *
+       T1 = ETIME( TARRAY )
+--- lapack/INSTALL/dsecnd.f	2026-07-21 12:39:57.595939285 +0200
++++ lapack/INSTALL/dsecnd.f	2026-07-21 12:42:01.380141824 +0200
+@@ -19,10 +19,6 @@
+ *     .. Local Arrays ..
+       REAL               TARRAY( 2 )
+ *     ..
+-*     .. External Functions ..
+-      REAL               ETIME
+-      EXTERNAL           ETIME
+-*     ..
+ *     .. Executable Statements ..
+ *
+       T1 = ETIME( TARRAY )
+--- lapack/INSTALL/second.f.RS6K	2026-07-21 12:39:38.694306324 +0200
++++ lapack/INSTALL/second.f.RS6K	2026-07-21 12:42:13.333168420 +0200
+@@ -19,10 +19,6 @@
+ *     .. Local Arrays ..
+       REAL               TARRAY( 2 )
+ *     ..
+-*     .. External Functions ..
+-      REAL               ETIME_
+-      EXTERNAL           ETIME_
+-*     ..
+ *     .. Executable Statements ..
+ *
+       T1 = ETIME_( TARRAY )
+--- lapack/INSTALL/dsecnd.f.RS6K	2026-07-21 12:39:57.596043873 +0200
++++ lapack/INSTALL/dsecnd.f.RS6K	2026-07-21 12:41:47.021109875 +0200
+@@ -19,10 +19,6 @@
+ *     .. Local Arrays ..
+       REAL               TARRAY( 2 )
+ *     ..
+-*     .. External Functions ..
+-      REAL               ETIME_
+-      EXTERNAL           ETIME_
+-*     ..
+ *     .. Executable Statements ..
+ *
+       T1 = ETIME_( TARRAY )

--- a/repos/spack_repo/builtin/packages/cernlib/package.py
+++ b/repos/spack_repo/builtin/packages/cernlib/package.py
@@ -45,6 +45,8 @@ class Cernlib(CMakePackage):
 
     # Fix build with GCC 14 and newer
     patch("fix_build_with_gcc14.patch", level=0)
+    # Fix build with GCC 16 and newer
+    patch("fix_build_with_gcc16.patch", level=0, when="%gcc@16:")
 
     def patch(self):
         if self.spec.satisfies("@:2023.08.14.0-free"):

--- a/repos/spack_repo/builtin/packages/cernlib/package.py
+++ b/repos/spack_repo/builtin/packages/cernlib/package.py
@@ -25,6 +25,7 @@ class Cernlib(CMakePackage):
     )
 
     variant("shared", default=True, description="Build shared libraries")
+    variant("internal_xbae", default=False, description="Use internal Xbae")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
@@ -38,7 +39,7 @@ class Cernlib(CMakePackage):
     depends_on("libxt")
     depends_on("libxcrypt")
 
-    depends_on("xbae", when="@2023:")
+    depends_on("xbae", when="@2023: ~internal_xbae")
 
     depends_on("openssl", when="platform=linux")
 
@@ -54,7 +55,10 @@ class Cernlib(CMakePackage):
             )
 
     def cmake_args(self):
-        args = [self.define_from_variant("CERNLIB_BUILD_SHARED", "shared")]
+        args = [
+            self.define_from_variant("CERNLIB_BUILD_SHARED", "shared"),
+            self.define_from_variant("CERNLIB_USE_INTERNAL_XBAE", "internal_xbae"),
+        ]
         # The package does not build with C dialects newer than gnu17, so set gnu17
         # for GCC 15 and newer which default to gnu23
         if self.spec.satisfies("%gcc@15:"):


### PR DESCRIPTION
These patches solve some issues with downstreams.
