### PR TITLE
matrix-switch: version bump, fixed detection of lapack/scalapack

### DIFF
--- a/repos/spack_repo/builtin/packages/matrix_switch/package.py
+++ b/repos/spack_repo/builtin/packages/matrix_switch/package.py
@@ -50,12 +50,12 @@ class MatrixSwitch(CMakePackage):
         ]
 
         if self.spec.satisfies("+lapack"):
-            args.append(self.define("LAPACK_LIBRARY", self.spec['lapack'].libs.ld_flags))
-            args.append(self.define("LAPACK_LIBRARY_DIR", self.spec['lapack'].prefix.lib))
+            args.append(self.define("LAPACK_LIBRARY", self.spec["lapack"].libs.ld_flags))
+            args.append(self.define("LAPACK_LIBRARY_DIR", self.spec["lapack"].prefix.lib))
 
         if self.spec.satisfies("+scalapack"):
-            args.append(self.define("SCALAPACK_LIBRARY", self.spec['scalapack'].libs.ld_flags))
-            args.append(self.define("SCALAPACK_LIBRARY_DIR", self.spec['scalapack'].prefix.lib))
+            args.append(self.define("SCALAPACK_LIBRARY", self.spec["scalapack"].libs.ld_flags))
+            args.append(self.define("SCALAPACK_LIBRARY_DIR", self.spec["scalapack"].prefix.lib))
 
         if self.spec.satisfies("+dbcsr"):
             args.append(self.define("DBCSR_ROOT", self.spec["dbcsr"].prefix))

--- a/repos/spack_repo/builtin/packages/matrix_switch/package.py
+++ b/repos/spack_repo/builtin/packages/matrix_switch/package.py
@@ -20,6 +20,8 @@ class MatrixSwitch(CMakePackage):
 
     license("BSD-2-Clause", checked_by="RMeli")
 
+    version("1.6.1", sha256="d86b089d63de7638ed9680cfbd77faa3acc3f045bb4102561da9c45cb202df67")
+    version("1.3.1", sha256="a5783dd8498feb1191577cc6b09dba6e4ac7de620b6a458ac14bc1eccffb01e9")
     version("1.2.1", sha256="a3c2bac20435a8217cd1a1abefa8b7f8c52b1c6f55a75b2861565ade5ecfe37f")
     version("master", branch="master")
 
@@ -29,6 +31,7 @@ class MatrixSwitch(CMakePackage):
     variant("dbcsr", default=False, when="+mpi", description="Build with DBCSR interface.")
 
     depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build", when="^[virtuals=scalapack]netlib-scalapack")
 
     depends_on("cmake@3.22:", type="build")
     generator("ninja")
@@ -45,6 +48,14 @@ class MatrixSwitch(CMakePackage):
             self.define_from_variant("WITH_SCALAPACK", "scalapack"),
             self.define_from_variant("WITH_DBCSR", "dbcsr"),
         ]
+
+        if self.spec.satisfies("+lapack"):
+            args.append(self.define("LAPACK_LIBRARY", self.spec['lapack'].libs.ld_flags))
+            args.append(self.define("LAPACK_LIBRARY_DIR", self.spec['lapack'].prefix.lib))
+
+        if self.spec.satisfies("+scalapack"):
+            args.append(self.define("SCALAPACK_LIBRARY", self.spec['scalapack'].libs.ld_flags))
+            args.append(self.define("SCALAPACK_LIBRARY_DIR", self.spec['scalapack'].prefix.lib))
 
         if self.spec.satisfies("+dbcsr"):
             args.append(self.define("DBCSR_ROOT", self.spec["dbcsr"].prefix))

--- a/repos/spack_repo/builtin/packages/matrix_switch/package.py
+++ b/repos/spack_repo/builtin/packages/matrix_switch/package.py
@@ -52,13 +52,17 @@ class MatrixSwitch(CMakePackage):
         if self.spec.satisfies("+lapack"):
             args.append(self.define("LAPACK_DETECTION", "OFF"))
             args.append(self.define("LAPACK_LIBRARY", self.spec["lapack"].libs.search_flags))
-            args.append(self.define("LAPACK_LIBRARY_DIR", self.spec["lapack"].headers.include_flags))
+            args.append(
+                self.define("LAPACK_LIBRARY_DIR", self.spec["lapack"].headers.include_flags)
+            )
             args.append(self.define("LAPACK_LINKER_FLAG", self.spec["lapack"].libs.link_flags))
 
         if self.spec.satisfies("+scalapack"):
             args.append(self.define("SCALAPACK_DETECTION", "OFF"))
             args.append(self.define("SCALAPACK_LIBRARY", self.spec["scalapack"].libs.link_flags))
-            args.append(self.define("SCALAPACK_LIBRARY_DIR", self.spec["scalapack"].libs.search_flags))
+            args.append(
+                self.define("SCALAPACK_LIBRARY_DIR", self.spec["scalapack"].libs.search_flags)
+            )
 
         if self.spec.satisfies("+dbcsr"):
             args.append(self.define("DBCSR_ROOT", self.spec["dbcsr"].prefix))

--- a/repos/spack_repo/builtin/packages/matrix_switch/package.py
+++ b/repos/spack_repo/builtin/packages/matrix_switch/package.py
@@ -30,7 +30,7 @@ class MatrixSwitch(CMakePackage):
     variant("scalapack", default=True, when="+mpi", description="Build with ScaLAPACK interface.")
     variant("dbcsr", default=False, when="+mpi", description="Build with DBCSR interface.")
 
-    depends_on("fortran", type="build")  # generated
+    depends_on("fortran", type="build")
     depends_on("c", type="build", when="^[virtuals=scalapack]netlib-scalapack")
 
     depends_on("cmake@3.22:", type="build")
@@ -50,12 +50,15 @@ class MatrixSwitch(CMakePackage):
         ]
 
         if self.spec.satisfies("+lapack"):
-            args.append(self.define("LAPACK_LIBRARY", self.spec["lapack"].libs.ld_flags))
-            args.append(self.define("LAPACK_LIBRARY_DIR", self.spec["lapack"].prefix.lib))
+            args.append(self.define("LAPACK_DETECTION", "OFF"))
+            args.append(self.define("LAPACK_LIBRARY", self.spec["lapack"].libs.search_flags))
+            args.append(self.define("LAPACK_LIBRARY_DIR", self.spec["lapack"].headers.include_flags))
+            args.append(self.define("LAPACK_LINKER_FLAG", self.spec["lapack"].libs.link_flags))
 
         if self.spec.satisfies("+scalapack"):
-            args.append(self.define("SCALAPACK_LIBRARY", self.spec["scalapack"].libs.ld_flags))
-            args.append(self.define("SCALAPACK_LIBRARY_DIR", self.spec["scalapack"].prefix.lib))
+            args.append(self.define("SCALAPACK_DETECTION", "OFF"))
+            args.append(self.define("SCALAPACK_LIBRARY", self.spec["scalapack"].libs.link_flags))
+            args.append(self.define("SCALAPACK_LIBRARY_DIR", self.spec["scalapack"].libs.search_flags))
 
         if self.spec.satisfies("+dbcsr"):
             args.append(self.define("DBCSR_ROOT", self.spec["dbcsr"].prefix))


### PR DESCRIPTION
I was running into problems getting matrix-switch installed using netlib-scalapack as the scalapack provider. A fix to this appeared to be depending on C when netlib-scalapack was the provider.

Additionally I noticed that during program compilation, it'd continue to choose OpenBLAS as the Scalapack provider, regardless of what the scalapack provider was chosen to be. I added some tooling to hopefully be a bit more strict with that (Sca)LAPACK libraries are chosen for compilation.

Also added a couple versions. While version 1.5.0 is _technically_ available as well, it appeared to have some function name conflicts so I opted to leave it out rather than writing a patch file for the outdated version.

Maintainer is @RMeli