### PR TITLE
cudss: build an MPI communication layer

### DIFF
--- a/repos/spack_repo/builtin/packages/cudss/package.py
+++ b/repos/spack_repo/builtin/packages/cudss/package.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 import platform
 
 from spack_repo.builtin.build_systems.generic import Package
@@ -67,7 +68,43 @@ class Cudss(Package):
         if pkg:
             version(ver, sha256=pkg[0], url=pkg[1])
 
+    variant(
+        "mpi",
+        default=False,
+        description="Build a communication layer for the selected MPI implementation",
+    )
+
     depends_on("cuda@12:")
+    depends_on("mpi", when="+mpi")
+
+    conflicts(
+        "+mpi",
+        when="@:0.6 target=aarch64:",
+        msg="cuDSS aarch64 archives provide communication-layer sources starting at 0.7.0",
+    )
 
     def install(self, spec, prefix):
         install_tree(".", prefix)
+
+        if "+mpi" in spec:
+            # NVIDIA calls this source and build target "openmpi", but it uses
+            # the standard MPI API and can be built against any MPI provider.
+            # Use a provider-neutral installed name because the concrete MPI
+            # dependency, rather than the filename, identifies its ABI.
+            with working_dir("src"):
+                with set_env(
+                    CUDA_PATH=spec["cuda"].prefix,
+                    CUDSS_PATH=self.stage.source_path,
+                    MPI_PATH=spec["mpi"].prefix,
+                    NVCC_PREPEND_FLAGS="-Xlinker=-rpath -Xlinker=%s:%s"
+                    % (spec["mpi"].prefix.lib64, spec["mpi"].prefix.lib),
+                ):
+                    bash = which("bash", required=True)
+                    bash("./cudss_build_commlayer.sh", "openmpi")
+
+                comm_layer = "libcudss_commlayer_openmpi.so"
+                if not os.path.isfile(comm_layer):
+                    raise InstallError(
+                        "cuDSS did not produce the requested MPI communication layer"
+                    )
+                install(comm_layer, join_path(prefix.lib, "libcudss_commlayer_mpi.so"))


### PR DESCRIPTION
Adds an optional `+mpi` variant that builds cuDSS's communication layer against the concrete MPI provider and installs it as `libcudss_commlayer_mpi.so`.

NVIDIA calls the source and build target `openmpi`, but it uses the standard MPI API and builds against `MPI_PATH`. The provider-neutral installed name prevents MPICH consumers from selecting NVIDIA's bundled Open MPI binary. The recipe rejects `+mpi` for aarch64 cuDSS 0.5–0.6 because those archives lack the source.

Validation:
- audited the source layout of every declared x86_64 and aarch64 archive;
- built with Open MPI and MPICH and verified linkage/RPATH with `readelf` and `ldd`;
- completed a two-rank GPU solve with the MPICH layer; and
- passed style and package audits.

Follow-up: #5681.
