### PR TITLE
openmpi: Restrict patches to versions 5.0.0 to 5.0.10

### DIFF
--- a/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -525,7 +525,7 @@ class Openmpi(AutotoolsPackage, CudaPackage, ROCmPackage):
     patch(
         "https://github.com/open-mpi/ompi/commit/aa024ac73d624611cfe3af6f541b5d28dedf07bb.patch?full_index=1",
         sha256="646eb1a7382d628eb821715ca69fc5467a9a25aaddfe8290dbce008536dbfaa0",
-        when="@5.0.0:",
+        when="@5.0.0:5.0.10",
     )
 
     # GCC 16: fix excessive brace initialization in memheap_base_frame.c
@@ -533,7 +533,7 @@ class Openmpi(AutotoolsPackage, CudaPackage, ROCmPackage):
     patch(
         "https://github.com/open-mpi/ompi/commit/b878c7d974dae767246ad20ef9124a331d0f59a4.patch?full_index=1",
         sha256="1dcebafdb310203f3b62456a5ba67e1a21ad3a88aaf40326734885d7b0d776f9",
-        when="@5.0.0: +openshmem",
+        when="@5.0.0:5.0.10 +openshmem",
     )
 
     FABRICS = (


### PR DESCRIPTION
Patches are now included in 5.0.x and main, and it causes build failures to try to apply them via Spack.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
