### PR TITLE
cuda: avoid installer trying to call $XTERM -title

### DIFF
--- a/repos/spack_repo/builtin/packages/cuda/package.py
+++ b/repos/spack_repo/builtin/packages/cuda/package.py
@@ -857,6 +857,7 @@ class Cuda(Package):
         return match.group(1) if match else None
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        env.unset("DISPLAY")  # avoid installer trying to call $XTERM -title
         if self.spec.satisfies("@:8.0.61"):
             # Perl 5.26 removed current directory from module search path,
             # CUDA 9 has a fix for this, but CUDA 8 and lower don't.


### PR DESCRIPTION
Under certain conditions, the Linux installer may attempt to call some X terminal and even when none can be found (e.g. on WSL2), it calls `$XTERM -title ...` and `spack install` of `cuda` fails with: `....run: 457: exec: -title: not found`

Prevent this from happening by unsetting the `DISPLAY` variable.

```sh
grep -B15 -a -- -title cuda_12.9.1_575.57.08_linux.run

    if tty -s; then                 # Do we have a terminal?
        :
    else
        if test x"$DISPLAY" != x -a x"$xterm_loop" = x; then  # No, but do we have X?
            if xset q > /dev/null 2>&1; then # Check for valid DISPLAY variable
                GUESS_XTERMS="xterm rxvt dtterm eterm Eterm kvt konsole aterm"
                for a in $GUESS_XTERMS; do
                    if type $a >/dev/null 2>&1; then
                        XTERM=$a
                        break
                    fi
                done
                chmod a+x $0 || echo Please add execution rights on $0
                if test `echo "$0" | cut -c1` = "/"; then # Spawn a terminal!
                    exec $XTERM -title "$label" -e "$0" --xwin "$initargs"
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
