### PR TITLE
Camp:Add camp v2026.07.0 release

### DIFF
--- a/repos/spack_repo/builtin/packages/camp/package.py
+++ b/repos/spack_repo/builtin/packages/camp/package.py
@@ -26,6 +26,12 @@ class Camp(CMakePackage, CudaPackage, ROCmPackage):
 
     version("main", branch="main", submodules=False)
     version(
+        "2026.07.0",
+        tag="v2026.07.0",
+        commit="824a6a3ba48a233791332c398e7f024b2191aa27",
+        submodules=False,
+    )
+    version(
         "2025.12.0",
         tag="v2025.12.0",
         commit="a8caefa9f4c811b1a114b4ed2c9b681d40f12325",

--- a/repos/spack_repo/builtin/packages/raja/package.py
+++ b/repos/spack_repo/builtin/packages/raja/package.py
@@ -290,7 +290,7 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("camp+omptarget", when="+omptarget")
     depends_on("camp+sycl", when="+sycl")
     # TODO(johnbowen42): Remove the following line after the June 2026 RAJA suite release
-    depends_on("camp@main commit=e75ab64c029aa27c80593715cb2a3ccad7453c8c", when="@develop")
+    depends_on("camp@2026.07", when="@develop")
     depends_on("camp@2025.12", when="@2025.12.0:2025.12.2")
     depends_on("camp@2025.09", when="@2025.09")
     depends_on("camp@2025.03", when="@2025.03")

--- a/repos/spack_repo/builtin/packages/umpire/package.py
+++ b/repos/spack_repo/builtin/packages/umpire/package.py
@@ -279,7 +279,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("camp+openmp", when="+openmp")
     depends_on("camp~cuda", when="~cuda")
     depends_on("camp~rocm", when="~rocm")
-    depends_on("camp@2025.12:", when="@2025.12:")
+    depends_on("camp@2025.12", when="@2025.12:")
     depends_on("camp@2025.09", when="@2025.09")
     depends_on("camp@2025.03", when="@2025.03")
     depends_on("camp@2024.07", when="@2024.07")


### PR DESCRIPTION
Adds camp version 2026.07.0 and updates RAJA develop to use current camp for develop branch.

Build has been verified to work.

```
*> spack debug report
* **Spack:** 1.3.0.dev0 (https://github.com/spack/spack/commit/2d1cea34f43d4d681c2ac4e310d97c4255b36cab)
* **Builtin repo:** https://github.com/spack/spack-packages/commit/d9d9597abca76603041a87706662ef2103dc7275
* **Python:** 3.13.2
* **Platform:** linux-rhel8-haswell
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
