### PR TITLE
ExodusII shared build fix

### DIFF
--- a/repos/spack_repo/builtin/packages/exodusii/package.py
+++ b/repos/spack_repo/builtin/packages/exodusii/package.py
@@ -126,7 +126,7 @@ class Exodusii(CMakePackage):
                 from_variant("BUILD_TESTING", "tests"),
                 from_variant("CMAKE_INSTALL_RPATH_USE_LINK_PATH", "shared"),
                 from_variant("BUILD_SHARED_LIBS", "shared"),
-                from_variant("SEACASExodus_ENABLE_SHARED", "shared"),                
+                from_variant("SEACASExodus_ENABLE_SHARED", "shared"),
                 from_variant("SEACASExodus_ENABLE_THREADSAFE", "thread_safe"),
                 from_variant("TPL_ENABLE_Pthread", "thread_safe"),
                 from_variant(project_name_base + "_ENABLE_Fortran", "fortran"),

--- a/repos/spack_repo/builtin/packages/exodusii/package.py
+++ b/repos/spack_repo/builtin/packages/exodusii/package.py
@@ -126,6 +126,7 @@ class Exodusii(CMakePackage):
                 from_variant("BUILD_TESTING", "tests"),
                 from_variant("CMAKE_INSTALL_RPATH_USE_LINK_PATH", "shared"),
                 from_variant("BUILD_SHARED_LIBS", "shared"),
+                from_variant("SEACASExodus_ENABLE_SHARED", "shared"),                
                 from_variant("SEACASExodus_ENABLE_THREADSAFE", "thread_safe"),
                 from_variant("TPL_ENABLE_Pthread", "thread_safe"),
                 from_variant(project_name_base + "_ENABLE_Fortran", "fortran"),


### PR DESCRIPTION
add SEACAS CMake option to disable shared build when the shared variant is set to false