### PR TITLE
SLEPc: Add switch for installing examples

### DIFF
--- a/repos/spack_repo/builtin/packages/slepc/package.py
+++ b/repos/spack_repo/builtin/packages/slepc/package.py
@@ -68,6 +68,10 @@ class Slepc(Package, CudaPackage, ROCmPackage):
     variant("arpack", default=False, description="Enables Arpack wrappers")
     variant("blopex", default=False, description="Enables BLOPEX wrappers")
     variant("hpddm", default=False, description="Enables HPDDM wrappers")
+    # Default installation contains ~1 k tutorial/example files.
+    # Give packagers a switch to trim them away (‘spack install slepc ~examples’)
+    # while preserving current behaviour by default.
+    variant("examples", default=True, description="Install test and tutorial example sources")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
@@ -175,7 +179,9 @@ class Slepc(Package, CudaPackage, ROCmPackage):
         if self.run_tests:
             make("test", parallel=False)
 
-        make("install", parallel=False)
+        # SLEPc provides a lighter target that omits docs/examples.
+        target = "install" if "+examples" in spec else "install-lib"
+        make(target, parallel=False)
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         # set SLEPC_DIR & PETSC_DIR in the module file


### PR DESCRIPTION
SLEPc installation also installs many examples and tutorials by default. We add here the same mechanism proposed in [PETSc recipe](https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/packages/petsc/package.py) to switch them off at will.

The added pieces of code are just a copy-paste of the related one in PETSc recipe.

Mantainers: @joseeroman @balay 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->