### PR TITLE
require patchelf at 'which'-time to improve errors

### DIFF
--- a/repos/spack_repo/builtin/packages/cudnn/package.py
+++ b/repos/spack_repo/builtin/packages/cudnn/package.py
@@ -619,7 +619,7 @@ class Cudnn(Package):
     # Note that libcudnn.so does come with the RPATH set.
     @run_after("install", when="@8")
     def ensure_rpaths(self):
-        patchelf = which("patchelf")
+        patchelf = which("patchelf", required=True)
         for path in Path(self.prefix.lib).rglob("lib*.so.*"):
             if not path.is_symlink() and not path.name.startswith("libcudnn.so"):
                 patchelf("--set-rpath", "$ORIGIN", str(path))

--- a/repos/spack_repo/builtin/packages/intel_oneapi_runtime/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_runtime/package.py
@@ -61,14 +61,13 @@ class IntelOneapiRuntime(Package):
             install(path, os.path.join(prefix.lib, os.path.basename(name)))
 
         if self.spec["intel-oneapi-compilers"].satisfies("+fix_rt_linkage"):
+            patchelf = which("patchelf", required=True)
             for _, name in libraries:
                 if name == "libimf.so":
-                    patchelf = which("patchelf")
                     patchelf.add_default_arg("--add-needed")
                     patchelf.add_default_arg("libm.so.6")
                     patchelf(join_path(prefix.lib, name), fail_on_error=True)
                 if name in ["libirc.so", "libimf.so"]:
-                    patchelf = which("patchelf")
                     patchelf.add_default_arg("--add-needed")
                     patchelf.add_default_arg("libc.so.6")
                     patchelf(join_path(prefix.lib, name), fail_on_error=True)

--- a/repos/spack_repo/builtin/packages/rust_bootstrap/package.py
+++ b/repos/spack_repo/builtin/packages/rust_bootstrap/package.py
@@ -250,9 +250,9 @@ class RustBootstrap(Package):
     def fixup_rpaths(self):
         # set rpaths of libLLVM.so and rust-ldd to zlib's lib directory
         rpaths = self.spec["zlib-api"].libs.directories
+        patchelf = which("patchelf", required=True)
 
         for binary in find(self.stage.source_path, ["libLLVM.so.*", "rust-lld"]):
-            patchelf = Executable("patchelf")
             patchelf("--add-rpath", ":".join(rpaths), binary)
 
     def install(self, spec, prefix):


### PR DESCRIPTION
This improves a couple of packages that require `patchelf` to fix up library rpaths. Without `required=True` the `which` command will return None (causing `TypeError` later) or for older spack versions just fail with a less clear error message.

Inspired by an `external` for patchelf that pointed to `/usr` but actually wasn't there.