### PR TITLE
py-parameterized: add v0.8.1, v0.9.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_parameterized/package.py
+++ b/repos/spack_repo/builtin/packages/py_parameterized/package.py
@@ -11,14 +11,13 @@ class PyParameterized(PythonPackage):
     """Parameterized testing with any Python test framework."""
 
     homepage = "https://github.com/wolever/parameterized"
-    pypi = "parameterized/parameterized-0.7.1.tar.gz"
+    pypi = "parameterized/parameterized-0.8.1.tar.gz"
 
     version("0.9.0", sha256="7fc905272cefa4f364c1a3429cbbe9c0f98b793988efb5bf90aac80f08db09b1")
     version("0.8.1", sha256="41bbff37d6186430f77f900d777e5bb6a24928a1c46fb1de692f8b52b8833b5c")
-    version("0.7.1", sha256="6a94dbea30c6abde99fd4c2f2042c1bf7f980e48908bf92ead62394f93cf57ed")
 
-    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@57:", type="build")
 
-    with when("@0.9.0"):
+    with when("@0.9.0:"):
         depends_on("python@3.7:")
         depends_on("py-setuptools@61.2:", type="build")

--- a/repos/spack_repo/builtin/packages/py_parameterized/package.py
+++ b/repos/spack_repo/builtin/packages/py_parameterized/package.py
@@ -6,13 +6,18 @@ from spack_repo.builtin.build_systems.python import PythonPackage
 
 from spack.package import *
 
-
 class PyParameterized(PythonPackage):
     """Parameterized testing with any Python test framework."""
 
     homepage = "https://github.com/wolever/parameterized"
     pypi = "parameterized/parameterized-0.7.1.tar.gz"
 
+    version("0.9.0", sha256="7fc905272cefa4f364c1a3429cbbe9c0f98b793988efb5bf90aac80f08db09b1")
+    version("0.8.1", sha256="41bbff37d6186430f77f900d777e5bb6a24928a1c46fb1de692f8b52b8833b5c")
     version("0.7.1", sha256="6a94dbea30c6abde99fd4c2f2042c1bf7f980e48908bf92ead62394f93cf57ed")
 
     depends_on("py-setuptools", type="build")
+
+    with when("@0.9.0"):
+        depends_on("python@3.7:")
+        depends_on("py-setuptools@61.2:", type="build")

--- a/repos/spack_repo/builtin/packages/py_parameterized/package.py
+++ b/repos/spack_repo/builtin/packages/py_parameterized/package.py
@@ -6,6 +6,7 @@ from spack_repo.builtin.build_systems.python import PythonPackage
 
 from spack.package import *
 
+
 class PyParameterized(PythonPackage):
     """Parameterized testing with any Python test framework."""
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
The py-parameterized version 0.7.1 seems to depend on an old setuptools version that is not available in the builtin spack packages anymore. But there are newer versions available that also work with newer setuptools. This MR drops 0.7.1 and adds 0.8.1 and 0.9.0 with updated dependencies.