### PR TITLE
WIP: Windows Developer Tool Stack

### DIFF
--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -498,6 +498,33 @@ developer-tools-darwin-build:
     - artifacts: True
       job: developer-tools-darwin-generate
 
+###########################################
+# Build tests for different developer tools
+# Windows
+###########################################
+.developer-tools-windows:
+  variables:
+    SPACK_CI_STACK_NAME: developer-tools-windows
+    # TODO: windows runners are currently m5.2xlarge with a max 8 vCPU and 32GiB MEM
+    # setting request to half of the available allocation to allow room for overhead.
+    KUBERNETES_CPU_REQUEST: 4000m
+    KUBERNETES_MEMORY_REQUEST: 16G
+
+developer-tools-windows-generate:
+  extends: [ ".developer-tools-windows", ".generate-win46"]
+
+developer-tools-windows-build:
+  extends: [ ".developer-tools-windows", ".build" ]
+  trigger:
+    << : *trigger_build
+    include:
+      - artifact: jobs_scratch_dir/developer-tools-windows/cloud-ci-pipeline.yml
+        job: developer-tools-windows-generate
+  needs:
+    - artifacts: True
+      job: developer-tools-windows-generate
+
+
 #########################################
 # RADIUSS
 #########################################

--- a/stacks/developer-tools-x86_64-windows-msvc/spack.yaml
+++ b/stacks/developer-tools-x86_64-windows-msvc/spack.yaml
@@ -1,0 +1,53 @@
+spack:
+  view: false
+
+  include:
+  - ../../.ci/gitlab/
+
+  packages:
+    all:
+      require:
+      - target=x86_64_v3
+      - ~cuda
+      - ~rocm
+      prefer:
+        - "%gcc"
+  concretizer:
+    unify: true
+    reuse: false
+    static_analysis: true
+
+  specs:
+    # runtimes and compilers
+  - python
+  - llvm+link_llvm_dylib~lld~offload~lldb~polly+python build_type=MinSizeRel   # for clangd, clang-format
+  - cmake
+  - go   # to build fzf, gh, hub
+  - rust+dev   # fd, ripgrep, hyperfine, exa, rust-analyzer
+  - cppcheck
+    # cli dev tools
+  - ripgrep
+  - gh
+  - fd
+  - bfs
+  - fzf
+  - tree
+  - jq
+  - py-yq
+  - ccache
+    # ensure we can use a jobserver build and do this fast
+  - ninja   # should be @kitware, can't be because of meson requirement
+  - openssl certs=system     # must be this, system external does not work
+  - flex
+  - graphviz
+  - doxygen
+  - meson
+  # spack developer tools
+  # style
+  - "py-mypy@0.900: ^py-mypy-extensions@:1.0"
+  - py-pytest@9.0.3
+  - py-ruff@0.15.0
+  - py-ty@0.0.20
+
+  cdash:
+    build-group: Windows Dev Tools (Kitware)


### PR DESCRIPTION
New CI Stack.

Adds a Developer tool GL CI stack for Windows, mirroring the CI stacks for MacOs and Linux, expands Gitlab CI testing coverage for Windows packages related to software development (in particular, languages and CLI dev tools, as well as ruff/ty)

The tested spec list is pared down substantially compared to other platforms, primarily because most of the other packages do not currently or will never build with native MSVC and no posix ecosystem. 
The current spec list targets specs that can/will build on Windows, or build currently and that we want to continue to guarantee support for on the platform. 