### PR TITLE
move flag handler method from Silo's Builder class to its Package class

### DIFF
--- a/repos/spack_repo/builtin/packages/silo/package.py
+++ b/repos/spack_repo/builtin/packages/silo/package.py
@@ -225,7 +225,6 @@ class Silo(autotools.AutotoolsPackage, cmake.CMakePackage):
 
 
 class AutotoolsBuilder(autotools.AutotoolsBuilder):
-
     @when("@:4.11.1 %clang@9:")
     def patch(self):
         self.clang_9_patch()

--- a/repos/spack_repo/builtin/packages/silo/package.py
+++ b/repos/spack_repo/builtin/packages/silo/package.py
@@ -174,8 +174,6 @@ class Silo(autotools.AutotoolsPackage, cmake.CMakePackage):
         when="@4.12.0",
     )
 
-
-class AutotoolsBuilder(autotools.AutotoolsBuilder):
     def flag_handler(self, name, flags):
         spec = self.spec
         if name == "ldflags":
@@ -224,6 +222,9 @@ class AutotoolsBuilder(autotools.AutotoolsBuilder):
             if spec.satisfies("%clang") or spec.satisfies("%apple-clang"):
                 flags.append("-Wno-implicit-function-declaration")
         return (flags, None, None)
+
+
+class AutotoolsBuilder(autotools.AutotoolsBuilder):
 
     @when("@:4.11.1 %clang@9:")
     def patch(self):


### PR DESCRIPTION
Move flag handler method from Silo's Builder class to its Package class.  This seemed like it was necessary for spack to properly use this method.