### PR TITLE
add numpy oneapi2025 fix

### DIFF
--- a/repos/spack_repo/builtin/packages/py_numpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_numpy/package.py
@@ -266,6 +266,14 @@ class PyNumpy(PythonPackage):
             if gcc_version <= Version("5.1"):
                 flags.append(self.compiler.c99_flag)
 
+        if self.spec.satisfies("@1.26 ^intel-oneapi-compilers@2025.2") and name in (
+            "cflags",
+            "cxxflags",
+            "fflags",
+        ):
+            flags = [flag for flag in flags if not flag.startswith("-O")]
+            flags.append("-O1")
+
         return (flags, None, None)
 
     def _blas_lapack_pkg_config_mkl(self, spec) -> str:


### PR DESCRIPTION
This PR attempts to fix build issues with py-numpy@1.26 using Intel's OneAPI 2025 compiler (see https://github.com/spack/spack-packages/issues/1477).  The existing workaround patches Meson's build file to lower the compiler optimization level to -O1. However, this doesn't remove optimization flags that are specified in the Spack environment. The proposed fix here manually injects -O1 in flag_handler and removes other optimization flags that were previously set, if they exist.