### PR TITLE
qt: disable vulkan only when possible

### DIFF
--- a/repos/spack_repo/builtin/packages/qt/package.py
+++ b/repos/spack_repo/builtin/packages/qt/package.py
@@ -660,10 +660,13 @@ class Qt(Package):
 
         if "+gui" in spec:
             use_spack_dep("freetype")
+
             if spec.satisfies("platform=linux") or spec.satisfies("platform=freebsd"):
                 config_args.append("-fontconfig")
-            # Avoid sporadic vkconvenience bug by explicitly disabling vulkan
-            config_args.append("-no-vulkan")
+
+            if spec.satisfies("@5.10:5"):
+                # Avoid sporadic vkconvenience bug by explicitly disabling vulkan
+                config_args.append("-no-vulkan")
         else:
             config_args.append("-no-freetype")
             config_args.append("-no-gui")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Switch introduced in this PR https://github.com/spack/spack-packages/pull/168 doesn't exist in `qt@:5.9`

<img width="121" height="153" alt="image" src="https://github.com/user-attachments/assets/b18460e6-494d-4026-9cc6-00f70c91d3a8" />

```
ERROR: Unknown command line option '-no-vulkan'.
  Command exited with status 3:
      ./configure -prefix qt-5.9.9-br4oalvcc5b4szatqksbe27frajrzbv2 -v -opensource -release -confirm-license -optimized-qmake -no-pch -no-opengl -system-freetype -Lfreetype-2.14.3-2xatpmmqafcjz7n3ybxwtt3sykvnv26k/lib -Ifreetype-2.14.3-2xatpmmqafcjz7n3ybxwtt3sykvnv26k/include/freetype2 -fontconfig -no-vulkan -no-openssl -system-sqlite -Lsqlite-3.53.1-pgktnfw6ali6zpeg26cq5oywyeaifqk6/lib -Isqlite-3.53.1-pgktnfw6ali6zpeg26cq5oywyeaifqk6/include -shared -system-pcre -Lpcre2-10.44-7unrwxij6woyu57gna7a6h4xagygrxcp/lib -Ipcre2-10.44-7unrwxij6woyu57gna7a6h4xagygrxcp/include -system-harfbuzz -Lharfbuzz-11.5.1-whgv2szukgsfxmtbcxbd4xts4yv7tjl7/lib -Iharfbuzz-11.5.1-whgv2szukgsfxmtbcxbd4xts4yv7tjl7/include -system-doubleconversion -Ldouble-conversion-3.4.0-uti5yz6ij3bzaf6cijgwpk22askq737a/lib -Idouble-conversion-3.4.0-uti5yz6ij3bzaf6cijgwpk22askq737a/include -system-libpng -Llibpng-1.6.58-h3pxosvmrh5kqdyfrhhfncdyizqu4zvz/lib -Ilibpng-1.6.58-h3pxosvmrh5kqdyfrhhfncdyizqu4zvz/include -system-libjpeg -Llibjpeg-turbo-3.1.3-rciosrtkvsdjqlfibi5fifea453vopqx/lib -Ilibjpeg-turbo-3.1.3-rciosrtkvsdjqlfibi5fifea453vopqx/include -system-zlib -Lzlib-ng-2.3.3-lacpoojkfvftk4uvko5n7fvdf5bkl3yv/lib -Izlib-ng-2.3.3-lacpoojkfvftk4uvko5n7fvdf5bkl3yv/include -nomake examples -no-dbus -platform linux-g++ -no-eglfs -no-directfb -no-gtk -xcb -skip webengine -skip wayland -skip multimedia -skip qt3d
````