### PR TITLE
nvtx: fix for GCC 15

### DIFF
--- a/repos/spack_repo/builtin/packages/nvtx/package.py
+++ b/repos/spack_repo/builtin/packages/nvtx/package.py
@@ -46,6 +46,11 @@ class Nvtx(Package, PythonExtension):
         setup = FileFilter("python/setup.py")
         setup.filter("include_dirs=include_dirs", f"include_dirs=['{include_dir}']", string=True)
 
+    def flag_handler(self, name, flags):
+        if name == "cflags" and self.spec.satisfies("@3.2: %gcc@15:"):
+            flags.append("-std=gnu17")
+        return (flags, None, None)
+
     def install(self, spec, prefix):
         install_tree("c/include", prefix.include)
         install("c/CMakeLists.txt", prefix)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

In building `nvtx` on my SLES 15 system, the build choked as NVTX 3.2+ now uses `char8_t` and at least on my system, GCC 15 needed `-std=gnu17` to build.

Per GPT 5.6 Terra who I asked to analyze:

> Disabling the C23 mode only turns off NVTX’s optional `char8_t` payload entry—the header has an explicit fallback for that case.