### PR TITLE
umpire: raise fmt upper bound to 12.1 for @2024.02.0:2025

### DIFF
--- a/repos/spack_repo/builtin/packages/umpire/package.py
+++ b/repos/spack_repo/builtin/packages/umpire/package.py
@@ -295,9 +295,11 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("mpi", when="+mpi")
 
     depends_on("fmt@12.1.0", when="@2026:")
-    depends_on("fmt@9.1:11.0", when="@2024.02.0:2025")
+    # Capped at 12.1 to avoid a regression (no operator "~") in 12.2.
+    # https://github.com/fmtlib/fmt/issues/4811
+    depends_on("fmt@9.1:12.1", when="@2024.02.0:2025")
     # We need c++ 17 only with intel
-    depends_on("fmt@9.1:11.0 cxxstd=17", when="@2024.02.0: %intel@19.1")
+    depends_on("fmt@9.1:12.1 cxxstd=17", when="@2024.02.0: %intel@19.1")
 
     with when("@5.0.0:"):
         with when("+cuda"):


### PR DESCRIPTION
PR #5309 added the following dependency between hipblaslt and fmt:

```
depends_on("fmt@11.1:", when="@7.0:")
```

This conflicted with umpire@2024:'s constraint on fmt@9.1:11.0. As a consequence of this, the concretizer fell back to umpire@2023.06.0 for the E4S stack because this version doesn't declare a dependency on fmt at all.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
