### PR TITLE
Add support for c++ 20 in rajaperf package.

### DIFF
--- a/repos/spack_repo/builtin/packages/raja/package.py
+++ b/repos/spack_repo/builtin/packages/raja/package.py
@@ -263,7 +263,7 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
     )
     conflicts("cxxstd=11", when="@0.14.0:")
     conflicts("cxxstd=14", when="@2025.09.0:")
-    conflicts("cxxstd=17", when="@2026.03.0:")
+    conflicts("cxxstd=17", when="@2026.07.0:")
     conflicts("+sycl cxxstd=14", when="@2024.07.0:")
 
     depends_on("cxx", type="build")

--- a/repos/spack_repo/builtin/packages/raja_perf/package.py
+++ b/repos/spack_repo/builtin/packages/raja_perf/package.py
@@ -222,12 +222,6 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
         if spec.satisfies("+rocm ^blt@:0.6"):
             entries.insert(0, cmake_cache_path("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
 
-        # adrienbernede-23-01
-        # Maybe we want to share this in the above llnl_link_helpers function.
-        compilers_using_cxx14 = ["intel-17", "intel-18", "xl"]
-        if any(compiler in self.compiler.cxx for compiler in compilers_using_cxx14):
-            entries.append(cmake_cache_string("BLT_CXX_STD", "c++14"))
-
         llnl_link_helpers(entries, spec, compiler)
 
         return entries

--- a/repos/spack_repo/builtin/packages/raja_perf/package.py
+++ b/repos/spack_repo/builtin/packages/raja_perf/package.py
@@ -120,6 +120,16 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
         default=False,
         description="For developers, lowers optimization level to pass tests with some compilers",
     )
+    variant(
+        "cxxstd",
+        default="20",
+        values=("11", "14", "17", "20"),
+        description="C++ standard to build with",
+    )
+    conflicts("cxxstd=11", when="@0.14.0:")
+    conflicts("cxxstd=14", when="@2025.09.0:")
+    conflicts("cxxstd=17", when="@2026.07.0:")
+    conflicts("+sycl cxxstd=14", when="@2024.07.0:")
 
     depends_on("cxx", type="build")  # generated
 
@@ -195,6 +205,10 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
             self.spec.compiler.version,
             self.spec.dag_hash(8),
         )
+
+    @property
+    def cxx_std(self):
+        return self.spec.variants.get("cxxstd").value
 
     def initconfig_compiler_entries(self):
         spec = self.spec
@@ -391,15 +405,8 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
         entries.append(cmake_cache_option("RAJA_ENABLE_OPENMP_TASK", "+omptask" in spec))
         entries.append(cmake_cache_option("RAJA_ENABLE_SYCL", spec.satisfies("+sycl")))
 
-        # C++17
-        if spec.satisfies("@2025.09.0:") or (
-            spec.satisfies("@2024.07.0:") and spec.satisfies("+sycl")
-        ):
-            entries.append(cmake_cache_string("BLT_CXX_STD", "c++17"))
-        # C++14
-        # Using RAJA version as threshold on purpose (no 0.14 version of RAJAPerf were released).
-        elif spec.satisfies("@0.14.0:2025.09.0"):
-            entries.append(cmake_cache_string("BLT_CXX_STD", "c++14"))
+        # C++ standard
+        entries.append(cmake_cache_string("BLT_CXX_STD", f"c++{self.cxx_std}"))
 
         entries.append(cmake_cache_option("ENABLE_BENCHMARKS", "tests=benchmarks" in spec))
         entries.append(


### PR DESCRIPTION
This PR adds support for c++20 in RAJAPerf mimicking wath is done in RAJA.

It also updates the virtual version 2026.03 to 2026.07 in both RAJA and RAJAPerf to match coming release. This change should have strictly no impact, what is important being that develop is greater than 2026.07.