### PR TITLE
HEP: replace all:require:[%gcc] with c,cxx,fortran:require:[gcc]

### DIFF
--- a/stacks/hep/spack.yaml
+++ b/stacks/hep/spack.yaml
@@ -15,13 +15,21 @@ spack:
     all:
       target: ["x86_64_v3"]
       require:
-      - "%gcc"
       - target=x86_64_v3
       providers:
         blas: [openblas]
         mpi: [mpich]
         tbb: [intel-tbb]
       variants: +mpi
+    c:
+      require:
+      - gcc
+    cpp:
+      require:
+      - gcc
+    fortran:
+      require:
+      - gcc
     acts:
       require:
       - +analysis +dd4hep +edm4hep +examples +fatras +geant4 +hepmc3 +onnx +podio +pythia8 +python +svg +tgeo cxxstd=20

--- a/stacks/hep/spack.yaml
+++ b/stacks/hep/spack.yaml
@@ -24,7 +24,7 @@ spack:
     c:
       require:
       - gcc
-    cpp:
+    cxx:
       require:
       - gcc
     fortran:


### PR DESCRIPTION
This PR updates the HEP stack to avoid the many warnings in CI (e.g. https://gitlab.spack.io/spack/spack-packages/-/jobs/23498498#L102):
```
==> Warning: /builds/spack/spack-packages/stacks/hep/spack.yaml:27: 'packages: all: require: ["%gcc"]' applies a dependency constraint to all packages. This often leads to concretization errors. This was likely intended as a requirement for a provider of a (language) virtual. Consider instead:
# For each language virtual (c, cxx, fortran, ...):
packages:
  c:
    require:
    - gcc
```
