### PR TITLE
gcc: specify build time tools explicitly

### DIFF
--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -903,6 +903,11 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         if spec.satisfies("languages=jit"):
             options.append("--enable-host-shared")
 
+        # https://github.com/spack/spack-packages/issues/5677
+        if spec.satisfies("+binutils"):
+            binutils = spec["binutils"].prefix.bin
+            options.append(f"--with-build-time-tools={binutils}")
+
         # enable_bootstrap
         if spec.satisfies("+bootstrap"):
             options.extend(["--enable-bootstrap"])


### PR DESCRIPTION
This fixes problems when trying to build GCC with older system binutils, e.g.: https://github.com/spack/spack-packages/issues/5677

Fixes #5677