### PR TITLE
root: ensure llvm+polly+clang when ~builtin_llvm

### DIFF
--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -445,7 +445,7 @@ class Root(CMakePackage):
     # (interpreter/llvm-project/clang) and builds it against the external LLVM, so
     # vanilla LLVM is sufficient here.  ROOT's patches to llvm-project only touch
     # clang/, not the LLVM core.
-    depends_on("llvm@20.1.0:20.1", when="@6.36: ~builtin_llvm")
+    depends_on("llvm@20.1.0:20.1+polly+clang", when="@6.36: ~builtin_llvm")
 
     depends_on("googletest", when="@6.28.00:", type="test")
 


### PR DESCRIPTION
When `root` is built with `~builtin_llvm` we should make sure to enable `+clang` and `+polly` (both of which are default in spack, but not necessarily available when `llvm` is an external). I don't have a good link for the polly dependency, but building `root ~builtin_llvm` fails without it...