### PR TITLE
Python: fix bad nuget link and improve python detection

### DIFF
--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -251,6 +251,12 @@ class Python(Package):
         depends_on("libxcrypt", when="+crypt")
 
     patch(
+        "https://github.com/python/cpython/commit/106eb532ea3b243423e62a702719e9d3c0e40c16.patch?full_index=1",
+        sha256="d01422e6c6cb1df21161f5fa261cfd12853756abbddf816543934f3fe96a5827",
+        when="@3.14:3.14.4 platform=windows"
+        )
+
+    patch(
         "https://bugs.python.org/file44413/alignment.patch",
         when="@3.6",
         sha256="d39bacde16128f380933992ea7f237ac8f70f9cdffb40c051aca3be46dc29bdf",
@@ -441,7 +447,13 @@ class Python(Package):
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         spec = self.spec
-
+        if sys.platform == "win32":
+            # on windows, python tries to find another python and if it fails to do
+            # so, downloads one via nuget.
+            # Just use Spack's python 
+            # temporary fix until the branch moving python to only use Spack based
+            # dependencies can land.
+            env.set("PYTHON_FOR_BUILD", sys.executable)
         # TODO: Python has incomplete support for Python modules with mixed
         # C/C++ source, and patches are required to enable building for these
         # modules. All Python versions without a viable patch are installed

--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -253,8 +253,8 @@ class Python(Package):
     patch(
         "https://github.com/python/cpython/commit/106eb532ea3b243423e62a702719e9d3c0e40c16.patch?full_index=1",
         sha256="d01422e6c6cb1df21161f5fa261cfd12853756abbddf816543934f3fe96a5827",
-        when="@3.14:3.14.4 platform=windows"
-        )
+        when="@3.14:3.14.4 platform=windows",
+    )
 
     patch(
         "https://bugs.python.org/file44413/alignment.patch",
@@ -450,7 +450,7 @@ class Python(Package):
         if sys.platform == "win32":
             # on windows, python tries to find another python and if it fails to do
             # so, downloads one via nuget.
-            # Just use Spack's python 
+            # Just use Spack's python
             # temporary fix until the branch moving python to only use Spack based
             # dependencies can land.
             env.set("PYTHON_FOR_BUILD", sys.executable)


### PR DESCRIPTION
Python (like many windows builds) decided to require another version of itself to build itself. If it cannot find an existing system python (it uses the python launcher to do this, so if you didn't explicitly click on that part of the installer, easy to not have), it downloads one with nuget.

Python 3.14 had a broken nuget link (seems like msft changed it on them), patch in the correct link from the upstream python PR.

Additionally, set the env variable to Spack's python to prevent this download in the first place.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
