### PR TITLE
julia 1.12: Fix LLVM's shared library symbol version

### DIFF
--- a/repos/spack_repo/builtin/packages/julia/package.py
+++ b/repos/spack_repo/builtin/packages/julia/package.py
@@ -107,7 +107,7 @@ class Julia(MakefilePackage):
         depends_on("libblastrampoline@5.13.1:5")
         depends_on("libgit2@1.9")
         depends_on("libssh2@1.11:1")
-        depends_on("llvm@18.1.8 +lld shlib_symbol_version=JL_LLVM_18.0")
+        depends_on("llvm@18.1.8 +lld shlib_symbol_version=JL_LLVM_18.1")
         depends_on("openssl@3.5.1:3.5")
         depends_on("openlibm@0.8.7:0.8", when="+openlibm")
         depends_on("nghttp2@1.64")


### PR DESCRIPTION
Julia 1.12 depends on LLVM 18.1.8 and the Julia ecosystem expects the LLVM's shared library symbol version to be "major.minor" (see https://github.com/JuliaLang/julia/blob/v1.12.6/deps/llvm-ver.make#L20).

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
