### PR TITLE
netcdf-c: Fix linking with hdf~shared+external-xdr^libtirpc when build_sytem=cmake

### DIFF
--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -473,21 +473,13 @@ class CMakeBuilder(AnyBuilder, cmake.CMakeBuilder):
                 self.define("PLUGIN_INSTALL_DIR", pathlib.Path(self.prefix.plugins).as_posix())
             )
 
-        linker_flags = []
-        if "+hdf4" in self.spec:
-            hdf = self.spec["hdf"]
-            if "~shared" in hdf:
-                if "+external-xdr ^libtirpc" in hdf:
-                    # This is somewhat ugly
-                    libdir = hdf["rpc"].prefix.lib
-                    lib = "tirpc"
-                    linker_flags.append(f"-L{libdir}")
-                    linker_flags.append(f"-l{lib}")
-
-        if linker_flags:
-            lflagstr = " ".join(linker_flags)
-            base_cmake_args.append(self.define("CMAKE_EXE_LINKER_FLAGS", lflagstr))
-            base_cmake_args.append(self.define("CMAKE_MODULE_LINKER_FLAGS", lflagstr))
+        # With static hdf+external-xdr we need to specify spack's libtirpc explicitly
+        # to avoid undefined references to xdr functions. Fixes spack-packages#5738:
+        if self.spec.satisfies("+hdf4"):
+            if self.spec["hdf"].satisfies("~shared +external-xdr ^libtirpc"):
+                tirpc = f"-L{self.spec['libtirpc'].prefix.lib} -ltirpc"
+                base_cmake_args.append(self.define("CMAKE_EXE_LINKER_FLAGS", tirpc))
+                base_cmake_args.append(self.define("CMAKE_MODULE_LINKER_FLAGS", tirpc))
 
         return base_cmake_args
 

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -480,18 +480,14 @@ class CMakeBuilder(AnyBuilder, cmake.CMakeBuilder):
                 if "+external-xdr ^libtirpc" in hdf:
                     # This is somewhat ugly
                     libdir = hdf["rpc"].prefix.lib
-                    lib="tirpc"
+                    lib = "tirpc"
                     linker_flags.append(f"-L{libdir}")
                     linker_flags.append(f"-l{lib}")
 
         if linker_flags:
             lflagstr = " ".join(linker_flags)
-            base_cmake_args.append( 
-                    self.define("CMAKE_EXE_LINKER_FLAGS", lflagstr)
-                )
-            base_cmake_args.append( 
-                    self.define("CMAKE_MODULE_LINKER_FLAGS", lflagstr)
-                )
+            base_cmake_args.append(self.define("CMAKE_EXE_LINKER_FLAGS", lflagstr))
+            base_cmake_args.append(self.define("CMAKE_MODULE_LINKER_FLAGS", lflagstr))
 
         return base_cmake_args
 

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -472,6 +472,27 @@ class CMakeBuilder(AnyBuilder, cmake.CMakeBuilder):
             base_cmake_args.append(
                 self.define("PLUGIN_INSTALL_DIR", pathlib.Path(self.prefix.plugins).as_posix())
             )
+
+        linker_flags = []
+        if "+hdf4" in self.spec:
+            hdf = self.spec["hdf"]
+            if "~shared" in hdf:
+                if "+external-xdr ^libtirpc" in hdf:
+                    # This is somewhat ugly
+                    libdir = hdf["rpc"].prefix.lib
+                    lib="tirpc"
+                    linker_flags.append(f"-L{libdir}")
+                    linker_flags.append(f"-l{lib}")
+
+        if linker_flags:
+            lflagstr = " ".join(linker_flags)
+            base_cmake_args.append( 
+                    self.define("CMAKE_EXE_LINKER_FLAGS", lflagstr)
+                )
+            base_cmake_args.append( 
+                    self.define("CMAKE_MODULE_LINKER_FLAGS", lflagstr)
+                )
+
         return base_cmake_args
 
     @run_after("install")


### PR DESCRIPTION
This seems to fix issue #5738

This is a somewhat ugly hack
I have tried to mimic the "hack" in AutotoolsBuilder by adding the appropriate linker flags to link to libtirpc.so.  Some of this is hardcoded, but I am not sure how to generalize.  In particular, libtirpc appears to be the only current provider of the "rpc" virtual, and something like rpclib does not include XDR routines.

@spackbot fix style
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
