### PR TITLE
py-uv: add v0.11.32

### DIFF
--- a/repos/spack_repo/builtin/packages/py_uv/package.py
+++ b/repos/spack_repo/builtin/packages/py_uv/package.py
@@ -24,6 +24,7 @@ class PyUv(PythonPackage, CargoPackage):
 
     executables = ["^uv$"]
 
+    version("0.11.32", sha256="5359a7b0de78ba99b2519d33c173e004c39111c4baebe1b7c3d111a2de2011e1")
     version("0.11.31", sha256="763609d59721af5b8522e16deac6cffe8055f82bb837740c708917506f305185")
     version("0.11.30", sha256="06f4b824c6123df1cd00a68367f970870e7252b0b11a4d03a06b2b4b433afcda")
     version("0.11.29", sha256="a4ca34dc3b247740e511ca7c718181d5300e7899bbef755db45bb6c993610a64")


### PR DESCRIPTION
- add [uv v0.11.32](https://github.com/astral-sh/uv/releases/tag/0.11.32)

```
❯ spack find -v py-uv@0.11.32
-- darwin-tahoe-m1 / %c=apple-clang@21.0.0 ----------------------
py-uv@0.11.32 build_system=cargo  py-uv@0.11.32 build_system=python_pip
==> 2 installed packages
```