### PR TITLE
spdlog, hipblaslt: Fix spdlog 1.17.0 version pairing with fmt

### DIFF
--- a/repos/spack_repo/builtin/packages/hipblaslt/package.py
+++ b/repos/spack_repo/builtin/packages/hipblaslt/package.py
@@ -178,9 +178,10 @@ class Hipblaslt(CMakePackage):
     depends_on("py-msgpack", when="@7.1:")
     depends_on("py-nanobind", when="@7.1:")
     # rocroller in ROCm 7.1+ fails to build with fmt 11 (consteval FMT_STRING errors).
-    # Keep spdlog/fmt on a known-compatible pair.
-    depends_on("spdlog@:1.14", when="@7.1:")
-    depends_on("fmt@11.1:", when="@7.0:")
+    conflicts("fmt@:1.11", when="@7.1:")
+    # spdlog pairs itself with fmt, so we only depend on "spdlog" for ROCm 7.1+
+    # and let it pair with the fmt version constraint as it sees fit.
+    depends_on("spdlog", when="@7.1:")
 
     resource(
         name="libdivide",
@@ -246,6 +247,14 @@ class Hipblaslt(CMakePackage):
 
         if self.spec.satisfies("@7.1") and self.run_tests:
             env.append_flags("LDFLAGS", "-lstdc++fs")
+
+        # hipblaslt up to 7.2.x expect stdint typedefs to be available in the global
+        # namespace without including stdint.h, which is not the case in all configurations.
+        # This can lead to build failures when compiling hipblaslt with certain libraries,
+        # so we add it to the compile flags to ensure it is available:
+
+        if self.spec.satisfies("@:7.2"):
+            env.append_flags("CXXFLAGS", "-include stdint.h")
 
     def patch(self):
         purelib = self.spec["python"].package.purelib

--- a/repos/spack_repo/builtin/packages/spdlog/package.py
+++ b/repos/spack_repo/builtin/packages/spdlog/package.py
@@ -96,6 +96,9 @@ class Spdlog(CMakePackage):
     # https://github.com/gabime/spdlog/releases/tag/v1.16.0
     depends_on("fmt@12.0.0:12", when="@1.16.0:")
 
+    # https://github.com/gabime/spdlog/releases#release-v1.17.0
+    depends_on("fmt@12.1.0:12", when="@1.17.0:")
+
     # spdlog@1.11.0 with fmt@10  https://github.com/gabime/spdlog/pull/2694
     patch(
         "https://github.com/gabime/spdlog/commit/0ca574ae168820da0268b3ec7607ca7b33024d05.patch?full_index=1",


### PR DESCRIPTION
A helpful comment by @Chrismarsh in the spdlog package.py file explains the version pairing of spdlog and fmt. The comment explains that while spdlog can work with different versions of fmt, it is best to assume that the internal fmt version is the minimum version for compatibility.

This change adds the missing version pairing for spdlog 1.17.0 with fmt. The spdlog package.py now depends on fmt 12.1 or later for spdlog 1.17.0 which is the recommended version pairing for spdlog 1.17.0 according to the comment in the spdlog package.py based on the spdlog release notes at https://github.com/gabime/spdlog/releases#release-v1.17.0.

Related to it, the last pull request for `hipblaslt` (#5309) assumed that it has to ensure proper version pairing while as explained above it should leave this to the spdlog recipe. The pairing added in #5309 conflicts with all existing spdlog/fmt pairings, so it was to possible to concretize hipblaslt@7.1: anymore.
    
Fix this by using a conflict for the fmt versions it does not support and leave the spdlog/fmt version pairing to the spdlog recipe.

- By resolving the version pairing issue, `hipblaslt@7.1:` should be able to be solvable again, which is also of interest request for the ROCm pull request to add the therock 7.13 release with #4964

> Fixes: 1769b893c6 #5467: "spdlog: add v1.17.0 && fmt: add v12.2.0"
> Fixes: 3e1fd7348c #5309: "hipblaslt: Support air-gapped build"

Review: @afzpatel, @srekolam, @renjithravindrankannath 
Cc: @m-fila, @yizeyi18, @williampiat3 