### PR TITLE
CP2K/DBCSR: Revise requirement for libxsmm, dftd4, and tblite

### DIFF
--- a/repos/spack_repo/builtin/packages/cp2k/package.py
+++ b/repos/spack_repo/builtin/packages/cp2k/package.py
@@ -1341,9 +1341,7 @@ class CMakeBuilder(cmake.CMakeBuilder):
         if "spla" in spec and (spec.satisfies("+cuda") or spec.satisfies("+rocm")):
             args += ["-DCP2K_USE_SPLA_GEMM_OFFLOADING=ON"]
 
-        use_libxsmm = spec.satisfies("smm=libxsmm") or spec.satisfies(
-            "@2026.2: +libxsmm"
-        )
+        use_libxsmm = spec.satisfies("smm=libxsmm") or spec.satisfies("@2026.2: +libxsmm")
         args += [
             self.define("CP2K_USE_LIBXSMM", use_libxsmm),
             self.define("CP2K_USE_LIBXS", spec.satisfies("smm=libxs")),

--- a/repos/spack_repo/builtin/packages/cp2k/package.py
+++ b/repos/spack_repo/builtin/packages/cp2k/package.py
@@ -521,6 +521,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
 
     with when("+tblite"):
         depends_on("tblite build_system=cmake")
+        depends_on("tblite@0.6", when="@2026.2")
         depends_on("tblite@0.7:", when="@2027.1:")
 
     with when("build_system=cmake"):

--- a/repos/spack_repo/builtin/packages/cp2k/package.py
+++ b/repos/spack_repo/builtin/packages/cp2k/package.py
@@ -118,10 +118,16 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     )
     variant(
         "smm",
-        default="blas",
-        values=("libsmm", "blas", "libxs"),
+        default="libxs",
+        values=("blas", "libxs"),
         description="Library for small matrix multiplications",
         when="@2026.2:",
+    )
+    variant(
+        "libxsmm",
+        default=True,
+        description="Use LIBXSMM as a JIT kernel provider for LIBXS",
+        when="@2026.2: smm=libxs",
     )
     variant("opencl", default=False, description="Enable OpenCL backend")
     variant("plumed", default=False, description="Enable PLUMED support")
@@ -328,6 +334,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     depends_on("lapack")
 
     depends_on("libxs@1:+fortran", when="smm=libxs")
+    depends_on("libxsmm@2:", when="@2026.2: +libxsmm")
 
     depends_on("fftw-api@3")
     depends_on("greenx", when="+greenx")
@@ -340,7 +347,6 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         depends_on("gauxc+fortran+mpi", when="+mpi")
         depends_on("gauxc+pic", when="+pic")
 
-    depends_on("tblite build_system=cmake", when="+tblite")
     # Force openmp propagation on some providers of blas / fftw-api
     with when("+openmp"):
         depends_on("fftw+openmp", when="^[virtuals=fftw-api] fftw")
@@ -509,7 +515,13 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("spglib", when="+spglib")
 
-    depends_on("dftd4@3.6.0: build_system=cmake", when="+dftd4")
+    with when("+dftd4"):
+        depends_on("dftd4@3.6.0: build_system=cmake")
+        depends_on("dftd4@:3", when="@:2026.1")
+
+    with when("+tblite"):
+        depends_on("tblite build_system=cmake")
+        depends_on("tblite@0.7:", when="@2027.1:")
 
     with when("build_system=cmake"):
         depends_on("cmake@3.22:", type="build")
@@ -527,6 +539,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         depends_on("dbcsr smm=blas", when="smm=blas")
         depends_on("dbcsr@2.10: smm=libxs", when="@2026.2: smm=libxs")
         depends_on("dbcsr+libxsmm", when="@2026.2: +libxsmm")
+        depends_on("dbcsr~libxsmm", when="@2026.2: ~libxsmm")
 
     with when("@2022: +rocm"):
         depends_on("hipblas")
@@ -1328,15 +1341,13 @@ class CMakeBuilder(cmake.CMakeBuilder):
         if "spla" in spec and (spec.satisfies("+cuda") or spec.satisfies("+rocm")):
             args += ["-DCP2K_USE_SPLA_GEMM_OFFLOADING=ON"]
 
-        if spec.satisfies("smm=libxsmm"):
-            args += ["-DCP2K_USE_LIBXSMM=ON"]
-        else:
-            args += ["-DCP2K_USE_LIBXSMM=OFF"]
-
-        if spec.satisfies("smm=libxs"):
-            args += ["-DCP2K_USE_LIBXS=ON"]
-        else:
-            args += ["-DCP2K_USE_LIBXS=OFF"]
+        use_libxsmm = spec.satisfies("smm=libxsmm") or spec.satisfies(
+            "@2026.2: +libxsmm"
+        )
+        args += [
+            self.define("CP2K_USE_LIBXSMM", use_libxsmm),
+            self.define("CP2K_USE_LIBXS", spec.satisfies("smm=libxs")),
+        ]
 
         lapack = spec["lapack"]
         blas = spec["blas"]

--- a/repos/spack_repo/builtin/packages/cp2k/package.py
+++ b/repos/spack_repo/builtin/packages/cp2k/package.py
@@ -334,7 +334,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     depends_on("lapack")
 
     depends_on("libxs@1:+fortran", when="smm=libxs")
-    depends_on("libxsmm@2:", when="@2026.2: +libxsmm")
+    depends_on("libxsmm@2:", when="+libxsmm")
 
     depends_on("fftw-api@3")
     depends_on("greenx", when="+greenx")
@@ -539,7 +539,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         depends_on("dbcsr@:2.9.1 smm=libxsmm", when="smm=libxsmm")
         depends_on("dbcsr smm=blas", when="smm=blas")
         depends_on("dbcsr@2.10: smm=libxs", when="@2026.2: smm=libxs")
-        depends_on("dbcsr~libxsmm", when="@2026.2: ~libxsmm")
+        depends_on("dbcsr~libxsmm", when="~libxsmm")
 
     with when("@2022: +rocm"):
         depends_on("hipblas")
@@ -1341,7 +1341,7 @@ class CMakeBuilder(cmake.CMakeBuilder):
         if "spla" in spec and (spec.satisfies("+cuda") or spec.satisfies("+rocm")):
             args += ["-DCP2K_USE_SPLA_GEMM_OFFLOADING=ON"]
 
-        use_libxsmm = spec.satisfies("smm=libxsmm") or spec.satisfies("@2026.2: +libxsmm")
+        use_libxsmm = spec.satisfies("smm=libxsmm") or spec.satisfies("+libxsmm")
         args += [
             self.define("CP2K_USE_LIBXSMM", use_libxsmm),
             self.define("CP2K_USE_LIBXS", spec.satisfies("smm=libxs")),

--- a/repos/spack_repo/builtin/packages/cp2k/package.py
+++ b/repos/spack_repo/builtin/packages/cp2k/package.py
@@ -526,6 +526,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         depends_on("dbcsr@:2.9.1 smm=libxsmm", when="smm=libxsmm")
         depends_on("dbcsr smm=blas", when="smm=blas")
         depends_on("dbcsr@2.10: smm=libxs", when="@2026.2: smm=libxs")
+        depends_on("dbcsr+libxsmm", when="@2026.2: +libxsmm")
 
     with when("@2022: +rocm"):
         depends_on("hipblas")

--- a/repos/spack_repo/builtin/packages/cp2k/package.py
+++ b/repos/spack_repo/builtin/packages/cp2k/package.py
@@ -111,14 +111,14 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     variant("openmp", default=True, description="Enable OpenMP support")
     variant(
         "smm",
-        default="libxsmm",
+        default="blas",
         values=("libxsmm", "libsmm", "blas"),
         description="Library for small matrix multiplications",
         when="@:2026.1",
     )
     variant(
         "smm",
-        default="libxs",
+        default="blas",
         values=("blas", "libxs"),
         description="Library for small matrix multiplications",
         when="@2026.2:",
@@ -538,7 +538,6 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         depends_on("dbcsr@:2.9.1 smm=libxsmm", when="smm=libxsmm")
         depends_on("dbcsr smm=blas", when="smm=blas")
         depends_on("dbcsr@2.10: smm=libxs", when="@2026.2: smm=libxs")
-        depends_on("dbcsr+libxsmm", when="@2026.2: +libxsmm")
         depends_on("dbcsr~libxsmm", when="@2026.2: ~libxsmm")
 
     with when("@2022: +rocm"):

--- a/repos/spack_repo/builtin/packages/dbcsr/package.py
+++ b/repos/spack_repo/builtin/packages/dbcsr/package.py
@@ -85,7 +85,7 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
 
     variant(
         "smm",
-        default="libxsmm",
+        default="blas",
         values=("libxsmm", "blas"),
         description="Library for small matrix multiplications",
         when="@:2.9.1",
@@ -99,7 +99,7 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
     )
     variant(
         "libxsmm",
-        default=False,
+        default=True,
         description="Enable LIBXSMM JIT kernels for LIBXS",
         when="@2.10: smm=libxs",
     )
@@ -256,7 +256,7 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
         if spec.satisfies("@2.10:"):
             args += [
                 self.define("USE_LIBXS", spec.satisfies("smm=libxs")),
-                self.define("USE_LIBXSMM", spec.satisfies("+libxsmm")),
+                self.define_from_variant("USE_LIBXSMM", "libxsmm"),
             ]
 
         if "@:2.9.1" in spec:

--- a/repos/spack_repo/builtin/packages/dbcsr/package.py
+++ b/repos/spack_repo/builtin/packages/dbcsr/package.py
@@ -97,6 +97,12 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
         description="Library for small matrix multiplications",
         when="@2.10:",
     )
+    variant(
+        "libxsmm",
+        default=False,
+        description="Enable LIBXSMM JIT kernels for LIBXS",
+        when="@2.10: smm=libxs",
+    )
 
     variant(
         "cuda_arch_35_k20x",
@@ -141,6 +147,10 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("hipblas", when="+rocm")
     depends_on("libxs@1:+fortran", when="@2.10: smm=libxs")
+    depends_on(
+        "libxsmm@2: build_system=cmake",
+        when="@2.10: +libxsmm",
+    )
 
     # Several packages provide "opencl" (incl. ICD/loader), e.g., "cuda"
     with when("+opencl"):
@@ -243,9 +253,10 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
             self.define_from_variant("BUILD_TESTING", "tests"),
         ]
 
-        if "smm=libxs" in spec:
+        if spec.satisfies("@2.10:"):
             args += [
-                "-DUSE_LIBXS=ON",
+                self.define("USE_LIBXS", spec.satisfies("smm=libxs")),
+                self.define("USE_LIBXSMM", spec.satisfies("+libxsmm")),
             ]
 
         if "@:2.9.1" in spec:

--- a/repos/spack_repo/builtin/packages/dbcsr/package.py
+++ b/repos/spack_repo/builtin/packages/dbcsr/package.py
@@ -149,7 +149,7 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("libxs@1:+fortran", when="@2.10: smm=libxs")
     depends_on(
         "libxsmm@2: build_system=cmake",
-        when="@2.10: +libxsmm",
+        when="+libxsmm",
     )
 
     # Several packages provide "opencl" (incl. ICD/loader), e.g., "cuda"


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

- Libxs can leverage libxsmm as JIT kernel provider, in which case libxsmm will be pulled in as a dependency of CP2K/DBCSR. Therefore, adds a variant `libxsmm` that's valid only when `@2026.2: smm=libxs`. Fixes https://github.com/cp2k/cp2k/issues/5619
- In the future versions tblite >=0.7.0 will be required (https://github.com/cp2k/cp2k/pull/5591).
- dftd4 v4.x API is introduced from v2026.2, and previous versions don't work with it; they will require v3.x.
