### PR TITLE
mivisionx: Add depends on "c" and fix build of `~hip`

### DIFF
--- a/repos/spack_repo/builtin/packages/mivisionx/package.py
+++ b/repos/spack_repo/builtin/packages/mivisionx/package.py
@@ -76,19 +76,21 @@ class Mivisionx(ROCmLibrary, CMakePackage):
     patch("0002-add-half-include-path-for-tests-6.2.0.patch", when="@6.2.0: +add_tests")
 
     def patch(self):
-        filter_file(
-            r"${ROCM_PATH}/include/miopen/config.h",
-            "{0}/include/miopen/config.h".format(self.spec["miopen-hip"].prefix),
-            "amd_openvx_extensions/CMakeLists.txt",
-            string=True,
-        )
-        filter_file(
-            r"${ROCM_PATH}/llvm/bin/clang++",
-            "{0}/bin/clang++".format(self.spec["llvm-amdgpu"].prefix),
-            "amd_openvx/openvx/hipvx/CMakeLists.txt",
-            "amd_openvx_extensions/amd_nn/nn_hip/CMakeLists.txt",
-            string=True,
-        )
+        if self.spec.satisfies("+hip"):
+            # miopen-hip and llvm-amdgpu are spec dependencies for HIP builds only:
+            filter_file(
+                r"${ROCM_PATH}/include/miopen/config.h",
+                f"{self.spec['miopen-hip'].prefix}/include/miopen/config.h",
+                "amd_openvx_extensions/CMakeLists.txt",
+                string=True,
+            )
+            filter_file(
+                r"${ROCM_PATH}/llvm/bin/clang++",
+                f"{self.spec['llvm-amdgpu'].prefix}/bin/clang++",
+                "amd_openvx/openvx/hipvx/CMakeLists.txt",
+                "amd_openvx_extensions/amd_nn/nn_hip/CMakeLists.txt",
+                string=True,
+            )
         if self.spec.satisfies("@:6.1 + hip"):
             filter_file(
                 r"${ROCM_PATH}/llvm/bin/clang++",
@@ -242,7 +244,8 @@ class Mivisionx(ROCmLibrary, CMakePackage):
             env.prepend_path("LD_LIBRARY_PATH", self.spec["hsa-rocr-dev"].prefix.lib)
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        if self.spec.satisfies("@6.1:"):
+        # llvm-amdgpu is only a dependency for HIP builds, we can use it only when +hip:
+        if self.spec.satisfies("@6.1: +hip"):
             env.set("CC", f"{self.spec['llvm-amdgpu'].prefix}/bin/clang")
             env.set("CXX", f"{self.spec['llvm-amdgpu'].prefix}/bin/clang++")
         if self.spec.satisfies("+asan"):
@@ -260,20 +263,19 @@ class Mivisionx(ROCmLibrary, CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
-        protobuf = spec["protobuf"].prefix.include
-        args = [
-            self.define("CMAKE_CXX_FLAGS", "-I{0}".format(protobuf)),
-            self.define("AMDRPP_LIBRARIES", "{0}/lib/librpp.so".format(spec["rpp"].prefix)),
-            self.define("AMDRPP_INCLUDE_DIRS", "{0}/include/rpp".format(spec["rpp"].prefix)),
-            self.define("CMAKE_INSTALL_PREFIX_PYTHON", spec.prefix),
-        ]
-        if self.spec.satisfies("+hip"):
-            args.append(self.define("BACKEND", "HIP"))
-            args.append(self.define("HSA_PATH", spec["hsa-rocr-dev"].prefix))
-            args.append(self.define("HIP_PATH", spec["hip"].prefix))
-
-        if self.spec.satisfies("~hip"):
-            args.append(self.define("BACKEND", "CPU"))
+        if spec.satisfies("+hip"):
+            args = [
+                self.define("BACKEND", "HIP"),
+                self.define("HIP_PATH", spec["hip"].prefix),
+                self.define("HSA_PATH", spec["hsa-rocr-dev"].prefix),
+                self.define("CMAKE_CXX_FLAGS", f"-I{spec['protobuf'].prefix.include}"),
+                # rpp is only a dependency for HIP builds, we can use it only when +hip:
+                self.define("AMDRPP_LIBRARIES", f"{spec['rpp'].prefix}/lib/librpp.so"),
+                self.define("AMDRPP_INCLUDE_DIRS", f"{spec['rpp'].prefix}/include/rpp"),
+                self.define("CMAKE_INSTALL_PREFIX_PYTHON", spec.prefix),
+            ]
+        else:
+            args = [self.define("BACKEND", "CPU")]
 
         if self.spec.satisfies("@:6.2.0"):
             args.append(

--- a/repos/spack_repo/builtin/packages/mivisionx/package.py
+++ b/repos/spack_repo/builtin/packages/mivisionx/package.py
@@ -169,7 +169,8 @@ class Mivisionx(ROCmLibrary, CMakePackage):
                 string=True,
             )
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("cmake@3.5:", type="build")
     depends_on("ffmpeg@4.4:", type="build")


### PR DESCRIPTION
Two small commits to fix the build of the ROCm package `mivisionx`:

1. Add the missing `depends_on("c", type="build")`
    
   This fixes the following error when building mivsionx
   ```py
   [spack cc]: Error: SPACK_CC_* variables not set: this usually means a missing
   `depends_on("c", type="build")` in package.py
   ```

2. Fix the build of non-hip builds by not referencing the dependencies that are only available when building with `+hip`:

   `"llvm-amdgpu"`, `"miopen-hip"` and `"rpp"` are only spec dependencies of `+hip` builds,
   do attempts to find them e.g. using `spec["rpp"]` fail with IndexError.
   
   `spec["rpp"]` is used in `cmake_args()`, so setting `args` is refactored accordingly.
   
   While at it convert the changed lines to use f-strings instead of .format().
   
For review: @renjithravindrankannath, @afzpatel, @srekolam

- This is also needed to fix the build of mivisionx in #4964