### PR TITLE
PEXSI: Allow OpenMP support for 2.0.0

### DIFF
--- a/repos/spack_repo/builtin/packages/pexsi/package.py
+++ b/repos/spack_repo/builtin/packages/pexsi/package.py
@@ -53,8 +53,8 @@ class Pexsi(MakefilePackage, CMakePackage):
         depends_on("cmake@3.10:", type="build")
         depends_on("cmake@3.17:", type="build", when="@2:")
 
-    variant("openmp", default=False, description="Build with OpenMP support", when="@1.2")
-    variant("fortran", default=False, description="Builds the Fortran interface")
+    variant("openmp", default=True, description="Build with OpenMP support", when="@1.2:")
+    variant("fortran", default=True, description="Builds the Fortran interface")
     variant("pic", default=True, description="Compile position independent code (PIC)")
 
     def url_for_version(self, version):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

PEXSI 2.0.0 has also `PEXSI_ENABLE_OPENMP` option whose default is `OFF`, so enable it in Spack.

And, change default value of `fortran` to `True` as Spack recipe of PEXSI already requires Fortran compiler unconditionally.