### PR TITLE
scale: Depend on parallel-netcdf 1.7.0 or later for single file I/O

### DIFF
--- a/repos/spack_repo/builtin/packages/scale/package.py
+++ b/repos/spack_repo/builtin/packages/scale/package.py
@@ -37,7 +37,7 @@ class Scale(MakefilePackage):
     depends_on("mpi@2:", type=("build", "link", "run"))
     depends_on("netcdf-c@:4.8.9")  # scale depends upon old nc-config that supports --fflags
     depends_on("netcdf-fortran")
-    depends_on("parallel-netcdf")
+    depends_on("parallel-netcdf@1.7.0:")
 
     patch("fj-own_compiler.patch", when="%fj")
 


### PR DESCRIPTION
https://scale.riken.jp/download/ states: 
Support single file I/O with PnetCDF (requires PnetCDF >= 1.7.0)

