### PR TITLE
gmgpolar: add possibility to run tests

### DIFF
--- a/repos/spack_repo/builtin/packages/gmgpolar/package.py
+++ b/repos/spack_repo/builtin/packages/gmgpolar/package.py
@@ -28,6 +28,9 @@ class Gmgpolar(CMakePackage):
     depends_on("kokkos@4.4.1:")
     depends_on("kokkos@:5")
 
+    depends_on("googletest@1.17:", type="test")
+    depends_on("googletest@:1", type="test")
+
     # Fixes missing headers in 2.3.1
     patch(
         "https://github.com/SciCompMod/GMGPolar/commit/9356b29a80848c9c88eaa748eb6ce4d8dc67028f.patch?full_index=1",
@@ -43,10 +46,10 @@ class Gmgpolar(CMakePackage):
 
     def cmake_args(self):
         args = [
-            self.define("GMGPOLAR_BUILD_TESTS", False),
+            self.define("GMGPOLAR_BUILD_TESTS", self.run_tests),
+            self.define("GMGPOLAR_ENABLE_COVERAGE", False),
             self.define("GMGPOLAR_USE_LIKWID", False),
             self.define("GMGPOLAR_USE_MUMPS", False),
-            self.define("GMGPOLAR_ENABLE_COVERAGE", False),
         ]
 
         if self.spec.satisfies("^kokkos+rocm"):


### PR DESCRIPTION
This allows to build and run tests of GMGPolar with `spack install --test root gmgpolar`. New dependencies can be found at https://github.com/SciCompMod/GMGPolar/blob/7ea865536a4e0adc783a3dca3057a39fc30b0800/CMakeLists.txt#L149-L155.