### PR TITLE
of-precice: Added gmake dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/of_precice/package.py
+++ b/repos/spack_repo/builtin/packages/of_precice/package.py
@@ -30,8 +30,9 @@ class OfPrecice(Package):
     version("1.1.0", sha256="c35340b50d1b01978635130da94a876e1fa846c80b62e45204aa727db2ef4983")
     version("1.0.0", sha256="b70e5bdce47328f789f76dc6187604f8568b4a996158b5a6f6c11f111ff10308")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("gmake", type="build")
 
     depends_on("openfoam+source")
     depends_on("precice")


### PR DESCRIPTION
Added a `depends_on` for gmake to of-precice. Without it, there are `internal error: invalid --jobserver-auth string` errors. From the Slack the fix for this seems to add gmake as a dep.

Maintainers are are @kjrstory and @MakisH