### PR TITLE
arrow: add xsimd constraint and gcc conflict

### DIFF
--- a/repos/spack_repo/builtin/packages/arrow/package.py
+++ b/repos/spack_repo/builtin/packages/arrow/package.py
@@ -90,12 +90,20 @@ class Arrow(CMakePackage, CudaPackage):
     depends_on("utf8proc@2.7.0: +shared", when="+gandiva")
     depends_on("utf8proc@2.7.0: +shared", when="+python")
     depends_on("xsimd@14:", when="@24:")
+    depends_on("xsimd@13:", when="@23:")
     depends_on("xsimd@8.1.0:", when="@9.0.0:")
     depends_on("zlib-api", when="+zlib @9:")
     depends_on("zlib-api", when="@:8")
     conflicts("^zlib~pic")
     depends_on("zstd", when="+zstd @9:")
     depends_on("zstd", when="@:8")
+
+    conflicts("@:23 %gcc@:9 ^xsimd@14", msg="Use newer Arrow or newer GCC")
+    conflicts(
+        "@23+parquet %gcc@:9",
+        msg="Arrow 23 requires 'C++20-enabled compiler' to build with parquet support",
+    )
+    conflicts("@24: %gcc@:9", msg="Arrow 24 requires 'C++20-enabled compiler'")
 
     variant("brotli", default=False, description="Build support for Brotli compression")
     variant("bz2", default=False, description="Build support for bzip2 compression")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Arrow 24 recommends GCC >= 12 in their documentation.  
In practice Arrow 24 builds with GCC 10 but fails with GCC 9 and older.
Arrow 23 does build with GCC 9 except when `+parquet` is enabled.  
Arrow 22 does build with GCC 9.

```python
> spack-stage/spack-stage-arrow-23.0.1-guealukzlvqkly3pptnvlskroyw7hkzw/spack-src/cpp/src/parquet/metadata.h:24:10: fatal error: span: No such file or directory
     24 | #include <span>
        |          ^~~~~~
  compilation terminated.
> make[2]: *** [src/parquet/CMakeFiles/parquet_objlib.dir/build.make:208: src/parquet/CMakeFiles/parquet_objlib.dir/bloom_filter_reader.cc.o] Error 1
> make[2]: *** [src/parquet/CMakeFiles/parquet_objlib.dir/build.make:264: src/parquet/CMakeFiles/parquet_objlib.dir/column_writer.cc.o] Error 1
> make[2]: *** [src/parquet/CMakeFiles/parquet_objlib.dir/build.make:180: src/parquet/CMakeFiles/parquet_objlib.dir/arrow/writer.cc.o] Error 1
  In file included from spack-stage/spack-stage-arrow-23.0.1-guealukzlvqkly3pptnvlskroyw7hkzw/spack-src/cpp/src/parquet/arrow/schema.cc:42:
> spack-stage/spack-stage-arrow-23.0.1-guealukzlvqkly3pptnvlskroyw7hkzw/spack-src/cpp/src/parquet/metadata.h:24:10: fatal error: span: No such file or directory
     24 | #include <span>
        |          ^~~~~~
  compilation terminated.
> make[2]: *** [src/parquet/CMakeFiles/parquet_objlib.dir/build.make:138: src/parquet/CMakeFiles/parquet_objlib.dir/arrow/schema.cc.o] Error 1
  make[2]: Leaving directory 'spack-stage/spack-stage-arrow-23.0.1-guealukzlvqkly3pptnvlskroyw7hkzw/spack-build-guealuk'
> make[1]: *** [CMakeFiles/Makefile2:1588: src/parquet/CMakeFiles/parquet_objlib.dir/all] Error 2
  make[1]: Leaving directory 'spack-stage/spack-stage-arrow-23.0.1-guealukzlvqkly3pptnvlskroyw7hkzw/spack-build-guealuk'
> make: *** [Makefile:149: all] Error 2
```

This PR adds

```python
conflicts("@24: %gcc@:9", msg="Arrow 24 requires 'C++20-enabled compiler'")
conflicts("@23+parquet %gcc@:9", msg="Arrow 23 requires 'C++20-enabled compiler' to build with parquet support")
```

The constraint on xsimd version is explicitly set in CMake files of Arrow 23

```python
> CMake Error at cmake_modules/ThirdpartyToolchain.cmake:313 (message):
    Couldn't find xsimd >= 13.0.0
  Call Stack (most recent call first):
    cmake_modules/ThirdpartyToolchain.cmake:2647 (resolve_dependency)
    CMakeLists.txt:537 (include)
```

This PR adds

```python
depends_on("xsimd@13:", when="@23:")
```

The incompatibility of `%gcc@9` with `xsimd@14` and `arrow@:24` (checked down to arrow 19) manifests with errors similar to error below

```python
  In file included from opt/spack/linux-skylake/xsimd-14.3.0-wtzbofuip6lxtqstprrotfk3mjrhugca/include/xsimd/arch/xsimd_isa.hpp:94,
                   from opt/spack/linux-skylake/xsimd-14.3.0-wtzbofuip6lxtqstprrotfk3mjrhugca/include/xsimd/types/xsimd_batch.hpp:669,
                   from opt/spack/linux-skylake/xsimd-14.3.0-wtzbofuip6lxtqstprrotfk3mjrhugca/include/xsimd/xsimd.hpp:34,
                   from spack-stage/spack-stage-arrow-23.0.1-lvygha7t5k2ijnqscebkxiccs6jd6par/spack-src/cpp/src/arrow/util/bpacking_simd512_generated_internal.h:27,
                   from spack-stage/spack-stage-arrow-23.0.1-lvygha7t5k2ijnqscebkxiccs6jd6par/spack-src/cpp/src/arrow/util/bpacking_simd_avx512.cc:19:
  opt/spack/linux-skylake/xsimd-14.3.0-wtzbofuip6lxtqstprrotfk3mjrhugca/include/xsimd/arch/xsimd_avx512f.hpp: In function '__m512i xsimd::kernel::detail::zero_extend(__m256i)':
> opt/spack/linux-skylake/xsimd-14.3.0-wtzbofuip6lxtqstprrotfk3mjrhugca/include/xsimd/arch/xsimd_avx512f.hpp:248:76: error: '_mm512_zextsi256_si512' was not declared in this scope; did you mean '_mm512_castsi256_si512'?
    248 |             XSIMD_INLINE __m512i zero_extend(__m256i lo) noexcept { return _mm512_zextsi256_si512(lo); }
        |                                                                            ^~~~~~~~~~~~~~~~~~~~~~
        |                                                                            _mm512_castsi256_si512
  opt/spack/linux-skylake/xsimd-14.3.0-wtzbofuip6lxtqstprrotfk3mjrhugca/include/xsimd/arch/xsimd_avx512f.hpp: In function '__m512 xsimd::kernel::detail::zero_extend(__m256)':
> opt/spack/linux-skylake/xsimd-14.3.0-wtzbofuip6lxtqstprrotfk3mjrhugca/include/xsimd/arch/xsimd_avx512f.hpp:249:74: error: '_mm512_zextps256_ps512' was not declared in this scope; did you mean '_mm512_castps256_ps512'?
    249 |             XSIMD_INLINE __m512 zero_extend(__m256 lo) noexcept { return _mm512_zextps256_ps512(lo); }
        |                                                                          ^~~~~~~~~~~~~~~~~~~~~~
        |                                                                          _mm512_castps256_ps512
  opt/spack/linux-skylake/xsimd-14.3.0-wtzbofuip6lxtqstprrotfk3mjrhugca/include/xsimd/arch/xsimd_avx512f.hpp: In function '__m512d xsimd::kernel::detail::zero_extend(__m256d)':
> opt/spack/linux-skylake/xsimd-14.3.0-wtzbofuip6lxtqstprrotfk3mjrhugca/include/xsimd/arch/xsimd_avx512f.hpp:250:76: error: '_mm512_zextpd256_pd512' was not declared in this scope; did you mean '_mm512_castpd256_pd512'?
    250 |             XSIMD_INLINE __m512d zero_extend(__m256d lo) noexcept { return _mm512_zextpd256_pd512(lo); }
        |                                                                            ^~~~~~~~~~~~~~~~~~~~~~
        |                                                                            _mm512_castpd256_pd512
> make[2]: *** [src/arrow/CMakeFiles/arrow_util.dir/build.make:866: src/arrow/CMakeFiles/arrow_util.dir/util/bpacking_simd_avx512.cc.o] Error 1
  make[2]: Leaving directory 'spack-stage/spack-stage-arrow-23.0.1-lvygha7t5k2ijnqscebkxiccs6jd6par/spack-build-lvygha7'
> make[1]: *** [CMakeFiles/Makefile2:1015: src/arrow/CMakeFiles/arrow_util.dir/all] Error 2
  make[1]: Leaving directory 'spack-stage/spack-stage-arrow-23.0.1-lvygha7t5k2ijnqscebkxiccs6jd6par/spack-build-lvygha7'
> make: *** [Makefile:149: all] Error 2
```

This PR adds

```python
conflicts("@:23 %gcc@:9 ^xsimd@14", msg="Use newer Arrow or newer GCC")
```