### PR TITLE
libidn2: Fix intel classic build

### DIFF
--- a/repos/spack_repo/builtin/packages/libidn2/package.py
+++ b/repos/spack_repo/builtin/packages/libidn2/package.py
@@ -37,3 +37,9 @@ class Libidn2(AutotoolsPackage, GNUMirrorPackage):
 
     # in-source build fails
     build_directory = "spack-build"
+
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        super().setup_build_environment(env)
+
+        if self.spec.satisfies("%intel"):
+            env.append_flags("CFLAGS", "-std=c11")

--- a/repos/spack_repo/builtin/packages/libidn2/package.py
+++ b/repos/spack_repo/builtin/packages/libidn2/package.py
@@ -38,8 +38,7 @@ class Libidn2(AutotoolsPackage, GNUMirrorPackage):
     # in-source build fails
     build_directory = "spack-build"
 
-    def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        super().setup_build_environment(env)
-
-        if self.spec.satisfies("%intel"):
-            env.append_flags("CFLAGS", "-std=c11")
+    def flag_handler(self, name, flags):
+        if name == "cflags" and self.spec.satisfies("%intel"):
+            flags.append("-std=c11")
+        return (flags, None, None)


### PR DESCRIPTION
This fixes a build error with the intel classic compiler:

> error #3895: expected a comma (the one-argument version of static_assert is not enabled in this mode)