### PR TITLE
gettext: Fix intel classic build

### DIFF
--- a/repos/spack_repo/builtin/packages/gettext/package.py
+++ b/repos/spack_repo/builtin/packages/gettext/package.py
@@ -100,6 +100,8 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
         # this goes together with gl_cv_libxml_force_included=no
         if name == "ldflags" and self.spec.satisfies("+libxml2"):
             flags.append("-lxml2")
+        if name == "cflags" and self.spec.satisfies("%intel"):
+            flags.append("-std=c11")
         return (flags, None, None)
 
     @classmethod

--- a/repos/spack_repo/builtin/packages/gettext/package.py
+++ b/repos/spack_repo/builtin/packages/gettext/package.py
@@ -184,9 +184,3 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
         # In addition to prefix/share/aclocal, newer versions of gettext also
         # install m4 files into prefix/share/gettext/m4.
         env.append_path("ACLOCAL_PATH", self.prefix.share.gettext.m4)
-
-    def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        super().setup_build_environment(env)
-
-        if self.spec.satisfies("%intel"):
-            env.append_flags("CFLAGS", "-std=c11")

--- a/repos/spack_repo/builtin/packages/gettext/package.py
+++ b/repos/spack_repo/builtin/packages/gettext/package.py
@@ -184,3 +184,9 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
         # In addition to prefix/share/aclocal, newer versions of gettext also
         # install m4 files into prefix/share/gettext/m4.
         env.append_path("ACLOCAL_PATH", self.prefix.share.gettext.m4)
+
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        super().setup_build_environment(env)
+
+        if self.spec.satisfies("%intel"):
+            env.append_flags("CFLAGS", "-std=c11")


### PR DESCRIPTION
This fixes a build error with the intel classic compiler:

> error https://github.com/spack/spack-packages/pull/3895: expected a comma (the one-argument version of static_assert is not enabled in this mode)