### PR TITLE
GNUMirrorPackage: improve upstream discovery of new versions

### DIFF
--- a/repos/spack_repo/builtin/build_systems/gnu.py
+++ b/repos/spack_repo/builtin/build_systems/gnu.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os.path
 from typing import Optional
 
 from spack.package import PackageBase, join_url
@@ -13,6 +14,9 @@ class GNUMirrorPackage(PackageBase):
     #: Path of the package in a GNU mirror
     gnu_mirror_path: Optional[str] = None
 
+    #: Depth of url spidering to search up the path for new versions
+    list_depth: int = 0
+
     #: List of GNU mirrors used by Spack
     base_mirrors = [
         "https://ftpmirror.gnu.org/",
@@ -23,9 +27,22 @@ class GNUMirrorPackage(PackageBase):
     ]
 
     @property
-    def urls(self):
+    def urls(self) -> list[str]:
         self._ensure_gnu_mirror_path_is_set_or_raise()
+        # narrow the type for the checker: the call above raises when None
+        if self.gnu_mirror_path is None:
+            return []
         return [join_url(m, self.gnu_mirror_path, resolve_href=True) for m in self.base_mirrors]
+
+    @property
+    def list_url(self):
+        if self.gnu_mirror_path is None:
+            return None
+
+        mirror_dir = os.path.dirname(self.gnu_mirror_path)
+        # Use the canonical ftp.gnu.org mirror for listing; the redirecting
+        # ftpmirror.gnu.org does not reliably serve directory indexes.
+        return join_url("https://ftp.gnu.org/gnu/", mirror_dir, resolve_href=True)
 
     def _ensure_gnu_mirror_path_is_set_or_raise(self):
         if self.gnu_mirror_path is None:

--- a/repos/spack_repo/builtin/build_systems/gnu.py
+++ b/repos/spack_repo/builtin/build_systems/gnu.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os.path
-from typing import Optional
+from typing import List, Optional
 
 from spack.package import PackageBase, join_url
 
@@ -27,7 +27,7 @@ class GNUMirrorPackage(PackageBase):
     ]
 
     @property
-    def urls(self) -> list[str]:
+    def urls(self) -> List[str]:
         self._ensure_gnu_mirror_path_is_set_or_raise()
         # narrow the type for the checker: the call above raises when None
         if self.gnu_mirror_path is None:


### PR DESCRIPTION
Improve upstream discovery logic for new versions for GNUMirrorPackages by only using canonical source.

I noticed when looking for new versions of many GNUMirrorPackages that running `spack version -n` inconsistently showed new versions available from one execution to another. This PR improves the upstream build system to improve the consistency of the spidering operations.