### PR TITLE
NMake provider: jom

### DIFF
--- a/repos/spack_repo/builtin/build_systems/nmake.py
+++ b/repos/spack_repo/builtin/build_systems/nmake.py
@@ -10,7 +10,9 @@ from spack.package import (
     Spec,
     build_system,
     conflicts,
+    depends_on,
     register_builder,
+    when,
     windows_sfn,
     working_dir,
 )
@@ -26,6 +28,10 @@ class NMakePackage(PackageBase):
     build_system("nmake")
     conflicts("platform=linux", when="build_system=nmake")
     conflicts("platform=darwin", when="build_system=nmake")
+
+    with when("build_system=nmake"):
+        # Either Visual Studio's nmake or a drop-in replacement such as jom
+        depends_on("nmake", type="build")
 
 
 @register_builder("nmake")

--- a/repos/spack_repo/builtin/build_systems/qmake.py
+++ b/repos/spack_repo/builtin/build_systems/qmake.py
@@ -1,6 +1,8 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import sys
+
 from spack.package import (
     BuilderWithDefaults,
     PackageBase,
@@ -10,6 +12,7 @@ from spack.package import (
     depends_on,
     register_builder,
     run_after,
+    when,
     working_dir,
 )
 
@@ -31,8 +34,12 @@ class QMakePackage(PackageBase):
 
     build_system("qmake")
 
-    depends_on("qmake", type="build", when="build_system=qmake")
-    depends_on("gmake", type="build")
+    with when("build_system=qmake"):
+        depends_on("qmake", type="build")
+        # qmake generates an NMake makefile on Windows and a GNU one everywhere else
+        depends_on("nmake", type="build", when="platform=windows")
+        for _plat in ("linux", "darwin", "freebsd"):
+            depends_on("gmake", type="build", when=f"platform={_plat}")
 
 
 @register_builder("qmake")
@@ -72,15 +79,22 @@ class QMakeBuilder(BuilderWithDefaults):
         with working_dir(self.build_directory):
             pkg.module.qmake(*self.qmake_args())
 
+    def _make(self, pkg: QMakePackage, *args: str) -> None:
+        """Drive the makefile qmake generated with the platform's make implementation."""
+        if sys.platform == "win32":
+            pkg.module.nmake(*args)
+        else:
+            pkg.module.make(*args)
+
     def build(self, pkg: QMakePackage, spec: Spec, prefix: Prefix) -> None:
         """Make the build targets"""
         with working_dir(self.build_directory):
-            pkg.module.make()
+            self._make(pkg)
 
     def install(self, pkg: QMakePackage, spec: Spec, prefix: Prefix) -> None:
         """Make the install targets"""
         with working_dir(self.build_directory):
-            pkg.module.make("install")
+            self._make(pkg, "install")
 
     def check(self):
         """Search the Makefile for a ``check:`` target and runs it if found."""

--- a/repos/spack_repo/builtin/packages/_7zip/package.py
+++ b/repos/spack_repo/builtin/packages/_7zip/package.py
@@ -29,6 +29,7 @@ class _7zip(SourceforgePackage, Package):
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
+    depends_on("nmake", type="build", when="platform=windows")
 
     variant(
         "link_type",

--- a/repos/spack_repo/builtin/packages/audacious/package.py
+++ b/repos/spack_repo/builtin/packages/audacious/package.py
@@ -35,7 +35,9 @@ class Audacious(AutotoolsPackage):
     depends_on("qt", when="@:4.3")
     depends_on("qmake", when="@4.4:")
     with when("^[virtuals=qmake] qt"):
-        depends_on("qt")
+        # Mirrors the qt-base branch below: audacious needs Qt's GUI, so a bare
+        # "qt" would also be satisfied by a qmake-only provider.
+        depends_on("qt+gui")
     with when("^[virtuals=qmake] qt-base"):
         depends_on("qt-base +gui +widgets")
         depends_on("qt-svg")

--- a/repos/spack_repo/builtin/packages/bzip2/package.py
+++ b/repos/spack_repo/builtin/packages/bzip2/package.py
@@ -49,6 +49,7 @@ class Bzip2(Package, SourcewarePackage):
         depends_on("diffutils", type="build")
 
     depends_on("c", type="build")  # generated
+    depends_on("nmake", type="build", when="platform=windows")
 
     depends_on("gmake", type="build", when="platform=linux")
     depends_on("gmake", type="build", when="platform=darwin")

--- a/repos/spack_repo/builtin/packages/curl/package.py
+++ b/repos/spack_repo/builtin/packages/curl/package.py
@@ -87,6 +87,7 @@ class Curl(NMakePackage, AutotoolsPackage, CMakePackage):
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
+    depends_on("nmake", type="build", when="platform=windows")
 
     depends_on("pkgconfig", type="build", when="platform=darwin")
     depends_on("pkgconfig", type="build", when="platform=linux")

--- a/repos/spack_repo/builtin/packages/jom/package.py
+++ b/repos/spack_repo/builtin/packages/jom/package.py
@@ -1,0 +1,82 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
+import re
+
+from spack_repo.builtin.build_systems import qmake
+from spack_repo.builtin.build_systems.qmake import QMakePackage
+
+from spack.package import *
+
+
+class Jom(QMakePackage):
+    """jom is a clone of nmake, Microsoft's make implementation, that supports the
+    execution of multiple independent commands in parallel. It is a drop-in
+    replacement for nmake and understands the same command line options."""
+
+    homepage = "https://wiki.qt.io/Jom"
+    url = "https://github.com/qt-labs/jom/archive/refs/tags/v1.1.7.tar.gz"
+    git = "https://code.qt.io/qt-labs/jom.git"
+
+    tags = ["build-tools", "windows"]
+
+    license("GPL-3.0-only")
+
+    version("1.1.7", sha256="17d3b34b8a1fd5a20acbafc504525b884be9b83f36b0e309d139b0922e09a1d3")
+    version("1.1.6", sha256="4718c916404fdd850b457c86e9100f8ad594c73b53ec9e224045c2f05aa15a0f")
+    version("1.1.5", sha256="ff72c0d484dac9792037354479984aa97c011011de556cc548d2423946ce1947")
+    version("1.1.4", sha256="e6d4bda0c9a264cb4ba1440d05df3728d6d0b55e3f3caa895a313fea1bd7d405")
+
+    provides("nmake")
+
+    executables = ["^jom$"]
+
+    depends_on("cxx", type="build")
+
+    requires("platform=windows", msg="jom is an nmake clone and only builds on Windows")
+    # jom is a Qt5 program: both jom.pro and CMakeLists.txt want Qt5 Core, so
+    # qt-base, which is Qt6, cannot act as its qmake provider.
+    requires("^[virtuals=qmake] qt", msg="jom requires Qt5, which qt-base (Qt6) does not provide")
+    # jom.pro hard-errors below 5.2.0 via its minQtVersion() check
+    depends_on("qt@5.2:", when="^[virtuals=qmake] qt")
+
+    # The inherited check phase runs `make check`, which does not exist on Windows
+    build_time_test_callbacks = []
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)("/VERSION", output=str, error=str)
+        match = re.search(r"jom version (\S+)", output)
+        return match.group(1) if match else None
+
+    @property
+    def jom_exe(self):
+        return os.path.join(self.prefix.bin, "jom.exe")
+
+    def setup_dependent_package(self, module, dependent_spec):
+        """Stand in for nmake in dependents that build with an nmake makefile."""
+        module.nmake = Executable(self.jom_exe)
+        module.jom = Executable(self.jom_exe)
+
+    def setup_dependent_build_environment(
+        self, env: EnvironmentModifications, dependent_spec: Spec
+    ) -> None:
+        env.prepend_path("PATH", self.prefix.bin)
+        # jom reads its default arguments from JOMFLAGS, falling back to MAKEFLAGS.
+        # Without this jom saturates every core regardless of Spack's job count.
+        jobs = determine_number_of_jobs(parallel=dependent_spec.package.parallel)
+        env.set("JOMFLAGS", "/J {0}".format(jobs))
+
+
+class QMakeBuilder(qmake.QMakeBuilder):
+    def qmake_args(self):
+        # app.pro appends a 'd' to the target name for debug builds; pin the
+        # configuration so the installed binary is always jom.exe
+        return ["CONFIG+=release"]
+
+    def install(self, pkg, spec, prefix):
+        # jom's .pro files declare no INSTALLS target. src/app/app.pro sets
+        # DESTDIR = ../../bin, so the binary lands in <source>/bin.
+        mkdirp(prefix.bin)
+        install(os.path.join(self.build_directory, "bin", "jom.exe"), prefix.bin)

--- a/repos/spack_repo/builtin/packages/msvc/package.py
+++ b/repos/spack_repo/builtin/packages/msvc/package.py
@@ -54,6 +54,7 @@ class Msvc(Package, CompilerPackage):
     compiler_wrapper_link_paths = {"c": "", "cxx": "", "fortran": ""}
 
     provides("c", "cxx", "fortran")
+    provides("nmake")
     requires("platform=windows", msg="MSVC is only supported on Windows")
 
     @classmethod
@@ -93,7 +94,13 @@ class Msvc(Package, CompilerPackage):
         """Populates dependent module with tooling available from VS"""
         # We want these to resolve to the paths set by MSVC's VCVARs
         # so no paths
-        module.nmake = Executable("nmake")
+        #
+        # `nmake` is a virtual, so stand aside when the dependent picked a
+        # different provider (jom, say). Dependents that call nmake() without
+        # declaring the dependency have no provider at all, and still get ours.
+        nmake_providers = dependent_spec.dependencies(virtuals=("nmake",))
+        if not nmake_providers or any(p.name == self.name for p in nmake_providers):
+            module.nmake = Executable("nmake")
         module.msbuild = Executable("msbuild")
 
     def setup_dependent_build_environment(

--- a/repos/spack_repo/builtin/packages/nasm/package.py
+++ b/repos/spack_repo/builtin/packages/nasm/package.py
@@ -44,6 +44,7 @@ class Nasm(AutotoolsPackage, Package):
 
     with when("platform=windows"):
         depends_on("perl")
+        depends_on("nmake", type="build")
         patch("msvc.mak.patch", when="@2.15.05")
 
     conflicts("%intel@:14", when="@2.14:", msg="Intel <= 14 lacks support for C11")

--- a/repos/spack_repo/builtin/packages/perl/package.py
+++ b/repos/spack_repo/builtin/packages/perl/package.py
@@ -45,6 +45,14 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     extendable = True
 
     depends_on("c", type="build")  # generated
+    depends_on("nmake", type="build", when="platform=windows")
+    # Perl's win32/Makefile does not build correctly under jom, so pin the nmake
+    # provider to the one from Visual Studio.
+    requires(
+        "%[virtuals=nmake] msvc",
+        when="platform=windows",
+        msg="Perl's Windows makefile requires MSVC's nmake; jom cannot build it",
+    )
 
     if sys.platform != "win32":
         depends_on("gmake", type="build")

--- a/repos/spack_repo/builtin/packages/qscintilla/package.py
+++ b/repos/spack_repo/builtin/packages/qscintilla/package.py
@@ -33,6 +33,13 @@ class Qscintilla(QMakePackage):
     depends_on("cxx", type="build")  # generated
 
     depends_on("qmake")
+    # QScintilla is a widgets library (QT += widgets printsupport), so it needs a
+    # real Qt build rather than a qmake-only or GUI-less provider, python bindings
+    # or not.
+    # Every version packaged here targets Qt5 or Qt6; without a floor the solver
+    # picks the cheapest Qt satisfying +gui, which is qt@3.
+    depends_on("qt@5: +gui", when="^[virtuals=qmake] qt")
+    depends_on("qt-base +gui +widgets", when="^[virtuals=qmake] qt-base")
     with when("+python"):
         depends_on("qt+opengl", when="^[virtuals=qmake] qt")
         depends_on("qt-base +opengl", when="^[virtuals=qmake] qt-base")

--- a/repos/spack_repo/builtin/packages/qt/package.py
+++ b/repos/spack_repo/builtin/packages/qt/package.py
@@ -79,14 +79,41 @@ class Qt(Package):
             # We can use llvm or angle for this, but those are not hardware accelerated, so are not
             # as useful for things like paraview
             variant("webkit", default=False, description="Build the Webkit extension")
+            conflicts("+webkit", when="+qmake_only")
     variant("location", default=False, description="Build the Qt Location module.")
     variant("phonon", default=False, description="Build with phonon support.")
     variant("shared", default=True, description="Build shared libraries.")
     variant("sql", default=True, description="Build with SQL support.")
     variant("ssl", default=True, description="Build with OpenSSL support.")
     variant("tools", default=True, description="Build tools, including Qt Designer.")
+    variant(
+        "qmake_only",
+        default=False,
+        description="Build only qmake and QtCore, skipping every other Qt module",
+    )
 
-    provides("qmake")
+    # qmake is one of Qt's tools, so a build that omits them does not provide it.
+    # +qmake_only skips the tools directory but still builds and installs qmake itself.
+    provides("qmake", when="+tools")
+    provides("qmake", when="+qmake_only")
+
+    conflicts("+tools", when="+qmake_only")
+    conflicts("+qmake_only", when="@:4", msg="The minimal qmake build is only supported for Qt 5")
+    # A qmake-only build is qtbase with everything switched off, so no component
+    # that would pull in a dependency can be enabled alongside it.
+    for _component in (
+        "gui",
+        "sql",
+        "ssl",
+        "dbus",
+        "opengl",
+        "gtk",
+        "doc",
+        "examples",
+        "phonon",
+        "location",
+    ):
+        conflicts(f"+{_component}", when="+qmake_only")
 
     # Patches for qt@3
     patch("qt3-accept.patch", when="@3")
@@ -207,18 +234,20 @@ class Qt(Package):
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
+    depends_on("nmake", type="build", when="platform=windows")
 
     # Build-only dependencies
     for plat in ["linux", "darwin", "freebsd"]:
         with when(f"platform={plat}"):
-            depends_on("pkgconfig", type="build")
-            depends_on("libsm", when="@3")
-            depends_on("glib", when="@4:")
-            depends_on("libmng")
-            depends_on("assimp@5.0.0:5", when="@5.5:+opengl")
-            depends_on("sqlite+column_metadata", when="+sql", type=("build", "run"))
-            depends_on("inputproto", when="@:5.8")
             depends_on("gmake", type="build")
+            with when("~qmake_only"):
+                depends_on("pkgconfig", type="build")
+                depends_on("libsm", when="@3")
+                depends_on("glib", when="@4:")
+                depends_on("libmng")
+                depends_on("assimp@5.0.0:5", when="@5.5:+opengl")
+                depends_on("sqlite+column_metadata", when="+sql", type=("build", "run"))
+                depends_on("inputproto", when="@:5.8")
 
     for plat in ["linux", "freebsd"]:
         with when(f"platform={plat} +gui"):
@@ -250,33 +279,37 @@ class Qt(Package):
             msg="Apple Silicon requires a very new version of qt",
         )
 
-    depends_on("python", when="@5.7.0:", type="build")
+    # A +qmake_only build configures qtbase with every feature disabled and Qt's own
+    # bundled copies of the few libraries it cannot do without, so none of the
+    # dependencies below apply to it.
+    with when("~qmake_only"):
+        depends_on("python", when="@5.7.0:", type="build")
 
-    # Dependencies, then variant- and version-specific dependencies
-    depends_on("icu4c@:74")  # @75: requires cxxstd 17 which is not modelled here
-    depends_on("jpeg")
-    depends_on("libtiff")
-    depends_on("libxml2")
-    depends_on("zlib-api")
-    depends_on("freetype", when="+gui")
-    depends_on("gtkplus", when="+gtk")
+        # Dependencies, then variant- and version-specific dependencies
+        depends_on("icu4c@:74")  # @75: requires cxxstd 17 which is not modelled here
+        depends_on("jpeg")
+        depends_on("libtiff")
+        depends_on("libxml2")
+        depends_on("zlib-api")
+        depends_on("freetype", when="+gui")
+        depends_on("gtkplus", when="+gtk")
 
-    depends_on("libpng@1.2.57", when="@3")
-    depends_on("pcre+multibyte", when="@5.0:5.8")
+        depends_on("libpng@1.2.57", when="@3")
+        depends_on("pcre+multibyte", when="@5.0:5.8")
 
-    with when("+ssl"):
-        depends_on("openssl")
-        depends_on("openssl@1.1.1:", when="@5.15.0:")
+        with when("+ssl"):
+            depends_on("openssl")
+            depends_on("openssl@1.1.1:", when="@5.15.0:")
 
-    depends_on("libpng", when="@4:")
-    depends_on("dbus", when="@4:+dbus")
-    depends_on("gl", when="@4:+opengl")
+        depends_on("libpng", when="@4:")
+        depends_on("dbus", when="@4:+dbus")
+        depends_on("gl", when="@4:+opengl")
 
-    depends_on("harfbuzz", when="@5:")
-    depends_on("double-conversion", when="@5.7:")
-    depends_on("pcre2+multibyte", when="@5.9:")
-    depends_on("llvm", when="@5.11: +doc")
-    depends_on("zstd@1.3:", when="@5.13:")
+        depends_on("harfbuzz", when="@5:")
+        depends_on("double-conversion", when="@5.7:")
+        depends_on("pcre2+multibyte", when="@5.9:")
+        depends_on("llvm", when="@5.11: +doc")
+        depends_on("zstd@1.3:", when="@5.13:")
 
     with when("+webkit"):
         patch(
@@ -784,6 +817,70 @@ class Qt(Package):
             config_args = self._quoted(config_args)
 
         configure(*config_args)
+
+    @when("+qmake_only")
+    def configure(self, spec, prefix):
+        """Configure a qtbase-only build that yields qmake, QtCore and the mkspecs.
+
+        Every optional feature is switched off and the handful of libraries qtbase
+        cannot do without are taken from Qt's bundled copies, so this build needs
+        nothing beyond a C/C++ compiler and a make implementation.
+
+        This deliberately bypasses ``common_config_args``, which dereferences
+        dependencies that a +qmake_only spec does not have.
+        """
+        config_args = [
+            "-prefix",
+            prefix,
+            "-opensource",
+            "-confirm-license",
+            "-{0}".format("debug" if "+debug" in spec else "release"),
+            "-{0}".format("shared" if "+shared" in spec else "static"),
+            "-optimized-qmake",
+            "-no-pch",
+            "-no-gui",
+            "-no-widgets",
+            "-no-opengl",
+            "-no-dbus",
+            "-no-openssl",
+            "-no-icu",
+            "-no-freetype",
+            "-no-harfbuzz",
+            "-no-libpng",
+            "-no-libjpeg",
+            # Bundled copies rather than Spack packages
+            "-qt-zlib",
+            "-qt-pcre",
+            "-nomake",
+            "examples",
+            "-nomake",
+            "tests",
+            "-nomake",
+            "tools",
+        ]
+
+        if spec.satisfies("@5.7:"):
+            config_args.append("-qt-doubleconversion")
+
+        comps = ["db2", "ibase", "oci", "tds", "mysql", "odbc", "psql", "sqlite", "sqlite2"]
+        config_args.extend("-no-sql-" + component for component in comps)
+
+        # Skip every module but qtbase. Which modules ship in the "everywhere"
+        # tarball varies across the 5.x series, so read them off the source tree
+        # rather than hard-coding a list.
+        for entry in sorted(os.listdir(self.stage.source_path)):
+            if entry.startswith("qt") and entry != "qtbase":
+                if os.path.isdir(os.path.join(self.stage.source_path, entry)):
+                    config_args.extend(["-skip", entry])
+
+        (_, qtplat) = self.get_mkspec()
+        if qtplat is not None:
+            config_args.extend(["-platform", qtplat])
+
+        if IS_WINDOWS:
+            Executable("configure.bat")(*self._quoted(config_args))
+        else:
+            configure(*config_args)
 
     @when("@5")
     def configure(self, spec, prefix):

--- a/repos/spack_repo/builtin/packages/qwt/package.py
+++ b/repos/spack_repo/builtin/packages/qwt/package.py
@@ -41,6 +41,12 @@ class Qwt(QMakePackage):
         depends_on("qt-tools", when="+designer")
         depends_on("qt-base+opengl+widgets", when="+opengl")
     with when("^[virtuals=qmake] qt"):
+        # Qwt is a widgets library, so a qmake-only Qt cannot build it. The Qt6
+        # branch above states this via qt-svg; say it explicitly for Qt5 too.
+        depends_on("qt+gui")
+        # Qwt dropped Qt4 support in 6.2; without a floor the solver picks qt@4
+        # because it is the cheapest Qt that satisfies +gui.
+        depends_on("qt@5:", when="@6.2:")
         depends_on("qt+tools", when="+designer")
         depends_on("qt+opengl", when="+opengl")
 

--- a/repos/spack_repo/builtin/packages/zlib/package.py
+++ b/repos/spack_repo/builtin/packages/zlib/package.py
@@ -42,6 +42,7 @@ class Zlib(MakefilePackage, Package):
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
+    depends_on("nmake", type="build", when="platform=windows")
 
     conflicts("build_system=makefile", when="platform=windows")
 


### PR DESCRIPTION
Adds `jom` as a package and provider of nmake, the Windows makefile builder. 
Jom is the qt project's implementation of `nmake` that directly supports building nmake build systems in parallel, similar to how make operates.

Openssl build times on Windows:
With vanilla nmake: ~12m
With jom: ~4m

Jom can be used as a drop in replacement (in most cases) for nmake, and thus is made a provider for the virtual nmake.
Packages can specify a requirement on vanilla nmake by requiring it be provided by MSVC via visual studio, or prefer the parallel jom through traditional provider spec syntax. 

Adds proper modeling for nmake dependencies to packages that rely on it vs relying on the implicit availability of the package via reliance on the MSVC compiler. 

Building jom is unfortunate, as it's a Qt5 based package, it requires QMake and qt core to build. Traditionally in spack, that requires a full Qt build, which, adding to the DAG in most cases removes any performance improvement provided by jom (for that dag, obviously future uses get the parallel builds for free). This PR adds a minimal Qt install that only builds qtcore and qmake, which jom leverages to reduce the overhead required to build it. 
Adds `+qmake_only` as a variant to the qt5 package. 

None of this applies to qt6, which abandons jom in favor of CMake and ninja. 

Requires changes to core before it can land allowing duplicate `jom`s in a graph