### PR TITLE
kokkos: remove restrictions for ~wrapper

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -331,7 +331,6 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("kokkos-nvcc-wrapper@develop", when="@develop+wrapper")
     conflicts("+wrapper", when="~cuda")
     conflicts("+wrapper", when="+cmake_lang")
-    requires("%clang", "%cce", "+cmake_lang", policy="any_of", when="~wrapper+cuda")
 
     # TODO new major: update c++ std
     with default_args(multi=False, description="C++ standard"):


### PR DESCRIPTION
Kokkos has had an automatic launch_compiler since 3.3 that will automatically redirect to either host or NVCC. The nvcc_wrapper replacement comes from a time where we needed to explicitly set the CXX compiler to the wrapper. This launch_compiler behavior is the recommended default, so don't artifically force +wrapper in the +cuda case, when it's not actually needed.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
