### PR TITLE
py_pyprecice: Change Maintainers

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pyprecice/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyprecice/package.py
@@ -16,7 +16,7 @@ class PyPyprecice(PythonPackage):
     homepage = "https://precice.org"
     git = "https://github.com/precice/python-bindings.git"
     url = "https://github.com/precice/python-bindings/archive/v3.1.1.tar.gz"
-    maintainers("ajaust", "BenjaminRodenberg", "IshaanDesai")
+    maintainers("fsimonis", "MakisH")
 
     license("LGPL-3.0")
 


### PR DESCRIPTION
This PR changes the no longer active maintainers of the `py_pyprecice` package from @ajaust, @BenjaminRodenberg, and @IshaanDesai to those of the `precice` package @fsimonis (me) and @MakisH.