### PR TITLE
Msmpi: Quote source tree paths for robocopy

### DIFF
--- a/repos/spack_repo/builtin/packages/msmpi/quote_source_tree_refs.patch
+++ b/repos/spack_repo/builtin/packages/msmpi/quote_source_tree_refs.patch
@@ -132,7 +132,7 @@ index 9eb7dff..884fd63 100644
    <ItemDefinitionGroup>
      <PostBuildEvent>
 -      <Command>robocopy $(OutDir) $(BinariesBuildTypeArchDirectory)\$(MPI_SDK_DESTINATION)\lib msmpi.lib
-+      <Command>robocopy "$(OutDir)" "$(BinariesBuildTypeArchDirectory)\$(MPI_SDK_DESTINATION)\lib" msmpi.lib
++      <Command>robocopy "$(OutDir)." "$(BinariesBuildTypeArchDirectory)\$(MPI_SDK_DESTINATION)\lib" msmpi.lib
  set rc=%errorlevel%
  if not %rc%==1 exit %rce% else exit 0</Command>
      </PostBuildEvent>


### PR DESCRIPTION
Msmpi's msbuild build system leverages robocopy. Previously msbuild was more tolerant about paths with spaces and handed them off to robocopy nicely, but more recent versions of visualstudio vendor an msbuild that is less tolerant, and passes broken paths to robocopy (if they're unqouted paths with spaces).
This breaks msmpi installs for spack with install trees or stages with spaces. 

Instead just quote the paths that robocopy will be moving via a patch.

Patch is not upstreamed as the project (msmpi) seems to be non active outside of patching vulnerabilities. 