### PR TITLE
r-rsamtools: add 2.24.1, 2.26.0, 2.28.0. Updated r-genomicranges dependency.

### DIFF
--- a/repos/spack_repo/builtin/packages/r_genomicranges/package.py
+++ b/repos/spack_repo/builtin/packages/r_genomicranges/package.py
@@ -48,14 +48,14 @@ class RGenomicranges(RPackage):
     depends_on("r-biocgenerics@0.25.3:", type=("build", "run"), when="@1.32.7:")
     depends_on("r-biocgenerics@0.21.2:", type=("build", "run"))
 
-    depends_on("r-seqinfo@0.99.3:", type=("build", "run"), when="@1.62.1:")
+    depends_on("r-seqinfo@0.99.3:", type=("build", "run"), when="@1.61.1:")
 
-    depends_on("r-genomeinfodb@1.43.1:1.47", type=("build", "run"), when="@1.59.1:1.61")
-    depends_on("r-genomeinfodb@1.15.2:1.47", type=("build", "run"), when="@1.32.7:1.61")
-    depends_on("r-genomeinfodb@1.13.1:1.47", type=("build", "run"), when="@1.30.3:1.61")
-    depends_on("r-genomeinfodb@1.11.5:1.47", type=("build", "run"), when="@:1.61")
+    depends_on("r-genomeinfodb@1.43.1:1.47", type=("build", "run"), when="@1.59.1:1.61.0")
+    depends_on("r-genomeinfodb@1.15.2:1.47", type=("build", "run"), when="@1.32.7:1.61.0")
+    depends_on("r-genomeinfodb@1.13.1:1.47", type=("build", "run"), when="@1.30.3:1.61.0")
+    depends_on("r-genomeinfodb@1.11.5:1.47", type=("build", "run"), when="@:1.61.0")
 
-    depends_on("r-iranges@2.43.6:", type=("build", "run"), when="@1.62.1:")
+    depends_on("r-iranges@2.43.6:", type=("build", "run"), when="@1.61.7:")
     depends_on("r-iranges@2.41.1:", type=("build", "run"), when="@1.59.1:")
     depends_on("r-iranges@2.37.1:", type=("build", "run"), when="@1.55.2:")
     depends_on("r-iranges@2.31.2:", type=("build", "run"), when="@1.50.1:")
@@ -72,6 +72,6 @@ class RGenomicranges(RPackage):
     depends_on("r-s4vectors@0.17.32:", type=("build", "run"), when="@1.32.7:")
     depends_on("r-s4vectors@0.9.47:", type=("build", "run"))
 
-    depends_on("r-xvector@0.29.2:", type=("build", "run"), when="@1.42.0:1.61")
-    depends_on("r-xvector@0.19.8:", type=("build", "run"), when="@1.32.7:1.61")
-    depends_on("r-xvector", type=("build", "run"), when="@:1.61")
+    depends_on("r-xvector@0.29.2:", type=("build", "run"), when="@1.42.0:1.61.7")
+    depends_on("r-xvector@0.19.8:", type=("build", "run"), when="@1.32.7:1.61.7")
+    depends_on("r-xvector", type=("build", "run"), when="@:1.61.7")

--- a/repos/spack_repo/builtin/packages/r_genomicranges/package.py
+++ b/repos/spack_repo/builtin/packages/r_genomicranges/package.py
@@ -24,6 +24,8 @@ class RGenomicranges(RPackage):
     bioc = "GenomicRanges"
 
     with default_args(get_full_repo=True):
+        version("1.64.0", commit="ac531f1ce56cc9119075d1c6862c68ad33f98536")  # bioc 3.23
+        version("1.62.1", commit="ce11a45400f198fbede382bf1f0ad137ef2d8a96")  # bioc 3.22
         version("1.60.0", commit="9d5d73b5f790c884d8acc18016943784cdc0b8c8")  # bioc 3.21
         version("1.52.0", commit="883f125ea593099293dc808ec2188be3cbdbd3a7")
         version("1.50.1", commit="6b3fb388ec038fb43f3cd26684ce778ee0e80e81")
@@ -46,11 +48,14 @@ class RGenomicranges(RPackage):
     depends_on("r-biocgenerics@0.25.3:", type=("build", "run"), when="@1.32.7:")
     depends_on("r-biocgenerics@0.21.2:", type=("build", "run"))
 
-    depends_on("r-genomeinfodb@1.43.1:", type=("build", "run"), when="@1.59.1:")
-    depends_on("r-genomeinfodb@1.15.2:", type=("build", "run"), when="@1.32.7:")
-    depends_on("r-genomeinfodb@1.13.1:", type=("build", "run"), when="@1.30.3:")
-    depends_on("r-genomeinfodb@1.11.5:", type=("build", "run"))
+    depends_on("r-seqinfo@0.99.3:", type=("build", "run"), when="@1.62.1:")
 
+    depends_on("r-genomeinfodb@1.43.1:1.47", type=("build", "run"), when="@1.59.1:1.61")
+    depends_on("r-genomeinfodb@1.15.2:1.47", type=("build", "run"), when="@1.32.7:1.61")
+    depends_on("r-genomeinfodb@1.13.1:1.47", type=("build", "run"), when="@1.30.3:1.61")
+    depends_on("r-genomeinfodb@1.11.5:1.47", type=("build", "run"), when="@:1.61")
+
+    depends_on("r-iranges@2.43.6:", type=("build", "run"), when="@1.62.1:")
     depends_on("r-iranges@2.41.1:", type=("build", "run"), when="@1.59.1:")
     depends_on("r-iranges@2.37.1:", type=("build", "run"), when="@1.55.2:")
     depends_on("r-iranges@2.31.2:", type=("build", "run"), when="@1.50.1:")
@@ -67,6 +72,6 @@ class RGenomicranges(RPackage):
     depends_on("r-s4vectors@0.17.32:", type=("build", "run"), when="@1.32.7:")
     depends_on("r-s4vectors@0.9.47:", type=("build", "run"))
 
-    depends_on("r-xvector@0.29.2:", type=("build", "run"), when="@1.42.0:")
-    depends_on("r-xvector@0.19.8:", type=("build", "run"), when="@1.32.7:")
-    depends_on("r-xvector", type=("build", "run"))
+    depends_on("r-xvector@0.29.2:", type=("build", "run"), when="@1.42.0:1.61")
+    depends_on("r-xvector@0.19.8:", type=("build", "run"), when="@1.32.7:1.61")
+    depends_on("r-xvector", type=("build", "run"), when="@:1.61")

--- a/repos/spack_repo/builtin/packages/r_rsamtools/package.py
+++ b/repos/spack_repo/builtin/packages/r_rsamtools/package.py
@@ -36,16 +36,23 @@ class RRsamtools(RPackage):
         version("1.30.0", commit="61b365fe3762e796b3808cec7238944b7f68d7a6")
         version("1.28.0", commit="dfa5b6abef68175586f21add7927174786412472")
 
+        # Commit was incorrectly marked as 2.24.0 while it is 2.24.1
+        version(
+            "2.24.0",
+            commit="5fa43af28dd6ae25fbabd23e2e7329003ba53e30",
+            deprecated=True,
+        )
+
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
     depends_on("r@3.5.0:", type=("build", "run"), when="@2.10.0:")
-    depends_on("r-seqinfo", type=("build", "run"), when="@2.26.0:")
+    depends_on("r-seqinfo", type=("build", "run"), when="@2.25.1:")
     depends_on("r-genomeinfodb@1.1.3:1.47", type=("build", "run"), when="@:2.24")
-    depends_on("r-genomicranges@1.61.1:", type=("build", "run"), when="@2.26.0:")
+    depends_on("r-genomicranges@1.61.1:", type=("build", "run"), when="@2.25.1:")
     depends_on("r-genomicranges@1.21.6:", type=("build", "run"))
     depends_on("r-genomicranges@1.31.8:", type=("build", "run"), when="@1.32.3:")
-    depends_on("r-biostrings@2.77.2:", type=("build", "run"), when="@2.26.0:")
+    depends_on("r-biostrings@2.77.2:", type=("build", "run"), when="@2.25.1:")
     depends_on("r-biostrings@2.37.1:", type=("build", "run"))
     depends_on("r-biostrings@2.47.6:", type=("build", "run"), when="@1.32.3:")
     depends_on("r-biocgenerics@0.1.3:", type=("build", "run"))
@@ -60,16 +67,20 @@ class RRsamtools(RPackage):
     depends_on("r-bitops", type=("build", "run"))
     depends_on("r-biocparallel", type=("build", "run"))
     depends_on("r-rhtslib@1.16.3", type=("build", "run"), when="@2.0.3")
-    depends_on("r-rhtslib@1.17.7:", type=("build", "run"), when="@2.2.1:")
-    depends_on("r-rhtslib@1.99.3:", type=("build", "run"), when="@2.14.0:")
+    depends_on("r-rhtslib@1.17.7:1.28.0", type=("build", "run"), when="@2.2.1:2.12.0")
+    depends_on("r-rhtslib@1.99.3:2.0.0", type=("build", "run"), when="@2.14.0:2.16.0")
     depends_on("r-rhtslib@3.3.1:", type=("build", "run"), when="@2.24.0:")
     depends_on("gmake", type="build")
 
     # this is not a listed dependency but is needed
     depends_on("curl")
     depends_on("zlib-api")
+    depends_on("bzip2")
+    depends_on("xz")
 
+    conflicts("r@:4.4", when="@2.28:")
     conflicts("r@4.5.0:", when="@:2.23")
+    conflicts("r@4.6:", when="@:2.26")
 
     def patch(self):
         with working_dir("src"):

--- a/repos/spack_repo/builtin/packages/r_rsamtools/package.py
+++ b/repos/spack_repo/builtin/packages/r_rsamtools/package.py
@@ -21,7 +21,9 @@ class RRsamtools(RPackage):
     license("MIT")
 
     with default_args(get_full_repo=True):
-        version("2.24.0", commit="5fa43af28dd6ae25fbabd23e2e7329003ba53e30")
+        version("2.28.0", commit="31add2895a57afb8e120f057f0f068ca69544f87")  # bioc 3.23
+        version("2.26.0", commit="ea99fb0d9481cc7c8f2734ddefb6892abba37d59")  # bioc 3.22
+        version("2.24.1", commit="5fa43af28dd6ae25fbabd23e2e7329003ba53e30")  # bioc 3.21
         version("2.16.0", commit="3eb6d03acecb8d640ec5201cacdc322e9e0c2445")
         version("2.14.0", commit="8302eb7fa1c40384f1af5855222d94f2efbdcad1")
         version("2.12.0", commit="d6a65dd57c5a17e4c441a27492e92072f69b175e")
@@ -38,9 +40,12 @@ class RRsamtools(RPackage):
     depends_on("cxx", type="build")  # generated
 
     depends_on("r@3.5.0:", type=("build", "run"), when="@2.10.0:")
-    depends_on("r-genomeinfodb@1.1.3:", type=("build", "run"))
+    depends_on("r-seqinfo", type=("build", "run"), when="@2.26.0:")
+    depends_on("r-genomeinfodb@1.1.3:1.47", type=("build", "run"), when="@:2.24")
+    depends_on("r-genomicranges@1.61.1:", type=("build", "run"), when="@2.26.0:")
     depends_on("r-genomicranges@1.21.6:", type=("build", "run"))
     depends_on("r-genomicranges@1.31.8:", type=("build", "run"), when="@1.32.3:")
+    depends_on("r-biostrings@2.77.2:", type=("build", "run"), when="@2.26.0:")
     depends_on("r-biostrings@2.37.1:", type=("build", "run"))
     depends_on("r-biostrings@2.47.6:", type=("build", "run"), when="@1.32.3:")
     depends_on("r-biocgenerics@0.1.3:", type=("build", "run"))


### PR DESCRIPTION
r-rsamtools:
- Removed version 2.24.0. The hash for this was actually version 2.24.1.
- Added versions 2.24.1, 2.26.0, 2.28.0
- Updated dependencies.

A dependency on `r-genomicranges@1.61.1:` was also added. In order to accomplish this, I had to update r-genomicranges as well.

r-genomicranges:
- Added versions 1.62.1, 1.64.0
- Dependency on `genomeinfodb` and `xvector` were dropped, so `depends_on` lines were updated.

If you'd like me to break the r-genomicranges changes into it's own PR, let me know and I can make it happen.