### PR TITLE
bigdft-futile: Fix PyYAML path to apped "site-packages"

### DIFF
--- a/repos/spack_repo/builtin/packages/bigdft_futile/package.py
+++ b/repos/spack_repo/builtin/packages/bigdft_futile/package.py
@@ -66,7 +66,9 @@ class BigdftFutile(AutotoolsPackage, CudaPackage):
         linalg = [spec["blas"].libs.ld_flags, spec["lapack"].libs.ld_flags]
 
         python_version = spec["python"].version.up_to(2)
-        pyyaml = join_path(spec["py-pyyaml"].prefix.lib, f"python{python_version}")
+        pyyaml = join_path(
+            spec["py-pyyaml"].prefix.lib, f"python{python_version}", "site-packages"
+        )
 
         openmp_flag = []
         if spec.satisfies("+openmp"):


### PR DESCRIPTION
PyYAML could not be detected by the configure script due to the missing `site-packages` directory in the provided path.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
