### PR TITLE
multicharge: fix mctc-lib requirement

### DIFF
--- a/repos/spack_repo/builtin/packages/multicharge/package.py
+++ b/repos/spack_repo/builtin/packages/multicharge/package.py
@@ -36,8 +36,8 @@ class Multicharge(CMakePackage, MesonPackage):
     depends_on("lapack")
     depends_on("mctc-lib build_system=cmake", when="build_system=cmake")
     depends_on("mctc-lib build_system=meson", when="build_system=meson")
-    depends_on("mctc-lib@0.4.0:", when="@0.4.0:")
-    depends_on("mctc-lib@0.3:0.4", when="@0.3:")
+    depends_on("mctc-lib@0.4:", when="@0.4:")
+    depends_on("mctc-lib@0.3:0.4", when="@0.3")
 
     def url_for_version(self, version):
         if self.spec.satisfies("@:0.3.0"):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

`depends_on("mctc-lib@0.3:0.4", when="@0.3:")` will make `depends_on("mctc-lib@0.4.0:", when="@0.4.0:")` invalid bacause `@0.3:` contains versions 0.4, 0.5, etc.