### PR TITLE
spdlog, hipblaslt: Fix spdlog 1.17.0 version pairing with fmt

### DIFF
--- a/repos/spack_repo/builtin/packages/hipblaslt/package.py
+++ b/repos/spack_repo/builtin/packages/hipblaslt/package.py
@@ -179,11 +179,9 @@ class Hipblaslt(ROCmLibrary, CMakePackage):
     depends_on("py-packaging", when="@7.1:")
     depends_on("py-msgpack", when="@7.1:")
     depends_on("py-nanobind", when="@7.1:")
-    # rocroller in ROCm 7.1-7.2 fails to build with fmt 11 (consteval FMT_STRING errors).
-    # Keep spdlog/fmt on a known-compatible pair for those versions.
-    depends_on("spdlog@:1.14", when="@7.1:7.2")
-    depends_on("spdlog", when="@7.13:")
-    depends_on("fmt@11.1:", when="@7.0:")
+    depends_on("spdlog", when="@7.1:")
+    # spdlog pairs itself with fmt, but we need to exclude fmt@11 for ROCm 7.1+:
+    conflicts("fmt@11", when="@7.1:", msg="rocroller in ROCm 7.1+ fails to build with fmt 11")
 
     resource(
         name="libdivide",
@@ -225,6 +223,20 @@ class Hipblaslt(ROCmLibrary, CMakePackage):
     patch("0005-add-offload-bundler-path.patch", when="@7.1:7.2")
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        # hipBLASLt's tensilelite/extops CMake code snapshots $ENV{PATH} at
+        # configure time and bakes it verbatim (without shell-escaping) into
+        # the generated Makefiles (see
+        # projects/hipblaslt/cmake/hipblaslt_python.cmake,
+        # hipblaslt_configure_bundled_python_command()). If PATH contains
+        # entries with spaces and/or parentheses -- e.g. WSL's interop PATH
+        # entries such as "/mnt/c/Program Files (x86)/...' -- the generated
+        # recipe fails with:
+        #   /bin/sh: 1: Syntax error: "(" unexpected
+        # Such entries are never needed to build hipblaslt, so drop them.
+        for entry in os.environ.get("PATH", "").split(os.pathsep):
+            if re.search(r"[()\s]", entry):
+                env.remove_path("PATH", entry)
+
         if self.spec.satisfies("@:6.4"):
             env.set("CXX", self.spec["hip"].hipcc)
         else:
@@ -249,6 +261,14 @@ class Hipblaslt(ROCmLibrary, CMakePackage):
 
         if self.spec.satisfies("@7.1") and self.run_tests:
             env.append_flags("LDFLAGS", "-lstdc++fs")
+
+        # hipblaslt up to 7.2.x expect stdint typedefs to be available in the global
+        # namespace without including stdint.h, which is not the case in all configurations.
+        # This can lead to build failures when compiling hipblaslt with certain libraries,
+        # so we add it to the compile flags to ensure it is available:
+
+        if self.spec.satisfies("@:7.2"):
+            env.append_flags("CXXFLAGS", "-include stdint.h")
 
     def patch(self):
         purelib = self.spec["python"].package.purelib

--- a/repos/spack_repo/builtin/packages/spdlog/package.py
+++ b/repos/spack_repo/builtin/packages/spdlog/package.py
@@ -82,7 +82,8 @@ class Spdlog(CMakePackage):
     depends_on("fmt@10.2.1:10", when="@1.14")
 
     # https://github.com/gabime/spdlog/releases/tag/v1.15.0
-    depends_on("fmt@11.0.2:11", when="@1.15.0")
+    # - Updated to not leave a hole in the version range for fmt
+    depends_on("fmt@11", when="@1.15.0")
 
     # https://github.com/gabime/spdlog/releases/tag/v1.15.1
     depends_on("fmt@11.1.3:11", when="@1.15.1")
@@ -94,7 +95,10 @@ class Spdlog(CMakePackage):
     depends_on("fmt@11.2.0:11", when="@1.15.3")
 
     # https://github.com/gabime/spdlog/releases/tag/v1.16.0
-    depends_on("fmt@12.0.0:12", when="@1.16.0:")
+    depends_on("fmt@12", when="@1.16.0:")
+
+    # https://github.com/gabime/spdlog/releases#release-v1.17.0
+    depends_on("fmt@12.1.0:12", when="@1.17.0:")
 
     # spdlog@1.11.0 with fmt@10  https://github.com/gabime/spdlog/pull/2694
     patch(


### PR DESCRIPTION
Test the fix of a version conflict to pass the GitLab CI pipeline:

A helpful comment in the spdlog package.py file explains the version pairing of spdlog and fmt. The comment explains that while spdlog can work with different versions of fmt, it is best to assume that the internal fmt version is the minimum version for compatibility.

This change adds the missing version pairing for spdlog 1.17.0 with fmt. The spdlog package.py now depends on fmt 12.1 or later for spdlog 1.17.0 which is the recommended version pairing for spdlog 1.17.0 according to the comment in the spdlog package.py.

Related to it, the last pull request for hipblaslt assumed that it has
to ensure proper version pairing while as explained above it should
leave this to the spdlog recipe. The pairing added  in the pull request
conflicts with all existin spdlog/fmt pairings, so it was to possible
to concretize hipblaslt@7.1: anymore. Also update the excusion constraint
due to consteval error from the affected fmt versions to `fmt@11` after
confirmation that for hipblaslt, `fmt@11` is the broken versiion range.
For more information, see: https://github.com/fmtlib/fmt/issues/4740

In some environments, hipblaslt also fails as it uses types like uint32_t
without including stdint.h, this also adds `-include stdint.h` for it.

In WSL build hosts, the PATH might also contain characters that need
escaping like () but should not be needed, so remove such paths that
would break with the way hipBLASlt generates the PATH into makefiles.

The 1st hurdle of this PR is to pass GitLab CI: #5743 failed in the build of rocblas not finding `hipblas-common`.