### PR TITLE
thrift: Properly send openssl variant to cmake build

### DIFF
--- a/repos/spack_repo/builtin/packages/thrift/package.py
+++ b/repos/spack_repo/builtin/packages/thrift/package.py
@@ -131,6 +131,7 @@ class CMakeBuilder(CMakeBuilder):
             self.define_from_variant("WITH_NODEJS", "nodejs"),
             self.define_from_variant("WITH_PYTHON", "python"),
             self.define_from_variant("WITH_ZLIB", "zlib"),
+            self.define_from_variant("WITH_OPENSSL", "openssl"),
         ]
 
 


### PR DESCRIPTION
This PR propagates the `openssl` variant into the CMake build. With `WITH_OPENSSL` unset, thrift's CMake code will unconditionally lookup openssl and flip `WITH_OPENSSL=ON` silently. If spack's openssl is not in the dependency tree, this will find whatever openssl might be installed on the system: not what we want.

When `WITH_OPENSSL` is synced to `openssl`, this is not the case, and with an explicit `OFF` thrift will also not use the speculatively found openssl to build.