### PR TITLE
py-resampy: Add version @0.4.3

### DIFF
--- a/repos/spack_repo/builtin/packages/py_resampy/package.py
+++ b/repos/spack_repo/builtin/packages/py_resampy/package.py
@@ -24,7 +24,8 @@ class PyResampy(PythonPackage):
     depends_on("py-numba@0.32:", type=("build", "run"))
     depends_on("py-six@1.3:", type=("build", "run"))
 
-    conflicts("^python@3.1.2:",
-            when="@:0.2.2",
-            msg="python@3.1.2 dropped imp module, fixed in py-resampy@0.3.0",
-        )
+    conflicts(
+        "^python@3.1.2:",
+        when="@:0.2.2",
+        msg="python@3.1.2 dropped imp module, fixed in py-resampy@0.3.0",
+    )

--- a/repos/spack_repo/builtin/packages/py_resampy/package.py
+++ b/repos/spack_repo/builtin/packages/py_resampy/package.py
@@ -15,6 +15,7 @@ class PyResampy(PythonPackage):
 
     license("ISC")
 
+    version("0.4.3", sha256="a0d1c28398f0e55994b739650afef4e3974115edbe96cd4bb81968425e916e47")
     version("0.2.2", sha256="62af020d8a6674d8117f62320ce9470437bb1d738a5d06cd55591b69b463929e")
 
     depends_on("py-setuptools", type="build")
@@ -22,3 +23,8 @@ class PyResampy(PythonPackage):
     depends_on("py-scipy@0.13:", type=("build", "run"))
     depends_on("py-numba@0.32:", type=("build", "run"))
     depends_on("py-six@1.3:", type=("build", "run"))
+
+    conflicts("^python@3.1.2:",
+            when="@:0.2.2",
+            msg="python@3.1.2 dropped imp module, fixed in py-resampy@0.3.0",
+        )


### PR DESCRIPTION
And add conflict on py-resampy@0.2.2 when using python@3.12 as setup.py for that version of resampy uses "import imp" and the imp module was dropped in python@3.12 (see e.g.
https://docs.python.org/3/whatsnew/3.12.html#imp ) py-resampy authors addressed in next release (py-resampy@0.3.0)

Should fix #5809

@spackbot fix style

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
