### PR TITLE
ci: invite package maintainers as outside collaborators for review

### DIFF
--- a/.github/workflows/bin/spack-invite-maintainers.py
+++ b/.github/workflows/bin/spack-invite-maintainers.py
@@ -20,7 +20,7 @@ def msg(message: str, entries=()):
 
 def main():
     # Validate required environment variables
-    required_vars = ["GH_REPO", "GH_PR_NUMBER"]
+    required_vars = ["GH_REPO", "GH_PR_NUMBER", "MAINTAINER_ROLE"]
     missing_vars = [var for var in required_vars if var not in os.environ]
     if missing_vars:
         raise Exception(f"Missing required environment variables: {', '.join(missing_vars)}")
@@ -28,6 +28,7 @@ def main():
     repository = os.environ["GH_REPO"]
     pr_number = os.environ["GH_PR_NUMBER"]
     token = os.environ.get("GH_TOKEN", "")
+    maintainer_role = os.environ["MAINTAINER_ROLE"]
 
     headers = {"Accept": "application/vnd.github+json", "User-Agent": "spack-reviewers"}
     if token:
@@ -50,15 +51,10 @@ def main():
         )
     pull_request = pull_request_resp.json()
 
-    if pull_request["draft"]:
-        msg("skipping draft pull request")
+    # the workflow trigger already filters to merged PRs, but check again here just in case
+    if not pull_request["merged"]:
+        msg("pull request was not merged, skipping")
         return
-
-    existing_reviewers = {reviewer["login"] for reviewer in pull_request["requested_reviewers"]}
-    if existing_reviewers:
-        msg("existing reviewers:", existing_reviewers)
-    else:
-        msg("no existing reviewers")
 
     pull_request_files = session.get(f"{pr_url}/files", headers=headers, timeout=30)
     if pull_request_files.status_code != 200:
@@ -86,45 +82,45 @@ def main():
             msg(f"warning: {e}")
             pass
 
-    # filter maintainers to those who have triage permissions in the repo
-    # users without triage permissions are unable to review PRs
+    if not maintainers:
+        msg("no maintainers for changed packages")
+        return
+
+    # only invite maintainers who aren't collaborators: we don't want to modify existing perms
     collab_url = f"{base_url}/collaborators"
-    pingable_maintainers = {
+    non_collaborators = {
         maintainer
         for maintainer in maintainers
         if session.get(f"{collab_url}/{maintainer}", headers=headers, timeout=30).status_code
-        == 204
+        != 204
     }
 
-    non_collaborators = maintainers - pingable_maintainers
-    if non_collaborators:
-        # outside collaborator invites for package maintainers are sent by the
-        # invite-maintainers workflow when a PR touching their package merges, not here
-        msg(
-            "the following package maintainers cannot be added as reviewers "
-            "without collaborator status (invite may be pending):",
-            sorted(non_collaborators),
-        )
-
-    author = pull_request["user"]["login"]
-    reviewers = (pingable_maintainers | existing_reviewers) - {author}
-
-    if existing_reviewers == reviewers:
-        msg("reviewers already up-to-date")
+    if not non_collaborators:
+        msg("all maintainers are already collaborators")
         return
 
-    added_reviewers = reviewers - existing_reviewers
-    if added_reviewers:
-        msg("adding reviewers:", added_reviewers)
+    msg(
+        f"inviting maintainers as outside collaborators ({maintainer_role}):",
+        sorted(non_collaborators),
+    )
 
+    # invite as outside collaborators so they can perform PR reviews
+    # they will need to accept the invitation before they can review PRs / be pinged
     if token:
-        resp = session.post(
-            f"{pr_url}/requested_reviewers",
-            json={"reviewers": list(reviewers)},
-            headers=headers,
-            timeout=30,
-        )
-        resp.raise_for_status()
+        for maintainer in sorted(non_collaborators):
+            invite_resp = session.put(
+                f"{collab_url}/{maintainer}",
+                json={"permission": maintainer_role},
+                headers=headers,
+                timeout=30,
+            )
+            if invite_resp.status_code in (201, 204):
+                msg(f"invited {maintainer} as an outside collaborator ({maintainer_role})")
+            else:
+                msg(
+                    f"failed to invite {maintainer} as a collaborator "
+                    f"[{invite_resp.status_code}]: {invite_resp.text}"
+                )
 
 
 if __name__ == "__main__":

--- a/.github/workflows/bin/spack-reviewers.py
+++ b/.github/workflows/bin/spack-reviewers.py
@@ -96,12 +96,31 @@ def main():
         == 204
     }
 
-    if maintainers != pingable_maintainers:
+    non_collaborators = maintainers - pingable_maintainers
+    if non_collaborators:
         msg(
             "the following package maintainers cannot be added as reviewers "
             "(no collaborator status):",
-            sorted(maintainers - pingable_maintainers),
+            sorted(non_collaborators),
         )
+
+        # invite as outside collaborators so they can perform PR reviews
+        # they will need to accept the invitation before they can review PRs / be pinged
+        if token:
+            for maintainer in sorted(non_collaborators):
+                invite_resp = session.put(
+                    f"{collab_url}/{maintainer}",
+                    json={"permission": "triage"},
+                    headers=headers,
+                    timeout=30,
+                )
+                if invite_resp.status_code in (201, 204):
+                    msg(f"invited {maintainer} as an outside collaborator (triage)")
+                else:
+                    msg(
+                        f"failed to invite {maintainer} as a collaborator "
+                        f"[{invite_resp.status_code}]: {invite_resp.text}"
+                    )
 
     author = pull_request["user"]["login"]
     reviewers = (pingable_maintainers | existing_reviewers) - {author}

--- a/.github/workflows/bin/spack-reviewers.py
+++ b/.github/workflows/bin/spack-reviewers.py
@@ -97,34 +97,54 @@ def main():
     }
 
     non_collaborators = maintainers - pingable_maintainers
+    invalid_maintainers: set[str] = set()
     if non_collaborators:
-        # outside collaborator invites for package maintainers are sent by the
-        # invite-maintainers workflow when a PR touching their package merges, not here
-        msg(
-            "the following package maintainers cannot be added as reviewers "
-            "without collaborator status (invite may be pending):",
-            sorted(non_collaborators),
-        )
+        # 404 on the collaborator check above means non-collaborator or non-GH user
+        # find invalid GH usersnames by checking the /users API
+        invalid_maintainers = {
+            maintainer
+            for maintainer in non_collaborators
+            if session.get(
+                f"https://api.github.com/users/{maintainer}", headers=headers, timeout=30
+            ).status_code
+            != 200
+        }
+
+        pending_invite = non_collaborators - invalid_maintainers
+        if pending_invite:
+            # outside collaborator invites for package maintainers are sent by the
+            # invite-maintainers workflow when a PR touching their package merges, not here
+            msg(
+                "the following package maintainers cannot be added as reviewers "
+                "without collaborator status (invite may be pending):",
+                sorted(pending_invite),
+            )
 
     author = pull_request["user"]["login"]
     reviewers = (pingable_maintainers | existing_reviewers) - {author}
 
     if existing_reviewers == reviewers:
         msg("reviewers already up-to-date")
-        return
+    else:
+        added_reviewers = reviewers - existing_reviewers
+        if added_reviewers:
+            msg("adding reviewers:", added_reviewers)
 
-    added_reviewers = reviewers - existing_reviewers
-    if added_reviewers:
-        msg("adding reviewers:", added_reviewers)
+        if token:
+            resp = session.post(
+                f"{pr_url}/requested_reviewers",
+                json={"reviewers": list(reviewers)},
+                headers=headers,
+                timeout=30,
+            )
+            resp.raise_for_status()
 
-    if token:
-        resp = session.post(
-            f"{pr_url}/requested_reviewers",
-            json={"reviewers": list(reviewers)},
-            headers=headers,
-            timeout=30,
+    # fail the triage run on each push if a maintainer's name is invalid
+    if invalid_maintainers:
+        raise Exception(
+            "the following maintainer entries are not valid GitHub usernames: "
+            f"{sorted(invalid_maintainers)}"
         )
-        resp.raise_for_status()
 
 
 if __name__ == "__main__":

--- a/.github/workflows/invite-maintainers.yml
+++ b/.github/workflows/invite-maintainers.yml
@@ -1,0 +1,47 @@
+#-----------------------------------------------------------------------
+# DO NOT modify unless you really know what you are doing.
+#
+# See https://stackoverflow.com/a/74959635 for more info.
+# Talk to @alecbcs if you have questions/are not sure of a change's
+# possible impact to security.
+#-----------------------------------------------------------------------
+name: invite-maintainers
+on:
+  pull_request_target:
+    types: [closed]
+    branches:
+      - develop
+
+jobs:
+  invite:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          ref: develop # DO NOT CHANGE
+
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        id: generate-spackbot-token
+        with:
+          client-id: ${{ secrets.SPACKBOT_TRIAGE_CLIENT_ID }}
+          private-key: ${{ secrets.SPACKBOT_TRIAGE_PRIVATE_KEY }}
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+      - uses: ./.github/actions/checkout-spack
+
+      - name: Install Python dependencies
+        run: pip install -r .github/workflows/requirements/triage/requirements.txt
+
+      - name: Invite package maintainers as outside collaborators
+        run: |
+          . spack-core/share/spack/setup-env.sh
+          spack-python .github/workflows/bin/spack-invite-maintainers.py
+        env:
+          GH_PR_NUMBER: ${{ github.event.number }}
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ steps.generate-spackbot-token.outputs.token }}
+          MAINTAINER_ROLE: "Package Maintainer"


### PR DESCRIPTION
This PR adds a CI workflow `invite-maintainers` that invites `maintainer()` entries as [outside collaborators](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-outside-collaborators/adding-outside-collaborators-to-repositories-in-your-organization) upon a merge to `develop`.

This helps reduce the number of accounts counting towards the org license count, and with the `Package Maintainer` role, we can further control the permissions for these outside collaborators.

There's also a commit in here that checks for invalid GH usernames within the `maintainers` but can revert that if out of scope.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
