### PR TITLE
py-audioread: Add version @3.1.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_audioread/package.py
+++ b/repos/spack_repo/builtin/packages/py_audioread/package.py
@@ -25,7 +25,7 @@ class PyAudioread(PythonPackage):
     depends_on("py-pytest-runner", type="build")
 
     conflicts(
-        "^python@3.1.2:",
+        "^python@3.12:",
         when="@:3.0.0",
-        msg="python@3.1.2 dropped imp module, fixed in py-audioread@3.0.1",
+        msg="python@3.12 dropped imp, use py-audioread >= 3.0.1 for 3.12 support",
     )

--- a/repos/spack_repo/builtin/packages/py_audioread/package.py
+++ b/repos/spack_repo/builtin/packages/py_audioread/package.py
@@ -20,6 +20,7 @@ class PyAudioread(PythonPackage):
     version("2.1.8", sha256="073904fabc842881e07bd3e4a5776623535562f70b1655b635d22886168dd168")
 
     depends_on("py-setuptools", type="build")
+    depends_on("py-poetry-core",  type="build")
     # the following does not seem to be used for building but is listed in
     # setup.py
     depends_on("py-pytest-runner", type="build")

--- a/repos/spack_repo/builtin/packages/py_audioread/package.py
+++ b/repos/spack_repo/builtin/packages/py_audioread/package.py
@@ -29,3 +29,17 @@ class PyAudioread(PythonPackage):
         when="@:3.0.0",
         msg="python@3.12 dropped imp, use py-audioread >= 3.0.1 for 3.12 support",
     )
+
+    conflicts(
+        "^python@:3.8",
+        when="@3.1:",
+        msg="py-audioread >= 3.1 requires python@3.9 or later",
+    )
+
+    # This can be replaced with dependencies on py-standard-aifc, py-standard-sunau once
+    # these packages are available in spack
+    conflicts(
+        "^python@3.13:",
+        when="@3.1:",
+        msg="py-audioread requires py-standard-aifc, py-standard-sunau packages with python@3.13:",
+    )

--- a/repos/spack_repo/builtin/packages/py_audioread/package.py
+++ b/repos/spack_repo/builtin/packages/py_audioread/package.py
@@ -20,7 +20,7 @@ class PyAudioread(PythonPackage):
     version("2.1.8", sha256="073904fabc842881e07bd3e4a5776623535562f70b1655b635d22886168dd168")
 
     depends_on("py-setuptools", type="build")
-    depends_on("py-poetry-core",  type="build")
+    depends_on("py-poetry-core", type="build")
     # the following does not seem to be used for building but is listed in
     # setup.py
     depends_on("py-pytest-runner", type="build")

--- a/repos/spack_repo/builtin/packages/py_audioread/package.py
+++ b/repos/spack_repo/builtin/packages/py_audioread/package.py
@@ -24,7 +24,8 @@ class PyAudioread(PythonPackage):
     # setup.py
     depends_on("py-pytest-runner", type="build")
 
-    conflicts("^python@3.1.2:",
-            when="@:3.0.0",
-            msg="python@3.1.2 dropped imp module, fixed in py-audioread@3.0.1",
-        )
+    conflicts(
+        "^python@3.1.2:",
+        when="@:3.0.0",
+        msg="python@3.1.2 dropped imp module, fixed in py-audioread@3.0.1",
+    )

--- a/repos/spack_repo/builtin/packages/py_audioread/package.py
+++ b/repos/spack_repo/builtin/packages/py_audioread/package.py
@@ -16,9 +16,15 @@ class PyAudioread(PythonPackage):
 
     license("MIT")
 
+    version("3.1.0", sha256="1c4ab2f2972764c896a8ac61ac53e261c8d29f0c6ccd652f84e18f08a4cab190")
     version("2.1.8", sha256="073904fabc842881e07bd3e4a5776623535562f70b1655b635d22886168dd168")
 
     depends_on("py-setuptools", type="build")
     # the following does not seem to be used for building but is listed in
     # setup.py
     depends_on("py-pytest-runner", type="build")
+
+    conflicts("^python@3.1.2:",
+            when="@:3.0.0",
+            msg="python@3.1.2 dropped imp module, fixed in py-audioread@3.0.1",
+        )


### PR DESCRIPTION
Also add conflict on versions @:3.0.0 when using python@3.12 setup.py in py-audioread@:3.0.0 includes "import imp" Imp module was removed in python@3.12 (see e.g.
https://docs.python.org/3/whatsnew/3.12.html#imp )

The setup stuff was changed in py-audioread@3.0.1: which seems to resolve this issue.

This PR should fix #5812

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
