### PR TITLE
cudss: Properly support CUDA 13

### DIFF
--- a/repos/spack_repo/builtin/packages/cudss/package.py
+++ b/repos/spack_repo/builtin/packages/cudss/package.py
@@ -10,7 +10,17 @@ from spack_repo.builtin.build_systems.generic import Package
 from spack.package import *
 
 _versions = {
-    "0.7.1": {
+    "0.7.1-13": {
+        "Linux-x86_64": (
+            "84b34ebe7fad40ec10f2aab2957a63b6070bd8ce16e3ada3e6bcac7317256347",
+            "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-x86_64/libcudss-linux-x86_64-0.7.1.4_cuda13-archive.tar.xz",
+        ),
+        "Linux-aarch64": (
+            "4085361899eaf08f6b707321b33a2d5263ac986015527bef8e500f2c102f0258",
+            "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-aarch64/libcudss-linux-aarch64-0.7.1.4_cuda13-archive.tar.xz",
+        ),
+    },
+    "0.7.1-12": {
         "Linux-x86_64": (
             "946571d9ea164f948e402dd97a14541cb90fbec800336cfa7ae644af5937632f",
             "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-x86_64/libcudss-linux-x86_64-0.7.1.4_cuda12-archive.tar.xz",
@@ -20,7 +30,7 @@ _versions = {
             "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-aarch64/libcudss-linux-aarch64-0.7.1.4_cuda12-archive.tar.xz",
         ),
     },
-    "0.7.0": {
+    "0.7.0-12": {
         "Linux-x86_64": (
             "c98d5ef87e8b6a356b21a678715033b19620ce58b5fa64c97e25e6d3e76e42dc",
             "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-x86_64/libcudss-linux-x86_64-0.7.0.20_cuda12-archive.tar.xz",
@@ -30,7 +40,7 @@ _versions = {
             "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-aarch64/libcudss-linux-aarch64-0.7.0.20_cuda12-archive.tar.xz",
         ),
     },
-    "0.6.0": {
+    "0.6.0-12": {
         "Linux-x86_64": (
             "159ce1d4e3e4bba13b0bd15cf943e44b869c53b7a94f9bac980768c927f02e75",
             "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-x86_64/libcudss-linux-x86_64-0.6.0.5_cuda12-archive.tar.xz",
@@ -40,7 +50,7 @@ _versions = {
             "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-aarch64/libcudss-linux-aarch64-0.6.0.5_cuda12-archive.tar.xz",
         ),
     },
-    "0.5.0": {
+    "0.5.0-12": {
         "Linux-x86_64": (
             "5245d2ba26a590839e2f1dd074f87e39ee5cc201c3b29245b35c7060d59c37a5",
             "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-x86_64/libcudss-linux-x86_64-0.5.0.16_cuda12-archive.tar.xz",
@@ -65,8 +75,10 @@ class Cudss(Package):
 
     for ver, packages in _versions.items():
         pkg = packages.get(f"{platform.system()}-{platform.machine()}")
+        cudss_ver, cuda_ver = ver.split("-")
         if pkg:
             version(ver, sha256=pkg[0], url=pkg[1])
+            depends_on("cuda@{}".format(cuda_ver), when="@{}".format(ver))
 
     variant(
         "mpi",
@@ -74,7 +86,6 @@ class Cudss(Package):
         description="Build a communication layer for the selected MPI implementation",
     )
 
-    depends_on("cuda@12:")
     depends_on("mpi", when="+mpi")
 
     conflicts(

--- a/repos/spack_repo/builtin/packages/cudss/package.py
+++ b/repos/spack_repo/builtin/packages/cudss/package.py
@@ -10,14 +10,35 @@ from spack_repo.builtin.build_systems.generic import Package
 from spack.package import *
 
 _versions = {
+    # Versions 0.7.0+ have both CUDA 12 and CUDA 13 precompiled binary versions
+    "0.8.0-13": {
+        "Linux-x86_64": (
+            "ba18f5fd80dcbbe905d158caac5b3061d848442bb5abd477b5f296b4257a4937",
+            "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-x86_64/libcudss-linux-x86_64-0.8.0.10_cuda13-archive.tar.xz",
+        ),
+        "Linux-aarch64": (
+            "c5fe7e5796792e10c3c5971bbb169ab3040ba61fe6fc99bdcbc02cf0f1ed9409",
+            "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-sbsa/libcudss-linux-sbsa-0.8.0.10_cuda13-archive.tar.xz",
+        ),
+    },
+    "0.8.0-12": {
+        "Linux-x86_64": (
+            "29716a05c64b28531309afcb7a9dd5044081a43197e72bdd0fbf29e9b4ee4707",
+            "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-x86_64/libcudss-linux-x86_64-0.8.0.10_cuda12-archive.tar.xz",
+        ),
+        "Linux-aarch64": (
+            "11cf97c8cecf3a651bab1890894c8b8793666a17ad3002104e573efa564af231",
+            "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-aarch64/libcudss-linux-aarch64-0.8.0.10_cuda12-archive.tar.xz",
+        ),
+    },
     "0.7.1-13": {
         "Linux-x86_64": (
             "84b34ebe7fad40ec10f2aab2957a63b6070bd8ce16e3ada3e6bcac7317256347",
             "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-x86_64/libcudss-linux-x86_64-0.7.1.4_cuda13-archive.tar.xz",
         ),
         "Linux-aarch64": (
-            "4085361899eaf08f6b707321b33a2d5263ac986015527bef8e500f2c102f0258",
-            "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-aarch64/libcudss-linux-aarch64-0.7.1.4_cuda13-archive.tar.xz",
+            "de8295cb6773992bd1ca7e2ad93caae1fd18eba39175f0101b85d53abd3e0179",
+            "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-sbsa/libcudss-linux-sbsa-0.7.1.4_cuda13-archive.tar.xz",
         ),
     },
     "0.7.1-12": {
@@ -30,6 +51,16 @@ _versions = {
             "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-aarch64/libcudss-linux-aarch64-0.7.1.4_cuda12-archive.tar.xz",
         ),
     },
+    "0.7.0-13": {
+        "Linux-x86_64": (
+            "939606e8d062ee0fc28094e7be19e22191662e8593bc7f5eec16220ad836feb9",
+            "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-x86_64/libcudss-linux-x86_64-0.7.0.20_cuda13-archive.tar.xz",
+        ),
+        "Linux-aarch64": (
+            "f915eb581ab965d0baa74cd1e529086fce00e9d14d9366da4480b5ef7fabb8a6",
+            "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-sbsa/libcudss-linux-sbsa-0.7.0.20_cuda13-archive.tar.xz",
+        ),
+    },
     "0.7.0-12": {
         "Linux-x86_64": (
             "c98d5ef87e8b6a356b21a678715033b19620ce58b5fa64c97e25e6d3e76e42dc",
@@ -40,7 +71,8 @@ _versions = {
             "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-aarch64/libcudss-linux-aarch64-0.7.0.20_cuda12-archive.tar.xz",
         ),
     },
-    "0.6.0-12": {
+    # Versions 0.6.0 and older only have CUDA 12 precompiled binaries
+    "0.6.0": {
         "Linux-x86_64": (
             "159ce1d4e3e4bba13b0bd15cf943e44b869c53b7a94f9bac980768c927f02e75",
             "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-x86_64/libcudss-linux-x86_64-0.6.0.5_cuda12-archive.tar.xz",
@@ -50,7 +82,7 @@ _versions = {
             "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-aarch64/libcudss-linux-aarch64-0.6.0.5_cuda12-archive.tar.xz",
         ),
     },
-    "0.5.0-12": {
+    "0.5.0": {
         "Linux-x86_64": (
             "5245d2ba26a590839e2f1dd074f87e39ee5cc201c3b29245b35c7060d59c37a5",
             "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-x86_64/libcudss-linux-x86_64-0.5.0.16_cuda12-archive.tar.xz",
@@ -69,16 +101,22 @@ class Cudss(Package):
 
     homepage = "https://developer.nvidia.com/cudss"
 
-    maintainers("ddement")
+    maintainers("ddement", "imciner2")
 
     skip_version_audit = ["platform=darwin", "platform=windows"]
 
     for ver, packages in _versions.items():
         pkg = packages.get(f"{platform.system()}-{platform.machine()}")
-        cudss_ver, cuda_ver = ver.split("-")
         if pkg:
             version(ver, sha256=pkg[0], url=pkg[1])
-            depends_on("cuda@{}".format(cuda_ver), when="@{}".format(ver))
+
+            ver_split = ver.split("-")
+            if len(ver_split) == 2:
+                _, cuda_ver = ver_split
+                depends_on("cuda@{}".format(cuda_ver), when="@{}".format(ver))
+
+    # Versions without CUDA 13 builds
+    depends_on("cuda@12", when="@:0.6")
 
     variant(
         "mpi",


### PR DESCRIPTION
The recipe pretended to be compatible with CUDA 12+ but it would always install precompiled libraries depending on CUDA 12.

Use the same mechanism as cuDNN recipe, that is adding the CUDA version as a suffix to the cuDSS version.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
