### PR TITLE
cusparselt: Reenable CUDA 13 support

### DIFF
--- a/repos/spack_repo/builtin/packages/cusparselt/package.py
+++ b/repos/spack_repo/builtin/packages/cusparselt/package.py
@@ -17,38 +17,35 @@ class Cusparselt(Package):
 
     maintainers("thomas-bouvier")
 
-    system = platform.system().lower()
-    arch = platform.machine()
-    if "linux" in system and arch == "x86_64":
-        # version(
-        #    "0.8.1-cuda130",
-        #    sha256="82dd3e5ebc199a27011f58857a80cd825e77bba634ab2286ba3d4e13115db89a",
-        #    url="https://developer.download.nvidia.com/compute/cusparselt/redist/libcusparse_lt/linux-x86_64/libcusparse_lt-linux-x86_64-0.8.1.1_cuda13-archive.tar.xz",
-        # )
-        version(
-            "0.8.1-cuda120",
-            sha256="b34272e683e9f798435af05dc124657d1444cd0e13802c3d2f3152e31cd898a3",
-            url="https://developer.download.nvidia.com/compute/cusparselt/redist/libcusparse_lt/linux-x86_64/libcusparse_lt-linux-x86_64-0.8.1.1_cuda12-archive.tar.xz",
-        )
-    elif "linux" in system and arch == "aarch64":
-        # version(
-        #    "0.8.1-cuda130",
-        #    sha256="0fcf5808f66c71f755b4a73af2e955292e4334fec6a851eea1ac2e20878602b7",
-        #    url="https://developer.download.nvidia.com/compute/cusparselt/redist/libcusparse_lt/linux-aarch64/libcusparse_lt-linux-aarch64-0.8.1.1_cuda13-archive.tar.xz",
-        # )
-        version(
-            "0.8.1-cuda120",
-            sha256="5426a897c73a9b98a83c4e132d15abc63dc4a00f7e38266e7b82c42cd58a01e1",
-            url="https://developer.download.nvidia.com/compute/cusparselt/redist/libcusparse_lt/linux-aarch64/libcusparse_lt-linux-aarch64-0.8.1.1_cuda12-archive.tar.xz",
-        )
+    _versions = {
+        "0.8.1-13": {
+            "Linux-x86_64": (
+                "82dd3e5ebc199a27011f58857a80cd825e77bba634ab2286ba3d4e13115db89a",
+                "https://developer.download.nvidia.com/compute/cusparselt/redist/libcusparse_lt/linux-x86_64/libcusparse_lt-linux-x86_64-0.8.1.1_cuda13-archive.tar.xz",
+            ),
+            "Linux-aarch64": (
+                "0fcf5808f66c71f755b4a73af2e955292e4334fec6a851eea1ac2e20878602b7",
+                "https://developer.download.nvidia.com/compute/cusparselt/redist/libcusparse_lt/linux-aarch64/libcusparse_lt-linux-aarch64-0.8.1.1_cuda13-archive.tar.xz",
+            ),
+        },
+        "0.8.1-12": {
+            "Linux-x86_64": (
+                "b34272e683e9f798435af05dc124657d1444cd0e13802c3d2f3152e31cd898a3",
+                "https://developer.download.nvidia.com/compute/cusparselt/redist/libcusparse_lt/linux-x86_64/libcusparse_lt-linux-x86_64-0.8.1.1_cuda12-archive.tar.xz",
+            ),
+            "Linux-aarch64": (
+                "5426a897c73a9b98a83c4e132d15abc63dc4a00f7e38266e7b82c42cd58a01e1",
+                "https://developer.download.nvidia.com/compute/cusparselt/redist/libcusparse_lt/linux-aarch64/libcusparse_lt-linux-aarch64-0.8.1.1_cuda12-archive.tar.xz",
+            ),
+        },
+    }
 
-    # cuda130_versions = ("@0.8.1-cuda130",)
-    cuda120_versions = ("@0.8.1-cuda120",)
-
-    # for v in cuda130_versions:
-    #    depends_on("cuda@13", when=v, type=("build", "run"))
-    for v in cuda120_versions:
-        depends_on("cuda@12", when=v, type=("build", "run"))
+    for ver, packages in _versions.items():
+        pkg = packages.get(f"{platform.system()}-{platform.machine()}")
+        cudss_ver, cuda_ver = ver.split("-")
+        if pkg:
+            version(ver, sha256=pkg[0], url=pkg[1])
+            depends_on("cuda@{}".format(cuda_ver), when="@{}".format(ver))
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")


### PR DESCRIPTION
Use the same mechanism as the cuDNN recipe.

I have renamed the CUDA version suffix to match what is done in the cuDNN recipe but I can revert that part if the majority thinks we should keep it as is.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
