### PR TITLE
cudss: add 0.8.0, add CUDA 13 versions, fix the CUDA dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/cudss/package.py
+++ b/repos/spack_repo/builtin/packages/cudss/package.py
@@ -9,7 +9,18 @@ from spack_repo.builtin.build_systems.generic import Package
 from spack.package import *
 
 _versions = {
-    "0.7.1": {
+    # Have both CUDA 12 and CUDA 13 precompiled binary versions
+    "0.7.1-13": {
+        "Linux-x86_64": (
+            "84b34ebe7fad40ec10f2aab2957a63b6070bd8ce16e3ada3e6bcac7317256347",
+            "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-x86_64/libcudss-linux-x86_64-0.7.1.4_cuda13-archive.tar.xz",
+        ),
+        "Linux-aarch64": (
+            "de8295cb6773992bd1ca7e2ad93caae1fd18eba39175f0101b85d53abd3e0179",
+            "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-sbsa/libcudss-linux-sbsa-0.7.1.4_cuda13-archive.tar.xz",
+        ),
+    },
+    "0.7.1-12": {
         "Linux-x86_64": (
             "946571d9ea164f948e402dd97a14541cb90fbec800336cfa7ae644af5937632f",
             "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-x86_64/libcudss-linux-x86_64-0.7.1.4_cuda12-archive.tar.xz",
@@ -19,7 +30,17 @@ _versions = {
             "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-aarch64/libcudss-linux-aarch64-0.7.1.4_cuda12-archive.tar.xz",
         ),
     },
-    "0.7.0": {
+    "0.7.0-13": {
+        "Linux-x86_64": (
+            "939606e8d062ee0fc28094e7be19e22191662e8593bc7f5eec16220ad836feb9",
+            "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-x86_64/libcudss-linux-x86_64-0.7.0.20_cuda13-archive.tar.xz",
+        ),
+        "Linux-aarch64": (
+            "f915eb581ab965d0baa74cd1e529086fce00e9d14d9366da4480b5ef7fabb8a6",
+            "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-sbsa/libcudss-linux-sbsa-0.7.0.20_cuda13-archive.tar.xz",
+        ),
+    },
+    "0.7.0-12": {
         "Linux-x86_64": (
             "c98d5ef87e8b6a356b21a678715033b19620ce58b5fa64c97e25e6d3e76e42dc",
             "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-x86_64/libcudss-linux-x86_64-0.7.0.20_cuda12-archive.tar.xz",
@@ -29,6 +50,7 @@ _versions = {
             "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-aarch64/libcudss-linux-aarch64-0.7.0.20_cuda12-archive.tar.xz",
         ),
     },
+    # Only have CUDA 12 precompiled binaries
     "0.6.0": {
         "Linux-x86_64": (
             "159ce1d4e3e4bba13b0bd15cf943e44b869c53b7a94f9bac980768c927f02e75",
@@ -64,10 +86,22 @@ class Cudss(Package):
 
     for ver, packages in _versions.items():
         pkg = packages.get(f"{platform.system()}-{platform.machine()}")
+
         if pkg:
             version(ver, sha256=pkg[0], url=pkg[1])
 
-    depends_on("cuda@12:")
+            ver_parts = ver.split("-")
+
+            if len(ver_parts) > 1:
+                cudss_ver = ver_parts[0]
+                cuda_ver = Version(ver_parts[1])
+
+                long_ver = f"{cudss_ver}-{cuda_ver}"
+                depends_on(f"cuda@{cuda_ver}", when=f"@{long_ver}")
+
+    # No CUDA 13 versions
+    depends_on("cuda@12", when="@0.6")
+    depends_on("cuda@12", when="@0.5")
 
     def install(self, spec, prefix):
         install_tree(".", prefix)

--- a/repos/spack_repo/builtin/packages/cudss/package.py
+++ b/repos/spack_repo/builtin/packages/cudss/package.py
@@ -10,6 +10,26 @@ from spack.package import *
 
 _versions = {
     # Have both CUDA 12 and CUDA 13 precompiled binary versions
+    "0.8.0-13": {
+        "Linux-x86_64": (
+            "ba18f5fd80dcbbe905d158caac5b3061d848442bb5abd477b5f296b4257a4937",
+            "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-x86_64/libcudss-linux-x86_64-0.8.0.10_cuda13-archive.tar.xz",
+        ),
+        "Linux-aarch64": (
+            "c5fe7e5796792e10c3c5971bbb169ab3040ba61fe6fc99bdcbc02cf0f1ed9409",
+            "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-sbsa/libcudss-linux-sbsa-0.8.0.10_cuda13-archive.tar.xz",
+        ),
+    },
+    "0.8.0-12": {
+        "Linux-x86_64": (
+            "29716a05c64b28531309afcb7a9dd5044081a43197e72bdd0fbf29e9b4ee4707",
+            "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-x86_64/libcudss-linux-x86_64-0.8.0.10_cuda12-archive.tar.xz",
+        ),
+        "Linux-aarch64": (
+            "11cf97c8cecf3a651bab1890894c8b8793666a17ad3002104e573efa564af231",
+            "https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-aarch64/libcudss-linux-aarch64-0.8.0.10_cuda12-archive.tar.xz",
+        ),
+    },
     "0.7.1-13": {
         "Linux-x86_64": (
             "84b34ebe7fad40ec10f2aab2957a63b6070bd8ce16e3ada3e6bcac7317256347",
@@ -80,7 +100,7 @@ class Cudss(Package):
 
     homepage = "https://developer.nvidia.com/cudss"
 
-    maintainers("ddement")
+    maintainers("ddement", "imciner2")
 
     skip_version_audit = ["platform=darwin", "platform=windows"]
 


### PR DESCRIPTION
Summary by @bernhardkaindl:
- #5821 is aimed into the same direction
- This PR also adds 0.8.0 and seems to add more logic that looks like to be helpful too.
- It also adds @imciner2 as an additional maintainer, great! 👍 
- It looks like this PR superseedes 5821 (but it needs a `git` conflict resolved)
----
Implement both CUDA 12 and CUDA 13 versions of the library, following the same method used by cuDNN (appending `-12` or `-13` to the end of the version to denote which CUDA version to use). CUDA 13 aarch64 uses the new SBSA build instead of the Jetson build.

Also, add the newest 0.8.0 version.
