### PR TITLE
ollama: add 0.32.5 and fix `ollama -v` to show the version

### DIFF
--- a/repos/spack_repo/builtin/packages/ollama/package.py
+++ b/repos/spack_repo/builtin/packages/ollama/package.py
@@ -20,6 +20,7 @@ class Ollama(GoPackage, CudaPackage):
     # A shell script is run by `go generate` which assumes source is in a git
     # repo.  So we must use git VCS and not tarballs and defeat source caching.
     with default_args(no_cache=True):
+        version("0.32.5", commit="eec8e0b9458b8a01be0c216a9cc53eefde24ef50")
         version("0.20.7", commit="8d0dcf4b6daf8d7833c8b55108e5b45063795e57")
         version("0.13.1", commit="5317202c38437867bc6c9ed21ffc5c949ab6794c")
         version("0.12.11", commit="c1149875234a51aa1e5e60b74f3807f5982c60fa")
@@ -52,6 +53,7 @@ class Ollama(GoPackage, CudaPackage):
     depends_on("go@1.23.4:", type="build", when="@0.5.2:")
     depends_on("go@1.24.0:", type="build", when="@0.5.13:")
     depends_on("go@1.24.1:", type="build", when="@0.12.10:")
+    depends_on("go@1.26.0:", type="build", when="@0.23.1:")
     depends_on("git", type="build")
 
 
@@ -71,6 +73,15 @@ class GoBuilder(go.GoBuilder):
     def generate_args(self):
         """Arguments for ``go generate``."""
         return ["./..."]
+
+    @property
+    def build_args(self):
+        """Arguments for ``go build``."""
+        # Manually set the version embedded into the executable because it normally uses git tags
+        # to determine this.
+        return [
+            f"-ldflags=-w -s -X=github.com/ollama/ollama/version.Version={self.spec.version.string} -X=github.com/ollama/ollama/server.mode=release"
+        ]
 
     def generate(self, pkg, spec, prefix):
         """Runs ``go generate`` in the source directory"""

--- a/repos/spack_repo/builtin/packages/ollama/package.py
+++ b/repos/spack_repo/builtin/packages/ollama/package.py
@@ -109,8 +109,10 @@ class GoBuilder(go.GoBuilder):
         """Arguments for ``go build``."""
         # Manually set the version embedded into the executable because it normally uses git tags
         # to determine this.
+        ver = self.spec.version.string
         return [
-            f"-ldflags=-w -s -X=github.com/ollama/ollama/version.Version={self.spec.version.string} -X=github.com/ollama/ollama/server.mode=release"
+            (f"-ldflags=-w -s -X=github.com/ollama/ollama/version.Version={ver}"
+            f"-X=github.com/ollama/ollama/server.mode=release")
         ]
 
     def generate(self, pkg, spec, prefix):

--- a/repos/spack_repo/builtin/packages/ollama/package.py
+++ b/repos/spack_repo/builtin/packages/ollama/package.py
@@ -112,7 +112,7 @@ class GoBuilder(go.GoBuilder):
         ver = self.spec.version.string
         return [
             (f"-ldflags=-w -s -X=github.com/ollama/ollama/version.Version={ver}"
-            f"-X=github.com/ollama/ollama/server.mode=release")
+            f" -X=github.com/ollama/ollama/server.mode=release")
         ]
 
     def generate(self, pkg, spec, prefix):

--- a/repos/spack_repo/builtin/packages/ollama/package.py
+++ b/repos/spack_repo/builtin/packages/ollama/package.py
@@ -9,6 +9,7 @@ from spack_repo.builtin.build_systems.go import GoPackage
 
 from spack.package import *
 
+
 class Ollama(CMakePackage, GoPackage, CudaPackage):
     """Run Llama 2, Code Llama, and other models. Customize and create your own."""
 

--- a/repos/spack_repo/builtin/packages/ollama/package.py
+++ b/repos/spack_repo/builtin/packages/ollama/package.py
@@ -3,19 +3,29 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems import go
+from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.go import GoPackage
 
 from spack.package import *
 
-
-class Ollama(GoPackage, CudaPackage):
+class Ollama(CMakePackage, GoPackage, CudaPackage):
     """Run Llama 2, Code Llama, and other models. Customize and create your own."""
 
     homepage = "https://ollama.com"
     git = "https://github.com/ollama/ollama.git"
 
     maintainers("teaguesterling", "brettviren")
+
+    # Starting with 0.30, the way ollama integrates the llama server was changed,
+    # and so now it must be built by the CMake included in ollama. That CMake
+    # system will call the go builder automatically during its processing.
+    # Before that, use the go system.
+    build_system(
+        conditional("cmake", when="@0.30:"),
+        conditional("go", when="@:0.29"),
+        default="cmake",
+    )
 
     # A shell script is run by `go generate` which assumes source is in a git
     # repo.  So we must use git VCS and not tarballs and defeat source caching.
@@ -55,6 +65,25 @@ class Ollama(GoPackage, CudaPackage):
     depends_on("go@1.24.1:", type="build", when="@0.12.10:")
     depends_on("go@1.26.0:", type="build", when="@0.23.1:")
     depends_on("git", type="build")
+
+    depends_on("cuda@13", when="+cuda")
+
+    def cmake_args(self):
+        spec = self.spec
+        args = [
+            self.define("OLLAMA_VERSION", self.spec.version.string),
+        ]
+
+        if spec.satisfies("+cuda"):
+            cuda_prefix = self.spec["cuda"].prefix
+            args += [
+                self.define("CUDACXX", cuda_prefix.bin.nvcc),
+                self.define("CUDA_LIB_DIR", cuda_prefix.lib),
+                self.define("CMAKE_CUDA_ARCHITECTURES", self.spec.variants["cuda_arch"].value),
+                self.define("OLLAMA_LLAMA_BACKENDS", "cuda_v13"),
+            ]
+
+        return args
 
 
 class GoBuilder(go.GoBuilder):

--- a/repos/spack_repo/builtin/packages/ollama/package.py
+++ b/repos/spack_repo/builtin/packages/ollama/package.py
@@ -111,8 +111,10 @@ class GoBuilder(go.GoBuilder):
         # to determine this.
         ver = self.spec.version.string
         return [
-            (f"-ldflags=-w -s -X=github.com/ollama/ollama/version.Version={ver}"
-            f" -X=github.com/ollama/ollama/server.mode=release")
+            (
+                f"-ldflags=-w -s -X=github.com/ollama/ollama/version.Version={ver}"
+                f" -X=github.com/ollama/ollama/server.mode=release"
+            )
         ]
 
     def generate(self, pkg, spec, prefix):


### PR DESCRIPTION
Adds the most recent ollama version and updates the Go version dependency (based on the upstream repo, 0.23.1 was the first to require Go 1.26.0).

This also fixes the build to pass the version number into the build system to embed it in the final binary. This is based on the way it is done in the upstream ollama build steps.

Now it will show
```
$ ollama -v
Warning: could not connect to a running Ollama instance
Warning: client version is 0.32.5
```
instead of 
```
$ ollama -v
Warning: could not connect to a running Ollama instance
Warning: client version is 0.0.0
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
