### PR TITLE
xtensor: cap xsimd at 13.x for 0.26.0:0.27

### DIFF
--- a/repos/spack_repo/builtin/packages/xtensor/package.py
+++ b/repos/spack_repo/builtin/packages/xtensor/package.py
@@ -48,7 +48,14 @@ class Xtensor(CMakePackage):
     depends_on("xtl@0.3.3:0.3", when="@0.13.1")
     depends_on("xsimd", when="@develop")
 
-    depends_on("xsimd@13.2.0:", when="@0.26.0: +xsimd")
+    # NOTE: exploratory tightening (not yet upstreamed) while packaging
+    # py-proteus -- the upstream depends_on() here is an open-ended lower
+    # bound, but xtensor@0.27.1's CMakeLists.txt find_package(xsimd) call
+    # rejects xsimd@14 ("compatible with requested version 13.2.0" not
+    # satisfied by 14.3.0), so the concretizer needs an explicit upper
+    # bound to avoid picking an incompatible xsimd.
+    depends_on("xsimd@13.2.0:13", when="@0.26.0:0.27 +xsimd")
+    depends_on("xsimd@13.2.0:", when="@0.28.0: +xsimd")
     depends_on("xsimd@11.0.0:", when="@0.25 +xsimd")
     depends_on("xsimd@10.0.0:", when="@0.24.4:0.24 +xsimd")
     depends_on("xsimd@9.0.1:", when="@0.24.3:0.24 +xsimd")


### PR DESCRIPTION
xtensor's own `depends_on("xsimd@13.2.0:", when="@0.26.0: +xsimd")` is
an open-ended lower bound, but xtensor@0.27.1's CMakeLists.txt
`find_package(xsimd)` call rejects xsimd@14 ("Mismatch xtensor
versions" — it wants same-major-version 13.x). Left unconstrained, the
concretizer is free to pick xsimd@14, which produces an ambiguous-
overload compile error inside xtensor's own `xsemantic.hpp`
(`xt::xsemantic_base::operator*=`) rather than a clean configure-time
failure, since the mismatch isn't caught until actual template
instantiation.

Left `@0.28.0:` on the existing open-ended constraint since that
release is presumably compatible with xsimd@14 already (untested here
— this fix only concerns 0.26.0:0.27, which is what's confirmed
broken).

Found and reproduced while packaging `py-proteus`
(github.com/erdc/proteus): its C++ combines `xt::pyarray` operators
with this exact xtensor/xsimd/pybind11 stack.