### PR TITLE
bigdft: Improve CUDA support

### DIFF
--- a/repos/spack_repo/builtin/packages/bigdft_chess/package.py
+++ b/repos/spack_repo/builtin/packages/bigdft_chess/package.py
@@ -111,6 +111,14 @@ class BigdftChess(AutotoolsPackage, CudaPackage):
             args.append(f"--with-cuda-path={spec['cuda'].prefix}")
             args.append(f"--with-cuda-libs={spec['cuda'].libs.link_flags}")
 
+            cuda_arch = [x for x in spec.variants["cuda_arch"].value if x and x != "none"]
+            if cuda_arch:
+                args.append(
+                    "NVCC_FLAGS={0} --compiler-options {1}".format(
+                        " ".join(self.cuda_flags(cuda_arch)), self.compiler.cxx_pic_flag
+                    )
+                )
+
         if spec.satisfies("+minpack"):
             args.append("--with-minpack")
 

--- a/repos/spack_repo/builtin/packages/bigdft_core/package.py
+++ b/repos/spack_repo/builtin/packages/bigdft_core/package.py
@@ -127,6 +127,14 @@ class BigdftCore(AutotoolsPackage, CudaPackage):
             args.append(f"--with-cuda-path={spec['cuda'].prefix}")
             args.append(f"--with-cuda-libs={spec['cuda'].libs.link_flags}")
 
+            cuda_arch = [x for x in spec.variants["cuda_arch"].value if x and x != "none"]
+            if cuda_arch:
+                args.append(
+                    "NVCC_FLAGS={0} --compiler-options {1}".format(
+                        " ".join(self.cuda_flags(cuda_arch)), self.compiler.cxx_pic_flag
+                    )
+                )
+
         if spec.satisfies("+openbabel"):
             args.append("--enable-openbabel")
             args.append(f"--with-openbabel-libs={spec['openbabel'].prefix.lib}")

--- a/repos/spack_repo/builtin/packages/bigdft_futile/package.py
+++ b/repos/spack_repo/builtin/packages/bigdft_futile/package.py
@@ -102,6 +102,14 @@ class BigdftFutile(AutotoolsPackage, CudaPackage):
             args.append("--enable-cuda-gpu")
             args.append(f"--with-cuda-path={spec['cuda'].prefix}")
 
+            cuda_arch = [x for x in spec.variants["cuda_arch"].value if x and x != "none"]
+            if cuda_arch:
+                args.append(
+                    "NVCC_FLAGS={0} --compiler-options {1}".format(
+                        " ".join(self.cuda_flags(cuda_arch)), self.compiler.cxx_pic_flag
+                    )
+                )
+
         return args
 
     @property

--- a/repos/spack_repo/builtin/packages/bigdft_psolver/package.py
+++ b/repos/spack_repo/builtin/packages/bigdft_psolver/package.py
@@ -105,6 +105,14 @@ class BigdftPsolver(AutotoolsPackage, CudaPackage):
             args.append(f"--with-cuda-path={spec['cuda'].prefix}")
             args.append(f"--with-cuda-libs={spec['cuda'].libs.link_flags}")
 
+            cuda_arch = [x for x in spec.variants["cuda_arch"].value if x and x != "none"]
+            if cuda_arch:
+                args.append(
+                    "NVCC_FLAGS={0} --compiler-options {1}".format(
+                        " ".join(self.cuda_flags(cuda_arch)), self.compiler.cxx_pic_flag
+                    )
+                )
+
         return args
 
     @property


### PR DESCRIPTION
Properly handle the cuda_arch variant in order to support other architectures than the builtin SM20 default.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
