### PR TITLE
hisat2: added missing cxx dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/hisat2/package.py
+++ b/repos/spack_repo/builtin/packages/hisat2/package.py
@@ -47,6 +47,8 @@ class Hisat2(MakefilePackage):
     depends_on("sra-tools", when="+sra")
     depends_on("ncbi-vdb", when="+sra")
 
+    depends_on("cxx")
+
     # patch to get SRA working
     patch("sra.patch", when="+sra")
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
