### PR TITLE
gpu-burn: added missing depends_on("c")

### DIFF
--- a/repos/spack_repo/builtin/packages/gpu_burn/package.py
+++ b/repos/spack_repo/builtin/packages/gpu_burn/package.py
@@ -20,6 +20,7 @@ class GpuBurn(MakefilePackage, CudaPackage):
     version("1.1", sha256="9876dbf7ab17b3072e9bc657034ab39bdedb219478f57c4e93314c78ae2d6376")
     version("1.0", sha256="d55994f0bee8dabf021966dbe574ef52be1e43386faeee91318dd4ebb36aa74a")
 
+    depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
     # This package uses CudaPackage to pick up the cuda_arch variant. A side


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
