### PR TITLE
Yasm: Windows support

### DIFF
--- a/repos/spack_repo/builtin/packages/yasm/package.py
+++ b/repos/spack_repo/builtin/packages/yasm/package.py
@@ -3,11 +3,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
 
 
-class Yasm(AutotoolsPackage):
+class Yasm(AutotoolsPackage, CMakePackage):
     """Yasm is a complete rewrite of the NASM-2.11.06 assembler. It
     supports the x86 and AMD64 instruction sets, accepts NASM and
     GAS assembler syntaxes and outputs binary, ELF32 and ELF64
@@ -22,13 +23,18 @@ class Yasm(AutotoolsPackage):
     version("develop", branch="master")
     version("1.3.0", sha256="3dce6601b495f5b3d45b59f7d2492a340ee7e84b5beca17e48f862502bd5603f")
 
+    build_system("autotools", "cmake", default="autotools")
+
+    requires("build_system=cmake", when="platform=windows")
+
     # Ensure C23 compliance in boolean enum
     # https://github.com/yasm/yasm/pull/287
     patch("libyasm_bitvect_c23_bool.patch")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
-    depends_on("autoconf", when="@develop")
-    depends_on("automake", when="@develop")
-    depends_on("libtool", when="@develop")
-    depends_on("m4", when="@develop")
+    with when("build_system=autotools"):
+        depends_on("autoconf", when="@develop")
+        depends_on("automake", when="@develop")
+        depends_on("libtool", when="@develop")
+        depends_on("m4", when="@develop")


### PR DESCRIPTION
Builds yasm for Windows by adding support for yasm's existing CMake system

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
