### PR TITLE
Ceres-solver: Windows support

### DIFF
--- a/repos/spack_repo/builtin/packages/ceres_solver/package.py
+++ b/repos/spack_repo/builtin/packages/ceres_solver/package.py
@@ -2,9 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import glob
-import os
-
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *

--- a/repos/spack_repo/builtin/packages/ceres_solver/package.py
+++ b/repos/spack_repo/builtin/packages/ceres_solver/package.py
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import glob
+import os
+
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
@@ -67,5 +70,18 @@ class CeresSolver(CMakePackage):
             args.append("-DBUILD_EXAMPLES=ON")
         else:
             args.append("-DBUILD_EXAMPLES=OFF")
+
+        # Use glog's exported CMake config rather than ceres' FindGlog.cmake so
+        # that the imported target carries the correct include/link paths.
+        args.append(self.define("GLOG_PREFER_EXPORTED_GLOG_CMAKE_CONFIGURATION", True))
+        if self.spec.satisfies("platform=windows"):
+            # CUDA support in ceres @2.2.0: has no Windows build path here yet.
+            if self.spec.satisfies("@2.2.0:"):
+                args.append(self.define("USE_CUDA", False))
+
+            # Test binaries link gmock_main which pulls in gflags; gflags may be
+            # built with a different CXX ABI than the test binary, causing linker
+            # errors.
+            args.append(self.define("BUILD_TESTING", False))
 
         return args


### PR DESCRIPTION
Adds appropriate CMake arguments for windows support

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
