### PR TITLE
mothur: fix c++ standard error for all versions @1.40:, not just @1.40.5

### DIFF
--- a/repos/spack_repo/builtin/packages/mothur/package.py
+++ b/repos/spack_repo/builtin/packages/mothur/package.py
@@ -49,7 +49,7 @@ class Mothur(MakefilePackage):
         filter_file(r"^.*DMOTHUR_TOOLS.*$", "", "Makefile")
         filter_file(r"^.*DMOTHUR_FILES.*$", "", "Makefile")
         filter_file(r"(\$\(skipUchime\))", r"\1, source/", "Makefile")
-        if spec.satisfies("@1.40.5"):
+        if spec.satisfies("@1.40:"):
             filter_file(
                 r"^(#define writer_h)", "\\1 \n#include<memory>", join_path("source", "writer.h")
             )


### PR DESCRIPTION
From building mothur@1.48.0 on GCC 13, there are multiple errors of:
```
source/writer.h:24:10: error: 'shared_ptr' in namespace 'std' does not name a template type
   24 |     std::shared_ptr<SynchronizedOutputFile> sf;
      |          ^~~~~~~~~~
source/writer.h:13:1: note: 'std::shared_ptr' is defined in header '<memory>'; did you forget to '#include <memory>'?
   12 | #include "sharedwriter.hpp"
  +++ |+#include <memory>
```

The source fix previously applied for @1.40.5 ([source file from 1.40.5](https://github.com/mothur/mothur/blob/v1.40.5/source/writer.h)) really applies to all versions @1.40: ([source file from 1.40.0](https://github.com/mothur/mothur/blob/v1.40.0/source/writer.h), [source file from 1.48.6](https://github.com/mothur/mothur/blob/v1.48.6/source/writer.h), [source file from master](https://github.com/mothur/mothur/blob/master/source/writer.h)).

Related issue from upstream: https://github.com/mothur/mothur/issues/873