### PR TITLE
sra-tools: constrain libxml2 version to work around "error: expected ';', ',' or ')' before 'ATTRIBUTE_UNUSED'" and related errors

### DIFF
--- a/repos/spack_repo/builtin/packages/sra_tools/package.py
+++ b/repos/spack_repo/builtin/packages/sra_tools/package.py
@@ -23,7 +23,7 @@ class SraTools(CMakePackage):
 
     depends_on("openjdk")
     depends_on("flex@2.6:")
-    depends_on("libxml2")
+    depends_on("libxml2@:2.13")
     depends_on("ncbi-vdb")
     depends_on("ncbi-vdb@3.0.2:", when="@3.0.3:")
     depends_on("ncbi-vdb@3.3.0:", when="@3.3.0:")


### PR DESCRIPTION
In sra-tools@3.3.0, and possibly earlier versions, depending on libxml2@2.15: cause build errors such as:

```
/tmp/spack1/spack-stage/spack-stage-sra-tools-3.3.0-bvl4bnfxt3gk3pzsii2rfbzhgqmvhw2i/spack-src/libs/kxml/xml.c:174:52: error: expected ';', ',' or ')' before 'ATTRIBUTE_UNUSED'
  174 | static void s_xmlGenericErrorDefaultFunc(void *ctx ATTRIBUTE_UNUSED,
      |                                                    ^~~~~~~~~~~~~~~~
```

libxml2@:2.13 does not exhibit the same behavior.