### PR TITLE
py-tensorflow: add libclang variant

### DIFF
--- a/repos/spack_repo/builtin/packages/py_tensorflow/package.py
+++ b/repos/spack_repo/builtin/packages/py_tensorflow/package.py
@@ -179,6 +179,11 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     variant("mpi", default=False, description="Build with MPI support")
     variant("android", default=False, description="Configure for Android builds")
     variant("ios", default=False, description="Build with iOS support (macOS only)")
+    variant(
+        "libclang",
+        default=True,
+        description="Use py-libclang instead of LLVM's bundled Python clang bindings",
+    )
     variant("monolithic", default=False, description="Static monolithic build")
     variant("numa", default=False, description="Build with NUMA support")
     variant(
@@ -245,8 +250,10 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         depends_on("py-gast@0.4.0", when="@2.5:2.6")
         depends_on("py-google-pasta@0.1.1:", when="@2.7:")
         depends_on("py-google-pasta@0.2:0", when="@2.4:2.6")
-        depends_on("py-libclang@13:", when="@2.9:")
-        depends_on("py-libclang@9.0.1:", when="@2.7:2.8")
+        depends_on("py-libclang@13:", when="@2.9: +libclang")
+        depends_on("py-libclang@9.0.1:", when="@2.7:2.8 +libclang")
+        depends_on("llvm@13: +clang+python", when="@2.9: ~libclang")
+        depends_on("llvm@9.0.1: +clang+python", when="@2.7:2.8 ~libclang")
         depends_on("py-opt-einsum@2.3.2:", when="@2.7:")
         depends_on("py-opt-einsum@3.3", when="@2.4:2.6")
         depends_on("py-packaging", when="@2.9:")


### PR DESCRIPTION
This PR adds to `py-tensorflow` a new variant `libclang` that decides whether to depend on `py-libclang` or `llvm +clang +python`. The last `libclang` [on PyPI](https://pypi.org/project/libclang/) (and in spack) is now 18.1.1, and there are more recent llvm releases that can be used with tensorflow. LLVM, the project, [has taken over](https://github.com/sighingnow/libclang/issues/84) the management of the python bindings but it hasn't resulted in a newer PyPI release.

This new variant defaults to the previous behavior, but in environments that include an `llvm` for other reasons, it may result in different concretization outcomes nonetheless (since the preference for newer versions may be weighted stronger than deviations from default variants).

(Not marking as draft to trigger a gitlab pipeline to see what it does for its concretization.)