### PR TITLE
HEP CI stack: disable herwig3's vbfnlo variant due to ICE-ing gfortran-13 in develop-branch pipelines

### DIFF
--- a/stacks/hep/spack.yaml
+++ b/stacks/hep/spack.yaml
@@ -112,7 +112,9 @@ spack:
   - hepmc
   # hepmc3 fixed to 3.3.0 due to whizard, see https://github.com/spack/spack-packages/pull/427#issuecomment-3167516435
   - hepmc3@3.3.0 +interfaces +protobuf +python +rootio
-  - herwig3 +njet +vbfnlo
+  # Note: ~vbfnlo for herwig3 works around gfortran-13 ICE in CI (does not reproduce locally).
+  # Re-enable once CI environment is updated with a fix, i.e. a fixed gfortran-13+.
+  - herwig3 +njet ~vbfnlo
   - hztool
   - lcio -examples ~jar +rootdict  # Note: lcio +examples ^ncurses -termlib, which leads to conflicts
   - lhapdf +python


### PR DESCRIPTION
## Summary

Temporarily disable the `vbfnlo` variant for `herwig3` in the HEP stack to work around a `gfortran-13` internal compiler error that occurs exclusively in GitLab CI, and only in CI for develop for branch merges.

## Problem

Since PR #5718 added `herwig3+vbfnlo` to the HEP stack a week ago, all GitLab CI pipeline builds for the develop branch have been failing with:

```py
gfortran: internal compiler error: Segmentation fault signal terminated program f951
Please submit a full bug report, with preprocessed source (by using -freport-bug).
See <file:///usr/share/doc/gcc-13/README.Bugs> for instructions.
```
**The issue does not reproduce in local Docker builds**, making it difficult to create a minimal reproducer for a GCC bug report. This appears to be specific to the GitLab CI environment. This didn't reproduce the issue locally inside docker of a WSL2 VM:
```py
spack ci reproduce-build https://gitlab.spack.io/api/v4/projects/57/jobs/23603202/artifact
```

## Solution

This PR disables `vbfnlo` for `herwig3` in the HEP stack (`stacks/hep/spack.yaml`) with an inline comment documenting the workaround. The variant should be re-enabled once the CI environment is updated with fixed `gfortran-13` build or a newer gfortran version which might not show the issue.

## Evidence

The earliest failing `vbfnlo` builds can be seen in this job query:
https://gitlab.spack.io/spack/spack-packages/-/jobs?name=vbfnlo&kind=BUILD

List of fails, it shows only merges to develop as the Job's branch
(altogh I believe I've seen some of PR branch fails of it occasionally):
https://gitlab.spack.io/spack/spack-packages/-/jobs?kind=BUILD&statuses=FAILED&name=vbfnlo