### PR TITLE
readline: switch url for patch download

### DIFF
--- a/repos/spack_repo/builtin/packages/readline/package.py
+++ b/repos/spack_repo/builtin/packages/readline/package.py
@@ -73,7 +73,7 @@ class Readline(AutotoolsPackage, GNUMirrorPackage):
     ]:
         ver = Version(verstr)
         patch(
-            f"https://ftpmirror.gnu.org/readline/readline-{ver}-patches/readline{ver.joined}-{num}",
+            f"https://ftp.gnu.org/gnu/readline/readline-{ver}-patches/readline{ver.joined}-{num}",
             level=0,
             when=f"@{ver}",
             sha256=checksum,


### PR DESCRIPTION
ftpmirror.gnu.org does not work any longer

----
Added by @bernhardkaindl:

Update:
- https://ftpmirror.gnu.org/readline/readline-8.3-patches/readline83-003 is responding normally again, but it was in mostly broken state for at last 16 hours.
- We might try and see if we can update to support fallback to ftp.gnu.org for patch() urls as well as we apparently do for the main `url` of the recipe.

---
https://ftpmirror.gnu.org has had more outages recently than before:

Here are some stats you can refresh:
- https://notopening.com/site/ftp.gnu.org - Works since some downtime last week
- https://notopening.com/site/ftpmirror.gnu.org - Was down for many hours.

For me, https://ftpmirror.gnu.org/readline/readline-8.3-patches/readline83-003 currently alternates beween:
- Rarely: Working, but with a long delay of 30 seconds, 37 seconds, 48 seconds, or more.
- Most often: Timeout
- Also often: 502: Bad Gateway.

We have reports in Slack that https://ftpmirror.gnu.org didn't work on:
- July 9 and 10
- April 24, 27 and 29
- September 2, 2025
- March 24, 2025