### PR TITLE
aocc: Enhance library search for GCC multiarch layout

### DIFF
--- a/repos/spack_repo/builtin/packages/aocc/package.py
+++ b/repos/spack_repo/builtin/packages/aocc/package.py
@@ -156,6 +156,12 @@ class Aocc(Package, LlvmDetection, CompilerPackage):
             libdir = join_path(self.compiler.prefix, lib)
             if glob.glob(join_path(libdir, "libquadmath.*")):
                 return libdir
+        # search gcc multiarch layout e.g. lib/gcc/x86_64-redhat-linux/13/
+        gcc_lib = join_path(self.compiler.prefix, "lib", "gcc")
+        if os.path.isdir(gcc_lib):
+            for root, dirs, files in os.walk(gcc_lib):
+                if any(f.startswith("libquadmath") for f in files):
+                    return root
         return None
 
     def _cc_path(self):


### PR DESCRIPTION
Description: The standard libquadmath detection fails for the GNU compiler in the Cray development environment on a Cray/HPE RHEL 9.6 system

Tested on a Cray/HPE system with the following : 
```
$ spack --version
1.2.2 (3e19345b6e12f5ff1b874f4059622fc6a1fd804a)
$ spack install aocc@5.0.0+license-agreed build_system=generic platform=linux os=rhel9 target=zen3 %c,cxx,fortran=gcc@14.2.1
$ ls -1 /opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/libquadmath.so
/opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/libquadmath.so
$ /opt/cray/pe/craype/2.7.35/bin/cc -craype-verbose --version
gcc -march=znver3 --version
gcc (GCC) 14.2.1 20250110 (Red Hat 14.2.1-9)
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
$ uname -srvmpio
Linux 5.14.0-570.69.1.el9_6.x86_64 #1 SMP PREEMPT_DYNAMIC Tue Nov 25 01:30:14 EST 2025 x86_64 x86_64 x86_64 GNU/Linux
```

