### PR TITLE
root: allow ~builtin_llvm with 6.40 and newer

### DIFF
--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -463,13 +463,6 @@ class Root(CMakePackage):
         when="@:6.35",
         msg="External LLVM is only supported for ROOT 6.36+ in this spack recipe",
     )
-    # In order to avoid adding newer versions with incorrect LLVM versions,
-    # newer versions are explicitly added as conflicts as well.
-    conflicts(
-        "~builtin_llvm",
-        when="@6.39:",
-        msg="External LLVM support for ROOT 6.39+ has not been validated",
-    )
 
     # GCC 15 support was added in 6.34.04
     conflicts("%gcc@15:", when="@:6.34.02")

--- a/stacks/hep/spack.yaml
+++ b/stacks/hep/spack.yaml
@@ -147,6 +147,7 @@ spack:
   - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf ~madgraph5amc +python +rivet ~root # pythia8 and root circularly depend
   - rivet
   - root ~cuda
+  - root ~builtin_llvm
   - sherpa +analysis ~blackhat +gzip +hepmc3 +hepmc3root +lhapdf +lhole +openloops +pythia ~python ~recola ~rivet +root +ufo cxxstd=20
   - tauola +hepmc3 +lhapdf cxxstd=20
   - thepeg hepmc=3 ~rivet


### PR DESCRIPTION
This PR removes the pessimistic `root ~builtin_llvm` conflict for 6.40. The defined dependency on llvm@20 works fine (and once 6.42 is released we will need to add a dependency on llvm@22).