### PR TITLE
Kokkos: Conflict non supported archs for CUDA and HIP

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -229,7 +229,6 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         "121": ("blackwell121", "@5.1.0:"),
     }
     cuda_arches = cuda_arch_map.values()
-    conflicts("+cuda", when="cuda_arch=none")
 
     # Kokkos support only one cuda_arch at a time
     variant(
@@ -241,6 +240,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         sticky=True,
         when="+cuda",
     )
+    conflicts("+cuda", when="cuda_arch=none")
 
     cuda_support_conflict_msg = (
         "{0} is not supported; "
@@ -248,7 +248,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     )
 
     # warn early if we do not support an arch
-    for arch in CudaPackage.cuda_targets:
+    for arch in CudaPackage.cuda_arch_values:
         if arch not in cuda_arch_map:
             conflicts(
                 "+cuda", when=f"cuda_target={arch}", msg=cuda_support_conflict_msg.format(arch)
@@ -279,6 +279,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         sticky=True,
         when="+rocm",
     )
+    conflicts("+rocm", when="amdgpu_target=none")
 
     amdgpu_apu_arch_map = {"gfx942": ("amd_gfx942_apu", "@4.5.00:")}
     # warn early if we do not support an arch
@@ -322,6 +323,8 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         values=("none",) + tuple(intel_gpu_arches.keys()),
         description="Intel GPU architecture",
     )
+    conflicts("+sycl", when="intel_gpu_arch=none")
+
     # FIXME this should move to the apu part
     variant("apu", default=False, description="Enable APU support", when="@4.5: +rocm")
 

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -242,6 +242,17 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         when="+cuda",
     )
 
+    cuda_support_conflict_msg = (
+        "{0} is not supported; "
+        "Kokkos supports the following Cuda GPU targets: " + ", ".join(cuda_arch_map.keys())
+    )
+
+    for arch in CudaPackage.cuda_targets:
+        if arch not in cuda_arch_map:
+            conflicts(
+                "+cuda", when=f"cuda_target={arch}", msg=cuda_support_conflict_msg.format(arch)
+            )
+
     # amdgpu_target : (cmake_arch_option, condition)
     amdgpu_arch_map = {
         "gfx900": ("vega900", None),

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -205,7 +205,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     # ("ARMV8_THUNDERX", None),  # Cavium ThunderX
 
     # cuda_arch : (cmake_arch_option, condition)
-    spack_cuda_arch_map = {
+    cuda_arch_map = {
         "30": ("kepler30", "@:4"),
         "32": ("kepler32", "@:4"),
         "35": ("kepler35", "@:4"),
@@ -228,7 +228,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         "120": ("blackwell120", "@4.7.00:"),
         "121": ("blackwell121", "@5.1.0:"),
     }
-    cuda_arches = spack_cuda_arch_map.values()
+    cuda_arches = cuda_arch_map.values()
     conflicts("+cuda", when="cuda_arch=none")
 
     # Kokkos support only one cuda_arch at a time
@@ -466,7 +466,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         if spec.satisfies("+cuda"):
             cuda_arch = spec.variants["cuda_arch"].value
             if cuda_arch != "none":
-                kokkos_arch_name, cond = self.spack_cuda_arch_map[cuda_arch]
+                kokkos_arch_name, cond = self.cuda_arch_map[cuda_arch]
 
                 if cond and not self.spec.satisfies(cond):
                     raise SpackError(f"Unsupported CUDA arch: {cuda_arch}")

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -235,22 +235,11 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     variant(
         "cuda_arch",
         description="CUDA architecture",
-        values=("none",) + CudaPackage.cuda_arch_values,
+        values=("none",) + tuple(cuda_arch_map.keys()),
         default="none",
         multi=False,
         sticky=True,
         when="+cuda",
-    )
-
-    # Since Kokkos supports only one amdgpu_target at a time, the multi-value property is disabled.
-    variant(
-        "amdgpu_target",
-        description="AMD GPU architecture",
-        values=("none",) + ROCmPackage.amdgpu_targets,
-        default="none",
-        multi=False,
-        sticky=True,
-        when="+rocm",
     )
 
     # amdgpu_target : (cmake_arch_option, condition)
@@ -267,6 +256,18 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         "gfx1103": ("amd_gfx1103", "@4.5.00:"),
         "gfx1201": ("amd_gfx1201", "@5.0.0:"),
     }
+
+    # Since Kokkos supports only one amdgpu_target at a time, the multi-value property is disabled.
+    variant(
+        "amdgpu_target",
+        description="AMD GPU architecture",
+        values=("none",) + tuple(amdgpu_arch_map.keys()),
+        default="none",
+        multi=False,
+        sticky=True,
+        when="+rocm",
+    )
+
     amdgpu_apu_arch_map = {"gfx942": ("amd_gfx942_apu", "@4.5.00:")}
     amd_support_conflict_msg = (
         "{0} is not supported; "

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -247,6 +247,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         "Kokkos supports the following Cuda GPU targets: " + ", ".join(cuda_arch_map.keys())
     )
 
+    # warn early if we do not support an arch
     for arch in CudaPackage.cuda_targets:
         if arch not in cuda_arch_map:
             conflicts(
@@ -280,6 +281,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     )
 
     amdgpu_apu_arch_map = {"gfx942": ("amd_gfx942_apu", "@4.5.00:")}
+    # warn early if we do not support an arch
     amd_support_conflict_msg = (
         "{0} is not supported; "
         "Kokkos supports the following AMD GPU targets: " + ", ".join(amdgpu_arch_map.keys())


### PR DESCRIPTION
This PR changes the kokkos package to only display the CUDA and HIP archs we actually support.
Furthermore, it causes an error if users do not supply a gpu arch but enable the backend (added for HIP and SYCL, CUDA was already in place).

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
