### PR TITLE
Fix font-util sandboxing issue

### DIFF
--- a/repos/spack_repo/builtin/packages/font_util/package.py
+++ b/repos/spack_repo/builtin/packages/font_util/package.py
@@ -254,10 +254,15 @@ class FontUtil(AutotoolsPackage, XorgPackage):
         fonts = self.spec.variants["fonts"].value
         autoreconf = which("autoreconf", required=True)
 
+        configure = Executable("./configure")
+        destdir = join_path(self.stage.path, "dest")
         for font in fonts:
             fontroot = find(font, "*", recursive=False)
             with working_dir(fontroot[0]):
                 autoreconf(*autoconf_args)
-                configure = Executable("./configure")
                 configure(f"--prefix={self.prefix}")
-                make("install")
+                make("install", f"DESTDIR={destdir}")
+        install_tree(
+            join_path(destdir, self.prefix.lstrip("/")),
+            self.prefix,
+        )


### PR DESCRIPTION
This PR attempts to fix #5590.

This is achieved by setting the `DESTDIR` variable. This automatically disables the call to fc-cache, one can see this kind of command in the Makefile:
```
RUN_FCCACHE = @(if test -z "$(DESTDIR)"; then echo $(FCCACHE) $(fontdir); $(FCCACHE) $(fontdir); else echo "** Warning: fonts.cache not built" ; echo "** Generate this file manually on host system using fc-cache" ; fi)
```

Note that:
1. on my system it used `/usr/bin/fc-cache` instead of the binary coming from this package. This is not fixed in this PR.
2. I am not very knowledgeable on this kind of software and build system so it needs a careful review ;)