### PR TITLE
py-wxwidgets: Fix setuptools and Python bounds of older releases

### DIFF
--- a/repos/spack_repo/builtin/packages/py_wxpython/package.py
+++ b/repos/spack_repo/builtin/packages/py_wxpython/package.py
@@ -21,11 +21,26 @@ class PyWxpython(PythonPackage):
     version("4.1.1", sha256="00e5e3180ac7f2852f342ad341d57c44e7e4326de0b550b9a5c4a8361b6c3528")
     version("4.0.6", sha256="35cc8ae9dd5246e2c9861bb796026bbcb9fb083e4d49650f776622171ecdab37")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    with default_args(type="build"):
+        depends_on("c")
+        depends_on("cxx")
+        depends_on("pkgconfig")
+        # As of 4.2.4, sdists no longer ship wx/svg/_nanosvg.c
+        # https://github.com/wxWidgets/Phoenix/issues/2843
+        depends_on("py-cython", when="@4.2.4:")
+        depends_on("py-pathlib2")
+        depends_on("py-requests")
+
+        depends_on("py-setuptools")
+        depends_on("py-setuptools@:75", when="@:4.1")
+        # Older 4.2 versions use the old copy_file() function of py-setuptools@:80
+        depends_on("py-setuptools@:80", when="@4.2:4.2.4")
 
     # Versions before 4.2.3 require distutils which is removed in python 3.12
     depends_on("python@:3.11", when="@:4.2.2")
+    # See https://www.wxpython.org/news/2022-08-07-wxpython-411-release/
+    depends_on("python@:3.9", when="@:4.1")
+
     # Pre-generated Cython C files fail to build with free-threaded Python
     # https://github.com/wxWidgets/Phoenix/issues/2707
     conflicts("^python+freethreading", when="@:4.2.3")
@@ -35,17 +50,6 @@ class PyWxpython(PythonPackage):
     depends_on("wxwidgets@3.2.7 +gui", when="@4.2.3")
     depends_on("wxwidgets@3.2.8.1 +gui", when="@4.2.4")
     depends_on("wxwidgets@3.2.9 +gui", when="@4.2.5")
-
-    # Needed by the buildtools/config.py script
-    depends_on("pkgconfig", type="build")
-    # Needed for the build.py script
-    depends_on("py-setuptools", type="build")
-    depends_on("py-setuptools@:75", type="build", when="@:4.1")  # deprecated license-file
-    # As of 4.2.4, sdists no longer ship wx/svg/_nanosvg.c
-    # https://github.com/wxWidgets/Phoenix/issues/2843
-    depends_on("py-cython", type="build", when="@4.2.4:")
-    depends_on("py-pathlib2", type="build")
-    depends_on("py-requests", type="build")
 
     # Needed at runtime
     depends_on("py-numpy", type=("build", "run"))


### PR DESCRIPTION
Hi @wdconinc, as mentioned in it, a follow-up after the review of #5650 updating this package:

wxPython 4.1 only supported up to Python 3.9, add a constraint for it.

Setuptools 81 removed the 8th argument from copy_file, and older wxPython 4.2 versions used that. Add a constraint for it.

Move all build dependencies below single context manager.