### PR TITLE
py-omegaconf: add 2.3.1 and update version constraints:

### DIFF
--- a/repos/spack_repo/builtin/packages/py_omegaconf/package.py
+++ b/repos/spack_repo/builtin/packages/py_omegaconf/package.py
@@ -14,19 +14,30 @@ class PyOmegaconf(PythonPackage):
     """
 
     homepage = "https://github.com/omry/omegaconf"
-    pypi = "omegaconf/omegaconf-2.3.0.tar.gz"
+    pypi = "omegaconf/omegaconf-2.3.1.tar.gz"
 
     maintainers("calebrob6")
 
     license("BSD-3-Clause")
 
+    version("2.3.1", sha256="e5e7de64aeebeddaf8e6d3f7a783b32ac2a01c0fbd9c878012caecb891a1f42a")
     version("2.3.0", sha256="d5d4b6d29955cc50ad50c46dc269bcd92c6e00f5f90d23ab5fee7bfca4ba4cc7")
-    version("2.2.2", sha256="10a89b5cb81887d68137b69a7c5c046a060e2239af4e37f20c3935ad2e5fd865")
-    version("2.1.0", sha256="a08aec03a63c66449b550b85d70238f4dee9c6c4a0541d6a98845dcfeb12439d")
+    version("2.2.2", sha256="65c85b2a84669a570c70f2df00de3cebcd9b47a8587d3c53b1aa5766bb096f77")
+    with default_args(deprecated=True):
+        version("2.1.0", sha256="a08aec03a63c66449b550b85d70238f4dee9c6c4a0541d6a98845dcfeb12439d")
 
-    depends_on("py-setuptools", type="build")
-    depends_on("py-pytest-runner", when="@2.1", type="build")
+    # https://github.com/omry/omegaconf/releases#release-v2.1.0
+    conflicts("python@3.10:", when="@:2.1", msg="Use Omegaconf >= 2.2.2 for Python 3.10 and newer")
+
+    # https://github.com/omry/omegaconf/releases#release-v2.3.0
+    conflicts("python@3.11:", when="@:2.2", msg="Use Omegaconf >= 2.3.x for Python 3.11 and newer")
+
+    with default_args(type="build"):
+        depends_on("py-setuptools@59.6:")
+        depends_on("py-setuptools@59.6:80", when="@:2.3.0")
+        depends_on("py-pytest-runner", when="@2.1")
+        depends_on("java")
+
     depends_on("py-antlr4-python3-runtime@4.9", when="@2.2.2:", type=("build", "run"))
     depends_on("py-antlr4-python3-runtime@4.8", when="@2.1", type=("build", "run"))
     depends_on("py-pyyaml@5.1:", type=("build", "run"))
-    depends_on("java", type="build")


### PR DESCRIPTION
`py-omegaconf`: add 2.3.1 (to not depend on old `py-setuptools`) and update version constraints:
- `py-omegaconf` before `2.3.1` depends on `pkg_resources` by `py-setuptools@:80`
- sha265 of `2.2.2` has changed (verified)
- `2.1.0` only supports up to Python 3.9
- `2.2.2` only supports up to Python 3.10
- Refactor build dependencies to use `default_args(type="build")`

Cc: @calebrob6, @LydDeb 