### PR TITLE
py-nvtx: Pass spack's nvtx install location to the build

### DIFF
--- a/repos/spack_repo/builtin/packages/py_nvtx/package.py
+++ b/repos/spack_repo/builtin/packages/py_nvtx/package.py
@@ -20,3 +20,6 @@ class PyNvtx(PythonPackage):
     depends_on("py-setuptools", type="build")
     depends_on("py-cython", type="build")
     depends_on("nvtx")
+
+    def setup_build_environment(self, env):
+        env.set("NVTX_PREFIX", self.spec["nvtx"].prefix.include)


### PR DESCRIPTION
py-nvtx needs the nvtx headers, but they weren't passed to the build.

Draft: LydDeb will submit another, superseding PR which will also contain a version update.