### PR TITLE
heffte: update FFTW dependency to use fftw-api

### DIFF
--- a/repos/spack_repo/builtin/packages/heffte/package.py
+++ b/repos/spack_repo/builtin/packages/heffte/package.py
@@ -70,11 +70,7 @@ class Heffte(CMakePackage, CudaPackage, ROCmPackage):
 
     # Only the fftw@3.3.8: backend implementation is verified in current testing.
     # Alternative fftw-api providers such as amdfftw and cray-fftw have not been tested.
-    depends_on(
-        "fftw-api",
-        when="+fftw",
-        type=("build", "run")
-    )
+    depends_on("fftw-api", when="+fftw", type=("build", "run"))
     depends_on("intel-oneapi-mkl", when="+mkl", type=("build", "run"))
     # mkl renamed dfti.hpp to dft.hpp in 2026.0, which breaks heffte@2.4.1 and earlier
     conflicts("^intel-oneapi-mkl@2026.0:", when="@:2.4.1")

--- a/repos/spack_repo/builtin/packages/heffte/package.py
+++ b/repos/spack_repo/builtin/packages/heffte/package.py
@@ -68,6 +68,7 @@ class Heffte(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("mpi", type=("build", "run"))
 
+    # Only the fftw@3.3.8 and rocfft@6.4.3 backend implementation used in our current testing is verified.
     depends_on(
         "fftw-api",
         when="+fftw",

--- a/repos/spack_repo/builtin/packages/heffte/package.py
+++ b/repos/spack_repo/builtin/packages/heffte/package.py
@@ -68,7 +68,11 @@ class Heffte(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("mpi", type=("build", "run"))
 
-    depends_on("fftw@3.3.8:", when="+fftw", type=("build", "run"))
+    depends_on(
+        "fftw-api",
+        when="+fftw",
+        type=("build", "run")
+    )
     depends_on("intel-oneapi-mkl", when="+mkl", type=("build", "run"))
     # mkl renamed dfti.hpp to dft.hpp in 2026.0, which breaks heffte@2.4.1 and earlier
     conflicts("^intel-oneapi-mkl@2026.0:", when="@:2.4.1")

--- a/repos/spack_repo/builtin/packages/heffte/package.py
+++ b/repos/spack_repo/builtin/packages/heffte/package.py
@@ -68,7 +68,8 @@ class Heffte(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("mpi", type=("build", "run"))
 
-    # Only the fftw@3.3.8 and rocfft@6.4.3 backend implementation used in our current testing is verified.
+    # Only the fftw@3.3.8: backend implementation is verified in current testing.
+    # Alternative fftw-api providers such as amdfftw and cray-fftw have not been tested.
     depends_on(
         "fftw-api",
         when="+fftw",


### PR DESCRIPTION
Switch the +fftw dependency from a hardcoded fftw@3.3.8: to the fftw-api virtual package. Depending directly on fftw prevents using alternative FFTW-API providers (e.g. amdfftw, cray-fftw, etc)