### PR TITLE
namd: enable cross-compilation and fix hip compilation for version 3.0.1

### DIFF
--- a/repos/spack_repo/builtin/packages/namd/package.py
+++ b/repos/spack_repo/builtin/packages/namd/package.py
@@ -314,8 +314,18 @@ class Namd(MakefilePackage, CudaPackage, ROCmPackage):
 
         if "+rocm" in spec:
             self._copy_arch_file("hip")
+            # Enable cross-compilation
+            filter_file(
+                r"HIPCCOPTS \+= -march=native",
+                r"HIPCCOPTS += ",
+                join_path("arch", self.arch + ".hip"),
+            )
             opts.append("--with-hip")
             opts.extend(["--rocm-prefix", os.environ["ROCM_PATH"]])
+
+            # Fix hip compilation
+            if spec.satisfies("@3.0.1"):
+                filter_file(r"__syncwarp", r"__syncthreads", "src/SequencerCUDAKernel.cu")
 
             if "+single_node_gpu" in spec:
                 opts.extend(["--with-single-node-hip"])


### PR DESCRIPTION
Fix cross-compilation issue causing illegal instruction at runtime on AMD MI250X GPUs, plus a HIP compilation fix for @3.0.1.

About the fix for v3.0.1 , here is the error I had 
```
/opt/rocm-6.1.2/bin/hipcc -m64 -std=c++17 -O3 -fPIE -fexpensive-optimizations -ffast-math  -D__HIP_PLATFORM_HCC__= -D__HIP_PLATFORM_AMD__= -I/lus/home/softs/rocm/6.1.2/include -I/lus/home/softs/rocm/6.2.1/lib/llvm/lib/clang/18    -march=native -ffast-math -fno-gpu-rdc -fcuda-flush-denormals-to-zero -Wno-invalid-command-line-argument -Wno-unused-command-line-argument -Wno-invalid-constexpr -Wno-ignored-optimization-argument -Wno-unused-private-field -fdenormal-fp-math=ieee -munsafe-fp-atomics --offload-arch=gfx90a -fno-slp-vectorize -DNAMD_HIP -I/opt/rocm-6.1.2/include -I/opt/rocm-6.1.2/include/hipfft -I/opt/rocm-6.1.2/include/rocfft -I/opt/rocm-6.1.2/include/hiprand -I/opt/rocm-6.1.2/include/rocrand -I/opt/rocm-6.1.2/include/roctracer  -DNODEGROUP_FORCE_REGISTER -o obj/SequencerCUDAKernel.o -c `echo src/`SequencerCUDAKernel.cu
src/SequencerCUDAKernel.cu:4234:67: error: use of undeclared identifier '__syncwarp'; did you mean '__sync_swap'?
 4234 |         k = WarpReduce(tempStorage).Sum(k);                       __syncwarp();
      |                                                                   ^~~~~~~~~~
      |                                                                   __sync_swap
src/SequencerCUDAKernel.cu:4234:67: note: '__sync_swap' declared here
src/SequencerCUDAKernel.cu:4234:78: error: too few arguments to function call, expected at least 1, have 0
 4234 |         k = WarpReduce(tempStorage).Sum(k);                       __syncwarp();
      |                                                                   ~~~~~~~~~~ ^
src/SequencerCUDAKernel.cu:4235:67: error: use of undeclared identifier '__syncwarp'; did you mean '__sync_swap'?
 4235 |         intK = WarpReduce(tempStorage).Sum(intK);                 __syncwarp();
      |                                                                   ^~~~~~~~~~
      |                                                                   __sync_swap
src/SequencerCUDAKernel.cu:4234:67: note: '__sync_swap' declared here
 4234 |         k = WarpReduce(tempStorage).Sum(k);                       __syncwarp();
      |                                                                   ^
src/SequencerCUDAKernel.cu:4235:78: error: too few arguments to function call, expected at least 1, have 0
 4235 |         intK = WarpReduce(tempStorage).Sum(intK);                 __syncwarp();
      |                                                                   ~~~~~~~~~~ ^
src/SequencerCUDAKernel.cu:4236:67: error: use of undeclared identifier '__syncwarp'; did you mean '__sync_swap'?
 4236 |         intVNormal = WarpReduceT(tempStorageT).Sum(intVNormal);   __syncwarp();
      |                                                                   ^~~~~~~~~~
      |                                                                   __sync_swap
src/SequencerCUDAKernel.cu:4234:67: note: '__sync_swap' declared here
 4234 |         k = WarpReduce(tempStorage).Sum(k);                       __syncwarp();
      |                                                                   ^
src/SequencerCUDAKernel.cu:4236:78: error: too few arguments to function call, expected at least 1, have 0
 4236 |         intVNormal = WarpReduceT(tempStorageT).Sum(intVNormal);   __syncwarp();
      |                                                                   ~~~~~~~~~~ ^
src/SequencerCUDAKernel.cu:4237:67: error: use of undeclared identifier '__syncwarp'; did you mean '__sync_swap'?
 4237 |         rigidV = WarpReduceT(tempStorageT).Sum(rigidV);           __syncwarp();
      |                                                                   ^~~~~~~~~~
      |                                                                   __sync_swap
src/SequencerCUDAKernel.cu:4234:67: note: '__sync_swap' declared here
 4234 |         k = WarpReduce(tempStorage).Sum(k);                       __syncwarp();
      |                                                                   ^
src/SequencerCUDAKernel.cu:4237:78: error: too few arguments to function call, expected at least 1, have 0
 4237 |         rigidV = WarpReduceT(tempStorageT).Sum(rigidV);           __syncwarp();
      |                                                                   ~~~~~~~~~~ ^
src/SequencerCUDAKernel.cu:4240:67: error: use of undeclared identifier '__syncwarp'; did you mean '__sync_swap'?
 4240 |             intVNbond = WarpReduceT(tempStorageT).Sum(intVNbond); __syncwarp();
      |                                                                   ^~~~~~~~~~
      |                                                                   __sync_swap
src/SequencerCUDAKernel.cu:4234:67: note: '__sync_swap' declared here
 4234 |         k = WarpReduce(tempStorage).Sum(k);                       __syncwarp();
      |                                                                   ^
src/SequencerCUDAKernel.cu:4240:78: error: too few arguments to function call, expected at least 1, have 0
 4240 |             intVNbond = WarpReduceT(tempStorageT).Sum(intVNbond); __syncwarp();
      |                                                                   ~~~~~~~~~~ ^
src/SequencerCUDAKernel.cu:4243:67: error: use of undeclared identifier '__syncwarp'; did you mean '__sync_swap'?
 4243 |             intVSlow = WarpReduceT(tempStorageT).Sum(intVSlow);   __syncwarp();
      |                                                                   ^~~~~~~~~~
      |                                                                   __sync_swap
src/SequencerCUDAKernel.cu:4234:67: note: '__sync_swap' declared here
 4234 |         k = WarpReduce(tempStorage).Sum(k);                       __syncwarp();
      |                                                                   ^
src/SequencerCUDAKernel.cu:4243:78: error: too few arguments to function call, expected at least 1, have 0
 4243 |             intVSlow = WarpReduceT(tempStorageT).Sum(intVSlow);   __syncwarp();
```