### PR TITLE
py-scipy: disable GNU version script for NAG compiler

### DIFF
--- a/repos/spack_repo/builtin/packages/py_scipy/nag_disable_version_script.patch
+++ b/repos/spack_repo/builtin/packages/py_scipy/nag_disable_version_script.patch
@@ -1,0 +1,5 @@
+--- a/meson.build
++++ b/meson.build
+@@ -168 +168 @@
+-if cc.get_id() != 'clang-cl'
++if cc.get_id() != 'clang-cl' and ff.get_id() != 'nagfor'

--- a/repos/spack_repo/builtin/packages/py_scipy/package.py
+++ b/repos/spack_repo/builtin/packages/py_scipy/package.py
@@ -189,6 +189,10 @@ class PyScipy(PythonPackage):
         when="@1.8.0:1.14.0",
     )
 
+    # NAG forwards GNU linker flags (e.g. --version-script) to GCC without
+    # the required -Wl, prefix, causing the link step to fail.
+    patch("nag_disable_version_script.patch", when="@1.17: %nag")
+
     @property
     def archive_files(self):
         return [join_path(self.stage.source_path, "build", "meson-logs", "meson-log.txt")]

--- a/repos/spack_repo/builtin/packages/py_scipy/package.py
+++ b/repos/spack_repo/builtin/packages/py_scipy/package.py
@@ -191,7 +191,7 @@ class PyScipy(PythonPackage):
 
     # NAG forwards GNU linker flags (e.g. --version-script) to GCC without
     # the required -Wl, prefix, causing the link step to fail.
-    patch("nag_disable_version_script.patch", when="@1.17: %nag")
+    patch("nag_disable_version_script.patch", when="@1.17:1 %nag")
 
     @property
     def archive_files(self):


### PR DESCRIPTION
NAG's linker forwards GNU linker flags (like --version-script) to GCC without the required -Wl, prefix, causing the link step to fail. Add a patch to scipy's meson.build that excludes nagfor from the version-script code path, matching the existing clang-cl exclusion.

A PR has been submitted upstream to scipy to fix this in the source directly: https://github.com/scipy/scipy/pull/25804

~The patch applies cleanly to scipy 1.17.0, 1.17.1, 1.18.0, and main. I've done `@1.17:` since, well, I'm not sure if it'll get into v2.0.0 or not. Depends on the upstream.~

scipy 2.0 won't depend on Fortran (see https://github.com/scipy/scipy/pull/25804#issuecomment-5181768203) So I've clamped to v1.

Note: GPT 5.6 Terra helped me figure out this fix.



<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
