### PR TITLE
py-scipy: add submodules=True to main branch

### DIFF
--- a/repos/spack_repo/builtin/packages/py_scipy/package.py
+++ b/repos/spack_repo/builtin/packages/py_scipy/package.py
@@ -18,7 +18,7 @@ class PyScipy(PythonPackage):
 
     license("BSD-3-Clause")
 
-    version("main", branch="main")
+    version("main", branch="main", submodules=True)
     version("1.18.0", sha256="67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378")
     version("1.17.1", sha256="95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0")
     version("1.17.0", sha256="2591060c8e648d8b96439e111ac41fd8342fdeff1876be2e19dea3fe8930454e")


### PR DESCRIPTION
This PR updates `py-scipy` to use [submodules](https://github.com/scipy/scipy/blob/main/.gitmodules) when fetching the `main` version branch. Without this, we get:
```
 ../meson.build:164:2: ERROR: Problem encountered: Missing the `array_api_compat` submodule! Run `git submodule update --init` to fix this.
```

Test build:
```
zfjvl42 py-scipy@main build_system=python_pip commit=0ed8a33ce90c6a28c580e163189648d80b0e6900
```