### PR TITLE
yoda: add v2.1.3

### DIFF
--- a/repos/spack_repo/builtin/packages/yoda/package.py
+++ b/repos/spack_repo/builtin/packages/yoda/package.py
@@ -12,11 +12,13 @@ class Yoda(AutotoolsPackage):
 
     homepage = "https://yoda.hepforge.org/"
     url = "https://yoda.hepforge.org/downloads/?f=YODA-1.8.3.tar.bz2"
+    git = "https://gitlab.com/hepcedar/yoda"
 
     tags = ["hep"]
 
     license("GPL-3.0-or-later")
 
+    version("2.1.3", sha256="f840228c73936163e5414799965571a4b19620480eb5e0fa883c33d776fa3b21")
     version("2.1.2", sha256="f11c9ad00d7db5da59950c834a094eadaf886dfd9d9ccac161afd44a6a334bf1")
     version("2.1.1", sha256="012f58ee682f3037842f23a2f6deb964572214a1d647258c277e0a097c39a66b")
     version("2.1.0", sha256="eba2efa58d407e5ca60205593339cdab12b7659255020358454b0f6502d115c2")


### PR DESCRIPTION
This PR adds to `yoda` the new version 2.1.3 ([diff](https://gitlab.com/hepcedar/yoda/-/compare/yoda-2.1.2...yoda-2.1.3?from_project_id=15398980)). No changes to build system or dependencies.

Test build:
```
h5y3qvx yoda@2.1.3+hdf5+highfive build_system=autotools
```