### PR TITLE
xrootd: add v6.1.0, 6.0.3, 5.9.6

### DIFF
--- a/repos/spack_repo/builtin/packages/xrootd/package.py
+++ b/repos/spack_repo/builtin/packages/xrootd/package.py
@@ -24,7 +24,10 @@ class Xrootd(CMakePackage):
 
     license("LGPL-3.0-only")
 
+    version("6.1.0", sha256="f50a835def0c5b2ff65d377ebbeed42cf1efe243ecd599218ff441a67854859e")
+    version("6.0.3", sha256="4b02d60bdfd67177f55df2252f2463d5304fc22ae1fc33223d36f2a836d0f44e")
     version("6.0.0", sha256="bc8d00b6c0b48f9186e3ad09e8e4e6eedf1067fad68f6d6a4f4e939bcf87007c")
+    version("5.9.6", sha256="84116cfd5bc6b17381031e70220d6dedbe251fe1a3ab0a4de084a3a6bcf31353")
     version("5.9.2", sha256="e29edb755d5f728eff0c74f7bd8cec35c954239ea747975eebd9c1e2bd61edb5")
     version("5.9.1", sha256="39946509a50e790ab3fcc77ba0f4c9b66abef221262756aa8bb2494f00a0e321")
     version("5.8.4", sha256="d8716bf764a7e8103aab83fbf4906ea2cc157646b1a633d99f91edbf204ff632")


### PR DESCRIPTION
This PR adds to `xrootd` the versions v6.1.0 ([diff](https://github.com/xrootd/xrootd/compare/v6.0.3...v6.1.0)), v6.0.3 ([diff](https://github.com/xrootd/xrootd/compare/v6.0.0...v6.0.3)), v5.9.6 ([diff](https://github.com/xrootd/xrootd/compare/v5.9.2...v5.9.6)). No build system or dependency changes.

Test build:
```
[+] zwrhvrs xrootd@6.1.0 /opt/software/linux-skylake/xrootd-6.1.0-zwrhvrs6jtexq26nbxrw56hgnv7i3apw (2m52s)
```