### PR TITLE
r: older r@:4.4.2 doesn't build with too new gcc@15:

### DIFF
--- a/repos/spack_repo/builtin/packages/r/package.py
+++ b/repos/spack_repo/builtin/packages/r/package.py
@@ -102,6 +102,8 @@ class R(AutotoolsPackage):
         when="@:4.3.3",
     )
 
+    conflicts("@:4.4.2 %gcc@15:")
+
     build_directory = "spack-build"
 
     @classmethod


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

See https://github.com/spack/spack-packages/pull/5796#issuecomment-5182750904

The same error appears for entire R version range `@:4.4.2`, checked with system GCC 15.2.0, 16.0.1 from Ubuntu 26.04 and with Spack-installed GCC 15.3.0.

```sh
        | attribute_hidden NORET
   1177 | void Rstd_CleanUp(SA_TYPE saveact, int status, int runLast)
        | ^~~~
> spack-stage/spack-stage-r-4.3.0-fgy4t2jksejljcprt5kgcawbmv7rq737/spack-src/src/unix/sys-std.c:1177:1: error: expected identifier or '(' before 'void'
> make[3]: *** [../../Makeconf:129: sys-std.o] Error 1
```