### PR TITLE
collier: add v1.2.10

### DIFF
--- a/repos/spack_repo/builtin/packages/collier/package.py
+++ b/repos/spack_repo/builtin/packages/collier/package.py
@@ -21,6 +21,7 @@ class Collier(CMakePackage):
 
     license("GPL-3.0-only")
 
+    version("1.2.10", sha256="460624ea709211506b642343a7f6be41d3883ccb52598b14950f8e07c0262713")
     version("1.2.8", sha256="5cb24ce24ba1f62b7a96c655b31e9fddccc603eff31e60f9033b16354a6afd89")
     version("1.2.7", sha256="fde4b144a17c1bf5aa2ceaa86c71c79da10c9de8fec7bd33c8bffb4198acd5ca")
     version("1.2.6", sha256="b0d517868c71d2d1b8b6d3e0c370a43c9eb18ea8393a6e80070a5a2206f7de36")

--- a/repos/spack_repo/builtin/packages/collier/package.py
+++ b/repos/spack_repo/builtin/packages/collier/package.py
@@ -37,6 +37,7 @@ class Collier(CMakePackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
+    depends_on("cmake@3.5:", type="build", when="@1.2.9:")
 
     @property
     def parallel(self):


### PR DESCRIPTION
This PR adds `collier` v1.2.10 ([all releases](https://collier.hepforge.org/releasehist.html)). No build system or dependency changes beyond cmake 3.5 required as of 1.2.9. This package is built in CI.

Test build:
```
5vdrff7 collier@1.2.10~ipo build_system=cmake build_type=Release generator=make
```