### PR TITLE
recola: add v2.3.0

### DIFF
--- a/repos/spack_repo/builtin/packages/recola/package.py
+++ b/repos/spack_repo/builtin/packages/recola/package.py
@@ -18,6 +18,7 @@ class Recola(CMakePackage):
 
     homepage = "https://recola.gitlab.io/recola2/"
     url = "https://gitlab.com/recola/recola2/-/archive/2.2.4/recola2-2.2.4.tar.gz"
+    git = "https://gitlab.com/recola/recola2.git"
 
     maintainers("vvolkl")
 
@@ -25,6 +26,7 @@ class Recola(CMakePackage):
 
     license("GPL-3.0-or-later")
 
+    version("2.3.0", sha256="e979c38edad4cab68338751e860ee238292ec0a4e14e67861175612542c6fdcd")
     version("2.2.4", sha256="212ae6141bc5de38c50be3e0c6947a3b0752aeb463cf850c22cfed5e61b1a64b")
     version("2.2.3", sha256="8dc25798960c272434fcde93817ed92aad82b2a7cf07438bb4deb5688d301086")
     version("2.2.2", sha256="a64cf2b4aa213289dfab6e2255a77264f281cd0ac85f5e9770c82b815272c5c9")

--- a/stacks/hep/spack.yaml
+++ b/stacks/hep/spack.yaml
@@ -145,6 +145,7 @@ spack:
   - py-vector
   - py-zfit
   - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf ~madgraph5amc +python +rivet ~root # pythia8 and root circularly depend
+  - recola
   - rivet
   - root ~cuda
   - root ~builtin_llvm


### PR DESCRIPTION
This PR adds to `recola` the new version v2.3.0 ([diff](https://gitlab.com/recola/recola2/-/compare/2.2.5...2.3.0?from_project_id=19348946)). No build system or dependency changes.

Test build:
```
[+] d3v5vy3 recola@2.3.0 /opt/software/linux-skylake/recola-2.3.0-d3v5vy3iui22izks46ezuxsxygx6yftd (44s)
```