### PR TITLE
hoppet: add thru v2.3.0

### DIFF
--- a/repos/spack_repo/builtin/packages/hoppet/package.py
+++ b/repos/spack_repo/builtin/packages/hoppet/package.py
@@ -7,17 +7,27 @@ from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack.package import *
 
 
-class Hoppet(AutotoolsPackage):
+class Hoppet(AutotoolsPackage, CMakePackage):
     """A Fortran 95 package for carrying out QCD DGLAP evolution and other
     common manipulations of parton distribution functions (PDFs)."""
 
     homepage = "https://hoppet.hepforge.org/"
     url = "https://github.com/gavinsalam/hoppet/archive/refs/tags/hoppet-1.2.0.tar.gz"
+    git = "https://github.com/gavinsalam/hoppet.git"
 
     tags = ["hep"]
     maintainers("haralmha")
 
+    build_system(
+        conditional("autotools", when="@:1"), conditional("cmake", when="@2:"), default="cmake"
+    )
+
+    version("2.3.0", sha256="d631c63baeb66977a4fa6c79c4603fe05db1b8f6b352121f72f019183bf05ecc")  
+    version("2.2.2", sha256="b750b2b9a8eb532d7bf2c8928710762fc28fb2b4c5c1f403fd6a1af35d8c983f")  
+    version("2.1.4", sha256="5b363c4ce97f39cbfd558280412a6f9268624067059005d1f12ab14582fcf813")
+    version("2.0.1", sha256="c95a47a4d9cdf241126614ab3f330e84a2ede7288eb3599bf2fef6b80be98030")
     version("1.2.0", sha256="6e00eb56a4f922d03dfceba7b389a3aaf51f277afa46d7b634d661e0797e8898")
 
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")

--- a/repos/spack_repo/builtin/packages/hoppet/package.py
+++ b/repos/spack_repo/builtin/packages/hoppet/package.py
@@ -22,8 +22,8 @@ class Hoppet(AutotoolsPackage, CMakePackage):
         conditional("autotools", when="@:1"), conditional("cmake", when="@2:"), default="cmake"
     )
 
-    version("2.3.0", sha256="d631c63baeb66977a4fa6c79c4603fe05db1b8f6b352121f72f019183bf05ecc")  
-    version("2.2.2", sha256="b750b2b9a8eb532d7bf2c8928710762fc28fb2b4c5c1f403fd6a1af35d8c983f")  
+    version("2.3.0", sha256="d631c63baeb66977a4fa6c79c4603fe05db1b8f6b352121f72f019183bf05ecc")
+    version("2.2.2", sha256="b750b2b9a8eb532d7bf2c8928710762fc28fb2b4c5c1f403fd6a1af35d8c983f")
     version("2.1.4", sha256="5b363c4ce97f39cbfd558280412a6f9268624067059005d1f12ab14582fcf813")
     version("2.0.1", sha256="c95a47a4d9cdf241126614ab3f330e84a2ede7288eb3599bf2fef6b80be98030")
     version("1.2.0", sha256="6e00eb56a4f922d03dfceba7b389a3aaf51f277afa46d7b634d661e0797e8898")

--- a/repos/spack_repo/builtin/packages/hoppet/package.py
+++ b/repos/spack_repo/builtin/packages/hoppet/package.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
 

--- a/stacks/hep/spack.yaml
+++ b/stacks/hep/spack.yaml
@@ -115,6 +115,7 @@ spack:
   # Note: ~vbfnlo for herwig3 works around gfortran-13 ICE in CI (does not reproduce locally).
   # Re-enable once CI environment is updated with a fix, i.e. a fixed gfortran-13+.
   - herwig3 +njet ~vbfnlo
+  - hoppet
   - hztool
   - lcio -examples ~jar +rootdict  # Note: lcio +examples ^ncurses -termlib, which leads to conflicts
   - lhapdf +python


### PR DESCRIPTION
This PR adds `hoppet` versions thru v2.3.0 ([diff](https://github.com/hoppet-code/hoppet/compare/hoppet-1.2.0...hoppet-2.3.0)). Changed from autotools to cmake.

Test build:
```
[+] tsnj54v hoppet@2.3.0 /opt/software/linux-skylake/hoppet-2.3.0-tsnj54vp3swg4wt3casq6tfyj3g5icb5 (3m21s)
```