### PR TITLE
gcc: Fix build of `gcc@13: +nvptx ^cuda@13:`

### DIFF
--- a/repos/spack_repo/builtin/packages/gcc/cuda11-drops-sm_30-support.patch
+++ b/repos/spack_repo/builtin/packages/gcc/cuda11-drops-sm_30-support.patch
@@ -1,0 +1,20 @@
+--- a/gcc/config.gcc	2025-05-23 06:02:04.272197204 -0500
++++ b/gcc/config.gcc.new	2026-08-03 17:25:30.299382587 -0500
+@@ -4105,7 +4105,7 @@
+       with_arch=mips2
+       ;;
+     nvptx-*)
+-      with_arch=sm_30
++      with_arch=sm_75
+       ;;
+   esac
+ 
+@@ -5569,7 +5569,7 @@
+ 				;;
+ 			sm_35 | sm_53 | sm_70 | sm_75 | sm_80 )
+ 				# OK, but we'd like 'sm_30', too.
+-				TM_MULTILIB_CONFIG="$TM_MULTILIB_CONFIG sm_30"
++				TM_MULTILIB_CONFIG="$TM_MULTILIB_CONFIG"
+ 				;;
+ 			* )
+ 				echo "Unknown arch used in --with-arch=$with_arch" 1>&2

--- a/repos/spack_repo/builtin/packages/gcc/cuda13-drops-sm_52-support.patch
+++ b/repos/spack_repo/builtin/packages/gcc/cuda13-drops-sm_52-support.patch
@@ -1,0 +1,22 @@
+diff --git a/gcc/config.gcc b/gcc/config.gcc.new
+index 087aaa7..ad8fc1f 100644
+--- a/gcc/config.gcc
++++ b/gcc/config.gcc.new
+@@ -4132,7 +4132,7 @@ if test x$with_arch = x ; then
+       with_arch=mips2
+       ;;
+     nvptx-*)
+-      with_arch=sm_52
++      with_arch=sm_75
+       ;;
+   esac
+ 
+@@ -5593,7 +5593,7 @@ case "${target}" in
+ 	nvptx-*)
+ 		supported_defaults=arch
+ 
+-		nvptx_multilibs_default=sm_52
++		nvptx_multilibs_default=sm_75
+ 
+ 		case "x${with_multilib_list}" in
+ 		x | xno)

--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -641,6 +641,8 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
 
     # see https://gcc.gnu.org/gcc-11/changes.html 11.5 Caveats
     patch("patch-5522dec054cb940fe83661b96249aa12c54c1d77.patch", when="@11.5.0 target=aarch64:")
+    patch("cuda11-drops-sm_30-support.patch", when="@13:14 +nvptx ^cuda@13:")
+    patch("cuda13-drops-sm_52-support.patch", when="@15: +nvptx ^cuda@13:")
 
     build_directory = "spack-build"
 


### PR DESCRIPTION
Related to #3533, this seems to address the issue both with `sm_52` and a similar issue with `sm_30`. Without something like this patch, it's impossible to build a new gcc with nvptx and CUDA 13.

Edits completely welcome.