### PR TITLE
bash: switch patch download url away from ftpmirror.gnu.org

### DIFF
--- a/repos/spack_repo/builtin/packages/bash/package.py
+++ b/repos/spack_repo/builtin/packages/bash/package.py
@@ -194,7 +194,7 @@ class Bash(AutotoolsPackage, GNUMirrorPackage):
     ):
         ver = Version(verstr)
         patch(
-            f"https://ftpmirror.gnu.org/bash/bash-{ver}-patches/bash{ver.joined}-{num}",
+            f"https://ftp.gnu.org/gnu/bash/bash-{ver}-patches/bash{ver.joined}-{num}",
             level=0,
             when=f"@{ver}",
             sha256=checksum,


### PR DESCRIPTION
Same underlying issue as #5863(readline)  - bash's patch loop is still uses ftpmirror.gnu.org for constructing the URLs, which has a documented history of intermittent outages(see #5863). 
Applying the same fix: switching to ftp.gnu.org for patch downloads. 
Tested locally with `spack install bash`, patches fetch and apply successfully.