### PR TITLE
ci: audit packages against released Spack versions

### DIFF
--- a/.github/actions/checkout-spack/action.yml
+++ b/.github/actions/checkout-spack/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: Path to checkout Spack repository
     required: false
     default: spack-core
+  ref:
+    description: 'Spack ref to checkout, defaults to SPACK_CHECKOUT_VERSION from .ci/env'
+    required: false
+    default: ""
   fetch-depth:
     description: Number of commits to fetch
     required: false
@@ -21,7 +25,8 @@ runs:
       shell: bash
       run: |
         source .ci/env
-        echo "version=${SPACK_CHECKOUT_VERSION}" >> $GITHUB_OUTPUT
+        REF="${{ inputs.ref }}"
+        echo "version=${REF:-$SPACK_CHECKOUT_VERSION}" >> $GITHUB_OUTPUT
         echo "gh-repo=${SPACK_CHECKOUT_REPO}" >> $GITHUB_OUTPUT
     - name: Checkout Spack
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -14,13 +14,18 @@ concurrency:
 jobs:
   # Run audits on all the packages in the built-in repository
   package-audits:
+    name: package-audits (${{ matrix.system.os }}, ${{ matrix.spack_ref || 'pinned' }})
     runs-on: ${{ matrix.system.os }}
     strategy:
+      fail-fast: false
       matrix:
         system:
         - { os: windows-latest, shell: powershell }
         - { os: ubuntu-latest, shell: bash }
         - { os: macos-latest, shell: bash }
+        # An empty ref means the commit pinned in .ci/env, the others are the
+        # released versions we keep the packages repository compatible with
+        spack_ref: ['', 'v1.2.2']
     defaults:
       run:
         shell: ${{ matrix.system.shell }}
@@ -36,6 +41,8 @@ jobs:
       run: |
         python -m pip install --upgrade pywin32
     - uses: ./.github/actions/checkout-spack
+      with:
+        ref: ${{ matrix.spack_ref }}
     - name: Package audits
       if: ${{ runner.os != 'Windows' }}
       run: |


### PR DESCRIPTION
Make the Spack checkout a matrix axis of the audit job, and run the audits against v1.2.2 as well as the commit pinned in `.ci/env`. This gives us some confidence that we won't introduce utterly breaking changes in packages, for older Spack versions we still support (e.g. use of new directives introduced on `spack/spack` develop etc.).

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
