### PR TITLE
armpl_gcc: add v26.07

### DIFF
--- a/repos/spack_repo/builtin/packages/armpl_gcc/package.py
+++ b/repos/spack_repo/builtin/packages/armpl_gcc/package.py
@@ -58,6 +58,10 @@ _os_pkg_map = {
 }
 
 _versions = {
+    "26.07": {
+        "deb": ("6024f534554260939b369030bc4b6b47196f64bde840700b72c602e311aa7610"),
+        "rpm": ("896863e1c7be03f997c9cdfe3e8f236355111a80e4826dc53c749cb7a6fae614"),
+    },
     "26.01.1": {
         "deb": ("97bea9a6b873d7fbbe0f85150ff32fdc1d08cb3bd012ab79e687a595eb90141f"),
         "rpm": ("c1206132a02e9ddd476862e63c97f7a3cfe79281788db1d107cd5aa7287c7c8a"),


### PR DESCRIPTION
This patch adds the latest release of ArmPL to the list of available versions of the package.
