### PR TITLE
geomodel: add v6.30.0 and v6.31.0

### DIFF
--- a/repos/spack_repo/builtin/packages/geomodel/package.py
+++ b/repos/spack_repo/builtin/packages/geomodel/package.py
@@ -19,6 +19,8 @@ class Geomodel(CMakePackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    version("6.31.0", sha256="19482e850fc6a38145e0c516ded2e07826d010ae098cf2236f98125581b1c803")
+    version("6.30.0", sha256="6153a9a98388dc8f154ea95c5c0936b5e8f6891d0551e358410904a9126b488b")
     version("6.29.0", sha256="529f3a4f7ab91baea1ca5244a6d9d3ca878185db9ccf5ad3ab6622ad31568000")
     version("6.28.0", sha256="b99d3ad4fc2bddaaa73c636ac473c3ddb89384f3edf918908f47b2da85ffdaf4")
     version("6.27.0", sha256="621f7d18d39fff1d9cced1b9c985b92cb35effb5afb4072b1aac2627729f54c5")


### PR DESCRIPTION
This commit adds versions 6.30.0 and 6.31.0 of the GeoModel package.