### PR TITLE
py-pybtex-docutils: add v1.0.1, v1.0.2, v1.0.3

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pybtex_docutils/package.py
+++ b/repos/spack_repo/builtin/packages/py_pybtex_docutils/package.py
@@ -14,6 +14,9 @@ class PyPybtexDocutils(PythonPackage):
 
     license("MIT")
 
+    version("1.0.3", sha256="3a7ebdf92b593e00e8c1c538aa9a20bca5d92d84231124715acc964d51d93c6b")
+    version("1.0.2", sha256="43aa353b6d498fd5ac30f0073a98e332d061d34fe619d3d50d1761f8fd4aa016")
+    version("1.0.1", sha256="d53aa0c31dc94d61fd30ea3f06c749e6f510f9ff0e78cb2765a9300f173d8626")
     version("1.0.0", sha256="cead6554b4af99c287dd29f38b1fa152c9542f56a51cb6cbc3997c95b2725b2e")
     version("0.2.2", sha256="ea90935da188a0f4de2fe6b32930e185c33a0e306154322ccc12e519ebb5fa7d")
     version("0.2.1", sha256="e4b075641c1d68a3e98a6d73ad3d029293fcf9e0773512315ef9c8482f251337")
@@ -21,6 +24,7 @@ class PyPybtexDocutils(PythonPackage):
     depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
     depends_on("python@3.6:", type=("build", "run"), when="@1.0.0:")
     depends_on("py-setuptools", type="build")
-    depends_on("py-docutils@0.8:", type=("build", "run"))
+    depends_on("py-docutils@0.8:0.13", type=("build", "run"), when="@1:1.0.2")
+    depends_on("py-docutils@0.14:", type=("build", "run"), when="@1.0.2:")
     depends_on("py-pybtex@0.16:", type=("build", "run"))
-    depends_on("py-six", type=("build", "run"), when="@:0.2.2")
+    depends_on("py-six", type=("build", "run"), when="@:0.2")

--- a/repos/spack_repo/builtin/packages/py_pybtex_docutils/package.py
+++ b/repos/spack_repo/builtin/packages/py_pybtex_docutils/package.py
@@ -13,6 +13,7 @@ class PyPybtexDocutils(PythonPackage):
     pypi = "pybtex-docutils/pybtex-docutils-0.2.1.tar.gz"
 
     license("MIT")
+    maintainers("sethrj")
 
     version("1.0.3", sha256="3a7ebdf92b593e00e8c1c538aa9a20bca5d92d84231124715acc964d51d93c6b")
     version("1.0.2", sha256="43aa353b6d498fd5ac30f0073a98e332d061d34fe619d3d50d1761f8fd4aa016")

--- a/repos/spack_repo/builtin/packages/py_pybtex_docutils/package.py
+++ b/repos/spack_repo/builtin/packages/py_pybtex_docutils/package.py
@@ -25,7 +25,7 @@ class PyPybtexDocutils(PythonPackage):
     depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
     depends_on("python@3.6:", type=("build", "run"), when="@1.0.0:")
     depends_on("py-setuptools", type="build")
-    depends_on("py-docutils@0.8:0.13", type=("build", "run"), when="@1:1.0.2")
+    depends_on("py-docutils@0.8:0.13", type=("build", "run"), when="@1:1.0.1")
     depends_on("py-docutils@0.14:", type=("build", "run"), when="@1.0.2:")
     depends_on("py-pybtex@0.16:", type=("build", "run"))
     depends_on("py-six", type=("build", "run"), when="@:0.2")


### PR DESCRIPTION
This adds versions 1.0.1–1.0.3 which include a compatibility update for the latest sphinx. Without this update, sphinxcontrib-bibtex fails with:
```
      File "…/pybtex/richtext.py", line 894, in render
        return backend.format_href(self.url, text, self.external)
               ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    TypeError: Backend.format_href() takes 3 positional arguments but 4 were given
```