### PR TITLE
mfem: constrain compatible cuDSS versions

### DIFF
--- a/repos/spack_repo/builtin/packages/mfem/package.py
+++ b/repos/spack_repo/builtin/packages/mfem/package.py
@@ -536,8 +536,8 @@ class Mfem(Package, CudaPackage, ROCmPackage):
             "amgx~mpi cuda_arch={0}".format(sm_), when="+amgx~mpi cuda_arch={0}".format(sm_)
         )
 
-    depends_on("cudss+mpi", when="+cudss+mpi")
-    depends_on("cudss~mpi", when="+cudss~mpi")
+    depends_on("cudss@0.6:0.7.1+mpi", when="+cudss+mpi")
+    depends_on("cudss@0.5:0.7.1~mpi", when="+cudss~mpi")
 
     depends_on("enzyme@0.0.176:", when="+enzyme")
     requires("%cxx=llvm", when="+enzyme~rocm")


### PR DESCRIPTION
See https://github.com/mfem/mfem/issues/5441.

I also added the lower bounds by the compatible syntax.