### PR TITLE
libtool: prepend_path to ACLOCAL_PATH

### DIFF
--- a/repos/spack_repo/builtin/packages/libtool/package.py
+++ b/repos/spack_repo/builtin/packages/libtool/package.py
@@ -85,7 +85,7 @@ class Libtool(AutotoolsPackage, GNUMirrorPackage):
     def setup_dependent_build_environment(
         self, env: EnvironmentModifications, dependent_spec: Spec
     ) -> None:
-        env.append_path("ACLOCAL_PATH", self.prefix.share.aclocal)
+        env.prepend_path("ACLOCAL_PATH", self.prefix.share.aclocal)
 
     def setup_dependent_package(self, module, dependent_spec):
         # Automake is very likely to be a build dependency, so we add


### PR DESCRIPTION
This PR updates `libtool` to prepend instead of append to `ACLOCAL_PATH`. Since `libtool.m4` can be in the host system's `/usr/share/aclocal`, and since the system's `ACLOCAL_PATH` can include `/usr/share/local` already, appending can lead to an incorrect version of `LT_INIT` being found. In my case this affects the build of `dcap` (with a local spack addition of `libtool@2.6.2` on an ubuntu system with `libtool 2.5.4-9`):
```
  libtool: Version mismatch error.  This is libtool 2.6.2, but the
  libtool: definition of this LT_INIT comes from libtool 2.5.4.
  libtool: You should recreate aclocal.m4 with macros from libtool 2.6.2
  libtool: and run autoconf again.
> make[2]: *** [Makefile:825: dcap_accept.lo] Error 63
  make[2]: *** Waiting for unfinished jobs....
```
After this change, `dcap` installs correctly:
```
[+] rkytwuc dcap@2.47.14 /opt/software/linux-skylake/dcap-2.47.14-rkytwuczymjjbjtytl6fd2utfu5yjr7u (24s)
```