### PR TITLE
fairroot: add v18.8.3, v19.0.1; add to HEP stack

### DIFF
--- a/repos/spack_repo/builtin/packages/fairroot/package.py
+++ b/repos/spack_repo/builtin/packages/fairroot/package.py
@@ -17,7 +17,9 @@ class Fairroot(CMakePackage):
 
     tags = ["hep"]
     version("develop", branch="dev")
+    version("19.0.1", sha256="7aac7288bb68f7e37535638f3fd4cf60c2c6b4fc30350462f398bbb93e8eea52")
     version("19.0.0", sha256="6ad650ece4b673f72f4ddfe2bffeb671239c775b672b4e99673e7145ea6d8ab2")
+    version("18.8.3", sha256="495776f1c7610eb80983a19c0d6120ce1ceb86eb263ebda1a19906b91fc14b83")
     version("18.8.2", sha256="0bc9bafd9583f8a4c92977647c1eb360d66f45fbc6c81a15c5a1613640934684")
 
     variant(

--- a/stacks/hep/spack.yaml
+++ b/stacks/hep/spack.yaml
@@ -100,6 +100,7 @@ spack:
   - dpmjet
   - edm4hep
   - evtgen +hepmc3 +photos +pythia8 +sherpa +tauola
+  - fairroot
   - fastjet plugins=all
   - feynhiggs
   - fjcontrib

--- a/stacks/hep/spack.yaml
+++ b/stacks/hep/spack.yaml
@@ -100,7 +100,6 @@ spack:
   - dpmjet
   - edm4hep
   - evtgen +hepmc3 +photos +pythia8 +sherpa +tauola
-  - fairroot
   - fastjet plugins=all
   - feynhiggs
   - fjcontrib


### PR DESCRIPTION
This PR adds to `fairroot` the new bugfix versions v19.0.1 ([diff](https://github.com/FairRootGroup/FairRoot/compare/v19.0.0...v19.0.1)) and v18.8.3 ([diff](https://github.com/FairRootGroup/FairRoot/compare/v18.8.2...v18.8.3)). No build system or dependency changes (in spack, `root` has no `proof` variant anyway). Also adding this to the HEP stack.
