### PR TITLE
singularityce: force -std=gnu17 on gcc@15:

### DIFF
--- a/repos/spack_repo/builtin/packages/singularityce/package.py
+++ b/repos/spack_repo/builtin/packages/singularityce/package.py
@@ -135,6 +135,7 @@ class SingularityBase(MakefilePackage):
         if name == "cflags" and self.spec.satisfies("%gcc@15:"):
             flags.append("-std=gnu17")
         return (flags, None, None)
+
     #
     # Assemble a script that fixes the ownership and permissions of several
     # key files, install it, and tty.warn() the user.

--- a/repos/spack_repo/builtin/packages/singularityce/package.py
+++ b/repos/spack_repo/builtin/packages/singularityce/package.py
@@ -129,6 +129,12 @@ class SingularityBase(MakefilePackage):
             join_path(prefix.etc, self.singularity_name, self.singularity_name + ".conf"),
         )
 
+    def flag_handler(self, name, flags):
+        # The package does not build with C dialects newer than gnu17, so set gnu17
+        # for GCC 15 and newer which default to gnu23
+        if name == "cflags" and self.spec.satisfies("%gcc@15:"):
+            flags.append("-std=gnu17")
+        return (flags, None, None)
     #
     # Assemble a script that fixes the ownership and permissions of several
     # key files, install it, and tty.warn() the user.


### PR DESCRIPTION
singularityce fails to compile on `gcc@15:`, due to gcc moving to the c23 standard by default. singularityce also appears to have some gnu17-specific language in it, so hard-coding this to gnu17 rather than using `c17_flag`.
