### PR TITLE
apptainer: force -std=gnu17 on gcc@15:

### DIFF
--- a/repos/spack_repo/builtin/packages/apptainer/package.py
+++ b/repos/spack_repo/builtin/packages/apptainer/package.py
@@ -99,9 +99,13 @@ class Apptainer(SingularityBase):
         return options
 
     def flag_handler(self, name, flags):
+        # The package does not build with C dialects newer than gnu17, so set gnu17
+        # for GCC 15 and newer which default to gnu23
+        if name == "cflags" and self.spec.satisfies("%gcc@15:"):
+            flags.append("-std=gnu17")
         # Certain go modules this build pulls in cannot be built with anything
         # other than -O0. Best to just discard any injected flags.
-        return (None, flags, None)
+        return (flags, None, None)
 
     # They started vendoring the fuse bits and assume they'll be in the
     # libexec/apptainer prefix as a result. When singularity is run with


### PR DESCRIPTION
apptainer fails to compile on `gcc@15:`, due to gcc moving to the c23 standard by default. apptainer also appears to have some gnu17-specific language in it, so hard-coding this to gnu17 rather than using `c17_flag`.

Arguably, the other comment about using `-O0` should be removed now, but I was trying to minimize changes.