### PR TITLE
Add Spack v1.1.1 to the audit job

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -25,7 +25,7 @@ jobs:
         - { os: macos-latest, shell: bash }
         # An empty ref means the commit pinned in .ci/env, the others are the
         # released versions we keep the packages repository compatible with
-        spack_ref: ['', 'v1.2.2']
+        spack_ref: ['', 'v1.2.2', 'v1.1.1']
     defaults:
       run:
         shell: ${{ matrix.system.shell }}

--- a/repos/spack_repo/builtin/packages/boost/package.py
+++ b/repos/spack_repo/builtin/packages/boost/package.py
@@ -296,12 +296,10 @@ class Boost(Package):
     conflicts("context-impl=ucontext", when="@:1.65.0")
     conflicts("context-impl=winfib", when="@:1.65.0")
 
-    # Coroutine, Context, Fiber, etc., are not straightforward.
-    conflicts("+context", when="@:1.50")  # Context since 1.51.0.
+    # Coroutine, Context, Fiber, etc., are not straightforward. The version ranges in which
+    # these libraries exist are encoded in the "when" clauses of the variants above.
     conflicts("cxxstd=98", when="+context")  # Context requires >=C++11.
-    conflicts("+coroutine", when="@:1.52")  # Context since 1.53.0.
     conflicts("~context", when="+coroutine")  # Coroutine requires Context.
-    conflicts("+fiber", when="@:1.61")  # Fiber since 1.62.0.
     conflicts("cxxstd=98", when="+fiber")  # Fiber requires >=C++11.
     conflicts("~context", when="+fiber")  # Fiber requires Context.
 
@@ -320,9 +318,6 @@ class Boost(Package):
 
     # boost-mpi depends on boost-python since 1.87.0
     conflicts("~python", when="+mpi @1.87.0:")
-
-    # Container's Extended Allocators were not added until 1.56.0
-    conflicts("+container", when="@:1.55")
 
     # Boost.System till 1.76 (included) was relying on mutex, which was not
     # detected correctly on Darwin platform when using GCC

--- a/repos/spack_repo/builtin/packages/genesis/package.py
+++ b/repos/spack_repo/builtin/packages/genesis/package.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
@@ -74,7 +75,7 @@ class Genesis(AutotoolsPackage, CudaPackage):
         options.extend(self.enable_or_disable("hmdisk"))
         if spec.satisfies("+cuda"):
             options.append("--enable-gpu")
-            options.append("--with-cuda=%s" % spec["cuda"].prefix)
+            options.append(f"--with-cuda={spec['cuda'].prefix}")
         else:
             options.append("--disable-gpu")
         if spec.target == "a64fx" and spec.satisfies("%fj"):
@@ -105,17 +106,23 @@ class Genesis(AutotoolsPackage, CudaPackage):
     def cache_test_sources(self):
         cache_extra_test_sources(self, ["tests"])
 
-    def test(self):
-        import os
-
-        os.environ["OMP_NUM_THREADS"] = "1"
-
-        exe_name = self.spec["python"].command.path
-        test_name = join_path(self.install_test_root, "tests", "regression_test", "test.py")
-        bin_name = join_path(self.prefix.bin, "spdyn")
+    def test_regression(self):
+        """run the spdyn regression test suite"""
+        work_dir = join_path(self.cached_tests_work_dir, "regression_test")
+        script = join_path(work_dir, "test.py")
+        if not os.path.exists(script):
+            raise SkipTest("Regression test sources are not cached")
 
         mpirun = self.spec["mpi"].mpirun
+        spdyn = join_path(self.prefix.bin, "spdyn")
 
-        opts = [test_name, f"{mpirun} -np 8 {bin_name}"]
-
-        self.run_test(exe_name, options=opts, expected="Passed  61 / 61")
+        with working_dir(work_dir):
+            python = self.spec["python"].command
+            out = python(
+                script,
+                f"{mpirun} -np 8 {spdyn}",
+                extra_env={"OMP_NUM_THREADS": "1"},
+                output=str,
+                error=str,
+            )
+            check_outputs("Passed  61 / 61", out)

--- a/repos/spack_repo/builtin/packages/samrai/package.py
+++ b/repos/spack_repo/builtin/packages/samrai/package.py
@@ -153,11 +153,6 @@ class Samrai(AutotoolsPackage, CachedCMakePackage, CudaPackage):
             flags.append("-lz")
         return (flags, None, None)
 
-    def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        spec = self.spec
-        if "+cuda" in spec:
-            env.set("CUDAHOSTCXX", spack_cxx)
-
     def check(self):
         if self.spec.satisfies("+tests"):
             with working_dir(self.build_directory):
@@ -169,6 +164,10 @@ class Samrai(AutotoolsPackage, CachedCMakePackage, CudaPackage):
 
 
 class CMakeBuilder(CachedCMakeBuilder):
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        if self.spec.satisfies("+cuda"):
+            env.set("CUDAHOSTCXX", spack_cxx)
+
     @property
     def libs(self):
         libs = [
@@ -259,16 +258,20 @@ class CMakeBuilder(CachedCMakeBuilder):
 
 
 class AutotoolsBuilder(autotools.AutotoolsBuilder):
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        if self.spec.satisfies("+cuda"):
+            env.set("CUDAHOSTCXX", spack_cxx)
+
     def configure_args(self):
         options = []
         options.extend(
             [
-                "--with-CXX=%s" % self.spec["mpi"].mpicxx,
-                "--with-CC=%s" % self.spec["mpi"].mpicc,
-                "--with-F77=%s" % self.spec["mpi"].mpifc,
-                "--with-M4=%s" % self.spec["m4"].prefix,
-                "--with-hdf5=%s" % self.spec["hdf5"].prefix,
-                "--with-zlib=%s" % self.spec["zlib-api"].prefix,
+                f"--with-CXX={self.spec['mpi'].mpicxx}",
+                f"--with-CC={self.spec['mpi'].mpicc}",
+                f"--with-F77={self.spec['mpi'].mpifc}",
+                f"--with-M4={self.spec['m4'].prefix}",
+                f"--with-hdf5={self.spec['hdf5'].prefix}",
+                f"--with-zlib={self.spec['zlib-api'].prefix}",
                 "--without-blas",
                 "--without-lapack",
                 "--with-hypre=no",
@@ -286,13 +289,13 @@ class AutotoolsBuilder(autotools.AutotoolsBuilder):
             options.extend(["--enable-opt", "--disable-debug"])
 
         if "+silo" in self.spec:
-            options.append("--with-silo=%s" % self.spec["silo"].prefix)
+            options.append(f"--with-silo={self.spec['silo'].prefix}")
 
         if "+shared" in self.spec:
             options.append("--enable-shared")
 
         if self.spec.satisfies("@3.0:3.11"):
-            options.append("--with-boost=%s" % self.spec["boost"].prefix)
+            options.append(f"--with-boost={self.spec['boost'].prefix}")
 
         return options
 


### PR DESCRIPTION
Due to a change in spack/spack#52113 some redundant conflicts in `boost` are flagged in v1.1.1 and are not in v1.2.2. The difference is that in v1.1.1 we were merging the conflict with its when clause before checking.

Since these conflicts just make the audits fail, but they don't compromise anything else - boost can still be installed, the error messages don't get worse, etc. here we remove those conflicts to make the new checks pass.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
