### PR TITLE
opari2: add 2.0.10, deprecate previous versions

### DIFF
--- a/repos/spack_repo/builtin/packages/opari2/package.py
+++ b/repos/spack_repo/builtin/packages/opari2/package.py
@@ -21,17 +21,21 @@ class Opari2(AutotoolsPackage):
     homepage = "https://www.vi-hps.org/projects/score-p"
     url = "https://perftools.pages.jsc.fz-juelich.de/cicd/opari2/tags/opari2-2.0.8/opari2-2.0.8.tar.gz"
 
-    version("2.0.9", sha256="d57139f757c5666afaaead45ed3d0954a9b98c4a6cef6b22afe672707cffd779")
-    version("2.0.8", sha256="196e59a2a625e6c795a6124c61e784bad142f9f38df0b4fa4d435ba9b9c19721")
-    version("2.0.7", sha256="e302a4cc265eb2a4aa27c16a90eabd9e1e58cb02a191dd1c4d86f9a0df128715")
-    version("2.0.6", sha256="55972289ce66080bb48622110c3189a36e88a12917635f049b37685b9d3bbcb0")
-    version("2.0.5", sha256="9034dd7596ac2176401090fd5ced45d0ab9a9404444ff767f093ccce68114ef5")
-    version("2.0.4", sha256="f69e324792f66780b473daf2b3c81f58ee8188adc72b6fe0dacf43d4c1a0a131")
-    version("2.0.3", sha256="7e2efcfbc99152ee6e31454ef4fb747f77165691539d5d2c1df2abc4612de86c")
-    version("2.0.1", sha256="f49d74d7533f428a4701cd561eba8a69f60615332e81b66f01ef1c9b7ee54666")
-    version("2.0", sha256="0c4e575be05627cd001d692204f10caef37b2f3d1ec825f98cbe1bfa4232b0b7")
-    version("1.1.4", sha256="b80c04fe876faaa4ee9a0654486ecbeba516b27fc14a90d20c6384e81060cffe")
-    version("1.1.2", sha256="8405c2903730d94c828724b3a5f8889653553fb8567045a6c54ac0816237835d")
+    # OPARI2 2.x gets bugfix releases that preserve backwards compatibility for all Score-P versions
+    # still in Spack. 1.x is ancient and is deprecated in anticipation of removal.
+    # Deprecating here as a _slightly_ gentler approach than hard-bumping the version dependencies downstream.
+    version("2.0.10", sha256="49d9526bf76ebf7836e62f70850d4d605b08910dbabddac3f7479b509abce887")
+    version("2.0.9", sha256="d57139f757c5666afaaead45ed3d0954a9b98c4a6cef6b22afe672707cffd779", deprecated=True)
+    version("2.0.8", sha256="196e59a2a625e6c795a6124c61e784bad142f9f38df0b4fa4d435ba9b9c19721", deprecated=True)
+    version("2.0.7", sha256="e302a4cc265eb2a4aa27c16a90eabd9e1e58cb02a191dd1c4d86f9a0df128715", deprecated=True)
+    version("2.0.6", sha256="55972289ce66080bb48622110c3189a36e88a12917635f049b37685b9d3bbcb0", deprecated=True)
+    version("2.0.5", sha256="9034dd7596ac2176401090fd5ced45d0ab9a9404444ff767f093ccce68114ef5", deprecated=True)
+    version("2.0.4", sha256="f69e324792f66780b473daf2b3c81f58ee8188adc72b6fe0dacf43d4c1a0a131", deprecated=True)
+    version("2.0.3", sha256="7e2efcfbc99152ee6e31454ef4fb747f77165691539d5d2c1df2abc4612de86c", deprecated=True)
+    version("2.0.1", sha256="f49d74d7533f428a4701cd561eba8a69f60615332e81b66f01ef1c9b7ee54666", deprecated=True)
+    version("2.0", sha256="0c4e575be05627cd001d692204f10caef37b2f3d1ec825f98cbe1bfa4232b0b7", deprecated=True)
+    version("1.1.4", sha256="b80c04fe876faaa4ee9a0654486ecbeba516b27fc14a90d20c6384e81060cffe", deprecated=True)
+    version("1.1.2", sha256="8405c2903730d94c828724b3a5f8889653553fb8567045a6c54ac0816237835d", deprecated=True)
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/opari2/package.py
+++ b/repos/spack_repo/builtin/packages/opari2/package.py
@@ -22,8 +22,7 @@ class Opari2(AutotoolsPackage):
     url = "https://perftools.pages.jsc.fz-juelich.de/cicd/opari2/tags/opari2-2.0.8/opari2-2.0.8.tar.gz"
 
     # OPARI2 2.x gets bugfix releases that preserve backwards compatibility for all Score-P versions
-    # still in Spack. 1.x is ancient and is deprecated in anticipation of removal.
-    # Deprecating here as a _slightly_ gentler approach than hard-bumping the version dependencies downstream.
+    # still in Spack.
     version("2.0.10", sha256="49d9526bf76ebf7836e62f70850d4d605b08910dbabddac3f7479b509abce887")
     with default_args(deprecated=True):
         version("2.0.9", sha256="d57139f757c5666afaaead45ed3d0954a9b98c4a6cef6b22afe672707cffd779")

--- a/repos/spack_repo/builtin/packages/opari2/package.py
+++ b/repos/spack_repo/builtin/packages/opari2/package.py
@@ -25,17 +25,61 @@ class Opari2(AutotoolsPackage):
     # still in Spack. 1.x is ancient and is deprecated in anticipation of removal.
     # Deprecating here as a _slightly_ gentler approach than hard-bumping the version dependencies downstream.
     version("2.0.10", sha256="49d9526bf76ebf7836e62f70850d4d605b08910dbabddac3f7479b509abce887")
-    version("2.0.9", sha256="d57139f757c5666afaaead45ed3d0954a9b98c4a6cef6b22afe672707cffd779", deprecated=True)
-    version("2.0.8", sha256="196e59a2a625e6c795a6124c61e784bad142f9f38df0b4fa4d435ba9b9c19721", deprecated=True)
-    version("2.0.7", sha256="e302a4cc265eb2a4aa27c16a90eabd9e1e58cb02a191dd1c4d86f9a0df128715", deprecated=True)
-    version("2.0.6", sha256="55972289ce66080bb48622110c3189a36e88a12917635f049b37685b9d3bbcb0", deprecated=True)
-    version("2.0.5", sha256="9034dd7596ac2176401090fd5ced45d0ab9a9404444ff767f093ccce68114ef5", deprecated=True)
-    version("2.0.4", sha256="f69e324792f66780b473daf2b3c81f58ee8188adc72b6fe0dacf43d4c1a0a131", deprecated=True)
-    version("2.0.3", sha256="7e2efcfbc99152ee6e31454ef4fb747f77165691539d5d2c1df2abc4612de86c", deprecated=True)
-    version("2.0.1", sha256="f49d74d7533f428a4701cd561eba8a69f60615332e81b66f01ef1c9b7ee54666", deprecated=True)
-    version("2.0", sha256="0c4e575be05627cd001d692204f10caef37b2f3d1ec825f98cbe1bfa4232b0b7", deprecated=True)
-    version("1.1.4", sha256="b80c04fe876faaa4ee9a0654486ecbeba516b27fc14a90d20c6384e81060cffe", deprecated=True)
-    version("1.1.2", sha256="8405c2903730d94c828724b3a5f8889653553fb8567045a6c54ac0816237835d", deprecated=True)
+    version(
+        "2.0.9",
+        sha256="d57139f757c5666afaaead45ed3d0954a9b98c4a6cef6b22afe672707cffd779",
+        deprecated=True,
+    )
+    version(
+        "2.0.8",
+        sha256="196e59a2a625e6c795a6124c61e784bad142f9f38df0b4fa4d435ba9b9c19721",
+        deprecated=True,
+    )
+    version(
+        "2.0.7",
+        sha256="e302a4cc265eb2a4aa27c16a90eabd9e1e58cb02a191dd1c4d86f9a0df128715",
+        deprecated=True,
+    )
+    version(
+        "2.0.6",
+        sha256="55972289ce66080bb48622110c3189a36e88a12917635f049b37685b9d3bbcb0",
+        deprecated=True,
+    )
+    version(
+        "2.0.5",
+        sha256="9034dd7596ac2176401090fd5ced45d0ab9a9404444ff767f093ccce68114ef5",
+        deprecated=True,
+    )
+    version(
+        "2.0.4",
+        sha256="f69e324792f66780b473daf2b3c81f58ee8188adc72b6fe0dacf43d4c1a0a131",
+        deprecated=True,
+    )
+    version(
+        "2.0.3",
+        sha256="7e2efcfbc99152ee6e31454ef4fb747f77165691539d5d2c1df2abc4612de86c",
+        deprecated=True,
+    )
+    version(
+        "2.0.1",
+        sha256="f49d74d7533f428a4701cd561eba8a69f60615332e81b66f01ef1c9b7ee54666",
+        deprecated=True,
+    )
+    version(
+        "2.0",
+        sha256="0c4e575be05627cd001d692204f10caef37b2f3d1ec825f98cbe1bfa4232b0b7",
+        deprecated=True,
+    )
+    version(
+        "1.1.4",
+        sha256="b80c04fe876faaa4ee9a0654486ecbeba516b27fc14a90d20c6384e81060cffe",
+        deprecated=True,
+    )
+    version(
+        "1.1.2",
+        sha256="8405c2903730d94c828724b3a5f8889653553fb8567045a6c54ac0816237835d",
+        deprecated=True,
+    )
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/opari2/package.py
+++ b/repos/spack_repo/builtin/packages/opari2/package.py
@@ -21,8 +21,8 @@ class Opari2(AutotoolsPackage):
     homepage = "https://www.vi-hps.org/projects/score-p"
     url = "https://perftools.pages.jsc.fz-juelich.de/cicd/opari2/tags/opari2-2.0.8/opari2-2.0.8.tar.gz"
 
-    # OPARI2 2.x gets bugfix releases that preserve backwards compatibility for all Score-P versions
-    # still in Spack.
+    # OPARI2 2.x gets bugfix releases that preserve backwards compatibility
+    # for all Score-P versions still in Spack.
     version("2.0.10", sha256="49d9526bf76ebf7836e62f70850d4d605b08910dbabddac3f7479b509abce887")
     with default_args(deprecated=True):
         version("2.0.9", sha256="d57139f757c5666afaaead45ed3d0954a9b98c4a6cef6b22afe672707cffd779")

--- a/repos/spack_repo/builtin/packages/opari2/package.py
+++ b/repos/spack_repo/builtin/packages/opari2/package.py
@@ -25,8 +25,8 @@ class Opari2(AutotoolsPackage):
     # still in Spack. 1.x is ancient and is deprecated in anticipation of removal.
     # Deprecating here as a _slightly_ gentler approach than hard-bumping the version dependencies downstream.
     version("2.0.10", sha256="49d9526bf76ebf7836e62f70850d4d605b08910dbabddac3f7479b509abce887")
-    version("2.0.9", sha256="d57139f757c5666afaaead45ed3d0954a9b98c4a6cef6b22afe672707cffd779")
     with default_args(deprecated=True):
+        version("2.0.9", sha256="d57139f757c5666afaaead45ed3d0954a9b98c4a6cef6b22afe672707cffd779")
         version("2.0.8", sha256="196e59a2a625e6c795a6124c61e784bad142f9f38df0b4fa4d435ba9b9c19721")
         version("2.0.7", sha256="e302a4cc265eb2a4aa27c16a90eabd9e1e58cb02a191dd1c4d86f9a0df128715")
         version("2.0.6", sha256="55972289ce66080bb48622110c3189a36e88a12917635f049b37685b9d3bbcb0")

--- a/repos/spack_repo/builtin/packages/opari2/package.py
+++ b/repos/spack_repo/builtin/packages/opari2/package.py
@@ -25,61 +25,18 @@ class Opari2(AutotoolsPackage):
     # still in Spack. 1.x is ancient and is deprecated in anticipation of removal.
     # Deprecating here as a _slightly_ gentler approach than hard-bumping the version dependencies downstream.
     version("2.0.10", sha256="49d9526bf76ebf7836e62f70850d4d605b08910dbabddac3f7479b509abce887")
-    version(
-        "2.0.9",
-        sha256="d57139f757c5666afaaead45ed3d0954a9b98c4a6cef6b22afe672707cffd779",
-        deprecated=True,
-    )
-    version(
-        "2.0.8",
-        sha256="196e59a2a625e6c795a6124c61e784bad142f9f38df0b4fa4d435ba9b9c19721",
-        deprecated=True,
-    )
-    version(
-        "2.0.7",
-        sha256="e302a4cc265eb2a4aa27c16a90eabd9e1e58cb02a191dd1c4d86f9a0df128715",
-        deprecated=True,
-    )
-    version(
-        "2.0.6",
-        sha256="55972289ce66080bb48622110c3189a36e88a12917635f049b37685b9d3bbcb0",
-        deprecated=True,
-    )
-    version(
-        "2.0.5",
-        sha256="9034dd7596ac2176401090fd5ced45d0ab9a9404444ff767f093ccce68114ef5",
-        deprecated=True,
-    )
-    version(
-        "2.0.4",
-        sha256="f69e324792f66780b473daf2b3c81f58ee8188adc72b6fe0dacf43d4c1a0a131",
-        deprecated=True,
-    )
-    version(
-        "2.0.3",
-        sha256="7e2efcfbc99152ee6e31454ef4fb747f77165691539d5d2c1df2abc4612de86c",
-        deprecated=True,
-    )
-    version(
-        "2.0.1",
-        sha256="f49d74d7533f428a4701cd561eba8a69f60615332e81b66f01ef1c9b7ee54666",
-        deprecated=True,
-    )
-    version(
-        "2.0",
-        sha256="0c4e575be05627cd001d692204f10caef37b2f3d1ec825f98cbe1bfa4232b0b7",
-        deprecated=True,
-    )
-    version(
-        "1.1.4",
-        sha256="b80c04fe876faaa4ee9a0654486ecbeba516b27fc14a90d20c6384e81060cffe",
-        deprecated=True,
-    )
-    version(
-        "1.1.2",
-        sha256="8405c2903730d94c828724b3a5f8889653553fb8567045a6c54ac0816237835d",
-        deprecated=True,
-    )
+    version("2.0.9", sha256="d57139f757c5666afaaead45ed3d0954a9b98c4a6cef6b22afe672707cffd779")
+    with default_args(deprecated=True):
+        version("2.0.8", sha256="196e59a2a625e6c795a6124c61e784bad142f9f38df0b4fa4d435ba9b9c19721")
+        version("2.0.7", sha256="e302a4cc265eb2a4aa27c16a90eabd9e1e58cb02a191dd1c4d86f9a0df128715")
+        version("2.0.6", sha256="55972289ce66080bb48622110c3189a36e88a12917635f049b37685b9d3bbcb0")
+        version("2.0.5", sha256="9034dd7596ac2176401090fd5ced45d0ab9a9404444ff767f093ccce68114ef5")
+        version("2.0.4", sha256="f69e324792f66780b473daf2b3c81f58ee8188adc72b6fe0dacf43d4c1a0a131")
+        version("2.0.3", sha256="7e2efcfbc99152ee6e31454ef4fb747f77165691539d5d2c1df2abc4612de86c")
+        version("2.0.1", sha256="f49d74d7533f428a4701cd561eba8a69f60615332e81b66f01ef1c9b7ee54666")
+        version("2.0", sha256="0c4e575be05627cd001d692204f10caef37b2f3d1ec825f98cbe1bfa4232b0b7")
+        version("1.1.4", sha256="b80c04fe876faaa4ee9a0654486ecbeba516b27fc14a90d20c6384e81060cffe")
+        version("1.1.2", sha256="8405c2903730d94c828724b3a5f8889653553fb8567045a6c54ac0816237835d")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/scorep/package.py
+++ b/repos/spack_repo/builtin/packages/scorep/package.py
@@ -87,7 +87,7 @@ class Scorep(AutotoolsPackage):
     depends_on("otf2@3.1:", when="@9:")
     depends_on("cubew@4.9:", when="@9:")
     depends_on("cubelib@4.9:", when="@9:")
-    depends_on("opari2@2.0.9", when="@9:")
+    depends_on("opari2@2.0.9:", when="@9:")
 
     # SCOREP 8
     depends_on("binutils", type="link", when="@8:")


### PR DESCRIPTION
OPARI2 2.0.10 fixes crash bugs when processing particular C++ codes. In general we want Score-P (and any other downstream users, if they exist) to stay on the latest OPARI2 version, but the old versions will _build_ with the older, buggy OPARI2s.

OPARI2 1.0 is ancient and unused and the deprecation is 100% pre-removal. OPARI2 < 2.0.6 is not depended on by any Spack-supported Score-P and can be removed next cycle after deprecation AFAIK.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
