### PR TITLE
glpk: fix build for gcc@15

### DIFF
--- a/repos/spack_repo/builtin/packages/glpk/package.py
+++ b/repos/spack_repo/builtin/packages/glpk/package.py
@@ -32,6 +32,12 @@ class Glpk(AutotoolsPackage, GNUMirrorPackage):
 
     depends_on("gmp", when="+gmp")
 
+    # Do not define bool, true, or false for C23 compatibility
+    patch(
+        "https://src.fedoraproject.org/rpms/glpk/raw/2f25ac1417ccd1a9e2773d63800d50a2ab326ede/f/glpk-5.0-bool.patch",
+        sha256="962e2526a1fab58cd3d577a786e714ca923086179bb94d9d4bf259f7e0f42c27",
+    )
+
     def configure_args(self):
         options = []
 


### PR DESCRIPTION
Add patch to fix the error
```
> ./minisat/minisat.h:37:13: error: 'bool' cannot be defined via 'typedef'
     37 | typedef int bool;
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
