### PR TITLE
r-fs: fix libuv as link dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/r_fs/package.py
+++ b/repos/spack_repo/builtin/packages/r_fs/package.py
@@ -35,7 +35,7 @@ class RFs(RPackage):
         depends_on("r@3.4:", when="@1.6.2:")
         depends_on("r@3.1:")
 
-        depends_on("libuv", when="@2.1.0:")
-
         # Historical dependencies
         depends_on("r-rcpp", when="@:1.3.1")
+
+    depends_on("libuv", when="@2.1.0:")


### PR DESCRIPTION
`libuv` also has to be a link dependency, otherwise I get the error:
```
> Error: package or namespace load failed for 'fs' in dyn.load(file, DLLpath = DLLpath, ...):
   unable to load shared object '/spack/opt/spack/linux-skylake/r-fs-2.1.0-wlcopzvsux56cocy6n36crxcrnivhadq/rlib/R/library/00LOCK-spack-src/00new/fs/libs/fs.so':
>   libuv.so.1: cannot open shared object file: No such file or directory
> Error: loading failed
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
