### PR TITLE
emacs: use the inherited GNUMirrorPackage list_url

### DIFF
--- a/repos/spack_repo/builtin/packages/emacs/package.py
+++ b/repos/spack_repo/builtin/packages/emacs/package.py
@@ -18,7 +18,7 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
     homepage = "https://www.gnu.org/software/emacs"
     gnu_mirror_path = "emacs/emacs-24.5.tar.gz"
     git = "https://git.savannah.gnu.org/git/emacs.git"
-    list_url = "https://ftpmirror.gnu.org/emacs/"
+
     list_depth = 0
 
     maintainers("alecbcs")


### PR DESCRIPTION
emacs overrides list_url with a plain class attribute pointing at ftpmirror.gnu.org. That shadows the GNUMirrorPackage.list_url property added in #5769, which deliberately uses ftp.gnu.org because — quoting the comment there — "the redirecting ftpmirror.gnu.org does not reliably serve directory indexes."

emacs is the only GNUMirrorPackage in the repo still overriding list_url with the redirector.

Current behaviour on develop:


$ spack versions --remote emacs
(no output)

$ curl -sSI https://ftpmirror.gnu.org/emacs/
HTTP/1.1 502 Bad Gateway
After removing the override, list_url resolves to https://ftp.gnu.org/gnu/emacs (HTTP 200) and remote version discovery works again.

Removing the line rather than rewriting it to ftp.gnu.org keeps emacs consistent with every other GNU package and means future GNU hosting changes only need fixing in one place.

Same underlying ftpmirror.gnu.org unreliability previously addressed in #5863 (readline) and #5922 (bash), though this affects version discovery rather than patch downloads.