### PR TITLE
glpk: fix build for %gcc@:14, %clang

### DIFF
--- a/repos/spack_repo/builtin/packages/glpk/package.py
+++ b/repos/spack_repo/builtin/packages/glpk/package.py
@@ -36,6 +36,7 @@ class Glpk(AutotoolsPackage, GNUMirrorPackage):
     patch(
         "https://src.fedoraproject.org/rpms/glpk/raw/2f25ac1417ccd1a9e2773d63800d50a2ab326ede/f/glpk-5.0-bool.patch",
         sha256="962e2526a1fab58cd3d577a786e714ca923086179bb94d9d4bf259f7e0f42c27",
+        when="%gcc@15:",
     )
 
     def configure_args(self):


### PR DESCRIPTION
Fix the build of glpk with compiler != %gcc@15:
The patch for gcc@15: must not be applied for other compilers, AFAICS.