### PR TITLE
cuda-samples: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/cuda_samples/package.py
+++ b/repos/spack_repo/builtin/packages/cuda_samples/package.py
@@ -1,0 +1,161 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (NVIDIA Software License Agreement)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems.cuda import CudaPackage
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
+
+from spack.package import *
+
+import os
+
+class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
+    """Samples for CUDA Developers which demonstrates features in CUDA
+    Toolkit."""
+
+    homepage = "https://github.com/NVIDIA/cuda-samples"
+    git = "https://github.com/NVIDIA/cuda-samples.git"
+    url = "https://github.com/NVIDIA/cuda-samples/archive/refs/tags/v13.0.tar.gz"
+
+    # Not sure if I can take the responsibility;
+    # I just added it since running benchmarks on HPC need it now.
+    #maintainers("guanyuming-he")
+
+    # This is a proprietary license. See 
+    # https://spack.readthedocs.io/en/latest/
+    # packaging_guide_creation.html#proprietary-software
+    license_required = True
+    license_comment = "#"
+    license_files = ["LICENSE"]
+    license_vars = []
+    license_url = (
+        "https://www.nvidia.com/en-us/agreements/"
+        "enterprise-software/nvidia-software-license-agreement/"
+    )
+
+    # Update this as CUDA is updated in Spack.
+    # Can execute `spack checksum cuda-samples`
+    _ver_map = {
+        "13.3": "fab59f405d6c0b87395ce6fc1d46d3f559c380c9a2704ab14d6dc0d3ce1cff16",
+        "13.2update": "057e68d22bd02e41d60c9826e7622ac1b88de0f1dbe25ed49bd995f768306f9d",
+        "13.2": "c7d8da987a43fd6ed7c2641df204dfc639768adbae070bc22f9df0e03005f7de",
+        "13.1": "03d7748a773fcd2350c2de88f2d167252c78ea90a52e229e7eb2a6922e3ba350",
+        "13.0": "63cc9d5d8280c87df3c1f4e2276234a0f42cc497c52b40dd5bdda2836607db79",
+        "12.9": "2e67e1f6bdb15bf11b21e07e988e2f9f60fb054eff51ef01cebdd47229788015",
+        "12.8": "fe82484f9a87334075498f4e023a304cc70f240a285c11678f720f0a1e54a89d",
+        "12.5": "5c40cc096706045b067ec5897f039403014aa7a39b970905698466a2d029b972",
+        "12.4.1": "01bb311cc8f802a0d243700e4abe6a2d402132c9d97ecf2c64f3fbb1006c304c",
+        "12.4": "aa28fa2227768dd31ebbf9cd48b265a0c8810fae03e02c6079c0fa71bbea7319",
+    }
+    for v,h in _ver_map.items():
+        version(v, sha256=h)
+        depends_on("cuda@"+v, when="@"+v)
+
+    # Don't need this variant now as CUDA is always required.
+    #variant("cuda", default=True, description="build using CUDA (required)")
+
+    # Don't know why it could build before without depending on it with gcc 14,
+    # but now it can't with gcc 12.
+    depends_on("mesa-glu")
+    # Cuda samples could build without each of the following, but some samples will be
+    # unavailable then.
+    variant("freeglut", default=False, description="build with freeglut.")
+    depends_on("freeglut", when="+freeglut")
+    # Can't do this now. Otherwise, spack will complain about
+    # internal_error("something depends_on a non-node")
+    #variant("freeimage", default=True, description="build with freeimage.")
+    #depends_on("freeimage", when="+freeimage")
+
+    # Allows one to specify the compilers to use. Please do specify it
+    # explicitly if the default is ambiguous.
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    # cuda-samples changed build systems starting with 12.8
+    build_system(
+        conditional("cmake", when="@12.8:"),
+        conditional("makefile", when="@:12.5"),
+        default="cmake",
+    )
+
+    # After the change to CMake, the build defaults to all GPU arches
+    # supported by the NVCC it depends on
+    conflicts("cuda_arch=none", when="@:12.5+cuda", 
+        msg="Please specify cuda_arch as variant for installation.\n"
+            "You can query it with \n"
+            "nvidia-smi --query-gpu=name,compute_cap --format=csv"
+    )
+
+    @when("@:12.5")
+    def setup_build_environment(self, env):
+        glu = self.spec["mesa-glu"]
+        env.append_flags("CPPFLAGS", f"-I{glu.prefix.include}")
+        env.append_flags("LDFLAGS", f"-L{glu.prefix.lib}")
+        if (self.spec.satisfies("+freeglut")):
+            freeglut = self.spec["freeglut"]
+            env.append_flags("CPPFLAGS", f"-I{freeglut.prefix.include}")
+            env.append_flags("CPPFLAGS", f"-I{freeglut.prefix.include}")
+        if (self.spec.satisfies("+freeimage")):
+            freeimg = self.spec["freeimage"]
+            env.append_flags("LDFLAGS", f"-L{freeimg.prefix.lib}")
+            env.append_flags("LDFLAGS", f"-L{freeimg.prefix.lib}")
+        env.set("CUDA_PATH", self.spec["cuda"].prefix)
+        env.set("SMS", self.spec.variants["cuda_arch"].value[0])
+
+    @when("@12.8:")
+    def cmake_args(self):
+        glu = self.spec["mesa-glu"]
+        args = [
+            "-DCUDAToolkit_ROOT=" + self.spec["cuda"].prefix,
+            self.define("GLU_INCLUDE_DIR", glu.prefix.include),
+            self.define("GLU_LIBRARY", glu.libs[0]),
+        ]
+        if (self.spec.satisfies("+freeglut")):
+            freeglut = self.spec["freeglut"]
+            args += [
+                self.define("GLUT_INCLUDE_DIR", freeglut.prefix.include),
+                self.define("GLUT_freeglut_LIBRARY", freeglut.libs[0]),
+            ]
+        if (self.spec.satisfies("+freeimage")):
+            freeimg = self.spec["freeimage"]
+            args += [
+                self.define("FreeImage_INCLUDE_DIR", freeimg.prefix.include),
+                self.define("FreeImage_LIBRARY", freeimg.libs[0]),
+            ]
+        return args
+
+    # cuda-samples doesn't actually install the samples in the
+    # CMAKE_INSTALL_PREFIX dir, so this copies them
+    @when("@12.8:")
+    def install(self, spec, prefix):
+        mkdir(prefix.bin)
+        install_tree(
+            os.path.join(self.build_directory, "Samples"),
+            prefix.bin
+        )
+        # Don't forget to install the common files!
+        mkdir(prefix.common)
+        install_tree(
+            os.path.join(self.stage.source_path, "Common"),
+            prefix.common
+        )
+        
+
+    # Similar to the CMake version, the Make version doesn't have an install
+    # phase but instead just creates binaries in a `bin` folder under the build
+    # directory
+    @when("@:12.5")
+    def install(self, spec, prefix):
+        mkdir(prefix.bin)
+        install_tree(
+            os.path.join(self.build_directory, "bin"), 
+            prefix.bin
+        )
+        # Don't forget to install the common files!
+        mkdir(prefix.common)
+        install_tree(
+            os.path.join(self.stage.source_path, "Common"),
+            prefix.common
+        )
+        

--- a/repos/spack_repo/builtin/packages/cuda_samples/package.py
+++ b/repos/spack_repo/builtin/packages/cuda_samples/package.py
@@ -12,8 +12,7 @@ from spack.package import *
 
 
 class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
-    """Samples for CUDA Developers which demonstrates features in CUDA
-    Toolkit."""
+    """Samples for CUDA Developers to demonstrate features of the CUDA Toolkit."""
 
     homepage = "https://github.com/NVIDIA/cuda-samples"
     git = "https://github.com/NVIDIA/cuda-samples.git"
@@ -28,7 +27,6 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
         "enterprise-software/nvidia-software-license-agreement/"
     )
 
-    # cuda-samples changed build systems starting with 12.8
     build_system(
         conditional("cmake", when="@12.8:"),
         conditional("makefile", when="@:12.5"),
@@ -50,21 +48,20 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
     for v, h in _ver_map.items():
         version(v, sha256=h)
 
-    # cuda-samples could build without each of the following, but some samples will be
-    # unavailable then.
-    variant("freeglut", default=False, 
-        description="build samples which need freeglut.")
-    # A bug somewhere prevents depending on freeimage.
-    # variant("freeimage", default=False, 
-    #    description="build samples which need freeimage.")
+    # freeimage is deprecated. Use --deprecated for cuda-samples+freeimage
+    variant("freeimage", default=False, description="add samples using freeimage")
+    variant("freeglut", default=False, description="add samples using freeglut")
 
-    depends_on("c", type="build")
-    depends_on("cxx", type="build")
-    for v, _ in _ver_map.items():
-        depends_on("cuda@" + v, when="@" + v)
+    with default_args(type="build"):
+        depends_on("c")
+        depends_on("cxx")
+        depends_on("cmake@3.10:")
+
     depends_on("mesa-glu")
     depends_on("freeglut", when="+freeglut")
-    # depends_on("freeimage", when="+freeimage")
+    depends_on("freeimage", when="+freeimage")
+    for v, _ in _ver_map.items():
+        depends_on("cuda@" + v, when="@" + v)
 
     conflicts(
         "cuda_arch=none",
@@ -92,11 +89,9 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
 
     @when("@12.8:")
     def cmake_args(self):
-        args = [
-            "-DCUDAToolkit_ROOT=" + self.spec["cuda"].prefix,
-        ]
         glu = self.spec["mesa-glu"]
-        args += [
+        args = [
+            self.define("CUDAToolkit_ROOT", self.spec["cuda"].prefix),
             self.define("GLU_INCLUDE_DIR", glu.prefix.include),
             self.define("GLU_LIBRARY", glu.libs[0]),
             self.define("OPENGL_INCLUDE_DIR", glu.prefix.include),
@@ -116,8 +111,7 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
             ]
         return args
 
-    # Starting with 13.1, cmake/InstallSamples.cmake installs cuda-samples
-    # Manual handling is required before.
+    # Below 13.1, installation is not handled by CMake or the Makefile.
     @when("@12.8:13.0")
     def install(self, spec, prefix):
         mkdir(prefix.bin)
@@ -125,9 +119,6 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
         mkdir(prefix.common)
         install_tree(os.path.join(self.stage.source_path, "Common"), prefix.common)
 
-    # Similar to the CMake version, the Make version doesn't have an install
-    # phase but instead just creates binaries in a `bin` folder under the build
-    # directory
     @when("@:12.5")
     def install(self, spec, prefix):
         mkdir(prefix.bin)

--- a/repos/spack_repo/builtin/packages/cuda_samples/package.py
+++ b/repos/spack_repo/builtin/packages/cuda_samples/package.py
@@ -76,19 +76,28 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
 
     @when("@:12.5")
     def setup_build_environment(self, env):
-        glu = self.spec["mesa-glu"]
+        spec = self.spec
+        glu = sepc["mesa-glu"]
         env.append_flags("CPPFLAGS", f"-I{glu.prefix.include}")
         env.append_flags("LDFLAGS", f"-L{glu.prefix.lib}")
-        if self.spec.satisfies("+freeglut"):
-            freeglut = self.spec["freeglut"]
+        gl_headers = [
+            spec["gl"].headers.directories, glu.headers.directories
+        ]
+        if spec.satisfies("^libx11"):
+            gl_headers += spec['libx11'].headers.directories[0]
+            gl_headers += spec['xproto'].headers.directories[0]
+        for h in gl_headers:
+            env.append_flags("CPPFLAGS", f"-I{h}")
+        if sepc.satisfies("+freeglut"):
+            freeglut = sepc["freeglut"]
             env.append_flags("CPPFLAGS", f"-I{freeglut.prefix.include}")
             env.append_flags("LDFLAGS", f"-L{freeglut.prefix.lib}")
-        if self.spec.satisfies("+freeimage"):
-            freeimg = self.spec["freeimage"]
+        if sepc.satisfies("+freeimage"):
+            freeimg = sepc["freeimage"]
             env.append_flags("CPPFLAGS", f"-I{freeimg.prefix.include}")
             env.append_flags("LDFLAGS", f"-L{freeimg.prefix.lib}")
-        env.set("CUDA_PATH", self.spec["cuda"].prefix)
-        env.set("SMS", self.spec.variants["cuda_arch"].value[0])
+        env.set("CUDA_PATH", sepc["cuda"].prefix)
+        env.set("SMS", sepc.variants["cuda_arch"].value[0])
 
     @when("@12.8:")
     def cmake_args(self):

--- a/repos/spack_repo/builtin/packages/cuda_samples/package.py
+++ b/repos/spack_repo/builtin/packages/cuda_samples/package.py
@@ -63,6 +63,8 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
     for v, _ in _ver_map.items():
         depends_on("cuda@" + v, when="@" + v)
 
+    conflicts("%gcc@15:", when="@:12", msg="GCC 15 is not supported for CUDA <= 12")
+    conflicts("%gcc@16:", when="@:13.3", msg="GCC 16 is not supported for CUDA <= 13.3")
     conflicts(
         "cuda_arch=none",
         when="@:12.5+cuda",

--- a/repos/spack_repo/builtin/packages/cuda_samples/package.py
+++ b/repos/spack_repo/builtin/packages/cuda_samples/package.py
@@ -130,9 +130,13 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
             ]
         return args
 
+    # After 13.0,
+    # they added ./cmake/InstallSamples.cmake 
+    # since commit 547f65851fafdb6a66f47ce56b4c0603db885910
+    # Before 13.0
     # cuda-samples doesn't actually install the samples in the
     # CMAKE_INSTALL_PREFIX dir, so this copies them
-    @when("@12.8:")
+    @when("@12.8:13.0")
     def install(self, spec, prefix):
         mkdir(prefix.bin)
         install_tree(os.path.join(self.build_directory, "Samples"), prefix.bin)

--- a/repos/spack_repo/builtin/packages/cuda_samples/package.py
+++ b/repos/spack_repo/builtin/packages/cuda_samples/package.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: (NVIDIA Software License Agreement)
 
+import os
+
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
 
 from spack.package import *
 
-import os
 
 class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
     """Samples for CUDA Developers which demonstrates features in CUDA
@@ -20,9 +21,9 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
 
     # Not sure if I can take the responsibility;
     # I just added it since running benchmarks on HPC need it now.
-    #maintainers("guanyuming-he")
+    # maintainers("guanyuming-he")
 
-    # This is a proprietary license. See 
+    # This is a proprietary license. See
     # https://spack.readthedocs.io/en/latest/
     # packaging_guide_creation.html#proprietary-software
     license_required = True
@@ -48,12 +49,12 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
         "12.4.1": "01bb311cc8f802a0d243700e4abe6a2d402132c9d97ecf2c64f3fbb1006c304c",
         "12.4": "aa28fa2227768dd31ebbf9cd48b265a0c8810fae03e02c6079c0fa71bbea7319",
     }
-    for v,h in _ver_map.items():
+    for v, h in _ver_map.items():
         version(v, sha256=h)
-        depends_on("cuda@"+v, when="@"+v)
+        depends_on("cuda@" + v, when="@" + v)
 
     # Don't need this variant now as CUDA is always required.
-    #variant("cuda", default=True, description="build using CUDA (required)")
+    # variant("cuda", default=True, description="build using CUDA (required)")
 
     # Don't know why it could build before without depending on it with gcc 14,
     # but now it can't with gcc 12.
@@ -64,8 +65,8 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
     depends_on("freeglut", when="+freeglut")
     # Can't do this now. Otherwise, spack will complain about
     # internal_error("something depends_on a non-node")
-    #variant("freeimage", default=True, description="build with freeimage.")
-    #depends_on("freeimage", when="+freeimage")
+    # variant("freeimage", default=True, description="build with freeimage.")
+    # depends_on("freeimage", when="+freeimage")
 
     # Allows one to specify the compilers to use. Please do specify it
     # explicitly if the default is ambiguous.
@@ -81,10 +82,12 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
 
     # After the change to CMake, the build defaults to all GPU arches
     # supported by the NVCC it depends on
-    conflicts("cuda_arch=none", when="@:12.5+cuda", 
+    conflicts(
+        "cuda_arch=none",
+        when="@:12.5+cuda",
         msg="Please specify cuda_arch as variant for installation.\n"
-            "You can query it with \n"
-            "nvidia-smi --query-gpu=name,compute_cap --format=csv"
+        "You can query it with \n"
+        "nvidia-smi --query-gpu=name,compute_cap --format=csv",
     )
 
     @when("@:12.5")
@@ -92,11 +95,11 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
         glu = self.spec["mesa-glu"]
         env.append_flags("CPPFLAGS", f"-I{glu.prefix.include}")
         env.append_flags("LDFLAGS", f"-L{glu.prefix.lib}")
-        if (self.spec.satisfies("+freeglut")):
+        if self.spec.satisfies("+freeglut"):
             freeglut = self.spec["freeglut"]
             env.append_flags("CPPFLAGS", f"-I{freeglut.prefix.include}")
             env.append_flags("CPPFLAGS", f"-I{freeglut.prefix.include}")
-        if (self.spec.satisfies("+freeimage")):
+        if self.spec.satisfies("+freeimage"):
             freeimg = self.spec["freeimage"]
             env.append_flags("LDFLAGS", f"-L{freeimg.prefix.lib}")
             env.append_flags("LDFLAGS", f"-L{freeimg.prefix.lib}")
@@ -111,13 +114,13 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
             self.define("GLU_INCLUDE_DIR", glu.prefix.include),
             self.define("GLU_LIBRARY", glu.libs[0]),
         ]
-        if (self.spec.satisfies("+freeglut")):
+        if self.spec.satisfies("+freeglut"):
             freeglut = self.spec["freeglut"]
             args += [
                 self.define("GLUT_INCLUDE_DIR", freeglut.prefix.include),
                 self.define("GLUT_freeglut_LIBRARY", freeglut.libs[0]),
             ]
-        if (self.spec.satisfies("+freeimage")):
+        if self.spec.satisfies("+freeimage"):
             freeimg = self.spec["freeimage"]
             args += [
                 self.define("FreeImage_INCLUDE_DIR", freeimg.prefix.include),
@@ -130,17 +133,10 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
     @when("@12.8:")
     def install(self, spec, prefix):
         mkdir(prefix.bin)
-        install_tree(
-            os.path.join(self.build_directory, "Samples"),
-            prefix.bin
-        )
+        install_tree(os.path.join(self.build_directory, "Samples"), prefix.bin)
         # Don't forget to install the common files!
         mkdir(prefix.common)
-        install_tree(
-            os.path.join(self.stage.source_path, "Common"),
-            prefix.common
-        )
-        
+        install_tree(os.path.join(self.stage.source_path, "Common"), prefix.common)
 
     # Similar to the CMake version, the Make version doesn't have an install
     # phase but instead just creates binaries in a `bin` folder under the build
@@ -148,14 +144,7 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
     @when("@:12.5")
     def install(self, spec, prefix):
         mkdir(prefix.bin)
-        install_tree(
-            os.path.join(self.build_directory, "bin"), 
-            prefix.bin
-        )
+        install_tree(os.path.join(self.build_directory, "bin"), prefix.bin)
         # Don't forget to install the common files!
         mkdir(prefix.common)
-        install_tree(
-            os.path.join(self.stage.source_path, "Common"),
-            prefix.common
-        )
-        
+        install_tree(os.path.join(self.stage.source_path, "Common"), prefix.common)

--- a/repos/spack_repo/builtin/packages/cuda_samples/package.py
+++ b/repos/spack_repo/builtin/packages/cuda_samples/package.py
@@ -1,6 +1,6 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
-# SPDX-License-Identifier: (NVIDIA Software License Agreement)
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
 

--- a/repos/spack_repo/builtin/packages/cuda_samples/package.py
+++ b/repos/spack_repo/builtin/packages/cuda_samples/package.py
@@ -57,6 +57,7 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
         depends_on("cxx")
         depends_on("cmake@3.10:")
 
+    depends_on("gl")
     depends_on("mesa-glu")
     depends_on("freeglut", when="+freeglut")
     depends_on("freeimage", when="+freeimage")
@@ -91,22 +92,23 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
 
     @when("@12.8:")
     def cmake_args(self):
-        glu = self.spec["mesa-glu"]
+        spec = self.spec
+        glu = spec["mesa-glu"]
         args = [
-            self.define("CUDAToolkit_ROOT", self.spec["cuda"].prefix),
+            self.define("CUDAToolkit_ROOT", spec["cuda"].prefix),
             self.define("GLU_INCLUDE_DIR", glu.prefix.include),
             self.define("GLU_LIBRARY", glu.libs[0]),
             self.define("OPENGL_INCLUDE_DIR", glu.prefix.include),
             self.define("OPENGL_glu_LIBRARY", glu.libs[0]),
         ]
-        if self.spec.satisfies("+freeglut"):
-            freeglut = self.spec["freeglut"]
+        if spec.satisfies("+freeglut"):
+            freeglut = spec["freeglut"]
             args += [
                 self.define("GLUT_INCLUDE_DIR", freeglut.prefix.include),
                 self.define("GLUT_freeglut_LIBRARY", freeglut.libs[0]),
             ]
-        if self.spec.satisfies("+freeimage"):
-            freeimg = self.spec["freeimage"]
+        if spec.satisfies("+freeimage"):
+            freeimg = spec["freeimage"]
             args += [
                 self.define("FreeImage_INCLUDE_DIR", freeimg.prefix.include),
                 self.define("FreeImage_LIBRARY", freeimg.libs[0]),

--- a/repos/spack_repo/builtin/packages/cuda_samples/package.py
+++ b/repos/spack_repo/builtin/packages/cuda_samples/package.py
@@ -21,7 +21,6 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
 
     maintainers("guanyuming-he")
 
-    # This is a proprietary license. 
     license_required = True
     license_files = ["LICENSE"]
     license_url = (
@@ -36,8 +35,6 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
         default="cmake",
     )
 
-    # Versions section
-    ######################################################################
     _ver_map = {
         "13.3": "fab59f405d6c0b87395ce6fc1d46d3f559c380c9a2704ab14d6dc0d3ce1cff16",
         "13.2update": "057e68d22bd02e41d60c9826e7622ac1b88de0f1dbe25ed49bd995f768306f9d",
@@ -53,35 +50,27 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
     for v, h in _ver_map.items():
         version(v, sha256=h)
 
-    # Variants section
-    ######################################################################
-    # Cuda samples could build without each of the following, but some samples will be
+    # cuda-samples could build without each of the following, but some samples will be
     # unavailable then.
-    variant("freeglut", default=False, description="build with freeglut.")
-    # Can't do this now. Otherwise, spack will complain about
-    # internal_error("something depends_on a non-node")
-    # Could be a bug of freeimage or the concretizer
-    # variant("freeimage", default=False, description="build with freeimage.")
+    variant("freeglut", default=False, 
+        description="build samples which need freeglut.")
+    # A bug somewhere prevents depending on freeimage.
+    # variant("freeimage", default=False, 
+    #    description="build samples which need freeimage.")
 
-    # Dependency section
-    ######################################################################
     depends_on("c", type="build")
     depends_on("cxx", type="build")
-
     for v, _ in _ver_map.items():
         depends_on("cuda@" + v, when="@" + v)
-
     depends_on("mesa-glu")
     depends_on("freeglut", when="+freeglut")
-    #depends_on("freeimage", when="+freeimage")
+    # depends_on("freeimage", when="+freeimage")
 
-    # The user must specific the desired compute_cap that the samples are built
-    # for.
     conflicts(
         "cuda_arch=none",
         when="@:12.5+cuda",
         msg="Please specify cuda_arch as variant for installation.\n"
-        "You can query it with \n"
+        "cuda_arch is the compute_cap you desire, which can be queried via \n"
         "nvidia-smi --query-gpu=name,compute_cap --format=csv",
     )
 
@@ -107,9 +96,6 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
             "-DCUDAToolkit_ROOT=" + self.spec["cuda"].prefix,
         ]
         glu = self.spec["mesa-glu"]
-        # Even though glu is just a utility helper for OpenGL,
-        # CMake groups it inside OpenGL, hence the macros that start with
-        # OPENGL_.
         args += [
             self.define("GLU_INCLUDE_DIR", glu.prefix.include),
             self.define("GLU_LIBRARY", glu.libs[0]),
@@ -130,12 +116,8 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
             ]
         return args
 
-    # After 13.0,
-    # they added ./cmake/InstallSamples.cmake 
-    # since commit 547f65851fafdb6a66f47ce56b4c0603db885910
-    # Before 13.0
-    # cuda-samples doesn't actually install the samples in the
-    # CMAKE_INSTALL_PREFIX dir, so this copies them
+    # Starting with 13.1, cmake/InstallSamples.cmake installs cuda-samples
+    # Manual handling is required before.
     @when("@12.8:13.0")
     def install(self, spec, prefix):
         mkdir(prefix.bin)

--- a/repos/spack_repo/builtin/packages/cuda_samples/package.py
+++ b/repos/spack_repo/builtin/packages/cuda_samples/package.py
@@ -19,24 +19,25 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
     git = "https://github.com/NVIDIA/cuda-samples.git"
     url = "https://github.com/NVIDIA/cuda-samples/archive/refs/tags/v13.0.tar.gz"
 
-    # Not sure if I can take the responsibility;
-    # I just added it since running benchmarks on HPC need it now.
-    # maintainers("guanyuming-he")
+    maintainers("guanyuming-he")
 
-    # This is a proprietary license. See
-    # https://spack.readthedocs.io/en/latest/
-    # packaging_guide_creation.html#proprietary-software
+    # This is a proprietary license. 
     license_required = True
-    license_comment = "#"
     license_files = ["LICENSE"]
-    license_vars = []
     license_url = (
         "https://www.nvidia.com/en-us/agreements/"
         "enterprise-software/nvidia-software-license-agreement/"
     )
 
-    # Update this as CUDA is updated in Spack.
-    # Can execute `spack checksum cuda-samples`
+    # cuda-samples changed build systems starting with 12.8
+    build_system(
+        conditional("cmake", when="@12.8:"),
+        conditional("makefile", when="@:12.5"),
+        default="cmake",
+    )
+
+    # Versions section
+    ######################################################################
     _ver_map = {
         "13.3": "fab59f405d6c0b87395ce6fc1d46d3f559c380c9a2704ab14d6dc0d3ce1cff16",
         "13.2update": "057e68d22bd02e41d60c9826e7622ac1b88de0f1dbe25ed49bd995f768306f9d",
@@ -51,37 +52,31 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
     }
     for v, h in _ver_map.items():
         version(v, sha256=h)
-        depends_on("cuda@" + v, when="@" + v)
 
-    # Don't need this variant now as CUDA is always required.
-    # variant("cuda", default=True, description="build using CUDA (required)")
-
-    # Don't know why it could build before without depending on it with gcc 14,
-    # but now it can't with gcc 12.
-    depends_on("mesa-glu")
+    # Variants section
+    ######################################################################
     # Cuda samples could build without each of the following, but some samples will be
     # unavailable then.
     variant("freeglut", default=False, description="build with freeglut.")
-    depends_on("freeglut", when="+freeglut")
     # Can't do this now. Otherwise, spack will complain about
     # internal_error("something depends_on a non-node")
-    # variant("freeimage", default=True, description="build with freeimage.")
-    # depends_on("freeimage", when="+freeimage")
+    # Could be a bug of freeimage or the concretizer
+    # variant("freeimage", default=False, description="build with freeimage.")
 
-    # Allows one to specify the compilers to use. Please do specify it
-    # explicitly if the default is ambiguous.
+    # Dependency section
+    ######################################################################
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
-    # cuda-samples changed build systems starting with 12.8
-    build_system(
-        conditional("cmake", when="@12.8:"),
-        conditional("makefile", when="@:12.5"),
-        default="cmake",
-    )
+    for v, _ in _ver_map.items():
+        depends_on("cuda@" + v, when="@" + v)
 
-    # After the change to CMake, the build defaults to all GPU arches
-    # supported by the NVCC it depends on
+    depends_on("mesa-glu")
+    depends_on("freeglut", when="+freeglut")
+    #depends_on("freeimage", when="+freeimage")
+
+    # The user must specific the desired compute_cap that the samples are built
+    # for.
     conflicts(
         "cuda_arch=none",
         when="@:12.5+cuda",
@@ -98,21 +93,28 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
         if self.spec.satisfies("+freeglut"):
             freeglut = self.spec["freeglut"]
             env.append_flags("CPPFLAGS", f"-I{freeglut.prefix.include}")
-            env.append_flags("CPPFLAGS", f"-I{freeglut.prefix.include}")
+            env.append_flags("LDFLAGS", f"-L{freeglut.prefix.lib}")
         if self.spec.satisfies("+freeimage"):
             freeimg = self.spec["freeimage"]
-            env.append_flags("LDFLAGS", f"-L{freeimg.prefix.lib}")
+            env.append_flags("CPPFLAGS", f"-I{freeimg.prefix.include}")
             env.append_flags("LDFLAGS", f"-L{freeimg.prefix.lib}")
         env.set("CUDA_PATH", self.spec["cuda"].prefix)
         env.set("SMS", self.spec.variants["cuda_arch"].value[0])
 
     @when("@12.8:")
     def cmake_args(self):
-        glu = self.spec["mesa-glu"]
         args = [
             "-DCUDAToolkit_ROOT=" + self.spec["cuda"].prefix,
+        ]
+        glu = self.spec["mesa-glu"]
+        # Even though glu is just a utility helper for OpenGL,
+        # CMake groups it inside OpenGL, hence the macros that start with
+        # OPENGL_.
+        args += [
             self.define("GLU_INCLUDE_DIR", glu.prefix.include),
             self.define("GLU_LIBRARY", glu.libs[0]),
+            self.define("OPENGL_INCLUDE_DIR", glu.prefix.include),
+            self.define("OPENGL_glu_LIBRARY", glu.libs[0]),
         ]
         if self.spec.satisfies("+freeglut"):
             freeglut = self.spec["freeglut"]
@@ -134,7 +136,6 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
     def install(self, spec, prefix):
         mkdir(prefix.bin)
         install_tree(os.path.join(self.build_directory, "Samples"), prefix.bin)
-        # Don't forget to install the common files!
         mkdir(prefix.common)
         install_tree(os.path.join(self.stage.source_path, "Common"), prefix.common)
 
@@ -145,6 +146,5 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
     def install(self, spec, prefix):
         mkdir(prefix.bin)
         install_tree(os.path.join(self.build_directory, "bin"), prefix.bin)
-        # Don't forget to install the common files!
         mkdir(prefix.common)
         install_tree(os.path.join(self.stage.source_path, "Common"), prefix.common)

--- a/repos/spack_repo/builtin/packages/cuda_samples/package.py
+++ b/repos/spack_repo/builtin/packages/cuda_samples/package.py
@@ -94,11 +94,15 @@ class CudaSamples(CMakePackage, MakefilePackage, CudaPackage):
     def cmake_args(self):
         spec = self.spec
         glu = spec["mesa-glu"]
+        gl_headers = ";".join(spec["gl"].headers.directories + glu.headers.directories)
+        if spec.satisfies("^libx11"):
+            gl_headers += f";{spec['libx11'].headers.directories[0]}"
+            gl_headers += f";{spec['xproto'].headers.directories[0]}"
         args = [
             self.define("CUDAToolkit_ROOT", spec["cuda"].prefix),
             self.define("GLU_INCLUDE_DIR", glu.prefix.include),
             self.define("GLU_LIBRARY", glu.libs[0]),
-            self.define("OPENGL_INCLUDE_DIR", glu.prefix.include),
+            self.define("OPENGL_INCLUDE_DIR", gl_headers),
             self.define("OPENGL_glu_LIBRARY", glu.libs[0]),
         ]
         if spec.satisfies("+freeglut"):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Previously, `cuda-samples` was attempted to by added to the spack pkg repo by the request https://github.com/spack/spack/pull/49179, but the original author later did not fix the problems and that pull request was abandoned.

Earlier, I needed to use `cuda-samples` (because I needed to use `rodinia`), and thought it would be a good idea to add it to spack repos. I picked up where things were left off at https://github.com/spack/spack/pull/49179 and fixed various problems.

I hope it could help. Previously, this was mentioned in another pull reuqest of mine https://github.com/spack/spack-packages/pull/5150 that had both `rodinia` and `cuda-samples`, which was perhaps one reason why it wasn't approved. I hope separating this out could help.