### PR TITLE
tree-sitter-ptx: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/tree_sitter_ptx/package.py
+++ b/repos/spack_repo/builtin/packages/tree_sitter_ptx/package.py
@@ -37,11 +37,12 @@ class TreeSitterPtx(CMakePackage):
 
     license("MIT", checked_by="guanyuming-he")
 
-    version("993c54d2c60a943b8c6bcfe0972ea1d9633f314",
-         sha256="7f6d7ec802c1342135087d0d0af8a9bfabff7d2e836fc5ed9a2b5de934a0883f",
-         extension="tar.gz")
+    version(
+        "993c54d2c60a943b8c6bcfe0972ea1d9633f314",
+        sha256="7f6d7ec802c1342135087d0d0af8a9bfabff7d2e836fc5ed9a2b5de934a0883f",
+        extension="tar.gz",
+    )
 
     depends_on("tree-sitter")
     depends_on("c", type="build")
     depends_on("cmake@3.13:", type="build")
-

--- a/repos/spack_repo/builtin/packages/tree_sitter_ptx/package.py
+++ b/repos/spack_repo/builtin/packages/tree_sitter_ptx/package.py
@@ -1,0 +1,47 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install tree-sitter-ptx
+#
+# You can edit this file again by typing:
+#
+#     spack edit tree-sitter-ptx
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class TreeSitterPtx(CMakePackage):
+    """tree-sitter-ptx is a highlight-grade formal grammar for NVIDIA PTX, used
+    with the tree-sitter parser generator."""
+
+    homepage = "https://github.com/JuliaGPU/tree-sitter-ptx"
+    url = "https://github.com/JuliaGPU/tree-sitter-ptx/tarball/a993c54d2c60a943b8c6bcfe0972ea1d9633f314"
+
+    supplier = "Tim Besard at JuliaGPU"
+
+    maintainers("guanyuming-he")
+
+    license("MIT", checked_by="guanyuming-he")
+
+    version("993c54d2c60a943b8c6bcfe0972ea1d9633f314",
+         sha256="7f6d7ec802c1342135087d0d0af8a9bfabff7d2e836fc5ed9a2b5de934a0883f",
+         extension="tar.gz")
+
+    depends_on("tree-sitter")
+    depends_on("c", type="build")
+    depends_on("cmake@3.13:", type="build")
+

--- a/repos/spack_repo/builtin/packages/tree_sitter_ptx/package.py
+++ b/repos/spack_repo/builtin/packages/tree_sitter_ptx/package.py
@@ -2,22 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install tree-sitter-ptx
-#
-# You can edit this file again by typing:
-#
-#     spack edit tree-sitter-ptx
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 

--- a/repos/spack_repo/builtin/packages/tree_sitter_ptx/package.py
+++ b/repos/spack_repo/builtin/packages/tree_sitter_ptx/package.py
@@ -1,6 +1,6 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage

--- a/repos/spack_repo/builtin/packages/tree_sitter_ptx/package.py
+++ b/repos/spack_repo/builtin/packages/tree_sitter_ptx/package.py
@@ -1,6 +1,6 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
-# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+# SPDX-License-Identifier: MIT
 
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

`tree-sitter-ptx` is a highlight-grade formal grammar for NVIDIA PTX, intended to be used with the `tree-sitter` parser generator, which is already in spack. 

I came to need this package during my parsing of NVIDIA PTX, and thought it could be a nice addition to the spack pkgs.