### PR TITLE
4c-multiphysics: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/_4c_multiphysics/dealii-force-bundled-boost.patch
+++ b/repos/spack_repo/builtin/packages/_4c_multiphysics/dealii-force-bundled-boost.patch
@@ -1,0 +1,22 @@
+Force deal.II 9.6.2 to use its bundled Boost implementation.
+
+Boost 1.90 no longer installs libboost_system, but deal.II 9.6.2's legacy
+FindBoost logic requires that compiled library. 4C's supported deal.II build
+already sets DEAL_II_FORCE_BUNDLED_BOOST=ON; make the same setting for this
+4C-scoped Spack dependency patch.
+
+--- a/cmake/configure/configure_20_boost.cmake
++++ b/cmake/configure/configure_20_boost.cmake
+@@ -30,6 +30,11 @@ set(DEAL_II_WITH_BOOST ON # Always true. We need it :-]
+   CACHE BOOL "Build deal.II with support for boost." FORCE
+   )
+
++set(DEAL_II_FORCE_BUNDLED_BOOST ON
++  CACHE BOOL "Use the bundled Boost implementation required by 4C." FORCE
++  )
++
++
+
+ macro(feature_boost_find_external var)
+   find_package(DEAL_II_BOOST)
+

--- a/repos/spack_repo/builtin/packages/_4c_multiphysics/dealii-petsc-3.25-domain-flags.patch
+++ b/repos/spack_repo/builtin/packages/_4c_multiphysics/dealii-petsc-3.25-domain-flags.patch
@@ -1,0 +1,20 @@
+Support PETSc 3.25's split SNES domain error flags.
+
+PETSc 3.25 replaced SNES::domainerror with separate function and objective
+domain error flags. Backport deal.II's upstream compatibility guard.
+
+--- a/source/lac/petsc_compatibility.cc
++++ b/source/lac/petsc_compatibility.cc
+@@ -70,7 +70,12 @@ namespace PETScWrappers
+ #  if DEAL_II_PETSC_VERSION_GTE(3, 11, 0)
+     snes->jacobiandomainerror = PETSC_FALSE;
+ #  endif
++#  if DEAL_II_PETSC_VERSION_GTE(3, 25, 0)
++    snes->functiondomainerror  = PETSC_FALSE;
++    snes->objectivedomainerror = PETSC_FALSE;
++#  else
+     snes->domainerror = PETSC_FALSE;
++#  endif
+   }
+ 
+   void

--- a/repos/spack_repo/builtin/packages/_4c_multiphysics/dealii-use-cxx20.patch
+++ b/repos/spack_repo/builtin/packages/_4c_multiphysics/dealii-use-cxx20.patch
@@ -1,0 +1,20 @@
+Build deal.II 9.6.2 with the C++ standard used by 4C.
+
+4C's supported dependency build configures deal.II with C++20. This is also
+required by current Taskflow releases, whose headers use C++20 concepts,
+std::bit_width, and atomic wait/notify operations.
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -90,6 +90,10 @@ endif()
+ #
+ verbose_include(${CMAKE_SOURCE_DIR}/cmake/setup_cached_variables.cmake)
+
++set(CMAKE_CXX_STANDARD 20 CACHE STRING
++  "The C++ standard required by 4C and Taskflow." FORCE
++  )
++
+ #
+ # Now, set the project and set up the rest:
+ #
+

--- a/repos/spack_repo/builtin/packages/_4c_multiphysics/identify-release-dealii.patch
+++ b/repos/spack_repo/builtin/packages/_4c_multiphysics/identify-release-dealii.patch
@@ -1,0 +1,19 @@
+diff --git a/cmake/configure/configure_deal.II.cmake b/cmake/configure/configure_deal.II.cmake
+index 584fe76f14..eff1fd56eb 100644
+--- a/cmake/configure/configure_deal.II.cmake
++++ b/cmake/configure/configure_deal.II.cmake
+@@ -28,6 +28,12 @@ else()
+ endif()
+
+ include(${DEAL_II_GIT_CONFIG})
+-set(FOUR_C_deal.II_GIT_HASH "${DEAL_II_GIT_REVISION}")
++if(DEAL_II_GIT_REVISION)
++  set(FOUR_C_deal.II_GIT_HASH "${DEAL_II_GIT_REVISION}")
++elseif(DEAL_II_PACKAGE_VERSION VERSION_EQUAL "9.6.2")
++  # Release archives do not retain Git metadata. Map the supported release to
++  # the exact commit pinned in dependencies/current/dealii/install.sh.
++  set(FOUR_C_deal.II_GIT_HASH "6890ca740b6e51530ebb7ae7e4932977010ef2be")
++endif()
+
+ four_c_remember_variable_for_install(FOUR_C_DEAL_II_ROOT)
+

--- a/repos/spack_repo/builtin/packages/_4c_multiphysics/link-installed-arborx.patch
+++ b/repos/spack_repo/builtin/packages/_4c_multiphysics/link-installed-arborx.patch
@@ -1,0 +1,15 @@
+diff --git a/cmake/configure/configure_ArborX.cmake b/cmake/configure/configure_ArborX.cmake
+index 02f3aac8b..aec46bd1d 100644
+--- a/cmake/configure/configure_ArborX.cmake
++++ b/cmake/configure/configure_ArborX.cmake
+@@ -39,7 +39,8 @@ else() # Fetch ArborX from GIT repository
+   fetchcontent_makeavailable(arborx)
+   set(FOUR_C_ARBORX_ROOT "${CMAKE_INSTALL_PREFIX}")
+
+-  four_c_add_external_dependency(four_c_all_enabled_external_dependencies ArborX::ArborX)
+ endif()
+
++four_c_add_external_dependency(four_c_all_enabled_external_dependencies ArborX::ArborX)
++
+ four_c_remember_variable_for_install(FOUR_C_ARBORX_FIND_INSTALLED FOUR_C_ARBORX_ROOT)
+

--- a/repos/spack_repo/builtin/packages/_4c_multiphysics/package.py
+++ b/repos/spack_repo/builtin/packages/_4c_multiphysics/package.py
@@ -1,0 +1,163 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
+
+from spack.package import *
+
+
+class _4cMultiphysics(CMakePackage):
+    """4C is a parallel multiphysics research code."""
+
+    homepage = "https://www.4c-multiphysics.org/"
+    url = "https://github.com/4C-multiphysics/4C/archive/refs/tags/v2025.3.0.tar.gz"
+    git = "https://github.com/4C-multiphysics/4C.git"
+
+    maintainers(
+        "bgoderbauer",
+        "c-p-schmidt",
+        "georghammerl",
+        "isteinbrecher",
+        "lauraengelhardt",
+        "mayrmt",
+        "rjoussen",
+    )
+    license("LGPL-3.0-or-later")
+
+    version("main", branch="main")
+    version("2026.2.0", sha256="57e05128934e06b67d5ae3c2d3402f80d1ddfc3975b1557670e5b1d3399a6c0b")
+    version("2026.1.0", sha256="9d95607a0b7668c9712392c81863b6327b8922745705b62e07f605f1d6932646")
+    version("2025.3.0", sha256="31088a9392bf55eb8c1b5a3b8426e8ae2b367327cef01f8f34aff55cb1153180")
+
+    # Keep these sources private to 4C until maintained packages are available
+    # in the builtin repository. FetchContent consumes the staged source trees.
+    resource(
+        name="ryml",
+        git="https://github.com/biojppm/rapidyaml.git",
+        commit="47ec2fa184209687c20fd5bc05621e1cb1200311",
+        submodules=True,
+        destination="spack-resources",
+        placement="ryml",
+    )
+    resource(
+        name="mirco",
+        url="https://github.com/imcs-compsim/MIRCO/archive/b9d0c4ba27ff8463a3d2b17163fead8800b2650c.tar.gz",
+        sha256="b3a16a0aeed5fcd778c8757d81af9070ec4964a5206f87b6257a402aa3fc4bfd",
+        destination="spack-resources",
+        placement="mirco",
+        when="+mirco",
+    )
+
+    variant("shared", default=True, description="Build shared libraries")
+    variant("qhull", default=True, description="Enable Qhull support")
+    variant("vtk", default=False, description="Enable VTK support")
+    variant("gmsh", default=False, description="Enable Gmsh support")
+    variant("dealii", default=False, description="Enable deal.II support")
+    variant("arborx", default=False, description="Enable ArborX support")
+    variant("fftw", default=False, description="Enable FFTW support")
+    variant("mirco", default=False, description="Enable MIRCO support")
+    variant("backtrace", default=False, description="Enable libbacktrace support")
+    variant("python", default=False, description="Enable Python build and test utilities")
+    variant("pybind11", default=False, description="Build the py4C Python bindings")
+
+    conflicts("~python", when="+pybind11", msg="+pybind11 requires +python")
+
+    patch("identify-release-dealii.patch", when="+dealii")
+    patch("link-installed-arborx.patch", when="+arborx")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("cmake@3.30:", type="build")
+    depends_on("ninja", type="build")
+
+    depends_on("mpi")
+    depends_on("hdf5+mpi+hl")
+    # Trilinos pulls in Fortran dependencies through MUMPS. A Fortran-capable
+    # compiler must therefore be registered even though 4C has no Fortran sources.
+    depends_on(
+        "trilinos@16.2.1+mpi+amesos+amesos2+belos+epetra+epetraext"
+        "+ifpack+ifpack2+intrepid2+isorropia+ml+muelu+nox+sacado+shards+stratimikos"
+        "+teko+thyra+tpetra+zoltan+zoltan2+explicit_template_instantiation"
+        "+mumps+superlu-dist+suite-sparse+exodus gotype=int",
+        patches=[patch("trilinos-iocgns-extern-c-linkage.patch")],
+    )
+    depends_on("boost+graph")
+    depends_on("cln")
+    depends_on("zlib-api")
+    depends_on("cli11@2.6.1")
+    depends_on("magic-enum@0.9.7")
+
+    # 4C uses Qhull's deprecated non-reentrant libqhull API.
+    depends_on("qhull@2019.1", when="+qhull")
+    depends_on("vtk@9:+shared", when="+vtk")
+    depends_on("gmsh@4.15.1+shared~cgns~fltk~med", when="+gmsh")
+    depends_on("dealii@9.6.2+trilinos+mpi~adol-c", when="+dealii")
+    depends_on("arborx@2.0.1+mpi", when="+arborx")
+    depends_on("fftw", when="+fftw")
+    depends_on("libbacktrace", when="+backtrace")
+    depends_on("python@3.12:", when="+python")
+    depends_on("python-venv", type=("build", "run"), when="+python")
+    depends_on("py-pybind11", when="+pybind11")
+
+    generator("ninja")
+
+    def cmake_args(self):
+        spec = self.spec
+        args = [
+            self.define_from_variant("FOUR_C_BUILD_SHARED_LIBS", "shared"),
+            self.define("FOUR_C_ENABLE_DEVELOPER_MODE", False),
+            self.define("FOUR_C_ENABLE_METADATA_GENERATION", False),
+            self.define("FETCHCONTENT_TRY_FIND_PACKAGE_MODE", "ALWAYS"),
+            self.define("FOUR_C_HDF5_ROOT", spec["hdf5"].prefix),
+            self.define("FOUR_C_MPI_ROOT", spec["mpi"].prefix),
+            self.define("FOUR_C_TRILINOS_ROOT", spec["trilinos"].prefix),
+            self.define("FOUR_C_BOOST_ROOT", spec["boost"].prefix),
+            self.define("FOUR_C_CLN_ROOT", spec["cln"].prefix),
+            self.define(
+                "FETCHCONTENT_SOURCE_DIR_RYML",
+                join_path(self.stage.source_path, "spack-resources", "ryml"),
+            ),
+            self.define("FOUR_C_MAGIC_ENUM_ROOT", spec["magic-enum"].prefix),
+            self.define("FOUR_C_ZLIB_ROOT", spec["zlib-api"].prefix),
+            self.define("FOUR_C_CLI11_ROOT", spec["cli11"].prefix),
+            self.define_from_variant("FOUR_C_WITH_QHULL", "qhull"),
+            self.define_from_variant("FOUR_C_WITH_VTK", "vtk"),
+            self.define_from_variant("FOUR_C_WITH_GMSH", "gmsh"),
+            self.define_from_variant("FOUR_C_WITH_DEAL_II", "dealii"),
+            self.define_from_variant("FOUR_C_WITH_ARBORX", "arborx"),
+            self.define_from_variant("FOUR_C_WITH_FFTW", "fftw"),
+            self.define_from_variant("FOUR_C_WITH_MIRCO", "mirco"),
+            self.define_from_variant("FOUR_C_WITH_BACKTRACE", "backtrace"),
+            self.define_from_variant("FOUR_C_WITH_PYTHON", "python"),
+            self.define_from_variant("FOUR_C_WITH_PYBIND11", "pybind11"),
+            self.define_from_variant("FOUR_C_ENABLE_PYTHON_BINDINGS", "pybind11"),
+        ]
+
+        roots = {
+            "qhull": ("FOUR_C_QHULL_ROOT", "qhull"),
+            "vtk": ("FOUR_C_VTK_ROOT", "vtk"),
+            "gmsh": ("FOUR_C_GMSH_ROOT", "gmsh"),
+            "dealii": ("FOUR_C_DEAL_II_ROOT", "dealii"),
+            "arborx": ("FOUR_C_ARBORX_ROOT", "arborx"),
+            "fftw": ("FOUR_C_FFTW_ROOT", "fftw"),
+            "backtrace": ("FOUR_C_BACKTRACE_ROOT", "libbacktrace"),
+            "python": ("FOUR_C_PYTHON_ROOT", "python"),
+            "pybind11": ("FOUR_C_PYBIND11_ROOT", "py-pybind11"),
+        }
+        for variant, (variable, dependency) in roots.items():
+            if "+" + variant in spec:
+                args.append(self.define(variable, spec[dependency].prefix))
+
+        if "+arborx" in spec:
+            args.append(self.define("FOUR_C_ARBORX_FIND_INSTALLED", True))
+        if "+mirco" in spec:
+            args.append(
+                self.define(
+                    "FETCHCONTENT_SOURCE_DIR_MIRCO",
+                    join_path(self.stage.source_path, "spack-resources", "mirco"),
+                )
+            )
+
+        return args
+

--- a/repos/spack_repo/builtin/packages/_4c_multiphysics/package.py
+++ b/repos/spack_repo/builtin/packages/_4c_multiphysics/package.py
@@ -58,10 +58,6 @@ class _4cMultiphysics(CMakePackage):
     variant("fftw", default=False, description="Enable FFTW support")
     variant("mirco", default=False, description="Enable MIRCO support")
     variant("backtrace", default=False, description="Enable libbacktrace support")
-    variant("python", default=False, description="Enable Python build and test utilities")
-    variant("pybind11", default=False, description="Build the py4C Python bindings")
-
-    conflicts("~python", when="+pybind11", msg="+pybind11 requires +python")
 
     patch("identify-release-dealii.patch", when="+dealii")
     patch("link-installed-arborx.patch", when="+arborx")
@@ -70,6 +66,7 @@ class _4cMultiphysics(CMakePackage):
     depends_on("cxx", type="build")
     depends_on("cmake@3.30:", type="build")
     depends_on("ninja", type="build")
+    requires("platform=linux")
 
     depends_on("mpi")
     depends_on("hdf5+mpi+hl")
@@ -106,9 +103,6 @@ class _4cMultiphysics(CMakePackage):
     depends_on("arborx@2.0.1+mpi", when="+arborx")
     depends_on("fftw", when="+fftw")
     depends_on("libbacktrace", when="+backtrace")
-    depends_on("python@3.12:", when="+python")
-    depends_on("python-venv", type=("build", "run"), when="+python")
-    depends_on("py-pybind11", when="+pybind11")
 
     generator("ninja")
 
@@ -139,9 +133,9 @@ class _4cMultiphysics(CMakePackage):
             self.define_from_variant("FOUR_C_WITH_FFTW", "fftw"),
             self.define_from_variant("FOUR_C_WITH_MIRCO", "mirco"),
             self.define_from_variant("FOUR_C_WITH_BACKTRACE", "backtrace"),
-            self.define_from_variant("FOUR_C_WITH_PYTHON", "python"),
-            self.define_from_variant("FOUR_C_WITH_PYBIND11", "pybind11"),
-            self.define_from_variant("FOUR_C_ENABLE_PYTHON_BINDINGS", "pybind11"),
+            self.define("FOUR_C_WITH_PYTHON", False),
+            self.define("FOUR_C_WITH_PYBIND11", False),
+            self.define("FOUR_C_ENABLE_PYTHON_BINDINGS", False),
         ]
 
         roots = {
@@ -152,8 +146,6 @@ class _4cMultiphysics(CMakePackage):
             "arborx": ("FOUR_C_ARBORX_ROOT", "arborx"),
             "fftw": ("FOUR_C_FFTW_ROOT", "fftw"),
             "backtrace": ("FOUR_C_BACKTRACE_ROOT", "libbacktrace"),
-            "python": ("FOUR_C_PYTHON_ROOT", "python"),
-            "pybind11": ("FOUR_C_PYBIND11_ROOT", "py-pybind11"),
         }
         for variant, (variable, dependency) in roots.items():
             if "+" + variant in spec:

--- a/repos/spack_repo/builtin/packages/_4c_multiphysics/package.py
+++ b/repos/spack_repo/builtin/packages/_4c_multiphysics/package.py
@@ -82,7 +82,9 @@ class _4cMultiphysics(CMakePackage):
         "+mumps+superlu-dist+suite-sparse+exodus gotype=int",
         patches=[patch("trilinos-iocgns-extern-c-linkage.patch")],
     )
-    depends_on("boost+graph")
+    # deal.II 9.6.2 uses bundled Boost 1.84. Keep 4C's compiled Boost.Graph
+    # library and headers ABI-compatible with the deal.II headers.
+    depends_on("boost@1.84.0+graph")
     depends_on("cln")
     depends_on("zlib-api")
     depends_on("cli11@2.6.1")
@@ -92,7 +94,15 @@ class _4cMultiphysics(CMakePackage):
     depends_on("qhull@2019.1", when="+qhull")
     depends_on("vtk@9:+shared", when="+vtk")
     depends_on("gmsh@4.15.1+shared~cgns~fltk~med", when="+gmsh")
-    depends_on("dealii@9.6.2+trilinos+mpi~adol-c", when="+dealii")
+    depends_on(
+        "dealii@9.6.2+trilinos+mpi~adol-c",
+        patches=[
+            patch("dealii-force-bundled-boost.patch"),
+            patch("dealii-use-cxx20.patch"),
+            patch("dealii-petsc-3.25-domain-flags.patch"),
+        ],
+        when="+dealii",
+    )
     depends_on("arborx@2.0.1+mpi", when="+arborx")
     depends_on("fftw", when="+fftw")
     depends_on("libbacktrace", when="+backtrace")
@@ -160,4 +170,3 @@ class _4cMultiphysics(CMakePackage):
             )
 
         return args
-

--- a/repos/spack_repo/builtin/packages/_4c_multiphysics/trilinos-iocgns-extern-c-linkage.patch
+++ b/repos/spack_repo/builtin/packages/_4c_multiphysics/trilinos-iocgns-extern-c-linkage.patch
@@ -7,7 +7,7 @@ which overrides the `extern "C"` language linkage. GCC 15 consequently
 emits a mangled reference instead of the plain C symbol exported by CGNS.
 Move the declaration to global scope so it retains external C linkage.
 
-Upstream context: https://github.com/CGNS/CGNS/issues/835
+Upstream report: https://github.com/sandialabs/seacas/issues/889
 
 --- a/packages/seacas/libraries/ioss/src/cgns/Iocgns_DatabaseIO.C
 +++ b/packages/seacas/libraries/ioss/src/cgns/Iocgns_DatabaseIO.C

--- a/repos/spack_repo/builtin/packages/_4c_multiphysics/trilinos-iocgns-extern-c-linkage.patch
+++ b/repos/spack_repo/builtin/packages/_4c_multiphysics/trilinos-iocgns-extern-c-linkage.patch
@@ -1,0 +1,44 @@
+Fix CGNS `ctx_cgio` link failure in SEACAS/Iocgns with GCC 15.
+
+Iocgns_DatabaseIO.C hand-declares the CGNS-internal global `ctx_cgio`
+(from the private header `cgio_internal_type.h`) inside an unnamed
+namespace. A name declared in an unnamed namespace has internal linkage,
+which overrides the `extern "C"` language linkage. GCC 15 consequently
+emits a mangled reference instead of the plain C symbol exported by CGNS.
+Move the declaration to global scope so it retains external C linkage.
+
+Upstream context: https://github.com/CGNS/CGNS/issues/835
+
+--- a/packages/seacas/libraries/ioss/src/cgns/Iocgns_DatabaseIO.C
++++ b/packages/seacas/libraries/ioss/src/cgns/Iocgns_DatabaseIO.C
+@@ -78,9 +78,13 @@
+
+ // extern char hdf5_access[64];
+
+-namespace {
+-  extern "C" {
+-  // From private CGNS header: `cgio_internal_type.h`
++// NOTE: this block must remain at global scope. A variable declared in an
++// unnamed namespace has internal linkage, which overrides the `extern "C"`
++// language linkage: the compiler then emits a mangled reference to
++// `(anonymous namespace)::ctx_cgio` instead of the plain C symbol
++// `ctx_cgio` that libcgns actually exports, and the link fails.
++extern "C" {
++// From private CGNS header: `cgio_internal_type.h`
+   typedef struct _cgns_io_ctx_t
+   {
+     /* Flag indicating if HDF5 file accesses is PARALLEL or NATIVE */
+@@ -97,8 +101,10 @@
+ #endif
+   } cgns_io_ctx_t;
+
+-  extern cgns_io_ctx_t ctx_cgio; /* located in cgns_io.c */
+-  }
++extern cgns_io_ctx_t ctx_cgio; /* located in cgns_io.c */
++}
++
++namespace {
+
+   // There is a bug in the CGNS library (4.4.0 and before) where it
+   // has a global symbol `ctx_cgio` which controls whether
+


### PR DESCRIPTION
4C Multiphysics is a powerful research code for multiphysics computer simulations. It is a cmake/ninja based C++ project which requires several dependencies to be compiled. The source code is available under https://github.com/4C-multiphysics/4C.

Recipe was developed on ubuntu24.04 with gcc13.3 (architecture: skylake). 4C Multiphysics is linux only (at the moment).

Assisted-by: GPT-5.6 Sol

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
