### PR TITLE
Fix no-Fortran builds for Scotch

### DIFF
--- a/repos/spack_repo/builtin/packages/scotch/package.py
+++ b/repos/spack_repo/builtin/packages/scotch/package.py
@@ -176,6 +176,9 @@ class CMakeBuilder(cmake.CMakeBuilder):
         if self.spec.satisfies("@7.0.7:"):
             args.append(self.define_from_variant("SCOTCH_DETERMINISTIC", "determinism"))
 
+        if self.spec.satisfies("@7.0.9:"):
+            args.append(self.define_from_variant("BUILD_FORTRAN", "fortran"))
+
         if "+int64" in self.spec:
             args.append("-DINTSIZE=64")
         elif self.is_64bit():


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR passes the `BUILD_FORTRAN` flag to CMake depending on the `fortran` variant.

Fixes #5972.

@AlexanderRichert-NOAA @climbfuji