### PR TITLE
bowtie2: Prevent compilation errors with gcc@:11 for version @2.5.5

### DIFF
--- a/repos/spack_repo/builtin/packages/bowtie2/package.py
+++ b/repos/spack_repo/builtin/packages/bowtie2/package.py
@@ -90,6 +90,10 @@ class Bowtie2(MakefilePackage):
         make_arg = ["PREFIX={0}".format(self.prefix)]
         if self.spec.satisfies("target=aarch64:"):
             make_arg.append("POPCNT_CAPABILITY=0")
+
+        if self.spec.satisfies("@2.5.5 %gcc@:11 target=x86_64:"):
+            # avoid __builtin_cpu_supports("x86-64-v3"), unsupported before GCC 12
+            make_arg.append("SSE_AVX2=0")
         return make_arg
 
     @property


### PR DESCRIPTION
`bowtie@2.5.5` introduces the use of `__builtin_cpu_supports("x86-64-v3")`, which fails for versions of GCC <= 11. A build flag was added which should avoid this block entirely.

This already seems to be fixed in the master branch, so I'd be fairly confident in keeping it strictly locked to the 2.5.5 version.

Possibly relevant readings:
https://github.com/BenLangmead/bowtie2/issues/522