### PR TITLE
edm4hep: url_for_version for main version

### DIFF
--- a/repos/spack_repo/builtin/packages/edm4hep/package.py
+++ b/repos/spack_repo/builtin/packages/edm4hep/package.py
@@ -123,6 +123,9 @@ class Edm4hep(CMakePackage):
         """
         base_url = self.url.rsplit("/", 1)[0]
 
+        if version.isdevelop():
+            return f"{base_url}/refs/heads/{version}.tar.gz"
+
         if len(version) == 1:
             major = version[0]
             minor, patch = 0, 0


### PR DESCRIPTION
This PR avoids in `edm4hep` the incorrect insertion of a named version (`main`) into an integer format placeholder. This is relevant for the SBOM generation, even though the version is checked out from the git repo.
```
Traceback (most recent call last):
  File "/home/wdconinc/git/spack/lib/spack/spack/hooks/sbom_generate.py", line 148, in generate_spdx_2_3
    pkg_entry = make_spdx_2_3_package_entry(spec)
  File "/home/wdconinc/git/spack/lib/spack/spack/hooks/sbom_generate.py", line 107, in make_spdx_2_3_package_entry
    "downloadLocation": get_download_location(spec) or "NOASSERTION",
                        ~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/wdconinc/git/spack/lib/spack/spack/hooks/sbom_generate.py", line 89, in get_download_location
    return str(pkg.url_for_version(spec.version))
               ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/home/wdconinc/git/spack-packages/repos/spack_repo/builtin/packages/edm4hep/package.py", line 139, in url_for_version
    version_str = "v%02d-%02d.tar.gz" % (major, minor)
                  ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
TypeError: %d format: a real number is required, not VersionStrComponent
```