### PR TITLE
miniprot: Added as new package

### DIFF
--- a/repos/spack_repo/builtin/packages/miniprot/package.py
+++ b/repos/spack_repo/builtin/packages/miniprot/package.py
@@ -1,0 +1,41 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.generic import Package
+
+from spack.package import *
+
+
+class Miniprot(Package):
+    """Miniprot aligns a protein sequence against a genome with affine gap penalty,
+    splicing and frameshift. It is primarily intended for annotating protein-coding
+    genes in a new species using known genes from other speciesa.
+
+    Miniprot is not optimized for mapping distant homologs because distant homologs
+    are less informative to gene annotations. Nonetheless, it is still possible to
+    tune seeding parameters to achieve higher sensitivity at the cost of
+    performance."""
+
+    homepage = "https://github.com/lh3/miniprot"
+    url = "https://github.com/lh3/miniprot/archive/refs/tags/v0.18.tar.gz"
+
+    license("MIT", checked_by="emwjacobson")
+
+    version("0.18", sha256="e1b5c08571fa3a4aa225da8ec9c6e744cd116b4dc50d9e187114cffe336921ee")
+    version("0.17", sha256="afdad05d18290756a7056ca7f67a91bd55d56006100653fd3dd956652206a415")
+    version("0.16", sha256="1ec0290552a6c80ad71657a44c767c3a2a2bbcfe3c7cc150083de7f9dc4b3ed0")
+
+    depends_on("c", type="build")
+    depends_on("gmake", type="build")
+    depends_on("zlib-api")
+
+    def install(self, spec, prefix):
+        filter_file("^CC=.*", "CC={0}".format(self.compiler.cc), "Makefile")
+        make()
+
+        mkdirp(prefix.bin)
+        install("miniprot", join_path(prefix.bin, "miniprot"))
+        set_executable(join_path(prefix.bin, "miniprot"))
+        mkdirp(prefix.man.man1)
+        install("miniprot.1", prefix.man.man1)


### PR DESCRIPTION
Adds miniprot as a new package, included the 3 latest versions.

Filtered the CC compiler just to make sure it picks up the correct one, not sure if this is 100% required though as it also seemed to compile file without it, but cant hurt to be safe? One additional thing to note - the Makefile has a flag for CXX as well, but it doesn't appear that any cpp files are actually compiled. Because of this I opted to not filter CXX and to not include a depends_on for cxx.

Tested with a handful of GCC versions. Rocky 9 machine.
| | miniprot@=0.18 | miniprot@=0.17 | miniprot@=0.16 |
|---|---|---|---|
| gcc@=16.1.0 | ✅ | ✅ | ✅ |
| gcc@=15.3.0 | ✅ | ✅ | ✅ |
| gcc@=14.4.0 | ✅ | ✅ | ✅ |
| gcc@=13.4.0 | ✅ | ✅ | ✅ |
| gcc@=12.5.0 | ✅ | ✅ | ✅ |
| gcc@=11.5.0 | ✅ | ✅ | ✅ |