### PR TITLE
netlib-scalapack: Add missing CMake version contraints

### DIFF
--- a/repos/spack_repo/builtin/packages/netlib_scalapack/package.py
+++ b/repos/spack_repo/builtin/packages/netlib_scalapack/package.py
@@ -22,7 +22,8 @@ class ScalapackBase(CMakePackage):
     depends_on("mpi")
     depends_on("lapack")
     depends_on("blas")
-    depends_on("cmake", when="@2.0.0:", type="build")
+    depends_on("cmake", when="@2.0.0:2.2.2", type="build")
+    depends_on("cmake@3.26:", when="@2.2.3:", type="build")
 
     # See: https://github.com/Reference-ScaLAPACK/scalapack/issues/9
     patch("cmake_fortran_mangle.patch", when="@2.0.2:2.0")


### PR DESCRIPTION
fixes #5722

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
