### PR TITLE
openblas: ensure no fortran auto-detection

### DIFF
--- a/repos/spack_repo/builtin/packages/openblas/package.py
+++ b/repos/spack_repo/builtin/packages/openblas/package.py
@@ -28,6 +28,7 @@ class Openblas(CMakePackage, MakefilePackage):
     license("BSD-3-Clause")
 
     version("develop", branch="develop")
+    version("0.3.34", sha256="cd7e129868320cc2d033afa920e31202dfe0b8066a5b66661900ccc0f197dfed")
     version("0.3.33", sha256="6761af1d9f5d353ab4f0b7497be2643313b36c8f31caec0144bfef198e71e6ab")
     version("0.3.32", sha256="f8a1138e01fddca9e4c29f9684fd570ba39dedc9ca76055e1425d5d4b1a4a766")
     version("0.3.30", sha256="27342cff518646afb4c2b976d809102e368957974c250a25ccc965e53063c95d")
@@ -576,6 +577,8 @@ class MakefileBuilder(makefile.MakefileBuilder):
         # Fortran-free compilation
         if "~fortran" in self.spec:
             make_defs += ["NOFORTRAN=1"]
+            # f_check still auto-detects Fortran compilers on PATH
+            make_defs += ["F_COMPILER=none"]
 
         if "~shared" in self.spec:
             if "+pic" in self.spec:


### PR DESCRIPTION
Depends on:
- [x] https://github.com/spack/spack-packages/pull/5883

(Originally written with new version inclusion; please focus on the no-fortran suppression below.)

This PR adds to `openblas` the new version v0.3.34 ([diff](https://github.com/OpenMathLib/OpenBLAS/compare/v0.3.33...v0.3.34)). No changes to build system or dependencies called out in release notes or apparent from a look through the diff (new CMake flag CPP_THREAD_SAFETY_USE_OPENMP is only active for a test we don't enable).

This also adds an extra no-fortran suppression since for Makefile builds the `f_check` build utility still finds non-spack system fortran and then tries to use it for linking (and fails in the spack wrapper). The definition of FC_compiler=none ensures that this doesn't happen. This fixes the following linking failure that happens for openblas~fortran when the system has flang:
```
[spack cc]: Error: SPACK_FC_* variables not set: this usually means a missing `depends_on("fortran", type="build")` in package.py
make[1]: *** [Makefile:208: ../libopenblas-r0.3.34.so] Error 1
make: *** [Makefile:150: shared] Error 2
```

Test build (wtihout fortran):
```
nkaa2py openblas@0.3.34~bignuma~consistent_fpcsr+dynamic_dispatch~fortran+ilp64+locking+pic+shared~static build_system=makefile patches:=9968625 symbol_suffix=none threads=none
[+] nkaa2py openblas@0.3.34 /opt/software/linux-skylake/openblas-0.3.34-nkaa2pylih65kzmz5xxevukrsaxoulnl (23m28s)
```
