### PR TITLE
r-xts: add @0.14.2, ^fortan and gcc conflicts

### DIFF
--- a/repos/spack_repo/builtin/packages/r_xts/package.py
+++ b/repos/spack_repo/builtin/packages/r_xts/package.py
@@ -19,6 +19,7 @@ class RXts(RPackage):
 
     license("GPL-2.0-or-later")
 
+    version("0.14.2", sha256="d4b68584b2b64664163850af6cb936b9bf14485bfb725d048c272cee0812dc6f")
     version("0.14.0", sha256="d28b16eefa9876a815bad3fc204779c197e3a0d7796b8dae8856fe153f5fcfd9")
     version("0.13.1", sha256="2c3907c6d0162e48d1898647105bbb32cfe0cb005788481a64ee675a941d825d")
     version("0.13.0", sha256="188e4d1d8c3ec56a544dfb9da002e8aac80b9303d0a5a1f62ff0e960aeef9674")
@@ -27,8 +28,12 @@ class RXts(RPackage):
     version("0.11-2", sha256="12772f6a66aab5b84b0665c470f11a3d8d8a992955c027261cfe8e6077ee13b8")
     version("0.9-7", sha256="f11f7cb98f4b92b7f6632a2151257914130880c267736ef5a264b5dc2dfb7098")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("fortran", type="build", when="@:0.10")
 
     depends_on("r@3.6.0:", type=("build", "run"), when="@0.13.0:")
 
     depends_on("r-zoo@1.7-12:", type=("build", "run"))
+
+    conflicts("%gcc@14: ^r@4.6:", when="@:0.14.1")
+    conflicts("%gcc@10:", when="@:0.11")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

## After

<img width="282" height="674" alt="image" src="https://github.com/user-attachments/assets/081782f6-187f-492c-92a3-d0bbf335deb1" />

## Prevents

<img width="282" height="674" alt="image" src="https://github.com/user-attachments/assets/d5e15db2-02a9-4aee-a1ac-85788859c5b7" />

```
spack/opt/spack/linux-skylake/compiler-wrapper-1.1.0-cpibo47dhvrie6bmdipqmwsblxhydz6r/libexec/spack/gcc/gcc -I"spack/opt/spack/linux-skylake/r-4.6.0-3ygoykywpgxgnn656la2pgupavbaasvf/rlib/R/include" -DNDEBUG -I../inst/include -I'spack/opt/spack/linux-skylake/r-zoo-1.8-12-wra5sduhoisowfapuehjgtme2wqwclol/rlib/R/library/zoo/include' -I/usr/local/include    -fpic  -g -O2  -c period_arithmetic.c -o period_arithmetic.o
  attr.c: In function 'do_xtsAttributes':
> attr.c:33:7: error: implicit declaration of function 'ATTRIB' [-Wimplicit-function-declaration]
     33 |   a = ATTRIB(x);
        |       ^~~~~~
> attr.c:33:5: error: assignment to 'SEXP' {aka 'struct SEXPREC *'} from 'int' makes pointer from integer without a cast [-Wint-conversion]
     33 |   a = ATTRIB(x);
        |     ^
  attr.c: In function 'do_xtsCoreAttributes':
> attr.c:76:5: error: assignment to 'SEXP' {aka 'struct SEXPREC *'} from 'int' makes pointer from integer without a cast [-Wint-conversion]
     76 |   a = ATTRIB(x);
        |     ^
  attr.c: In function 'copyAttributes':
> attr.c:116:8: error: assignment to 'SEXP' {aka 'struct SEXPREC *'} from 'int' makes pointer from integer without a cast [-Wint-conversion]
    116 |   attr = ATTRIB(x);  /* this returns a LISTSXP */
        |        ^
> make: *** [spack/opt/spack/linux-skylake/r-4.6.0-3ygoykywpgxgnn656la2pgupavbaasvf/rlib/R/etc/Makeconf.spack:190: attr.o] Error 1
  make: *** Waiting for unfinished jobs....
  ERROR: compilation failed for package 'xts'
  * removing 'spack/opt/spack/linux-skylake/r-xts-0.14.1-mw33holu3aksdvbzptyzwrxbf6zkepyn/rlib/R/library/xts'
  Command exited with status 1
```

```
spack/opt/spack/linux-skylake/compiler-wrapper-1.1.0-cpibo47dhvrie6bmdipqmwsblxhydz6r/libexec/spack/gcc/gfortran  -fpic  -g -O2  -c period.min.f -o period.min.o
> [spack cc]: Error: SPACK_FC_* variables not set: this usually means a missing `depends_on("fortran", type="build")` in package.py
> make: *** [spack/opt/spack/linux-skylake/r-4.3.3-52rhmbzujtc4qu6rorrpmefigxwakyi3/rlib/R/etc/Makeconf.spack:214: period.max.o] Error 1
  make: *** Waiting for unfinished jobs....
> [spack cc]: Error: SPACK_FC_* variables not set: this usually means a missing `depends_on("fortran", type="build")` in package.py
> make: *** [spack/opt/spack/linux-skylake/r-4.3.3-52rhmbzujtc4qu6rorrpmefigxwakyi3/rlib/R/etc/Makeconf.spack:214: period.min.o] Error 1
  ERROR: compilation failed for package 'xts'
  * removing 'spack/opt/spack/linux-skylake/r-xts-0.9-7-sgcslqvz6scntz5hcp75mqo7jh4l2lol/rlib/R/library/xts'
  Command exited with status 1
```

```
> /usr/bin/x86_64-linux-gnu-ld.bfd: unique.time.o:r-grid/.tmp/spack-stage/spack-stage-r-xts-0.11-2-q4kw7kyitalgava5dfiznts7z7qr6ylh/spack-src/src/../inst/include/xts.h:65: multiple definition of `zoo_lag'; attr.o:r-grid/.tmp/spack-stage/spack-stage-r-xts-0.11-2-q4kw7kyitalgava5dfiznts7z7qr6ylh/spack-src/src/../inst/include/xts.h:65: first defined here
> /usr/bin/x86_64-linux-gnu-ld.bfd: unique.time.o:r-grid/.tmp/spack-stage/spack-stage-r-xts-0.11-2-q4kw7kyitalgava5dfiznts7z7qr6ylh/spack-src/src/../inst/include/xts.h:34: multiple definition of `xts_IndexTzoneSymbol'; attr.o:r-grid/.tmp/spack-stage/spack-stage-r-xts-0.11-2-q4kw7kyitalgava5dfiznts7z7qr6ylh/spack-src/src/../inst/include/xts.h:34: first defined here
> /usr/bin/x86_64-linux-gnu-ld.bfd: unique.time.o:r-grid/.tmp/spack-stage/spack-stage-r-xts-0.11-2-q4kw7kyitalgava5dfiznts7z7qr6ylh/spack-src/src/../inst/include/xts.h:33: multiple definition of `xts_IndexTclassSymbol'; attr.o:r-grid/.tmp/spack-stage/spack-stage-r-xts-0.11-2-q4kw7kyitalgava5dfiznts7z7qr6ylh/spack-src/src/../inst/include/xts.h:33: first defined here
> /usr/bin/x86_64-linux-gnu-ld.bfd: unique.time.o:r-grid/.tmp/spack-stage/spack-stage-r-xts-0.11-2-q4kw7kyitalgava5dfiznts7z7qr6ylh/spack-src/src/../inst/include/xts.h:32: multiple definition of `xts_IndexTZSymbol'; attr.o:r-grid/.tmp/spack-stage/spack-stage-r-xts-0.11-2-q4kw7kyitalgava5dfiznts7z7qr6ylh/spack-src/src/../inst/include/xts.h:32: first defined here
> /usr/bin/x86_64-linux-gnu-ld.bfd: unique.time.o:r-grid/.tmp/spack-stage/spack-stage-r-xts-0.11-2-q4kw7kyitalgava5dfiznts7z7qr6ylh/spack-src/src/../inst/include/xts.h:31: multiple definition of `xts_IndexClassSymbol'; attr.o:r-grid/.tmp/spack-stage/spack-stage-r-xts-0.11-2-q4kw7kyitalgava5dfiznts7z7qr6ylh/spack-src/src/../inst/include/xts.h:31: first defined here
> /usr/bin/x86_64-linux-gnu-ld.bfd: unique.time.o:r-grid/.tmp/spack-stage/spack-stage-r-xts-0.11-2-q4kw7kyitalgava5dfiznts7z7qr6ylh/spack-src/src/../inst/include/xts.h:30: multiple definition of `xts_IndexFormatSymbol'; attr.o:r-grid/.tmp/spack-stage/spack-stage-r-xts-0.11-2-q4kw7kyitalgava5dfiznts7z7qr6ylh/spack-src/src/../inst/include/xts.h:30: first defined here
> /usr/bin/x86_64-linux-gnu-ld.bfd: unique.time.o:r-grid/.tmp/spack-stage/spack-stage-r-xts-0.11-2-q4kw7kyitalgava5dfiznts7z7qr6ylh/spack-src/src/../inst/include/xts.h:29: multiple definition of `xts_ClassSymbol'; attr.o:r-grid/.tmp/spack-stage/spack-stage-r-xts-0.11-2-q4kw7kyitalgava5dfiznts7z7qr6ylh/spack-src/src/../inst/include/xts.h:29: first defined here
> collect2: error: ld returned 1 exit status
```