### PR TITLE
detray: propagate acts-algebra-plugins dependencies; add to HEP stack

### DIFF
--- a/repos/spack_repo/builtin/packages/detray/package.py
+++ b/repos/spack_repo/builtin/packages/detray/package.py
@@ -197,6 +197,10 @@ class Detray(CMakePackage):
     depends_on("covfie@0.15.3:", when="@0.102:")
     depends_on("nlohmann-json@3.11.0:", when="+json")
     depends_on("dfelibs@20211029:", when="@:0.88")
+    with when("@0.111:"):
+        depends_on("vc@1.4.5:", when="+vc")
+        depends_on("eigen@3.4.0:", when="+eigen")
+        depends_on("root@6.18.0:", when="+smatrix")
     with when("@:0.110"):
         depends_on("acts-algebra-plugins@0.18.0: +vecmem")
         depends_on("acts-algebra-plugins +vc", when="+vc")

--- a/repos/spack_repo/builtin/packages/detray/package.py
+++ b/repos/spack_repo/builtin/packages/detray/package.py
@@ -200,7 +200,10 @@ class Detray(CMakePackage):
     with when("@0.111:"):
         depends_on("vc@1.4.5:", when="+vc")
         depends_on("eigen@3.4.0:", when="+eigen")
-        depends_on("root@6.18.0:", when="+smatrix")
+        with when("+smatrix"):
+            depends_on("root@6.18.0:")
+            depends_on("root cxxstd=20", when="cxxstd=20")
+            conflicts("cxxstd=23")
     with when("@:0.110"):
         depends_on("acts-algebra-plugins@0.18.0: +vecmem")
         depends_on("acts-algebra-plugins +vc", when="+vc")

--- a/stacks/hep/spack.yaml
+++ b/stacks/hep/spack.yaml
@@ -97,6 +97,7 @@ spack:
   - collier
   - dd4hep +ddalign +ddcad +ddcond +dddetectors +dddigi +ddeve +ddg4 +ddrec +edm4hep +hepmc3 +lcio +utilityapps +xercesc
   - delphes +pythia8
+  - detray
   - dpmjet
   - edm4hep
   - evtgen +hepmc3 +photos +pythia8 +sherpa +tauola


### PR DESCRIPTION
This PR modifies `detray` to propagate the dependencies that used to be enforced through `acts-algebra-plugins` until that code base was integrated into `detray` (https://github.com/spack/spack-packages/pull/3854). This intends to fix the CI failure in https://gitlab.spack.io/spack/spack-packages/-/jobs/23828128#L324.