### PR TITLE
hepmc3: patch to remove cdll.LoadLibrary of unversioned libCore.so

### DIFF
--- a/repos/spack_repo/builtin/packages/hepmc3/package.py
+++ b/repos/spack_repo/builtin/packages/hepmc3/package.py
@@ -60,6 +60,13 @@ class Hepmc3(CMakePackage):
     # See https://gitlab.cern.ch/hepmc/HepMC3/-/merge_requests/58.diff
     patch("ba38f14d8f56c16cc4105d98f6d4540c928c6150.patch", when="@3.1.2:3.2.1 %gcc@9.3.0")
 
+    # Drop cdll.LoadLibrary("libCore.so") in ROOT IO python __init__.py
+    patch(
+        "https://gitlab.cern.ch/hepmc/HepMC3/-/commit/68901dfb4e4f19539ec31630f529095e96718935.diff",
+        sha256="a9210112d98566c47195c5a2ad1a6aa07b452e5bf9e9b6980c3031052ff41610",
+        when="@3.3.1",
+    )
+
     extends("python", when="+python")
 
     @property

--- a/repos/spack_repo/builtin/packages/hepmc3/package.py
+++ b/repos/spack_repo/builtin/packages/hepmc3/package.py
@@ -64,7 +64,7 @@ class Hepmc3(CMakePackage):
     patch(
         "https://gitlab.cern.ch/hepmc/HepMC3/-/commit/68901dfb4e4f19539ec31630f529095e96718935.diff",
         sha256="a9210112d98566c47195c5a2ad1a6aa07b452e5bf9e9b6980c3031052ff41610",
-        when="@3.3.1",
+        when="@3.2.6:3.3.1",
     )
 
     extends("python", when="+python")


### PR DESCRIPTION
This PR patches `hepmc3` to remove the explicit `cdll.LoadLibrary("libCore.so")` in the rootIO __init__.py (see https://gitlab.cern.ch/hepmc/HepMC3/-/merge_requests/400).

This is billed by upstream as obsolete code for EPEL7 but the motivation here is that it has recently (ROOT 6.38 and in particular 6.40) started to act up since ROOT now requires the library filename to be identical to the SONAME when determining the lib dir (core/base/src/TROOT.cxx, TROOT::GetSharedLibDir), which is then needed to find the include dir with ROOT.modulemap. In the case of hepmc3's loading of `libCore.so` the filename will never agree with the SONAME of e.g. `libCore.so.6.40`. That then results in:
```
fatal error: module map file '../../include/root/ROOT.modulemap' not found
fatal error: module map file '../../include/root/ROOT.modulemap' not found
 *** Break *** segmentation violation
```

Without this explicit load, the library SONAME in DT_NEEDED of the libHepMC3rootIO.so is loaded.

This patch is already in the upstream main branch and will be in the next release. It is applied to 3.2.6 which is the earliest it applies cleanly.

Test build (not really any changes, just to show the patch applies cleanly I guess):
```
[+] 4zn7dqs hepmc3@3.3.1 /opt/software/linux-skylake/hepmc3-3.3.1-4zn7dqs3swx6u7ncegx5tcgtgf3qepzn (3m29s)
```

This will also be built in CI.