### PR TITLE
r-libpressio: newer versions need newer gcc; libpressio-tools: needs c compiler

### DIFF
--- a/repos/spack_repo/builtin/packages/libpressio_tools/package.py
+++ b/repos/spack_repo/builtin/packages/libpressio_tools/package.py
@@ -42,7 +42,8 @@ class LibpressioTools(CMakePackage):
     version("0.0.16", sha256="1299e441fb15666d1c8abfd40f3f52b1bf55b6bfda4bfcc71177eec37160a95e")
     version("0.0.15", sha256="bcdf865d77969a34e2d747034ceeccf5cb766a4c11bcc856630d837f442ee33e")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("libpressio-adios1@0.0.2:", when="+adios1")
     depends_on("lc-framework@1.1.1:+libpressio", when="+lc")

--- a/repos/spack_repo/builtin/packages/r_libpressio/package.py
+++ b/repos/spack_repo/builtin/packages/r_libpressio/package.py
@@ -16,8 +16,6 @@ class RLibpressio(RPackage):
     maintainers("robertu94")
 
     version("1.6.0", sha256="4f8a712e5e84a201373a104e73b10282fcf98f1c7672cc1dd5a2ff07a32d54f6")
-
-    version("1.6.0", sha256="4f8a712e5e84a201373a104e73b10282fcf98f1c7672cc1dd5a2ff07a32d54f6")
     version("1.5.0", sha256="6b0e095610f190aad5dded0dbc6c0783893d4d5e773afc80328fc8c5befeff58")
     version("1.4.1", sha256="fa9d47c84ddeb4edd9c5250067a87cc1bb549b9b1dd71e2501dd39ee4e171c27")
     version("1.3.2", sha256="6afc907aa3663fbb9bfc7c92ca57e15d05ecbec59f94badec24e8da99ac1422f")
@@ -30,7 +28,7 @@ class RLibpressio(RPackage):
         "third_party", description="include support for 3rd party compressor modules", default=True
     )
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
 
     depends_on("r@3.3.0:", type=("build", "run"))
     depends_on("r-rcpp", type=("build", "link", "run"))
@@ -39,3 +37,5 @@ class RLibpressio(RPackage):
     depends_on("libpressio@0.88.0:", type=("build", "link", "run"), when="@1.6:")
     depends_on("pkgconfig", type=("build"))
     depends_on("libpressio-tools@0.1.4:", type=("build", "link", "run"), when="+third_party")
+
+    conflicts("%gcc@:9", when="@1.3:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

* Prevents use of GCC <= 9 with newer versions or `r-libpressio`.
* Adds C compiler as dependency of `libpressio-tools` otherwise all versions fail to build.