### PR TITLE
MPICH: Add variant to enable MPI5 ABI

### DIFF
--- a/repos/spack_repo/builtin/packages/mpich/package.py
+++ b/repos/spack_repo/builtin/packages/mpich/package.py
@@ -167,6 +167,13 @@ supported, and netmod is ignored if device is ch3:sock.""",
     )
 
     variant(
+        "mpi5-abi",
+        default=False,
+        when="@5:",
+        description="Enable MPI-5 standard ABI.",
+    )
+
+    variant(
         "datatype-engine",
         default="auto",
         description="controls the datatype engine to use",
@@ -554,6 +561,9 @@ supported, and netmod is ignored if device is ch3:sock.""",
             )
 
         config_args.extend(self.enable_or_disable("fortran"))
+
+        if spec.satisfies("@5:"):
+            config_args.extend(self.enable_or_disable("mpi-abi", variant="mpi5-abi"))
 
         if "+slurm" in spec:
             config_args.append("--with-slurm=yes")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Add variant `mpi5-abi` for MPICH version >=5.0.0 to enable building MPI-5 standard ABI.