### PR TITLE
numdiff: Fix build for gcc@15+: Set C standard to C17 [TODO: use `def flag_handler`]

### DIFF
--- a/repos/spack_repo/builtin/packages/numdiff/package.py
+++ b/repos/spack_repo/builtin/packages/numdiff/package.py
@@ -31,6 +31,10 @@ class Numdiff(AutotoolsPackage):
     def configure_args(self):
         spec = self.spec
         args = []
+        # Fix for GCC 15+ defaulting to C23 where 'false', 'true', 'bool' are keywords
+        # Force C17 standard to avoid conflicts with legacy code
+        cflags = "-std=c17"
+        
         if "+nls" in spec:
             args.append("--enable-nls")
         else:


### PR DESCRIPTION
Added C17 standard flag to configure arguments to avoid conflicts with legacy code due to GCC 15+.
