### PR TITLE
r-ash: depends on c compiler

### DIFF
--- a/repos/spack_repo/builtin/packages/r_ash/package.py
+++ b/repos/spack_repo/builtin/packages/r_ash/package.py
@@ -19,4 +19,5 @@ class RAsh(RPackage):
 
     version("1.0-15", sha256="8b0a7bc39dd0ce2172f09edc5b5e029347d041a4d508bbff3f3fd6f69450c2ab")
 
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Packages failing to install due to failing `r-ash`
* `r-hdrcde`
* `r-rainbow`
* `r-fds`
* `r-fda`
* `r-cca`