### PR TITLE
imod: require mercurial for its hg-based fetch, Qt's gui/sql modules,…

### DIFF
--- a/repos/spack_repo/builtin/packages/imod/package.py
+++ b/repos/spack_repo/builtin/packages/imod/package.py
@@ -24,6 +24,11 @@ class Imod(MakefilePackage, CudaPackage):
 
     version("5.2.3", revision="b520a584fca2")
 
+    # hg is needed by the version("5.2.3", revision=...) fetcher above.
+    depends_on("mercurial", type="build")
+
+    parallel = False
+
     variant("fftw", default=False, description="Use external FFTW?")
 
     depends_on("c", type="build")
@@ -31,7 +36,12 @@ class Imod(MakefilePackage, CudaPackage):
     depends_on("fortran", type="build")
     depends_on("java@17:")
 
-    depends_on("qt+opengl@5.12:")  # Can do with 4.6:, but they themselves recommend 5.12+
+    # +gui: imod's own build needs Qt's gui/widgets modules for its viewer
+    # programs, or configure fails with "Unknown module(s) in QT: gui widgets".
+    # +sql: imod's help file (IMOD.qch) is a SQLite database, built via Qt's
+    # qcollectiongenerator/qhelpgenerator - without it Qt configures with
+    # -no-sql-sqlite and both tools fail to open it.
+    depends_on("qt+opengl+gui+sql@5.12:")  # Can do with 4.6:, but they themselves recommend 5.12+
     depends_on("cuda", when="+cuda")
     depends_on("libtiff@4:")
     depends_on("fftw@3:", when="+fftw")
@@ -60,8 +70,14 @@ class Imod(MakefilePackage, CudaPackage):
             filter_file(r"-arch sm_\d{2}", cuda_flags, "configure")
 
     def flag_handler(self, name: str, flags: List[str]):
+        if name == "cflags":
+            flags.append("-Wno-incompatible-pointer-types")
+            if self.spec.satisfies("@:5.2.3 %gcc@15:"):
+                flags.append("-std=gnu17")
         if name == "fflags":
             flags.append("-fallow-argument-mismatch")
+        if name == "ldflags":
+            flags.append("-lrt")
         return (flags, None, None)
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:


### PR DESCRIPTION
- mercurial added as a build dependency: needed by the version(revision=...) hg fetcher.
- qt dependency now requires +gui (imod's build needs Qt's gui/widgets modules, or configure fails with "Unknown module(s) in QT: gui widgets") and +sql (imod's help file, IMOD.qch, is a SQLite database built via Qt's qcollectiongenerator/qhelpgenerator - without +sql, Qt configures with -no-sql-sqlite and both tools fail to open it).
- parallel = False, and the cflags/ldflags additions in flag_handler (-Wno-incompatible-pointer-types, -std=gnu17 on %gcc@15:, -lrt), are earlier accumulated fixes from building this recipe repeatedly on this cluster's toolchain - kept here since they're already proven working in a real install, though I don't have as detailed a verification trail for them individually as for the mercurial/qt changes above.

