### PR TITLE
py-relion-classranker: fix numpy/matplotlib version conflicts

### DIFF
--- a/repos/spack_repo/builtin/packages/py_relion_classranker/package.py
+++ b/repos/spack_repo/builtin/packages/py_relion_classranker/package.py
@@ -26,4 +26,9 @@ class PyRelionClassranker(PythonPackage):
 
     depends_on("py-torch@2.0.1:", type=("build", "run"))
     depends_on("py-torchvision@0.15.2:", type=("build", "run"))
-    depends_on("py-numpy@1.24.4", type=("build", "run"))
+    # classranker's requirements.txt only declares numpy>=1.24.4 (no ceiling); numpy<2.0
+    # doesn't support python@3.13, so the floor is raised to match py-relion's own numpy floor.
+    depends_on("py-numpy@1.26.1:", type=("build", "run"))
+    # classranker's training/test_*.py import matplotlib directly. Floor is past 3.8.3, which
+    # caps numpy at <2.0.
+    depends_on("py-matplotlib@3.9.0:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_relion_classranker/package.py
+++ b/repos/spack_repo/builtin/packages/py_relion_classranker/package.py
@@ -26,9 +26,9 @@ class PyRelionClassranker(PythonPackage):
 
     depends_on("py-torch@2.0.1:", type=("build", "run"))
     depends_on("py-torchvision@0.15.2:", type=("build", "run"))
-    # classranker's requirements.txt only declares numpy>=1.24.4 (no ceiling); numpy<2.0
-    # doesn't support python@3.13, so the floor is raised to match py-relion's own numpy floor.
+    # 1.26.1 matches py-relion's own numpy floor: numpy<2.0 doesn't support python@3.13.
+    # classranker's requirements.txt itself only declares numpy>=1.24.4, with no ceiling.
     depends_on("py-numpy@1.26.1:", type=("build", "run"))
-    # classranker's training/test_*.py import matplotlib directly. Floor is past 3.8.3, which
-    # caps numpy at <2.0.
+    # classranker's training/test_*.py import matplotlib directly; matplotlib up to 3.8.3 caps
+    # numpy at <2.0, conflicting with the numpy floor above.
     depends_on("py-matplotlib@3.9.0:", type=("build", "run"))


### PR DESCRIPTION
Edit by @bernhardkaindl:
- This PR fixes concretization of `py-relion-classranker` in spack by fixing the current incorrect pinned version dependency for `py-numpy@1.24.4` which, in reality, is not exact, it is only the minimum, so the range must be open-ended by appending the missing `:` to the required minimum version.
- py-matplotlib does not show to to required as it is only used in tools that are neither installer installed, nor used or tested in any way.

----
Submitter's description:
- py-numpy widened from an exact 1.24.4 pin (conflicting with py-relion's own numpy floor) to a range matching py-relion/model-angelo.
- py-matplotlib added: classranker's own training/test_*.py import it directly, with a floor past 3.8.3 (which caps numpy at <2.0).
