### PR TITLE
py-fair-esm: gate ESMFold-only dependencies behind +esmfold

### DIFF
--- a/repos/spack_repo/builtin/packages/py_fair_esm/package.py
+++ b/repos/spack_repo/builtin/packages/py_fair_esm/package.py
@@ -22,11 +22,10 @@ class PyFairEsm(PythonPackage):
 
     variant("esmfold", default=True, description="Enable dependencies for OpenFold")
     depends_on("py-biopython@1.79:", when="+esmfold", type=("build", "run"))
-
-    depends_on("py-deepspeed", type=("build", "run"))
-    depends_on("py-dm-tree", type=("build", "run"))
-    depends_on("py-pytorch-lightning", type=("build", "run"))
-    depends_on("py-omegaconf", type=("build", "run"))
-    depends_on("py-ml-collections", type=("build", "run"))
+    depends_on("py-deepspeed", when="+esmfold", type=("build", "run"))
+    depends_on("py-dm-tree", when="+esmfold", type=("build", "run"))
+    depends_on("py-pytorch-lightning", when="+esmfold", type=("build", "run"))
+    depends_on("py-omegaconf", when="+esmfold", type=("build", "run"))
+    depends_on("py-ml-collections", when="+esmfold", type=("build", "run"))
     depends_on("py-einops", type=("build", "run"))
     depends_on("py-scipy", type=("build", "run"))


### PR DESCRIPTION
Only ESMFold structure prediction needs deepspeed/pytorch-lightning/dm-tree/omegaconf/ml-collections; plain checkpoint loading (esm.pretrained.*) doesn't. Previously unconditional, dragging the whole stack into every consumer regardless of whether ESMFold is used.

