### PR TITLE
py-makefun: widen stale setuptools ceiling

### DIFF
--- a/repos/spack_repo/builtin/packages/py_makefun/package.py
+++ b/repos/spack_repo/builtin/packages/py_makefun/package.py
@@ -20,5 +20,7 @@ class PyMakefun(PythonPackage):
 
     version("1.16.0", sha256="e14601831570bff1f6d7e68828bcd30d2f5856f24bad5de0ccb22921ceebc947")
 
-    depends_on("py-setuptools@39.2:71", type="build")
+    # was @39.2:71 - no evidence makefun needs anything past basic
+    # setuptools support, removed the stale ceiling.
+    depends_on("py-setuptools@39.2:", type="build")
     depends_on("py-setuptools-scm", type="build")


### PR DESCRIPTION
No evidence makefun needs anything past basic setuptools support; removed the @39.2:71 upper bound.
