### PR TITLE
pbzip2: fix Makefile CXXFLAGS/LDFLAGS injection and clang-family lite…

### DIFF
--- a/repos/spack_repo/builtin/packages/pbzip2/package.py
+++ b/repos/spack_repo/builtin/packages/pbzip2/package.py
@@ -30,16 +30,23 @@ class Pbzip2(MakefilePackage):
         makefile = FileFilter("Makefile")
         makefile.filter("PREFIX = .*", f"PREFIX = {prefix}")
 
-    def flag_handler(self, name: str, flags: List[str]):
-        if name == "cxxflags":
-            # pbzip2 uses C99 PRIuMAX macros without the C++11-required space
-            # between the string literal and the macro (e.g., "%"PRIuMAX).
-            # Clang-based compilers (including Intel oneAPI icpx) treat this
-            # as an error. Suppress it since the code is functionally correct.
-            if (
-                self.spec.satisfies("%cxx=clang")
-                or self.spec.satisfies("%cxx=apple-clang")
-                or self.spec.satisfies("%cxx=oneapi")
-            ):
-                flags.append("-Wno-reserved-user-defined-literal")
-        return (flags, None, None)
+        # This Makefile assigns CXXFLAGS/LDFLAGS with plain `=`, so neither
+        # depends_on-provided include paths nor flag_handler()-injected
+        # flags reach the compiler - patch the Makefile text directly
+        # instead, the same way PREFIX is handled above.
+        extra_cxxflags = ""
+        # bzip2's include path is never seen otherwise ("bzlib.h file not found").
+        bzip2_prefix = spec["bzip2"].prefix
+        extra_cxxflags += f" -I{bzip2_prefix.include}"
+        # pbzip2 uses C99 PRIuMAX macros without the C++11-required space
+        # (e.g. "%"PRIuMAX). Clang-based compilers treat this as an error.
+        if (
+            self.spec.satisfies("%cxx=clang")
+            or self.spec.satisfies("%cxx=apple-clang")
+            or self.spec.satisfies("%cxx=oneapi")
+            or self.spec.satisfies("%cxx=aocc")  # AMD's compiler is clang-based too
+        ):
+            extra_cxxflags += " -Wno-reserved-user-defined-literal"
+
+        makefile.filter(r"^CXXFLAGS = -O2$", f"CXXFLAGS = -O2{extra_cxxflags}")
+        makefile.filter(r"^LDFLAGS =$", f"LDFLAGS = -L{bzip2_prefix.lib}")


### PR DESCRIPTION
This Makefile assigns CXXFLAGS/LDFLAGS with plain `=`, so neither depends_on-provided include paths nor flag_handler()-injected flags reach the compiler:
- bzip2's include path was never seen ("bzlib.h file not found") - now patched directly into the Makefile text, same as PREFIX is handled.
- pbzip2 uses C99 PRIuMAX macros without the C++11-required space (e.g. "%"PRIuMAX); clang-family compilers (including AMD's aocc) treat this as an error, suppressed via -Wno-reserved-user-defined-literal.

