### PR TITLE
py-pyhmmer: add 0.11.0 with build dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/py_pyhmmer/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyhmmer/package.py
@@ -19,11 +19,16 @@ class PyPyhmmer(PythonPackage):
 
     license("MIT", checked_by="luke-dt")
 
+    # lowest pyhmmer release with a cp313 wheel.
+    version("0.11.0", sha256="4a4c3d72d2da0a46a083c1431739eb256e6850287120f99267a18cc5c57e8ab7")
     version("0.10.15", sha256="bf8e97ce8da6fb5850298f3074640f3e998d5a655877f865c1592eb057dc7921")
     version("0.10.14", sha256="eb50bdfdf67a3b1fecfe877d7ca6d9bade9a9f3dea3ad60c959453bbb235573d")
     version("0.7.1", sha256="e746cfc3b352656757286106fd210763f835ac20cf8466141bca5588567bcb5c")
 
     depends_on("python@3.6:", type=("build", "run"))
-    depends_on("py-setuptools@46.4:", type="build")
+    # 0.11.0's build-system.requires switched to scikit-build-core; earlier
+    # versions use plain setuptools.
+    depends_on("py-setuptools@46.4:", type="build", when="@:0.10")
+    depends_on("py-scikit-build-core", type="build", when="@0.11:")
     depends_on("py-cython@3.0", type="build")
     depends_on("py-psutil@5.8:", type=("build", "run"))


### PR DESCRIPTION
0.11.0 (the lowest release with a cp313 wheel) existed on PyPI but was never added to this recipe. Its build-system.requires also switched to scikit-build-core; earlier versions use plain setuptools.
