### PR TITLE
r-flashclust: depend on c compiler

### DIFF
--- a/repos/spack_repo/builtin/packages/r_flashclust/package.py
+++ b/repos/spack_repo/builtin/packages/r_flashclust/package.py
@@ -14,6 +14,7 @@ class RFlashclust(RPackage):
 
     version("1.01-2", sha256="48a7849bb86530465ff3fbfac1c273f0df4b846e67d5eee87187d250c8bf9450")
 
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
 
     depends_on("r@2.3.0:", type=("build", "run"))


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Packages failing to install due to failing `r-flashclust`
* `r-factominer`
* `r-factoextra`