### PR TITLE
lp-solve: Fixed compiling with newer compilers

### DIFF
--- a/repos/spack_repo/builtin/packages/lp_solve/package.py
+++ b/repos/spack_repo/builtin/packages/lp_solve/package.py
@@ -18,13 +18,26 @@ class LpSolve(Package):
     depends_on("c", type="build")  # generated
 
     def install(self, spec, prefix):
+        # GCC 14+ breaks their isnan() detection and causes failures in the build.
+        # GCC 15+ gnu23 default drops implicit-int support, so pin -std=gnu17
+        cc_flags = []
+        if spec.satisfies("%gcc@14:"):
+            cc_flags += ["-Wno-error=implicit-int", "-Wno-error=implicit-function-declaration"]
+        if spec.satisfies("%gcc@15:"):
+            cc_flags.append("-std=gnu17")
+        cc_line = 'c="cc ' + " ".join(cc_flags) + '"' if cc_flags else "c=cc"
+
         with working_dir("lpsolve55"):
             mkdir(prefix.lib)
+            if cc_flags:
+                filter_file("^c=cc$", cc_line, "ccc")
             sh = which("sh", required=True)
             sh("-x", "ccc")
             install_tree("bin/ux64", prefix.lib)
         with working_dir("lp_solve"):
             mkdir(prefix.bin)
+            if cc_flags:
+                filter_file("^c=cc$", cc_line, "ccc")
             sh = which("sh", required=True)
             sh("-x", "ccc")
             install_tree("bin/ux64", prefix.bin)


### PR DESCRIPTION
Newer compilers, specifically gcc 14+, didn't like compiling lp-solve. This fixes that. Tested with gcc versions 11 through 16.