### PR TITLE
acts: prepend to PYTHONPATH

### DIFF
--- a/repos/spack_repo/builtin/packages/acts/package.py
+++ b/repos/spack_repo/builtin/packages/acts/package.py
@@ -383,3 +383,9 @@ class Acts(CMakePackage, CudaPackage):
         args.append(self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"))
 
         return args
+
+    def setup_run_environment(self, env: EnvironmentModifications) -> None:
+        # Acts installs in non-standard python path
+        if self.spec.satisfies("+python"):
+            env.prepend_path("PYTHONPATH", self.prefix.python)
+        

--- a/repos/spack_repo/builtin/packages/acts/package.py
+++ b/repos/spack_repo/builtin/packages/acts/package.py
@@ -388,4 +388,3 @@ class Acts(CMakePackage, CudaPackage):
         # Acts installs in non-standard python path
         if self.spec.satisfies("+python"):
             env.prepend_path("PYTHONPATH", self.prefix.python)
-        


### PR DESCRIPTION
This PR fixes `acts` to prepend `self.prefix.python` to `PYTHONPATH`, since that's where Acts installs the python stuff (see e.g. https://github.com/acts-project/acts/issues/5033).
