### PR TITLE
py-onnx: only self.spec["py-nanobind"].prefix when depends_on py-nanobind

### DIFF
--- a/repos/spack_repo/builtin/packages/py_onnx/package.py
+++ b/repos/spack_repo/builtin/packages/py_onnx/package.py
@@ -130,7 +130,7 @@ class PyOnnx(PythonPackage):
         env.set(
             "CMAKE_BUILD_DIR", join_path(self.stage.path, f"spack-build-{self.spec.dag_hash(7)}")
         )
-        if self.spec.satisfies("@1.20:"):
+        if self.spec.satisfies("^py-nanobind"):
             purelib = self.spec["python"].package.purelib
             nanobind_site_packages = os.path.join(self.spec["py-nanobind"].prefix, purelib)
             env.append_path("CMAKE_PREFIX_PATH", f"{nanobind_site_packages}/nanobind/cmake")

--- a/repos/spack_repo/builtin/packages/py_onnx/package.py
+++ b/repos/spack_repo/builtin/packages/py_onnx/package.py
@@ -130,6 +130,7 @@ class PyOnnx(PythonPackage):
         env.set(
             "CMAKE_BUILD_DIR", join_path(self.stage.path, f"spack-build-{self.spec.dag_hash(7)}")
         )
-        purelib = self.spec["python"].package.purelib
-        nanobind_site_packages = os.path.join(self.spec["py-nanobind"].prefix, purelib)
-        env.append_path("CMAKE_PREFIX_PATH", f"{nanobind_site_packages}/nanobind/cmake")
+        if self.spec.satisfies("@1.20:"):
+            purelib = self.spec["python"].package.purelib
+            nanobind_site_packages = os.path.join(self.spec["py-nanobind"].prefix, purelib)
+            env.append_path("CMAKE_PREFIX_PATH", f"{nanobind_site_packages}/nanobind/cmake")


### PR DESCRIPTION
This PR fixes `py-onnx` for older versions `@:1.19` that do not depend on `py-nanobind`. In those cases, the package installation fails with
```
    File "/Users/runner/work/eic-spack/eic-spack/spack/lib/spack/spack/spec.py", line 3811, in __getitem__
      raise KeyError(f"No spec with name {name} in {self}") from e
  KeyError: 'No spec with name py-nanobind in py-onnx@1.19.1/2ffi2yfps6lwcfr73ne7jyitwkhab42l'
```