### PR TITLE
r-later: add version 1.4.8, add r-rcpp constraint and add glibc conflict

### DIFF
--- a/repos/spack_repo/builtin/packages/r_later/package.py
+++ b/repos/spack_repo/builtin/packages/r_later/package.py
@@ -17,15 +17,19 @@ class RLater(RPackage):
 
     license("MIT")
 
+    version("1.4.8", sha256="ce5d88b3fd1df409eaa21aa53bf20b1a9331f75cd69e7e9b2a27b40d2290d219")
     version("1.3.2", sha256="52f5073d33cd0d3c12e56526c9c53c323ebafcc79b22cc6e51fb0c41ee2b561e")
     version("1.3.0", sha256="08f50882ca3cfd2bb68c83f1fcfbc8f696f5cfb5a42c1448c051540693789829")
     version("1.1.0.1", sha256="71baa7beae774a35a117e01d7b95698511c3cdc5eea36e29732ff1fe8f1436cd")
     version("0.8.0", sha256="6b2a28b43c619b2c7890840c62145cd3a34a7ed65b31207fdedde52efb00e521")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
+    depends_on("r-rcpp@1.0.10:", when="@1.4.5:", type=("build", "run"))
     depends_on("r-rcpp@0.12.9:", type=("build", "run"))
     depends_on("r-rlang", type=("build", "run"))
 
     depends_on("r-bh", type=("build", "run"), when="@:1.1.0.1")
+
+    conflicts("^glibc@2.43:", when="@:1.4.6")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Changes to `r-later` recipe follow the changelog of the package  
https://cran.r-project.org/web/packages/later/news/news.html

## Before the change

`r-later` doesn't build on Ubuntu 26.04 regardless of it's version, `r-rcpp` version or `gcc` version.

The failures are due to `glibc` version.

Failing installation of `r-later` prevents building of following packages on recent Linux distributions

* `r-adegenet`
* `r-adespatial`
* `r-champ`
* `r-colourpicker`
* `r-crosstalk`
* `r-dt`
* `r-ggvis`
* `r-hh`
* `r-httpuv`
* `r-interactivedisplaybase`
* `r-manipulatewidget`
* `r-miniui`
* `r-mlinterfaces`
* `r-plotly`
* `r-pool`
* `r-promises`
* `r-questionr`
* `r-rgl`
* `r-samr`
* `r-sankeyd3`
* `r-scater`
* `r-servr`
* `r-seurat`
* `r-shiny`
* `r-shinydashboard`
* `r-shinyfiles`
* `r-shinyjs`
* `r-shinystan`
* `r-shinythemes`
* `r-shinywidgets`
* `r-spades-addins`

## After the change

<img width="317" height="313" alt="image" src="https://github.com/user-attachments/assets/61a0262e-6b70-434f-b1b8-998025a419e4" />
