### PR TITLE
target requirement for armpl-gcc

### DIFF
--- a/repos/spack_repo/builtin/packages/armpl_gcc/package.py
+++ b/repos/spack_repo/builtin/packages/armpl_gcc/package.py
@@ -373,9 +373,7 @@ class ArmplGcc(Package):
             expand = extension != ".dmg"
             version(ver, sha256=sha256sum, url=url, extension=extension, expand=expand)
 
-    conflicts("target=x86:", msg="Only available on Aarch64")
-    conflicts("target=ppc64:", msg="Only available on Aarch64")
-    conflicts("target=ppc64le:", msg="Only available on Aarch64")
+    requires("target=aarch64:", msg="Only available on Aarch64")
 
     conflicts("%gcc@:11", when="@23.10_gcc-12.2")
     conflicts("%gcc@:10", when="@23.10_gcc-11.3")


### PR DESCRIPTION
Previously, we expressed the requirement as a bunch of constraints on other architectures, and we missed `x86_64` (which does not inherit from `x86` since they're fundamentally incompatibl).

Instead of just adding the conflict, switch to expressing it as a `requires('target=aarch64:')` to be robust against future architectures.
