### PR TITLE
Curl: No more NMake on Windows

### DIFF
--- a/repos/spack_repo/builtin/packages/cmake/package.py
+++ b/repos/spack_repo/builtin/packages/cmake/package.py
@@ -170,19 +170,31 @@ class Cmake(Package):
     # provide Spack's TLS libs anyways, which is not flexible, and actually
     # leads to issues where we have to keep track of the vendored curl version
     # and its conflicts with OpenSSL.
-    depends_on("curl@:8.15", when="@:3.25")
-    depends_on("curl")
+    #
+    # Windows is the exception, since Spack's curl defaults to tls=sspi
+    # on Windows, the same Schannel stack CMake's vendored cmcurl already uses.
+    # Keeping the default (+ownlibs) free of curl lets CMake bootstrap on
+    # Windows from nothing
+    for _system_curl in (
+        "platform=linux",
+        "platform=darwin",
+        "platform=freebsd",
+        "platform=windows ~ownlibs",
+    ):
+        with when(_system_curl):
+            depends_on("curl@:8.15", when="@:3.25")
+            depends_on("curl")
 
-    # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/11134
-    conflicts("curl@8.16:", when="@:3.30")
+            # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/11134
+            conflicts("curl@8.16:", when="@:3.30")
 
-    # When using curl, cmake defaults to using system zlib too, probably because
-    # curl already depends on zlib. Therefore, also unconditionaly depend on zlib.
-    depends_on("zlib-api")
+            # When using curl, cmake defaults to using system zlib too, probably
+            # because curl already depends on zlib. Therefore, also depend on zlib.
+            depends_on("zlib-api")
 
     with when("~ownlibs"):
-        depends_on("expat")
         # expat/zlib are used in CMake/CTest, so why not require them in libarchive.
+        depends_on("expat")
         for plat in ["darwin", "linux", "freebsd"]:
             with when("platform=%s" % plat):
                 depends_on("libarchive@3.1.0: xar=expat compression=bz2lib,lzma,zlib,zstd")
@@ -325,6 +337,22 @@ class Cmake(Package):
             args.append("--")
         else:
             args.append("-DCMAKE_INSTALL_PREFIX=%s" % self.prefix)
+
+            # There is no bootstrap script on Windows -- the build is driven by an
+            # existing cmake.exe -- so the --system-* flags above have no analogue
+            # here and the cache variables have to be set directly. Opt in per
+            # library rather than with CMAKE_USE_SYSTEM_LIBRARIES, because most of
+            # what CMake vendors is unavailable on Windows: libarchive is
+            # autotools-only in Spack, nghttp2 and rhash cannot build here at all,
+            # and cppdap is not packaged. Those stay vendored.
+            if spec.satisfies("~ownlibs"):
+                args.extend(
+                    [
+                        "-DCMAKE_USE_SYSTEM_LIBRARY_CURL=ON",
+                        "-DCMAKE_USE_SYSTEM_LIBRARY_EXPAT=ON",
+                        "-DCMAKE_USE_SYSTEM_LIBRARY_ZLIB=ON",
+                    ]
+                )
 
         # Make CMake find its own dependencies.
         prefixes = get_cmake_prefix_path(self)

--- a/repos/spack_repo/builtin/packages/cmake/package.py
+++ b/repos/spack_repo/builtin/packages/cmake/package.py
@@ -175,13 +175,13 @@ class Cmake(Package):
     # on Windows, the same Schannel stack CMake's vendored cmcurl already uses.
     # Keeping the default (+ownlibs) free of curl lets CMake bootstrap on
     # Windows from nothing
-    for _system_curl in (
+    for _requires_system_curl in (
         "platform=linux",
         "platform=darwin",
         "platform=freebsd",
         "platform=windows ~ownlibs",
     ):
-        with when(_system_curl):
+        with when(_requires_system_curl):
             depends_on("curl@:8.15", when="@:3.25")
             depends_on("curl")
 
@@ -338,13 +338,6 @@ class Cmake(Package):
         else:
             args.append("-DCMAKE_INSTALL_PREFIX=%s" % self.prefix)
 
-            # There is no bootstrap script on Windows -- the build is driven by an
-            # existing cmake.exe -- so the --system-* flags above have no analogue
-            # here and the cache variables have to be set directly. Opt in per
-            # library rather than with CMAKE_USE_SYSTEM_LIBRARIES, because most of
-            # what CMake vendors is unavailable on Windows: libarchive is
-            # autotools-only in Spack, nghttp2 and rhash cannot build here at all,
-            # and cppdap is not packaged. Those stay vendored.
             if spec.satisfies("~ownlibs"):
                 args.extend(
                     [

--- a/repos/spack_repo/builtin/packages/curl/package.py
+++ b/repos/spack_repo/builtin/packages/curl/package.py
@@ -9,14 +9,13 @@ import sys
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsBuilder, AutotoolsPackage
 from spack_repo.builtin.build_systems.cmake import CMakeBuilder, CMakePackage
-from spack_repo.builtin.build_systems.nmake import NMakeBuilder, NMakePackage
 
 from spack.package import *
 
 IS_WINDOWS = sys.platform == "win32"
 
 
-class Curl(NMakePackage, AutotoolsPackage, CMakePackage):
+class Curl(AutotoolsPackage, CMakePackage):
     """cURL is an open source command line tool and library for
     transferring data with URL syntax"""
 
@@ -120,7 +119,6 @@ class Curl(NMakePackage, AutotoolsPackage, CMakePackage):
     build_system(
         "autotools",
         "cmake",
-        conditional("nmake", when="@:8.11 platform=windows"),
         default="cmake" if IS_WINDOWS else "autotools",
     )
 
@@ -235,70 +233,6 @@ class AutotoolsBuilder(AutotoolsBuilder):
             return "--with-secure-transport"
         else:
             return "--without-secure-transport"
-
-
-class NMakeBuilder(BuildEnvironment, NMakeBuilder):
-    phases = ["install"]
-
-    def nmake_args(self):
-        args = []
-        mode = "dll" if self.spec.satisfies("libs=shared") else "static"
-        args.append("mode=%s" % mode)
-        args.append("WITH_ZLIB=%s" % mode)
-        args.append("ZLIB_PATH=%s" % self.spec["zlib-api"].prefix)
-        args.append("WINBUILD_ACKNOWLEDGE_DEPRECATED=yes")
-        if self.spec.satisfies("+libssh"):
-            args.append("WITH_SSH=%s" % mode)
-        if self.spec.satisfies("+libssh2"):
-            args.append("WITH_SSH2=%s" % mode)
-            args.append("SSH2_PATH=%s" % self.spec["libssh2"].prefix)
-        if self.spec.satisfies("+nghttp2"):
-            args.append("WITH_NGHTTP2=%s" % mode)
-            args.append("NGHTTP2=%s" % self.spec["nghttp2"].prefix)
-        if self.spec.satisfies("tls=openssl"):
-            args.append("WITH_SSL=%s" % mode)
-            args.append("SSL_PATH=%s" % self.spec["openssl"].prefix)
-        elif self.spec.satisfies("tls=mbedtls"):
-            args.append("WITH_MBEDTLS=%s" % mode)
-            args.append("MBEDTLS_PATH=%s" % self.spec["mbedtls"].prefix)
-        elif self.spec.satisfies("tls=sspi"):
-            args.append("ENABLE_SSPI=%s" % mode)
-
-        # The trailing path seperator is REQUIRED for cURL to install
-        # otherwise cURLs build system will interpret the path as a file
-        # and the install will fail with ambiguous errors
-        inst_prefix = self.prefix + "\\"
-        args.append(f"WITH_PREFIX={windows_sfn(inst_prefix)}")
-        return args
-
-    def install(self, pkg, spec, prefix):
-        # Spack's env CC and CXX values will cause an error
-        # if there is a path in the space, and escaping with
-        # double quotes raises a syntax issues, instead
-        # cURLs nmake will automatically invoke proper cl.exe if
-        # no env value for CC, CXX is specified
-        # Unset the value to allow for cURLs heuristics (derive via VCVARS)
-        # to derive the proper compiler
-        env = os.environ
-        env["CC"] = ""
-        env["CXX"] = ""
-        winbuild_dir = os.path.join(self.stage.source_path, "winbuild")
-        winbuild_dir = windows_sfn(winbuild_dir)
-        with working_dir(winbuild_dir):
-            nmake("/f", "Makefile.vc", *self.nmake_args(), ignore_quotes=True)
-        with working_dir(os.path.join(self.stage.source_path, "builds")):
-            install_dir = glob.glob("libcurl-**")[0]
-            install_tree(install_dir, self.prefix)
-        if spec.satisfies("libs=static"):
-            # curl is named libcurl_a when static on Windows
-            # Consumers look for just libcurl
-            # make a symlink to make consumers happy
-            libcurl_a = os.path.join(prefix.lib, "libcurl_a.lib")
-            libcurl = os.path.join(self.prefix.lib, "libcurl.lib")
-            # safeguard against future curl releases that do this for us
-            if os.path.exists(libcurl_a) and not os.path.exists(libcurl):
-                symlink(libcurl_a, libcurl)
-
 
 class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):

--- a/repos/spack_repo/builtin/packages/curl/package.py
+++ b/repos/spack_repo/builtin/packages/curl/package.py
@@ -163,15 +163,6 @@ class Curl(AutotoolsPackage, CMakePackage):
         return flags, None, build_system_flags
 
 
-class BuildEnvironment:
-    def setup_dependent_build_environment(
-        self, env: EnvironmentModifications, dependent_spec: Spec
-    ) -> None:
-        if self.spec.satisfies("libs=static"):
-            env.append_flags("CFLAGS", "-DCURL_STATICLIB")
-            env.append_flags("CXXFLAGS", "-DCURL_STATICLIB")
-
-
 class AutotoolsBuilder(AutotoolsBuilder):
     def configure_args(self):
         spec = self.spec

--- a/repos/spack_repo/builtin/packages/curl/package.py
+++ b/repos/spack_repo/builtin/packages/curl/package.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import glob
-import os
 import re
 import sys
 
@@ -224,6 +222,7 @@ class AutotoolsBuilder(AutotoolsBuilder):
             return "--with-secure-transport"
         else:
             return "--without-secure-transport"
+
 
 class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):


### PR DESCRIPTION
The last version of curl supporting their NMake build system was removed from spack a while ago (due to CVEs). That effort left a vestigial NMake build system used by nothing except bootstraps of Clingo with no external CMake (which we evidently do not test on Windows) that quietly bit rotted and is now both broken and vestigial.

This PR removes the dead NMake build system.

This leaves a cycle, `cmake -> curl -> cmake`, which, previously broken by the nmake system, is no longer. Typically cycles with CMake are broken by `+ownlibs`, but due to issues modeling SSL with CMake's internal curl, this isn't the case for Curl. 

To break the cycle for Windows, we include curl in `+ownlibs`, as the default curl recipe tls layer is the same `schannel` backend that CMake's internal curl is built against (in general readily available certs is something that can be relied on on Windows), not openssl, so we avoid the issues that prevent curl from being included with `+ownlibs` on Linux. 

This PR will need a companion PR in core Spack that updates the clingo spec stubs to use curl's CMake builder instead of the nmake builder. 