### PR TITLE
hdf5: Fix %gcc >= 14 for < v1.10.8: disable specific gcc warnings

### DIFF
--- a/repos/spack_repo/builtin/packages/hdf5/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5/package.py
@@ -377,6 +377,14 @@ class Hdf5(CMakePackage):
                 # in C99:
                 cmake_flags.append("-Wno-error=implicit-function-declaration")
                 # Note that this flag will cause an error if building %nvhpc.
+            if spec.satisfies("@:1.10.8 %gcc@14:"):
+                cmake_flags.extend(
+                    [
+                        "-Wno-error=implicit-int",
+                        "-Wno-error=incompatible-pointer-types",
+                        "-Wno-error=int-conversion",
+                    ]
+                )
             if spec.satisfies("@:1.8.12~shared"):
                 # More recent versions set CMAKE_POSITION_INDEPENDENT_CODE to
                 # True and build with PIC flags.
@@ -579,6 +587,9 @@ class Hdf5(CMakePackage):
             self.define_from_variant("HDF5_BUILD_JAVA", "java"),
             self.define_from_variant("HDF5_BUILD_TOOLS", "tools"),
         ]
+
+        if spec.satisfies("@:1.10.8 %gcc@14:"):
+            args.append(self.define("HDF5_DISABLE_COMPILER_WARNINGS", True))
 
         # Always enable this option. This does not actually enable any
         # features: it only *allows* the user to specify certain combinations


### PR DESCRIPTION
Fixes the build of older hdf5 versions (requested by some builds) with gcc-14 to gcc-16.

The method is disabling certain warnings. It already a widely used method in spack for gcc-14 issues.

- Example: #6021
   ```py
        # GCC 14+ breaks their isnan() detection and causes failures in the build.
        # GCC 15+ gnu23 default drops implicit-int support, so pin -std=gnu17
        cc_flags = []
        if spec.satisfies("%gcc@14:"):
            cc_flags += ["-Wno-error=implicit-int", "-Wno-error=implicit-function-eclaration"]
        if spec.satisfies("%gcc@15:"):
            cc_flags.append("-std=gnu17")
  ```

The changes are the end-result after extensive test builds across all non-deprecated versions:
```py
$ spack find -v hdf5
-- linux-ubuntu24.04-x86_64_v4 / %c=clang@18.1.3 ----------------
hdf5@1.8.23~cxx~fortran~hl~ipo+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=f42732a

-- linux-ubuntu24.04-x86_64_v4 / %c=gcc@15.2.0 ------------------
hdf5@1.14.4-3~cxx~fortran~hl~ipo~java~map+mpi+shared~subfiling~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=f42732a
hdf5@1.14.5~cxx~fortran~hl~ipo~java~map+mpi+shared~subfiling~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make
hdf5@1.14.6~cxx~fortran~hl~ipo~java~map~mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make
hdf5@1.14.6~cxx~fortran+hl~ipo~java~map+mpi+shared~subfiling~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make
hdf5@2.1.0~cxx~fortran~hl~ipo~java~map+mpi+shared~subfiling~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=cf8056e

-- linux-ubuntu24.04-x86_64_v4 / %c=gcc@16.0.1 ------------------
hdf5@1.8.10~cxx~fortran~hl~ipo+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=0e20187,464de11,b61e2f0
hdf5@1.8.12~cxx~fortran~hl~ipo+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=0e20187,b61e2f0
hdf5@1.8.13~cxx~fortran~hl~ipo+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=0e20187,b61e2f0
hdf5@1.8.14~cxx~fortran~hl~ipo+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=0e20187,b61e2f0
hdf5@1.8.15~cxx~fortran~hl~ipo+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=0e20187,b61e2f0
hdf5@1.8.16~cxx~fortran~hl~ipo+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=0e20187,b61e2f0,f42732a
hdf5@1.8.17~cxx~fortran~hl~ipo+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=0e20187,b61e2f0,f42732a
hdf5@1.8.18~cxx~fortran~hl~ipo+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=0e20187,b61e2f0,f42732a
hdf5@1.8.19~cxx~fortran~hl~ipo+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=0e20187,b61e2f0,f42732a
hdf5@1.8.21~cxx~fortran~hl~ipo+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=0e20187,b61e2f0,f42732a
hdf5@1.8.22~cxx~fortran~hl~ipo+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=f42732a
hdf5@1.10.0-patch1~cxx~fortran~hl~ipo~java+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=b61e2f0,f42732a
hdf5@1.10.1~cxx~fortran~hl~ipo~java+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=b61e2f0,f42732a
hdf5@1.10.2~cxx~fortran~hl~ipo~java+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=57cee5f,b61e2f0,f42732a
hdf5@1.10.3~cxx~fortran~hl~ipo~java+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=b61e2f0,f42732a
hdf5@1.10.4~cxx~fortran~hl~ipo~java+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=b61e2f0,f42732a
hdf5@1.10.5~cxx~fortran~hl~ipo~java+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=b61e2f0,f42732a
hdf5@1.10.6~cxx~fortran~hl~ipo~java+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=f42732a
hdf5@1.10.7~cxx~fortran~hl~ipo~java+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=2a1e311,f42732a
hdf5@1.10.8~cxx~fortran~hl~ipo~java+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=ee351eb,f42732a
hdf5@1.10.9~cxx~fortran~hl~ipo~java+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=f42732a
hdf5@1.10.10~cxx~fortran~hl~ipo~java+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=f42732a
hdf5@1.10.11~cxx~fortran~hl~ipo~java+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=f42732a
hdf5@1.12.0~cxx~fortran~hl~ipo~java+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=f42732a
hdf5@1.12.1~cxx~fortran~hl~ipo~java+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=ee351eb,f42732a
hdf5@1.12.2~cxx~fortran~hl~ipo~java+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=f42732a
hdf5@1.12.3~cxx~fortran~hl~ipo~java+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=f42732a
hdf5@1.14.0~cxx~fortran~hl~ipo~java~map+mpi+shared~subfiling~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=0b5dd6f,f42732a
hdf5@1.14.1-2~cxx~fortran~hl~ipo~java~map+mpi+shared~subfiling~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=f42732a
hdf5@1.14.2~cxx~fortran~hl~ipo~java~map+mpi+shared~subfiling~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=f42732a
hdf5@1.14.3~cxx~fortran~hl~ipo~java~map+mpi+shared~subfiling~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches:=82088c8,f42732a
hdf5@1.14.6~cxx~fortran+hl~ipo~java~map~mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make
==> 38 installed packages
```