### PR TITLE
accfft and opensubdiv: Fix CUDA arch filtering.

### DIFF
--- a/repos/spack_repo/builtin/packages/accfft/package.py
+++ b/repos/spack_repo/builtin/packages/accfft/package.py
@@ -45,7 +45,7 @@ class Accfft(CMakePackage, CudaPackage):
         ]
 
         if spec.satisfies("+cuda"):
-            cuda_arch = [x for x in spec.variants["cuda_arch"].value if x]
+            cuda_arch = [x for x in spec.variants["cuda_arch"].value if x and x != "none"]
             if cuda_arch:
                 args.append(f"-DCUDA_NVCC_FLAGS={' '.join(self.cuda_flags(cuda_arch))}")
 

--- a/repos/spack_repo/builtin/packages/opensubdiv/package.py
+++ b/repos/spack_repo/builtin/packages/opensubdiv/package.py
@@ -66,7 +66,7 @@ class Opensubdiv(CMakePackage, CudaPackage):
         if "+cuda" in spec:
             args.append("-DNO_CUDA=0")
 
-            cuda_arch = [x for x in spec.variants["cuda_arch"].value if x]
+            cuda_arch = [x for x in spec.variants["cuda_arch"].value if x and x != "none"]
             if cuda_arch:
                 args.append(
                     "-DOSD_CUDA_NVCC_FLAGS={0}".format(" ".join(self.cuda_flags(cuda_arch)))


### PR DESCRIPTION
Explicitly setting `cuda_arch=none` would cause the CUDA arch not to be correctly filtered.

Brought up by @iamashwin99 in #5830.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
