### PR TITLE
r-waldo: add @0.6.2, require older r-glue for older versions, retire some dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/r_waldo/package.py
+++ b/repos/spack_repo/builtin/packages/r_waldo/package.py
@@ -18,19 +18,26 @@ class RWaldo(RPackage):
 
     license("MIT")
 
+    version("0.6.2", sha256="b22a746be625eec49736d2a0a18d96c45c14d97e30e42bc81a0740f3194e07fa")
+    version("0.5.3", sha256="d9686d4b34df8fb9ee365962c731241edefdee8cc3206c899e32da483e1c7b06")
     version("0.5.2", sha256="82cdae1ab2c5e7e5dbf5c6bdf832020b46e152732053fb45de7c9a81afdf2e05")
     version("0.4.0", sha256="57ee89eec9bcbba58cf8fa29c8e097f038768c30833eaf812682826333127eaa")
     version("0.3.1", sha256="ec2c8c1afbc413f8db8b6b0c6970194a875f616ad18e1e72a004bc4497ec019b")
     version("0.2.3", sha256="1fbab22fe9be6ca8caa3df7306c763d7025d81ab6f17b85daaf8bdc8c9455c53")
 
-    depends_on("r@3.6:", type=("build", "run"), when="@0.5.2:")
     depends_on("r-cli", type=("build", "run"))
-    depends_on("r-diffobj", type=("build", "run"))
+
     depends_on("r-diffobj@0.3.4:", type=("build", "run"), when="@0.3.1:")
-    depends_on("r-fansi", type=("build", "run"))
+    depends_on("r-diffobj", type=("build", "run"))
+
+    depends_on("r-glue@:1.7", type=("build", "run"), when="@:0.5.2")
     depends_on("r-glue", type=("build", "run"))
-    depends_on("r-rematch2", type=("build", "run"))
-    depends_on("r-rlang", type=("build", "run"))
-    depends_on("r-rlang@0.4.10:", type=("build", "run"), when="@0.3.1:")
+
     depends_on("r-rlang@1.0.0:", type=("build", "run"), when="@0.4.0:")
-    depends_on("r-tibble", type=("build", "run"))
+    depends_on("r-rlang@0.4.10:", type=("build", "run"), when="@0.3.1:")
+    depends_on("r-rlang", type=("build", "run"))
+
+    # Past dependencies
+    depends_on("r-fansi", type=("build", "run"), when="@:0.5.2")
+    depends_on("r-rematch2", type=("build", "run"), when="@:0.5")
+    depends_on("r-tibble", type=("build", "run"), when="@:0.5")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

All available versions of `r-waldo` were failing to install due to latest `r-glue@1.8` dependency being selected by the default. A fix was to either prevent the latest, incompatible `r-glue` from being selected or to add a newer version of `r-waldo`.

This pull request adds both the latest version of `r-waldo` and prevents wrong `r-glue` from being used with older version.

Installation failure of `r-waldo` was preventing installation of following packages:

* `r-testthat`
* `mlpack`
* `r-devtools`
  * `r-irkernel`
  * `r-pacman`
  * `r-spades-addins`
    * `r-spades`
  * `r-wru`
* `r-ebseq`
* `r-isoband`
  * `r-ggplot2` (plus a few dozens of packages that depend on it)
* `r-lidr`
* `r-mockery`
* `r-nloptr`
  * `r-corhmm`
  * `r-lme4` (plus a dozen of packages that depend on it)
  * `r-optimx`
  * `r-ptw`
    * `r-alsace`