### PR TITLE
CP2K: Require +kxc when enabling libxc

### DIFF
--- a/repos/spack_repo/builtin/packages/cp2k/package.py
+++ b/repos/spack_repo/builtin/packages/cp2k/package.py
@@ -410,6 +410,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         depends_on("libxc@6.2:", when="@2023.2:")
         depends_on("libxc@:6", when="@:2024.3")
         depends_on("libxc@7 build_system=cmake", when="@2025.2:")
+        depends_on("libxc+kxc", when="@8.2:")
 
     with when("+spla"):
         depends_on("spla+cuda+fortran", when="+cuda")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

To be consistent with downstream requirement ([toolchain](https://github.com/cp2k/cp2k/blob/efe57105bb8d6956ae33be3f1814b1c0490b9899/tools/toolchain/scripts/stage3/install_libxc.sh#L53) and [Spack](https://github.com/cp2k/cp2k/blob/efe57105bb8d6956ae33be3f1814b1c0490b9899/tools/spack/cp2k_deps_p.yaml#L138)). `kxc` variant is only available in Spack swhen `libxc@5:`.