### PR TITLE
expat: 2.8.3 + deprecate vulnerable 2.8.2

### DIFF
--- a/repos/spack_repo/builtin/packages/expat/package.py
+++ b/repos/spack_repo/builtin/packages/expat/package.py
@@ -19,6 +19,10 @@ class Expat(AutotoolsPackage, CMakePackage):
 
     license("MIT")
     version(
+        "2.8.3",
+        sha256="b4cc2483927d5e90bf8c40b44a6b95b368b42a8a96e25883fce188b48a92b670",
+    )
+    version(
         "2.8.2",
         sha256="69e7f52417d85b1c2b7fe855e176eec55d0b2d7d92d691372d833a1c7df7923b",
     )

--- a/repos/spack_repo/builtin/packages/expat/package.py
+++ b/repos/spack_repo/builtin/packages/expat/package.py
@@ -22,11 +22,12 @@ class Expat(AutotoolsPackage, CMakePackage):
         "2.8.3",
         sha256="b4cc2483927d5e90bf8c40b44a6b95b368b42a8a96e25883fce188b48a92b670",
     )
+    # deprecate all releases before 2.8.3 because of various security issues
     version(
         "2.8.2",
         sha256="69e7f52417d85b1c2b7fe855e176eec55d0b2d7d92d691372d833a1c7df7923b",
+        deprecated=True,
     )
-    # deprecate all releases before 2.8.2 because of various security issues
     version(
         "2.8.1",
         sha256="f5833dd2e1cd7739ec9182804a1a29c4f0cc7c2f26b633d3a2188b7766a88ecb",


### PR DESCRIPTION
Similar to #5334

Related blog post: https://blog.hartwork.org/posts/expat-2-8-3-released/

- CVE-2026-72522

CC @wdconinc