### PR TITLE
py-cftime: more recent setuptools is needed

### DIFF
--- a/repos/spack_repo/builtin/packages/py_cftime/package.py
+++ b/repos/spack_repo/builtin/packages/py_cftime/package.py
@@ -24,8 +24,9 @@ class PyCftime(PythonPackage):
     # https://github.com/Unidata/cftime/blob/v1.6.3rel/Changelog#L7
     depends_on("python@:3.11", when="@:1.6.2")
 
-    depends_on("py-setuptools@18.0:", type="build", when="@1.0.3.4")
+    depends_on("py-setuptools@77:", type="build", when="@1.6.5:")
     depends_on("py-setuptools@41.2:", type="build", when="@1.6.4:")
+    depends_on("py-setuptools@18.0:", type="build", when="@1.0.3.4")
 
     depends_on("py-cython@0.19:", type="build", when="@1.0.3.4")
     depends_on("py-cython@0.29.20:", type="build", when="@1.6.4:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
For `py-cftime@1.6.5` anything below `py-setuptools@:76` gives the following error:

```
% spack install py-cftime@1.6.5 ^py-setuptools@76
[x] joiauyl py-cftime@1.6.5 failed: /tmp/tbouvier/spack-stage/spack-stage-py-cftime-1.6.5-joiauylnjofon4gcc4xutoybe7e7agal-_415yzc6.log (5s)
-- lines 117 to 129 --
    ╰─> No available output.

    note: This error originates from a subprocess, and is likely not a problem with pip.
    full command: /home/tbouvier/git/spack/opt/spack/linux-sapphirerapids/python-venv-1.0-3egme7ca7anjuh3clbttiocnk5n42ha6/bin/python3 /home/tbouvier/git/spack/opt/spack/linux-sapphirerapids/py-pip-26.1.2-w2ztxcod6aset3riawfjcwxive6yijns/lib/python3.14/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py prepare_metadata_for_build_wheel /tmp/tmpe7559q8x
    cwd: /tmp/tbouvier/spack-stage/spack-stage-py-cftime-1.6.5-joiauylnjofon4gcc4xutoybe7e7agal/spack-src
    Preparing metadata (pyproject.toml): finished with status 'error'
> error: metadata-generation-failed

  × Encountered error while generating package metadata.
  ╰─> from file:///tmp/tbouvier/spack-stage/spack-stage-py-cftime-1.6.5-joiauylnjofon4gcc4xutoybe7e7agal/spack-src

  note: This is an issue with the package mentioned above, not pip.
  hint: See above for details.
-- lines 253 to 272 --
      self.req.prepare_metadata()
      ~~~~~~~~~~~~~~~~~~~~~~~~~^^
    File "/home/tbouvier/git/spack/opt/spack/linux-sapphirerapids/py-pip-26.1.2-w2ztxcod6aset3riawfjcwxive6yijns/lib/python3.14/site-packages/pip/_internal/req/req_install.py", line 540, in prepare_metadata
      self.metadata_directory = generate_metadata(
                                ~~~~~~~~~~~~~~~~~^
          build_env=self.build_env,
          ^^^^^^^^^^^^^^^^^^^^^^^^^
          backend=self.pep517_backend,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          details=details,
          ^^^^^^^^^^^^^^^^
      )
      ^
    File "/home/tbouvier/git/spack/opt/spack/linux-sapphirerapids/py-pip-26.1.2-w2ztxcod6aset3riawfjcwxive6yijns/lib/python3.14/site-packages/pip/_internal/operations/build/metadata.py", line 36, in generate_metadata
      raise MetadataGenerationFailed(package_details=details) from error
  pip._internal.exceptions.MetadataGenerationFailed: metadata generation failed
  Removed file:///tmp/tbouvier/spack-stage/spack-stage-py-cftime-1.6.5-joiauylnjofon4gcc4xutoybe7e7agal/spack-src from build tracker '/tmp/pip-build-tracker-_599a4zs'
  Removed build tracker: '/tmp/pip-build-tracker-_599a4zs'
  Command exited with status 1:
      /home/tbouvier/git/spack/opt/spack/linux-sapphirerapids/python-venv-1.0-3egme7ca7anjuh3clbttiocnk5n42ha6/bin/python3 -m pip -vvv --no-input --no-cache-dir --disable-pip-version-check install --no-deps --ignore-installed --no-build-isolation --no-warn-script-location --no-index --prefix=/home/tbouvier/git/spack/opt/spack/linux-sapphirerapids/py-cftime-1.6.5-joiauylnjofon4gcc4xutoybe7e7agal .
==> Error: The following packages failed to install:
py-cftime@1.6.5/joiauylnjofon4gcc4xutoybe7e7agal: /tmp/tbouvier/spack-stage/spack-stage-py-cftime-1.6.5-joiauylnjofon4gcc4xutoybe7e7agal-_415yzc6.log
```

Installation is successful with `py-setuptools@77` on my system:

```
% spack install py-cftime@1.6.5 ^py-setuptools@77
[+] 3q6uggk py-setuptools@77.0.3 /home/tbouvier/git/spack/opt/spack/linux-sapphirerapids/py-setuptools-77.0.3-3q6uggkzbmc4txsbwna3ww4r7cnobrdf (10s)
[+] svd7nh2 py-cython@3.2.4 /home/tbouvier/git/spack/opt/spack/linux-sapphirerapids/py-cython-3.2.4-svd7nh2yh4fstsjqenc2qh53le7w2425 (2m19s)
[+] 65wvyqo py-cftime@1.6.5 /home/tbouvier/git/spack/opt/spack/linux-sapphirerapids/py-cftime-1.6.5-65wvyqonomo3emmtsqq3qmld4mitm2td
```