### PR TITLE
py-cachetools: more recent setuptools is needed

### DIFF
--- a/repos/spack_repo/builtin/packages/py_cachetools/package.py
+++ b/repos/spack_repo/builtin/packages/py_cachetools/package.py
@@ -32,6 +32,7 @@ class PyCachetools(PythonPackage):
         depends_on("python@3.9:3", when="@6:")
 
     with default_args(type="build"):
-        depends_on("py-setuptools")
+        depends_on("py-setuptools@77:", when="@7.1.1:")
+        depends_on("py-setuptools@61:", when="@6.2.3:")
         depends_on("py-setuptools@46.4.0:", when="@4.2.2:")
-        depends_on("py-setuptools@61.0.0:", when="@6.2.3:")
+        depends_on("py-setuptools")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
For py-cachetools@7.1.1 anything below py-setuptools@:76 gives the following error:

```
% spack install py-cachetools@7.1.1 ^py-setuptools@76
[x] 4gygj2i py-cachetools@7.1.1 failed: /tmp/tbouvier/spack-stage/spack-stage-py-cachetools-7.1.1-4gygj2ivttbwlwlewup336bjulypk2cr-1xk0eecw.log (4s)
-- lines 116 to 128 --
    ╰─> No available output.

    note: This error originates from a subprocess, and is likely not a problem with pip.
    full command: /home/tbouvier/git/spack/opt/spack/linux-sapphirerapids/python-venv-1.0-3egme7ca7anjuh3clbttiocnk5n42ha6/bin/python3 /home/tbouvier/git/spack/opt/spack/linux-sapphirerapids/py-pip-26.1.2-w2ztxcod6aset3riawfjcwxive6yijns/lib/python3.14/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py prepare_metadata_for_build_wheel /tmp/tmpjuqaqztd
    cwd: /tmp/tbouvier/spack-stage/spack-stage-py-cachetools-7.1.1-4gygj2ivttbwlwlewup336bjulypk2cr/spack-src
    Preparing metadata (pyproject.toml): finished with status 'error'
> error: metadata-generation-failed

  × Encountered error while generating package metadata.
  ╰─> from file:///tmp/tbouvier/spack-stage/spack-stage-py-cachetools-7.1.1-4gygj2ivttbwlwlewup336bjulypk2cr/spack-src

  note: This is an issue with the package mentioned above, not pip.
  hint: See above for details.
-- lines 252 to 271 --
      self.req.prepare_metadata()
      ~~~~~~~~~~~~~~~~~~~~~~~~~^^
    File "/home/tbouvier/git/spack/opt/spack/linux-sapphirerapids/py-pip-26.1.2-w2ztxcod6aset3riawfjcwxive6yijns/lib/python3.14/site-packages/pip/_internal/req/req_install.py", line 540, in prepare_metadata
      self.metadata_directory = generate_metadata(
                                ~~~~~~~~~~~~~~~~~^
          build_env=self.build_env,
          ^^^^^^^^^^^^^^^^^^^^^^^^^
          backend=self.pep517_backend,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          details=details,
          ^^^^^^^^^^^^^^^^
      )
      ^
    File "/home/tbouvier/git/spack/opt/spack/linux-sapphirerapids/py-pip-26.1.2-w2ztxcod6aset3riawfjcwxive6yijns/lib/python3.14/site-packages/pip/_internal/operations/build/metadata.py", line 36, in generate_metadata
      raise MetadataGenerationFailed(package_details=details) from error
  pip._internal.exceptions.MetadataGenerationFailed: metadata generation failed
  Removed file:///tmp/tbouvier/spack-stage/spack-stage-py-cachetools-7.1.1-4gygj2ivttbwlwlewup336bjulypk2cr/spack-src from build tracker '/tmp/pip-build-tracker-gbc79woz'
  Removed build tracker: '/tmp/pip-build-tracker-gbc79woz'
  Command exited with status 1:
      /home/tbouvier/git/spack/opt/spack/linux-sapphirerapids/python-venv-1.0-3egme7ca7anjuh3clbttiocnk5n42ha6/bin/python3 -m pip -vvv --no-input --no-cache-dir --disable-pip-version-check install --no-deps --ignore-installed --no-build-isolation --no-warn-script-location --no-index --prefix=/home/tbouvier/git/spack/opt/spack/linux-sapphirerapids/py-cachetools-7.1.1-4gygj2ivttbwlwlewup336bjulypk2cr .
==> Error: The following packages failed to install:
py-cachetools@7.1.1/4gygj2ivttbwlwlewup336bjulypk2cr: /tmp/tbouvier/spack-stage/spack-stage-py-cachetools-7.1.1-4gygj2ivttbwlwlewup336bjulypk2cr-1xk0eecw.log
```

Installation is successful with `py-setuptools@77` on my system.