### PR TITLE
qt: ensure patch application has correct version bounds

### DIFF
--- a/repos/spack_repo/builtin/packages/qt/package.py
+++ b/repos/spack_repo/builtin/packages/qt/package.py
@@ -177,7 +177,7 @@ class Qt(Package):
         "https://github.com/qt/qtbase/commit/cdf64b0e47115cc473e1afd1472b4b09e130b2a5.patch?full_index=1",
         sha256="2b881ffb2808f8fa79f51f8bec71be91a886bcdc59b1d7b6986cba26ed18d1d3",
         working_dir="qtbase",
-        when="@5.12.1:5:15.17 %apple-clang@15:",
+        when="@5.12.1:5.15.17 %apple-clang@15:",
     )
     conflicts("%apple-clang@15:", when="@:5.12.0")
 

--- a/repos/spack_repo/builtin/packages/qt/package.py
+++ b/repos/spack_repo/builtin/packages/qt/package.py
@@ -177,7 +177,7 @@ class Qt(Package):
         "https://github.com/qt/qtbase/commit/cdf64b0e47115cc473e1afd1472b4b09e130b2a5.patch?full_index=1",
         sha256="2b881ffb2808f8fa79f51f8bec71be91a886bcdc59b1d7b6986cba26ed18d1d3",
         working_dir="qtbase",
-        when="@5.12.1: %apple-clang@15:",
+        when="@5.12.1:5:15.17 %apple-clang@15:",
     )
     conflicts("%apple-clang@15:", when="@:5.12.0")
 


### PR DESCRIPTION
Qt patch was being applied to a version that contained the fix already, resulting in gnu patch prompting the user for a reversal.

Add proper patch bounds.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
