### PR TITLE
podio,sio: url_for_version for main version

### DIFF
--- a/repos/spack_repo/builtin/packages/podio/package.py
+++ b/repos/spack_repo/builtin/packages/podio/package.py
@@ -171,6 +171,9 @@ class Podio(CMakePackage):
         """
         base_url = self.url.rsplit("/", 1)[0]
 
+        if version.isdevelop():
+            return f"{base_url}/refs/heads/{version}.tar.gz"
+
         if len(version) == 1:
             major = version[0]
             minor, patch = 0, 0

--- a/repos/spack_repo/builtin/packages/sio/package.py
+++ b/repos/spack_repo/builtin/packages/sio/package.py
@@ -70,6 +70,9 @@ class Sio(CMakePackage):
         """
         base_url = self.url.rsplit("/", 1)[0]
 
+        if version.isdevelop():
+            return f"{base_url}/refs/heads/{version}.tar.gz"
+
         if len(version) == 1:
             major = version[0]
             minor, patch = 0, 0


### PR DESCRIPTION
This PR avoids in `podio` and `sio` the incorrect insertion of a named version (`main` or `master`) into an integer format placeholder. This is relevant for the SBOM generation, even though the version is checked out from the git repo.

This is the same as #5975, but now I verified this pattern doesn't happen in any other packages.