### PR TITLE
fms: patch cmake for +yaml

### DIFF
--- a/repos/spack_repo/builtin/packages/fms/fms-link-libyaml.patch
+++ b/repos/spack_repo/builtin/packages/fms/fms-link-libyaml.patch
@@ -1,0 +1,13 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -417,6 +417,10 @@
+                                          NetCDF::NetCDF_Fortran
+                                          MPI::MPI_Fortran)
+
++  if(WITH_YAML)
++    target_link_libraries(${libTgt} PRIVATE ${LIBYAML_LIBRARIES})
++  endif()
++
+   if(OpenMP_Fortran_FOUND)
+     target_link_libraries(${libTgt} PRIVATE OpenMP::OpenMP_C OpenMP::OpenMP_Fortran)
+   endif()

--- a/repos/spack_repo/builtin/packages/fms/package.py
+++ b/repos/spack_repo/builtin/packages/fms/package.py
@@ -119,6 +119,14 @@ class Fms(CMakePackage):
         description="yaml input file support(requires libyaml)",
         when="@2021.04:",
     )
+
+    # fms CMake omits a needed target_link_libraries statement, so the yaml symbols
+    # never get linked into the exported fms target, causing downstream consumers to
+    # fail with "undefined reference to yaml_*" at link time. Fixed upstream in
+    # 2026.01 (github.com/noaa-gfdl/FMS commit d814ff6a, PR #1822); not backported to
+    # any earlier release. This patch covers a recent part of the range.
+    patch("fms-link-libyaml.patch", when="+yaml @2025.02:2025.04")
+
     variant(
         "constants",
         default="GFDL",


### PR DESCRIPTION
When compiling an application that depends on FMS 2025.03's yaml features using fms@2025.03+yaml, the build fails at the linking stage due to missing symbols from libyaml. This bug [was fixed in the upstream](https://github.com/NOAA-GFDL/FMS/pull/1822/changes#diff-5d3d35a2f345719a38a400a0160578378b3136b52db27fad76d1f5edc39a84f7), however the fix never made it into the affected 2025 (and older) versions.

This PR patches the missing `target_link_libraries`. I've confirmed this works for versions `2025.02:2025.04` (#4737 adds `2025.04:2026.01.01`). The patch should apply to older affected versions, but my testing was blocked by a separate bug. So, this PR only includes those versions I've tested. If support for older versions is desirable, I can open a new issue to sort out the separate bug. I can attach the MRE I used for testing on request.

Depends on #4737