### PR TITLE
flecsi: add v2.4.2

### DIFF
--- a/repos/spack_repo/builtin/packages/flecsi/package.py
+++ b/repos/spack_repo/builtin/packages/flecsi/package.py
@@ -24,6 +24,7 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
 
     tags = ["e4s"]
 
+    version("2.4.2", tag="v2.4.2", commit="65b070310350f2d95d2b266145929c8d4b90a7b7")
     version("2.4.1", tag="v2.4.1", commit="f57a634e3f1f136e8932ad81f267d3b69657ae15")
     version("2.4.0", tag="v2.4.0", commit="598d518b4105ec91ee42ee50420aa46a32a0f60f")
     version("2.3.2", tag="v2.3.2", commit="736fc74248777a00dbd41f1a66ae49e615c8a514")
@@ -130,6 +131,11 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
         conflicts(f"^boost cxxstd={cxxstd}")
         conflicts(f"^hpx cxxstd={cxxstd}", when="backend=hpx")
 
+    # C++20 required since 2.4.2
+    conflicts("^boost cxxstd=17", when="@2.4.2:")
+    conflicts("^hpx cxxstd=17", when="@2.4.2: backend=hpx")
+    conflicts("^legion cxxstd=17", when="@2.4.2: backend=legion")
+
     def cmake_args(self):
         spec = self.spec
         options = [
@@ -153,7 +159,5 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
             if self.spec.satisfies("backend=legion"):
                 # CMake pulled in via find_package(Legion) won't work without this
                 options.append(self.define("HIP_PATH", "{0}/hip".format(spec["hip"].prefix)))
-        elif self.spec.satisfies("^kokkos +cuda"):
-            options.append(self.define("CMAKE_CXX_COMPILER", self["kokkos"].kokkos_cxx))
 
         return options

--- a/stacks/e4s-oneapi/spack.yaml
+++ b/stacks/e4s-oneapi/spack.yaml
@@ -92,7 +92,6 @@ spack:
   - e4s-cl
   - exaworks
   - faodel
-  - flecsi
   - flit
   - flux-core
   - gasnet
@@ -194,6 +193,7 @@ spack:
   - upcxx +level_zero
 
   # Current errors:
+  # - flecsi                      # hdf5-1.14.6:Fatal Error: Reading module '/home/software/spack/[padded-to-256-chars]/linux-x86_64_v3/intel-oneapi-mpi-2021.18.0-lufklfi5m4d7ozbwg6hawancq32cwynz/mpi/2021.18/include/mpi/mpi.mod' at line 1 column 2: Unexpected EOF
   # - gptune ~mpispawn            # py-gpy-1.13.2: GPy/kern/src/stationary_cython.c:17564:41: error: no member named 'subarray' in 'struct _PyArray_Descr'
   # - hypre +sycl                 # Could NOT find IntelSYCL (missing: SYCL_INCLUDE_DIR SYCL_LIBRARY_DIR SYCL_LIBRARY) (found version "202012")
   # - nco                         # hdf5-1.14.6:Fatal Error: Reading module '/home/software/spack/[padded-to-256-chars]/linux-x86_64_v3/intel-oneapi-mpi-2021.17.2-4qz7nzr4kheywlw2dln3vwbe4527tdck/mpi/2021.17/include/mpi/mpi.mod' at line 1 column 2: Unexpected EOF 


### PR DESCRIPTION
- add FleCSI v2.4.2 release
- requires C++20 moving forward
- remove `kokkos_cxx` usage because it never made sense for the cases we care about. this is part of a larger effort to remove `kokkos_cxx` from dependents.