### PR TITLE
mpsolve: regenerate parser w/ bison to fix gcc@14 build

### DIFF
--- a/repos/spack_repo/builtin/packages/mpsolve/package.py
+++ b/repos/spack_repo/builtin/packages/mpsolve/package.py
@@ -34,3 +34,11 @@ class Mpsolve(AutotoolsPackage):
     depends_on("fortran", type="build")
 
     depends_on("gmp")
+
+    # regenerate parser w/ bison (https://github.com/robol/MPSolve/issues/48)
+    depends_on("bison", type="build", when="@3.2.3")
+
+    @when("@3.2.3")
+    def patch(self):
+        force_remove("src/libmps/monomial/yacc-parser.c")
+        force_remove("src/libmps/monomial/yacc-parser.h")


### PR DESCRIPTION
The parser distributed in the tarball was generated using byacc and compiling w/ gcc 14 gives us "implicit declaration" errors for `yyparse`.

See https://github.com/robol/MPSolve/issues/48 and the discussion in https://github.com/spack/spack-packages/pull/5033 w/ @bernhardkaindl.
