### PR TITLE
flux: Aug26 updates for core/sched/pmix

### DIFF
--- a/repos/spack_repo/builtin/packages/flux_core/package.py
+++ b/repos/spack_repo/builtin/packages/flux_core/package.py
@@ -22,6 +22,8 @@ class FluxCore(AutotoolsPackage):
     license("LGPL-3.0-only")
 
     version("master", branch="master")
+    version("0.88.0", sha256="e7c5a48045a0574aa330f9bf94cad0a5de47f88c206f66387bfe8fd062c21a1c")
+    version("0.87.0", sha256="7a91d222c00cc559c21dbc66312967974a01b17d00778dc549830c6f416831e7")
     version("0.86.0", sha256="0339f1c45af02a2c2ccafddc3d37da4bcf0318c7e6be50dd557ee4cb7b9421f5")
     version("0.85.0", sha256="b413ab4b5a7ff3dd037cc4976691e9bbb1d5ebe2f1ba7b011995903a1b27c056")
     version("0.84.0", sha256="6cf45d418ff021eb38300ca594501804e1ab74fc8aabc2fd103023e1284bc3bc")
@@ -102,8 +104,11 @@ class FluxCore(AutotoolsPackage):
     depends_on("libarchive+iconv", when="@0.38.0:")
     depends_on("ncurses@6.2:", when="@0.32.0:")
     depends_on("libzmq@4.0.4:")
+    depends_on("libzmq@4.2.0:", when="@0.87.0:")
     depends_on("czmq@3.0.1:", when="@:0.54.0")
     depends_on("hwloc@1.11.1:")
+    depends_on("hwloc@2.0.0:", when="@0.85.0:")
+    depends_on("hwloc@2.1.0:", when="@0.87.0:")
     depends_on("hwloc +cuda", when="+cuda")
     # Provide version hints for lua so that the concretizer succeeds when no
     # explicit flux-core version is given. See issue #10000 for details

--- a/repos/spack_repo/builtin/packages/flux_pmix/package.py
+++ b/repos/spack_repo/builtin/packages/flux_pmix/package.py
@@ -19,6 +19,7 @@ class FluxPmix(AutotoolsPackage):
     maintainers("grondo")
 
     version("main", branch="main")
+    version("0.7.1", sha256="0530d203370b13b63263ee48ecc829ab6bddadabf4e66ea470983f6f530a410f")
     version("0.7.0", sha256="0ad9fa0d76e8ffeaa4aa45bd39760b623219e8d3d2a66eb62e8832c2f7e3f47b")
     version("0.6.0", sha256="31f9d9b99f8a75c05e2fd183a35998f104d8e80bd819c57252aca477be0d4c6e")
     version("0.5.0", sha256="f382800b1a342df0268146ea7ce33011299bf0c69a46ac8a52e87de6026c9322")
@@ -60,6 +61,7 @@ class FluxPmix(AutotoolsPackage):
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         spec = self.spec
+        env.set("FLUX_PMI_CLIENT_METHODS", "simple pmix libpmi2 libpmi single")
         env.prepend_path("FLUX_SHELL_RC_PATH", join_path(self.prefix.etc, "flux/shell/lua.d"))
         if spec.satisfies("@0.3.0:"):
             env.prepend_path(

--- a/repos/spack_repo/builtin/packages/flux_sched/package.py
+++ b/repos/spack_repo/builtin/packages/flux_sched/package.py
@@ -23,6 +23,8 @@ class FluxSched(CMakePackage, AutotoolsPackage):
     license("LGPL-3.0-only")
 
     version("master", branch="master")
+    version("0.54.0", sha256="de8edcc3b3cb637939bd0fe7b25870fae2bcb0326629e2e3ad4efcb9da77b96a")
+    version("0.53.0", sha256="21726fcaf589cbc2f13b3339e04f668a197e2642d1a8484e5c45819864cc712d")
     version("0.52.0", sha256="dde25922e387a23654b04e731c5916a922ce5369911b253bcc2e825a52fe0f01")
     version("0.51.0", sha256="e4241ae45cd8f22ad2b45adb766567d52a5990d8145c1e70157b52b547bfd0d8")
     version("0.50.0", sha256="f1f434f9a89cff676a56d24c46876393b8a1d4e341748467ed710ce33a103e77")


### PR DESCRIPTION
Adds releases from previous 2 months.

Also adds an environment variable for `flux-pmix` to add `pmix` to the list of PMI methods tried during bootstrap, with the default `simple` method left in first position (i.e. it will try `pmix` automatically but only if `simple` fails first). I'm not particularly familiar with Spack, so hopefully that is the correct way to set it :)
```
env.set("FLUX_PMI_CLIENT_METHODS", "simple pmix libpmi2 libpmi single")
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
