### PR TITLE
parallelio: skip RPATHs with NAG

### DIFF
--- a/repos/spack_repo/builtin/packages/parallelio/package.py
+++ b/repos/spack_repo/builtin/packages/parallelio/package.py
@@ -105,6 +105,9 @@ class Parallelio(CMakePackage):
             define("PIO_ENABLE_EXAMPLES", False),
             define_from_variant("WITH_PNETCDF", "pnetcdf"),
         ]
+        if spec.satisfies("%nag"):
+            # NAG cannot pass Spack's padded build rpath through its linker.
+            args.append(define("CMAKE_SKIP_RPATH", True))
         if spec.satisfies("+ncint"):
             args.extend([define("PIO_ENABLE_NETCDF_INTEGRATION", True)])
         if spec.satisfies("+pnetcdf"):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

NAG cannot pass Spack's padded build rpath through its linker. Setting `CMAKE_SKIP_RPATH` avoids the invalid linker invocation while preserving successful `parallelio` builds with `%nag`.