### PR TITLE
Augustus: fixed dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/augustus/package.py
+++ b/repos/spack_repo/builtin/packages/augustus/package.py
@@ -53,8 +53,12 @@ class Augustus(MakefilePackage):
     depends_on(Boost.with_default_variants)
     depends_on("zlib-api")
     depends_on("htslib")
+    depends_on("htslib@1.10:", when="@3.4.0:")
     depends_on("bcftools")
     depends_on("samtools")
+    # bam2wig/checkTargetSortedness use the legacy samtools API (sam.h, libbam.a),
+    # which was removed in samtools 1.14
+    depends_on("samtools@:1.13", when="@:3.3.2")
     depends_on("ncurses")
     depends_on("curl", when="@3.3.1:")
     depends_on("sqlite", when="@3.4.0:")
@@ -66,6 +70,11 @@ class Augustus(MakefilePackage):
     # Trying to use filter_file here got too complicated so use a patch with a
     # corresponding environment variable
     patch("bam2wig_Makefile.patch", when="@3.4.0")
+
+    # bam2wig links samtools' libbam.a, which calls bam_name2id. This became a static
+    # inline in htslib 1.10. Only 2 versions of augustus are affected. Earlier ones don't
+    # build bam2wig and 3.4.0+ links -lhts only.
+    conflicts("^htslib@1.10:", when="@3.3.1-tag1:3.3.2 ^samtools@:1.2")
 
     def edit(self, spec, prefix):
         # Set compile commands for each compiler and
@@ -129,6 +138,13 @@ class Augustus(MakefilePackage):
                     "LIBS = -lbamtools -lz", f"LIBS = {bamtools}/lib/bamtools/libbamtools.a -lz"
                 )
 
+        # For 3.3, when building with newer versions of Boost, the -ansi flag causes an old
+        # standard to be used which boost complains about.
+        if spec.satisfies("@=3.3"):
+            with working_dir("src"):
+                makefile = FileFilter("Makefile")
+                makefile.filter("-ansi", "-std=c++14")
+
         if self.version < Version("3.4.0"):
             with working_dir(join_path("auxprogs", "bam2wig")):
                 makefile = FileFilter("Makefile")
@@ -137,9 +153,13 @@ class Augustus(MakefilePackage):
                 makefile.filter("SAMTOOLS=.*$", f"SAMTOOLS={samtools}/include")
                 makefile.filter("HTSLIB=.*$", f"HTSLIB={htslib}/include")
 
-                # fix bad linking dirs
+                # fix bad linking dirs; libhts.a is linked statically, so
+                # anything it was built against must be named explicitly
+                hts = "$(HTSLIB)/../lib/libhts.a"
+                if spec.satisfies("^libdeflate"):
+                    hts += " " + spec["libdeflate"].libs.ld_flags
                 makefile.filter("$(SAMTOOLS)/libbam.a", "$(SAMTOOLS)/../lib/libbam.a", string=True)
-                makefile.filter("$(HTSLIB)/libhts.a", "$(HTSLIB)/../lib/libhts.a", string=True)
+                makefile.filter("$(HTSLIB)/libhts.a", hts, string=True)
             with working_dir(join_path("auxprogs", "checkTargetSortedness")):
                 makefile = FileFilter("Makefile")
                 makefile.filter("SAMTOOLS.*=.*$", f"SAMTOOLS={samtools}/include")


### PR DESCRIPTION
This update mainly focuses on getting Augustus to compile with some newer tool versions. Mainly building augustus with older versions of htslib causes problems. In doing so I ran into some additional problems:
- samtools (L59-L61): With older versions of samtools, augustus attempted to compile against headers that didnt exist.
- htslib (L74-L77): Older versions of augustus attempted to link against function definitions that didnt exist in htslib while in the presence of an old samtools.
- boost (L141-L147): When building older Augustus with a newer boost, and `-ansi` flag caused complaints from boost about not supporting c++11 or newer
- libdeflate (L156-L162): htslib@1.8: will pull in libdeflate. augustus had problems detecting the libraries, so if it is a dependency then tweaks the args to include it.

Built with gcc@11.5.0
  | augustus@=3.5.0 | =3.4.0 | =3.3.2 | =3.3.1-tag1 | =3.3 | =3.2.3
-- | -- | -- | -- | -- | -- | --
samtools@=1.23.1 | ✅ | ✅ | ❌ | ❌ | ❌ | ✅
samtools@=1.21 | ✅ | ✅ | ❌ | ❌ | ❌ | ✅
samtools@=1.19.2 | ✅ | ✅ | ❌ | ❌ | ❌ | ✅
samtools@=1.19 | ✅ | ✅ | ❌ | ❌ | ❌ | ✅
samtools@=1.18 | ✅ | ✅ | ❌ | ❌ | ❌ | ✅
samtools@=1.17 | ✅ | ✅ | ❌ | ❌ | ❌ | ✅
samtools@=1.16.1 | ✅ | ✅ | ❌ | ❌ | ❌ | ✅
samtools@=1.15.1 | ✅ | ✅ | ❌ | ❌ | ❌ | ✅
samtools@=1.15 | ✅ | ✅ | ❌ | ❌ | ❌ | ✅
samtools@=1.14 | ✅ | ✅ | ❌ | ❌ | ❌ | ✅
samtools@=1.13 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅
samtools@=1.12 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅
samtools@=1.11 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌
samtools@=1.10 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅
samtools@=1.9 | ❌ | ❌ | ✅ | ✅ | ✅ | ✅
samtools@=1.8 | ❌ | ❌ | ✅ | ✅ | ✅ | ✅
samtools@=1.7 | ❌ | ❌ | ✅ | ✅ | ✅ | ✅
samtools@=1.6 | ❌ | ❌ | ✅ | ✅ | ✅ | ✅
samtools@=1.5 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌
samtools@=1.4 | ❌ | ❌ | ✅ | ✅ | ✅ | ✅
samtools@=1.3.1 | ❌ | ❌ | ✅ | ✅ | ✅ | ✅
samtools@=1.2 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅

✅ = success
❌ = conflict

Note: There was a "global" failure to solve for samtools@=1.11 (and I believe 1.5) and any version of augustus that appeared before this work. I couldn't nail down why this was caused exactly...