### PR TITLE
Remove gtest as a dependency of STK for Trilinos16.*

### DIFF
--- a/repos/spack_repo/builtin/packages/trilinos/package.py
+++ b/repos/spack_repo/builtin/packages/trilinos/package.py
@@ -383,7 +383,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     with when("~gtest"):
         conflicts("+minitensor")
         conflicts("+rol")
-        conflicts("+stk")
+        conflicts("+stk", when="@17:")
     # this does alleviate needing: conflicts("+test", when="@17: ~gtest")
     # see https://github.com/spack/spack-packages/pull/3361 for explanation
 


### PR DESCRIPTION
Some downstream applications break when Trilinos +stk is always built with gtest, when gtest is pulled in as a different dependency in downstream applications. There was a brief moment where this was not the case, commit: 1a79dd1ae9ff26bd0dda5a6fdc10d95df46c6ff0. This makes it so that Trilinos +stk can be built without gtest.
