### PR TITLE
HEP: disable py-zfit

### DIFF
--- a/stacks/hep/spack.yaml
+++ b/stacks/hep/spack.yaml
@@ -147,7 +147,7 @@ spack:
   - py-uhi
   - py-uproot +lz4 +xrootd +zstd
   - py-vector
-  - py-zfit
+  #- py-zfit
   - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf ~madgraph5amc +python +rivet ~root # pythia8 and root circularly depend
   - recola
   - rivet


### PR DESCRIPTION
This PR disables `py-zfit` from the HEP stack. `py-zfit` depends on `py-tensorflow`. Since #3698, the `py-protobuf` version is restricted to `@:7` when `@2.20` (reasonably so, since it is likely explicitly restricted to `@:7` when `@2.21:` per @adamjstewart's addition). This means that `protobuf` is restricted to `@:28` instead of allowing a newer version to be installed. This older version fails to compile in the HEP stack, e.g. https://gitlab.spack.io/spack/spack-packages/-/jobs/23900447. 