### PR TITLE
protobuf: conflict with abseil-cpp@20250512: for @26:29

### DIFF
--- a/repos/spack_repo/builtin/packages/protobuf/package.py
+++ b/repos/spack_repo/builtin/packages/protobuf/package.py
@@ -118,6 +118,10 @@ class Protobuf(CMakePackage):
     depends_on("abseil-cpp@20230125.3:", when="@22.5:")
     # https://github.com/protocolbuffers/protobuf/issues/11828#issuecomment-1433557509
     depends_on("abseil-cpp@20230125:", when="@22:")
+    # protobuf@26:29 link to absl::if_constexpr, which was removed from abseil-cpp in the
+    # 20250512 release.
+    # https://github.com/protocolbuffers/protobuf/issues/24785
+    conflicts("^abseil-cpp@20250512:", when="@26:29")
     depends_on("zlib-api")
 
     # See https://github.com/protocolbuffers/protobuf/issues/26383

--- a/stacks/hep/spack.yaml
+++ b/stacks/hep/spack.yaml
@@ -147,7 +147,7 @@ spack:
   - py-uhi
   - py-uproot +lz4 +xrootd +zstd
   - py-vector
-  #- py-zfit
+  - py-zfit
   - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf ~madgraph5amc +python +rivet ~root # pythia8 and root circularly depend
   - recola
   - rivet


### PR DESCRIPTION
The `absl::if_constexpr` target was removed in the 20250512 release of abseil-cpp. protobuf attempts to link to it in versions 26:29