### PR TITLE
Fix missing depends_on("c") in 21 packages without maintainer

### DIFF
--- a/repos/spack_repo/builtin/packages/accfft/package.py
+++ b/repos/spack_repo/builtin/packages/accfft/package.py
@@ -23,7 +23,8 @@ class Accfft(CMakePackage, CudaPackage):
     variant("pnetcdf", default=True, description="Add support for parallel NetCDF")
     variant("shared", default=True, description="Enables the build of shared libraries")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     # See: http://accfft.org/articles/install/#installing-dependencies
     depends_on("fftw precision=float,double ~mpi+openmp")

--- a/repos/spack_repo/builtin/packages/aspa/package.py
+++ b/repos/spack_repo/builtin/packages/aspa/package.py
@@ -24,7 +24,8 @@ class Aspa(MakefilePackage):
 
     variant("mpi", default=True, description="Build with MPI Support")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("lapack")
     depends_on("blas")

--- a/repos/spack_repo/builtin/packages/bookleaf_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/bookleaf_cpp/package.py
@@ -27,7 +27,8 @@ class BookleafCpp(CMakePackage):
     variant("silo", default=False, description="Use Silo")
     variant("caliper", default=False, description="Use Caliper")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("caliper", when="+caliper")
     depends_on("parmetis", when="+parmetis")

--- a/repos/spack_repo/builtin/packages/channelflow/package.py
+++ b/repos/spack_repo/builtin/packages/channelflow/package.py
@@ -32,7 +32,8 @@ class Channelflow(CMakePackage):
     )
     variant("python", default=False, description="Build python bindings")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("eigen")
     depends_on("fftw")

--- a/repos/spack_repo/builtin/packages/cmdlime/package.py
+++ b/repos/spack_repo/builtin/packages/cmdlime/package.py
@@ -18,4 +18,5 @@ class Cmdlime(CMakePackage):
 
     version("2.5.0", sha256="d5188d7f075142fcb546099a4ee2a967f8248109c0bee8c084e0e00f37603481")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")

--- a/repos/spack_repo/builtin/packages/dorian3d_dlib/package.py
+++ b/repos/spack_repo/builtin/packages/dorian3d_dlib/package.py
@@ -18,7 +18,8 @@ class Dorian3dDlib(CMakePackage):
 
     version("master", branch="master")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("cmake@3.0:", type="build")
     depends_on("opencv+calib3d+features2d+highgui+imgproc+imgcodecs+flann")

--- a/repos/spack_repo/builtin/packages/dsqss/package.py
+++ b/repos/spack_repo/builtin/packages/dsqss/package.py
@@ -24,7 +24,8 @@ class Dsqss(CMakePackage):
 
     variant("mpi", default=True, description="build mpi support")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("mpi", when="+mpi")
     depends_on("python", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/entt/package.py
+++ b/repos/spack_repo/builtin/packages/entt/package.py
@@ -22,7 +22,8 @@ class Entt(CMakePackage):
     version("3.11.1", sha256="0ac010f232d3089200c5e545bcbd6480cf68b705de6930d8ff7cdb0a29f5b47b")
     version("3.5.2", sha256="f9271293c44518386c402c9a2188627819748f66302df48af4f6d08e30661036")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("cmake@3.7.0:", type="build")
     depends_on("doxygen@1.8.0:", type="build")

--- a/repos/spack_repo/builtin/packages/eprosima_fastcdr/package.py
+++ b/repos/spack_repo/builtin/packages/eprosima_fastcdr/package.py
@@ -21,4 +21,5 @@ class EprosimaFastcdr(CMakePackage):
     version("2.2.0", sha256="8a75ee3aed59f495e95208050920d2c2146df92f073809505a3bd29011c21f20")
     version("1.0.27", sha256="a9bc8fd31a2c2b95e6d2fb46e6ce1ad733e86dc4442f733479e33ed9cdc54bf6")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")

--- a/repos/spack_repo/builtin/packages/mongo_cxx_driver/package.py
+++ b/repos/spack_repo/builtin/packages/mongo_cxx_driver/package.py
@@ -38,7 +38,8 @@ class MongoCxxDriver(CMakePackage):
     version("3.2.1", sha256="d5e62797cbc48c6e5e18bc0a66c14556e78871d05db4bccc295074af51b8421e")
     version("3.2.0", sha256="e26edd44cf20bd6be91907403b6d63a065ce95df4c61565770147a46716aad8c")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("mongo-c-driver@1.9.2:")
 

--- a/repos/spack_repo/builtin/packages/muster/package.py
+++ b/repos/spack_repo/builtin/packages/muster/package.py
@@ -21,7 +21,8 @@ class Muster(CMakePackage):
     version("1.0.1", sha256="71e2fcdd7abf7ae5cc648a5f310e1c5369e4889718eab2a045e747c590d2dd71")
     version("1.0", sha256="370a670419e391494fcca0294882ee5f83c5d8af94ca91ac4182235332bd56d6")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("boost+exception+serialization+random")
     depends_on("mpi")

--- a/repos/spack_repo/builtin/packages/nnvm/package.py
+++ b/repos/spack_repo/builtin/packages/nnvm/package.py
@@ -21,7 +21,8 @@ class Nnvm(CMakePackage):
 
     variant("shared", default=True, description="Build a shared NNVM lib.")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("dmlc-core")
 

--- a/repos/spack_repo/builtin/packages/opensubdiv/package.py
+++ b/repos/spack_repo/builtin/packages/opensubdiv/package.py
@@ -35,7 +35,8 @@ class Opensubdiv(CMakePackage, CudaPackage):
     variant("tbb", default=False, description="Builds with Intel TBB support")
     variant("openmp", default=False, description="Builds with OpenMP support")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("cmake@2.8.6:", type="build")
     depends_on("gl")

--- a/repos/spack_repo/builtin/packages/rust_bindgen/package.py
+++ b/repos/spack_repo/builtin/packages/rust_bindgen/package.py
@@ -24,7 +24,8 @@ class RustBindgen(CargoPackage):
     version("0.66.0", sha256="d2c8e8c1c9fbabecaa1146a02cc3bbbf968931136e7dc94614af06880d291685")
     version("0.20.5", sha256="4f5236e7979d262c43267afba365612b1008b91b8f81d1efc6a8a2199d52bb37")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     def build(self, spec, prefix):
         # The carogopackage installer doesn't allow for an option to install from a subdir

--- a/repos/spack_repo/builtin/packages/sigcpp/package.py
+++ b/repos/spack_repo/builtin/packages/sigcpp/package.py
@@ -24,7 +24,8 @@ class Sigcpp(CMakePackage):
 
     variant("doc", default=True, description="Keep man files")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     @run_after("install")
     def drop_doc(self):

--- a/repos/spack_repo/builtin/packages/tinyobjloader/package.py
+++ b/repos/spack_repo/builtin/packages/tinyobjloader/package.py
@@ -17,6 +17,7 @@ class Tinyobjloader(CMakePackage):
 
     version("1.0.6", sha256="19ee82cd201761954dd833de551edb570e33b320d6027e0d91455faf7cd4c341")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("cmake@2.8.11:", type="build")

--- a/repos/spack_repo/builtin/packages/umesimd/package.py
+++ b/repos/spack_repo/builtin/packages/umesimd/package.py
@@ -25,4 +25,5 @@ class Umesimd(CMakePackage):
     version("0.3.2", sha256="90399fa64489ca4d492a57a49582f5b827d4710a691f533822fd61edc346e8f6")
     version("0.3.1", sha256="9bab8b4c70e11dbdd864a09053225c74cfabb801739e09a314ddeb1d84a43f0a")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")

--- a/repos/spack_repo/builtin/packages/uvw/package.py
+++ b/repos/spack_repo/builtin/packages/uvw/package.py
@@ -24,7 +24,8 @@ class Uvw(CMakePackage):
 
     variant("docs", default=False, description="Builds and install the documentation")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("libuv", type="link")
     depends_on("doxygen", type="build", when="+docs")

--- a/repos/spack_repo/builtin/packages/valijson/package.py
+++ b/repos/spack_repo/builtin/packages/valijson/package.py
@@ -22,4 +22,5 @@ class Valijson(CMakePackage):
     version("1.0.2", sha256="35d86e54fc727f1265226434dc996e33000a570f833537a25c8b702b0b824431")
     version("1.0", sha256="6b9f0bc89880feb3fe09aa469cd81f6168897d2fbb4e715853da3b94afd3779a")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")

--- a/repos/spack_repo/builtin/packages/xcdf/package.py
+++ b/repos/spack_repo/builtin/packages/xcdf/package.py
@@ -18,7 +18,8 @@ class Xcdf(CMakePackage):
     version("3.01", sha256="39fe816f40d6af18e16e71ffcf958258fdac4959ac894a60d1b863efaa57754e")
     version("3.00.03", sha256="4e445a2fea947ba14505d08177c8d5b55856f8411f28de1fe4d4c00f6824b711")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     patch("remove_python_support.patch", when="@3.00.03")
 

--- a/repos/spack_repo/builtin/packages/xrdcl_record/package.py
+++ b/repos/spack_repo/builtin/packages/xrdcl_record/package.py
@@ -18,6 +18,9 @@ class XrdclRecord(CMakePackage):
 
     version("5.4.2", sha256="fb76284491ff4e723bce4c9e9d87347e98e278e70c597167bc39a162bc876734")
 
-    depends_on("cxx", type="build")  # generated
+    with default_args(type="build"):
+        depends_on("c")
+        depends_on("cxx")
+        depends_on("pkgconfig")
 
     depends_on("xrootd")


### PR DESCRIPTION
Hi, while reviewing and building packages for reviews, I saw a few cases of missing `depends_on("c")`,
where `depends_on("cxx")` was generated, but `depends_on("c")` not. But, "c" was in fact also needed.

To fix most similar packages in one or a few PRs, I grepped the potentially affected packages (with the generated "cxx" line, and without "c") and started building all I could build.
- [x] By far, most of the total grepped list of 644 packages in this class did build fine.

I grepped the build logs of the fails (and also config.log files) for the recommendation to add `depends_on("c")`, mass-edited the those packages using `sed` and restarted building them.

- [x] Some edited packages still failed to build: But those are not included here, they need more work.

- [x] This PR is restricted to only packages without maintainers:
  - With 21 packages, this PR has a lot of files on its own.

Checked:
- [x] No AI used for this PR to ensure there's 0% chance of any hallucination.
- [x] I double-checked that these changes fixed the build of these packages.
- [x] The last recipe in this PR has a manual change to add the missing pkgconfig dependency too.