### PR TITLE
cxi: add new versions

### DIFF
--- a/repos/spack_repo/builtin/packages/cassini_headers/package.py
+++ b/repos/spack_repo/builtin/packages/cassini_headers/package.py
@@ -18,11 +18,13 @@ class CassiniHeaders(Package):
     license("GPL-2.0-only or BSD-2-Clause")
 
     version("main", branch="main")
-    version("13.1.0", tag="release/shs-13.1.0")
-    version("13.0.0", tag="release/shs-13.0.0")
-    version("12.0.2", tag="release/shs-12.0.2")
-    version("12.0.1", tag="release/shs-12.0.1")
-    version("12.0.0", tag="release/shs-12.0.0")
+    version("14.0.1", tag="release/shs-14.0.1", commit="125b3d00d0d65029a21aa139f8dce88d845491c5")
+    version("14.0.0", tag="release/shs-14.0.0", commit="96e971c9cf26c8fa3aa2f33be55fc36f25055b14")
+    version("13.1.0", tag="release/shs-13.1.0", commit="2f6e60a44367ff7439dbb2315531b73fcf5dc4c8")
+    version("13.0.0", tag="release/shs-13.0.0", commit="144056ff2143b99ec08b3f1cd07c5e3ae176878d")
+    version("12.0.2", tag="release/shs-12.0.2", commit="b3f65f01296e4f486bb41fafed7ff6ee686cee8f")
+    version("12.0.1", tag="release/shs-12.0.1", commit="b3f65f01296e4f486bb41fafed7ff6ee686cee8f")
+    version("12.0.0", tag="release/shs-12.0.0", commit="b3f65f01296e4f486bb41fafed7ff6ee686cee8f")
 
     def install(self, spec, prefix):
         with working_dir(self.stage.source_path):

--- a/repos/spack_repo/builtin/packages/cxi_driver/package.py
+++ b/repos/spack_repo/builtin/packages/cxi_driver/package.py
@@ -17,11 +17,13 @@ class CxiDriver(Package):
     license("GPL-2.0")
 
     version("main", branch="main")
-    version("13.1.0", tag="release/shs-13.1.0")
-    version("13.0.0", tag="release/shs-13.0.0")
-    version("12.0.2", tag="release/shs-12.0.2")
-    version("12.0.1", tag="release/shs-12.0.1")
-    version("12.0.0", tag="release/shs-12.0.0")
+    version("14.0.1", tag="release/shs-14.0.1", commit="bb11c8594e4cffb90f83f687c6c339a5e2e67045")
+    version("14.0.0", tag="release/shs-14.0.0", commit="021715bc84423aa552e811299bcbefba68f87bec")
+    version("13.1.0", tag="release/shs-13.1.0", commit="a1d91b2b0cca3782b7587dadfe7f660e326b53cb")
+    version("13.0.0", tag="release/shs-13.0.0", commit="f62ae06d0b05774eb8dc4d8f347b4eb881ae35cb")
+    version("12.0.2", tag="release/shs-12.0.2", commit="27f7be52e4b1ee6e8ce0c5674352a60869c02105")
+    version("12.0.1", tag="release/shs-12.0.1", commit="d1ebe2db2ad311cc7bcae5b6ae11da1d82d198b2")
+    version("12.0.0", tag="release/shs-12.0.0", commit="af5d2ed4114134ea4eaf095d16af619573729045")
 
     def install(self, spec, prefix):
         with working_dir(self.stage.source_path):

--- a/repos/spack_repo/builtin/packages/libcxi/package.py
+++ b/repos/spack_repo/builtin/packages/libcxi/package.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.cxi_driver.package import CxiDriver
 
 from spack.package import *
 
@@ -17,11 +18,13 @@ class Libcxi(AutotoolsPackage):
     license("LGPL-2.1-or-later or BSD-3-Clause")
 
     version("main", branch="main")
-    version("13.1.0", tag="release/shs-13.1.0")
-    version("13.0.0", tag="release/shs-13.0.0")
-    version("12.0.2", tag="release/shs-12.0.2")
-    version("12.0.1", tag="release/shs-12.0.1")
-    version("12.0.0", tag="release/shs-12.0.0")
+    version("14.0.1", tag="release/shs-14.0.1", commit="136a213673e9e41c9229236b84a2cc6a013d278e")
+    version("14.0.0", tag="release/shs-14.0.0", commit="136a213673e9e41c9229236b84a2cc6a013d278e")
+    version("13.1.0", tag="release/shs-13.1.0", commit="9d460216fdc449d53c5c3ff367bbc7c9c65c02fe")
+    version("13.0.0", tag="release/shs-13.0.0", commit="4b7fc964bf5065539a631abf425ba5a1a340e5ba")
+    version("12.0.2", tag="release/shs-12.0.2", commit="30fa2ddd65a234158b9331e39d6786bf0c337dc0")
+    version("12.0.1", tag="release/shs-12.0.1", commit="1571bd348bb75a8fe4a40c58240b0f687d6d5537")
+    version("12.0.0", tag="release/shs-12.0.0", commit="3a33b3966d2898ab129458c8813b0cbcdcec06f5")
 
     variant("level_zero", default=False, description="Enable level zero support")
     variant("cuda", default=False, description="Build with CUDA support")
@@ -35,8 +38,9 @@ class Libcxi(AutotoolsPackage):
         depends_on("libtool")
         depends_on("pkgconfig")
 
-    depends_on("cassini-headers")
-    depends_on("cxi-driver")
+    for v in CxiDriver.versions:
+        depends_on(f"cassini-headers@{v}", when=f"@{v}")
+        depends_on(f"cxi-driver@{v}", when=f"@{v}")
 
     depends_on("libconfig@1.5:")
     depends_on("libuv@1.18:")


### PR DESCRIPTION
- cxi-driver: add v14.0.0 and v14.0.1
- cassini-headers: add v14.0.0 and v14.0.1
- libcxi: add v14.0.0 and v14.0.1
- adds constraints for cxi-driver and cassini-headers
- adds commit matching to tag of all versions