### PR TITLE
Fix missing depends_on("c") in 13 packages with maintainers

### DIFF
--- a/repos/spack_repo/builtin/packages/amqp_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/amqp_cpp/package.py
@@ -32,7 +32,8 @@ class AmqpCpp(CMakePackage):
 
     conflicts("+tcp", when="platform=darwin", msg="TCP module requires Linux")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("cmake@3.5:", type="build")
     depends_on("openssl@1.1.1:", when="+tcp", type=("build", "link", "run"))

--- a/repos/spack_repo/builtin/packages/babelflow/package.py
+++ b/repos/spack_repo/builtin/packages/babelflow/package.py
@@ -24,7 +24,8 @@ class Babelflow(CMakePackage):
     version("1.0.1", sha256="b7817870b7a1d7ae7ae2eff1a1acec2824675fb856f666d5dc95c41ce453ae91")
     version("1.0.0", sha256="4c4d7ddf60e25e8d3550c07875dba3e46e7c9e61b309cc47a409461b7ffa405e")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("mpi")
 

--- a/repos/spack_repo/builtin/packages/isaac/package.py
+++ b/repos/spack_repo/builtin/packages/isaac/package.py
@@ -33,7 +33,8 @@ class Isaac(CMakePackage):
     # variant('alpaka', default=False,
     #         description='Generate kernels via Alpaka, for CPUs or GPUs')
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("cmake@3.3:", type="build")
     depends_on("jpeg", type="link")

--- a/repos/spack_repo/builtin/packages/lc_framework/package.py
+++ b/repos/spack_repo/builtin/packages/lc_framework/package.py
@@ -37,7 +37,8 @@ class LcFramework(CMakePackage, CudaPackage):
             "cuda_arch={sm}".format(sm=sm), when="+cuda", msg="cuda_arch 60 or newer is required"
         )
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("python", type=("build",))
     depends_on("libpressio@0.98.0:", when="+libpressio")

--- a/repos/spack_repo/builtin/packages/mpiwrapper/package.py
+++ b/repos/spack_repo/builtin/packages/mpiwrapper/package.py
@@ -40,7 +40,8 @@ class Mpiwrapper(CMakePackage):
     version("2.0.0", sha256="cdc81f3fae459569d4073d99d068810689a19cf507d9c4e770fa91e93650dbe4")
     version("1.0.1", sha256="29d5499a1a7a358d69dd744c581e57cac9223ebde94b52fa4a2b98c730ad47ff")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
     depends_on("fortran", type="build")  # generated
 
     depends_on("mpi @3.1:")

--- a/repos/spack_repo/builtin/packages/mrcpp/package.py
+++ b/repos/spack_repo/builtin/packages/mrcpp/package.py
@@ -39,7 +39,8 @@ class Mrcpp(CMakePackage):
     variant("mpi", default=True, description="Enable MPI support")
     depends_on("mpi", when="+mpi")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("cmake@3.11:", type="build")
     depends_on("eigen")

--- a/repos/spack_repo/builtin/packages/pajeng/package.py
+++ b/repos/spack_repo/builtin/packages/pajeng/package.py
@@ -40,7 +40,8 @@ class Pajeng(CMakePackage):
     variant("tools", default=True, description="Build auxiliary tools")
     variant("gui", default=False, description="The PajeNG visualization tool")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("boost+exception+regex")
     depends_on("flex")

--- a/repos/spack_repo/builtin/packages/simulationio/package.py
+++ b/repos/spack_repo/builtin/packages/simulationio/package.py
@@ -33,7 +33,8 @@ class Simulationio(CMakePackage):
 
     variant("pic", default=True, description="Produce position-independent code")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("asdf-cxx ~python", when="+asdf")
     depends_on("asdf-cxx ~python", when="+asdf ~python")

--- a/repos/spack_repo/builtin/packages/sympack/package.py
+++ b/repos/spack_repo/builtin/packages/sympack/package.py
@@ -24,7 +24,8 @@ class Sympack(CMakePackage, CudaPackage):
     version("2.0.1", sha256="21c172e902531c94c3bb5932c15de4b4ec9adf9c0d8e2071bb12cdbdfa25ca52")
     version("2.0", sha256="93fcfbadab73718e249e7ed12641a3c6be58b19cafdf6bad12a6a09c3d1eb4a1")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
     depends_on("fortran", type="build")  # generated
 
     depends_on("cmake@3.11:", type="build")

--- a/repos/spack_repo/builtin/packages/sz_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/sz_cpp/package.py
@@ -19,7 +19,8 @@ class SzCpp(CMakePackage):
 
     variant("shared", description="build shared libs", default=True)
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("zstd")
     depends_on("pkgconfig")

--- a/repos/spack_repo/builtin/packages/szx/package.py
+++ b/repos/spack_repo/builtin/packages/szx/package.py
@@ -16,7 +16,7 @@ class Szx(CMakePackage, AutotoolsPackage, CudaPackage):
     url = "https://github.com/szcompressor/SZx/archive/refs/tags/1.1.1.tar.gz"
     git = "https://github.com/szcompressor/szx"
 
-    maintainers = ["robertu94"]
+    maintainers("robertu94")
 
     version("main", branch="main")
     version("1.1.1", commit="b1609dde7702135b647fb92f91833fc84de2492e")
@@ -32,7 +32,8 @@ class Szx(CMakePackage, AutotoolsPackage, CudaPackage):
     variant("examples", default=False, description="install the examples", when="@1.1.1:")
     conflicts("+cuda", when="@:1.1.0")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     with when("build_system=autotools"):
         depends_on("autoconf", type="build")

--- a/repos/spack_repo/builtin/packages/xeus/package.py
+++ b/repos/spack_repo/builtin/packages/xeus/package.py
@@ -30,7 +30,11 @@ class Xeus(CMakePackage):
     conflicts("%clang@:3.6")
     conflicts("%intel@:17")
 
-    depends_on("cxx", type="build")  # generated
+    with default_args(type="build"):
+        depends_on("c")
+        depends_on("cxx")
+        depends_on("openssl")
+        depends_on("pkgconfig")
 
     depends_on("libzmq@4.2.5:-libsodium")
     depends_on("cppzmq@4.7.1:", when="@1.0.4:")

--- a/repos/spack_repo/builtin/packages/xproperty/package.py
+++ b/repos/spack_repo/builtin/packages/xproperty/package.py
@@ -21,7 +21,8 @@ class Xproperty(CMakePackage):
     version("master", branch="master")
     version("0.11.0", sha256="bf86a11c6758308aa0aa0f64d8dd24cd3e9d78378467b74002f552bfb75fc0eb")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("xtl@0.7.0:0.7", when="@0.11.0:")
 


### PR DESCRIPTION
Hi, while reviewing and building packages for reviews, I saw a few cases of missing `depends_on("c")`, where `depends_on("cxx")` was generated and `depends_on("c")` was not generated. In some cases, "c" was in fact also needed.

This is the 2nd PR in this series (the 1st PR is for packages without maintainers):
- #6071
- This PR is for packages with maintainers

Dear maintainers: You'd only have to look at your package(s) in this PR. Even if your package doesn't use C, often CMake or configure scripts check for a C compiler (unless the check for "C" is removed) which causes spack to fail if `depends_on("c")` isn't added.

Approach:

To fix most similar packages in one or a few PRs, I grepped the potentially affected packages (with the generated "cxx" line, and without "c") and started building all I could build.
- [x] By far, most of the total grepped list of 644 packages in this class did build fine.

I grepped the build logs of the fails (and also config.log files) for the recommendation to add `depends_on("c")`, mass-edited the those packages using `sed` and restarted building them.

- [x] Some edited packages still failed to build: But those are not included here, they need more work.

- [x] This PR is restricted to only packages with maintainers:
  - The mainainer-less packages are in #6071.

Checked:
- [x] No AI used for this PR to ensure there's 0% chance of any hallucination.
- [x] I double-checked that these changes fixed the build of these packages.
- [x] The xeus recipe also adds pkgconfig and openssl to fix the build on a system without them preinstalled on the host.