### PR TITLE
ginkgo: fix missing test dependencies

### DIFF
--- a/repos/spack_repo/builtin/packages/ginkgo/package.py
+++ b/repos/spack_repo/builtin/packages/ginkgo/package.py
@@ -94,6 +94,8 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("papi@7.1.0: +sde", when="+sde")
 
     depends_on("googletest", type="test")
+    depends_on("nlohmann-json@3.9:3", type="test")
+    depends_on("yaml-cpp@0.8:0", type="test")
     depends_on("numactl", type="test", when="+hwloc")
 
     depends_on("intel-oneapi-mkl", when="+sycl")


### PR DESCRIPTION
This PR fixes missing test dependencies:
- nlohmann-json, see https://github.com/ginkgo-project/ginkgo/blob/0391af28c6db6da2ad2bd6178fb92567f052d87d/third_party/CMakeLists.txt#L12-L16
- yaml-cpp, see https://github.com/ginkgo-project/ginkgo/blob/0391af28c6db6da2ad2bd6178fb92567f052d87d/extensions/test/config/CMakeLists.txt#L1-L30

Without these dependencies, sandboxing fails.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
