### PR TITLE
Fix missing depends_on("c") and similar dependencies in 10 recipes

### DIFF
--- a/repos/spack_repo/builtin/packages/brigand/package.py
+++ b/repos/spack_repo/builtin/packages/brigand/package.py
@@ -25,7 +25,8 @@ class Brigand(CMakePackage):
     version("1.1.0", sha256="afdcc6909ebff6994269d3039c31698c2b511a70280072f73382b26855221f64")
     version("1.0.0", sha256="8daf7686ff39792f851ef1977323808b80aab31c5f38ef0ba4e6a8faae491f8d")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     def cmake_args(self):
         args = [self.define("BUILD_TESTING", self.run_tests)]

--- a/repos/spack_repo/builtin/packages/glibmm/package.py
+++ b/repos/spack_repo/builtin/packages/glibmm/package.py
@@ -20,7 +20,8 @@ class Glibmm(AutotoolsPackage):
     version("2.16.0", sha256="99795b9c6e58e490df740a113408092bf47a928427cbf178d77c35adcb6a57a3")
     version("2.4.8", sha256="78b97bfa1d001cc7b398f76bf09005ba55b45ae20780b297947a1a71c4f07e1f")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("libsigcpp")
     # https://libsigcplusplus.github.io/libsigcplusplus/index.html

--- a/repos/spack_repo/builtin/packages/hssp/package.py
+++ b/repos/spack_repo/builtin/packages/hssp/package.py
@@ -34,7 +34,8 @@ class Hssp(AutotoolsPackage):
     version("3.0.2", sha256="76b4275c8cde120509d7920609fca983f2b04249a649d0aa802c69fd09e5f8cf")
     version("3.0.1", sha256="62a703d15bdfec82fdbd2a4275e1973b6a1ac6ccd4dbec75036f16faacaa9dce")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")

--- a/repos/spack_repo/builtin/packages/ilmbase/package.py
+++ b/repos/spack_repo/builtin/packages/ilmbase/package.py
@@ -36,4 +36,5 @@ class Ilmbase(AutotoolsPackage):
         url="http://download.savannah.nongnu.org/releases/openexr/ilmbase-0.9.0.tar.gz",
     )
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")

--- a/repos/spack_repo/builtin/packages/isaac_server/package.py
+++ b/repos/spack_repo/builtin/packages/isaac_server/package.py
@@ -35,9 +35,12 @@ class IsaacServer(CMakePackage):
     #     description="Support for RTP streams, e.g. to Twitch or Youtube"
     # )
 
-    depends_on("cxx", type="build")  # generated
+    with default_args(type="build"):
+        depends_on("c")
+        depends_on("cxx")
+        depends_on("pkgconfig")
+        depends_on("cmake@3.3:")
 
-    depends_on("cmake@3.3:", type="build")
     depends_on("jpeg", type="link")
     depends_on("jansson@:2.9", type="link", when="@:1.5.1")
     depends_on("jansson", type="link")

--- a/repos/spack_repo/builtin/packages/libbinio/package.py
+++ b/repos/spack_repo/builtin/packages/libbinio/package.py
@@ -18,4 +18,5 @@ class Libbinio(AutotoolsPackage):
     version("1.5", sha256="398b2468e7838d2274d1f62dbc112e7e043433812f7ae63ef29f5cb31dc6defd")
     version("1.4", sha256="4a32d3154517510a3fe4f2dc95e378dcc818a4a921fc0cb992bdc0d416a77e75")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")

--- a/repos/spack_repo/builtin/packages/scripts/package.py
+++ b/repos/spack_repo/builtin/packages/scripts/package.py
@@ -16,7 +16,8 @@ class Scripts(AutotoolsPackage, XorgPackage):
 
     version("1.0.1", sha256="0ed6dabdbe821944d61830489ad5f21bd934550456b9157a1cd8a32f76e08279")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("libx11")
 

--- a/repos/spack_repo/builtin/packages/talass/package.py
+++ b/repos/spack_repo/builtin/packages/talass/package.py
@@ -15,7 +15,7 @@ class Talass(CMakePackage):
     < StreamingTopology and any of the subsets can be build stand-
     alone."""
 
-    homepage = "http://www.cedmav.org/research/topology/72-talass.html"
+    homepage = "https://bitbucket.org/cedmav/talass"
     git = "https://bitbucket.org/cedmav/talass.git"
 
     maintainers("lpottier")
@@ -43,7 +43,10 @@ class Talass(CMakePackage):
         description="Number of bits used for the local index space",
     )
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    conflicts("%gcc@13:", msg="GCC 13+ is not supported by Talass source code")
 
     root_cmakelists_dir = "StreamingTopology"
 

--- a/repos/spack_repo/builtin/packages/tempestremap/package.py
+++ b/repos/spack_repo/builtin/packages/tempestremap/package.py
@@ -36,7 +36,8 @@ class Tempestremap(AutotoolsPackage):
     version("2.0.1", sha256="a3f1bef8cc413a689d429ac56f2bcc2e1d282d99797c3375233de792a7448ece")
     version("2.0.0", sha256="5850e251a4ad04fc924452f49183e5e12c38725832a568e57fa424a844b8a000")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")

--- a/repos/spack_repo/builtin/packages/templight_tools/package.py
+++ b/repos/spack_repo/builtin/packages/templight_tools/package.py
@@ -17,7 +17,11 @@ class TemplightTools(CMakePackage):
 
     version("develop", branch="master")
 
-    depends_on("cxx", type="build")  # generated
+    with default_args(type="build"):
+        depends_on("c")
+        depends_on("cxx")
+        depends_on("cmake @2.8.7:")
 
-    depends_on("cmake @2.8.7:", type="build")
-    depends_on("boost @1.48.1: +exception+filesystem+system+graph+program_options+test+container")
+    depends_on(
+        "boost @1.56:1.88 +exception+filesystem+system+graph+program_options+test+container"
+    )


### PR DESCRIPTION
Hi, while reviewing and building packages for reviews, I saw a few cases of missing `depends_on("c")`, where `depends_on("cxx")` was generated and `depends_on("c")` was not generated. In some cases, "c" was in fact also needed.

This is the 3rd PR in this series, the previous PRs are:
- #6071
- #6073

Dear maintainers: You'd only have to look at your package(s) in this PR. Even if your package doesn't use C, often CMake or configure scripts check for a C compiler (unless the check for "C" is removed) which causes spack to fail if `depends_on("c")` isn't added.

Approach taken:

To fix most similar packages in one or a few PRs, I grepped the potentially affected packages (with the generated "cxx" line, and without "c") and started building all packages I could build.
- [x] By far, most of the total grepped list of 644 packages in this class did build fine.

I grepped the build logs of the fails (and also config.log files) for the recommendation to add `depends_on("c")`, mass-edited the those packages using `sed` and restarted building them.

- [x] Some edited packages still failed to build: But those are not included here, they need more work.

Checked:
- [x] No AI used for this PR to ensure there's 0% chance of any hallucination.
- [x] I double-checked that these changes fixed the build of these packages.
- [x] Two recipes needed further manual fixes, but are limited to build dependences and versions (e.g. since boost-89, the component boost_system isn't in the compiled library anymore even though it still exists in the headers-only part, as far as I could understand)
