### PR TITLE
grads: set std=gnu17 for gcc@15

### DIFF
--- a/repos/spack_repo/builtin/packages/grads/package.py
+++ b/repos/spack_repo/builtin/packages/grads/package.py
@@ -88,6 +88,9 @@ class Grads(AutotoolsPackage):
             if any(spec.satisfies(s) for s in strict_compilers):
                 flags.append("-Wno-error=implicit-function-declaration")
 
+            if name == "cflags" and self.spec.satisfies("%gcc@15:"):
+                flags.append("-std=gnu17")
+
         return (flags, None, None)
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Yet another in the long line of "GCC 15 defaults to gnu23" PRs. This update `grads`