### PR TITLE
r: prevent invalid substitution of paths in LDFLAGS

### DIFF
--- a/repos/spack_repo/builtin/packages/r/package.py
+++ b/repos/spack_repo/builtin/packages/r/package.py
@@ -219,7 +219,7 @@ class R(AutotoolsPackage):
             ("icuuc", "icu4c"),
         ]:
             filter_file(
-                f"-l{_lib}",
+                rf"-l{_lib}\b",
                 f"-L{self.spec[_pkg].libs.directories[0]} -l{_lib}",
                 join_path(self.etcdir, "Makeconf"),
             )


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Resolves https://github.com/spack/spack-packages/issues/6078