### PR TITLE
Augustus: include stdint.h using the -include flag (fixes gcc-14 to 16)

### DIFF
--- a/repos/spack_repo/builtin/packages/augustus/package.py
+++ b/repos/spack_repo/builtin/packages/augustus/package.py
@@ -76,6 +76,11 @@ class Augustus(MakefilePackage):
     # build bam2wig and 3.4.0+ links -lhts only.
     conflicts("^htslib@1.10:", when="@3.3.1-tag1:3.3.2 ^samtools@:1.2")
 
+    def flag_handler(self, name, flags):
+        if name == "cppflags":
+            flags.append("-include stdint.h")  # needed for gcc 14 and newer
+        return (flags, None, None)
+
     def edit(self, spec, prefix):
         # Set compile commands for each compiler and
         # Fix for using 'boost' on Spack. (only after ver.3.3.1-tag1)


### PR DESCRIPTION
Fix the build of augustus with gcc-14 to 16:

- include stdint.h using the -include flag

This is a smaller version of this PR to not require a patch for the fix:
- #5956 (Cc: @mikerenfro)

Alternatively, #5956 could be merged, but I wanted to fix to be tiny.

Cc: @emwjacobson (as you just made the previous fixes):
FYI, in case you build with gcc@14 or newer, this fixes it!