### PR TITLE
kokkos: filter compiler wrappers also in lib

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -403,7 +403,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         filter_compiler_wrappers(
             "KokkosConfigCommon.cmake",
             relative_root=os.path.join(libdir, "cmake", "Kokkos"),
-        ) 
+        )
 
     # sanity check
     sanity_check_is_file = [

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -399,12 +399,11 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     # Filter spack-generated files that may include links to the
     # spack compiler wrappers
     filter_compiler_wrappers("kokkos_launch_compiler", relative_root="bin")
-    filter_compiler_wrappers(
-        "KokkosConfigCommon.cmake", relative_root=os.path.join("lib", "cmake", "Kokkos")
-    )
-    filter_compiler_wrappers(
-        "KokkosConfigCommon.cmake", relative_root=os.path.join("lib64", "cmake", "Kokkos")
-    )
+    for libdir in ("lib", "lib64"):
+        filter_compiler_wrappers(
+            "KokkosConfigCommon.cmake",
+            relative_root=os.path.join(libdir, "cmake", "Kokkos"),
+        ) 
 
     # sanity check
     sanity_check_is_file = [

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -400,6 +400,9 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     # spack compiler wrappers
     filter_compiler_wrappers("kokkos_launch_compiler", relative_root="bin")
     filter_compiler_wrappers(
+        "KokkosConfigCommon.cmake", relative_root=os.path.join("lib", "cmake", "Kokkos")
+    )
+    filter_compiler_wrappers(
         "KokkosConfigCommon.cmake", relative_root=os.path.join("lib64", "cmake", "Kokkos")
     )
 


### PR DESCRIPTION
On some systems the CMake files are installed in lib instead of lib64. This adds the missing filter logic.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
