### PR TITLE
add depends_on(c) directives to mergiraf, typos, and difftastic

### DIFF
--- a/repos/spack_repo/builtin/packages/difftastic/package.py
+++ b/repos/spack_repo/builtin/packages/difftastic/package.py
@@ -31,3 +31,4 @@ class Difftastic(CargoPackage):
     depends_on("rust@1.74.1:", type="build", when="@0.62:")
 
     depends_on("gmake", type="build")
+    depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/mergiraf/package.py
+++ b/repos/spack_repo/builtin/packages/mergiraf/package.py
@@ -29,3 +29,5 @@ class Mergiraf(CargoPackage):
     version("0.6.0", sha256="548b0ae3d811d6410beae9e7294867c7e6d791cf9f68ddda5c24e287f7978030")
 
     depends_on("rust@1.89:", type="build", when="@0.12:")
+
+    depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/typos/package.py
+++ b/repos/spack_repo/builtin/packages/typos/package.py
@@ -28,4 +28,6 @@ class Typos(CargoPackage):
     depends_on("rust@1.87:", type="build", when="@1.39.1:")
     depends_on("rust@1.80:", type="build")
 
+    depends_on("c", type="build")
+
     build_directory = "crates/typos-cli"


### PR DESCRIPTION
without a C dependency, components of these packages may fail to build if the default system compiler is selected (like Cray CCE). adding C as a dep allows for more control over the compiler used and injected build flags

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
