### PR TITLE
pyzmq: remove dependency on old setuptools

### DIFF
--- a/repos/spack_repo/builtin/packages/py_circus/package.py
+++ b/repos/spack_repo/builtin/packages/py_circus/package.py
@@ -24,5 +24,5 @@ class PyCircus(PythonPackage):
     depends_on("py-flit-core@3.4:3", type="build")
 
     depends_on("py-psutil", type=("build", "run"))
-    depends_on("py-pyzmq@17.0:", type=("build", "run"))
+    depends_on("py-pyzmq@17.0: +green", type=("build", "run"))
     depends_on("py-tornado@5.0.2:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_gevent/package.py
+++ b/repos/spack_repo/builtin/packages/py_gevent/package.py
@@ -44,10 +44,6 @@ class PyGevent(PythonPackage):
         depends_on("python@3.8:", when="@23.7.0:")
         depends_on("python@:3.10", when="@:21.12")
 
-        depends_on("py-setuptools@40.8:", when="@20.5.1:")
-        # https://github.com/pypa/distutils/pull/335
-        depends_on("py-setuptools@:80")
-
         depends_on("py-cffi@1.17.1:", when="@24.10.1:")
         depends_on("py-cffi@1.12.3:")
         depends_on("py-greenlet@3.2.2:", when="@25.5.1:")  # setup.py
@@ -64,6 +60,8 @@ class PyGevent(PythonPackage):
     conflicts("^py-cython@3.1:", when="@:24.10.3")
     # https://github.com/gevent/gevent/issues/1599
     conflicts("^py-cython@3:", when="@:20.5.0")
+    # https://github.com/gevent/gevent/issues/2201
+    conflicts("py-setuptools@80:", when="@:26.4")
 
     # Deprecated compiler options. upstream PR: https://github.com/gevent/gevent/pull/1896
     patch("icc.patch", when="@:21.12.0 %intel")

--- a/repos/spack_repo/builtin/packages/py_gevent/package.py
+++ b/repos/spack_repo/builtin/packages/py_gevent/package.py
@@ -16,6 +16,7 @@ class PyGevent(PythonPackage):
 
     license("MIT")
 
+    version("26.5.0", sha256="1655eb04c1e20d71b2aa4a3c7528162dd58ff6cc46a037af1f01f534c80fefba")
     version("26.4.0", sha256="288d03addfccf0d1c67268358b6759b04392bf3bc35d26f3d9a45c82899c292d")
     version("25.5.1", sha256="582c948fa9a23188b890d0bc130734a506d039a2e5ad87dae276a456cc683e61")
     version("24.11.1", sha256="8bd1419114e9e4a3ed33a5bad766afff9a3cf765cb440a582a1b3a9bc80c1aca")

--- a/repos/spack_repo/builtin/packages/py_pyzmq/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyzmq/package.py
@@ -28,6 +28,10 @@ class PyPyzmq(PythonPackage):
     version("17.1.2", sha256="a72b82ac1910f2cf61a49139f4974f994984475f771b0faa730839607eeedddf")
     version("16.0.2", sha256="0322543fff5ab6f87d11a8a099c4c07dd8a1719040084b6ce9162bcdf5c45c9d")
 
+    # Runtime variants
+    variant("green", default=False, description="enable zmq.green")
+    variant("ssh", default=False, description="enable zqm.ssh")
+
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
@@ -43,8 +47,9 @@ class PyPyzmq(PythonPackage):
     depends_on("libzmq@3.2.2:", type=("build", "link"), when="@22.3.0:")
     depends_on("libzmq", type=("build", "link"))
 
-    # Undocumented dependencies
-    depends_on("py-gevent", type=("build", "run"))
+    # Undocumented runtime dependencies
+    depends_on("py-gevent", type="run", when="+green")
+    depends_on("py-paramiko", type="run", when="+ssh")
 
     # https://github.com/zeromq/pyzmq/issues/1915
     conflicts("^py-cython@3.1:", when="@:25")

--- a/repos/spack_repo/builtin/packages/py_pyzmq/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyzmq/package.py
@@ -29,8 +29,8 @@ class PyPyzmq(PythonPackage):
     version("16.0.2", sha256="0322543fff5ab6f87d11a8a099c4c07dd8a1719040084b6ce9162bcdf5c45c9d")
 
     # Runtime variants
-    variant("green", default=False, description="enable zmq.green")
-    variant("ssh", default=False, description="enable zqm.ssh")
+    variant("green", default=False, description="enable pyzmq.green")
+    variant("ssh", default=False, description="enable pyzmq.ssh")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")


### PR DESCRIPTION
A transient dependency through py-gevent was limiting installs to setuptools@0.80. The dependency of zmq on gevent is *only* needed for a runtime `pyzmq.green` module access, which ipykernel doesn't use. Only `circus` seems to use `pyzmq.green`, and no one on github uses `pyzmq.ssh`.