### PR TITLE
shapelib: add tests variant

### DIFF
--- a/repos/spack_repo/builtin/packages/shapelib/package.py
+++ b/repos/spack_repo/builtin/packages/shapelib/package.py
@@ -24,3 +24,12 @@ class Shapelib(CMakePackage):
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
+
+    # Tests require internet access during build because upstream fetches
+    # GoogleTest and Google Benchmark via CMake FetchContent. Disabled by default
+    # to support offline and air-gapped builds.
+    variant("tests", default=False, description="Build tests (requires internet access)")
+
+    def cmake_args(self):
+        args = [self.define_from_variant("BUILD_TESTING", "tests")]
+        return args


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

In doing a build test on an air-gapped node where I'd pre-fetched my sources, I found I couldn't build `shapelib`. By default, their CMake seems to enable testing as long as `bash` can be found (see https://github.com/OSGeo/shapelib/blob/6e3ac42088274d3a68c0c35aa42e0ddf7f80104e/CMakeLists.txt#L207-L213).

This then triggers a `FetchContent` call to download Google benchmark and GoogleTest which weren't prefetched and crash.

So this PR adds a `tests` variant which defaults to False.