### PR TITLE
ci: update SPACK_EXTRA_MIRROR to use branch ref instead of stack name

### DIFF
--- a/.ci/gitlab/configs/ci.yaml
+++ b/.ci/gitlab/configs/ci.yaml
@@ -22,7 +22,7 @@ ci:
         - k=$CI_GPG_KEY_ROOT/intermediate_ci_signing_key.gpg; [[ -r $k ]] && spack gpg trust -y $k
         - k=$CI_GPG_KEY_ROOT/spack_public_key.gpg; [[ -r $k ]] && spack gpg trust -y $k
       script::
-      - - if [ -n "$SPACK_EXTRA_MIRROR" ]; then spack mirror add local "${SPACK_EXTRA_MIRROR}/${SPACK_CI_STACK_NAME}"; fi
+      - - if [ -n "$SPACK_EXTRA_MIRROR" ]; then spack mirror add local "${SPACK_EXTRA_MIRROR}/${PR_TARGET_REF_NAME:-$CI_COMMIT_REF_NAME}"; fi
         - spack config blame mirrors
         - spack spec "/${SPACK_JOB_SPEC_DAG_HASH}"
       - - spack --color=always ci rebuild -j ${SPACK_BUILD_JOBS} --tests --timeout 300 > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)


### PR DESCRIPTION
The University of Oregon is maintaining a local copy of our top-level develop buildcache to speed up download times and reduce data egress charges.

Change the way this environment variable is used by removing the stack name and replacing it with the base ref (currently `develop`). This fixes a layout problem and allows us to maintain separate develop vs. release buildcache copies at UO if the need arises.


