### PR TITLE
mpsolve: ensure that we have bison 3

### DIFF
--- a/repos/spack_repo/builtin/packages/mpsolve/package.py
+++ b/repos/spack_repo/builtin/packages/mpsolve/package.py
@@ -36,7 +36,7 @@ class Mpsolve(AutotoolsPackage):
     depends_on("gmp")
 
     # regenerate parser w/ bison (https://github.com/robol/MPSolve/issues/48)
-    depends_on("bison", type="build", when="@3.2.3")
+    depends_on("bison@3:", type="build", when="@3.2.3")
 
     @when("@3.2.3")
     def patch(self):


### PR DESCRIPTION
This is a quick followup to #6056, which fixed a build issue in mpsolve.  The parser shipped with the tarball is broken with newer versions of GCC, so we now regenerate it with bison first.

*However*, we need to ensure that we have a new enough bison, as otherwise, we'll just regenerate the same broken parser we had in the first place!
