### PR TITLE
flint: fix git + macos builds

### DIFF
--- a/repos/spack_repo/builtin/packages/flint/package.py
+++ b/repos/spack_repo/builtin/packages/flint/package.py
@@ -41,6 +41,23 @@ class Flint(AutotoolsPackage):
 
     depends_on("m4", type="build")
 
+    # generate configure script when building from git
+    with when("@main"):
+        depends_on("autoconf", type="build")
+        depends_on("automake", type="build")
+        depends_on("libtool", type="build")
+
+    # https://github.com/flintlib/flint/pull/2800
+    @when("@3.4.0:")
+    @run_before("configure")
+    def fix_in_tree_detection(self):
+        filter_file(
+            'if test "$ac_abs_confdir" = "`pwd`";',
+            'if test "`cd "$ac_abs_confdir" && pwd -P`" = "`pwd -P`";',
+            "configure",
+            string=True,
+        )
+
     def configure_args(self):
         spec = self.spec
         return [f"--with-gmp={spec['gmp'].prefix}", f"--with-mpfr={spec['mpfr'].prefix}"]

--- a/repos/spack_repo/builtin/packages/flint/package.py
+++ b/repos/spack_repo/builtin/packages/flint/package.py
@@ -48,8 +48,7 @@ class Flint(AutotoolsPackage):
         depends_on("libtool", type="build")
 
     # https://github.com/flintlib/flint/pull/2800
-    @when("@3.4.0:")
-    @run_before("configure")
+    @run_before("configure", when="@3.4.0")
     def fix_in_tree_detection(self):
         filter_file(
             'if test "$ac_abs_confdir" = "`pwd`";',


### PR DESCRIPTION
The "main" build from git was failing because we didn't have the necessary autotools dependencies to generate the configure script.

Also add a fix for builds on macOS, which were failing because of the `/var` -> `/private/var` symlink confusing the build system into thinking it was an out-of-tree build when it was really an in-tree build (see https://github.com/flintlib/flint/issues/2799 and https://github.com/flintlib/flint/pull/2800).
