### PR TITLE
clingo: add v5.8.2, remove preferred=True for v5.7.1

### DIFF
--- a/repos/spack_repo/builtin/packages/clingo/package.py
+++ b/repos/spack_repo/builtin/packages/clingo/package.py
@@ -29,13 +29,10 @@ class Clingo(CMakePackage):
     version("master", branch="master", submodules=True)
     version("spack", commit="2a025667090d71b2c9dce60fe924feb6bde8f667", submodules=True)
 
+    version("5.8.2", sha256="af961e4e8122b9e1fa325ae20c98f0a17b2087e2c777832ae6e47025ec921331")
     version("5.8.1", sha256="28fe78322cefb92e0f68f350777e19407d07bbb5179ca725fc6f77d538f0d19a")
     version("5.8.0", sha256="4ddd5975e79d7a0f8d126039f1b923a371b1a43e0e0687e1537a37d6d6d5cc7c")
-    version(
-        "5.7.1",
-        sha256="544b76779676075bb4f557f05a015cbdbfbd0df4b2cc925ad976e86870154d81",
-        preferred=True,
-    )
+    version("5.7.1", sha256="544b76779676075bb4f557f05a015cbdbfbd0df4b2cc925ad976e86870154d81")
     version("5.6.2", sha256="81eb7b14977ac57c97c905bd570f30be2859eabc7fe534da3cdc65eaca44f5be")
     version("5.5.2", sha256="a2a0a590485e26dce18860ac002576232d70accc5bfcb11c0c22e66beb23baa6")
     version("5.4.1", sha256="ac6606388abfe2482167ce8fd4eb0737ef6abeeb35a9d3ac3016c6f715bfee02")


### PR DESCRIPTION
Clingo v5.8.1 and v5.8.2 contain:
- https://github.com/potassco/clasp/commit/a9abf29f978cb47467d90ac5cf0cc197229964e7

Measuring on a couple test specs using:

* **Spack:** 1.3.0.dev0 (https://github.com/spack/spack/commit/b3d615cd64eefec84e2ada7b280eca69d9180a0a)
* **Builtin repo:** https://github.com/spack/spack-packages (8f2f815)
* **Python:** 3.14.5
* **Platform:** linux-ubuntu24.04-alderlake

it seems there's no perf difference between v5.7.1 and v5.7.2, therefore remove `preferred=True`.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
