### PR TITLE
r-rcurl: add @1.98-1.19, deprecate R <= 4.1 versions, add conflicts

### DIFF
--- a/repos/spack_repo/builtin/packages/r_rcurl/package.py
+++ b/repos/spack_repo/builtin/packages/r_rcurl/package.py
@@ -22,20 +22,33 @@ class RRcurl(RPackage):
 
     cran = "RCurl"
 
+    version("1.98-1.19", sha256="57300322f0da21deef5094f12b4a7a94834e60262859e5afb5ff16ac7d431205")
     version("1.98-1.16", sha256="1a8dc40e10593617348071c6265cc7fac22e26271564206b308a3badfc6c0da7")
     version("1.98-1.12", sha256="1a83fef04e9573b402171a6e4a4b27857a3d045eec8970f8f7233850bba626b2")
     version("1.98-1.9", sha256="f28d4871675ec3d2b45fb5d36f7647f546f81121510954c3ad24fdec1643cec5")
     version("1.98-1.6", sha256="6cb56864ac043195b658bbdb345518d561507d84ccd60362866e970c2f71d1a2")
     version("1.98-1.5", sha256="73187c9a039188ffdc255fb7fa53811a6abfb31e6375a51eae8c763b37dd698d")
     version("1.98-1.2", sha256="5d74a0cdc3c5684b0348b959f67039e3c2a5da2bbb6176f6800a94124895a7a8")
-    version("1.95-4.12", sha256="393779efafdf40823dac942a1e028905d65c34f3d41cfd21bcd225e411385ff4")
-    version("1.95-4.8", sha256="e72243251bbbec341bc5864305bb8cc23d311d19c5d0d9310afec7eb35aa2bfb")
+
+    with default_args(deprecated=True):
+        version("1.95-4.12", sha256="393779efafdf40823dac942a1e028905d65c34f3d41cfd21bcd225e411385ff4")
+        version("1.95-4.8", sha256="e72243251bbbec341bc5864305bb8cc23d311d19c5d0d9310afec7eb35aa2bfb")
 
     depends_on("c", type="build")
 
-    depends_on("r@3.0.0:", type=("build", "run"))
-    depends_on("r@3.4.0:", type=("build", "run"), when="@1.98:")
+    depends_on("r@3.4:", type=("build", "run"), when="@1.98:")
+    depends_on("r@3:", type=("build", "run"))
+
     depends_on("r-bitops", type=("build", "run"))
+
     depends_on("curl")
+
     depends_on("gmake", type="build")
+
     depends_on("icu4c", type=("build", "link", "run"))
+
+    # > curl.c:737:22: error: implicit declaration of function 'Rf_findVarInFrame'
+    conflicts("^r@4.6:", when="@:1.98-1.17 %gcc@14:")
+
+    # > json.c:86:21: error: 'PROBLEM' undeclared
+    conflicts("^r@4.2:", when="@:1.95")

--- a/repos/spack_repo/builtin/packages/r_rcurl/package.py
+++ b/repos/spack_repo/builtin/packages/r_rcurl/package.py
@@ -31,8 +31,12 @@ class RRcurl(RPackage):
     version("1.98-1.2", sha256="5d74a0cdc3c5684b0348b959f67039e3c2a5da2bbb6176f6800a94124895a7a8")
 
     with default_args(deprecated=True):
-        version("1.95-4.12", sha256="393779efafdf40823dac942a1e028905d65c34f3d41cfd21bcd225e411385ff4")
-        version("1.95-4.8", sha256="e72243251bbbec341bc5864305bb8cc23d311d19c5d0d9310afec7eb35aa2bfb")
+        version(
+            "1.95-4.12", sha256="393779efafdf40823dac942a1e028905d65c34f3d41cfd21bcd225e411385ff4"
+        )
+        version(
+            "1.95-4.8", sha256="e72243251bbbec341bc5864305bb8cc23d311d19c5d0d9310afec7eb35aa2bfb"
+        )
 
     depends_on("c", type="build")
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

## Before

<img width="317" height="250" alt="image" src="https://github.com/user-attachments/assets/da326078-98f6-46b1-b851-aea270e1386d" />

## After

<img width="317" height="366" alt="image" src="https://github.com/user-attachments/assets/6484c98b-0547-4e30-bb65-ca35831cd868" />
