### PR TITLE
gcc: disable debug info checking for `gcc@16 +bootstrap` according to upstream bug report

### DIFF
--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -877,6 +877,11 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
             # Improve the build time for stage 2 a bit by enabling -O1 in stage 1.
             # Note: this is ignored under ~bootstrap.
             f.write("STAGE1_CFLAGS += -O1\n")
+            if self.spec.satisfies("+bootstrap @16:16.2"):
+                # GCC 16 fails in compairing debug infos. See:
+                # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=125598
+                with open("config/bootstrap-debug.mk") as bd:
+                    f.write(bd.read())
 
     # https://gcc.gnu.org/install/configure.html
     def configure_args(self):

--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -407,7 +407,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         conflicts("+bootstrap")
 
     # Graphite loop optimizations cause bootstrap comparison failures
-    conflicts("+graphite +bootstrap")
+    conflicts("+graphite +bootstrap", when="@:15")
 
     # Binutils can't build ld on macOS
     conflicts("+binutils", when="platform=darwin")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Both in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=125598 and #5980 people say their gcc 16.2 fails in bootstrapping with non-default build config; the GCC side report claims that it may be caused by debug section only, so this PR was made.

This PR disables debug section comparison during bootstrapping GCC 16 with gcc's default build config. 

EDIT: test on my local machine shows that with this patch on `spack.mk`, `+graphite +bootstrap` also passes so a `when` was appended to the conflict.