### PR TITLE
4c-multiphysics: enable python support

### DIFF
--- a/repos/spack_repo/builtin/packages/_4c_multiphysics/package.py
+++ b/repos/spack_repo/builtin/packages/_4c_multiphysics/package.py
@@ -28,15 +28,13 @@ class _4cMultiphysics(CMakePackage):
     version("main", branch="main")
     version("2026.2.0", sha256="57e05128934e06b67d5ae3c2d3402f80d1ddfc3975b1557670e5b1d3399a6c0b")
     version("2026.1.0", sha256="9d95607a0b7668c9712392c81863b6327b8922745705b62e07f605f1d6932646")
-    version("2025.3.0", sha256="31088a9392bf55eb8c1b5a3b8426e8ae2b367327cef01f8f34aff55cb1153180")
 
     # Keep these sources private to 4C until maintained packages are available
     # in the builtin repository. FetchContent consumes the staged source trees.
     resource(
         name="ryml",
-        git="https://github.com/biojppm/rapidyaml.git",
-        commit="47ec2fa184209687c20fd5bc05621e1cb1200311",
-        submodules=True,
+        url="https://github.com/biojppm/rapidyaml/releases/download/v0.9.0/rapidyaml-0.9.0-src.tgz",
+        sha256="e01c66b21dfbe3d7382ecab3dfe7efcdc47a068cd25fcc8279e8f462f69c995d",
         destination="spack-resources",
         placement="ryml",
     )
@@ -58,9 +56,15 @@ class _4cMultiphysics(CMakePackage):
     variant("fftw", default=False, description="Enable FFTW support")
     variant("mirco", default=False, description="Enable MIRCO support")
     variant("backtrace", default=False, description="Enable libbacktrace support")
+    variant("python", default=False, description="Enable Python build and test utilities")
+    variant("pybind11", default=False, description="Build the py4C Python bindings")
+
+    conflicts("~python", when="+pybind11", msg="+pybind11 requires +python")
 
     patch("identify-release-dealii.patch", when="+dealii")
     patch("link-installed-arborx.patch", when="+arborx")
+    patch("use-installed-googletest.patch", when="@2026.1.0:2026.2.0")
+    patch("python-venv-no-downloads-2026.2.patch", when="@2026.1.0:2026.2.0+python")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
@@ -86,6 +90,7 @@ class _4cMultiphysics(CMakePackage):
     depends_on("zlib-api")
     depends_on("cli11@2.6.1")
     depends_on("magic-enum@0.9.7")
+    depends_on("googletest@1.15.2+gmock", when="@2026.1.0:2026.2.0")
 
     # 4C uses Qhull's deprecated non-reentrant libqhull API.
     depends_on("qhull@2019.1", when="+qhull")
@@ -103,6 +108,26 @@ class _4cMultiphysics(CMakePackage):
     depends_on("arborx@2.0.1+mpi", when="+arborx")
     depends_on("fftw", when="+fftw")
     depends_on("libbacktrace", when="+backtrace")
+    depends_on("python@3.12:", type=("build", "link", "run"), when="+python")
+    depends_on("python-venv", type=("build", "run"), when="+python")
+    depends_on("py-pip", type="build", when="+python")
+    depends_on("py-setuptools", type="build", when="+python")
+    depends_on("py-numpy", type=("build", "run"), when="+python")
+    depends_on("py-scipy", type=("build", "run"), when="+python")
+    depends_on("py-pytest", type=("build", "run"), when="+python")
+    depends_on("py-pyyaml", type=("build", "run"), when="+python")
+    # Newer jsonschema releases require the Rust-backed rpds-py package. 4C
+    # only uses the validator_for and RefResolver APIs available in 4.17.3.
+    depends_on("py-jsonschema@:4.17.3", type=("build", "run"), when="+python")
+    depends_on("vtk@9.4.2:9.6+python", type=("build", "run"), when="+python")
+    depends_on("py-pyvista", type=("build", "run"), when="+python")
+    depends_on("py-jinja2", type=("build", "run"), when="+python")
+    depends_on("py-matplotlib", type=("build", "run"), when="+python")
+    depends_on("py-myst-parser", type=("build", "run"), when="+python")
+    depends_on("py-nbsphinx", type=("build", "run"), when="+python")
+    depends_on("py-sphinx", type=("build", "run"), when="+python")
+    depends_on("py-sphinx-rtd-theme", type=("build", "run"), when="+python")
+    depends_on("py-pybind11", type=("build", "link", "run"), when="+pybind11")
 
     generator("ninja")
 
@@ -133,9 +158,9 @@ class _4cMultiphysics(CMakePackage):
             self.define_from_variant("FOUR_C_WITH_FFTW", "fftw"),
             self.define_from_variant("FOUR_C_WITH_MIRCO", "mirco"),
             self.define_from_variant("FOUR_C_WITH_BACKTRACE", "backtrace"),
-            self.define("FOUR_C_WITH_PYTHON", False),
-            self.define("FOUR_C_WITH_PYBIND11", False),
-            self.define("FOUR_C_ENABLE_PYTHON_BINDINGS", False),
+            self.define_from_variant("FOUR_C_WITH_PYTHON", "python"),
+            self.define_from_variant("FOUR_C_WITH_PYBIND11", "pybind11"),
+            self.define_from_variant("FOUR_C_ENABLE_PYTHON_BINDINGS", "pybind11"),
         ]
 
         roots = {
@@ -146,6 +171,8 @@ class _4cMultiphysics(CMakePackage):
             "arborx": ("FOUR_C_ARBORX_ROOT", "arborx"),
             "fftw": ("FOUR_C_FFTW_ROOT", "fftw"),
             "backtrace": ("FOUR_C_BACKTRACE_ROOT", "libbacktrace"),
+            "python": ("FOUR_C_PYTHON_ROOT", "python"),
+            "pybind11": ("FOUR_C_PYBIND11_ROOT", "py-pybind11"),
         }
         for variant, (variable, dependency) in roots.items():
             if "+" + variant in spec:

--- a/repos/spack_repo/builtin/packages/_4c_multiphysics/python-venv-no-downloads-2026.2.patch
+++ b/repos/spack_repo/builtin/packages/_4c_multiphysics/python-venv-no-downloads-2026.2.patch
@@ -1,0 +1,111 @@
+Keep the configure-time virtual environment connected to Python packages
+provided by Spack and prevent pip from contacting package indexes. Use
+Spack-packaged equivalents for requirements that have no builtin recipes,
+and omit the unsupported sphinx-multibuild and PyVista Jupyter extras.
+
+--- a/cmake/configure/configure_Python.cmake
++++ b/cmake/configure/configure_Python.cmake
+@@ -71,6 +71,7 @@ _execute_process(
+   ${Python_EXECUTABLE}
+   -m
+   venv
++  --system-site-packages
+   ${FOUR_C_PYTHON_VENV_BUILD}
+   )
+ _execute_process(
+@@ -77,6 +78,9 @@ _execute_process(
+   PROCESS_COMMAND
+   ${FOUR_C_PYTHON_VENV_BUILD}/bin/pip
+   install
++  --no-deps
++  --no-build-isolation
++  --no-index
+   -e
+   ${PROJECT_SOURCE_DIR}/utilities/four_c_python[build]
+   )
+--- a/utilities/four_c_python/requirements.txt
++++ b/utilities/four_c_python/requirements.txt
+@@ -1,3 +1,3 @@
+-rapidyaml
+-jsonschema-rs
++pyyaml
++jsonschema
+ 
+--- a/utilities/four_c_python/build-requirements.txt
++++ b/utilities/four_c_python/build-requirements.txt
+@@ -13,7 +13,6 @@ matplotlib
+ myst-parser
+ nbsphinx
+ scipy
+-sphinx-multibuild
+ sphinx-rtd-theme
+ pyyaml
+-pyvista[jupyter]
+\ No newline at end of file
++pyvista
+\ No newline at end of file
+--- a/utilities/four_c_python/src/four_c_common_utils/io.py
++++ b/utilities/four_c_python/src/four_c_common_utils/io.py
+@@ -5,10 +5,9 @@
+ #
+ # SPDX-License-Identifier: LGPL-3.0-or-later
+ 
+-import ryml
+ import pathlib
+-import json
+-import re
++
++import yaml
+ 
+ 
+ def load_yaml(path_to_yaml_file: str | pathlib.Path) -> dict:
+@@ -16,16 +15,4 @@ def load_yaml(path_to_yaml_file: str | pathlib.Path) -> dict:
+     Duplicated from fourcipp.
+     """
+ 
+-    json_str = ryml.emit_json(
+-        ryml.parse_in_arena(pathlib.Path(path_to_yaml_file).read_bytes())
+-    )
+-
+-    # Convert `inf` to a string to avoid JSON parsing errors, see https://github.com/biojppm/rapidyaml/issues/312
+-    json_str = re.sub(r":\s*(-?)inf\b", r': "\1inf"', json_str)
+-    # Convert floats that are missing digits on either side of the decimal point
+-    json_str = re.sub(r":\s*(-?)\.([0-9]+)", r": \g<1>0.\2", json_str)
+-    json_str = re.sub(r":\s*(-?)([0-9]+)\.(\D)", r": \1\2.0\3", json_str)
+-
+-    data = json.loads(json_str)
+-
+-    return data
++    return yaml.safe_load(pathlib.Path(path_to_yaml_file).read_text())
+--- a/utilities/four_c_python/src/four_c_metadata/validate_test_input_files.py
++++ b/utilities/four_c_python/src/four_c_metadata/validate_test_input_files.py
+@@ -6,7 +6,7 @@
+ # SPDX-License-Identifier: LGPL-3.0-or-later
+ 
+ import argparse
+-import jsonschema_rs
++import jsonschema
+ import json
+ import pathlib
+ from four_c_common_utils.io import load_yaml
+@@ -30,8 +30,10 @@ def cli():
+ 
+     args = parser.parse_args()
+ 
+     json_schema = json.loads(pathlib.Path(args.schema).read_text())
+-    validator = jsonschema_rs.validator_for(json_schema)
++    validator_class = jsonschema.validators.validator_for(json_schema)
++    validator_class.check_schema(json_schema)
++    validator = validator_class(json_schema)
+ 
+     def format_dotted(left: str, right: str) -> str:
+         dots = "." * (300 - len(left) - len(right))
+@@ -45,7 +50,7 @@ def cli():
+             validator.validate(data)
+             print(format_dotted(yaml_file, "passed"))
+ 
+-        except jsonschema_rs.ValidationError as e:
++        except jsonschema.ValidationError as e:
+             print(format_dotted(yaml_file, "failed"))
+             print(f"{e}")
+             files_with_errors.append(yaml_file)

--- a/repos/spack_repo/builtin/packages/_4c_multiphysics/use-installed-googletest.patch
+++ b/repos/spack_repo/builtin/packages/_4c_multiphysics/use-installed-googletest.patch
@@ -1,0 +1,22 @@
+Use the GoogleTest installation supplied by the package manager instead of
+downloading a private copy during CMake configuration.
+
+--- a/cmake/setup_tests.cmake
++++ b/cmake/setup_tests.cmake
+@@ -44,13 +44,9 @@ if(FOUR_C_WITH_GOOGLETEST)
+       )
+   endif()
+ 
+-  include(FetchContent)
+-  fetchcontent_declare(
+-    googletest
+-    GIT_REPOSITORY https://github.com/google/googletest.git
+-    GIT_TAG b514bdc898e2951020cbdca1304b75f5950d1f59 # v1.15.2
+-    )
+-  fetchcontent_makeavailable(googletest)
++  find_package(GTest 1.15.2 CONFIG REQUIRED)
++  add_library(gtest ALIAS GTest::gtest)
++  add_library(gmock ALIAS GTest::gmock)
+ 
+   math(EXPR UNITTEST_TIMEOUT "10*${FOUR_C_TEST_TIMEOUT_SCALE}")
+   message(STATUS "The scaled unit test timeout is ${UNITTEST_TIMEOUT} s.")


### PR DESCRIPTION
Add Python dependencies to enable `+python` build (also offline) without contacting PyPI.
For more details, see https://github.com/spack/spack-packages/pull/5967#discussion_r3740821554 .

Assisted-by: GPT-5.6 Sol
