### PR TITLE
legion: disable parallel build for `+rocm`

### DIFF
--- a/repos/spack_repo/builtin/packages/legion/package.py
+++ b/repos/spack_repo/builtin/packages/legion/package.py
@@ -366,7 +366,7 @@ class Legion(CMakePackage, CudaPackage, ROCmPackage):
 
     @property
     def parallel(self):
-        return not self.spec.satisfies("+rocm")
+        return not self.spec.satisfies("@:26.06 +rocm")
 
     def flag_handler(self, name, flags):
         if name == "cxxflags":

--- a/repos/spack_repo/builtin/packages/legion/package.py
+++ b/repos/spack_repo/builtin/packages/legion/package.py
@@ -364,6 +364,10 @@ class Legion(CMakePackage, CudaPackage, ROCmPackage):
         "sysomp", default=False, description="Use system OpenMP implementation instead of Realm's"
     )
 
+    @property
+    def parallel(self):
+        return not self.spec.satisfies("+rocm")
+
     def flag_handler(self, name, flags):
         if name == "cxxflags":
             if self.spec.satisfies("%oneapi@2025:") or self.spec.satisfies("%cxx=clang@20:"):


### PR DESCRIPTION
Extract legion changes for rocm build from #4411

I noticed a problem with an intermittent build error (some sort of race condition) in CI when building `legion+rocm` in #4411