### PR TITLE
babeltrace2: depend on cxx compiler for @2.1:

### DIFF
--- a/repos/spack_repo/builtin/packages/babeltrace2/package.py
+++ b/repos/spack_repo/builtin/packages/babeltrace2/package.py
@@ -36,6 +36,7 @@ class Babeltrace2(AutotoolsPackage):
     variant("manpages", default=True, description="Build man pages")
 
     depends_on("c", type="build")
+    depends_on("cxx", type="build", when="@2.1:")
 
     depends_on("pkgconfig", type="build")
     depends_on("autoconf", type="build")


### PR DESCRIPTION
commit c20049fd0678f462f621c80f9e91c1ba16e6b656: 
"Add C++11 support to the build system"

$ git tag --contains c20049fd0678f462f621c80f9e91c1ba16e6b656
v2.1.0
v2.1.0-rc1
v2.1.1
v2.1.2