### PR TITLE
re2: add 2025 releases up to 2025-11-05

### DIFF
--- a/repos/spack_repo/builtin/packages/re2/package.py
+++ b/repos/spack_repo/builtin/packages/re2/package.py
@@ -17,6 +17,21 @@ class Re2(CMakePackage):
     license("BSD-3-Clause", checked_by="wdconinc")
 
     version(
+        "2025-11-05", sha256="87f6029d2f6de8aa023654240a03ada90e876ce9a4676e258dd01ea4c26ffd67"
+    )
+    version(
+        "2025-08-12", sha256="2f3bec634c3e51ea1faf0d441e0a8718b73ef758d7020175ed7e352df3f6ae12"
+    )
+    version(
+        "2025-08-05", sha256="b5708d8388110624c85f300e7e9b39c4ed5469891eb1127dd7f9d61272d04907"
+    )
+    version(
+        "2025-07-22", sha256="f54c29f1c3e13e12693e3d6d1230554df3ab3a1066b2e1f28c5330bfbf6db1e3"
+    )
+    version(
+        "2025-07-17", sha256="41bea2a95289d112e7c2ccceeb60ee03d54269e7fe53e3a82bab40babdfa51ef"
+    )
+    version(
         "2024-07-02", sha256="eb2df807c781601c14a260a507a5bb4509be1ee626024cb45acbd57cb9d4032b"
     )
     version(
@@ -70,6 +85,11 @@ class Re2(CMakePackage):
 
     # shared libs must have position-independent code
     conflicts("+shared ~pic")
+
+    # re2/re2.h uses std::optional (C++17) since 2025-08-05; abseil-cpp's cxxstd variant drives
+    # this build's CMAKE_CXX_STANDARD (see cmake_args), so pre-C++17 values cannot compile it.
+    conflicts("^abseil-cpp cxxstd=11", when="@2025-08-05:")
+    conflicts("^abseil-cpp cxxstd=14", when="@2025-08-05:")
 
     def cmake_args(self):
         args = [


### PR DESCRIPTION
Adds the five re2 releases published since 2024-07-02: 2025-07-17, 2025-07-22, 2025-08-05, 2025-08-12 and 2025-11-05.

Starting with 2025-08-05, the public header `re2/re2.h` uses `std::optional` instead of `absl::optional`, so building those versions requires C++17. Since this recipe derives `CMAKE_CXX_STANDARD` from abseil-cpp's `cxxstd` variant, a `conflicts()` guards `cxxstd=11/14` for `@2025-08-05:`. With current abseil-cpp (which only allows `cxxstd=14` up to `@20250127`) the default concretization is unaffected.

Follow-up to the review discussion in #6015, where @bernhardkaindl verified that `re2@2025-11-05` builds cleanly in spack. Note for #6015: the `absl::optional` → `std::optional` switch is at 2025-08-05, not 2025-11-05 — the existing `re2@:2024-07-02` cap there remains safe either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JsmQ4tuGUiLpRbL9GiPfXq