### PR TITLE
multicharge: add dependencies for BLAS and LAPACK libraries

### DIFF
--- a/repos/spack_repo/builtin/packages/multicharge/package.py
+++ b/repos/spack_repo/builtin/packages/multicharge/package.py
@@ -33,7 +33,9 @@ class Multicharge(CMakePackage, MesonPackage):
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")
+    depends_on("blas")
     depends_on("lapack")
+    depends_on("libfabric", when="^cray-libsci")
     depends_on("mctc-lib build_system=cmake", when="build_system=cmake")
     depends_on("mctc-lib build_system=meson", when="build_system=meson")
     depends_on("mctc-lib@0.4:", when="@0.4:")
@@ -51,6 +53,8 @@ class CMakeBuilder(cmake.CMakeBuilder):
         args = [
             self.define_from_variant("WITH_OpenMP", "openmp"),
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            "-DBLAS_LIBRARIES=%s" % self.spec["blas"].libs.joined(";"),
+            "-DLAPACK_LIBRARIES=%s" % self.spec["lapack"].libs.joined(";"),
         ]
         return args
 


### PR DESCRIPTION
Multicharge: add dependencies for BLAS and LAPACK libraries and add libfabric dependency when building with cray-libsci


```
$ spack --version
1.2.2 (3e19345b6e12f5ff1b874f4059622fc6a1fd804a)

[...]
[+]  uh4ybdn          ^multicharge@0.3.1~ipo+openmp+shared build_system=cmake build_type=Release generator=make platform=linux os=rhel9 target=zen3 %c,fortran=gcc@14.2.1
```
On a Cray system, I had that issue `undefined reference`
```
> CMake Error at /lus/scratch/BCINES/dci/gaia/spack/spack-installs/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_pl/cmake-3.31.12-gcc-14.2.1-pra2/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
  undefined reference
```
and then some `undefined reference`

```
[ 95%] Linking Fortran executable multicharge
  cd /tmp/local/spack-stage/spack-stage-multicharge-0.3.1-o4ewnkwspuj57xyybunpsicwsbq3jvtd/spack-build-o4ewnkw/app && /lus/scratch/BCINES/dci/gaia/spack/spack-installs/                        __spack_path_placeholder__/__spack_path_placeholder__/__spack_path_pl/cmake-3.31.12-gcc-14.2.1-pra2/bin/cmake -E cmake_link_script CMakeFiles/multicharge-exe.dir/link.txt --verbose=1
> /opt/rh/gcc-toolset-14/root/usr/libexec/gcc/x86_64-redhat-linux/14/ld: warning: libfabric.so.1, needed by /opt/cray/pe/lib64/libmpi_gnu_112.so.12, not found (try using -rpath or -rpath-link)
> /opt/rh/gcc-toolset-14/root/usr/libexec/gcc/x86_64-redhat-linux/14/ld: /opt/cray/pe/lib64/libmpi_gnu_112.so.12: undefined reference to `fi_getinfo@FABRIC_1.3'
> /opt/rh/gcc-toolset-14/root/usr/libexec/gcc/x86_64-redhat-linux/14/ld: /opt/cray/pe/lib64/libmpi_gnu_112.so.12: undefined reference to `fi_version@FABRIC_1.0'
> /opt/rh/gcc-toolset-14/root/usr/libexec/gcc/x86_64-redhat-linux/14/ld: /opt/cray/pe/lib64/libmpi_gnu_112.so.12: undefined reference to `fi_freeinfo@FABRIC_1.3'
> /opt/rh/gcc-toolset-14/root/usr/libexec/gcc/x86_64-redhat-linux/14/ld: /opt/cray/pe/lib64/libmpi_gnu_112.so.12: undefined reference to `fi_strerror@FABRIC_1.0'
> /opt/rh/gcc-toolset-14/root/usr/libexec/gcc/x86_64-redhat-linux/14/ld: /opt/cray/pe/lib64/libmpi_gnu_112.so.12: undefined reference to `fi_fabric@FABRIC_1.1'
> /opt/rh/gcc-toolset-14/root/usr/libexec/gcc/x86_64-redhat-linux/14/ld: /opt/cray/pe/lib64/libmpi_gnu_112.so.12: undefined reference to `fi_dupinfo@FABRIC_1.3'
```