### PR TITLE
flint: apply macos bug fix in all versions since 3.4.0

### DIFF
--- a/repos/spack_repo/builtin/packages/flint/package.py
+++ b/repos/spack_repo/builtin/packages/flint/package.py
@@ -48,7 +48,7 @@ class Flint(AutotoolsPackage):
         depends_on("libtool", type="build")
 
     # https://github.com/flintlib/flint/pull/2800
-    @run_before("configure", when="@3.4.0")
+    @run_before("configure", when="@3.4.0:")
     def fix_in_tree_detection(self):
         filter_file(
             'if test "$ac_abs_confdir" = "`pwd`";',


### PR DESCRIPTION
This is a quick followup to #6103.

I just noticed that @alalazo's suggestion in https://github.com/spack/spack-packages/pull/6103#discussion_r3803939351 switched `@3.4.0:` -> `@3.4.0`.  The bug that this part of the formula is fixing is present in all flint versions since 3.4.0, so we need that trailing colon.

I should have looked more carefully before I clicked the "Apply suggestion" button!  :)