### PR TITLE
Dftd4 blas and lapack detection

### DIFF
--- a/repos/spack_repo/builtin/packages/dftd4/package.py
+++ b/repos/spack_repo/builtin/packages/dftd4/package.py
@@ -95,7 +95,10 @@ class MesonBuilder(meson.MesonBuilder):
 
 class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
-        return [
-            self.define_from_variant("WITH_OPENMP", "openmp"),
+        args = [
+            self.define_from_variant("WITH_OpenMP", "openmp"),
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            "-DBLAS_LIBRARIES=%s" % self.spec["blas"].libs.joined(";"),
+            "-DLAPACK_LIBRARIES=%s" % self.spec["lapack"].libs.joined(";"),
         ]
+        return args

--- a/repos/spack_repo/builtin/packages/multicharge/package.py
+++ b/repos/spack_repo/builtin/packages/multicharge/package.py
@@ -33,7 +33,9 @@ class Multicharge(CMakePackage, MesonPackage):
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")
+    depends_on("blas")
     depends_on("lapack")
+    depends_on("libfabric", when="^cray-libsci")
     depends_on("mctc-lib build_system=cmake", when="build_system=cmake")
     depends_on("mctc-lib build_system=meson", when="build_system=meson")
     depends_on("mctc-lib@0.4:", when="@0.4:")
@@ -51,6 +53,8 @@ class CMakeBuilder(cmake.CMakeBuilder):
         args = [
             self.define_from_variant("WITH_OpenMP", "openmp"),
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            "-DBLAS_LIBRARIES=%s" % self.spec["blas"].libs.joined(";"),
+            "-DLAPACK_LIBRARIES=%s" % self.spec["lapack"].libs.joined(";"),
         ]
         return args
 

--- a/repos/spack_repo/builtin/packages/multicharge/package.py
+++ b/repos/spack_repo/builtin/packages/multicharge/package.py
@@ -33,9 +33,7 @@ class Multicharge(CMakePackage, MesonPackage):
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")
-    depends_on("blas")
     depends_on("lapack")
-    depends_on("libfabric", when="^cray-libsci")
     depends_on("mctc-lib build_system=cmake", when="build_system=cmake")
     depends_on("mctc-lib build_system=meson", when="build_system=meson")
     depends_on("mctc-lib@0.4:", when="@0.4:")
@@ -53,8 +51,6 @@ class CMakeBuilder(cmake.CMakeBuilder):
         args = [
             self.define_from_variant("WITH_OpenMP", "openmp"),
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
-            "-DBLAS_LIBRARIES=%s" % self.spec["blas"].libs.joined(";"),
-            "-DLAPACK_LIBRARIES=%s" % self.spec["lapack"].libs.joined(";"),
         ]
         return args
 


### PR DESCRIPTION
Dftd 4 had an issue detecting BLAS and LAPACK with CMake

$ spack --version
1.2.2 (3e19345b6e12f5ff1b874f4059622fc6a1fd804a)

I got 2 errors during cp2k compilation with multicharge :

```
-   isvwowh  cp2k@2026.1+cosma~cuda+dbm_gpu~deepmd+dftd4~dlaf~elpa~enable_regtests~greenx+grid_gpu~grpp~hdf5~ipo+libint+libvori+libxc+mpi~mpi_f08~opencl+openmp~pexsi+pic+plumed~pw_gpu~pytorch+                 rocm~shared~sirius~smeagol+spglib~spla~tblite~trexio amdgpu_target:=gfx90a build_system=cmake build_type=Release generator=ninja lmax=5 smm=blas platform=linux os=rhel9 target=zen3 %c,cxx,fortran=gcc@14.2.1
[+]  w4bekpz      ^cosma@2.8.4~apps~cuda~gpu_direct~ipo~profiling~rccl+rocm+scalapack+shared~tests~unified_memory build_system=cmake build_type=Release generator=make platform=linux os=rhel9 target=zen3 %c,cxx,fortran=gcc@14.2.1
[+]  nvi57tc          ^costa@2.3.2~apps~benchmarks~ipo~profiling+scalapack+shared~tests build_system=cmake build_type=Release generator=make platform=linux os=rhel9 target=zen3 %cxx=gcc@14.2.1
[+]  un76hwc          ^tiled-mm@2.3.2~cuda~examples~ipo+rocm+shared~tests amdgpu_target:=gfx90a build_system=cmake build_type=Release generator=make platform=linux os=rhel9 target=zen3 %cxx=gcc@14.2.1
[e]  3bm23ac      ^cray-fftw@3.3.10.8+mpi+openmp build_system=generic precision:=double,float platform=linux os=rhel9 target=x86_64
[e]  ltci52q      ^cray-libsci@25.09.0+mpi+openmp+shared build_system=generic platform=linux os=rhel9 target=x86_64 %c=gcc@14.2.1
[+]  z2igonw      ^dbcsr@2.9.1~cuda~cuda_arch_35_k20x~examples~ipo+mpi~mpi_f08~opencl+openmp+rocm+shared~tests amdgpu_target:=gfx90a build_system=cmake build_type=Release generator=ninja smm=blas               platform=linux os=rhel9 target=zen3 %c,cxx,fortran=gcc@14.2.1
 -   3lsuqj4      ^dftd4@3.7.0~ipo+openmp+shared build_system=cmake build_type=Release generator=make platform=linux os=rhel9 target=zen3 %c,fortran=gcc@14.2.1
[+]  h7x47rb          ^mctc-lib@0.3.2~ipo~json~openmp+shared build_system=cmake build_type=Release generator=make platform=linux os=rhel9 target=zen3 %fortran=gcc@14.2.1
[+]  uh4ybdn          ^multicharge@0.3.1~ipo+openmp+shared build_system=cmake build_type=Release generator=make platform=linux os=rhel9 target=zen3 %c,fortran=gcc@14.2.1

```

```
> CMake Error at /lus/scratch/BCINES/dci/gaia/spack/spack-installs/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_pl/cmake-3.31.12-gcc-14.2.1-pra2/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
    Could NOT find BLAS (missing: BLAS_LIBRARIES)
``` 
and 
```
  -- Could NOT find LAPACK (missing: LAPACK_LIBRARIES)
> CMake Warning at config/cmake/dftd4-utils.cmake:36 (find_package):
```