### PR TITLE
py-torch: fix INTEL_MKL_DIR lookup for intel-oneapi-mkl

### DIFF
--- a/repos/spack_repo/builtin/packages/py_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_torch/package.py
@@ -825,7 +825,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
         elif self.spec["blas"].name == "intel-oneapi-mkl":
             env.set("BLAS", "MKL")
             env.set("WITH_BLAS", "mkl")
-            env.set("INTEL_MKL_DIR", self.spec["mkl"].prefix.mkl.latest)
+            env.set("INTEL_MKL_DIR", self.spec["intel-oneapi-mkl"].prefix.mkl.latest)
         elif self.spec["blas"].name == "openblas":
             env.set("BLAS", "OpenBLAS")
             env.set("WITH_BLAS", "open")


### PR DESCRIPTION
In `setup_build_environment()`, when `self.spec["blas"].name == "intel-oneapi-mkl"`, `py-torch` was accessing `self.spec["mkl"].prefix.mkl.latest`.

When `py-torch` is built with `~mkldnn`, `mkl` is not a direct virtual dependency in the DAG, causing `self.spec["mkl"]` to raise `KeyError: 'mkl'`.

Changing this to `self.spec["intel-oneapi-mkl"].prefix.mkl.latest` directly references the active `intel-oneapi-mkl` BLAS provider package, consistent with how `atlas` and `openblas` are looked up.

NOTE: Gemini 5.7 Flash helped me prepare this PR. I made the changes for the package.