### PR TITLE
mille: add v01-01-00

### DIFF
--- a/repos/spack_repo/builtin/packages/mille/package.py
+++ b/repos/spack_repo/builtin/packages/mille/package.py
@@ -18,6 +18,7 @@ class Mille(CMakePackage):
     license("LGPL-2.0-only", checked_by="paulgessinger")
 
     version("main", branch="main")
+    version("01-01-00", sha256="57eb5ec11fc9506038151d2a4abcf0d891d05a3f7de526cdb99bf51461cd324b")
     version("01-00-05", sha256="00efaa82631482f3ead7bec548a09a80938c08950f84cdbc2e7bb47de9186228")
     version("01-00-04", sha256="9d3f9113609c1b1328dd0dde10730c7cbccb95e1637bb82ab88d32cda8a5cca2")
     version("01-00-03", sha256="1953e2a341fed3a1c431c954d6e8f1c823926bc2886bdc209d859d2cb9dac6d8")


### PR DESCRIPTION
Add Mille V-01-01-00, providing thread-safety protection.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
