### PR TITLE
py-protobuf: Add current versions, deprecate versions affected by CVE-2026-0994

### DIFF
--- a/repos/spack_repo/builtin/packages/lbann/package.py
+++ b/repos/spack_repo/builtin/packages/lbann/package.py
@@ -231,7 +231,11 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("python@3: +shared", type=("build", "run"), when="+pfe")
     extends("python", when="+pfe")
     depends_on("py-setuptools", type="build", when="+pfe")
-    depends_on("py-protobuf@3.10.0:4.21.12", type=("build", "run"), when="+pfe")
+
+    # Allow lbann@0.104: to use the new, not deprecated py-protobuf versions
+    with default_args(type=("build", "run")):
+        depends_on("py-protobuf@3.10.0:", when="@0.104:+pfe")
+        depends_on("py-protobuf@3.10.0:4.21.12", when="@0.103+pfe")
 
     depends_on("protobuf@3.10.0:21.12")
     depends_on("zlib-api", when="^protobuf@3.11.0:")

--- a/repos/spack_repo/builtin/packages/protobuf/package.py
+++ b/repos/spack_repo/builtin/packages/protobuf/package.py
@@ -30,13 +30,17 @@ class Protobuf(CMakePackage):
     #
     # Hence language runtime version has explicted also the protobuf version it is compatible with.
 
+    version("35.1", sha256="22775f9376938295efa2d59a59bde4cd075a42df5a9b4d27aa9b99fa6a413bd2")
+    version("34.2", sha256="c0156673c0977bff3bf7c605dad47b216b05c2e1bf143ca0c72b0e4f382d1f59")
     version("34.1", sha256="a83103b7ed3afaeedee9a212c8f65825444f58144f5e075b73c83f2b4ff27b62")
     version("34.0", sha256="61c47fabb1190e0acb2d47e67f31baac05d9b4ce69d7d1b43f6c83744f83898e")
+    version("33.6", sha256="e825cac584256f88840ab6cf37add69ba0c6145811329d75642698a622d13498")
     version("33.1", sha256="0c98bb704ceb4e68c92f93907951ca3c36130bc73f87264e8c0771a80362ac97")
     version("33.0", sha256="b6b03fbaa3a90f3d4f2a3fa4ecc41d7cd0326f92fcc920a7843f12206c8d52cd")
     version("32.1", sha256="d2081ab9528292f7980ef2d88d2be472453eea4222141046ad4f660874d5f24e")
     version("31.1", sha256="c3a0a9ece8932e31c3b736e2db18b1c42e7070cd9b881388b26d01aa71e24ca2")
     version("30.2", sha256="07a43d88fe5a38e434c7f94129cad56a4c43a51f99336074d0799c2f7d4e44c5")
+    version("29.6", sha256="2af2352d9e89992ae634257a16cff4c5143c8504db972307e49e61ed1047334e")
     version("29.3", sha256="c8d0ed0085f559444f70311791cf7aef414246b9942441443963184b534dbf9e")
     version("28.3", sha256="7c3ebd7aaedd86fa5dc479a0fda803f602caaf78d8aff7ce83b89e1b8ae7442a")
     version("28.2", sha256="1b6b6a7a7894f509f099c4469b5d4df525c2f3c9e4009e5b2db5b0f66cb8ee0e")
@@ -115,6 +119,7 @@ class Protobuf(CMakePackage):
     depends_on("cxx", type="build")
 
     depends_on("abseil-cpp cxxstd=17", when="@32.1:")
+    depends_on("abseil-cpp@20250127:", when="@35:")
     depends_on("abseil-cpp@20230125.3:", when="@22.5:")
     # https://github.com/protocolbuffers/protobuf/issues/11828#issuecomment-1433557509
     depends_on("abseil-cpp@20230125:", when="@22:")

--- a/repos/spack_repo/builtin/packages/py_protobuf/cve-2026-0994.patch
+++ b/repos/spack_repo/builtin/packages/py_protobuf/cve-2026-0994.patch
@@ -1,0 +1,25 @@
+Subject: [PATCH] Fix Any recursion depth bypass in Python json_format.ParseDict
+
+Backport of https://github.com/protocolbuffers/protobuf/commit/d2b001626d137c62dfee6c88c87324102531868b
+for the protobuf 4.25 Python runtime.
+---
+ google/protobuf/json_format.py | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/google/protobuf/json_format.py b/google/protobuf/json_format.py
+index 327dce4..d4e18a2 100644
+--- a/google/protobuf/json_format.py
++++ b/google/protobuf/json_format.py
+@@ -643,9 +643,7 @@
+       self._ConvertWrapperMessage(value['value'], sub_message,
+                                   '{0}.value'.format(path))
+     elif full_name in _WKTJSONMETHODS:
+-      methodcaller(_WKTJSONMETHODS[full_name][1], value['value'], sub_message,
+-                   '{0}.value'.format(path))(
+-                       self)
++      self.ConvertMessage(value['value'], sub_message, '{0}.value'.format(path))
+     else:
+       del value['@type']
+       self._ConvertFieldValuePair(value, sub_message, path)
+--
+2.43.0

--- a/repos/spack_repo/builtin/packages/py_protobuf/package.py
+++ b/repos/spack_repo/builtin/packages/py_protobuf/package.py
@@ -16,63 +16,144 @@ class PyProtobuf(PythonPackage):
     and using a variety of languages."""
 
     homepage = "https://developers.google.com/protocol-buffers/"
-    pypi = "protobuf/protobuf-3.11.0.tar.gz"
+    pypi = "protobuf/protobuf-7.35.1.tar.gz"
 
-    version("6.32.1", sha256="ee2469e4a021474ab9baafea6cd070e5bf27c7d29433504ddea1a4ee5850f68d")
-    version("5.28.3", sha256="64badbc49180a5e401f373f9ce7ab1d18b63f7dd4a9cdc43c92b9f0b481cef7b")
-    version("5.28.2", sha256="59379674ff119717404f7454647913787034f03fe7049cbef1d74a97bb4593f0")
-    version("5.27.5", sha256="7fa81bc550201144a32f4478659da06e0b2ebe4d5303aacce9a202a1c3d5178d")
-    version("5.26.1", sha256="8ca2a1d97c290ec7b16e4e5dff2e5ae150cc1582f55b5ab300d45cb0dfa90e51")
-    version("4.25.3", sha256="25b5d0b42fd000320bd7830b349e3b696435f3b329810427a6bcce6a5492cc5c")
-    version("4.24.4", sha256="5a70731910cd9104762161719c3d883c960151eea077134458503723b60e3667")
-    version("4.24.3", sha256="12e9ad2ec079b833176d2921be2cb24281fa591f0b119b208b788adc48c2561d")
-    version("4.23.3", sha256="7a92beb30600332a52cdadbedb40d33fd7c8a0d7f549c440347bc606fb3fe34b")
-    version("4.21.9", sha256="61f21493d96d2a77f9ca84fefa105872550ab5ef71d21c458eb80edcf4885a99")
-    version("4.21.7", sha256="71d9dba03ed3432c878a801e2ea51e034b0ea01cf3a4344fb60166cb5f6c8757")
-    version("4.21.5", sha256="eb1106e87e095628e96884a877a51cdb90087106ee693925ec0a300468a9be3a")
-    version("3.20.3", sha256="2e3427429c9cffebf259491be0af70189607f365c2f41c7c3764af6f337105f2")
-    version("3.20.2", sha256="712dca319eee507a1e7df3591e639a2b112a2f4a62d40fe7832a16fd19151750")
-    version("3.20.1", sha256="adc31566d027f45efe3f44eeb5b1f329da43891634d61c75a5944e9be6dd42c9")
-    version("3.20.0", sha256="71b2c3d1cd26ed1ec7c8196834143258b2ad7f444efff26fdc366c6f5e752702")
-    version("3.19.4", sha256="9df0c10adf3e83015ced42a9a7bd64e13d06c4cf45c340d2c63020ea04499d0a")
-    version("3.19.3", sha256="d975a6314fbf5c524d4981e24294739216b5fb81ef3c14b86fb4b045d6690907")
-    version("3.19.2", sha256="392f928e57054520276fdad412e045910268224b9446c218702e577d26eaf557")
-    version("3.19.1", sha256="62a8e4baa9cb9e064eb62d1002eca820857ab2138440cb4b3ea4243830f94ca7")
-    version("3.19.0", sha256="6a1dc6584d24ef86f5b104bcad64fa0fe06ed36e5687f426e0445d363a041d18")
-    version("3.18.1", sha256="1c9bb40503751087300dd12ce2e90899d68628977905c76effc48e66d089391e")
-    version("3.17.3", sha256="72804ea5eaa9c22a090d2803813e280fb273b62d5ae497aaf3553d141c4fdd7b")
-    version("3.17.2", sha256="5a3450acf046716e4a4f02a3f7adfb7b86f1b5b3ae392cec759915e79538d40d")
-    version("3.17.1", sha256="25bc4f1c23aced9b3a9e70eef7f03e63bcbd6cfbd881a91b5688412dce8992e1")
-    version("3.17.0", sha256="05dfe9319939a8473c21b469f34f6486646e54fb8542637cf7ed8e2fbfe21538")
-    version("3.16.0", sha256="228eecbedd46d75010f1e0f8ce34dbcd11ae5a40c165a9fc9d330a58aa302818")
-    version("3.15.8", sha256="0277f62b1e42210cafe79a71628c1d553348da81cbd553402a7f7549c50b11d0")
-    version("3.15.7", sha256="2d03fc2591543cd2456d0b72230b50c4519546a8d379ac6fd3ecd84c6df61e5d")
-    version("3.15.6", sha256="2b974519a2ae83aa1e31cff9018c70bbe0e303a46a598f982943c49ae1d4fcd3")
-    version("3.15.5", sha256="be8a929c6178bb6cbe9e2c858be62fa08966a39ae758a8493a88f0ed1efb6097")
-    version("3.15.1", sha256="824dbae3390fcc3ea1bf96748e6da951a601802894cf7e1465e72b4732538cab")
-    version("3.13.0", sha256="6a82e0c8bb2bf58f606040cc5814e07715b2094caeba281e2e7d0b0e2e397db5")
-    version("3.12.2", sha256="49ef8ab4c27812a89a76fa894fe7a08f42f2147078392c0dee51d4a444ef6df5")
-    version("3.11.2", sha256="3d7a7d8d20b4e7a8f63f62de2d192cfd8b7a53c56caba7ece95367ca2b80c574")
-    version("3.11.1", sha256="aecdf12ef6dc7fd91713a6da93a86c2f2a8fe54840a3b1670853a2b7402e77c9")
-    version("3.11.0", sha256="97b08853b9bb71512ed52381f05cf2d4179f4234825b505d8f8d2bb9d9429939")
-    version("3.10.0", sha256="db83b5c12c0cd30150bb568e6feb2435c49ce4e68fe2d7b903113f0e221e58fe")
-    version("3.9.2", sha256="843f498e98ad1469ad54ecb4a7ccf48605a1c5d2bd26ae799c7a2cddab4a37ec")
-    version("3.9.1", sha256="d831b047bd69becaf64019a47179eb22118a50dd008340655266a906c69c6417")
-    version("3.8.0", sha256="8c61cc8a76e9d381c665aecc5105fa0f1878cf7db8b5cd17202603bcb386d0fc")
-    version("3.7.1", sha256="21e395d7959551e759d604940a115c51c6347d90a475c9baf471a1a86b5604a9")
-    version("3.6.1", sha256="1489b376b0f364bcc6f89519718c057eb191d7ad6f1b395ffd93d1aa45587811")
-    version("3.6.0", sha256="a37836aa47d1b81c2db1a6b7a5e79926062b5d76bd962115a0e615551be2b48d")
-    version("3.5.2", sha256="09879a295fd7234e523b62066223b128c5a8a88f682e3aff62fb115e4a0d8be0")
-    version("3.5.1", sha256="95b78959572de7d7fafa3acb718ed71f482932ddddddbd29ba8319c10639d863")
-    version("3.4.0", sha256="ef02609ef445987976a3a26bff77119c518e0915c96661c3a3b17856d0ef6374")
-    version("3.3.0", sha256="1cbcee2c45773f57cb6de7ee0eceb97f92b9b69c0178305509b162c0160c1f04")
-    version("3.0.0", sha256="ecc40bc30f1183b418fe0ec0c90bc3b53fa1707c4205ee278c6b90479e5b6ff5")
+    version("7.35.1", sha256="ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a")
+    version("7.34.2", sha256="b58a902c4ff7aecae0d61d4ced2cef066d7cc737ebb5bbb4b6a0f349ff331589")
+    version("6.33.6", sha256="a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135")
+    version("5.29.6", sha256="da9ee6a5424b6b30fd5e45c5ea663aef540ca95f9ad99d1e887e819cdf9b8723")
+
+    with default_args(deprecated=True):
+        # CVE-2026-0994 https://github.com/protocolbuffers/protobuf/issues/25070#issuecomment-4297395015
+        version(
+            "5.28.3", sha256="64badbc49180a5e401f373f9ce7ab1d18b63f7dd4a9cdc43c92b9f0b481cef7b"
+        )
+        version(
+            "5.28.2", sha256="59379674ff119717404f7454647913787034f03fe7049cbef1d74a97bb4593f0"
+        )
+        version(
+            "5.27.5", sha256="7fa81bc550201144a32f4478659da06e0b2ebe4d5303aacce9a202a1c3d5178d"
+        )
+        version(
+            "5.26.1", sha256="8ca2a1d97c290ec7b16e4e5dff2e5ae150cc1582f55b5ab300d45cb0dfa90e51"
+        )
+        version(
+            "4.25.3", sha256="25b5d0b42fd000320bd7830b349e3b696435f3b329810427a6bcce6a5492cc5c"
+        )
+        version(
+            "4.24.4", sha256="5a70731910cd9104762161719c3d883c960151eea077134458503723b60e3667"
+        )
+        version(
+            "4.24.3", sha256="12e9ad2ec079b833176d2921be2cb24281fa591f0b119b208b788adc48c2561d"
+        )
+        version(
+            "4.23.3", sha256="7a92beb30600332a52cdadbedb40d33fd7c8a0d7f549c440347bc606fb3fe34b"
+        )
+        version(
+            "4.21.9", sha256="61f21493d96d2a77f9ca84fefa105872550ab5ef71d21c458eb80edcf4885a99"
+        )
+        version(
+            "4.21.7", sha256="71d9dba03ed3432c878a801e2ea51e034b0ea01cf3a4344fb60166cb5f6c8757"
+        )
+        version(
+            "4.21.5", sha256="eb1106e87e095628e96884a877a51cdb90087106ee693925ec0a300468a9be3a"
+        )
+        version(
+            "3.20.3", sha256="2e3427429c9cffebf259491be0af70189607f365c2f41c7c3764af6f337105f2"
+        )
+        version(
+            "3.20.2", sha256="712dca319eee507a1e7df3591e639a2b112a2f4a62d40fe7832a16fd19151750"
+        )
+        version(
+            "3.20.1", sha256="adc31566d027f45efe3f44eeb5b1f329da43891634d61c75a5944e9be6dd42c9"
+        )
+        version(
+            "3.20.0", sha256="71b2c3d1cd26ed1ec7c8196834143258b2ad7f444efff26fdc366c6f5e752702"
+        )
+        version(
+            "3.19.4", sha256="9df0c10adf3e83015ced42a9a7bd64e13d06c4cf45c340d2c63020ea04499d0a"
+        )
+        version(
+            "3.19.3", sha256="d975a6314fbf5c524d4981e24294739216b5fb81ef3c14b86fb4b045d6690907"
+        )
+        version(
+            "3.19.2", sha256="392f928e57054520276fdad412e045910268224b9446c218702e577d26eaf557"
+        )
+        version(
+            "3.19.1", sha256="62a8e4baa9cb9e064eb62d1002eca820857ab2138440cb4b3ea4243830f94ca7"
+        )
+        version(
+            "3.19.0", sha256="6a1dc6584d24ef86f5b104bcad64fa0fe06ed36e5687f426e0445d363a041d18"
+        )
+        version(
+            "3.18.1", sha256="1c9bb40503751087300dd12ce2e90899d68628977905c76effc48e66d089391e"
+        )
+        version(
+            "3.17.3", sha256="72804ea5eaa9c22a090d2803813e280fb273b62d5ae497aaf3553d141c4fdd7b"
+        )
+        version(
+            "3.17.2", sha256="5a3450acf046716e4a4f02a3f7adfb7b86f1b5b3ae392cec759915e79538d40d"
+        )
+        version(
+            "3.17.1", sha256="25bc4f1c23aced9b3a9e70eef7f03e63bcbd6cfbd881a91b5688412dce8992e1"
+        )
+        version(
+            "3.17.0", sha256="05dfe9319939a8473c21b469f34f6486646e54fb8542637cf7ed8e2fbfe21538"
+        )
+        version(
+            "3.16.0", sha256="228eecbedd46d75010f1e0f8ce34dbcd11ae5a40c165a9fc9d330a58aa302818"
+        )
+        version(
+            "3.15.8", sha256="0277f62b1e42210cafe79a71628c1d553348da81cbd553402a7f7549c50b11d0"
+        )
+        version(
+            "3.15.7", sha256="2d03fc2591543cd2456d0b72230b50c4519546a8d379ac6fd3ecd84c6df61e5d"
+        )
+        version(
+            "3.15.6", sha256="2b974519a2ae83aa1e31cff9018c70bbe0e303a46a598f982943c49ae1d4fcd3"
+        )
+        version(
+            "3.15.5", sha256="be8a929c6178bb6cbe9e2c858be62fa08966a39ae758a8493a88f0ed1efb6097"
+        )
+        version(
+            "3.15.1", sha256="824dbae3390fcc3ea1bf96748e6da951a601802894cf7e1465e72b4732538cab"
+        )
+        version(
+            "3.13.0", sha256="6a82e0c8bb2bf58f606040cc5814e07715b2094caeba281e2e7d0b0e2e397db5"
+        )
+        version(
+            "3.12.2", sha256="49ef8ab4c27812a89a76fa894fe7a08f42f2147078392c0dee51d4a444ef6df5"
+        )
+        version(
+            "3.11.2", sha256="3d7a7d8d20b4e7a8f63f62de2d192cfd8b7a53c56caba7ece95367ca2b80c574"
+        )
+        version(
+            "3.11.1", sha256="aecdf12ef6dc7fd91713a6da93a86c2f2a8fe54840a3b1670853a2b7402e77c9"
+        )
+        version(
+            "3.11.0", sha256="97b08853b9bb71512ed52381f05cf2d4179f4234825b505d8f8d2bb9d9429939"
+        )
+        version(
+            "3.10.0", sha256="db83b5c12c0cd30150bb568e6feb2435c49ce4e68fe2d7b903113f0e221e58fe"
+        )
+        version("3.9.2", sha256="843f498e98ad1469ad54ecb4a7ccf48605a1c5d2bd26ae799c7a2cddab4a37ec")
+        version("3.9.1", sha256="d831b047bd69becaf64019a47179eb22118a50dd008340655266a906c69c6417")
+        version("3.8.0", sha256="8c61cc8a76e9d381c665aecc5105fa0f1878cf7db8b5cd17202603bcb386d0fc")
+        version("3.7.1", sha256="21e395d7959551e759d604940a115c51c6347d90a475c9baf471a1a86b5604a9")
+        version("3.6.1", sha256="1489b376b0f364bcc6f89519718c057eb191d7ad6f1b395ffd93d1aa45587811")
+        version("3.6.0", sha256="a37836aa47d1b81c2db1a6b7a5e79926062b5d76bd962115a0e615551be2b48d")
+        version("3.5.2", sha256="09879a295fd7234e523b62066223b128c5a8a88f682e3aff62fb115e4a0d8be0")
+        version("3.5.1", sha256="95b78959572de7d7fafa3acb718ed71f482932ddddddbd29ba8319c10639d863")
+        version("3.4.0", sha256="ef02609ef445987976a3a26bff77119c518e0915c96661c3a3b17856d0ef6374")
+        version("3.3.0", sha256="1cbcee2c45773f57cb6de7ee0eceb97f92b9b69c0178305509b162c0160c1f04")
+        version("3.0.0", sha256="ecc40bc30f1183b418fe0ec0c90bc3b53fa1707c4205ee278c6b90479e5b6ff5")
 
     depends_on("c", type="build")
 
     depends_on("python", type=("build", "link", "run"))
     # https://github.com/protocolbuffers/protobuf/issues/12186
     depends_on("python@:3.13", when="@:5.26", type=("build", "link", "run"))
+    depends_on("python@3.10:", when="@7.34:", type=("build", "link", "run"))
     depends_on("py-setuptools", type=("build", "run"))
     depends_on("py-six@1.9:", when="@3.0:3.17", type=("build", "run"))
 
@@ -80,6 +161,8 @@ class PyProtobuf(PythonPackage):
     depends_on("py-setuptools@:81", when="@:6.31", type=("build", "run"))
 
     # https://protobuf.dev/support/version-support/#python
+    for ver in range(34, 35):
+        depends_on(f"protobuf@{ver}", when=f"@7.{ver}")
     for ver in range(30, 33):
         depends_on(f"protobuf@{ver}", when=f"@6.{ver}")
     for ver in range(26, 30):

--- a/repos/spack_repo/builtin/packages/py_protobuf/package.py
+++ b/repos/spack_repo/builtin/packages/py_protobuf/package.py
@@ -23,6 +23,13 @@ class PyProtobuf(PythonPackage):
     version("6.33.6", sha256="a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135")
     version("5.29.6", sha256="da9ee6a5424b6b30fd5e45c5ea663aef540ca95f9ad99d1e887e819cdf9b8723")
 
+    # Backport of CVE-2026-0994 applies to these versions: Fixes py-tensorflow %gcc@11 for E4S
+    version("4.25.8", sha256="6135cf8affe1fc6f76cced2641e4ea8d3e59518d1f24ae41ba97bcad82d397cd")
+    version("4.24.4", sha256="5a70731910cd9104762161719c3d883c960151eea077134458503723b60e3667")
+    version("4.23.3", sha256="7a92beb30600332a52cdadbedb40d33fd7c8a0d7f549c440347bc606fb3fe34b")
+    version("4.21.9", sha256="61f21493d96d2a77f9ca84fefa105872550ab5ef71d21c458eb80edcf4885a99")
+    version("3.20.3", sha256="2e3427429c9cffebf259491be0af70189607f365c2f41c7c3764af6f337105f2")
+
     with default_args(deprecated=True):
         # CVE-2026-0994 https://github.com/protocolbuffers/protobuf/issues/25070#issuecomment-4297395015
         version(
@@ -41,25 +48,13 @@ class PyProtobuf(PythonPackage):
             "4.25.3", sha256="25b5d0b42fd000320bd7830b349e3b696435f3b329810427a6bcce6a5492cc5c"
         )
         version(
-            "4.24.4", sha256="5a70731910cd9104762161719c3d883c960151eea077134458503723b60e3667"
-        )
-        version(
             "4.24.3", sha256="12e9ad2ec079b833176d2921be2cb24281fa591f0b119b208b788adc48c2561d"
-        )
-        version(
-            "4.23.3", sha256="7a92beb30600332a52cdadbedb40d33fd7c8a0d7f549c440347bc606fb3fe34b"
-        )
-        version(
-            "4.21.9", sha256="61f21493d96d2a77f9ca84fefa105872550ab5ef71d21c458eb80edcf4885a99"
         )
         version(
             "4.21.7", sha256="71d9dba03ed3432c878a801e2ea51e034b0ea01cf3a4344fb60166cb5f6c8757"
         )
         version(
             "4.21.5", sha256="eb1106e87e095628e96884a877a51cdb90087106ee693925ec0a300468a9be3a"
-        )
-        version(
-            "3.20.3", sha256="2e3427429c9cffebf259491be0af70189607f365c2f41c7c3764af6f337105f2"
         )
         version(
             "3.20.2", sha256="712dca319eee507a1e7df3591e639a2b112a2f4a62d40fe7832a16fd19151750"
@@ -147,6 +142,9 @@ class PyProtobuf(PythonPackage):
         version("3.4.0", sha256="ef02609ef445987976a3a26bff77119c518e0915c96661c3a3b17856d0ef6374")
         version("3.3.0", sha256="1cbcee2c45773f57cb6de7ee0eceb97f92b9b69c0178305509b162c0160c1f04")
         version("3.0.0", sha256="ecc40bc30f1183b418fe0ec0c90bc3b53fa1707c4205ee278c6b90479e5b6ff5")
+
+    # Backport of https://github.com/protocolbuffers/protobuf/commit/d2b001626d137c62dfee6c88c87324102531868b
+    patch("cve-2026-0994.patch", when="@3.20:5.25")
 
     depends_on("c", type="build")
 


### PR DESCRIPTION
Due to CVE-2026-0994 for py-protobuf, add fixed versions and deprecated the affected versions:
- Add py-protobuf 5.29.6, 6.33.6, 7.34.2 and 7.35.1, deprecate all previous versions.
- Add protofbuf 29.6, 33.6, 34.2 and 35.1

Background: While reviewing
- #6052
  I saw that upstream has bumped it's protobuf version constraint to >= 6.33.5 due to CVE-2026-0994:
  - https://github.com/microsoft/onnxruntime/pull/29606
  - https://github.com/advisories/GHSA-7gcm-g887-7qv7

It appears to be difficult to check which other packages need updates as the py-protofuf versions are pinned to corresponding protobuf versions:

```py
    # https://protobuf.dev/support/version-support/#python
    for ver in range(30, 33):
        depends_on(f"protobuf@{ver}", when=f"@6.{ver}")
    for ver in range(26, 30):
        depends_on(f"protobuf@{ver}", when=f"@5.{ver}")
    for ver in range(21, 26):
        depends_on(f"protobuf@{ver}", when=f"@4.{ver}")
    for ver in range(0, 21):
        depends_on(f"protobuf@3.{ver}", when=f"@3.{ver}")
```
   
The dependents in spack-packages are:
```py
git grep '"py-onnxruntime'
repos/spack_repo/builtin/packages/acts/package.py:    depends_on("py-onnxruntime@1.12:", when="+onnx")
repos/spack_repo/builtin/packages/purify/package.py:    depends_on("py-onnxruntime@1.17.1:", when="+onnxrt")
repos/spack_repo/builtin/packages/py_earth2mip/package.py:            depends_on("py-onnxruntime@1.15.1:")
repos/spack_repo/builtin/packages/py_onnx_opcounter/package.py:        depends_on("py-onnxruntime")
repos/spack_repo/builtin/packages/py_onnxmltools/package.py:    depends_on("py-onnxruntime", type=("build", "run"))
repos/spack_repo/builtin/packages/sopt/package.py:    depends_on("py-onnxruntime@1.17.1:", when="+onnxrt")
```