### PR TITLE
mapl: add v2.71.0

### DIFF
--- a/repos/spack_repo/builtin/packages/mapl/package.py
+++ b/repos/spack_repo/builtin/packages/mapl/package.py
@@ -41,10 +41,11 @@ class Mapl(CMakePackage):
 
     # Remember if there is a new ESMA_cmake, to update the resources too
     version(
-        "2.70.0",
-        sha256="c31a390f39260ef25620c9d0367dc111e354d1f3e83157209ee2aca03249d804",
+        "2.71.0",
+        sha256="0f763e1b74d227a06eff16daeb8d86425d75597f299d35cd3453a32f5c4864ef",
         preferred=True,
     )
+    version("2.70.0", sha256="c31a390f39260ef25620c9d0367dc111e354d1f3e83157209ee2aca03249d804")
     version("2.69.1", sha256="d34ba656c06a1ab0f306e22a8615a694f87c24626fc4cc8da3fe6f19fcbf3a4d")
     version("2.69.0", sha256="ba5d08dbcfd6765955b19d944748d93506df649c59781e7307c14ca2ef613d92")
     version("2.68.0", sha256="ccba8339569d4a8f64fd2435bcde1b09a41c6a54aae798eb8d4cc44a30e2a495")
@@ -163,9 +164,17 @@ class Mapl(CMakePackage):
     resource(
         name="esma_cmake",
         git="https://github.com/GEOS-ESM/ESMA_cmake.git",
+        tag="v4.44.0",
+        commit="3a024a54bb086a16d7ccbb5ff854d8be4b3c3a27",
+        when="@2.71:",
+        placement="ESMA_cmake",
+    )
+    resource(
+        name="esma_cmake",
+        git="https://github.com/GEOS-ESM/ESMA_cmake.git",
         tag="v4.40.0",
         commit="bfea7ae9482f508f66f7964cf98908c7a6c63ce8",
-        when="@2.70:",
+        when="@2.70",
         placement="ESMA_cmake",
     )
     resource(

--- a/repos/spack_repo/builtin/packages/mapl/package.py
+++ b/repos/spack_repo/builtin/packages/mapl/package.py
@@ -29,8 +29,6 @@ class Mapl(CMakePackage):
         "mathomp4",
         "tclune",
         "climbfuji",
-        "edwardhartnett",
-        "Hang-Lei-NOAA",
         "AlexanderRichert-NOAA",
     )
 
@@ -537,7 +535,7 @@ class Mapl(CMakePackage):
             nc_pc_cmd = ["nc-config", "--static", "--libs"]
             nc_flags = subprocess.check_output(nc_pc_cmd, encoding="utf8").strip()
             filter_file(
-                "(target_link_libraries[^)]+PUBLIC )", r"\1 %s " % nc_flags, "pfio/CMakeLists.txt"
+                "(target_link_libraries[^)]+PUBLIC )", rf"\1 {nc_flags} ", "pfio/CMakeLists.txt"
             )
 
         # https://community.intel.com/t5/Intel-Fortran-Compiler/Regression-with-fpp-2025-2-0/td-p/1703735


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This adds MAPL v2.71.0

I also made a fix suggested by `ruff` based on:

UP031: Use format specifiers instead of percent format