### PR TITLE
acts: allow builds with cxxstd=23

### DIFF
--- a/repos/spack_repo/builtin/packages/acts/package.py
+++ b/repos/spack_repo/builtin/packages/acts/package.py
@@ -87,7 +87,7 @@ class Acts(CMakePackage, CudaPackage):
     variant(
         "benchmarks", default=False, description="Build the performance benchmarks", when="@0.16:"
     )
-    _cxxstd_values = (conditional("20", when="@24:"),)
+    _cxxstd_values = (conditional("20", when="@24:"), conditional("23", when="@46:"))
     _cxxstd_common = {
         "values": _cxxstd_values,
         "multi": False,


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Support landed with https://github.com/acts-project/acts/pull/5223 (i.e. 46.0.0)