### PR TITLE
glpk: use Debian patch instead of Fedora for C23 bool compatibility

### DIFF
--- a/repos/spack_repo/builtin/packages/glpk/package.py
+++ b/repos/spack_repo/builtin/packages/glpk/package.py
@@ -34,9 +34,8 @@ class Glpk(AutotoolsPackage, GNUMirrorPackage):
 
     # Do not define bool, true, or false for C23 compatibility
     patch(
-        "https://src.fedoraproject.org/rpms/glpk/raw/2f25ac1417ccd1a9e2773d63800d50a2ab326ede/f/glpk-5.0-bool.patch",
-        sha256="962e2526a1fab58cd3d577a786e714ca923086179bb94d9d4bf259f7e0f42c27",
-        when="%gcc@15:",
+        "https://salsa.debian.org/science-team/glpk/-/raw/2dd3b283654555100edde4d72fbe1b1a4883292a/debian/patches/gcc-15.patch",
+        sha256="f9a1fc747a8cf9a484e517fbc105d3e8e50ac588430614267444271d3411f0ac",
     )
 
     def configure_args(self):


### PR DESCRIPTION
The Fedora patch just removed the true/false `#define`'s in GCC 15+, which is fragile, e.g.:

* On some systems, we might use GCC for the Fortran compiler but another compiler (e.g., Apple Clang) for C, and this patch would fire even if we didn't want it to.  This is currently the case in macOS, where glpk fails to build (`unknown type name 'bool'`).

* Presumably, Clang will make C23 the default at some point, and then we'd need to adjust the `when` clause for this patch again.

The Debian patch removes the `#define`'s, but also includes `stdbool.h`, which will give us what we want regardless of the compiler.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
