### PR TITLE
kokkos: add v5.2.1

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -28,6 +28,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
 
     version("develop", branch="develop")
 
+    version("5.2.1", sha256="3f754c99aa6130b1dd6520d904db7b2fd44ed618cd91e0dfd921956f23f6812d")
     version("5.2.0", sha256="54993e0682d80b78939bbf260490f8cf31428bb883c0309961369997f15d94df")
     version("5.1.1", sha256="8bdbee0f0ac383436743ad8a9e3e928705b34b31a25a92dc5179c52a3aa98519")
     version("5.1.0", sha256="7bdbdfc88033ed7d940c7940ed8919e1f2b78a9656c69276beb76ad45c41ec4e")

--- a/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
@@ -26,6 +26,7 @@ class KokkosKernels(CMakePackage, CudaPackage):
 
     version("develop", branch="develop")
 
+    version("5.2.1", sha256="346068d9c3bf25293f0460a8edc16cb02edf327d2c4197840ecd26ac37844df7")
     version("5.2.0", sha256="57f278e7a25940f9a1237d8b370a1de7f09ea282626b4594e4880042181acdcd")
     version("5.1.1", sha256="4415c2a6e14e2bba9aa978917d2ffbcbe32760d3aba3a33bf7a267d50e7e20c9")
     version("5.1.0", sha256="c003cd53126dee651f41a3b003e443950c3030246785ae968055ce015c89e0d5")


### PR DESCRIPTION
Just adding the new release numbers and associated SHAs for Kokkos and Kokkos Kernels.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
