### PR TITLE
kahip: build with NONATIVEOPTIMIZATIONS to respect Spack's target flags

### DIFF
--- a/repos/spack_repo/builtin/packages/kahip/package.py
+++ b/repos/spack_repo/builtin/packages/kahip/package.py
@@ -53,6 +53,13 @@ class Kahip(CMakePackage):
 
     patch("cstdint.patch")
 
+    def cmake_args(self):
+        # Upstream forces '-march=native' via add_definitions() unless
+        # NONATIVEOPTIMIZATIONS is set, overriding Spack's target flags.
+        return [self.define("NONATIVEOPTIMIZATIONS", True)]
+
     @when("@3.13:")
     def cmake_args(self):
-        return [self.define_from_variant("DETERMINISTIC_PARHIP", "deterministic")]
+        args = super().cmake_args()
+        args.append(self.define_from_variant("DETERMINISTIC_PARHIP", "deterministic"))
+        return args

--- a/repos/spack_repo/builtin/packages/kahip/package.py
+++ b/repos/spack_repo/builtin/packages/kahip/package.py
@@ -60,6 +60,7 @@ class Kahip(CMakePackage):
 
     @when("@3.13:")
     def cmake_args(self):
-        args = super().cmake_args()
-        args.append(self.define_from_variant("DETERMINISTIC_PARHIP", "deterministic"))
-        return args
+        return [
+            self.define("NONATIVEOPTIMIZATIONS", True),
+            self.define_from_variant("DETERMINISTIC_PARHIP", "deterministic"),
+        ]


### PR DESCRIPTION
Upstream forces `-march=native` via `add_definitions()` unless `NONATIVEOPTIMIZATIONS` is set, overriding Spack's target-derived flags and breaking build cache consumers with a narrower CPU.