### PR TITLE
relion: simplify ctffind bounds

### DIFF
--- a/repos/spack_repo/builtin/packages/relion/package.py
+++ b/repos/spack_repo/builtin/packages/relion/package.py
@@ -111,8 +111,7 @@ class Relion(CMakePackage, CudaPackage):
     conflicts("cuda@13:", when="@:5.0.0 +cuda")
     depends_on("tbb", when="+altcpu")
     depends_on("mkl", when="+mklfft")
-    depends_on("ctffind@4.1:4", type="run", when="@5")
-    depends_on("ctffind@:4", type="run")
+    depends_on("ctffind@4.1:4", type="run")
     depends_on("motioncor2", type="run", when="+external_motioncor2")
 
     # ghostscript is only needed at runtime for merging EPS diagnostic plots


### PR DESCRIPTION
ctffind@4.1: is required since RELION 2.0 (released a decade ago). No
support for ctffind@5 yet, not even in development branches.

The `@5` condition should've been `@5:` for future releases (e.g. master), but in the end it simplifies to an unconditional lower/upper bound.
