### PR TITLE
ascent: fix CUDA 13 build and allow raja@develop

### DIFF
--- a/repos/spack_repo/builtin/packages/ascent/ascent-blt-cuda13-memory-clock.patch
+++ b/repos/spack_repo/builtin/packages/ascent/ascent-blt-cuda13-memory-clock.patch
@@ -1,0 +1,21 @@
+diff --git a/src/blt/tests/smoke/blt_cuda_runtime_smoke.cpp b/src/blt/tests/smoke/blt_cuda_runtime_smoke.cpp
+index ab505ca2249f..e188c7500da4 100644
+--- a/src/blt/tests/smoke/blt_cuda_runtime_smoke.cpp
++++ b/src/blt/tests/smoke/blt_cuda_runtime_smoke.cpp
+@@ -30,12 +30,16 @@ int main()
+     cudaGetDeviceProperties(&prop, i);
+     printf("Device Number: %d\n", i);
+     printf("  Device name: %s\n", prop.name);
++#if defined(CUDART_VERSION) && CUDART_VERSION < 13000
+     printf("  Memory Clock Rate (KHz): %d\n",
+            prop.memoryClockRate);
++#endif
+     printf("  Memory Bus Width (bits): %d\n",
+            prop.memoryBusWidth);
++#if defined(CUDART_VERSION) && CUDART_VERSION < 13000
+     printf("  Peak Memory Bandwidth (GB/s): %f\n\n",
+            2.0*prop.memoryClockRate*(prop.memoryBusWidth/8)/1.0e6);
++#endif
+   }
+ 
+   return 0;

--- a/repos/spack_repo/builtin/packages/ascent/package.py
+++ b/repos/spack_repo/builtin/packages/ascent/package.py
@@ -235,7 +235,8 @@ class Ascent(CMakePackage, CudaPackage, ROCmPackage):
     #######################
     with when("+raja"):
         depends_on("raja")
-        depends_on("raja@2024.02.1:2025.03.1", when="@0.9.3:")
+        # develop needs raja@develop, so restrict the release range to 0.9.x
+        depends_on("raja@2024.02.1:2025.03.1", when="@0.9.3:0.9.5")
         depends_on("raja+openmp", when="+openmp")
         depends_on("raja~openmp", when="~openmp")
         depends_on("raja+rocm", when="+rocm")
@@ -654,6 +655,14 @@ class Ascent(CMakePackage, CudaPackage, ROCmPackage):
                     "CMAKE_CUDA_ARCHITECTURES", ";".join(spec.variants["cuda_arch"].values)
                 )
             )
+            # Camp/RAJA headers need the CUDA standard to match the C++ standard
+            # they were built with (RAJA develop currently defaults to C++20).
+            if spec.satisfies("+raja"):
+                cfg.write(
+                    cmake_cache_entry(
+                        "CMAKE_CUDA_STANDARD", str(spec["raja"].variants["cxxstd"].value)
+                    )
+                )
 
         else:
             cfg.write(cmake_cache_entry("ENABLE_CUDA", "OFF"))

--- a/repos/spack_repo/builtin/packages/ascent/package.py
+++ b/repos/spack_repo/builtin/packages/ascent/package.py
@@ -173,6 +173,10 @@ class Ascent(CMakePackage, CudaPackage, ROCmPackage):
         sha256="0dc417d8a454d235cdeb9e0f0bb527dc3c42a1eb6ae80e8bd5b33ead19198329",
     )
 
+    # cudaDeviceProp.memoryClockRate was removed in CUDA 13.0
+    patch("ascent-blt-cuda13-memory-clock.patch", when="@:0.9.5 +cuda")
+    patch("ascent-blt-cuda13-memory-clock.patch", when="@develop +cuda")
+
     ##########################################################################
     # package dependencies
     ###########################################################################


### PR DESCRIPTION
This PR fixes two issues that prevent `ascent@develop +cuda` from building with CUDA 13 and `raja@develop`.

1. **CUDA 13 compatibility**
   CUDA 13.0 removed `cudaDeviceProp.memoryClockRate`. The bundled BLT smoke test `blt_cuda_runtime_smoke.cpp` still references it, causing:
   ```text
   error: 'struct cudaDeviceProp' has no member named 'memoryClockRate'
   Add a patch that guards the memoryClockRate usage with #if defined(CUDART_VERSION) && CUDART_VERSION < 13000.
2. Allow raja@develop
The dependency depends_on("raja@2024.02.1:2025.03.1", when="@0.9.3:") also matched @develop, blocking raja@develop. Narrow it to @0.9.3:0.9.5.
3. Match CUDA C++ standard to RAJA
With raja@develop built as C++20, the bundled camp headers require C++20 concepts, but CUDA files were compiled with CMake's default CMAKE_CUDA_STANDARD=17. Set CMAKE_CUDA_STANDARD from RAJA's cxxstd variant when +raja.
Tested by building ascent@develop +cuda with cuda@13.0.2 and raja@develop.