### PR TITLE
libfabric: fix null deref in ofi_import_monitor_unsubscribe

### DIFF
--- a/repos/spack_repo/builtin/packages/libfabric/mr_unsubscribe.patch
+++ b/repos/spack_repo/builtin/packages/libfabric/mr_unsubscribe.patch
@@ -1,0 +1,13 @@
+diff --git a/prov/util/src/import_mem_monitor.c b/prov/util/src/import_mem_monitor.c
+index e7be581526f0..1f1f4a971099 100644
+--- a/prov/util/src/import_mem_monitor.c
++++ b/prov/util/src/import_mem_monitor.c
+@@ -111,7 +111,7 @@ static void ofi_import_monitor_unsubscribe(struct ofi_mem_monitor *notifier,
+ 					   const void *addr, size_t len,
+ 					   union ofi_mr_hmem_info *hmem_info)
+ {
+-	assert(impmon.impfid);
++	if (!impmon.impfid) return;
+ 	impmon.impfid->export_ops->unsubscribe(impmon.impfid, addr, len);
+ }
+ 

--- a/repos/spack_repo/builtin/packages/libfabric/package.py
+++ b/repos/spack_repo/builtin/packages/libfabric/package.py
@@ -157,6 +157,9 @@ class Libfabric(AutotoolsPackage, CudaPackage, ROCmPackage):
     # Fix for the inline assembly problem for the Nvidia compilers
     # https://github.com/ofiwg/libfabric/pull/7665
     patch("nvhpc-symver.patch", when="@1.6.0:1.14.0 %nvhpc")
+    # Fix null deref in ofi_import_monitor_unsubscribe when no imported monitor
+    # is active. File introduced in v2.1.0; still unfixed as of v2.6.0/main.
+    patch("mr_unsubscribe.patch", when="@2.1.0:")
 
     depends_on("c", type="build")  # generated
 


### PR DESCRIPTION
`ofi_import_monitor_unsubscribe()` in `prov/util/src/import_mem_monitor.c` asserts `impmon.impfid` before dereferencing it, but the function can be called when no imported monitor has been set up. Replace the assert with a null check / early return to avoid a crash.

The imported memory monitor file was introduced in libfabric v2.1.0 and the issue is still present in v2.6.0 and `main`, so scope the patch with `when="@2.1.0:"`.