### PR TITLE
py-dm-tree: 0.1.10 needs abseil-cpp@20250814: for absl:MutexLock(mutex)

### DIFF
--- a/repos/spack_repo/builtin/packages/py_dm_tree/package.py
+++ b/repos/spack_repo/builtin/packages/py_dm_tree/package.py
@@ -41,7 +41,8 @@ class PyDmTree(CMakePackage, PythonExtension):
         depends_on("python@:3.11", when="@:0.1.8")
         depends_on("python@:3.10", when="@:0.1.7")
 
-    depends_on("abseil-cpp cxxstd=17", type="link", when="@0.1.10:")
+    # 0.1.10 added using absl::MutexLock lock(mutex_) which needs abseil-cpp@20250814.1:
+    depends_on("abseil-cpp@20250814.1: cxxstd=17", type="link", when="@0.1.10:")
     depends_on("abseil-cpp cxxstd=14", type="link", when="@0.1.8:0.1.9")
     depends_on("py-attrs@18.2.0:", type=("build", "run"), when="@0.1.9:")
     depends_on("py-wrapt@1.11.2:", type=("build", "run"), when="@0.1.9:")


### PR DESCRIPTION
py-dm-tree@0.1.10: started to use `absl:MutexLock(mutex)`:
https://github.com/google-deepmind/tree/compare/0.1.9...0.1.10#diff-ae58474be80ffb81dab28f1870a4514f935ede4508766a4461f7b88563330c4fR118
 
`absl:MutexLock(mutex)` started to be provided with `abseil-cpp@20250814:`, so update the unversioned dependency for `abseil-cpp` to use this as the minimum version.

This should fix the HEP stack GitLab CI pipelines for the `develop` branch which are currently failing because of this missing constraint for `py-dm-tree@0.1.10`:
- https://gitlab.spack.io/spack/spack-packages/-/jobs/24059703
- https://gitlab.spack.io/spack/spack-packages/-/jobs/24059178
- https://gitlab.spack.io/spack/spack-packages/-/jobs/24058804