### PR TITLE
ROCm: Fix ROCm external detection for TheRock installations

### DIFF
--- a/repos/spack_repo/builtin/packages/comgr/package.py
+++ b/repos/spack_repo/builtin/packages/comgr/package.py
@@ -141,5 +141,5 @@ class Comgr(ROCmLibrary, CMakePackage):
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
         else:
-            ver = None
-        return ver or super().determine_version(lib)
+            ver = super().determine_version(lib)
+        return ver

--- a/repos/spack_repo/builtin/packages/comgr/package.py
+++ b/repos/spack_repo/builtin/packages/comgr/package.py
@@ -5,11 +5,12 @@
 import re
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems.rocm import ROCmLibrary
 
 from spack.package import *
 
 
-class Comgr(CMakePackage):
+class Comgr(ROCmLibrary, CMakePackage):
     """This provides various Lightning Compiler related services. It currently
     contains one library, the Code Object Manager (Comgr)"""
 
@@ -141,4 +142,4 @@ class Comgr(CMakePackage):
             )
         else:
             ver = None
-        return ver
+        return ver or super().determine_version(lib)

--- a/repos/spack_repo/builtin/packages/hip/package.py
+++ b/repos/spack_repo/builtin/packages/hip/package.py
@@ -394,6 +394,12 @@ class Hip(ROCmLibrary, CMakePackage):
 
     @classmethod
     def determine_version(cls, lib):
+        # TheRock 7.13+ encodes the ROCm major and minor versions directly in
+        # the library name, followed by a HIP build number.
+        match = re.search(r"lib\S*\.so\.(7)\.(1[34])\.\d+(?:-|$)", lib)
+        if match:
+            return "{0}.{1}.0".format(int(match.group(1)), int(match.group(2)))
+
         match = re.search(r"lib\S*\.so\.\d+\.\d+\.(\d)(\d\d)(\d\d)", lib)
         if match:
             ver = "{0}.{1}.{2}".format(

--- a/repos/spack_repo/builtin/packages/hip/package.py
+++ b/repos/spack_repo/builtin/packages/hip/package.py
@@ -406,7 +406,7 @@ class Hip(ROCmLibrary, CMakePackage):
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
         else:
-            ver = None
+            ver = super().determine_version(lib)
         return ver
 
     def set_variables(self, env):

--- a/repos/spack_repo/builtin/packages/hip_tensor/package.py
+++ b/repos/spack_repo/builtin/packages/hip_tensor/package.py
@@ -123,7 +123,7 @@ class HipTensor(ROCmLibrary, CMakePackage, ROCmPackage):
             )
         else:
             ver = None
-        return ver
+        return ver or super().determine_version(lib)
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("@6.1"):

--- a/repos/spack_repo/builtin/packages/hip_tensor/package.py
+++ b/repos/spack_repo/builtin/packages/hip_tensor/package.py
@@ -122,8 +122,8 @@ class HipTensor(ROCmLibrary, CMakePackage, ROCmPackage):
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
         else:
-            ver = None
-        return ver or super().determine_version(lib)
+            ver = super().determine_version(lib)
+        return ver
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("@6.1"):

--- a/repos/spack_repo/builtin/packages/hipblas/package.py
+++ b/repos/spack_repo/builtin/packages/hipblas/package.py
@@ -190,8 +190,8 @@ class Hipblas(ROCmLibrary, CMakePackage, CudaPackage, ROCmPackage):
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
         else:
-            ver = None
-        return ver or super().determine_version(lib)
+            ver = super().determine_version(lib)
+        return ver
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("+asan"):

--- a/repos/spack_repo/builtin/packages/hipblas/package.py
+++ b/repos/spack_repo/builtin/packages/hipblas/package.py
@@ -191,7 +191,7 @@ class Hipblas(ROCmLibrary, CMakePackage, CudaPackage, ROCmPackage):
             )
         else:
             ver = None
-        return ver
+        return ver or super().determine_version(lib)
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("+asan"):

--- a/repos/spack_repo/builtin/packages/hipblaslt/package.py
+++ b/repos/spack_repo/builtin/packages/hipblaslt/package.py
@@ -331,8 +331,8 @@ class Hipblaslt(ROCmLibrary, CMakePackage):
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
         else:
-            ver = None
-        return ver or super().determine_version(lib)
+            ver = super().determine_version(lib)
+        return ver
 
     @property
     def root_cmakelists_dir(self):

--- a/repos/spack_repo/builtin/packages/hipblaslt/package.py
+++ b/repos/spack_repo/builtin/packages/hipblaslt/package.py
@@ -332,7 +332,7 @@ class Hipblaslt(ROCmLibrary, CMakePackage):
             )
         else:
             ver = None
-        return ver
+        return ver or super().determine_version(lib)
 
     @property
     def root_cmakelists_dir(self):

--- a/repos/spack_repo/builtin/packages/hipcc/package.py
+++ b/repos/spack_repo/builtin/packages/hipcc/package.py
@@ -75,7 +75,7 @@ class Hipcc(ROCmLibrary, CMakePackage):
     def determine_version(cls, exe):
         output = Executable(exe)("--version", output=str, error=str)
         match = re.search(r"roc-(\S+)", output)
-        return match.group(1) if match else None
+        return match.group(1) if match else super().determine_version(exe)
 
     def patch(self):
         numactl = self.spec["numactl"].prefix.lib

--- a/repos/spack_repo/builtin/packages/hipdnn/package.py
+++ b/repos/spack_repo/builtin/packages/hipdnn/package.py
@@ -118,8 +118,8 @@ class Hipdnn(ROCmLibrary, CMakePackage):
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
         else:
-            ver = None
-        return ver or super().determine_version(lib)
+            ver = super().determine_version(lib)
+        return ver
 
     @property
     def root_cmakelists_dir(self):

--- a/repos/spack_repo/builtin/packages/hipdnn/package.py
+++ b/repos/spack_repo/builtin/packages/hipdnn/package.py
@@ -119,7 +119,7 @@ class Hipdnn(ROCmLibrary, CMakePackage):
             )
         else:
             ver = None
-        return ver
+        return ver or super().determine_version(lib)
 
     @property
     def root_cmakelists_dir(self):

--- a/repos/spack_repo/builtin/packages/hipfft/package.py
+++ b/repos/spack_repo/builtin/packages/hipfft/package.py
@@ -139,7 +139,7 @@ class Hipfft(ROCmLibrary, CMakePackage, CudaPackage, ROCmPackage):
             )
         else:
             ver = None
-        return ver
+        return ver or super().determine_version(lib)
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("+asan"):

--- a/repos/spack_repo/builtin/packages/hipfft/package.py
+++ b/repos/spack_repo/builtin/packages/hipfft/package.py
@@ -138,8 +138,8 @@ class Hipfft(ROCmLibrary, CMakePackage, CudaPackage, ROCmPackage):
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
         else:
-            ver = None
-        return ver or super().determine_version(lib)
+            ver = super().determine_version(lib)
+        return ver
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("+asan"):

--- a/repos/spack_repo/builtin/packages/hiprand/package.py
+++ b/repos/spack_repo/builtin/packages/hiprand/package.py
@@ -144,8 +144,8 @@ class Hiprand(ROCmLibrary, CMakePackage, CudaPackage, ROCmPackage):
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
         else:
-            ver = None
-        return ver or super().determine_version(lib)
+            ver = super().determine_version(lib)
+        return ver
 
     def cmake_args(self):
         args = [

--- a/repos/spack_repo/builtin/packages/hiprand/package.py
+++ b/repos/spack_repo/builtin/packages/hiprand/package.py
@@ -145,7 +145,7 @@ class Hiprand(ROCmLibrary, CMakePackage, CudaPackage, ROCmPackage):
             )
         else:
             ver = None
-        return ver
+        return ver or super().determine_version(lib)
 
     def cmake_args(self):
         args = [

--- a/repos/spack_repo/builtin/packages/hipsolver/package.py
+++ b/repos/spack_repo/builtin/packages/hipsolver/package.py
@@ -157,7 +157,7 @@ class Hipsolver(ROCmLibrary, CMakePackage, CudaPackage, ROCmPackage):
             )
         else:
             ver = None
-        return ver
+        return ver or super().determine_version(lib)
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("+asan"):

--- a/repos/spack_repo/builtin/packages/hipsolver/package.py
+++ b/repos/spack_repo/builtin/packages/hipsolver/package.py
@@ -156,8 +156,8 @@ class Hipsolver(ROCmLibrary, CMakePackage, CudaPackage, ROCmPackage):
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
         else:
-            ver = None
-        return ver or super().determine_version(lib)
+            ver = super().determine_version(lib)
+        return ver
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("+asan"):

--- a/repos/spack_repo/builtin/packages/hipsparse/package.py
+++ b/repos/spack_repo/builtin/packages/hipsparse/package.py
@@ -140,8 +140,8 @@ class Hipsparse(ROCmLibrary, CMakePackage, CudaPackage, ROCmPackage):
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
         else:
-            ver = None
-        return ver or super().determine_version(lib)
+            ver = super().determine_version(lib)
+        return ver
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("+asan"):

--- a/repos/spack_repo/builtin/packages/hipsparse/package.py
+++ b/repos/spack_repo/builtin/packages/hipsparse/package.py
@@ -141,7 +141,7 @@ class Hipsparse(ROCmLibrary, CMakePackage, CudaPackage, ROCmPackage):
             )
         else:
             ver = None
-        return ver
+        return ver or super().determine_version(lib)
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("+asan"):

--- a/repos/spack_repo/builtin/packages/hipsparselt/package.py
+++ b/repos/spack_repo/builtin/packages/hipsparselt/package.py
@@ -201,8 +201,8 @@ class Hipsparselt(ROCmLibrary, CMakePackage, ROCmPackage):
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
         else:
-            ver = None
-        return ver or super().determine_version(lib)
+            ver = super().determine_version(lib)
+        return ver
 
     def patch(self):
         purelib = self.spec["python"].package.purelib

--- a/repos/spack_repo/builtin/packages/hipsparselt/package.py
+++ b/repos/spack_repo/builtin/packages/hipsparselt/package.py
@@ -202,7 +202,7 @@ class Hipsparselt(ROCmLibrary, CMakePackage, ROCmPackage):
             )
         else:
             ver = None
-        return ver
+        return ver or super().determine_version(lib)
 
     def patch(self):
         purelib = self.spec["python"].package.purelib

--- a/repos/spack_repo/builtin/packages/hsa_amd_aqlprofile/package.py
+++ b/repos/spack_repo/builtin/packages/hsa_amd_aqlprofile/package.py
@@ -5,11 +5,12 @@
 import re
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems.rocm import ROCmLibrary
 
 from spack.package import *
 
 
-class HsaAmdAqlprofile(CMakePackage):
+class HsaAmdAqlprofile(ROCmLibrary, CMakePackage):
     """Architected Queuing Language Profiling Library
     AQLprofile is an open source library that enables advanced
     GPU profiling and tracing on AMD platforms"""
@@ -66,4 +67,4 @@ class HsaAmdAqlprofile(CMakePackage):
                 ver = None
         else:
             ver = None
-        return ver
+        return ver or super().determine_version(lib)

--- a/repos/spack_repo/builtin/packages/hsa_amd_aqlprofile/package.py
+++ b/repos/spack_repo/builtin/packages/hsa_amd_aqlprofile/package.py
@@ -66,5 +66,5 @@ class HsaAmdAqlprofile(ROCmLibrary, CMakePackage):
             if major < 7:
                 ver = None
         else:
-            ver = None
-        return ver or super().determine_version(lib)
+            ver = super().determine_version(lib)
+        return ver

--- a/repos/spack_repo/builtin/packages/hsa_rocr_dev/package.py
+++ b/repos/spack_repo/builtin/packages/hsa_rocr_dev/package.py
@@ -166,7 +166,7 @@ class HsaRocrDev(ROCmLibrary, CMakePackage):
             )
         else:
             ver = None
-        return ver
+        return ver or super().determine_version(lib)
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("@5.7: +asan"):

--- a/repos/spack_repo/builtin/packages/hsa_rocr_dev/package.py
+++ b/repos/spack_repo/builtin/packages/hsa_rocr_dev/package.py
@@ -165,8 +165,8 @@ class HsaRocrDev(ROCmLibrary, CMakePackage):
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
         else:
-            ver = None
-        return ver or super().determine_version(lib)
+            ver = super().determine_version(lib)
+        return ver
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("@5.7: +asan"):

--- a/repos/spack_repo/builtin/packages/miopen_hip/package.py
+++ b/repos/spack_repo/builtin/packages/miopen_hip/package.py
@@ -239,8 +239,8 @@ class MiopenHip(ROCmLibrary, CMakePackage):
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
         else:
-            ver = None
-        return ver or super().determine_version(lib)
+            ver = super().determine_version(lib)
+        return ver
 
     def cmake_args(self):
         spec = self.spec

--- a/repos/spack_repo/builtin/packages/miopen_hip/package.py
+++ b/repos/spack_repo/builtin/packages/miopen_hip/package.py
@@ -240,7 +240,7 @@ class MiopenHip(ROCmLibrary, CMakePackage):
             )
         else:
             ver = None
-        return ver
+        return ver or super().determine_version(lib)
 
     def cmake_args(self):
         spec = self.spec

--- a/repos/spack_repo/builtin/packages/rccl/package.py
+++ b/repos/spack_repo/builtin/packages/rccl/package.py
@@ -5,12 +5,12 @@
 import re
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
-from spack_repo.builtin.build_systems.rocm import ROCmPackage
+from spack_repo.builtin.build_systems.rocm import ROCmLibrary, ROCmPackage
 
 from spack.package import *
 
 
-class Rccl(CMakePackage):
+class Rccl(ROCmLibrary, CMakePackage):
     """RCCL (pronounced "Rickle") is a stand-alone library
     of standard collective communication routines for GPUs,
     implementing all-reduce, all-gather, reduce, broadcast,
@@ -197,7 +197,7 @@ class Rccl(CMakePackage):
             )
         else:
             ver = None
-        return ver
+        return ver or super().determine_version(lib)
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         env.set("CXX", self.spec["hip"].hipcc)

--- a/repos/spack_repo/builtin/packages/rccl/package.py
+++ b/repos/spack_repo/builtin/packages/rccl/package.py
@@ -196,8 +196,8 @@ class Rccl(ROCmLibrary, CMakePackage):
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
         else:
-            ver = None
-        return ver or super().determine_version(lib)
+            ver = super().determine_version(lib)
+        return ver
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         env.set("CXX", self.spec["hip"].hipcc)

--- a/repos/spack_repo/builtin/packages/rdc/package.py
+++ b/repos/spack_repo/builtin/packages/rdc/package.py
@@ -6,11 +6,12 @@
 import re
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems.rocm import ROCmLibrary
 
 from spack.package import *
 
 
-class Rdc(CMakePackage):
+class Rdc(ROCmLibrary, CMakePackage):
     """ROCm Data Center Tool"""
 
     homepage = "https://github.com/ROCm/rdc"
@@ -161,7 +162,7 @@ class Rdc(CMakePackage):
             return "{0}.{1}.{2}".format(
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
-        return None
+        return super().determine_version(lib)
 
     def cmake_args(self):
         args = [self.define("GRPC_ROOT", self.spec["grpc"].prefix)]

--- a/repos/spack_repo/builtin/packages/rocblas/package.py
+++ b/repos/spack_repo/builtin/packages/rocblas/package.py
@@ -290,8 +290,8 @@ class Rocblas(ROCmLibrary, CMakePackage):
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
         else:
-            ver = None
-        return ver or super().determine_version(lib)
+            ver = super().determine_version(lib)
+        return ver
 
     def cmake_args(self):
         args = [

--- a/repos/spack_repo/builtin/packages/rocblas/package.py
+++ b/repos/spack_repo/builtin/packages/rocblas/package.py
@@ -291,7 +291,7 @@ class Rocblas(ROCmLibrary, CMakePackage):
             )
         else:
             ver = None
-        return ver
+        return ver or super().determine_version(lib)
 
     def cmake_args(self):
         args = [

--- a/repos/spack_repo/builtin/packages/rocfft/package.py
+++ b/repos/spack_repo/builtin/packages/rocfft/package.py
@@ -167,7 +167,7 @@ class Rocfft(ROCmLibrary, CMakePackage):
             return "{0}.{1}.{2}".format(
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
-        return None
+        return super().determine_version(lib)
 
     def cmake_args(self):
         args = [

--- a/repos/spack_repo/builtin/packages/rocm_opencl/package.py
+++ b/repos/spack_repo/builtin/packages/rocm_opencl/package.py
@@ -156,7 +156,7 @@ class RocmOpencl(ROCmLibrary, CMakePackage):
             )
         else:
             ver = None
-        return ver
+        return ver or super().determine_version(lib)
 
     def cmake_args(self):
         args = ["-DUSE_COMGR_LIBRARY=yes", "-DBUILD_TESTS=ON"]

--- a/repos/spack_repo/builtin/packages/rocm_opencl/package.py
+++ b/repos/spack_repo/builtin/packages/rocm_opencl/package.py
@@ -155,8 +155,8 @@ class RocmOpencl(ROCmLibrary, CMakePackage):
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
         else:
-            ver = None
-        return ver or super().determine_version(lib)
+            ver = super().determine_version(lib)
+        return ver
 
     def cmake_args(self):
         args = ["-DUSE_COMGR_LIBRARY=yes", "-DBUILD_TESTS=ON"]

--- a/repos/spack_repo/builtin/packages/rocm_smi_lib/package.py
+++ b/repos/spack_repo/builtin/packages/rocm_smi_lib/package.py
@@ -174,7 +174,7 @@ class RocmSmiLib(ROCmLibrary, CMakePackage):
             return "{0}.{1}.{2}".format(
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
-        return None
+        return super().determine_version(lib)
 
     @run_after("build")
     @on_package_attributes(run_tests=True)

--- a/repos/spack_repo/builtin/packages/rocprofiler_dev/package.py
+++ b/repos/spack_repo/builtin/packages/rocprofiler_dev/package.py
@@ -170,7 +170,7 @@ class RocprofilerDev(ROCmLibrary, CMakePackage):
             return "{0}.{1}.{2}".format(
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
-        return None
+        return super().determine_version(lib)
 
     def cmake_args(self):
         args = [

--- a/repos/spack_repo/builtin/packages/rocrand/package.py
+++ b/repos/spack_repo/builtin/packages/rocrand/package.py
@@ -130,7 +130,7 @@ class Rocrand(ROCmLibrary, CMakePackage):
             return "{0}.{1}.{2}".format(
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
-        return None
+        return super().determine_version(lib)
 
     def cmake_args(self):
         args = [self.define("BUILD_BENCHMARK", "OFF"), self.define("BUILD_TEST", self.run_tests)]

--- a/repos/spack_repo/builtin/packages/rocsolver/package.py
+++ b/repos/spack_repo/builtin/packages/rocsolver/package.py
@@ -134,7 +134,7 @@ class Rocsolver(ROCmLibrary, CMakePackage):
             return "{0}.{1}.{2}".format(
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
-        return None
+        return super().determine_version(lib)
 
     def cmake_args(self):
         args = [

--- a/repos/spack_repo/builtin/packages/rocsparse/package.py
+++ b/repos/spack_repo/builtin/packages/rocsparse/package.py
@@ -298,7 +298,7 @@ class Rocsparse(ROCmLibrary, CMakePackage):
             return "{0}.{1}.{2}".format(
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
-        return None
+        return super().determine_version(lib)
 
     def cmake_args(self):
         args = [

--- a/repos/spack_repo/builtin/packages/roctracer_dev/package.py
+++ b/repos/spack_repo/builtin/packages/roctracer_dev/package.py
@@ -119,7 +119,7 @@ class RoctracerDev(ROCmLibrary, CMakePackage, ROCmPackage):
             return "{0}.{1}.{2}".format(
                 int(match.group(1)), int(match.group(2)), int(match.group(3))
             )
-        return None
+        return super().determine_version(lib)
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("+asan"):


### PR DESCRIPTION
Several ROCm libraries and tools no longer expose the ROCm version through library names or `--version` output. Affected packages now fall back to `ROCmLibrary.determine_version()`, and `llvm-amdgpu` falls back to parsing `/opt/rocm-<ver>/` or `/opt/rocm/core-<ver>/` installation paths.