### PR TITLE
dd4hep: url_for_version for master version

### DIFF
--- a/repos/spack_repo/builtin/packages/dd4hep/package.py
+++ b/repos/spack_repo/builtin/packages/dd4hep/package.py
@@ -264,6 +264,10 @@ class Dd4hep(CMakePackage):
         # the patch version is omitted when 0
         # so for example v01-12-01, v01-12 ...
         base_url = self.url.rsplit("/", 1)[0]
+
+        if version.isdevelop():
+            return f"{base_url}/refs/heads/{version}.tar.gz"
+
         if len(version) == 1:
             major = version[0]
             minor, patch = 0, 0


### PR DESCRIPTION
This PR avoids in `dd4hep` the incorrect insertion of a named version (`master`) into an integer format placeholder. This is relevant for the SBOM generation, even though the version is checked out from the git repo.

 See also #6049 and #5975. 