### PR TITLE
gromacs: make variant openmp_max_threads conditional on +openmp

### DIFF
--- a/repos/spack_repo/builtin/packages/gromacs/package.py
+++ b/repos/spack_repo/builtin/packages/gromacs/package.py
@@ -179,8 +179,8 @@ class Gromacs(CMakePackage, CudaPackage):
     )
 
     variant(
-        "openmp_max_threads", 
-        default="none", 
+        "openmp_max_threads",
+        default="none",
         description="Max number of OpenMP threads",
         when="+openmp",
     )

--- a/repos/spack_repo/builtin/packages/gromacs/package.py
+++ b/repos/spack_repo/builtin/packages/gromacs/package.py
@@ -178,9 +178,11 @@ class Gromacs(CMakePackage, CudaPackage):
         msg="OpenMP not available for the Apple clang compiler",
     )
 
-    variant("openmp_max_threads", default="none", description="Max number of OpenMP threads")
-    conflicts(
-        "+openmp_max_threads", when="~openmp", msg="OpenMP is off but OpenMP Max threads is set"
+    variant(
+        "openmp_max_threads", 
+        default="none", 
+        description="Max number of OpenMP threads",
+        when="+openmp",
     )
     variant(
         "sve",


### PR DESCRIPTION
This should fix issue #6098

The issue described in #6098 appears to be manifested because of the conflict on openmp_max_threads being set when ~openmp.  That conflict used "+openmp_max_threads", causing a TypeError is openmp_max_threads is set to any value.

This PR removes the conflict, and makes the openmp_max_threads variant conditional on +openmp, thereby making the conflict moot.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
