### PR TITLE
pandora*: Update PandoraPFA repository URLs

### DIFF
--- a/repos/spack_repo/builtin/packages/pandoramonitoring/package.py
+++ b/repos/spack_repo/builtin/packages/pandoramonitoring/package.py
@@ -12,9 +12,9 @@ class Pandoramonitoring(CMakePackage):
     """ROOT-based Event Visualisation Environment for Pandora with
     tree-writing functionality"""
 
-    url = "https://github.com/PandoraPFA/PandoraMonitoring/archive/v03-04-00.tar.gz"
-    homepage = "https://github.com/PandoraPFA/PandoraMonitoring"
-    git = "https://github.com/PandoraPFA/PandoraMonitoring.git"
+    url = "https://github.com/PandoraPFAOrg/PandoraMonitoring/archive/v03-04-00.tar.gz"
+    homepage = "https://github.com/PandoraPFAOrg/PandoraMonitoring"
+    git = "https://github.com/PandoraPFAOrg/PandoraMonitoring.git"
 
     tags = ["hep"]
 
@@ -34,7 +34,7 @@ class Pandoramonitoring(CMakePackage):
     depends_on("pandorasdk")
     depends_on("pandorasdk@4:", when="@4:")
 
-    # https://github.com/PandoraPFA/PandoraMonitoring/pull/13
+    # https://github.com/PandoraPFAOrg/PandoraMonitoring/pull/13
     @when("@:3.6.0")
     def patch(self):
         filter_file(

--- a/repos/spack_repo/builtin/packages/pandorapfa/package.py
+++ b/repos/spack_repo/builtin/packages/pandorapfa/package.py
@@ -13,9 +13,9 @@ class Pandorapfa(Package):
     NOTE: this recipe is not used to install  other pandora packages, for which
     separate recipes exist. It only installs the cmakemodules directory."""
 
-    url = "https://github.com/PandoraPFA/PandoraPFA/archive/v03-14-00.tar.gz"
-    homepage = "https://github.com/PandoraPFA/PandoraPFA"
-    git = "https://github.com/PandoraPFA/PandoraPFA.git"
+    url = "https://github.com/PandoraPFAOrg/PandoraPFA/archive/v03-14-00.tar.gz"
+    homepage = "https://github.com/PandoraPFAOrg/PandoraPFA"
+    git = "https://github.com/PandoraPFAOrg/PandoraPFA.git"
 
     tags = ["hep"]
 

--- a/repos/spack_repo/builtin/packages/pandorasdk/package.py
+++ b/repos/spack_repo/builtin/packages/pandorasdk/package.py
@@ -11,9 +11,9 @@ from spack.package import *
 class Pandorasdk(CMakePackage):
     """Pandora Software Development Kit for pattern-recognition algorithms"""
 
-    url = "https://github.com/PandoraPFA/PandoraSDK/archive/v03-04-00.tar.gz"
-    homepage = "https://github.com/PandoraPFA/PandoraSDK"
-    git = "https://github.com/PandoraPFA/PandoraSDK.git"
+    url = "https://github.com/PandoraPFAOrg/PandoraSDK/archive/v03-04-00.tar.gz"
+    homepage = "https://github.com/PandoraPFAOrg/PandoraSDK"
+    git = "https://github.com/PandoraPFAOrg/PandoraSDK.git"
 
     tags = ["hep"]
 


### PR DESCRIPTION
## Summary
- update PandoraPFA, PandoraMonitoring, and PandoraSDK URLs to the PandoraPFAOrg GitHub organization
- update the referenced PandoraMonitoring pull request URL

## Validation
- python3 -m py_compile for all three package recipes
- git diff --check
- confirmed the package archive URLs redirect successfully from GitHub