### PR TITLE
libensemble: fix dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/py_libensemble/package.py
+++ b/repos/spack_repo/builtin/packages/py_libensemble/package.py
@@ -77,7 +77,7 @@ class PyLibensemble(PythonPackage):
     depends_on("py-setuptools", when="@0.10.2:", type="build")
     depends_on("py-setuptools", when="@:0.10.1", type=("build", "run"))
     depends_on("py-pydantic@1.10:", when="@1.2.0:", type=("build", "run"))
-    depends_on("py-pydantic@:1", when="@0.10:", type=("build", "run"))
+    depends_on("py-pydantic@:1", when="@0.10:1.2", type=("build", "run"))
     depends_on("py-tomli@1.2.1:", when="@1:", type=("build", "run"))
     depends_on("py-tomli", when="@0.10:", type=("build", "run"))
     depends_on("py-pyyaml@6.0:", when="@1:", type=("build", "run"))


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
fixes:
```
balay@pj01:~/spack$ ./bin/spack spec py-libensemble@develop
==> Error: failed to concretize `py-libensemble@develop` for the following reasons:
     1. Cannot satisfy 'py-libensemble@develop'
     2. Cannot satisfy 'py-libensemble@develop' (version 1.5.0 does not match)
        required because py-libensemble@develop requested explicitly 
```