### PR TITLE
BLT: drop language requirements

### DIFF
--- a/repos/spack_repo/builtin/packages/blt/package.py
+++ b/repos/spack_repo/builtin/packages/blt/package.py
@@ -85,10 +85,6 @@ class Blt(Package):
         when="@0.7.1",
     )
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
-
     depends_on("cmake", type="run")
 
     def install(self, spec, prefix):


### PR DESCRIPTION
BLT is a Package, that simply copies itself into the install tree, there is no building, and thus, no requirement on any compilers.

Remove the language dependencies.

