### PR TITLE
py-onnxruntime: Allow builds with gcc16 for 1.22.2

### DIFF
--- a/repos/spack_repo/builtin/packages/py_onnxruntime/package.py
+++ b/repos/spack_repo/builtin/packages/py_onnxruntime/package.py
@@ -157,6 +157,14 @@ class PyOnnxruntime(CMakePackage, PythonExtension, ROCmPackage, CudaPackage):
     # https://github.com/microsoft/onnxruntime/pull/25200
     patch("pr25200-fix-linker-flags.patch", when="@1.21:1.22")
 
+    # optimizer_api.h uses uint8_t/int32_t without including <cstdint>, which
+    # newer libstdc++ no longer provides transitively
+    patch(
+        "https://github.com/microsoft/onnxruntime/commit/f7619dc93f592ddfc10f12f7145f9781299163a0.patch?full_index=1",
+        sha256="c0d1112d5ad4bae4260c0b1b13eb1397d87fdcec8c21c02467f31e6e0db1b906",
+        when="@1.17:1.22",
+    )
+
     dynamic_cpu_arch_values = ("NOAVX", "AVX", "AVX2", "AVX512")
 
     variant(


### PR DESCRIPTION
Apply patch that landed upstream after 1.22.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
