### PR TITLE
acts: allow builds with more recent numpys

### DIFF
--- a/repos/spack_repo/builtin/packages/acts/package.py
+++ b/repos/spack_repo/builtin/packages/acts/package.py
@@ -241,7 +241,8 @@ class Acts(CMakePackage, CudaPackage):
     # robust solution is available we pretend that these packages are also
     # run- and link-time dependencies.
     depends_on("python@3.12:", when="@44:")
-    depends_on("py-numpy @2.2", when="@44:")
+    depends_on("py-numpy @2.2", when="@44:45")
+    depends_on("py-numpy @2.3:", when="@46:")  # TODO: verify
     depends_on("py-onnxruntime@1.12:", when="+onnx")
     depends_on("py-particle @0.24", when="@44:")
     depends_on("py-pybind11 @2.13.1:", when="+python")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This is a first shot at allowing to build acts with newer versions of numpy. I have successfully built the current main branch with this. I *think* this should be possible from acts@46 onwards, but I am not entirely sure.