### PR TITLE
py-ipyvuetify: add v3.0.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_ipyvuetify/package.py
+++ b/repos/spack_repo/builtin/packages/py_ipyvuetify/package.py
@@ -33,4 +33,3 @@ class PyIpyvuetify(PythonPackage):
 
     depends_on("py-ipyvue@3:", when="@3:", type=("build", "run"))
     depends_on("py-jupyter-builder@1.0.0:", when="@3:", type=("build", "run"))
-    

--- a/repos/spack_repo/builtin/packages/py_ipyvuetify/package.py
+++ b/repos/spack_repo/builtin/packages/py_ipyvuetify/package.py
@@ -20,12 +20,17 @@ class PyIpyvuetify(PythonPackage):
 
     maintainers("jeremyfix")
 
+    version("3.0.0", sha256="265402700632d2c31257824cd266211cdbae755b80343a145881f97acdcb53ab")
     version("1.9.0", sha256="9c537e218299de32194b1da949d6b96bffe6c00f36bb6035409f2485feb881e7")
 
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools@40.8.0:", type="build")
-
-    depends_on("py-jupyter-packaging@0.7.9:0.7", type="build")
     depends_on("py-jupyterlab@3", type="build")
     depends_on("py-pynpm", type="build")
-    depends_on("py-ipyvue@1.7:1", type=("build", "run"))
+
+    depends_on("py-jupyter-packaging@0.7.9:0.7.12", when="@1.9.0", type="build")
+    depends_on("py-ipyvue@1.7:1", when="@1.9.0", type=("build", "run"))
+
+    depends_on("py-ipyvue@3:", when="@3:", type=("build", "run"))
+    depends_on("py-jupyter-builder@1.0.0:", when="@3:", type=("build", "run"))
+    

--- a/repos/spack_repo/builtin/packages/py_ipyvuetify/package.py
+++ b/repos/spack_repo/builtin/packages/py_ipyvuetify/package.py
@@ -25,7 +25,7 @@ class PyIpyvuetify(PythonPackage):
 
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools@40.8.0:", type="build")
-    depends_on("py-jupyterlab@3", type="build")
+    depends_on("py-jupyterlab@3:", type="build")
     depends_on("py-pynpm", type="build")
 
     depends_on("py-jupyter-packaging@0.7.9:0.7.12", when="@1.9.0", type="build")


### PR DESCRIPTION
This is adding ipyvuetify version 3.0.0

It requires PR #6164 because ipyvuetify 3.0.0 introduces a dependency on jupyter-builder

The sha can be verified from the pypi page : https://pypi.org/project/ipyvuetify/3.0.0/#ipyvuetify-3.0.0.tar.gz

It relies on ipyvue 3 which brings support for Vue 3 which is being added by PR #6179 