### PR TITLE
cairo: Fixed new compilers, old builds

### DIFF
--- a/repos/spack_repo/builtin/packages/cairo/package.py
+++ b/repos/spack_repo/builtin/packages/cairo/package.py
@@ -110,6 +110,7 @@ class Cairo(AutotoolsPackage, MesonPackage):
     depends_on("freetype", when="+ft")
     depends_on("libpng", when="+png")
     depends_on("glib")
+    depends_on("pixman@0.30.0:")
     depends_on("pixman@0.36.0:", when="@1.17.2:")
     depends_on("fontconfig@2.10.91:", when="+fc")
 
@@ -145,6 +146,14 @@ class Cairo(AutotoolsPackage, MesonPackage):
     # Don't regenerate docs to avoid a dependency on gtk-doc
     patch("disable-gtk-docs.patch", when="build_system=autotools")
 
+    def flag_handler(self, name, flags):
+        # gcc@15: defaults to -std=gnu23, causing errors with "typedef int bool;"
+        if name == "cflags" and self.spec.satisfies(
+            "build_system=autotools %gcc@15:"
+        ):
+            flags.append("-std=gnu17")
+        return (flags, None, None)
+
 
 class MesonBuilder(meson.MesonBuilder):
     def enable_or_disable(self, feature_name, variant=None):
@@ -171,6 +180,9 @@ class MesonBuilder(meson.MesonBuilder):
             self.enable_or_disable("glib", variant="gobject"),
             "-Dspectre=disabled",
             "-Dsymbol-lookup=disabled",
+            # test/ and perf/ are never installed, and perf/meson.build probes for a
+            # system gtk+-2.0 regardless of -Dgtk2-utils, which fails to link when ~X
+            "-Dtests=disabled",
         ]
         return args
 

--- a/repos/spack_repo/builtin/packages/cairo/package.py
+++ b/repos/spack_repo/builtin/packages/cairo/package.py
@@ -148,9 +148,7 @@ class Cairo(AutotoolsPackage, MesonPackage):
 
     def flag_handler(self, name, flags):
         # gcc@15: defaults to -std=gnu23, causing errors with "typedef int bool;"
-        if name == "cflags" and self.spec.satisfies(
-            "build_system=autotools %gcc@15:"
-        ):
+        if name == "cflags" and self.spec.satisfies("build_system=autotools %gcc@15:"):
             flags.append("-std=gnu17")
         return (flags, None, None)
 


### PR DESCRIPTION
Got a bit carried away fixing cairo. Started with `cairo~X` still attempting to use libraries when compiling the `test` and `perf` directories. Resolved by just not compiling them (also reduces compilation time a little bit).

From there, installing with newer GCC versions (15:) caused problems with the c standard. I locked to `-std=gnu17`.

Finally, older versions of cairo still appear to require pixman, despite the package originally starting that dependency at `cairo@1.17.2:`. Without pixman, the confirugation step fails. Not too sure how these versions managed to install before, but the additional `depends_on` resolved this for me.

|  | cairo~X@1.18.4 | 1.18.2 | 1.18.0 | 1.17.4 | 1.17.2 | 1.16.0 | 1.14.12 | 1.14.8 | 1.14.0 |
|---|---|---|---|---|---|---|---|---|---|
| **gcc@16.2.0** | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  |
| **15.3.0** | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  |
| **14.4.0** | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  |
| **13.4.0** | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  |
| **12.5.0** | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  |
| **11.5.0** | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  |