### PR TITLE
Make noop jobs timeout faster

### DIFF
--- a/.ci/gitlab/configs/ci.yaml
+++ b/.ci/gitlab/configs/ci.yaml
@@ -128,6 +128,7 @@ ci:
   - noop-job:
       tags: ["service_noop"]
       image: busybox@sha256:37f7b378a29ceb4c551b1b5582e27747b855bbfaa73fa11914fe0df028dc581f
+      timeout: 1 seconds
       variables:
         CI_OIDC_REQUIRED: 0
         GIT_STRATEGY: "none"

--- a/.ci/gitlab/scripts/common/noop_job.py
+++ b/.ci/gitlab/scripts/common/noop_job.py
@@ -24,6 +24,7 @@ noop:
   tags: [service_noop, spack]
   retry: 0
   allow_failure: true
+  timeout: 1 seconds
 workflow:
   rules:
   - when: always


### PR DESCRIPTION
These are not required to pass and do nothing, set a minimal timeout.