### PR TITLE
ICON Subclassing without parsing configure args

### DIFF
--- a/repos/spack_repo/builtin/packages/icon/package.py
+++ b/repos/spack_repo/builtin/packages/icon/package.py
@@ -147,13 +147,9 @@ class Icon(AutotoolsPackage):
     for __x in nvidia_targets.keys():
         depends_on("cuda", when="gpu={0}".format(__x))
 
-    def __init__(self, spec: spack.spec.Spec) -> None:
-        super().__init__()
-        self.single_args: list[str] = []
-        self.flags: dict(str, list[str]) = defaultdict(list)
-
     def set_configure_args(self) -> None:
-        self.single_args.append("--disable-rpaths")
+        self.flags: dict(str, list[str]) = defaultdict(list)
+        self.single_args: list[str] = ["--disable-rpaths"]
         libs = LibraryList([])
 
         for x in [
@@ -313,6 +309,11 @@ class Icon(AutotoolsPackage):
 
         self.flags["LIBS"].append(libs.link_flags)
 
+        self.extend_configure_args()
+
+    def extend_configure_args(self) -> None:
+        """Placeholder for subclasses extending the recipe"""
+        pass
 
     def configure_args(self) -> list[str]:
         # Set configure args

--- a/repos/spack_repo/builtin/packages/icon/package.py
+++ b/repos/spack_repo/builtin/packages/icon/package.py
@@ -312,7 +312,7 @@ class Icon(AutotoolsPackage):
         self.extend_configure_args()
 
     def extend_configure_args(self) -> None:
-        """Placeholder for subclasses extending the recipe"""
+        """Placeholder for subclasses extending the self.args and self.flags"""
         pass
 
     def configure_args(self) -> list[str]:

--- a/repos/spack_repo/builtin/packages/icon/package.py
+++ b/repos/spack_repo/builtin/packages/icon/package.py
@@ -316,10 +316,10 @@ class Icon(AutotoolsPackage):
         # Populate self.single_args and self.flags
         self.set_configure_args()
         self.flags["LIBS"].append(self.config_libs.link_flags)
-        # Remove duplicates while keeping the original order
-        self.single_args = list(dict.fromkeys(self.single_args))
+        # De-duplicate
+        self.single_args = list(dedupe(self.single_args))
         for key, values in self.flags.items():
-            self.flags[key] = list(dict.fromkeys(values))
+            self.flags[key] = list(dedupe(values))
         # Return final list
         return [
             *chain(

--- a/repos/spack_repo/builtin/packages/icon/package.py
+++ b/repos/spack_repo/builtin/packages/icon/package.py
@@ -310,7 +310,7 @@ class Icon(AutotoolsPackage):
         self.flags["LIBS"].append(libs.link_flags)
 
     def extend_configure_args(self) -> None:
-        """Placeholder for subclasses extending the self.args and self.flags"""
+        """Placeholder for subclasses extending self.args and self.flags"""
         pass
 
     def configure_args(self) -> list[str]:

--- a/repos/spack_repo/builtin/packages/icon/package.py
+++ b/repos/spack_repo/builtin/packages/icon/package.py
@@ -147,9 +147,13 @@ class Icon(AutotoolsPackage):
     for __x in nvidia_targets.keys():
         depends_on("cuda", when="gpu={0}".format(__x))
 
+    def __init__(self, spec: spack.spec.Spec) -> None:
+        super().__init__(spec)
+        self.single_args: list[str] = []
+        self.flags: dict(str, list[str]) = defaultdict(list)
+
     def set_configure_args(self) -> None:
-        self.flags: defaultdict[str, list[str]] = defaultdict(list)
-        self.single_args: list[str] = ["--disable-rpaths"]
+        self.single_args.append("--disable-rpaths")
         libs = LibraryList([])
 
         for x in [
@@ -309,18 +313,13 @@ class Icon(AutotoolsPackage):
 
         self.flags["LIBS"].append(libs.link_flags)
 
-    def extend_configure_args(self) -> None:
-        """Placeholder for subclasses extending self.args and self.flags"""
-        pass
-
     def configure_args(self) -> list[str]:
         # Populate self.single_args and self.flags
         self.set_configure_args()
-        self.extend_configure_args()
-        # Remove duplicates
-        self.single_args = list(set(self.single_args))
+        # Remove duplicates while keeping the original order
+        self.single_args = list(dict.fromkeys(self.single_args))
         for key, values in self.flags.items():
-            self.flags[key] = list(set(values))
+            self.flags[key] = list(dict.fromkeys(values))
         # Return final list
         return [
             *chain(

--- a/repos/spack_repo/builtin/packages/icon/package.py
+++ b/repos/spack_repo/builtin/packages/icon/package.py
@@ -152,10 +152,10 @@ class Icon(AutotoolsPackage):
         super().__init__(spec)
         self.single_args: list[str] = []
         self.flags: dict(str, list[str]) = defaultdict(list)
+        self.libs: LibraryList = LibraryList([])
 
     def set_configure_args(self) -> None:
         self.single_args.append("--disable-rpaths")
-        libs = LibraryList([])
 
         for x in [
             "atmo",
@@ -182,13 +182,13 @@ class Icon(AutotoolsPackage):
 
         if self.spec.satisfies("+art"):
             self.single_args.append("--enable-art")
-            libs += self.spec["libxml2"].libs
+            self.libs += self.spec["libxml2"].libs
         else:
             self.single_args.append("--disable-art")
 
         if self.spec.satisfies("+coupling"):
             self.single_args.append("--enable-coupling")
-            libs += self.spec["libfyaml"].libs
+            self.libs += self.spec["libfyaml"].libs
         else:
             self.single_args.append("--disable-coupling")
 
@@ -202,18 +202,18 @@ class Icon(AutotoolsPackage):
                     "SB2PP={0}".format(self.spec["serialbox"].pp_ser),
                 ]
             )
-            libs += self.spec["serialbox:fortran"].libs
+            self.libs += self.spec["serialbox:fortran"].libs
 
         if self.spec.satisfies("+grib2"):
             self.single_args.append("--enable-grib2")
-            libs += self.spec["eccodes:c"].libs
+            self.libs += self.spec["eccodes:c"].libs
         else:
             self.single_args.append("--disable-grib2")
 
-        libs += self.spec["lapack:fortran"].libs
-        libs += self.spec["blas:fortran"].libs
-        libs += self.spec["netcdf-fortran"].libs
-        libs += self.spec["netcdf-c"].libs
+        self.libs += self.spec["lapack:fortran"].libs
+        self.libs += self.spec["blas:fortran"].libs
+        self.libs += self.spec["netcdf-fortran"].libs
+        self.libs += self.spec["netcdf-c"].libs
 
         if self.spec.satisfies("+mpi"):
             self.single_args.extend(
@@ -239,7 +239,7 @@ class Icon(AutotoolsPackage):
                 "-arch=sm_{0}".format(self.nvidia_targets[gpu]),
                 "-ccbin={0}".format(spack_cxx),
             ]
-            libs += self.spec["cuda"].libs
+            self.libs += self.spec["cuda"].libs
         else:
             self.single_args.append("--disable-gpu")
 
@@ -312,11 +312,10 @@ class Icon(AutotoolsPackage):
             self.flags["CFLAGS"].extend(["-g", "-O2"])
             self.flags["FCFLAGS"].extend(["-g", "-O2"])
 
-        self.flags["LIBS"].append(libs.link_flags)
-
     def configure_args(self) -> list[str]:
         # Populate self.single_args and self.flags
         self.set_configure_args()
+        self.flags["LIBS"].append(libs.link_flags)
         # Remove duplicates while keeping the original order
         self.single_args = list(dict.fromkeys(self.single_args))
         for key, values in self.flags.items():

--- a/repos/spack_repo/builtin/packages/icon/package.py
+++ b/repos/spack_repo/builtin/packages/icon/package.py
@@ -9,6 +9,7 @@ from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 
 from spack.package import *
+from spack.spec import Spec
 
 
 class Icon(AutotoolsPackage):
@@ -147,7 +148,7 @@ class Icon(AutotoolsPackage):
     for __x in nvidia_targets.keys():
         depends_on("cuda", when="gpu={0}".format(__x))
 
-    def __init__(self, spec: spack.spec.Spec) -> None:
+    def __init__(self, spec: Spec) -> None:
         super().__init__(spec)
         self.single_args: list[str] = []
         self.flags: dict(str, list[str]) = defaultdict(list)

--- a/repos/spack_repo/builtin/packages/icon/package.py
+++ b/repos/spack_repo/builtin/packages/icon/package.py
@@ -314,7 +314,7 @@ class Icon(AutotoolsPackage):
         pass
 
     def configure_args(self) -> list[str]:
-        # Populate configure self.single_args and self.flags
+        # Populate self.single_args and self.flags
         self.set_configure_args()
         self.extend_configure_args()
         # Remove duplicates

--- a/repos/spack_repo/builtin/packages/icon/package.py
+++ b/repos/spack_repo/builtin/packages/icon/package.py
@@ -314,7 +314,7 @@ class Icon(AutotoolsPackage):
         pass
 
     def configure_args(self) -> list[str]:
-        # Set configure args
+        # Populate configure self.single_args and self.flags
         self.set_configure_args()
         self.extend_configure_args()
         # Remove duplicates

--- a/repos/spack_repo/builtin/packages/icon/package.py
+++ b/repos/spack_repo/builtin/packages/icon/package.py
@@ -148,7 +148,7 @@ class Icon(AutotoolsPackage):
         depends_on("cuda", when="gpu={0}".format(__x))
 
     def set_configure_args(self) -> None:
-        self.flags: dict(str, list[str]) = defaultdict(list)
+        self.flags: defaultdict[str, list[str]] = defaultdict(list)
         self.single_args: list[str] = ["--disable-rpaths"]
         libs = LibraryList([])
 

--- a/repos/spack_repo/builtin/packages/icon/package.py
+++ b/repos/spack_repo/builtin/packages/icon/package.py
@@ -309,8 +309,6 @@ class Icon(AutotoolsPackage):
 
         self.flags["LIBS"].append(libs.link_flags)
 
-        self.extend_configure_args()
-
     def extend_configure_args(self) -> None:
         """Placeholder for subclasses extending the self.args and self.flags"""
         pass
@@ -318,6 +316,7 @@ class Icon(AutotoolsPackage):
     def configure_args(self) -> list[str]:
         # Set configure args
         self.set_configure_args()
+        self.extend_configure_args()
         # Remove duplicates
         self.single_args = list(set(self.single_args))
         for key, values in self.flags.items():

--- a/repos/spack_repo/builtin/packages/icon/package.py
+++ b/repos/spack_repo/builtin/packages/icon/package.py
@@ -152,7 +152,7 @@ class Icon(AutotoolsPackage):
         super().__init__(spec)
         self.single_args: list[str] = []
         self.flags: dict(str, list[str]) = defaultdict(list)
-        self.libs: LibraryList = LibraryList([])
+        self.config_libs: LibraryList = LibraryList([])
 
     def set_configure_args(self) -> None:
         self.single_args.append("--disable-rpaths")
@@ -182,13 +182,13 @@ class Icon(AutotoolsPackage):
 
         if self.spec.satisfies("+art"):
             self.single_args.append("--enable-art")
-            self.libs += self.spec["libxml2"].libs
+            self.config_libs += self.spec["libxml2"].libs
         else:
             self.single_args.append("--disable-art")
 
         if self.spec.satisfies("+coupling"):
             self.single_args.append("--enable-coupling")
-            self.libs += self.spec["libfyaml"].libs
+            self.config_libs += self.spec["libfyaml"].libs
         else:
             self.single_args.append("--disable-coupling")
 
@@ -202,18 +202,18 @@ class Icon(AutotoolsPackage):
                     "SB2PP={0}".format(self.spec["serialbox"].pp_ser),
                 ]
             )
-            self.libs += self.spec["serialbox:fortran"].libs
+            self.config_libs += self.spec["serialbox:fortran"].libs
 
         if self.spec.satisfies("+grib2"):
             self.single_args.append("--enable-grib2")
-            self.libs += self.spec["eccodes:c"].libs
+            self.config_libs += self.spec["eccodes:c"].libs
         else:
             self.single_args.append("--disable-grib2")
 
-        self.libs += self.spec["lapack:fortran"].libs
-        self.libs += self.spec["blas:fortran"].libs
-        self.libs += self.spec["netcdf-fortran"].libs
-        self.libs += self.spec["netcdf-c"].libs
+        self.config_libs += self.spec["lapack:fortran"].libs
+        self.config_libs += self.spec["blas:fortran"].libs
+        self.config_libs += self.spec["netcdf-fortran"].libs
+        self.config_libs += self.spec["netcdf-c"].libs
 
         if self.spec.satisfies("+mpi"):
             self.single_args.extend(
@@ -239,7 +239,7 @@ class Icon(AutotoolsPackage):
                 "-arch=sm_{0}".format(self.nvidia_targets[gpu]),
                 "-ccbin={0}".format(spack_cxx),
             ]
-            self.libs += self.spec["cuda"].libs
+            self.config_libs += self.spec["cuda"].libs
         else:
             self.single_args.append("--disable-gpu")
 

--- a/repos/spack_repo/builtin/packages/icon/package.py
+++ b/repos/spack_repo/builtin/packages/icon/package.py
@@ -148,6 +148,28 @@ class Icon(AutotoolsPackage):
     for __x in nvidia_targets.keys():
         depends_on("cuda", when="gpu={0}".format(__x))
 
+    EN_DIS_ABLE_FLAGS = (
+        "atmo",
+        "les",
+        "upatmo",
+        "ocean",
+        "jsbach",
+        "waves",
+        "aes",
+        "nwp",
+        "ecrad",
+        "rte-rrtmgp",
+        "openmp",
+        "mpi-gpu",
+        "parallel-netcdf",
+        "cdi-pio",
+        "yaxt",
+        "mixed-precision",
+        "single-precision",
+        "single-precision-ecrad",
+        "comin",
+    )
+
     def __init__(self, spec: Spec) -> None:
         super().__init__(spec)
         self.single_args: list[str] = []
@@ -157,27 +179,7 @@ class Icon(AutotoolsPackage):
     def set_configure_args(self) -> None:
         self.single_args.append("--disable-rpaths")
 
-        for x in [
-            "atmo",
-            "les",
-            "upatmo",
-            "ocean",
-            "jsbach",
-            "waves",
-            "aes",
-            "nwp",
-            "ecrad",
-            "rte-rrtmgp",
-            "openmp",
-            "mpi-gpu",
-            "parallel-netcdf",
-            "cdi-pio",
-            "yaxt",
-            "mixed-precision",
-            "single-precision",
-            "single-precision-ecrad",
-            "comin",
-        ]:
+        for x in self.EN_DIS_ABLE_FLAGS:
             self.single_args.extend(self.enable_or_disable(x))
 
         if self.spec.satisfies("+art"):

--- a/repos/spack_repo/builtin/packages/icon/package.py
+++ b/repos/spack_repo/builtin/packages/icon/package.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from collections import defaultdict
+from itertools import chain
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
@@ -146,9 +147,13 @@ class Icon(AutotoolsPackage):
     for __x in nvidia_targets.keys():
         depends_on("cuda", when="gpu={0}".format(__x))
 
-    def configure_args(self):
-        args = ["--disable-rpaths"]
-        flags = defaultdict(list)
+    def __init__(self, spec: spack.spec.Spec) -> None:
+        super().__init__()
+        self.single_args: list[str] = []
+        self.flags: dict(str, list[str]) = defaultdict(list)
+
+    def set_configure_args(self) -> None:
+        self.args = ["--disable-rpaths"]
         libs = LibraryList([])
 
         for x in [
@@ -172,25 +177,25 @@ class Icon(AutotoolsPackage):
             "single-precision-ecrad",
             "comin",
         ]:
-            args += self.enable_or_disable(x)
+            self.single_args.extend(self.enable_or_disable(x))
 
         if self.spec.satisfies("+art"):
-            args.append("--enable-art")
+            self.single_args.append("--enable-art")
             libs += self.spec["libxml2"].libs
         else:
-            args.append("--disable-art")
+            self.single_args.append("--disable-art")
 
         if self.spec.satisfies("+coupling"):
-            args.append("--enable-coupling")
+            self.single_args.append("--enable-coupling")
             libs += self.spec["libfyaml"].libs
         else:
-            args.append("--disable-coupling")
+            self.single_args.append("--disable-coupling")
 
         serialization = self.spec.variants["serialization"].value
         if serialization == "none":
-            args.append("--disable-serialization")
+            self.single_args.append("--disable-serialization")
         else:
-            args.extend(
+            self.single_args.extend(
                 [
                     "--enable-serialization={0}".format(serialization),
                     "SB2PP={0}".format(self.spec["serialbox"].pp_ser),
@@ -199,10 +204,10 @@ class Icon(AutotoolsPackage):
             libs += self.spec["serialbox:fortran"].libs
 
         if self.spec.satisfies("+grib2"):
-            args.append("--enable-grib2")
+            self.single_args.append("--enable-grib2")
             libs += self.spec["eccodes:c"].libs
         else:
-            args.append("--disable-grib2")
+            self.single_args.append("--disable-grib2")
 
         libs += self.spec["lapack:fortran"].libs
         libs += self.spec["blas:fortran"].libs
@@ -210,7 +215,7 @@ class Icon(AutotoolsPackage):
         libs += self.spec["netcdf-c"].libs
 
         if self.spec.satisfies("+mpi"):
-            args.extend(
+            self.single_args.extend(
                 [
                     "--enable-mpi",
                     # We cannot provide a universal value for MPI_LAUNCH, therefore we have to
@@ -221,13 +226,13 @@ class Icon(AutotoolsPackage):
                 ]
             )
         else:
-            args.append("--disable-mpi")
+            self.single_args.append("--disable-mpi")
 
         gpu = self.spec.variants["gpu"].value
 
         if gpu in self.nvidia_targets:
-            args.append("--enable-gpu=openacc+cuda")
-            flags["CUDAFLAGS"] = [
+            self.single_args.append("--enable-gpu=openacc+cuda")
+            self.flags["CUDAFLAGS"] = [
                 "-g",
                 "-O3",
                 "-arch=sm_{0}".format(self.nvidia_targets[gpu]),
@@ -235,31 +240,31 @@ class Icon(AutotoolsPackage):
             ]
             libs += self.spec["cuda"].libs
         else:
-            args.append("--disable-gpu")
+            self.single_args.append("--disable-gpu")
 
         if gpu in self.nvidia_targets or self.spec.satisfies("+comin"):
-            flags["ICON_LDFLAGS"].extend(self.compiler.stdcxx_libs)
+            self.flags["ICON_LDFLAGS"].extend(self.compiler.stdcxx_libs)
 
         if self.compiler.name == "gcc":
-            flags["CFLAGS"].append("-g")
-            flags["ICON_CFLAGS"].append("-O3")
-            flags["ICON_BUNDLED_CFLAGS"].append("-O2")
-            flags["FCFLAGS"].append("-g")
-            flags["ICON_FCFLAGS"].append("-O2")
+            self.flags["CFLAGS"].append("-g")
+            self.flags["ICON_CFLAGS"].append("-O3")
+            self.flags["ICON_BUNDLED_CFLAGS"].append("-O2")
+            self.flags["FCFLAGS"].append("-g")
+            self.flags["ICON_FCFLAGS"].append("-O2")
             if self.spec.satisfies("+ocean"):
-                flags["ICON_OCEAN_FCFLAGS"].extend(["-O3", "-fno-tree-loop-vectorize"])
-                args.extend(
+                self.flags["ICON_OCEAN_FCFLAGS"].extend(["-O3", "-fno-tree-loop-vectorize"])
+                self.single_args.extend(
                     ["--enable-fcgroup-OCEAN", "ICON_OCEAN_PATH=src/hamocc:src/ocean:src/sea_ice"]
                 )
 
         elif self.compiler.name in ["intel", "oneapi"]:
-            args.append("--enable-intel-consistency")
+            self.single_args.append("--enable-intel-consistency")
 
-            flags["CFLAGS"].extend(["-g", "-ftz", "-fma", "-ip", "-qno-opt-dynamic-align"])
-            flags["ICON_CFLAGS"].append("-O3")
-            flags["ICON_BUNDLED_CFLAGS"].append("-O2")
-            flags["FCFLAGS"].extend(["-g", "-fp-model source"])
-            flags["ICON_FCFLAGS"].extend(
+            self.flags["CFLAGS"].extend(["-g", "-ftz", "-fma", "-ip", "-qno-opt-dynamic-align"])
+            self.flags["ICON_CFLAGS"].append("-O3")
+            self.flags["ICON_BUNDLED_CFLAGS"].append("-O2")
+            self.flags["FCFLAGS"].extend(["-g", "-fp-model source"])
+            self.flags["ICON_FCFLAGS"].extend(
                 [
                     "-O3",
                     "-ftz",
@@ -272,41 +277,57 @@ class Icon(AutotoolsPackage):
             )
 
             if self.spec.satisfies("+coupling%oneapi"):
-                flags["ICON_YAC_CFLAGS"].extend(["-O2", "-fp-model precise"])
+                self.flags["ICON_YAC_CFLAGS"].extend(["-O2", "-fp-model precise"])
 
             if self.spec.satisfies("+ocean"):
-                flags["ICON_OCEAN_FCFLAGS"].extend(
+                self.flags["ICON_OCEAN_FCFLAGS"].extend(
                     ["-O3", "-assume norealloc_lhs", "-reentrancy threaded"]
                 )
-                args.extend(
+                self.single_args.extend(
                     ["--enable-fcgroup-OCEAN", "ICON_OCEAN_PATH=src/hamocc:src/ocean:src/sea_ice"]
                 )
 
                 if self.spec.satisfies("+openmp"):
-                    flags["ICON_OCEAN_FCFLAGS"].extend(["-DOCE_SOLVE_OMP"])
+                    self.flags["ICON_OCEAN_FCFLAGS"].extend(["-DOCE_SOLVE_OMP"])
 
             if self.spec.satisfies("+ecrad"):
-                flags["ICON_ECRAD_FCFLAGS"].extend(["-qno-opt-dynamic-align", "-no-fma", "-fpe0"])
+                self.flags["ICON_ECRAD_FCFLAGS"].extend(["-qno-opt-dynamic-align", "-no-fma", "-fpe0"])
 
         elif self.compiler.name == "nvhpc":
-            flags["CFLAGS"].extend(["-g", "-O2"])
-            flags["FCFLAGS"].extend(
+            self.flags["CFLAGS"].extend(["-g", "-O2"])
+            self.flags["FCFLAGS"].extend(
                 ["-g", "-O2", "-Mrecursive", "-Mallocatable=03", "-Mstack_arrays"]
             )
 
             if gpu in self.nvidia_targets:
-                flags["FCFLAGS"].extend(
+                self.flags["FCFLAGS"].extend(
                     ["-acc=gpu", "-gpu=cc{0}".format(self.nvidia_targets[gpu])]
                 )
 
             if self.spec.satisfies("+coupling%nvhpc@:23.9"):
-                args.append("yac_cv_fc_is_contiguous_works=yes")
+                self.single_args.append("yac_cv_fc_is_contiguous_works=yes")
 
         else:
-            flags["CFLAGS"].extend(["-g", "-O2"])
-            flags["FCFLAGS"].extend(["-g", "-O2"])
+            self.flags["CFLAGS"].extend(["-g", "-O2"])
+            self.flags["FCFLAGS"].extend(["-g", "-O2"])
 
-        args.extend(["{0}={1}".format(name, " ".join(value)) for name, value in flags.items()])
-        args.append("LIBS={0}".format(libs.link_flags))
+        self.flags["LIBS"].append(libs.link_flags)
 
-        return args
+
+    def configure_args(self) -> list[str]:
+        # Set configure args
+        self.set_configure_args()
+        # Remove duplicates
+        self.single_args = list(set(self.single_args))
+        for key, values in self.flags.items():
+            self.flags[key] = list(set(values))
+        # Return final list
+        return [
+            *chain(
+                self.single_args,
+                (
+                    "{0}={1}".format(name, " ".join(values))
+                    for name, values in self.flags.items()
+                ),
+            )
+        ]

--- a/repos/spack_repo/builtin/packages/icon/package.py
+++ b/repos/spack_repo/builtin/packages/icon/package.py
@@ -315,7 +315,7 @@ class Icon(AutotoolsPackage):
     def configure_args(self) -> list[str]:
         # Populate self.single_args and self.flags
         self.set_configure_args()
-        self.flags["LIBS"].append(libs.link_flags)
+        self.flags["LIBS"].append(self.config_libs.link_flags)
         # Remove duplicates while keeping the original order
         self.single_args = list(dict.fromkeys(self.single_args))
         for key, values in self.flags.items():

--- a/repos/spack_repo/builtin/packages/icon/package.py
+++ b/repos/spack_repo/builtin/packages/icon/package.py
@@ -153,7 +153,7 @@ class Icon(AutotoolsPackage):
         self.flags: dict(str, list[str]) = defaultdict(list)
 
     def set_configure_args(self) -> None:
-        self.args = ["--disable-rpaths"]
+        self.single_args.append("--disable-rpaths")
         libs = LibraryList([])
 
         for x in [


### PR DESCRIPTION
In order to make extending the ICON package recipe easier, we suggest the following:

- Store the variants to be en-or-disabled in the `EN_DIS_ABLE_FLAGS` class variable.
- Create 3 new attributes, `single_args`, `flags` and `config_libs` to host configure args.
- Populate them in the new `set_configure_args` method.
- `configure_args` becomes a small method that concatenate the content of these 3 attributes in the final `list[str]`.

Doing this would greatly improve the subclassing experience of the ICON package recipe like it is done [here](https://github.com/C2SM/spack-c2sm/blob/main/repos/spack_repo/c2sm/packages/icon_nwp/package.py) where parsing of the configure args is necessary. With this PR, we could modify `self.single_args` and `self.flags` where we need, e.g. with
```python
    def set_configure_args(self) -> None:
        super().set_configure_args()
        # Modify self.single_args, self.flags and self.config_libs
```
or
```python
    @run_before("configure")
    def extend_configure_args(self) -> None:
        # Modify self.single_args, self.flags and self.config_libs
```
Also extending  `EN_DIS_ABLE_FLAGS`  would help by keeping the logic in the parent class.