### PR TITLE
py-dotmatch: Add 0.2.2

### DIFF
--- a/repos/spack_repo/builtin/packages/py_dotmatch/package.py
+++ b/repos/spack_repo/builtin/packages/py_dotmatch/package.py
@@ -1,0 +1,22 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyDotmatch(PythonPackage):
+    """Known-target short-DNA assignment from FASTQ."""
+
+    homepage = "https://github.com/dnncha/dotmatch"
+    pypi = "dotmatch/dotmatch-0.2.2.tar.gz"
+
+    license("Apache-2.0")
+
+    version("0.2.2", sha256="c441aaafb6b29db51560d3fc68c52a8ad01ed0f08158a89544c1d9366f12fce8")
+
+    depends_on("python@3.9:", type=("build", "run"))
+    depends_on("py-setuptools@77:", type="build")
+    depends_on("py-tomli", when="^python@:3.10", type="run")


### PR DESCRIPTION
## Description
Add DotMatch 0.2.2, a known-target short-DNA assignment tool for FASTQ and other short-DNA target sets.

## Checks
- PyPI sdist URL and SHA256 verified against the published archive.
- Package module loads with Spack 1.3.0.dev0 package API.
- `python3 -m py_compile repos/spack_repo/builtin/packages/py_dotmatch/package.py`
- `git diff --check`

## Dependencies
- Python 3.9 or newer
- setuptools 77 or newer for the PEP 517 build
- tomli at runtime for Python 3.10 and older

This adds a distribution route only; package downloads or user adoption are not claimed by this PR.