### PR TITLE
pandora*: add v5.*

### DIFF
--- a/repos/spack_repo/builtin/packages/pandoramonitoring/package.py
+++ b/repos/spack_repo/builtin/packages/pandoramonitoring/package.py
@@ -21,14 +21,16 @@ class Pandoramonitoring(CMakePackage):
     maintainers("jmcarcell", "wdconinc")
 
     version("master", branch="master")
+    version("5.0.0", sha256="5e0ae85eae9ed4b04018104ab920c4259c6f17a582fd105ff75e85e34ff43ecc")
     version("4.0.3", sha256="00830b83b99e6da9e9f70b4bfeaebca2a1af6a10fb6dbf8324bc6e9d6f1224e2")
     version("3.7.0", sha256="3d0ba671bdf9ed408ac410c054e67ad93d46cd8690113f1fd34ab133a1658467")
     version("3.6.3", sha256="c6859c60b75bf467dcee983085a2613921872aabf914769d4701a0d2ee68bf97")
     version("3.6.0", sha256="5fc9574faa3e90d96e5d2a27dea46b55f844499cf21e39060acb1e4c080dec77")
     version("3.5.0", sha256="274562abb7c797194634d5460a56227444a1de07a240c88ae35ca806abcbaf60")
 
-    depends_on("c", type="build")
+    depends_on("c", type="build", when="@:4")
     depends_on("cxx", type="build")
+    depends_on("cmake@3.20:", type="build", when="@5:")
 
     depends_on("root@6.18.04: +geom +opengl +x")
     depends_on("pandorasdk")

--- a/repos/spack_repo/builtin/packages/pandorapfa/package.py
+++ b/repos/spack_repo/builtin/packages/pandorapfa/package.py
@@ -22,6 +22,8 @@ class Pandorapfa(Package):
     maintainers("jmcarcell", "wdconinc")
 
     version("master", branch="master")
+    version("5.3.0", sha256="87d5af118cff21ced26ad5338da5ce09ce55e0795d3fe8beb30c7e6ae81245d6")
+    version("4.20.0", sha256="a04ac3c5519ae12ad91f19641ebf8e58bf978d510c199044597a1a624e6ce4c9")
     version("4.17.4", sha256="c8c35258cb447372ddb17b8647b4a7ce912e74ee9b0cbad470daadf669888393")
     version("4.16.3", sha256="68b149449fcc5b1c21567092cdebc723c2c150cd2d73689453a081fb05619f36")
     version("4.15.2", sha256="ed52c05e70452548ca97015ea255437698c9b97637c2da6a7d452bc2d16b980b")

--- a/repos/spack_repo/builtin/packages/pandorasdk/package.py
+++ b/repos/spack_repo/builtin/packages/pandorasdk/package.py
@@ -20,6 +20,8 @@ class Pandorasdk(CMakePackage):
     maintainers("jmcarcell", "wdconinc")
 
     version("master", branch="master")
+    version("5.0.0", sha256="d4f57bd5d9aa8a2a588816fc1da2b78e0704405b48674ae18d597d99769c0142")
+    version("4.1.0", sha256="30f544c7f8981f40e7544e004db8d67bd2399a3c067a4010da3b012182c6fd25")
     version("4.0.2", sha256="9c8e051dbfd3be711dc7940658b78558277e2ec1c6305c0f7c7bb271abd3e4a8")
     version("3.4.3", sha256="7590cfa27df47dce99c6fecf4a178f1bb1fa025aaf7d7da9c6176787f66a04be")
     version("3.4.2", sha256="e076adb2e3d28d3ac5dcc06bcc6e96815d23ef7782e1a87842b1e3e96e194994")
@@ -34,10 +36,12 @@ class Pandorasdk(CMakePackage):
         description="Use the specified C++ standard when building.",
     )
 
-    depends_on("c", type="build")
+    depends_on("c", type="build", when="@:4")
     depends_on("cxx", type="build")
+    depends_on("cmake@3.20:", type="build", when="@5:")
 
     depends_on("pandorapfa")
+    depends_on("pandorapfa@5:", when="@5:")
 
     def cmake_args(self):
         args = [


### PR DESCRIPTION
This PR adds `pandora*` package updates to v5.*. The main change is the requirement of a more modern CMake (i.e. not 2.8 anymore...).

Test builds:
```
-- linux-ubuntu26.04-skylake / %c,cxx=clang@23.0.0 --------------
wfe2iuy pandorasdk@5.0.0~ipo build_system=cmake build_type=Release cxxstd=17 generator=make
```

I didn't actually try the `c` limits but the CMakeLists.txt now has only CXX as language.

These packages will be built in CI.