### PR TITLE
linbox: new package

### DIFF
--- a/repos/spack_repo/builtin/packages/givaro/package.py
+++ b/repos/spack_repo/builtin/packages/givaro/package.py
@@ -33,3 +33,6 @@ class Givaro(AutotoolsPackage):
     depends_on("m4", type="build")
 
     depends_on("gmp")
+
+    def configure_args(self):
+        return [f"--with-gmp={self.spec['gmp'].prefix}"]

--- a/repos/spack_repo/builtin/packages/linbox/package.py
+++ b/repos/spack_repo/builtin/packages/linbox/package.py
@@ -1,0 +1,46 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+
+from spack.package import *
+
+
+class Linbox(AutotoolsPackage):
+    """LinBox is a C++ template library for exact, high-performance linear
+    algebra computation with dense, sparse, and structured matrices over
+    the integers and over finite fields."""
+
+    homepage = "https://linalg.org/"
+    url = "https://github.com/linbox-team/linbox/releases/download/v1.7.1/linbox-1.7.1.tar.gz"
+
+    maintainers("d-torrance")
+
+    license("LGPL-2.1-or-later", checked_by="d-torrance")
+
+    version("1.7.1", sha256="a2b5f910a54a46fa75b03f38ad603cae1afa973c95455813d85cf72c27553bd8")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("pkgconfig", type="build")
+
+    depends_on("fflas-ffpack")
+    depends_on("givaro")
+
+    variant("flint", default=False, description="Enable FLINT support")
+    depends_on("flint", when="+flint")
+
+    variant("fplll", default=False, description="Enable fpLLL support")
+    depends_on("fplll", when="+fplll")
+    depends_on("mpfr", when="+fplll")
+
+    variant("ntl", default=False, description="Enable NTL support")
+    depends_on("ntl", when="+ntl")
+
+    def configure_args(self):
+        args = []
+        for var in ["flint", "fplll", "ntl"]:
+            args += self.with_or_without(var, activation_value="prefix")
+        args += self.with_or_without("mpfr", variant="fplll", activation_value="prefix")
+        return args


### PR DESCRIPTION
We add [linbox](https://linalg.org/), a C++ library for exact computation algebra.

We also make a small update to givaro, one of linbox's dependencies, so that the correct gmp flags end up in givaro's pkg-config file.