### PR TITLE
macaulay2: drop -lquadmath from FLIBS hack

### DIFF
--- a/repos/spack_repo/builtin/packages/macaulay2/package.py
+++ b/repos/spack_repo/builtin/packages/macaulay2/package.py
@@ -86,7 +86,7 @@ class Macaulay2(AutotoolsPackage):
 
     def configure_args(self) -> List[str]:
         # workaround for https://github.com/Macaulay2/M2/issues/4074
-        flibs = "-lgfortran -lm -lquadmath"
+        flibs = "-lgfortran -lm"
 
         return [
             "--with-system-libs",


### PR DESCRIPTION
It was causing linking errors on ARM machines, where libquadmath isn't available.  It was really only there because we needed something nonempty to avoid `AC_FC_LIBRARY_LDFLAGS` trying to generate them (resulting in https://github.com/Macaulay2/M2/issues/4074), and `-lquadmath` was there on x86_64.  The build works just fine without it.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
