### PR TITLE
r-gensa: Added 1.1.15. Improved compilation compatability with R and GCC

### DIFF
--- a/repos/spack_repo/builtin/packages/r_gensa/package.py
+++ b/repos/spack_repo/builtin/packages/r_gensa/package.py
@@ -15,6 +15,7 @@ class RGensa(RPackage):
 
     cran = "GenSA"
 
+    version("1.1.15", sha256="68970dc3b463986b5b7130acbd42a5ae5a85835d004fb54f81b3ef5c2fccf925")
     version("1.1.14", sha256="66e455bb0e66d3c04af84d9dddc9b89f40b4cf9fe9ad1cf0714bcf30aa1b6837")
     version("1.1.8", sha256="375e87541eb6b098584afccab361dc28ff09d03cf1d062ff970208e294eca216")
     version("1.1.7", sha256="9d99d3d0a4b7770c3c3a6de44206811272d78ab94481713a8c369f7d6ae7b80f")
@@ -23,3 +24,19 @@ class RGensa(RPackage):
     depends_on("cxx", type="build")  # generated
 
     depends_on("r@2.12.0:", type=("build", "run"))
+    # Rf_allocLang() was only added in r@4.4.1.
+    depends_on("r@4.4.1:", type=("build", "run"), when="@1.1.15:")
+
+    # Versions <= 1.1.14 use SET_TYPEOF, which was removed from Rinternals.h in r@4.6.0
+    conflicts("r@4.6:", when="@:1.1.14")
+
+    def patch(self):
+        if self.spec.satisfies("@:1.1.8 ^r@4.4.0:"):
+            # Utils.h relied on transitively including R_ext/BLAS.h from R_ext/Applic.h
+            # r@4.4.0 removed this, so patch in BLAS.h header to allow for compilation
+            with working_dir("src"):
+                filter_file(
+                    r"#include <R_ext/Applic.h>",
+                    "#include <R_ext/Applic.h>\n#include <R_ext/BLAS.h>",
+                    "Utils.h",
+                )

--- a/repos/spack_repo/builtin/packages/r_gensa/package.py
+++ b/repos/spack_repo/builtin/packages/r_gensa/package.py
@@ -26,8 +26,9 @@ class RGensa(RPackage):
     depends_on("r@2.12.0:", type=("build", "run"))
     # Rf_allocLang() was only added in r@4.4.1.
     depends_on("r@4.4.1:", type=("build", "run"), when="@1.1.15:")
+
     # Versions <= 1.1.14 use SET_TYPEOF, which was removed from Rinternals.h in r@4.6.0
-    depends_on("r@4.6:", type=("build", "run"), when="@1.1.15:")
+    conflicts("r@4.6:", when="@:1.1.14")
 
     def patch(self):
         if self.spec.satisfies("@:1.1.8 ^r@4.4.0:"):

--- a/repos/spack_repo/builtin/packages/r_gensa/package.py
+++ b/repos/spack_repo/builtin/packages/r_gensa/package.py
@@ -26,9 +26,8 @@ class RGensa(RPackage):
     depends_on("r@2.12.0:", type=("build", "run"))
     # Rf_allocLang() was only added in r@4.4.1.
     depends_on("r@4.4.1:", type=("build", "run"), when="@1.1.15:")
-
     # Versions <= 1.1.14 use SET_TYPEOF, which was removed from Rinternals.h in r@4.6.0
-    conflicts("r@4.6:", when="@:1.1.14")
+    depends_on("r@4.6:", type=("build", "run"), when="@1.1.15:")
 
     def patch(self):
         if self.spec.satisfies("@:1.1.8 ^r@4.4.0:"):


### PR DESCRIPTION
Bumps the version to 1.1.15 which improves compatibility with newer R versions as well as newer versions of GCC.

Also added a patch for older r-densa versions (1.1.8 and 1.1.7) that are compiled with r@4.4.0: that no longer transitively include R_ext/BLAS.h

  | | r-gensa@=1.1.15 | r-gensa@=1.1.14 | r-gensa@=1.1.8 | r-gensa@=1.1.7 |
  |---|---|---|---|---|
  | r@=4.6.1 %gcc@=15.3.0 | ✅ | UnsatisfiableSpecError | UnsatisfiableSpecError | UnsatisfiableSpecError |
  | r@=4.6.1 %gcc@=13.4.0 | ✅ | UnsatisfiableSpecError | UnsatisfiableSpecError | UnsatisfiableSpecError |
  | r@=4.6.1 %gcc@=12.2.0 | ✅ | UnsatisfiableSpecError | UnsatisfiableSpecError | UnsatisfiableSpecError |
  | r@=4.6.1 %gcc@=9.5.0 | ✅ | UnsatisfiableSpecError | UnsatisfiableSpecError | UnsatisfiableSpecError |
  | r@=4.5.3 %gcc@=15.3.0 | ✅ | ✅ | ✅ | ✅ |
  | r@=4.5.3 %gcc@=13.4.0 | ✅ | ✅ | ✅ | ✅ |
  | r@=4.5.3 %gcc@=12.2.0 | ✅ | ✅ | ✅ | ✅ |
  | r@=4.5.3 %gcc@=9.5.0 | ✅ | ✅ | ✅ | ✅ |
  | r@=4.4.3 %gcc@=15.3.0 | ✅ | ✅ | ✅ | ✅ |
  | r@=4.4.3 %gcc@=13.4.0 | ✅ | ✅ | ✅ | ✅ |
  | r@=4.4.3 %gcc@=12.2.0 | ✅ | ✅ | ✅ | ✅ |
  | r@=4.4.3 %gcc@=9.5.0 | ✅ | ✅ | ✅ | ✅ |
  | r@=4.3.3 %gcc@=15.3.0 | UnsatisfiableSpecError | UnsatisfiableSpecError | UnsatisfiableSpecError | UnsatisfiableSpecError |
  | r@=4.3.3 %gcc@=13.4.0 | UnsatisfiableSpecError | ✅ | ✅ | ✅ |
  | r@=4.3.3 %gcc@=12.2.0 | UnsatisfiableSpecError | ✅ | ✅ | ✅ |
  | r@=4.3.3 %gcc@=9.5.0 | UnsatisfiableSpecError | ✅ | ✅ | ✅ |

Mentioning @w8jcik as they're working on R compatibility in #5998