### PR TITLE
acts: pass root variant to examples

### DIFF
--- a/repos/spack_repo/builtin/packages/acts/package.py
+++ b/repos/spack_repo/builtin/packages/acts/package.py
@@ -336,6 +336,7 @@ class Acts(CMakePackage, CudaPackage):
             plugin_cmake_variant("PODIO", "podio"),
             example_cmake_variant("PYTHIA8", "pythia8"),
             example_cmake_variant("PYTHON_BINDINGS", "python"),
+            example_cmake_variant("ROOT", "root"),
             self.define_from_variant("ACTS_CUSTOM_SCALARTYPE", "scalar"),
             plugin_cmake_variant("ACTSVG", "svg"),
             plugin_cmake_variant("TGEO", "root"),


### PR DESCRIPTION
This PR fixes `acts` to pass the `root` variant to the examples, e.g. https://github.com/acts-project/acts/blob/3676c466c414dbd83777a83b93f7d34635b65f7f/Examples/Io/CMakeLists.txt#L8.