### PR TITLE
octave: fix opengl/fltk boolean-logic bug and missing gl/glu deps for +qt

### DIFF
--- a/repos/spack_repo/builtin/packages/octave/package.py
+++ b/repos/spack_repo/builtin/packages/octave/package.py
@@ -336,11 +336,12 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
         else:
             config_args.append("--disable-java")
 
-        # NOTE: the original condition here was ,
-        # which Python parses as  -- the
-        # non-empty string literal "~opengl" is always truthy, so this always
-        # reduced to just , silently adding --without-opengl
-        # any time ~fltk was set, regardless of +opengl/+qt actually being on.
+        # The original condition here was the string "~opengl" ANDed with
+        # the membership test "~fltk" in spec, which Python parses as
+        # bool("~opengl") and ("~fltk" in spec) -- the non-empty string
+        # literal is always truthy, so the check silently collapsed to just
+        # "~fltk" in spec, adding --without-opengl whenever ~fltk was set
+        # regardless of +opengl or +qt actually being active.
         if "~opengl" in spec and "~fltk" in spec and "~qt" in spec:
             config_args.extend(["--without-opengl", "--without-framework-opengl"])
         # TODO:  opengl dependency and package is missing?

--- a/repos/spack_repo/builtin/packages/octave/package.py
+++ b/repos/spack_repo/builtin/packages/octave/package.py
@@ -122,6 +122,15 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
     depends_on("llvm", when="+llvm")
     depends_on("gl", when="+opengl")
     depends_on("gl", when="+fltk")
+    # octave's own GUI code (libgui/graphics/gl-select.cc) calls the GL
+    # API directly, but this dependency was missing when +qt is active
+    # without +opengl/+fltk, so the build never had mesa's include/lib
+    # paths and failed with undeclared GL symbols.
+    depends_on("gl", when="+qt")
+    # configure only defines HAVE_OPENGL (and runs the -lGL link check)
+    # if both GL/gl.h AND GL/glu.h are found -- GLU is not part of the
+    # system's opengl package on many distros, so build it via Spack too.
+    depends_on("glu", when="+qt")
     depends_on("qhull", when="+qhull")
     depends_on("qrupdate", when="+qrupdate")
     depends_on("qscintilla", when="+qscintilla")
@@ -327,7 +336,12 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
         else:
             config_args.append("--disable-java")
 
-        if "~opengl" and "~fltk" in spec:
+        # NOTE: the original condition here was ,
+        # which Python parses as  -- the
+        # non-empty string literal "~opengl" is always truthy, so this always
+        # reduced to just , silently adding --without-opengl
+        # any time ~fltk was set, regardless of +opengl/+qt actually being on.
+        if "~opengl" in spec and "~fltk" in spec and "~qt" in spec:
             config_args.extend(["--without-opengl", "--without-framework-opengl"])
         # TODO:  opengl dependency and package is missing?
 

--- a/repos/spack_repo/builtin/packages/octave/package.py
+++ b/repos/spack_repo/builtin/packages/octave/package.py
@@ -122,19 +122,21 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
     depends_on("llvm", when="+llvm")
     depends_on("gl", when="+opengl")
     depends_on("gl", when="+fltk")
-    # octave's own GUI code (libgui/graphics/gl-select.cc) calls the GL
-    # API directly, but this dependency was missing when +qt is active
-    # without +opengl/+fltk, so the build never had mesa's include/lib
-    # paths and failed with undeclared GL symbols.
-    depends_on("gl", when="+qt")
-    # configure only defines HAVE_OPENGL (and runs the -lGL link check)
-    # if both GL/gl.h AND GL/glu.h are found -- GLU is not part of the
-    # system's opengl package on many distros, so build it via Spack too.
-    depends_on("glu", when="+qt")
     depends_on("qhull", when="+qhull")
     depends_on("qrupdate", when="+qrupdate")
     depends_on("qscintilla", when="+qscintilla")
     depends_on("qt+opengl", when="+qt")
+    # 6/8 (softadm): fix ya validado en el store viejo -- octave's own
+    # GUI code (libgui/graphics/gl-select.cc) llama la API de GL
+    # directamente, pero esta dependencia faltaba cuando +qt esta
+    # activo sin +opengl/+fltk, asi que el build nunca tenia los
+    # include/lib paths de mesa y fallaba con simbolos GL sin declarar.
+    depends_on("gl", when="+qt")
+    # 6/8 (softadm): configure solo define HAVE_OPENGL (y corre el
+    # chequeo de link -lGL) si se encuentran GL/gl.h Y GL/glu.h -- GLU
+    # no es parte del external opengl del sistema (libglu1-mesa-dev no
+    # esta instalado), asi que lo buildeamos via spack en cambio.
+    depends_on("glu", when="+qt")
     depends_on("suite-sparse", when="+suitesparse")
     depends_on("zlib-api", when="+zlib")
 
@@ -336,13 +338,10 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
         else:
             config_args.append("--disable-java")
 
-        # The original condition here was the string "~opengl" ANDed with
-        # the membership test "~fltk" in spec, which Python parses as
-        # bool("~opengl") and ("~fltk" in spec) -- the non-empty string
-        # literal is always truthy, so the check silently collapsed to just
-        # "~fltk" in spec, adding --without-opengl whenever ~fltk was set
-        # regardless of +opengl or +qt actually being active.
-        if "~opengl" in spec and "~fltk" in spec and "~qt" in spec:
+        # --without-opengl only makes sense when opengl, fltk, and qt are
+        # all disabled (qt+opengl forces GL regardless via the depends_on
+        # above).
+        if spec.satisfies("~opengl~fltk~qt"):
             config_args.extend(["--without-opengl", "--without-framework-opengl"])
         # TODO:  opengl dependency and package is missing?
 

--- a/repos/spack_repo/builtin/packages/octave/package.py
+++ b/repos/spack_repo/builtin/packages/octave/package.py
@@ -126,16 +126,7 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
     depends_on("qrupdate", when="+qrupdate")
     depends_on("qscintilla", when="+qscintilla")
     depends_on("qt+opengl", when="+qt")
-    # 6/8 (softadm): fix ya validado en el store viejo -- octave's own
-    # GUI code (libgui/graphics/gl-select.cc) llama la API de GL
-    # directamente, pero esta dependencia faltaba cuando +qt esta
-    # activo sin +opengl/+fltk, asi que el build nunca tenia los
-    # include/lib paths de mesa y fallaba con simbolos GL sin declarar.
     depends_on("gl", when="+qt")
-    # 6/8 (softadm): configure solo define HAVE_OPENGL (y corre el
-    # chequeo de link -lGL) si se encuentran GL/gl.h Y GL/glu.h -- GLU
-    # no es parte del external opengl del sistema (libglu1-mesa-dev no
-    # esta instalado), asi que lo buildeamos via spack en cambio.
     depends_on("glu", when="+qt")
     depends_on("suite-sparse", when="+suitesparse")
     depends_on("zlib-api", when="+zlib")


### PR DESCRIPTION
## Problem

`octave`'s configure-args logic for `--without-opengl` has a boolean-logic bug:

```python
if "~opengl" and "~fltk" in spec:
    config_args.extend(["--without-opengl", "--without-framework-opengl"])
```

Python parses this as `bool("~opengl") and ("~fltk" in spec)`. `"~opengl"` is a
non-empty string literal, always truthy, so the check silently collapses to just
`"~fltk" in spec` -- `--without-opengl` gets added any time `~fltk` is set,
regardless of whether `+opengl` (or `+qt`, which pulls in `qt+opengl`) is
actually active.

Separately, `+qt` alone (without `+opengl`/`+fltk`) has no `depends_on` on
`gl`/`glu`. octave's own GUI code (`libgui/graphics/gl-select.cc`) calls the
GL API directly, so without these deps the build has no GL/GLU include/lib
paths and fails with undeclared GL symbols, even though `qt+opengl` is already
a transitive dependency.

## Fix

- Correct the condition to `"~opengl" in spec and "~fltk" in spec and "~qt" in spec`.
- Add `depends_on("gl", when="+qt")` and `depends_on("glu", when="+qt")`.

## Testing

Building `octave+qt` (no `+fltk`) previously failed with undeclared GL symbols
in `gl-select.cc`; with `gl`/`glu` deps added and the corrected condition
(so `--without-opengl` is no longer wrongly injected), it builds and links
successfully. Verified on our own AOCC/GCC14 HPC stack (Spack 1.2.2) before
upstreaming.
