### PR TITLE
hpl: neutralize nvblas false-positive in BLAS auto-probe

### DIFF
--- a/repos/spack_repo/builtin/packages/hpl/package.py
+++ b/repos/spack_repo/builtin/packages/hpl/package.py
@@ -122,6 +122,19 @@ class Hpl(AutotoolsPackage):
 
     @when("@2.3:")
     def configure_args(self):
+        # configure's BLAS auto-probe tries a fixed, ordered list of
+        # candidates (libs1..libs9, ending with NVIDIA nvblas at libs9)
+        # before falling back to our explicit libs10 override below. If
+        # any dependency in the spec pulls in a CUDA-enabled library that
+        # happens to make nvblas reachable on the linker search path (e.g.
+        # a CUDA-enabled MPI), the libs9 candidate silently "wins" the
+        # probe before libs10 is ever tried, even though hpl itself has no
+        # CUDA dependency and nvblas does not provide the Fortran BLAS
+        # symbols configure/hpl actually link against (idamax_, dgemv_,
+        # etc.), producing undefined-symbol link errors. Neutralize the
+        # libs9 candidate so the probe always falls through to libs10,
+        # which is set from the real, Spack-selected BLAS provider above.
+        filter_file(r"^libs9=.*", "libs9=", "configure")
         filter_file(r"^libs10=.*", "libs10=%s" % self.spec["blas"].libs.ld_flags, "configure")
 
         cflags, ldflags = ["-O3", "-DHPL_PROGRESS_REPORT", "-DHPL_DETAILED_TIMING"], []


### PR DESCRIPTION
## Problem

`hpl@2.3:`'s `configure` runs a fixed, ordered BLAS auto-probe (`libs1`
through `libs9`, the last of which is NVIDIA's `nvblas`) before the recipe's
own explicit override at `libs10` (set from the Spack-selected `blas`
provider) ever gets a chance.

If anything else in the concretized spec makes `nvblas` reachable on the
linker's search path -- for example a CUDA-enabled MPI used only for
inter-node comms, with no CUDA dependency on `hpl` itself -- the `libs9`
candidate "wins" the probe before `libs10` is tried. `nvblas` doesn't provide
the Fortran BLAS symbols `hpl`/`configure` actually link against (`idamax_`,
`dgemv_`, etc.), so the build fails with undefined-reference link errors that
have nothing to do with the real, intended BLAS provider.

## Fix

Blank out the `libs9` candidate line before the existing `libs10` override,
so the probe always falls through to the real, Spack-selected BLAS.

## Testing

Reproduced on our HPC stack: `hpl ^openmpi+cuda ^amdblis` (no CUDA on `hpl`
itself) failed to link with undefined `idamax_`/`dgemv_`/etc. against
`nvblas`; with the `libs9` neutralized, the build links against `amdblis` as
intended and the resulting binary runs a full HPL benchmark to completion.
