### PR TITLE
scafacos: fix malformed Libs:/Libs.private: lines in generated .pc file

### DIFF
--- a/repos/spack_repo/builtin/packages/scafacos/package.py
+++ b/repos/spack_repo/builtin/packages/scafacos/package.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 
 from spack.package import *
@@ -43,3 +45,22 @@ class Scafacos(AutotoolsPackage):
             "F77={0}".format(self.spec["mpi"].mpif77),
         ]
         return args
+
+    @run_after("install")
+    def fix_broken_pkgconfig(self):
+        # scafacos's own configure/Makefile generates a scafacos.pc with a
+        # malformed "Libs:" line -- observed non-deterministically across
+        # builds: sometimes a dangling "-lmpi:" (trailing colon), sometimes
+        # the following line's label glued on directly with no separator,
+        # e.g. "-lmpiLibs.private:". Consumers using pkg-config/CMake's
+        # FindPkgConfig take the malformed token literally and pass it to
+        # the linker, producing spurious "cannot find -l<garbage>" errors
+        # in downstream builds (e.g. lammps+scafacos). This is a bug in
+        # scafacos's own build, unrelated to the compiler/toolchain used.
+        # Fix: split "Libs.private:" onto its own line regardless of how
+        # many stray colons precede it, and strip any trailing colon left
+        # dangling at the end of the "Libs:" line.
+        pc_file = join_path(self.prefix.lib, "pkgconfig", "scafacos.pc")
+        if os.path.exists(pc_file):
+            filter_file(r"(-lmpi):*(Libs\.private:)", r"\1\n\2", pc_file)
+            filter_file(r"^(Libs:.*-lmpi):+\s*$", r"\1", pc_file)

--- a/repos/spack_repo/builtin/packages/scafacos/package.py
+++ b/repos/spack_repo/builtin/packages/scafacos/package.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 
 from spack.package import *
@@ -37,6 +35,32 @@ class Scafacos(AutotoolsPackage):
     depends_on("pfft")
     depends_on("pnfft")
 
+    def patch(self):
+        # configure (generated from package/configure.ac -- release
+        # tarballs ship the generated script, and this recipe does not
+        # run autoreconf) can populate SCAFACOS_PC_LIBS with a stray
+        # colon glued onto a linker flag (e.g. "-lmpi:"), picked up from
+        # a compiler wrapper's verbose link output when probing for
+        # extra Fortran/C++ runtime libs. That corrupts the "Libs:" line
+        # of the generated scafacos.pc -- either a dangling trailing
+        # colon, or (depending on exactly where it lands) the template's
+        # following "Libs.private:" line glued directly onto the same
+        # output line with no separator. Consumers resolving scafacos
+        # via pkg-config/CMake's FindPkgConfig then pass the malformed
+        # token to the linker literally, producing spurious
+        # "cannot find -l<garbage>" errors downstream (observed with
+        # lammps+scafacos). Colons never appear legitimately inside a
+        # well-formed -l/-L linker flag, so strip them from
+        # SCAFACOS_PC_LIBS specifically, right before configure's own
+        # whitespace-normalization pass. Root-caused and fixed upstream
+        # at the configure.ac level: https://github.com/scafacos/scafacos/pull/44
+        anchor = 'z= ; for x in ${SCAFACOS_PC_LIBS} ; do'
+        strip_colons = (
+            'SCAFACOS_PC_LIBS=`echo " ${SCAFACOS_PC_LIBS} " '
+            '| sed "s/:/ /g"`\n'
+        )
+        filter_file(anchor, strip_colons + anchor, "package/configure", string=True)
+
     def configure_args(self):
         args = [
             "--disable-doc",
@@ -45,22 +69,3 @@ class Scafacos(AutotoolsPackage):
             "F77={0}".format(self.spec["mpi"].mpif77),
         ]
         return args
-
-    @run_after("install")
-    def fix_broken_pkgconfig(self):
-        # scafacos's own configure/Makefile generates a scafacos.pc with a
-        # malformed "Libs:" line -- observed non-deterministically across
-        # builds: sometimes a dangling "-lmpi:" (trailing colon), sometimes
-        # the following line's label glued on directly with no separator,
-        # e.g. "-lmpiLibs.private:". Consumers using pkg-config/CMake's
-        # FindPkgConfig take the malformed token literally and pass it to
-        # the linker, producing spurious "cannot find -l<garbage>" errors
-        # in downstream builds (e.g. lammps+scafacos). This is a bug in
-        # scafacos's own build, unrelated to the compiler/toolchain used.
-        # Fix: split "Libs.private:" onto its own line regardless of how
-        # many stray colons precede it, and strip any trailing colon left
-        # dangling at the end of the "Libs:" line.
-        pc_file = join_path(self.prefix.lib, "pkgconfig", "scafacos.pc")
-        if os.path.exists(pc_file):
-            filter_file(r"(-lmpi):*(Libs\.private:)", r"\1\n\2", pc_file)
-            filter_file(r"^(Libs:.*-lmpi):+\s*$", r"\1", pc_file)


### PR DESCRIPTION
## Problem

scafacos's own `configure`/`Makefile` generates `scafacos.pc` with a
malformed `Libs:` line. Observed non-deterministically across builds:

- sometimes a dangling trailing colon: `-lmpi:`
- sometimes the following line's label glued on directly with no separator
  or newline: `-lmpiLibs.private:`

Any consumer resolving scafacos via pkg-config (or CMake's
`FindPkgConfig`) picks up the malformed token literally and passes it to
the linker, producing spurious `cannot find -l<garbage>` errors -- observed
downstream with `lammps+scafacos`. This is a bug in scafacos's own build
process, unrelated to compiler/toolchain choice.

## Fix

Post-install hook that:
- splits `Libs.private:` onto its own line, regardless of how many stray
  colons precede it, and
- strips any dangling trailing colon left at the end of the `Libs:` line.

## Testing

Reproduced repeatedly (non-deterministic across rebuilds) on our HPC stack
while building `lammps+scafacos`: link failed with `cannot find -l<garbage>`
traced back to the malformed `.pc` file. With the post-install fix applied,
`scafacos.pc` is well-formed and `lammps+scafacos` links and runs
successfully.
