### PR TITLE
gnuplot: fix build under clang/aocc (ld.lld rejects --copy-dt-needed-entries)

### DIFF
--- a/repos/spack_repo/builtin/packages/gnuplot/package.py
+++ b/repos/spack_repo/builtin/packages/gnuplot/package.py
@@ -82,6 +82,21 @@ class Gnuplot(AutotoolsPackage):
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("%gcc@7:"):
             env.set("LDFLAGS", "-Wl,--copy-dt-needed-entries")
+        # ld.lld (used by clang/aocc toolchains) does not support
+        # --copy-dt-needed-entries at all ("unknown argument"), which
+        # breaks even the most basic configure check ("C compiler cannot
+        # create executables"). Unlike GNU ld, lld does not resolve
+        # symbols through transitive shared-library dependencies, which is
+        # what --copy-dt-needed-entries works around for GNU ld in the
+        # first place (hence "undefined symbol: libiconv_open" without
+        # it). The real fix for lld is to link -liconv explicitly rather
+        # than try to imitate the GNU ld flag.
+        if self.spec.satisfies("%clang") or self.spec.satisfies("%aocc"):
+            iconv_prefix = self.spec["iconv"].prefix
+            env.append_flags(
+                "LDFLAGS", "-L{0} -Wl,-rpath,{0}".format(iconv_prefix.lib)
+            )
+            env.append_flags("LIBS", "-liconv")
 
     def configure_args(self):
         # see https://github.com/Homebrew/homebrew-core/blob/master/Formula/gnuplot.rb


### PR DESCRIPTION
## Problem

The existing `%gcc@7:` branch sets `LDFLAGS=-Wl,--copy-dt-needed-entries` to
work around GNU ld not resolving symbols through transitive shared-library
dependencies (`undefined symbol: libiconv_open` otherwise).

`ld.lld` (the default/common linker for clang-based toolchains, including
AOCC) does not support `--copy-dt-needed-entries` **at all** -- it errors
with "unknown argument", which breaks even the most basic `configure` check
("C compiler cannot create executables"), so the build never gets anywhere
near the actual iconv symbol issue.

`lld`'s handling of transitive shared-library dependencies is different from
GNU ld's, so imitating the GNU ld flag isn't the right fix under `lld`
anyway -- the correct fix is to link `-liconv` explicitly.

## Fix

Under `%clang`/`%aocc`, link against the `iconv` virtual's prefix explicitly
(`-L`, `-Wl,-rpath`, `-liconv`) instead of the GNU-ld-specific flag.

## Testing

Validated concretely with `%aocc` (AOCC 5.0.0, `ld.lld`) on our HPC stack:
before the fix, `configure` failed at the earliest compiler-sanity check;
after, gnuplot configures, builds, and links successfully. Gated on
`%clang` as well since AOCC is clang-based and the root cause (`lld`'s
symbol-resolution behavior, not anything AOCC-specific) applies to any
clang+lld combination -- we haven't separately validated a plain
`%clang` build, but the fix is a no-op-safe explicit link addition even
where `lld` isn't in use.
