### PR TITLE
grace: fix Motif detection on Xpm-bundled builds + GCC14 strictness

### DIFF
--- a/repos/spack_repo/builtin/packages/grace/package.py
+++ b/repos/spack_repo/builtin/packages/grace/package.py
@@ -32,6 +32,15 @@ class Grace(AutotoolsPackage):
     depends_on("libice")
     depends_on("libsm")
     depends_on("motif")
+    # Some Motif builds (e.g. 2.3.8) compile Xpm support INTO libXm.so
+    # rather than as a separate libXpm, but grace's configure explicitly
+    # probes for "-lXpm" as a standalone library ("checking for
+    # XpmCreatePixmapFromData in -lXpm... no" -> reported as "M*tif has
+    # not been found", which is misleading since the real problem has
+    # nothing to do with Motif itself). libxpm (standalone, X.Org)
+    # provides that symbol regardless of how the system/vendor Motif was
+    # built.
+    depends_on("libxpm")
     depends_on("jpeg")
     depends_on("libpng")
     depends_on("fftw@2.0:2")
@@ -53,6 +62,48 @@ class Grace(AutotoolsPackage):
             "char CurFontName[4096];",
             "T1lib/type1/fontfcn.c",
             string=True,
+        )
+
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        # With libxpm linked, the link check itself passes ("checking for
+        # XpmCreatePixmapFromData in -lXpm... yes"), but configure also
+        # probes for the bare header "xpm.h" (not "X11/xpm.h", which is
+        # where libxpm actually installs it -- standard X.Org convention).
+        # Without the bare header, the final combined check ("a Motif >=
+        # 1002 compatible API") still fails even though the link works.
+        env.append_flags("CPPFLAGS", "-I{0}".format(self.spec["libxpm"].prefix.include.X11))
+        # The include for motif should be injected automatically via the
+        # normal depends_on-based compiler wrapper, but in practice that
+        # was not enough to make "Xm/XmAll.h" resolve during configure.
+        # Add it explicitly, same pattern as libxpm above, rather than
+        # rely on auto-injection always working.
+        env.append_flags("CPPFLAGS", "-I{0}".format(self.spec["motif"].prefix.include))
+        # The final "a Motif >= 1002 compatible API" check is not just a
+        # compile check -- it uses ac_fn_c_try_run, which COMPILES AND
+        # RUNS a test binary calling XmVersion/XmRegisterConverters
+        # (Xm/XmAll.h) during configure itself. At that point the final
+        # RPATH has not been applied yet (that only happens at the real
+        # link/install step), so the dynamic linker can't find
+        # libXm.so/libXpm.so and the test binary fails to start --
+        # autoconf then reports "Motif not found" even though compiling
+        # and linking both succeeded. Make the libraries findable at
+        # configure time via LD_LIBRARY_PATH.
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["motif"].prefix.lib)
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["libxpm"].prefix.lib)
+        # Newer GCC (13/14) treats several patterns that used to be mere
+        # warnings as hard errors by default: implicit function
+        # declarations (e.g. exit() used without <stdlib.h> -- including
+        # in the autoconf-generated conftest.c for the check above, which
+        # otherwise fails to even compile), K&R-style function
+        # definitions without explicit parameter types (Xbae/Draw.c,
+        # legal C89, now -Wimplicit-int), and implicit int/pointer
+        # conversions. Downgrade these back to warnings so the build can
+        # proceed as it always has on older GCC.
+        env.append_flags(
+            "CFLAGS",
+            "-Wno-error=implicit-function-declaration "
+            "-Wno-error=implicit-int "
+            "-Wno-error=int-conversion",
         )
 
     def configure_args(self):

--- a/repos/spack_repo/builtin/packages/grace/package.py
+++ b/repos/spack_repo/builtin/packages/grace/package.py
@@ -90,7 +90,7 @@ class Grace(AutotoolsPackage):
         # configure time via LD_LIBRARY_PATH.
         env.prepend_path("LD_LIBRARY_PATH", self.spec["motif"].prefix.lib)
         env.prepend_path("LD_LIBRARY_PATH", self.spec["libxpm"].prefix.lib)
-        # Newer GCC (13/14) treats several patterns that used to be mere
+        # Newer GCC (14+) treats several patterns that used to be mere
         # warnings as hard errors by default: implicit function
         # declarations (e.g. exit() used without <stdlib.h> -- including
         # in the autoconf-generated conftest.c for the check above, which

--- a/repos/spack_repo/builtin/packages/grace/package.py
+++ b/repos/spack_repo/builtin/packages/grace/package.py
@@ -99,12 +99,13 @@ class Grace(AutotoolsPackage):
         # legal C89, now -Wimplicit-int), and implicit int/pointer
         # conversions. Downgrade these back to warnings so the build can
         # proceed as it always has on older GCC.
-        env.append_flags(
-            "CFLAGS",
-            "-Wno-error=implicit-function-declaration "
-            "-Wno-error=implicit-int "
-            "-Wno-error=int-conversion",
-        )
+        if self.spec.satisfies("%gcc@14:"):
+            env.append_flags(
+                "CFLAGS",
+                "-Wno-error=implicit-function-declaration "
+                "-Wno-error=implicit-int "
+                "-Wno-error=int-conversion",
+            )
 
     def configure_args(self):
         args = []


### PR DESCRIPTION
Several independent issues found while packaging grace against a modern
Motif + GCC 13/14 toolchain -- all reproduced concretely, not speculative.

## 1. Missing libxpm dependency

Some Motif builds (e.g. 2.3.8) compile Xpm support directly into `libXm.so`
rather than shipping a separate `libXpm`. grace's `configure` explicitly
probes for a standalone `-lXpm` ("checking for `XpmCreatePixmapFromData` in
`-lXpm`... no"), and reports this as **"M\*tif has not been found"** --
misleading, since the real gap has nothing to do with Motif itself.
`libxpm` (standalone, X.Org) provides that symbol regardless of how the
system/vendor Motif was built.

## 2. Missing bare `xpm.h` include path

Even with libxpm linked, `configure` also probes for a bare `"xpm.h"` (not
`"X11/xpm.h"`, which is where libxpm actually installs it -- standard X.Org
convention). Without the bare header on the include path, the final
combined "a Motif >= 1002 compatible API" check still fails despite the
link succeeding.

## 3. motif include not reliably auto-injected

`"Xm/XmAll.h: No such file or directory"` -- motif's include path should
come for free via the normal `depends_on`-driven compiler wrapper, but in
practice that wasn't sufficient. Added explicitly, same pattern as (2).

## 4. Motif-API check runs a test binary before RPATH is applied

The final "a Motif >= 1002 compatible API" check isn't just a compile
check -- it uses `ac_fn_c_try_run`, which **compiles and runs** a test
binary (calling `XmVersion`/`XmRegisterConverters`) during `configure`
itself. At that point Spack's final RPATH hasn't been applied yet (that
only happens at the real link/install step), so the dynamic linker can't
find `libXm.so`/`libXpm.so`, the test binary fails to start, and autoconf
reports "Motif not found" even though compiling and linking both actually
succeeded. Fixed by prepending both libraries' lib dirs to
`LD_LIBRARY_PATH` for the duration of the build.

## 5. GCC 13/14 strictness

Newer GCC makes several old-C patterns hard errors by default: implicit
function declarations (`exit()` used without `<stdlib.h>` -- including in
the autoconf-generated `conftest.c` for the check in (4), which then fails
to even compile), K&R-style function definitions without explicit
parameter types (`Xbae/Draw.c`, legal C89), and implicit int/pointer
conversions. Downgraded back to warnings via `CFLAGS`.

## Testing

All five issues were hit in sequence while bringing grace up on an
AOCC/GCC14 HPC stack (Motif 2.3.8, GCC 14.2.0); each fix was isolated by
reverting it individually and confirming the corresponding failure mode
reappeared. With all five applied, grace configures, builds, links, and
`gracebat -version` runs correctly reporting Motif support.
