### PR TITLE
r-backports: add v1.5.1

### DIFF
--- a/repos/spack_repo/builtin/packages/r_backports/package.py
+++ b/repos/spack_repo/builtin/packages/r_backports/package.py
@@ -35,7 +35,7 @@ class RBackports(RPackage):
 
     depends_on("r@3.0.0:", type=("build", "run"))
 
-    # Versions <= 1.5.0 call the removed-from-public-API findVar() in
-    # dotsElt.c/dotsLength.c/dotsNames.c, which r@4.6.0 gated behind
-    # ENABLE_LEGACY_NONAPI_FUNS. 1.5.1 switched to the new R_Dots* API.
-    conflicts("r@4.6:", when="@:1.5.0")
+#    # Versions <= 1.5.0 call the removed-from-public-API findVar() in
+#    # dotsElt.c/dotsLength.c/dotsNames.c, which r@4.6.0 gated behind
+#    # ENABLE_LEGACY_NONAPI. 1.5.1 switched to the new R_Dots* API.
+#    conflicts("r@4.6:", when="@:1.5.0")

--- a/repos/spack_repo/builtin/packages/r_backports/package.py
+++ b/repos/spack_repo/builtin/packages/r_backports/package.py
@@ -21,6 +21,7 @@ class RBackports(RPackage):
 
     license("GPL-2.0-only OR GPL-3.0-only")
 
+    version("1.5.1", sha256="b8eeeabe3c27e1486f43e0b18dae57f0e870dd7c6979d3668df76bf0d4735bad")
     version("1.5.0", sha256="0d3ed9db8f1505e88967f48d669b2a257e0c6b7e6320ea64b946c1bd40897ca2")
     version("1.4.1", sha256="845c3c59fbb05e5a892c4231b955a0afdd331d82b7cc815bcff0672023242474")
     version("1.4.0", sha256="e7611565d24a852ad8b08579a7c67ad9121c1bda148bade98c7bec686e8dabbf")
@@ -33,3 +34,8 @@ class RBackports(RPackage):
     depends_on("c", type="build")
 
     depends_on("r@3.0.0:", type=("build", "run"))
+
+    # Versions <= 1.5.0 call the removed-from-public-API findVar() in
+    # dotsElt.c/dotsLength.c/dotsNames.c, which r@4.6.0 gated behind
+    # ENABLE_LEGACY_NONAPI_FUNS. 1.5.1 switched to the new R_Dots* API.
+    conflicts("r@4.6:", when="@:1.5.0")

--- a/repos/spack_repo/builtin/packages/r_backports/package.py
+++ b/repos/spack_repo/builtin/packages/r_backports/package.py
@@ -35,7 +35,7 @@ class RBackports(RPackage):
 
     depends_on("r@3.0.0:", type=("build", "run"))
 
-#    # Versions <= 1.5.0 call the removed-from-public-API findVar() in
-#    # dotsElt.c/dotsLength.c/dotsNames.c, which r@4.6.0 gated behind
-#    # ENABLE_LEGACY_NONAPI. 1.5.1 switched to the new R_Dots* API.
-#    conflicts("r@4.6:", when="@:1.5.0")
+    # Versions <= 1.5.0 call the removed-from-public-API findVar() in
+    # dotsElt.c/dotsLength.c/dotsNames.c, which r@4.6.0 gated behind
+    # ENABLE_LEGACY_NONAPI. 1.5.1 switched to the new R_Dots* API.
+    conflicts("r@4.6:", when="@:1.5.0")

--- a/repos/spack_repo/builtin/packages/r_backports/package.py
+++ b/repos/spack_repo/builtin/packages/r_backports/package.py
@@ -35,7 +35,6 @@ class RBackports(RPackage):
 
     depends_on("r@3.0.0:", type=("build", "run"))
 
-    # Versions <= 1.5.0 call the removed-from-public-API findVar() in
-    # dotsElt.c/dotsLength.c/dotsNames.c, which r@4.6.0 gated behind
-    # ENABLE_LEGACY_NONAPI. 1.5.1 switched to the new R_Dots* API.
-    conflicts("r@4.6:", when="@:1.5.0")
+    # Versions <= 1.5.0 calls the removed-from-public-API findVar()
+    # 1.5.1 switched to the new R_Dots* API.
+    depends_on("r@4.6:", type=("build", "run"), when="@1.5.1:")


### PR DESCRIPTION
| | r-backports@=1.5.1 | =1.5.0 | =1.4.1 | =1.4.0 | =1.2.1 | =1.1.4 | =1.1.3 | =1.1.1 | =1.1.0 |
  |---|---|---|---|---|---|---|---|---|---|
  | r@=4.6.1 %gcc@=15.3.0 | ✅ | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable |
  | r@=4.6.1 %gcc@=13.4.0 | ✅ | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable |
  | r@=4.6.1 %gcc@=12.2.0 | ✅ | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable |
  | r@=4.6.1 %gcc@=9.5.0 | ✅ | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable |
  | r@=4.5.3 %gcc@=15.3.0 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
  | r@=4.5.3 %gcc@=13.4.0 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
  | r@=4.5.3 %gcc@=12.2.0 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
  | r@=4.5.3 %gcc@=9.5.0 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
  | r@=4.4.3 %gcc@=15.3.0 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
  | r@=4.4.3 %gcc@=13.4.0 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
  | r@=4.4.3 %gcc@=12.2.0 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
  | r@=4.4.3 %gcc@=9.5.0 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
  | r@=4.3.3 %gcc@=15.3.0 | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable | Unsatisfiable |
  | r@=4.3.3 %gcc@=13.4.0 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
  | r@=4.3.3 %gcc@=12.2.0 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
  | r@=4.3.3 %gcc@=9.5.0 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |

The "r@=4.3.3 %gcc@=15.3.0" string of Unsatisfiablity comes from R@4.3.3 not compiling with newer GCC versions.

No maintainers, but still mentioning @w8jcik due to their work on R packages.