### PR TITLE
compiler-wrapper: add 1.1.0-build-id prototype version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,211 @@
+# Spack packages v2026.06.0
+
+The v2026.06.0 release of the spack packages is released along with version 1.2 of
+the Spack tool. This release brings new packages and package version updates
+and deprecations that are not made available via backports to previous releases.
+
+## Spack version compatibility
+
+This release continues to use the v2.2 Package API. This is the Package API
+version introduced by the Spack v1.0.0 release. Any Spack version 1.0.0 or newer
+is compatible with this release of the packages repo.
+
+This release was tested against Spack v1.2.0 (63943396d634faa92cb59474df3558ec9b9b2425).
+The stack environments used to generate the binary caches use new features 
+that are part of the Spack 1.2 release. The binary caches themselves are
+compatible with any Spack v1.0.0 or newer (any Spack that supports the v3
+URL build cache layout).
+
+See the [Package API
+Documentation](https://spack.readthedocs.io/en/latest/package_api.html)
+for full details on package versioning and compatibility.
+
+## Package statistics
+
+There are now 8917 packages in the spack-packages builtin repo. This
+is up from 8752 in the previous release.
+
+## New and removed packages
+
+This release contains a number of deprecations to address CVEs in a number
+of projects.
+
+In addition to new deprecations, all package versions deprecated prior to
+the v2026.03 release have been removed with a few exceptions.
+
+### New packages
+
+*  adios-catalyst
+*  apfelxx
+*  aretomo3
+*  cimfomfa
+*  clingo-bootstrap-pgo
+*  coinmp
+*  comet
+*  cosimio
+*  crux-toolkit
+*  cry
+*  dia-umpire-se
+*  dineof
+*  epic
+*  exchcxx
+*  flamegraph
+*  fortuno
+*  g4adept
+*  g4hepem
+*  gau2grid
+*  gauxc
+*  generalbrokenlines
+*  gfan
+*  ghex
+*  gridtools
+*  hammer
+*  helm
+*  hpckit
+*  hwmalloc
+*  hycom
+*  hypredrive
+*  icey
+*  integratorxx
+*  kagen
+*  kynema-driver
+*  kynema-fmb
+*  kynema-sgf
+*  kynema-ugf
+*  lean4
+*  libcifpp
+*  libleidenalg
+*  libmcfp
+*  libsegfault
+*  llhttp
+*  mille
+*  nsjail
+*  nvpl-common
+*  oc
+*  omnictl
+*  oomph
+*  osmosis
+*  partons
+*  partons-elementary-utils
+*  partons-numa
+*  pelican
+*  percolator
+*  pflare
+*  pprof
+*  proteowizard
+*  py-aiowebdav2
+*  py-apprise
+*  py-asgi-lifespan
+*  py-ast-serialize
+*  py-asyncpg
+*  py-bibtexparser
+*  py-clarabel
+*  py-cloudpathlib
+*  py-coolname
+*  py-cuda-core
+*  py-cuda-pathfinder
+*  py-curryreader
+*  py-deepmerge
+*  py-docket
+*  py-elecsolver
+*  py-fakeredis
+*  py-fastobo
+*  py-gest-api
+*  py-h3
+*  py-hdf5plugin
+*  py-heavyball
+*  py-highspy
+*  py-igwn-auth-utils
+*  py-imagecorruptions-imaug
+*  py-imaug
+*  py-jinja2-humanize-extension
+*  py-key-value-aio
+*  py-langchain-core
+*  py-langchain-protocol
+*  py-langgraph
+*  py-langgraph-checkpoint
+*  py-langgraph-prebuilt
+*  py-langgraph-sdk
+*  py-leidenalg
+*  py-logomaker
+*  py-lupa
+*  py-memelite
+*  py-mmengine
+*  py-modisco
+*  py-olmoearth-pretrain-minimal
+*  py-openai-whisper
+*  py-opentelemetry-api
+*  py-opentelemetry-exporter-prometheus
+*  py-opentelemetry-instrumentation
+*  py-opentelemetry-sdk
+*  py-opentelemetry-semantic-conventions
+*  py-ormsgpack
+*  py-pathlib-abc
+*  py-peft
+*  py-pelicanfs
+*  py-pendulum
+*  py-pipcl
+*  py-plaid
+*  py-prefect
+*  py-psims
+*  py-pycgns
+*  py-pyevtk
+*  py-pyfive
+*  py-pylibjpeg-openjpeg
+*  py-pymupdf
+*  py-pymupdf-fonts
+*  py-pynumpress
+*  py-pyrodigal-gv
+*  py-pyrometheus
+*  py-pyspod
+*  py-pyteomics
+*  py-pytest-reportlog
+*  py-pytest-retry
+*  py-python-discovery
+*  py-python-mumps
+*  py-pytokens
+*  py-pywinpty
+*  py-rachis
+*  py-rassumfrassum
+*  py-rfc3987-syntax
+*  py-safe-netrc
+*  py-scitokens
+*  py-smolagents
+*  py-snakemake-storage-plugin-pelican
+*  py-spectrum-utils
+*  py-sphinx-github-changelog
+*  py-tf2onnx
+*  py-timezonefinder
+*  py-uuid-utils
+*  py-uv-build
+*  py-uv-dynamic-versioning
+*  py-webdavclient3
+*  py-whenever
+*  py-zensical
+*  pyrefly
+*  r-bench
+*  r-d3r
+*  r-pepxmltab
+*  r-profmem
+*  r-s7
+*  r-shinyfiletree
+*  rocprofiler-compute-viewer
+*  roounfold
+*  sage
+*  saltfm
+*  sfml
+*  shtns
+*  syclomatic
+*  talosctl
+*  tofu-ls
+*  trng
+*  turbovnc
+*  velero
+
+### Removed packages
+
+*  salt
+
 # Spack packages v2026.03.0
 
 The 2026.03.0 release of the spack packages is released out of phase from

--- a/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
+++ b/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
@@ -1,12 +1,14 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
 import pathlib
 import shutil
 import sys
 
 from spack_repo.builtin.build_systems.generic import Package
 
+import spack.builder
 from spack.package import *
 
 
@@ -40,6 +42,13 @@ class CompilerWrapper(Package):
     if sys.platform != "win32":
         version("1.1.0", sha256="a07b35081d14b0729090bc1e5790a5dda2d5b997e064c62da39a1224ee249b2a")
         version("1.0", sha256="ac876f7600fa6cb0c74ae172ef1c61661aacff03a6befbc7d87e092e2f2233f9")
+        # Prototype: pulls in --build-id/-Wl,--build-id injection ahead of an official release.
+        version(
+            "1.1.0-build-id",
+            git="https://github.com/SebastianPaucar/compiler-wrapper.git",
+            commit="6db88149277190ae93e40f90d3550ebf937ce056",
+        )
+
     else:
         version("1.0")
         has_code = False
@@ -228,6 +237,23 @@ class CompilerWrapper(Package):
         if extra_rpaths:
             extra_rpaths = dedupe(extra_rpaths)
             env.set("SPACK_COMPILER_EXTRA_RPATHS", ":".join(extra_rpaths))
+
+        # Set SPACK_PREFIX_MAP and SPACK_BUILD_PREFIX_MAP, so
+        # the source tree and and the out-of-source build directory
+        # are remapped to . and ./build respectively
+        staging_src = dependent_spec.package.stage.source_path
+        env.set("SPACK_PREFIX_MAP", staging_src)
+
+        try:
+            builder = spack.builder.create(dependent_spec.package)
+            build_dir = getattr(builder, "build_directory", None)
+        except Exception:
+            build_dir = None
+
+        if build_dir and os.path.isabs(build_dir):
+            env.set("SPACK_BUILD_PREFIX_MAP", build_dir)
+        else:
+            env.set("SPACK_BUILD_PREFIX_MAP", staging_src)
 
         env.set("SPACK_ENABLE_NEW_DTAGS", self.enable_new_dtags)
         env.set("SPACK_DISABLE_NEW_DTAGS", self.disable_new_dtags)


### PR DESCRIPTION
This PR adds a prototype version of `compiler-wrapper` that pulls in the `--build-id`, `-Wl,--build-id` and `-ffile-prefix-map` injection currently under review at spack/compiler-wrapper#19, ahead of an official tagged release. cc @wdconinc 
