### PR TITLE
coinhsl: Split package.py into builder classes

### DIFF
--- a/repos/spack_repo/builtin/packages/coinhsl/package.py
+++ b/repos/spack_repo/builtin/packages/coinhsl/package.py
@@ -72,31 +72,27 @@ class Coinhsl(meson.MesonPackage, autotools.AutotoolsPackage):
 
     # Autotools builds
     version(
-        "2019.05.21",
-        sha256="95ce1160f0b013151a3e25d40337775c760a8f3a79d801a1d190598bf4e4c0c3"
+        "2019.05.21", sha256="95ce1160f0b013151a3e25d40337775c760a8f3a79d801a1d190598bf4e4c0c3"
     )
     version(
-        "2015.06.23",
-        sha256="3e955a2072f669b8f357ae746531b37aea921552e415dc219a5dd13577575fb3"
+        "2015.06.23", sha256="3e955a2072f669b8f357ae746531b37aea921552e415dc219a5dd13577575fb3"
     )
     version(
-        "2014.01.17",
-        sha256="ed49fea62692c5d2f928d4007988930da9ff9a2e944e4c559d028671d122437b"
+        "2014.01.17", sha256="ed49fea62692c5d2f928d4007988930da9ff9a2e944e4c559d028671d122437b"
     )
     version(
-        "2014.01.10",
-        sha256="7c2be60a3913b406904c66ee83acdbd0709f229b652c4e39ee5d0876f6b2e907"
+        "2014.01.10", sha256="7c2be60a3913b406904c66ee83acdbd0709f229b652c4e39ee5d0876f6b2e907"
     )
 
     with when("build_system=autotools"):
         parallel = False
-        variant("blas", default=False,
-                description="Link to external BLAS library")
+        variant("blas", default=False, description="Link to external BLAS library")
         depends_on("blas", when="+blas")
 
 
 class MesonBuilder(meson.MesonBuilder):
     """Builder class to hold functions specific to meson"""
+
     def meson_args(self) -> list[str]:
         """Add arguments for calling meson setup"""
         spec = self.spec
@@ -108,17 +104,13 @@ class MesonBuilder(meson.MesonBuilder):
 
         # Configure blas
         blas: str = spec["blas"].libs.names[0]
-        blas_paths: list[str] = [
-            sf[2:] for sf in spec["blas"].libs.search_flags.split()
-        ]
+        blas_paths: list[str] = [sf[2:] for sf in spec["blas"].libs.search_flags.split()]
         args.append(f"-Dlibblas={blas}")
         args.extend([f"-Dlibblas_path={p}" for p in blas_paths])
 
         # Configure lapack
         lapack: str = spec["lapack"].libs.names[0]
-        lapack_paths: list[str] = [
-            sf[2:] for sf in spec["lapack"].libs.search_flags.split()
-        ]
+        lapack_paths: list[str] = [sf[2:] for sf in spec["lapack"].libs.search_flags.split()]
         args.append(f"-Dliblapack={lapack}")
         args.extend([f"-Dliblapack_path={p}" for p in lapack_paths])
 
@@ -140,6 +132,7 @@ class MesonBuilder(meson.MesonBuilder):
 
 class AutotoolsBuilder(autotools.AutotoolsBuilder):
     """Builder class to hold functions specific to autotools"""
+
     def configure_args(self) -> list[str]:
         """Add arguments for the calling configure"""
         spec = self.spec

--- a/repos/spack_repo/builtin/packages/coinhsl/package.py
+++ b/repos/spack_repo/builtin/packages/coinhsl/package.py
@@ -4,8 +4,9 @@
 
 import os
 
-from spack.package import *
 from spack_repo.builtin.build_systems import autotools, meson
+
+from spack.package import *
 
 
 class Coinhsl(meson.MesonPackage, autotools.AutotoolsPackage):

--- a/repos/spack_repo/builtin/packages/coinhsl/package.py
+++ b/repos/spack_repo/builtin/packages/coinhsl/package.py
@@ -4,14 +4,15 @@
 
 import os
 
-from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
-from spack_repo.builtin.build_systems.meson import MesonPackage
+from spack_repo.builtin.build_systems import autotools
+from spack_repo.builtin.build_systems import meson
 
 from spack.package import *
 
 
-class Coinhsl(MesonPackage, AutotoolsPackage):
-    """CoinHSL is a collection of linear algebra libraries (KB22, MA27,
+class Coinhsl(meson.MesonPackage, autotools.AutotoolsPackage):
+    """
+    CoinHSL is a collection of linear algebra libraries (KB22, MA27,
     MA28, MA54, MA57, MA64, MA77, MA86, MA97, MC19, MC34, MC64, MC68,
     MC69, MC78, MC80, OF01, ZB01, ZB11) bundled for use with IPOPT and
     other applications that use these HSL routines.
@@ -19,13 +20,27 @@ class Coinhsl(MesonPackage, AutotoolsPackage):
     Note: CoinHSL is licensed software. You will need to request a
     license from Research Councils UK and download a .tar.gz archive
     of CoinHSL yourself. Spack will search your current directory for
-    the download file. Alternatively, add this file to a mirror so
-    that Spack can find it. For instructions on how to set up a
-    mirror, see https://spack.readthedocs.io/en/latest/mirrors.html"""
+    the download file.
+
+    To get a personal licence for the archive version, request the
+    licence here: https://licences.stfc.ac.uk/product/coin-hsl-archive
+    """
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")
 
+    # Since the 2024 release, coinhsl uses meson and files are
+    # distributed with names such as:
+    # - coinhsl-2024.05.15.tar.gz
+    # - coinhsl-archive-2024.05.15.tar.gz
+    # Prior to this release, coinhsl used autotools and both the reduced
+    # "archive" and full libraries just had a date.
+    # The version system is used here to differentiate the three:
+    # - `"2023" < version` - This will always be a full meson build
+    # - `version < "b"` - The version starts with "a" and is an archive.
+    #                     This convention came in after the autotools
+    #                     build so is a meson build
+    # - `"b" < version < "2023"` - The old autotools builds
     build_system(
         conditional("autotools", when="@b:2019.05.21"),
         conditional("meson", when="@2023:,:b"),
@@ -33,7 +48,7 @@ class Coinhsl(MesonPackage, AutotoolsPackage):
     )
 
     homepage = "https://www.hsl.rl.ac.uk/ipopt/"
-    url = f"file://{os.getcwd()}/coinhsl-2023.11.17.tar.gz"
+    url = f"file://{os.getcwd()}/coinhsl-2024.05.15.tar.gz"
     manual_download = True
 
     maintainers("AndrewLister-STFC")
@@ -49,26 +64,66 @@ class Coinhsl(MesonPackage, AutotoolsPackage):
         sha256="1d907ce5d84331ce8f78125d5fc766184f0fce9a7b340db7f3c4821a7f4b7c4c",
     )
 
+    # Full lib requires extra deps (archive has no deps)
     with when("build_system=meson @2023:"):
         depends_on("blas")
         depends_on("lapack")
         variant("metis", default=True, description="Build with Metis support.")
         depends_on("metis", when="+metis")
 
-    def meson_args(self):
+    # Autotools builds
+    version(
+        "2019.05.21",
+        sha256="95ce1160f0b013151a3e25d40337775c760a8f3a79d801a1d190598bf4e4c0c3"
+    )
+    version(
+        "2015.06.23",
+        sha256="3e955a2072f669b8f357ae746531b37aea921552e415dc219a5dd13577575fb3"
+    )
+    version(
+        "2014.01.17",
+        sha256="ed49fea62692c5d2f928d4007988930da9ff9a2e944e4c559d028671d122437b"
+    )
+    version(
+        "2014.01.10",
+        sha256="7c2be60a3913b406904c66ee83acdbd0709f229b652c4e39ee5d0876f6b2e907"
+    )
+
+    with when("build_system=autotools"):
+        parallel = False
+        variant("blas", default=False,
+                description="Link to external BLAS library")
+        depends_on("blas", when="+blas")
+
+
+class MesonBuilder(meson.MesonBuilder):
+    """Builder class to hold functions specific to meson"""
+    def meson_args(self) -> list[str]:
+        """Add arguments for calling meson setup"""
         spec = self.spec
-        args = []
+        args: list[str] = []
+
+        # archive versions have no deps
         if spec.satisfies("@:b"):
             return []
 
-        blas = spec["blas"].libs.names[0]
-        blas_paths = [sf[2:] for sf in spec["blas"].libs.search_flags.split()]
-        lapack = spec["lapack"].libs.names[0]
-        lapack_paths = [sf[2:] for sf in spec["lapack"].libs.search_flags.split()]
+        # Configure blas
+        blas: str = spec["blas"].libs.names[0]
+        blas_paths: list[str] = [
+            sf[2:] for sf in spec["blas"].libs.search_flags.split()
+        ]
         args.append(f"-Dlibblas={blas}")
         args.extend([f"-Dlibblas_path={p}" for p in blas_paths])
+
+        # Configure lapack
+        lapack: str = spec["lapack"].libs.names[0]
+        lapack_paths: list[str] = [
+            sf[2:] for sf in spec["lapack"].libs.search_flags.split()
+        ]
         args.append(f"-Dliblapack={lapack}")
         args.extend([f"-Dliblapack_path={p}" for p in lapack_paths])
+
+        # Configure metis
         if spec.satisfies("+metis"):
             metis = spec["metis"]
             if metis.satisfies("@5"):
@@ -83,28 +138,16 @@ class Coinhsl(MesonPackage, AutotoolsPackage):
             )
         return args
 
-    # Autotools builds
-    version(
-        "2019.05.21", sha256="95ce1160f0b013151a3e25d40337775c760a8f3a79d801a1d190598bf4e4c0c3"
-    )
-    version(
-        "2015.06.23", sha256="3e955a2072f669b8f357ae746531b37aea921552e415dc219a5dd13577575fb3"
-    )
-    version(
-        "2014.01.17", sha256="ed49fea62692c5d2f928d4007988930da9ff9a2e944e4c559d028671d122437b"
-    )
-    version(
-        "2014.01.10", sha256="7c2be60a3913b406904c66ee83acdbd0709f229b652c4e39ee5d0876f6b2e907"
-    )
 
-    with when("build_system=autotools"):
-        parallel = False
-        variant("blas", default=False, description="Link to external BLAS library")
-        depends_on("blas", when="+blas")
-
-    def configure_args(self):
+class AutotoolsBuilder(autotools.AutotoolsBuilder):
+    """Builder class to hold functions specific to autotools"""
+    def configure_args(self) -> list[str]:
+        """Add arguments for the calling configure"""
         spec = self.spec
-        args = []
+        args: list[str] = []
+
+        # Configure blas
         if spec.satisfies("+blas"):
             args.append(f"--with-blas={spec['blas'].libs.ld_flags}")
+
         return args

--- a/repos/spack_repo/builtin/packages/coinhsl/package.py
+++ b/repos/spack_repo/builtin/packages/coinhsl/package.py
@@ -4,10 +4,8 @@
 
 import os
 
-from spack_repo.builtin.build_systems import autotools
-from spack_repo.builtin.build_systems import meson
-
 from spack.package import *
+from spack_repo.builtin.build_systems import autotools, meson
 
 
 class Coinhsl(meson.MesonPackage, autotools.AutotoolsPackage):

--- a/repos/spack_repo/builtin/packages/coinhsl/package.py
+++ b/repos/spack_repo/builtin/packages/coinhsl/package.py
@@ -95,24 +95,23 @@ class Coinhsl(meson.MesonPackage, autotools.AutotoolsPackage):
 
 
 class MesonBuilder(meson.MesonBuilder):
-
     def meson_args(self):
         spec = self.spec
-        args: list[str] = []
+        args = []
 
         # archive versions have no deps
         if spec.satisfies("@:b"):
             return []
 
         # Configure blas
-        blas: str = spec["blas"].libs.names[0]
-        blas_paths: list[str] = [sf[2:] for sf in spec["blas"].libs.search_flags.split()]
+        blas = spec["blas"].libs.names[0]
+        blas_paths = [sf[2:] for sf in spec["blas"].libs.search_flags.split()]
         args.append(f"-Dlibblas={blas}")
         args.extend([f"-Dlibblas_path={p}" for p in blas_paths])
 
         # Configure lapack
-        lapack: str = spec["lapack"].libs.names[0]
-        lapack_paths: list[str] = [sf[2:] for sf in spec["lapack"].libs.search_flags.split()]
+        lapack = spec["lapack"].libs.names[0]
+        lapack_paths = [sf[2:] for sf in spec["lapack"].libs.search_flags.split()]
         args.append(f"-Dliblapack={lapack}")
         args.extend([f"-Dliblapack_path={p}" for p in lapack_paths])
 
@@ -136,9 +135,9 @@ class AutotoolsBuilder(autotools.AutotoolsBuilder):
     """Builder class to hold functions specific to autotools"""
 
     def configure_args(self):
-        """Add arguments for the calling configure"""
+        """Add arguments for calling configure"""
         spec = self.spec
-        args: list[str] = []
+        args = []
 
         # Configure blas
         if spec.satisfies("+blas"):

--- a/repos/spack_repo/builtin/packages/coinhsl/package.py
+++ b/repos/spack_repo/builtin/packages/coinhsl/package.py
@@ -85,14 +85,18 @@ class Coinhsl(meson.MesonPackage, autotools.AutotoolsPackage):
     )
 
     with when("build_system=autotools"):
-        parallel = False
         variant("blas", default=False, description="Link to external BLAS library")
         depends_on("blas", when="+blas")
+
+    @property
+    def parallel(self):
+        """The autotools builds are not parallel safe"""
+        return not self.spec.satisfies("build_system=autotools")
 
 
 class MesonBuilder(meson.MesonBuilder):
 
-    def meson_args(self) -> list[str]:
+    def meson_args(self):
         spec = self.spec
         args: list[str] = []
 
@@ -131,7 +135,7 @@ class MesonBuilder(meson.MesonBuilder):
 class AutotoolsBuilder(autotools.AutotoolsBuilder):
     """Builder class to hold functions specific to autotools"""
 
-    def configure_args(self) -> list[str]:
+    def configure_args(self):
         """Add arguments for the calling configure"""
         spec = self.spec
         args: list[str] = []

--- a/repos/spack_repo/builtin/packages/coinhsl/package.py
+++ b/repos/spack_repo/builtin/packages/coinhsl/package.py
@@ -91,10 +91,8 @@ class Coinhsl(meson.MesonPackage, autotools.AutotoolsPackage):
 
 
 class MesonBuilder(meson.MesonBuilder):
-    """Builder class to hold functions specific to meson"""
 
     def meson_args(self) -> list[str]:
-        """Add arguments for calling meson setup"""
         spec = self.spec
         args: list[str] = []
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Following a discussion in the slack. This PR tidies up the coinhsl package.py to follow the builder class convention. I also added some context for why the versioning is not ideal.