### PR TITLE
simgrid: add graphviz dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/simgrid/package.py
+++ b/repos/spack_repo/builtin/packages/simgrid/package.py
@@ -84,6 +84,8 @@ class Simgrid(CMakePackage):
     depends_on("boost@:1.69.0", when="@:3.21")
     depends_on("boost+exception")
 
+    depends_on("graphviz")
+
     conflicts(
         "%gcc@10:",
         when="@:3.23",


### PR DESCRIPTION
Simgrid's CMake setup looks for graphviz and then enables `HAVE_GRAPHVIZ` if it is found. For me, this lead to the simgrid build picking up the system's `libgraph` which was later "updated away", breaking the simgrid installation.

As proposed here, I think the easiest way to handle this behavior is to add an explicit dependency on graphviz, thus making the build more predictable and robust.