### PR TITLE
py-ipykernel: add v7.3.0; py-nest-asyncio2: new package; py-jupyter-client: add v8.9.1

### DIFF
--- a/repos/spack_repo/builtin/packages/py_ipykernel/package.py
+++ b/repos/spack_repo/builtin/packages/py_ipykernel/package.py
@@ -67,6 +67,7 @@ class PyIpykernel(PythonPackage):
         depends_on("py-traitlets@4.1.0:")
         depends_on("py-traitlets@:5", when="@:6.10")
 
+        depends_on("py-jupyter-client@8.9:", when="@7.3:")
         depends_on("py-jupyter-client@8.8:", when="@7.2:")
         depends_on("py-jupyter-client@8:", when="@6.30:")
         depends_on("py-jupyter-client@6.1.12:", when="@6.11:")

--- a/repos/spack_repo/builtin/packages/py_ipykernel/package.py
+++ b/repos/spack_repo/builtin/packages/py_ipykernel/package.py
@@ -74,7 +74,7 @@ class PyIpykernel(PythonPackage):
         depends_on("py-jupyter-client@:7", when="@:6.10")
         depends_on("py-jupyter-client@:6", when="@:6.1")
 
-        depends_on("py-jupyter-core@5.1:", when="@7.2:")
+        depends_on("py-jupyter-core@5.1:5", when="@7.2:")
         depends_on("py-jupyter-core@4.12:", when="@6.22:")
 
         depends_on("py-nest-asyncio@1.4:", when="@6.30:7.2")

--- a/repos/spack_repo/builtin/packages/py_ipykernel/package.py
+++ b/repos/spack_repo/builtin/packages/py_ipykernel/package.py
@@ -77,9 +77,9 @@ class PyIpykernel(PythonPackage):
         depends_on("py-jupyter-core@5.1:5", when="@7.2:")
         depends_on("py-jupyter-core@4.12:", when="@6.22:")
 
+        depends_on("py-nest-asyncio2@1.7:", when="@7.3:")
         depends_on("py-nest-asyncio@1.4:", when="@6.30:7.2")
         depends_on("py-nest-asyncio", when="@6.6.1:7.2")
-        depends_on("py-nest-asyncio2@1.7:", when="@7.3:")
 
         depends_on("py-tornado@6.4.1:", when="@7.2:")
         depends_on("py-tornado@6.2:", when="@6.30:")

--- a/repos/spack_repo/builtin/packages/py_ipykernel/package.py
+++ b/repos/spack_repo/builtin/packages/py_ipykernel/package.py
@@ -18,6 +18,7 @@ class PyIpykernel(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("7.3.0", sha256="9acaaaf97d16355166e4085afe9d225bfbdf2b7ef520f9df3be8f2b248275e09")
     version("7.2.0", sha256="18ed160b6dee2cbb16e5f3575858bc19d8f1fe6046a9a680c708494ce31d909e")
     version("6.30.1", sha256="6abb270161896402e76b91394fcdce5d1be5d45f456671e5080572f8505be39b")
     version("6.29.5", sha256="f093a22c4a40f8828f8e330a9c297cb93dcab13bd9678ded6de8e5cf81c56215")
@@ -76,8 +77,9 @@ class PyIpykernel(PythonPackage):
         depends_on("py-jupyter-core@5.1:", when="@7.2:")
         depends_on("py-jupyter-core@4.12:", when="@6.22:")
 
-        depends_on("py-nest-asyncio@1.4:", when="@6.30:")
-        depends_on("py-nest-asyncio", when="@6.6.1:")
+        depends_on("py-nest-asyncio@1.4:", when="@6.30:7.2")
+        depends_on("py-nest-asyncio", when="@6.6.1:7.2")
+        depends_on("py-nest-asyncio2@1.7:", when="@7.3:")
 
         depends_on("py-tornado@6.4.1:", when="@7.2:")
         depends_on("py-tornado@6.2:", when="@6.30:")

--- a/repos/spack_repo/builtin/packages/py_jupyter_client/package.py
+++ b/repos/spack_repo/builtin/packages/py_jupyter_client/package.py
@@ -16,6 +16,7 @@ class PyJupyterClient(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("8.9.1", sha256="a58f730dd9e728ba16ba1d62ebccf7ffe1ebbdbce4e95cfae941b7321ae1f4fa")
     version("8.8.0", sha256="d556811419a4f2d96c869af34e854e3f059b7cc2d6d01a9cd9c85c267691be3e")
     version("8.6.3", sha256="35b3a0947c4a6e9d589eb97d7d4cd5e90f910ee73101611f01283732bd6d9419")
     version("8.2.0", sha256="9fe233834edd0e6c0aa5f05ca2ab4bdea1842bfd2d8a932878212fc5301ddaf0")
@@ -59,6 +60,7 @@ class PyJupyterClient(PythonPackage):
         depends_on("py-tornado@4.1:", when="@5:")
         depends_on("py-traitlets@5.3:", when="@8:")
         depends_on("py-traitlets")
+        depends_on("py-typing-extensions@4.13:", when="@8.9:")
 
         # Historical dependencies
         depends_on("py-importlib-metadata@4.8.3:", when="@8:8.6 ^python@:3.9")

--- a/repos/spack_repo/builtin/packages/py_nest_asyncio2/package.py
+++ b/repos/spack_repo/builtin/packages/py_nest_asyncio2/package.py
@@ -1,0 +1,21 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyNestAsyncio2(PythonPackage):
+    """Patch asyncio to allow nested event loops."""
+
+    homepage = "https://github.com/Chaoses-Ib/nest-asyncio2"
+    pypi = "nest_asyncio2/nest_asyncio2-1.7.2.tar.gz"
+
+    license("BSD-2-Clause")
+
+    version("1.7.2", sha256="1921d70b92cc4612c374928d081552efb59b83d91b2b789d935c665fa01729a8")
+
+    depends_on("py-setuptools@42:", type="build")
+    depends_on("py-setuptools-scm@3.4.3: +toml", type="build")


### PR DESCRIPTION
`ipykernel` switched to [`nest-asyncio2`](https://pypi.org/project/nest-asyncio2/) since version 7.3.0, see [release info](https://github.com/ipython/ipykernel/releases/tag/v7.3.0). This latter package was not yet in the collection and had to be added.

BTW, developers say that `nest-asyncio` is no longer maintained.

Maintainer: @ChristopherChristofi 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
