### PR TITLE
scotch: add v7.0.13

### DIFF
--- a/repos/spack_repo/builtin/packages/scotch/package.py
+++ b/repos/spack_repo/builtin/packages/scotch/package.py
@@ -21,6 +21,7 @@ class Scotch(CMakePackage, MakefilePackage):
 
     maintainers("AlexanderRichert-NOAA", "climbfuji")
 
+    version("7.0.13", sha256="6457d1f177fce9c07324b8c57ad1086402b0e61bd9ecf5c30b2b481944ea8fe7")
     version("7.0.12", sha256="870bf681e7e40b6b01c3890dbe7b27da2617660f1722541919a865a6729dcbf2")
     version("7.0.11", sha256="ce1ea6e16ca36ae91426a360f639c8f575fccebc0116fbcb381f164c5e862768")
     version("7.0.10", sha256="8327725a08cdd4fc7575e291251883b4f93f75b07a54bc58f89f50dcbba7b244")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Release notes : https://gitlab.inria.fr/scotch/scotch/-/releases/v7.0.13

```
$ spack find scotch
-- linux-debian13-x86_64_v4 / %c,cxx,fortran=gcc@14.2.0 ---------
scotch@7.0.10  scotch@7.0.10  scotch@7.0.10  scotch@7.0.12  scotch@7.0.12  scotch@7.0.12  scotch@7.0.13
==> 7 installed packages
```