### PR TITLE
py-tabulate: add v0.10.0

### DIFF
--- a/repos/spack_repo/builtin/packages/py_tabulate/package.py
+++ b/repos/spack_repo/builtin/packages/py_tabulate/package.py
@@ -26,5 +26,7 @@ class PyTabulate(PythonPackage):
     version("0.7.7", sha256="83a0b8e17c09f012090a50e1e97ae897300a72b35e0c86c0b53d3bd2ae86d8c6")
 
     # TODO: it moved to flit[-scm] after 0.10.0
+    depends_on("py-setuptools@77.0.3:", type="build", when="@0.10")
+    depends_on("py-setuptools@61.2:", type="build", when="@0.9")
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools-scm@3.4.3: +toml", type="build", when="@0.9:0.10")

--- a/repos/spack_repo/builtin/packages/py_tabulate/package.py
+++ b/repos/spack_repo/builtin/packages/py_tabulate/package.py
@@ -15,6 +15,7 @@ class PyTabulate(PythonPackage):
 
     license("MIT")
 
+    version("0.10.0", sha256="e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d")
     version("0.9.0", sha256="0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c")
     version("0.8.10", sha256="6c57f3f3dd7ac2782770155f3adb2db0b1a269637e42f27599925e64b114f519")
     version("0.8.9", sha256="eb1d13f25760052e8931f2ef80aaf6045a6cceb47514db8beab24cded16f13a7")
@@ -24,4 +25,6 @@ class PyTabulate(PythonPackage):
     version("0.8.3", sha256="8af07a39377cee1103a5c8b3330a421c2d99b9141e9cc5ddd2e3263fea416943")
     version("0.7.7", sha256="83a0b8e17c09f012090a50e1e97ae897300a72b35e0c86c0b53d3bd2ae86d8c6")
 
+    # TODO: it moved to flit[-scm] after 0.10.0
     depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools-scm@3.4.3 +toml", type="build", when="0.9:0.10")

--- a/repos/spack_repo/builtin/packages/py_tabulate/package.py
+++ b/repos/spack_repo/builtin/packages/py_tabulate/package.py
@@ -27,4 +27,4 @@ class PyTabulate(PythonPackage):
 
     # TODO: it moved to flit[-scm] after 0.10.0
     depends_on("py-setuptools", type="build")
-    depends_on("py-setuptools-scm@3.4.3 +toml", type="build", when="0.9:0.10")
+    depends_on("py-setuptools-scm@3.4.3: +toml", type="build", when="@0.9:0.10")


### PR DESCRIPTION
Missing dependency on `setuptools-scm` (see [`pyproject.toml`](https://github.com/astanin/python-tabulate/blob/v0.9.0/pyproject.toml#L2)) led to unknown version, i.e., directory `tabulate-0.0.0.dist-info` and `Version: 0.0.0` in `METADATA`.

Left a `TODO` comment to notify that in master they switch to `flit` as build back-end (instead of `setuptools`).

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
