### PR TITLE
butterflypack: fix invalid comparison and non-OpenMP builds

### DIFF
--- a/repos/spack_repo/builtin/packages/butterflypack/package.py
+++ b/repos/spack_repo/builtin/packages/butterflypack/package.py
@@ -72,9 +72,9 @@ class Butterflypack(CMakePackage):
     )
     # Fix OpenMP-disabled builds.
     patch(
-        "https://github.com/Sbozzolo/ButterflyPACK/commit/2e7bf495dc641dbbe8c22eff739da57c4e433ae8.patch?full_index=1",
+        "https://github.com/liuyangzhuan/ButterflyPACK/pull/45.patch?full_index=1",
         sha256="cf6c3adb2563d9ef90303846915a65f3024771165a281a3dd915b6f4c2b2e8d7",
-        when="@4.1.0",
+        when="@4.0.0:5.0.0",
     )
     patch(
         "https://github.com/liuyangzhuan/ButterflyPACK/commit/1393fc11b390934cbb020700397cc75bab87c783.patch?full_index=1",

--- a/repos/spack_repo/builtin/packages/butterflypack/package.py
+++ b/repos/spack_repo/builtin/packages/butterflypack/package.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from typing import ClassVar
+
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
@@ -26,7 +28,7 @@ class Butterflypack(CMakePackage):
     url = "https://github.com/liuyangzhuan/ButterflyPACK/archive/v2.2.0.tar.gz"
     maintainers("liuyangzhuan")
 
-    tags = ["e4s"]
+    tags: ClassVar = ["e4s"]
 
     license("BSD-3-Clause-LBNL")
 
@@ -64,6 +66,12 @@ class Butterflypack(CMakePackage):
 
     conflicts("%gcc@:7", when="@2.2.1:")
 
+    # Fix missing hostname declarations on macOS.
+    patch(
+        "https://github.com/liuyangzhuan/ButterflyPACK/commit/4b70741a5e69644bccba13dc9f100b101d45a09c.patch?full_index=1",
+        sha256="c164600adbc0cb06a779a449835f5bf4e0aa1176f5d4bafa8dc9516da48b7e0c",
+        when="@4.1.0",
+    )
     # Fix an invalid comparison in BF_block_MVP_dat_batch_mkl.
     patch(
         "https://github.com/liuyangzhuan/ButterflyPACK/commit/757dcb23d88d27fa24a9ad3078100ebcccad3d6f.patch?full_index=1",
@@ -99,13 +107,13 @@ class Butterflypack(CMakePackage):
         spec = self.spec
 
         args = [
-            "-DCMAKE_C_COMPILER=%s" % spec["mpi"].mpicc,
-            "-DCMAKE_Fortran_COMPILER=%s" % spec["mpi"].mpifc,
-            "-DCMAKE_CXX_COMPILER=%s" % spec["mpi"].mpicxx,
-            "-DTPL_BLAS_LIBRARIES=%s" % spec["blas"].libs.joined(";"),
-            "-DTPL_LAPACK_LIBRARIES=%s" % spec["lapack"].libs.joined(";"),
-            "-DTPL_SCALAPACK_LIBRARIES=%s" % spec["scalapack"].libs.joined(";"),
-            "-DTPL_ARPACK_LIBRARIES=%s" % spec["arpack-ng"].libs.joined(";"),
+            f"-DCMAKE_C_COMPILER={spec['mpi'].mpicc}",
+            f"-DCMAKE_Fortran_COMPILER={spec['mpi'].mpifc}",
+            f"-DCMAKE_CXX_COMPILER={spec['mpi'].mpicxx}",
+            f"-DTPL_BLAS_LIBRARIES={spec['blas'].libs.joined(';')}",
+            f"-DTPL_LAPACK_LIBRARIES={spec['lapack'].libs.joined(';')}",
+            f"-DTPL_SCALAPACK_LIBRARIES={spec['scalapack'].libs.joined(';')}",
+            f"-DTPL_ARPACK_LIBRARIES={spec['arpack-ng'].libs.joined(';')}",
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
         ]
         args.append("-Denable_openmp=%s" % ("ON" if "+openmp" in spec else "OFF"))

--- a/repos/spack_repo/builtin/packages/butterflypack/package.py
+++ b/repos/spack_repo/builtin/packages/butterflypack/package.py
@@ -70,6 +70,12 @@ class Butterflypack(CMakePackage):
         sha256="48ad9acbf96d625cff53a485bd64bdc32ae391b266292fa35f2a863892d0c459",
         when="@4.1.0",
     )
+    # Fix OpenMP-disabled builds.
+    patch(
+        "https://github.com/Sbozzolo/ButterflyPACK/commit/2e7bf495dc641dbbe8c22eff739da57c4e433ae8.patch?full_index=1",
+        sha256="cf6c3adb2563d9ef90303846915a65f3024771165a281a3dd915b6f4c2b2e8d7",
+        when="@4.1.0",
+    )
     patch(
         "https://github.com/liuyangzhuan/ButterflyPACK/commit/1393fc11b390934cbb020700397cc75bab87c783.patch?full_index=1",
         sha256="a662fc51552eac3911cd7987bb2ebb283f6513e1bde094769f1fe9eba6878a18",

--- a/repos/spack_repo/builtin/packages/butterflypack/package.py
+++ b/repos/spack_repo/builtin/packages/butterflypack/package.py
@@ -64,6 +64,12 @@ class Butterflypack(CMakePackage):
 
     conflicts("%gcc@:7", when="@2.2.1:")
 
+    # Fix an invalid comparison in BF_block_MVP_dat_batch_mkl.
+    patch(
+        "https://github.com/liuyangzhuan/ButterflyPACK/commit/757dcb23d88d27fa24a9ad3078100ebcccad3d6f.patch?full_index=1",
+        sha256="48ad9acbf96d625cff53a485bd64bdc32ae391b266292fa35f2a863892d0c459",
+        when="@4.1.0",
+    )
     patch(
         "https://github.com/liuyangzhuan/ButterflyPACK/commit/1393fc11b390934cbb020700397cc75bab87c783.patch?full_index=1",
         sha256="a662fc51552eac3911cd7987bb2ebb283f6513e1bde094769f1fe9eba6878a18",
@@ -71,7 +77,7 @@ class Butterflypack(CMakePackage):
     )
     # ifx rejects SIZEOF on components of assumed-size dummy arrays.
     patch(
-        "https://github.com/liuyangzhuan/ButterflyPACK/pull/42.patch?full_index=1",
+        "https://github.com/liuyangzhuan/ButterflyPACK/commit/19fc92ec31a9e13c699dce5092e94750238f9862.patch?full_index=1",
         sha256="c7a22ed21b7eb3f2f295e7ed2b04099a108151c64da61b87c823dc8e0b3f950d",
         when="@4.1.0 %oneapi",
     )

--- a/repos/spack_repo/builtin/packages/butterflypack/package.py
+++ b/repos/spack_repo/builtin/packages/butterflypack/package.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from typing import ClassVar
-
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
@@ -28,7 +26,7 @@ class Butterflypack(CMakePackage):
     url = "https://github.com/liuyangzhuan/ButterflyPACK/archive/v2.2.0.tar.gz"
     maintainers("liuyangzhuan")
 
-    tags: ClassVar = ["e4s"]
+    tags = ["e4s"]
 
     license("BSD-3-Clause-LBNL")
 
@@ -80,7 +78,7 @@ class Butterflypack(CMakePackage):
     )
     # Fix OpenMP-disabled builds.
     patch(
-        "https://github.com/liuyangzhuan/ButterflyPACK/pull/45.patch?full_index=1",
+        "https://github.com/liuyangzhuan/ButterflyPACK/commit/80a68716310a4bb47555b6c1605bebe85346569d.patch?full_index=1",
         sha256="cf6c3adb2563d9ef90303846915a65f3024771165a281a3dd915b6f4c2b2e8d7",
         when="@4.0.0:5.0.0",
     )


### PR DESCRIPTION
Fix two ButterflyPACK source issues exposed by current Palace builds:

- Backport the upstream invalid-comparison fix to v4.1.0.
- Apply liuyangzhuan/ButterflyPACK#45 to releases v4.0.0 through v5.0.0, which call OpenMP functions unconditionally when OpenMP is disabled. The defect is present in those three tags and absent from v3.2.0.
- Replace the merged ButterflyPACK PR 42 patch URL with its immutable commit URL.

The non-OpenMP failure was found in https://github.com/awslabs/palace/actions/runs/32950594265/job/98120897831. The v4.1.0 library targets build locally with `enable_openmp=OFF` after applying the patch. Once ButterflyPACK PR 45 merges, its pull URL should likewise be replaced by the merged commit URL.