### PR TITLE
packages: fix wrong use of the `when` and `run_*` decorator

### DIFF
--- a/repos/spack_repo/builtin/packages/crtm/package.py
+++ b/repos/spack_repo/builtin/packages/crtm/package.py
@@ -128,8 +128,7 @@ class Crtm(CMakePackage):
         if not self.run_tests:
             filter_file(r"add_subdirectory\(test\)", "# disable testing", "CMakeLists.txt")
 
-    @when("@3.1.1-build1")
-    @run_after("install")
+    @run_after("install", when="@3.1.1-build1")
     def cmake_config_softlinks(self):
         cmake_config_files = glob.glob(join_path(self.prefix, "cmake/crtm/*"))
         for srcpath in cmake_config_files:

--- a/repos/spack_repo/builtin/packages/gurobi/package.py
+++ b/repos/spack_repo/builtin/packages/gurobi/package.py
@@ -62,8 +62,7 @@ class Gurobi(Package):
 
     # the Python package installation was deprecated after version 10,
     # to be superseded by pip/conda installs
-    @when("@:10")
-    @run_after("install")
+    @run_after("install", when="@:10")
     def gurobipy(self):
         with working_dir("linux64"):
             python("setup.py", "install", "--prefix={0}".format(self.prefix))

--- a/repos/spack_repo/builtin/packages/mapl/package.py
+++ b/repos/spack_repo/builtin/packages/mapl/package.py
@@ -1,15 +1,10 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 import subprocess
 
-from package_base import on_package_attributes
 from spack_repo.builtin.build_systems.cmake import CMakePackage
-
 from spack.package import *
-
-from spec import Spec
 
 
 class Mapl(CMakePackage):

--- a/repos/spack_repo/builtin/packages/mapl/package.py
+++ b/repos/spack_repo/builtin/packages/mapl/package.py
@@ -4,9 +4,12 @@
 
 import subprocess
 
+from package_base import on_package_attributes
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
+
+from spec import Spec
 
 
 class Mapl(CMakePackage):
@@ -565,10 +568,10 @@ cpp -P -traditional-cpp -undef \"$@\"
 
     # We can run some tests to make sure the build is working
     # but we can only do it if the pfunit variant is enabled
-    @when("+pfunit")
-    @run_after("build")
     @on_package_attributes(run_tests=True)
     def check(self):
+        if not self.spec.satisfies("+pfunit"):
+            return
         with working_dir(self.build_directory):
             # The test suite contains a lot of tests. We select only those
             # that are cheap. Note this requires MPI and 6 processes

--- a/repos/spack_repo/builtin/packages/mapl/package.py
+++ b/repos/spack_repo/builtin/packages/mapl/package.py
@@ -4,6 +4,7 @@
 import subprocess
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+
 from spack.package import *
 
 

--- a/repos/spack_repo/builtin/packages/nest/package.py
+++ b/repos/spack_repo/builtin/packages/nest/package.py
@@ -126,8 +126,7 @@ class Nest(CMakePackage):
 
         return args
 
-    @when("@:2.14.0+modules")
-    @run_after("install")
+    @run_after("install", when="@:2.14.0+modules")
     def install_headers(self):
         # copy source files to installation folder for older versions
         # (these are needed for modules to build against)

--- a/repos/spack_repo/builtin/packages/openfoam/package.py
+++ b/repos/spack_repo/builtin/packages/openfoam/package.py
@@ -647,8 +647,7 @@ class Openfoam(Package):
         if os.path.exists(controlDict):
             filter_file(r"trapFpe\s+\d+\s*;", "trapFpe 0;", controlDict, backup=False)
 
-    @when("@:2106 %aocc@3.2.0:")
-    @run_before("configure")
+    @run_before("configure", when="@:2106 %aocc@3.2.0:")
     def make_amd_rules(self):
         """Due to the change in the linker behavior in AOCC v3.2, it is now
         issuing diagnostic messages for the unreferenced symbols in the
@@ -660,8 +659,7 @@ class Openfoam(Package):
             "clang++", spack_cxx + " -pthread", join_path(src, "c++"), backup=False, string=True
         )
 
-    @when("@1812: %fj")
-    @run_before("configure")
+    @run_before("configure", when="@1812: %fj")
     def make_fujitsu_rules(self):
         """Create Fujitsu rules (clang variant) unless supplied upstream.
         Implemented for 1812 and later (older rules are too messy to edit).

--- a/repos/spack_repo/builtin/packages/py_matplotlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_matplotlib/package.py
@@ -379,8 +379,7 @@ class PyMatplotlib(PythonPackage):
         env.set("CPATH", ":".join(include))
         env.set("LIBRARY_PATH", ":".join(library))
 
-    @when("@:3.8")
-    @run_before("install")
+    @run_before("install", when="@:3.8")
     def configure(self):
         """Set build options with regards to backend GUI libraries."""
 

--- a/repos/spack_repo/builtin/packages/py_metatensor_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_metatensor_torch/package.py
@@ -58,8 +58,7 @@ class PyMetatensorTorch(PythonPackage):
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         env.set("METATENSOR_TORCH_PYTHON_USE_EXTERNAL_LIB", "ON")
 
-    @when("@:0.8")
-    @run_after("install")
+    @run_after("install", when="@:0.8")
     def workaround(self):
         """
         Workaround for the incorrect usage of namespace packages.

--- a/repos/spack_repo/builtin/packages/py_nbconvert/package.py
+++ b/repos/spack_repo/builtin/packages/py_nbconvert/package.py
@@ -118,8 +118,7 @@ class PyNbconvert(PythonPackage):
         expand=False,
     )
 
-    @run_before("install")
-    @when("@6:")
+    @run_before("install", when="@6:")
     def install_css(self):
         css = {
             # target filename: [subdir, source filename]

--- a/repos/spack_repo/builtin/packages/py_numpy/package.py
+++ b/repos/spack_repo/builtin/packages/py_numpy/package.py
@@ -520,8 +520,7 @@ class PyNumpy(PythonPackage):
                 write_library_dirs(f, lapack_lib_dirs)
                 f.write("include_dirs = {0}\n".format(lapack_header_dirs))
 
-    @when("@:1.25")
-    @run_before("install")
+    @run_before("install", when="@:1.25")
     def set_blas_lapack(self):
         self.blas_lapack_site_cfg()
 


### PR DESCRIPTION
Found with https://github.com/spack/spack/pull/52952

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
