### PR TITLE
mdspan: refactoring

### DIFF
--- a/repos/spack_repo/builtin/packages/mdspan/package.py
+++ b/repos/spack_repo/builtin/packages/mdspan/package.py
@@ -20,7 +20,6 @@ class Mdspan(CMakePackage):
     version("stable", branch="stable")
     version("0.6.0", sha256="d6b7b9d4f472106df1d28729bd8383a8a7ea7938adf9f82d3be9c151344830d9")
 
-    variant("benchmarks", default=False, description="Enable benchmarks")
     variant(
         "cxxstd", default="17", values=["14", "17", "20"], multi=False, description="C++ standard"
     )
@@ -33,16 +32,15 @@ class Mdspan(CMakePackage):
 
     depends_on("cxx", type="build")
 
-    depends_on("benchmark", when="+benchmarks")
     depends_on("googletest@1.14:1", type="test")
 
     def cmake_args(self):
         args = [
+            self.define("MDSPAN_ENABLE_BENCHMARKS", False),
             self.define("MDSPAN_ENABLE_EXAMPLES", False),
             self.define("MDSPAN_ENABLE_TESTS", self.run_tests),
             self.define("MDSPAN_GENERATE_STD_NAMESPACE_TARGETS", False),
             self.define("MDSPAN_USE_SYSTEM_GTEST", self.run_tests),
-            self.define_from_variant("MDSPAN_ENABLE_BENCHMARKS", "benchmarks"),
             self.define_from_variant("MDSPAN_CXX_STANDARD", "cxxstd"),
             self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
             self.define_from_variant("MDSPAN_INSTALL_STDMODE_HEADERS", "stdheaders"),

--- a/repos/spack_repo/builtin/packages/mdspan/package.py
+++ b/repos/spack_repo/builtin/packages/mdspan/package.py
@@ -40,6 +40,7 @@ class Mdspan(CMakePackage):
         args = [
             self.define("MDSPAN_ENABLE_EXAMPLES", False),
             self.define("MDSPAN_ENABLE_TESTS", self.run_tests),
+            self.define("MDSPAN_GENERATE_STD_NAMESPACE_TARGETS", False),
             self.define("MDSPAN_USE_SYSTEM_GTEST", self.run_tests),
             self.define_from_variant("MDSPAN_ENABLE_BENCHMARKS", "benchmarks"),
             self.define_from_variant("MDSPAN_CXX_STANDARD", "cxxstd"),

--- a/repos/spack_repo/builtin/packages/mdspan/package.py
+++ b/repos/spack_repo/builtin/packages/mdspan/package.py
@@ -20,7 +20,6 @@ class Mdspan(CMakePackage):
     version("stable", branch="stable")
     version("0.6.0", sha256="d6b7b9d4f472106df1d28729bd8383a8a7ea7938adf9f82d3be9c151344830d9")
 
-    variant("examples", default=True, description="Enable examples")
     variant("tests", default=False, description="Enable tests")
     variant("benchmarks", default=False, description="Enable benchmarks")
     variant(
@@ -43,7 +42,7 @@ class Mdspan(CMakePackage):
             self.define_from_variant("MDSPAN_ENABLE_TESTS", "tests"),
             self.define_from_variant("MDSPAN_USE_SYSTEM_GTEST", "tests"),
             self.define_from_variant("MDSPAN_ENABLE_BENCHMARKS", "benchmarks"),
-            self.define_from_variant("MDSPAN_ENABLE_EXAMPLES", "examples"),
+            self.define("MDSPAN_ENABLE_EXAMPLES", False),
             self.define_from_variant("MDSPAN_CXX_STANDARD", "cxxstd"),
             self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
             self.define_from_variant("MDSPAN_INSTALL_STDMODE_HEADERS", "stdheaders"),

--- a/repos/spack_repo/builtin/packages/mdspan/package.py
+++ b/repos/spack_repo/builtin/packages/mdspan/package.py
@@ -20,7 +20,6 @@ class Mdspan(CMakePackage):
     version("stable", branch="stable")
     version("0.6.0", sha256="d6b7b9d4f472106df1d28729bd8383a8a7ea7938adf9f82d3be9c151344830d9")
 
-    variant("tests", default=False, description="Enable tests")
     variant("benchmarks", default=False, description="Enable benchmarks")
     variant(
         "cxxstd", default="17", values=["14", "17", "20"], multi=False, description="C++ standard"
@@ -35,14 +34,14 @@ class Mdspan(CMakePackage):
     depends_on("cxx", type="build")
 
     depends_on("benchmark", when="+benchmarks")
-    depends_on("googletest@1.14:1", when="+tests")
+    depends_on("googletest@1.14:1", type="test")
 
     def cmake_args(self):
         args = [
-            self.define_from_variant("MDSPAN_ENABLE_TESTS", "tests"),
-            self.define_from_variant("MDSPAN_USE_SYSTEM_GTEST", "tests"),
-            self.define_from_variant("MDSPAN_ENABLE_BENCHMARKS", "benchmarks"),
             self.define("MDSPAN_ENABLE_EXAMPLES", False),
+            self.define("MDSPAN_ENABLE_TESTS", self.run_tests),
+            self.define("MDSPAN_USE_SYSTEM_GTEST", self.run_tests),
+            self.define_from_variant("MDSPAN_ENABLE_BENCHMARKS", "benchmarks"),
             self.define_from_variant("MDSPAN_CXX_STANDARD", "cxxstd"),
             self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
             self.define_from_variant("MDSPAN_INSTALL_STDMODE_HEADERS", "stdheaders"),


### PR DESCRIPTION
- favor usage of `--test root` instead of having a dedicated `tests` variant
- remove the variant `examples`, nothing is installed when enabling the variant
- enforce `MDSPAN_INSTALL_STDMODE_HEADERS=OFF`

I also wonder if the variant `benchmarks` is useful. If we keep it I think we could make the dependency only `build`, as nothing is installed, we shouldn't need to preserve the dependency after the installation of the package.