### PR TITLE
libxsmm: fix macOS dylib install names

### DIFF
--- a/repos/spack_repo/builtin/packages/libxsmm/package.py
+++ b/repos/spack_repo/builtin/packages/libxsmm/package.py
@@ -155,13 +155,13 @@ class MakefileBuilder(makefile.MakefileBuilder):
     def build(self, pkg, spec, prefix):
         # include symbols by default
         make_args = [
-            "CC={0}".format(spack_cc),
-            "CXX={0}".format(spack_cxx),
-            "FC={0}".format(spack_fc),
-            "PREFIX=%s" % prefix,
+            f"CC={spack_cc}",
+            f"CXX={spack_cxx}",
+            f"FC={spack_fc}",
+            f"PREFIX={prefix}",
         ]
         if spec.satisfies("@1.17-cp2k"):
-            make_args += ["WRAP={0}".format(spec.variants["wrap"].value)]
+            make_args += [f"WRAP={spec.variants['wrap'].value}"]
 
         # JIT (AVX and later) makes MNK, M, N, or K spec. superfluous
         # make_args += ['MNK=1 4 5 6 8 9 13 16 17 22 23 24 26 32']
@@ -173,7 +173,7 @@ class MakefileBuilder(makefile.MakefileBuilder):
 
         blas_val = spec.variants["blas"].value
         if blas_val != "default":
-            make_args += ["BLAS={0}".format(blas_val)]
+            make_args += [f"BLAS={blas_val}"]
 
         if spec.satisfies("+large_jit_buffer"):
             make_args += ["CODE_BUF_MAXSIZE=262144"]
@@ -194,6 +194,17 @@ class MakefileBuilder(makefile.MakefileBuilder):
 
         # always install libraries
         install_tree("lib", prefix.lib)
+
+        # On macOS the Makefile build bakes the build-tree path into each
+        # dylib's install name (LC_ID_DYLIB), so consumers record a
+        # spack-stage path that disappears after install and fail at load
+        # time with "Library not loaded". Rewrite the id to the final
+        # location. (No-op on Linux, which uses sonames + rpaths.)
+        if spec.satisfies("platform=darwin +shared"):
+            for lib in glob(join_path(prefix.lib, "libxsmm*.dylib")):
+                if not os.path.islink(lib):
+                    install_name_tool = which("install_name_tool")
+                    install_name_tool("-id", lib, lib)
 
         if spec.satisfies("+header-only"):
             install_tree("src", prefix.src)

--- a/repos/spack_repo/builtin/packages/libxsmm/package.py
+++ b/repos/spack_repo/builtin/packages/libxsmm/package.py
@@ -152,8 +152,7 @@ class CMakeBuilder(cmake.CMakeBuilder):
 
 
 class MakefileBuilder(makefile.MakefileBuilder):
-    def build(self, pkg, spec, prefix):
-        # include symbols by default
+    def _make_args(self, spec, prefix):
         make_args = [
             f"CC={spack_cc}",
             f"CXX={spack_cxx}",
@@ -178,6 +177,12 @@ class MakefileBuilder(makefile.MakefileBuilder):
         if spec.satisfies("+large_jit_buffer"):
             make_args += ["CODE_BUF_MAXSIZE=262144"]
 
+        return make_args
+
+    def build(self, pkg, spec, prefix):
+        # include symbols by default
+        make_args = self._make_args(spec, prefix)
+
         if spec.satisfies("+shared"):
             make(*(make_args + ["STATIC=0"]))
 
@@ -185,6 +190,15 @@ class MakefileBuilder(makefile.MakefileBuilder):
         make(*make_args)
 
     def install(self, pkg, spec, prefix):
+        # The 2.x install target relocates installed libraries on macOS and
+        # Linux. The main-2023 snapshot predates this despite satisfying @2:.
+        if spec.satisfies("@2:") and not spec.satisfies("@main-2023-11"):
+            make_args = self._make_args(spec, prefix)
+            if spec.satisfies("+shared"):
+                make_args += ["STATIC=0"]
+            make("install", *make_args)
+            return
+
         install_tree("include", prefix.include)
 
         # move pkg-config files to their right place
@@ -194,17 +208,6 @@ class MakefileBuilder(makefile.MakefileBuilder):
 
         # always install libraries
         install_tree("lib", prefix.lib)
-
-        # On macOS the Makefile build bakes the build-tree path into each
-        # dylib's install name (LC_ID_DYLIB), so consumers record a
-        # spack-stage path that disappears after install and fail at load
-        # time with "Library not loaded". Rewrite the id to the final
-        # location. (No-op on Linux, which uses sonames + rpaths.)
-        if spec.satisfies("platform=darwin +shared"):
-            for lib in glob(join_path(prefix.lib, "libxsmm*.dylib")):
-                if not os.path.islink(lib):
-                    install_name_tool = which("install_name_tool")
-                    install_name_tool("-id", lib, lib)
 
         if spec.satisfies("+header-only"):
             install_tree("src", prefix.src)

--- a/repos/spack_repo/builtin/packages/libxsmm/package.py
+++ b/repos/spack_repo/builtin/packages/libxsmm/package.py
@@ -209,6 +209,11 @@ class MakefileBuilder(makefile.MakefileBuilder):
         # always install libraries
         install_tree("lib", prefix.lib)
 
+        # The 1.x releases and main-2023 snapshot predate the relocation in
+        # the upstream install target.
+        if spec.satisfies("platform=darwin +shared"):
+            fix_darwin_install_name(prefix.lib)
+
         if spec.satisfies("+header-only"):
             install_tree("src", prefix.src)
 


### PR DESCRIPTION
The GNU Make build on macOS embeds the build-tree path in each shared library's `LC_ID_DYLIB`. Consumers therefore record a path under the Spack stage, which disappears after installation and causes runtime failures such
as:
```
Library not loaded: .../spack-stage-libxsmm-2.1.0-.../spack-src/lib/libxsmm.2.dylib
```

Rewrite the IDs of installed, non-symlink dylibs to their final paths with `install_name_tool`. Linux is unaffected because it uses sonames and rpaths.

The failure was reproduced in: https://github.com/awslabs/palace/actions/runs/32965751532/job/98167779439

(The string-format changes are mechanical updates required by the current Ruff baseline when modifying this recipe.)