### PR TITLE
fms: disable unit tests for 2026.01.01

### DIFF
--- a/repos/spack_repo/builtin/packages/fms/cmake-build-tests-option-2026.01.01.patch
+++ b/repos/spack_repo/builtin/packages/fms/cmake-build-tests-option-2026.01.01.patch
@@ -1,0 +1,25 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -56,6 +56,7 @@ option(64BIT       "Build 64-bit (r8) FMS library"        OFF)
+ option(FPIC        "Build with position independent code" OFF)
+ option(SHARED_LIBS "Build shared/dynamic libraries"       OFF)
+ option(OPENACC     "Build FMS with OpenACC support"       OFF)
++option(UNIT_TESTS  "Build FMS tests"                      OFF)
+ 
+ # Options for compiler definitions
+ option(INTERNAL_FILE_NML     "Enable compiler definition -DINTERNAL_FILE_NML"      ON)
+@@ -584,6 +585,7 @@ install(
+   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ 
+ ### Unit Testing
++if(UNIT_TESTS)
+ include(CTest)
+ 
+ # TODO autotools also checks if srun is available
+@@ -1004,6 +1006,7 @@ set(CMAKE_CTEST_ARGUMENTS "--output-on-failure")
+ 
+ set(CMAKE_CTEST_ARGUMENTS "--output-on-failure")
+ 
++endif()
+ ### Package config
+ include(CMakePackageConfigHelpers)

--- a/repos/spack_repo/builtin/packages/fms/package.py
+++ b/repos/spack_repo/builtin/packages/fms/package.py
@@ -88,6 +88,11 @@ class Fms(CMakePackage):
         sha256="eb043f992942224e3f8fc8dae22f4e53294ecadad83dd80a031c3d4465b7e4b8",
         when="@=2026.01",
     )
+    patch(
+        "cmake-build-tests-option-2026.01.01.patch",
+        sha256="948342aceb3befcbbe5d4edc755a0d34ea5a7181052ac46b40f5429dcfbc09e6",
+        when="@=2026.01.01",
+    )
 
     # https://github.com/NOAA-GFDL/FMS/issues/1417
     patch(


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR disable FMS unit-test targets during normal package builds for FMS 2026.01.01.

This follows the approach used for the earlier FMS releases in #4737 by @rem1776. That one had similar patches for 2025.04 and 2026.01

Luckily, this is the last one. In 2026.02 the CMake should be fixed in code. 