### PR TITLE
petsc: add thrust/tuple.h include to curand2.cu for CUDA 13.3

### DIFF
--- a/repos/spack_repo/builtin/packages/petsc/package.py
+++ b/repos/spack_repo/builtin/packages/petsc/package.py
@@ -231,6 +231,13 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     patch("petsc_modifiable_lvalue.patch", when="@3.21.6:3.22.4+rocm")
     patch("petsc_modifiable_lvalue.patch", when="@3.21.6:3.22.4+cuda")
 
+    # fixes build with: +complex ^cuda@13.3. Upstream fix: petsc!9532.
+    patch(
+        "https://gitlab.com/petsc/petsc/-/commit/c0f7467a2261011568d510ece23f14cad8dcaaa4.diff",
+        sha256="e91c9b9323f22fe8988f5707eb262290e850b81262cf41557dc552848313a6b8",
+        when="@3.16:3.25.5 +cuda +complex ^cuda@13.3:",
+    )
+
     # These require +mpi
     mpi_msg = "Requires +mpi"
     conflicts("+cgns", when="~mpi", msg=mpi_msg)


### PR DESCRIPTION
Under CUDA 13.3, thrust headers no longer pull `<thrust/tuple.h>` in transitively. PETSc's `src/sys/classes/random/impls/curand/curand2.cu` uses `thrust::tuple/get/make_tuple`, so nvcc fails with 'namespace "thrust" has no member "tuple"'. Add the missing include via a patch gated on +cuda ^cuda@13.3:. Mirrors the upstream PETSc fix in [MR!9321](https://gitlab.com/petsc/petsc/-/merge_requests/9321), which added the same include to `aijcupm.hpp` but not to `curand2.cu`.

Unfortunately, I cannot upstream this patch (because I cannot open a GitLab account), but I would be thrilled if a PETSc maintainer reading this applied the fix upstream.

Failing build: https://github.com/awslabs/palace/actions/runs/32969345089
Working build (with the patch): https://github.com/awslabs/palace/actions/runs/32975197965/job/98198161666

