### PR TITLE
repo: do not mutate Spec objects

### DIFF
--- a/repos/spack_repo/builtin/packages/berkeleygw/package.py
+++ b/repos/spack_repo/builtin/packages/berkeleygw/package.py
@@ -183,14 +183,11 @@ class Berkeleygw(MakefilePackage):
         if spec.satisfies("+mpi"):
             paraflags.append("-DMPI")
 
-        # We need to copy fflags in case we append to it (#34019):
-        cflags = spec.compiler_flags["cflags"][:]
-        fflags = spec.compiler_flags["fflags"][:]
-        cflags.append(self.compiler.cc_pic_flag)
-        fflags.append(self.compiler.fc_pic_flag)
+        cflags = [spec["c"].package.pic_flag]
+        fflags = [spec["fortran"].package.pic_flag]
         if spec.satisfies("+openmp"):
             paraflags.append("-DOMP")
-            fflags.append(self.compiler.openmp_flag)
+            fflags.append(spec["fortran"].package.openmp_flag)
 
         if spec.satisfies("+mpi"):
             buildopts.append("C_PARAFLAG=-DPARA")
@@ -217,7 +214,7 @@ class Berkeleygw(MakefilePackage):
 
         mathflags.append("-DUSEFFTW3")
         buildopts.append("FFTWINCLUDE=%s" % spec["fftw-api"].prefix.include)
-        fftwspec = spec["fftw-api:openmp" if "+openmp" in spec else "fftw-api"]
+        fftwspec = spec["fftw-api:openmp" if spec.satisfies("+openmp") else "fftw-api"]
         buildopts.append("FFTWLIB=%s" % fftwspec.libs.ld_flags)
 
         buildopts.append("LAPACKLIB=%s" % spec["lapack"].libs.ld_flags)
@@ -226,7 +223,7 @@ class Berkeleygw(MakefilePackage):
             mathflags.append("-DUSESCALAPACK")
             buildopts.append("SCALAPACKLIB=%s" % spec["scalapack"].libs.ld_flags)
 
-        if spec.satisfies("%intel"):
+        if spec.satisfies("%fortran=intel"):
             buildopts.append("COMPFLAG=-DINTEL")
             buildopts.append("MOD_OPT=-module ")
             buildopts.append("FCPP=cpp -C -P -ffreestanding")
@@ -241,11 +238,11 @@ class Berkeleygw(MakefilePackage):
                 buildopts.append("C_COMP=%s" % spack_cc)
                 buildopts.append("CC_COMP=%s" % spack_cxx)
             buildopts.append("FOPTS=%s" % " ".join(fflags))
-        elif spec.satisfies("%gcc"):
+        elif spec.satisfies("%fortran=gcc"):
             c_flags = "-std=c99"
             cxx_flags = "-std=c++0x"
             f90_flags = "-ffree-form -ffree-line-length-none -fno-second-underscore"
-            if spec.satisfies("%gcc@10:"):
+            if spec.satisfies("%fortran=gcc@10:"):
                 c_flags += " -fcommon"
                 cxx_flags += " -fcommon"
                 f90_flags += " -fallow-argument-mismatch"
@@ -254,7 +251,7 @@ class Berkeleygw(MakefilePackage):
             # std c11 prevents problems with linebreaks and fortran comments
             # containing // (which is interpreted as C++ style comment)
             buildopts.append(
-                "FCPP=%s -C -nostdinc -std=c11" % join_path(self.compiler.prefix, "bin", "cpp")
+                "FCPP=%s -C -nostdinc -std=c11" % join_path(spec["c"].prefix, "bin", "cpp")
             )
             if spec.satisfies("+mpi"):
                 buildopts.append("F90free=%s %s" % (spec["mpi"].mpifc, f90_flags))
@@ -265,7 +262,7 @@ class Berkeleygw(MakefilePackage):
                 buildopts.append("C_COMP=%s %s" % (spack_cc, c_flags))
                 buildopts.append("CC_COMP=%s %s" % (spack_cxx, cxx_flags))
             buildopts.append("FOPTS=%s" % " ".join(fflags))
-        elif spec.satisfies("%fj"):
+        elif spec.satisfies("%fortran=fj"):
             c_flags = "-std=c99"
             cxx_flags = "-std=c++0x"
             f90_flags = "-Free"
@@ -284,7 +281,7 @@ class Berkeleygw(MakefilePackage):
         else:
             raise InstallError(
                 "Spack does not yet have support for building "
-                "BerkeleyGW with compiler %s" % spec.compiler
+                "BerkeleyGW with compiler %s" % spec["fortran"]
             )
 
         if spec.satisfies("+hdf5"):

--- a/repos/spack_repo/builtin/packages/boost/package.py
+++ b/repos/spack_repo/builtin/packages/boost/package.py
@@ -691,7 +691,7 @@ class Boost(Package):
             # Any lib that is in self.all_libs AND in the variants dictionary
             # AND is set to False should be added to options in a --without flag
             for lib in self.all_libs:
-                if lib not in self.spec.variants.dict or self.spec.satisfies(f"+{lib}"):
+                if lib not in self.spec.variants or self.spec.satisfies(f"+{lib}"):
                     continue
                 options.append(f"--without-{lib}")
 

--- a/repos/spack_repo/builtin/packages/lci/package.py
+++ b/repos/spack_repo/builtin/packages/lci/package.py
@@ -154,13 +154,16 @@ class Lci(CMakePackage):
     depends_on("python@3.8:", type="build", when="@2:")
 
     def cmake_args(self):
+        # The deprecated variants override the bootstrap value used below.
+        bootstrap = self.spec.variants["bootstrap"].value
+
         if not self.spec.satisfies("enable-pm=auto"):
             warnings.warn(
                 "The 'enable-pm' variant is deprecated, use 'bootstrap' instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )
-            self.spec.variants["bootstrap"].value = self.spec.variants["enable-pm"].value
+            bootstrap = self.spec.variants["enable-pm"].value
 
         if not self.spec.satisfies("default-pm=auto"):
             warnings.warn(
@@ -168,7 +171,7 @@ class Lci(CMakePackage):
                 DeprecationWarning,
                 stacklevel=2,
             )
-            self.spec.variants["bootstrap"].value = self.spec.variants["default-pm"].value
+            bootstrap = self.spec.variants["default-pm"].value
 
         args = [
             self.define_from_variant("LCI_WITH_EXAMPLES", "examples"),
@@ -181,8 +184,8 @@ class Lci(CMakePackage):
             self.define_from_variant("LCI_USE_TCMALLOC", "tcmalloc"),
         ]
 
-        if not self.spec.satisfies("bootstrap=auto"):
-            if self.spec.satisfies("bootstrap=cray"):
+        if "auto" not in bootstrap:
+            if "cray" in bootstrap:
                 args.extend(
                     [
                         self.define("LCI_PMI_BACKEND_DEFAULT", "pmi1"),
@@ -192,19 +195,11 @@ class Lci(CMakePackage):
             else:
                 args.extend(
                     [
-                        self.define(
-                            "LCT_PMI_BACKEND_ENABLE_PMI1", self.spec.satisfies("bootstrap=pmi1")
-                        ),
-                        self.define(
-                            "LCT_PMI_BACKEND_ENABLE_PMI2", self.spec.satisfies("bootstrap=pmi2")
-                        ),
-                        self.define(
-                            "LCT_PMI_BACKEND_ENABLE_MPI", self.spec.satisfies("bootstrap=mpi")
-                        ),
-                        self.define(
-                            "LCT_PMI_BACKEND_ENABLE_PMIX", self.spec.satisfies("bootstrap=pmix")
-                        ),
-                        self.define_from_variant("LCI_PMI_BACKEND_DEFAULT", "bootstrap"),
+                        self.define("LCT_PMI_BACKEND_ENABLE_PMI1", "pmi1" in bootstrap),
+                        self.define("LCT_PMI_BACKEND_ENABLE_PMI2", "pmi2" in bootstrap),
+                        self.define("LCT_PMI_BACKEND_ENABLE_MPI", "mpi" in bootstrap),
+                        self.define("LCT_PMI_BACKEND_ENABLE_PMIX", "pmix" in bootstrap),
+                        self.define("LCI_PMI_BACKEND_DEFAULT", sorted(bootstrap)),
                     ]
                 )
 

--- a/repos/spack_repo/builtin/packages/mfem/package.py
+++ b/repos/spack_repo/builtin/packages/mfem/package.py
@@ -743,7 +743,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
 
         cuda_arch = None if "~cuda" in spec else spec.variants["cuda_arch"].value
 
-        cxxflags = spec.compiler_flags["cxxflags"].copy()
+        cxxflags = list(spec.compiler_flags["cxxflags"])
 
         if cxxflags:
             # Add opt/debug flags if they are not present in global cxx flags

--- a/repos/spack_repo/builtin/packages/nek5000/package.py
+++ b/repos/spack_repo/builtin/packages/nek5000/package.py
@@ -72,45 +72,41 @@ class Nek5000(Package):
     def install(self, spec, prefix):
         bin_dir = "bin"
 
-        # Do not use the Spack compiler wrappers.
-        # Use directly the compilers:
-        fc = self.compiler.f77
-        cc = self.compiler.cc
+        # The installed 'makenek' runs outside a Spack build environment, where wrappers fail.
+        fc = spec["fortran"].package.fortran
+        cc = spec["c"].package.cc
 
-        fflags = spec.compiler_flags["fflags"]
-        cflags = spec.compiler_flags["cflags"]
+        # the flag lists stored on the spec must not be modified in place
+        fflags = list(spec.compiler_flags["fflags"])
+        cflags = list(spec.compiler_flags["cflags"])
 
-        if self.compiler.name in ["xl", "xl_r"]:
+        if spec.satisfies("%fortran=xl"):
             # Use '-qextname' to add underscores.
             # Use '-WF,-qnotrigraph' to fix an error about a string: '... ??'
             fflags += ["-qextname", "-WF,-qnotrigraph"]
 
-        error = Executable(fc)("empty.f", output=str, error=str, fail_on_error=False)
-
-        if "gfortran" in error or "GNU" in error or "gfortran" in fc:
-            # Use '-std=legacy' to suppress an error that used to be a
-            # warning in previous versions of gfortran.
+        if spec.satisfies("%fortran=gcc"):
+            # Use '-std=legacy' to suppress an error that was a warning in older gfortran.
             fflags += ["-std=legacy"]
 
         fflags = " ".join(fflags)
         cflags = " ".join(cflags)
 
         with working_dir(bin_dir):
-            if "+mpi" in spec:
+            if spec.satisfies("+mpi"):
                 fc = spec["mpi"].mpif77
                 cc = spec["mpi"].mpicc
             else:
                 filter_file(r"^#MPI=0", "MPI=0", "makenek")
 
-            # Make sure nekmpi wrapper uses srun when we know OpenMPI
-            # is not built with mpiexec
-            if "^openmpi~legacylaunchers" in spec:
+            # The nekmpi wrapper uses srun when OpenMPI is not built with mpiexec
+            if spec.satisfies("^openmpi~legacylaunchers"):
                 filter_file(r"mpiexec -np", "srun -n", "nekmpi")
 
-            if "+profiling" not in spec:
+            if not spec.satisfies("+profiling"):
                 filter_file(r"^#PROFILING=0", "PROFILING=0", "makenek")
 
-            if "+visit" in spec:
+            if spec.satisfies("+visit"):
                 filter_file(r"^#VISIT=1", "VISIT=1", "makenek")
                 filter_file(
                     r"^#VISIT_INSTALL=.*",
@@ -141,10 +137,8 @@ class Nek5000(Package):
                 filter_file(r"^#CFLAGS=.*", 'CFLAGS+=" {0}"'.format(cflags), "makenek")
 
         with working_dir("core"):
-            if self.compiler.name in ["xl", "xl_r"]:
-                # Patch 'core/makenek.inc' and 'makefile.template' to use
-                # '-qextname' when checking for underscore becasue 'xl'/'xl_r'
-                # use this option to enable the addition of the underscore.
+            if spec.satisfies("%fortran=xl"):
+                # 'xl' adds underscores with '-qextname', so patch the underscore check.
                 filter_file(r"^\$FCcomp -c ", "$FCcomp -qextname -c ", "makenek.inc")
                 filter_file(
                     r"\$\(FC\) -c \$\(L0\)", "$(FC) -c -qextname $(L0)", "makefile.template"

--- a/repos/spack_repo/builtin/packages/nekcem/package.py
+++ b/repos/spack_repo/builtin/packages/nekcem/package.py
@@ -71,6 +71,10 @@ class Nekcem(Package):
             fflags += ["-I."]
             cflags += ["-I.", "-DGLOBAL_LONG_LONG"]
 
+            # The C sources rely on tentative definitions.
+            if spec.satisfies("%c=gcc@10:") or spec.satisfies("%c=llvm@11:"):
+                cflags += ["-fcommon"]
+
             if spec.satisfies("%fortran=gcc") or spec.satisfies("%fortran=llvm"):
                 # 'flang' accepts the same flags as 'gfortran'
                 fflags += ["-fdefault-real-8", "-fdefault-double-8"]

--- a/repos/spack_repo/builtin/packages/nekcem/package.py
+++ b/repos/spack_repo/builtin/packages/nekcem/package.py
@@ -52,14 +52,16 @@ class Nekcem(Package):
         configurenek = "configurenek"
         makenek = "makenek"
 
-        fc = self.compiler.f77
-        cc = self.compiler.cc
+        # The installed 'makenek' runs outside a Spack build environment, where wrappers fail.
+        fc = spec["fortran"].package.fortran
+        cc = spec["c"].package.cc
 
-        fflags = spec.compiler_flags["fflags"]
-        cflags = spec.compiler_flags["cflags"]
-        ldflags = spec.compiler_flags["ldflags"]
+        # the flag lists stored on the spec must not be modified in place
+        fflags = list(spec.compiler_flags["fflags"])
+        cflags = list(spec.compiler_flags["cflags"])
+        ldflags = list(spec.compiler_flags["ldflags"])
 
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             fc = spec["mpi"].mpif77
             cc = spec["mpi"].mpicc
 
@@ -69,25 +71,22 @@ class Nekcem(Package):
             fflags += ["-I."]
             cflags += ["-I.", "-DGLOBAL_LONG_LONG"]
 
-            if self.compiler.name == "gcc" or self.compiler.name == "clang":
-                # assuming 'clang' uses 'gfortran'
+            if spec.satisfies("%fortran=gcc") or spec.satisfies("%fortran=llvm"):
+                # 'flang' accepts the same flags as 'gfortran'
                 fflags += ["-fdefault-real-8", "-fdefault-double-8"]
                 cflags += ["-DUNDERSCORE"]
-            elif self.compiler.name == "intel":
+            elif spec.satisfies("%fortran=intel"):
                 fflags += ["-r8"]
                 cflags += ["-DUNDERSCORE"]
-            elif self.compiler.name == "xl" or self.compiler.name == "xl_r":
+            elif spec.satisfies("%fortran=xl"):
                 fflags += ["-qrealsize=8"]
                 cflags += ["-DPREFIX=jl_", "-DIBM"]
 
-            error = Executable(fc)("empty.f", output=str, error=str, fail_on_error=False)
-
-            if "gfortran" in error or "GNU" in error or "gfortran" in fc:
-                # Use '-std=legacy' to suppress an error that used to be a
-                # warning in previous versions of gfortran.
+            if spec.satisfies("%fortran=gcc"):
+                # Use '-std=legacy' to suppress an error that was a warning in older gfortran.
                 fflags += ["-std=legacy"]
 
-            if "+mpi" in spec:
+            if spec.satisfies("+mpi"):
                 fflags += ["-DMPI", "-DMPIIO"]
                 cflags += ["-DMPI", "-DMPIIO"]
             blas_lapack = spec["lapack"].libs + spec["blas"].libs

--- a/repos/spack_repo/builtin/packages/nektools/package.py
+++ b/repos/spack_repo/builtin/packages/nektools/package.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import numbers
-import os
 
 from spack_repo.builtin.build_systems.generic import Package
 
@@ -70,6 +69,18 @@ class Nektools(Package):
     depends_on("libxt", when="+postnek")
     depends_on("visit", when="+visit")
 
+    def flag_handler(self, name, flags):
+        if name == "fflags":
+            if self.spec.satisfies("%fortran=xl"):
+                # Use '-qextname' to add underscores.
+                # Use '-WF,-qnotrigraph' to fix an error about a string: '... ??'
+                flags.extend(["-qextname", "-WF,-qnotrigraph"])
+            elif self.spec.satisfies("%fortran=gcc"):
+                # Use '-std=legacy' to suppress an error that was a warning in older gfortran.
+                flags.append("-std=legacy")
+
+        return flags, None, None
+
     def install(self, spec, prefix):
         tools_dir = "tools"
         bin_dir = "bin"
@@ -77,55 +88,15 @@ class Nektools(Package):
         fc = env["FC"]
         cc = env["CC"]
 
-        fflags = spec.compiler_flags["fflags"]
-        cflags = spec.compiler_flags["cflags"]
-        if ("+prenek" in spec) or ("+postnek" in spec):
-            libx11_h = find_headers("Xlib", spec["libx11"].prefix.include, recursive=True)
-            if not libx11_h:
-                raise RuntimeError("Xlib.h not found in %s" % spec["libx11"].prefix.include)
-            cflags += ["-I%s" % os.path.dirname(libx11_h.directories[0])]
-
-            xproto_h = find_headers("X", spec["xproto"].prefix.include, recursive=True)
-            if not xproto_h:
-                raise RuntimeError("X.h not found in %s" % spec["xproto"].prefix.include)
-            cflags += ["-I%s" % os.path.dirname(xproto_h.directories[0])]
-
-            libxt_h = find_headers("Intrinsic", spec["libxt"].prefix.include, recursive=True)
-            if not libxt_h:
-                raise RuntimeError(
-                    "X11/Intrinsic.h not found in %s" % spec["libxt"].prefix.include
-                )
-            cflags += ["-I%s" % os.path.dirname(libxt_h.directories[0])]
-        if self.compiler.name in ["xl", "xl_r"]:
-            # Use '-qextname' to add underscores.
-            # Use '-WF,-qnotrigraph' to fix an error about a string: '... ??'
-            fflags += ["-qextname", "-WF,-qnotrigraph"]
-
-        error = Executable(fc)("empty.f", output=str, error=str, fail_on_error=False)
-
-        if "gfortran" in error or "GNU" in error or "gfortran" in fc:
-            # Use '-std=legacy' to suppress an error that used to be a
-            # warning in previous versions of gfortran.
-            fflags += ["-std=legacy"]
-
-        fflags = " ".join(fflags)
-        cflags = " ".join(cflags)
-
         # Build the tools, maketools copy them to Nek5000/bin by default.
         # We will then install Nek5000/bin under prefix after that.
         with working_dir(tools_dir):
             # Update the maketools script to use correct compilers
             filter_file(r"^#FC\s*=.*", 'FC="{0}"'.format(fc), "maketools")
             filter_file(r"^#CC\s*=.*", 'CC="{0}"'.format(cc), "maketools")
-            if fflags:
-                filter_file(r"^#FFLAGS=.*", 'FFLAGS="{0}"'.format(fflags), "maketools")
-            if cflags:
-                filter_file(r"^#CFLAGS=.*", 'CFLAGS="{0}"'.format(cflags), "maketools")
 
-            if self.compiler.name in ["xl", "xl_r"]:
-                # Patch 'maketools' to use '-qextname' when checking for
-                # underscore becasue 'xl'/'xl_r' use this option to enable the
-                # addition of the underscore.
+            if spec.satisfies("%fortran=xl"):
+                # 'xl' adds underscores with '-qextname', so patch the check in 'maketools'.
                 filter_file(r"^\$FC -c ", "$FC -qextname -c ", "maketools")
 
             libx11_lib = find_libraries(
@@ -142,7 +113,7 @@ class Nektools(Package):
             filter_file(r"-L\$\(X\)", libx11_lib.search_flags, join_path("prenek", "makefile"))
             filter_file(r"-L\$\(X\)", libx11_lib.search_flags, join_path("postnek", "makefile"))
 
-            if self.compiler.name in ["xl", "xl_r"]:
+            if spec.satisfies("%fortran=xl"):
                 # Use '-qextname' when compiling mxm.f
                 filter_file(r"\$\(OLAGS\)", "-qextname $(OLAGS)", join_path("postnek", "makefile"))
             # Define 'rename_' function that calls 'rename'
@@ -155,19 +126,19 @@ class Nektools(Package):
             maketools = Executable("./maketools")
 
             # Build the tools
-            if "+genbox" in spec:
+            if spec.satisfies("+genbox"):
                 maketools("genbox")
-            if "+n2to3" in spec:
+            if spec.satisfies("+n2to3"):
                 maketools("n2to3")
-            if "+postnek" in spec:
+            if spec.satisfies("+postnek"):
                 maketools("postnek")
-            if "+reatore2" in spec:
+            if spec.satisfies("+reatore2"):
                 maketools("reatore2")
-            if "+genmap" in spec:
+            if spec.satisfies("+genmap"):
                 maketools("genmap")
-            if "+nekmerge" in spec:
+            if spec.satisfies("+nekmerge"):
                 maketools("nekmerge")
-            if "+prenek" in spec:
+            if spec.satisfies("+prenek"):
                 maketools("prenek")
 
         # Install Nek5000/bin in prefix/bin

--- a/repos/spack_repo/builtin/packages/stripack/package.py
+++ b/repos/spack_repo/builtin/packages/stripack/package.py
@@ -34,15 +34,15 @@ class Stripack(MakefilePackage):
 
     depends_on("fortran", type="build")
 
+    build_targets = ["all"]
+
     @run_before("build")
     def run_mkmake(self):
         config = [
             "BUILDIR ?= " + join_path(self.build_directory, "build"),
             "DYLIB=" + dso_suffix,
-            "F90=" + self.compiler.fc,
-            "LD=" + self.compiler.fc,
-            "FFLAGS=" + self.compiler.fc_pic_flag,
-            "LDFLAGS=" + self.compiler.fc_pic_flag,
+            "F90=" + spack_fc,
+            "LD=" + spack_fc,
             ".SUFFIXES: .f .f90 .F90",
             "$(BUILDIR)/%.o: %.f90",
             "\t$(F90) $(FFLAGS) -c $< -o $@",
@@ -60,23 +60,27 @@ class Stripack(MakefilePackage):
             "VISIT_FFP_STRIPACK_PATH", join_path(self.spec.prefix.lib, "libstripack." + dso_suffix)
         )
 
-    def build(self, spec, prefix):
-        fflags = spec.compiler_flags["fflags"]
-        # Setting the double precision mode
-        # needed for the original Fortran 77 version
-        satisfies = spec.satisfies
-        if satisfies("%gcc") or satisfies("%clang") or satisfies("%flang"):
-            fflags += ["-fdefault-real-8", "-fdefault-double-8"]
-        elif satisfies("%intel") or satisfies("%oneapi") or satisfies("%aocc"):
-            fflags += ["-r8"]
-        elif satisfies("%xl") or satisfies("%xl_r"):
-            fflags += ["-qrealsize=8"]
-        elif satisfies("%fj"):
-            fflags += ["-CcdRR8"]
-        elif satisfies("%nvhpc"):
-            fflags += ["-r8"]
-        fflags += [self.compiler.fc_pic_flag]
-        make("all", "FFLAGS={0}".format(" ".join(fflags)))
+    def flag_handler(self, name, flags):
+        if name != "fflags":
+            return flags, None, None
+
+        spec = self.spec
+
+        # The original Fortran 77 version has to be built in double precision mode.
+        if spec.satisfies("%fortran=gcc") or spec.satisfies("%fortran=llvm"):
+            flags.extend(["-fdefault-real-8", "-fdefault-double-8"])
+        elif spec.satisfies("%fortran=xl"):
+            flags.append("-qrealsize=8")
+        elif spec.satisfies("%fortran=fj"):
+            flags.append("-CcdRR8")
+        elif any(
+            spec.satisfies(f"%fortran={compiler}")
+            for compiler in ("intel", "oneapi", "aocc", "nvhpc")
+        ):
+            flags.append("-r8")
+
+        flags.append(spec["fortran"].package.pic_flag)
+        return flags, None, None
 
     def install(self, spec, prefix):
         mkdirp(prefix.lib)


### PR DESCRIPTION
Fix a couple issues with packages that mutate `self.spec` or use some internals I would consider not covered by the package API.

`nek5000`, `nektools`, `nekcem` and `stripack` appended to `spec.compiler_flags[...]`

`lci` assigned to `spec.variants["bootstrap"].value`.

`boost` read the private `spec.variants.dict`.

`mfem` called `.copy()` and `berkeleygw` sliced with `[:]` on flags, which works assuming it's a list, but this to me sounds like assuming too much about the implementation and will fail if compiler flags are immutable tuples
(https://github.com/spack/spack/pull/52947).

Use `flag_handler` instead of something ad-hoc in `strippack`, `nektools`, `berkeleygw`

Use the compiler wrapper `spack_fc` instead of the backing compiler in `stripack`.

Drop the custom logic for X11 include paths, cause it coincides with the default `-I` flags added through the compiler wrapper.

Branch on `%fortran=<name>` in `nek5000`, `nektools` and `nekcem` instead of something custom.

The builds of berkeleygw, boost, lci, mfem, nek5000, nekcem, nektools and stripack succeeded using gcc 13.3.0.