### PR TITLE
py-albucore: pkg_resources removal from py-setuptools

### DIFF
--- a/repos/spack_repo/builtin/packages/py_albucore/package.py
+++ b/repos/spack_repo/builtin/packages/py_albucore/package.py
@@ -33,3 +33,6 @@ class PyAlbucore(PythonPackage):
     depends_on("py-simsimd@5.9.2:", type=("build", "run"), when="@:0.0.41")
     depends_on("py-typing-extensions@4.9:", type=("build", "run"), when="@:0.0.33 ^python@:3.9")
     depends_on("opencv@4.9.0.80:+python3+contrib", type=("build", "run"), when="@:0.0.34")
+
+    # pkg_resources removal from py-setuptools
+    conflicts("^py-setuptools@81:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
