### PR TITLE
Mark proprietary packages non-redistributable

### DIFF
--- a/repos/spack_repo/builtin/packages/acfl/package.py
+++ b/repos/spack_repo/builtin/packages/acfl/package.py
@@ -331,6 +331,9 @@ class Acfl(Package, CompilerPackage):
 
     maintainers("paolotricerri")
 
+    redistribute(source=False, binary=False)
+    license("LicenseRef-ARM-Proprietary", checked_by="tgamblin")
+
     # Build Versions
     for ver, packages in _versions.items():
         acfl_os = get_os(ver)

--- a/repos/spack_repo/builtin/packages/aocc/package.py
+++ b/repos/spack_repo/builtin/packages/aocc/package.py
@@ -35,6 +35,9 @@ class Aocc(Package, LlvmDetection, CompilerPackage):
 
     maintainers("amd-toolchain-support")
 
+    redistribute(source=False, binary=False)
+    license("LicenseRef-AMD-Proprietary", checked_by="tgamblin")
+
     version(
         ver="5.2.0",
         sha256="f98af7e2ae8801dd4ba443520653acb739536a86c2a1caf096310c3cfd554ca0",

--- a/repos/spack_repo/builtin/packages/aqlprofile/package.py
+++ b/repos/spack_repo/builtin/packages/aqlprofile/package.py
@@ -275,6 +275,12 @@ class Aqlprofile(Package):
 
     maintainers("afzpatel", "srekolam", "renjithravindrankannath")
 
+    # aqlprofile is only open source (MIT) as of rocm-7.0.0; all versions here are
+    # prebuilt proprietary binaries from repo.radeon.com that predate that release
+    license("LicenseRef-AMD-Proprietary", when="@:6", checked_by="tgamblin")
+    license("MIT", when="@7:", checked_by="tgamblin")
+    redistribute(source=False, binary=False, when="@:6")
+
     libraries = ["libhsa-amd-aqlprofile64"]
 
     spack_os = host_platform().default_os

--- a/repos/spack_repo/builtin/packages/armpl_gcc/package.py
+++ b/repos/spack_repo/builtin/packages/armpl_gcc/package.py
@@ -367,6 +367,9 @@ class ArmplGcc(Package):
     homepage = "https://developer.arm.com/tools-and-software/server-and-hpc/downloads/arm-performance-libraries"
     maintainers("paolotricerri")
 
+    redistribute(source=False, binary=False)
+    license("LicenseRef-ARM-Proprietary", checked_by="tgamblin")
+
     for ver, packages in _versions.items():
         key = get_os_or_pkg_manager(ver)
         sha256sum = packages.get(key)

--- a/repos/spack_repo/builtin/packages/charmpp/package.py
+++ b/repos/spack_repo/builtin/packages/charmpp/package.py
@@ -24,6 +24,10 @@ class Charmpp(Package):
     git = "https://github.com/UIUC-PPL/charm.git"
 
     maintainers("matthiasdiener")
+    # relicensed from a non-commercial license to Apache-2.0 in May 2024, after v7.0.0
+    license("LicenseRef-Charmpp-Non-Commercial", when="@:7.0", checked_by="tgamblin")
+    license("Apache-2.0 WITH LLVM-exception", when="@7.1:", checked_by="tgamblin")
+    redistribute(source=False, binary=False, when="@:7.0")
 
     version("main", branch="main")
 

--- a/repos/spack_repo/builtin/packages/dislin/package.py
+++ b/repos/spack_repo/builtin/packages/dislin/package.py
@@ -15,6 +15,9 @@ class Dislin(Package):
     homepage = "https://www.mps.mpg.de/dislin"
     url = "ftp://ftp.gwdg.de/pub/grafik/dislin/linux/i586_64/dislin-11.0.linux.i586_64.tar.gz"
 
+    license("LicenseRef-DISLIN-Proprietary", checked_by="tgamblin")
+    redistribute(source=False, binary=False)
+
     version("11.0", sha256="13d28188924e0b0b803d72aa4b48be4067e98e890701b0aa6f54a11c7d34dd10")
 
     depends_on("motif")

--- a/repos/spack_repo/builtin/packages/namd/package.py
+++ b/repos/spack_repo/builtin/packages/namd/package.py
@@ -21,7 +21,9 @@ class Namd(MakefilePackage, CudaPackage, ROCmPackage):
     url = "file://{0}/NAMD_2.12_Source.tar.gz".format(os.getcwd())
     git = "https://charm.cs.illinois.edu/gerrit/namd.git"
     manual_download = True
+
     redistribute(source=False, binary=False)
+    license("LicenseRef-NAMD-Proprietary", checked_by="tgamblin")
 
     maintainers("jcphill")
 

--- a/repos/spack_repo/builtin/packages/psipred/package.py
+++ b/repos/spack_repo/builtin/packages/psipred/package.py
@@ -18,6 +18,9 @@ class Psipred(MakefilePackage):
 
     license_url = "http://bioinfadmin.cs.ucl.ac.uk/downloads/psipred/LICENSE"
 
+    license("LicenseRef-UCL-Proprietary", checked_by="tgamblin")
+    redistribute(source=False, binary=False)
+
     version("4.02", sha256="b4009b6a5f8b76c6d60ac91c4a743512d844864cf015c492fb6d1dc0d092c467")
 
     depends_on("c", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/py_x21/package.py
+++ b/repos/spack_repo/builtin/packages/py_x21/package.py
@@ -15,6 +15,9 @@ class PyX21(PythonPackage):
     homepage = "https://pypi.org/project/x21/"
     list_url = "https://pypi.org/simple/x21/"
 
+    license("LicenseRef-X21-Proprietary", checked_by="tgamblin")
+    redistribute(source=False, binary=False)
+
     def url_for_version(self, version):
         url = "https://pypi.io/packages/cp{1}/x/x21/x21-{0}-cp{1}-cp{1}-{2}.whl"
 


### PR DESCRIPTION
While working on the source mirror sync job (see #6245), I found a number of packages whose sources we can't legally mirror. `acfl` was already failing this way in the reverted nightly job. This adds `license()` and `redistribute(source=False, binary=False)` to:

- `acfl`, `armpl-gcc`: Arm EULA
- `aocc`: AMD EULA (install already requires `+license-agreed`)
- `aqlprofile`: proprietary binaries; MIT as of rocm 7.0.0, so scoped to `@:6`
- `dislin`: proprietary freeware
- `namd`: UIUC non-commercial license (was already non-redistributable)
- `psipred`: UCL non-commercial license
- `py-x21`: closed-source wheels
- `charmpp`: Apache-2.0 as of v7.1; older versions are non-commercial

With these, the mirror sync job will skip these packages instead of trying to fetch them every night and failing.