### PR TITLE
r-manipulatewidget: add missing r-lazyeval dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/r_manipulatewidget/package.py
+++ b/repos/spack_repo/builtin/packages/r_manipulatewidget/package.py
@@ -39,3 +39,6 @@ class RManipulatewidget(RPackage):
     depends_on("r-codetools", type=("build", "run"))
     depends_on("r-webshot", type=("build", "run"))
     depends_on("r-shinyjs", type=("build", "run"), when="@0.11.1:")
+
+    # Historical dependencies
+    depends_on("r-lazyeval", type=("build", "run"), when="@0.6:0.7")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
