### PR TITLE
e4s: add kokkos-tools

### DIFF
--- a/repos/spack_repo/builtin/packages/kokkos_tools/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos_tools/package.py
@@ -31,6 +31,7 @@ class KokkosTools(CMakePackage):
     depends_on("kokkos")
     depends_on("mpi", when="+mpi")
     depends_on("papi", when="+papi")
+    depends_on("rocprofiler-sdk", when="^kokkos +rocm")
 
     def cmake_args(self):
         # The plugins are intentionally disabled the time to properly introduce new variants

--- a/stacks/e4s-cray-rhel/spack.yaml
+++ b/stacks/e4s-cray-rhel/spack.yaml
@@ -123,6 +123,7 @@ spack:
   - kokkos +openmp
   - kokkos-fft host_backend=fftw-openmp
   - kokkos-kernels +openmp
+  - kokkos-tools
   - libnrm
   - libquo
   - libunwind

--- a/stacks/e4s-cray-sles/spack.yaml
+++ b/stacks/e4s-cray-sles/spack.yaml
@@ -91,6 +91,7 @@ spack:
   - kokkos +openmp
   - kokkos-kernels +openmp
   - kokkos-fft host_backend=fftw-openmp
+  - kokkos-tools
   - lammps
   - legion
   - libnrm

--- a/stacks/e4s-neoverse-v2/spack.yaml
+++ b/stacks/e4s-neoverse-v2/spack.yaml
@@ -92,6 +92,7 @@ spack:
   - kokkos +openmp
   - kokkos-kernels +openmp
   - kokkos-fft host_backend=fftw-openmp
+  - kokkos-tools
   - lammps
   - lbann
   - legion
@@ -205,6 +206,7 @@ spack:
   - kokkos +wrapper +cuda cuda_arch=90
   - kokkos-kernels +cuda cuda_arch=90 ^kokkos +wrapper +cuda cuda_arch=90
   - kokkos-fft device_backend=cufft ^kokkos +wrapper +cuda cuda_arch=90
+  - kokkos-tools ^kokkos +wrapper +cuda cuda_arch=90
   - libceed +cuda cuda_arch=90
   - magma +cuda cuda_arch=90
   - mfem +cuda cuda_arch=90

--- a/stacks/e4s-oneapi/spack.yaml
+++ b/stacks/e4s-oneapi/spack.yaml
@@ -111,6 +111,7 @@ spack:
   - hypre
   - kokkos +openmp
   - kokkos-kernels +openmp
+  - kokkos-tools
   - laghos ^mfem~cuda
   - lammps +amoeba +asphere +bocs +body +bpm +brownian +cg-dna +cg-spica +class2 +colloid +colvars +compress +coreshell +dielectric +diffraction +dipole +dpd-basic +dpd-meso +dpd-react +dpd-smooth +drude +eff +electrode +extra-compute +extra-dump +extra-fix +extra-molecule +extra-pair +fep +granular +interlayer +kspace +lepton +machdyn +manybody +mc +meam +mesont +misc +ml-iap +ml-pod +ml-snap +mofff +molecule +openmp-package +opt +orient +peri +phonon +plugin +poems +qeq +reaction +reaxff +replica +rigid +shock +sph +spin +srd +tally +uef +voronoi +yaff
   - legion
@@ -188,6 +189,7 @@ spack:
   - hpctoolkit +level_zero
   - kokkos +sycl +openmp cxxstd=17
   - kokkos-kernels ^kokkos +sycl +openmp cxxstd=17
+  - kokkos-tools ^kokkos +sycl +openmp cxxstd=17
   - sundials +sycl +examples-install cxxstd=17
   - tau +mpi +opencl +python +level_zero +syscall
   - upcxx +level_zero

--- a/stacks/e4s-rocm-external/spack.yaml
+++ b/stacks/e4s-rocm-external/spack.yaml
@@ -245,6 +245,7 @@ spack:
   - heffte +rocm amdgpu_target=gfx90a
   - kokkos +rocm amdgpu_target=gfx90a
   - kokkos-fft device_backend=hipfft ^kokkos +rocm amdgpu_target=gfx90a
+  - kokkos-tools ^kokkos +rocm amdgpu_target=gfx90a
   - legion +rocm amdgpu_target=gfx90a %c,cxx=gcc
   - libceed +rocm amdgpu_target=gfx90a
   - mfem +rocm amdgpu_target=gfx90a

--- a/stacks/e4s/spack.yaml
+++ b/stacks/e4s/spack.yaml
@@ -113,6 +113,7 @@ spack:
     - kokkos
     - kokkos-kernels
     - kokkos-fft device_backend=cufft
+    - kokkos-tools
     - legion
     - libceed
     - libpressio +bitgrooming +bzip2 +fpzip +hdf5 +libdistributed +lua +openmp +python +sz +sz3 +unix +zfp +json +remote +netcdf +cusz +mgard ^cusz
@@ -191,6 +192,7 @@ spack:
   - kokkos +openmp
   - kokkos-kernels +openmp
   - kokkos-fft host_backend=fftw-openmp
+  - kokkos-tools
   - laghos
   - lammps +amoeba +asphere +bocs +body +bpm +brownian +cg-dna +cg-spica +class2 +colloid +colvars +compress +coreshell +dielectric +diffraction +dipole +dpd-basic +dpd-meso +dpd-react +dpd-smooth +drude +eff +electrode +extra-compute +extra-dump +extra-fix +extra-molecule +extra-pair +fep +granular +interlayer +kspace +lepton +machdyn +manybody +mc +meam +mesont +misc +ml-iap +ml-pod +ml-snap +mofff +molecule +openmp-package +opt +orient +peri +phonon +plugin +poems +qeq +reaction +reaxff +replica +rigid +shock +sph +spin +srd +tally +uef +voronoi +yaff
   - lbann
@@ -392,6 +394,7 @@ spack:
     - hpx
     - hypre
     - kokkos
+    - kokkos-tools
     - lammps
     - legion
     - libceed


### PR DESCRIPTION
@eugeneswalker Is it ok to add Kokkos Tools to E4S stacks ? If so, I am wondering if I should always add `^kokkos ...` ? This is done in some stacks but not all.

Adding `rocprofiler-sdk` dependency to kokkos-tools, the package seems to provide the correct CMake package https://github.com/ROCm/rocprofiler-sdk/blob/rocm-6.3.3/cmake/rocprofiler_config_install_roctx.cmake. See https://gitlab.spack.io/spack/spack-packages/-/jobs/24119218 for the complete error log:
```
-- Could NOT find rocprofiler-sdk-roctx (missing: rocprofiler-sdk-roctx_DIR)
CMake Error at profiling/roctx-connector/CMakeLists.txt:11 (find_library):
  Could not find ROCM_ROCTX_LIB using the following names: roctx64
```