### PR TITLE
root: add v6.40.04

### DIFF
--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -36,6 +36,7 @@ class Root(CMakePackage):
     version("develop", branch="master")
 
     # Production release series
+    version("6.40.04", sha256="44ada253b1935d34b6801222232d50731fe7c5e3cbcfab47734c85031cfbe4d3")
     version("6.40.02", sha256="f631eebee3dbea128f1415f4b784f5e83637a2b431193bce75f10385f71efc56")
     version("6.40.00", sha256="676f8fde8926ce05902be7f44ce7d492a4a2060022fcab0e3d1c44f6dc0fbde8")
     version("6.36.12", sha256="1243fc48b7c1358ebf69e6140a13d9c27e0fd84663632cc6217beda875a4a317")


### PR DESCRIPTION
This PR adds the new `root` release, v6.40.04 ([release notes](https://github.com/root-project/root/releases/tag/v6-40-04), [diff](https://github.com/root-project/root/compare/v6-40-02...v6-40-04)). No build system changes; bugfixes only.