### PR TITLE
ectrans: add option to trust ecbuild compiler flags

### DIFF
--- a/repos/spack_repo/builtin/packages/ectrans/package.py
+++ b/repos/spack_repo/builtin/packages/ectrans/package.py
@@ -51,6 +51,11 @@ class Ectrans(CMakePackage):
 
     variant("mkl", default=False, description="Use MKL")
     variant("fftw", default=True, description="Use FFTW")
+    variant(
+        "trust_ecbuild_flags",
+        default=False,
+        description="Skip ecbuild compiler-flag probes",
+    )
 
     variant(
         "etrans",
@@ -70,6 +75,7 @@ class Ectrans(CMakePackage):
     depends_on("cmake@3.25:", when="@1.5:", type="build")
 
     depends_on("ecbuild", type="build")
+    depends_on("ecbuild@3.6:", when="+trust_ecbuild_flags", type="build")
     depends_on("mpi", when="+mpi")
     depends_on("blas")
     depends_on("lapack")
@@ -108,4 +114,6 @@ class Ectrans(CMakePackage):
             # https://github.com/JCSDA/spack-stack/issues/1522
             "-DECTRANS_HAVE_CONTIGUOUS_ISSUE=ON",
         ]
+        if "+trust_ecbuild_flags" in self.spec:
+            args.append(self.define("ECBUILD_TRUST_FLAGS", True))
         return args


### PR DESCRIPTION
## Summary

Add an opt-in `+trust_ecbuild_flags` variant for ectrans. When enabled, it configures ectrans with `-DECBUILD_TRUST_FLAGS=ON` and requires `ecbuild@3.6:`, which provides that option.

The default is `False` to preserve current behavior with no variants.

## Context

This was encountered while building a portable Spack Stack environment at NAS, where the installation target is constrained to `x86_64_v3` because the cluster contains multiple processor generations.

With oneAPI classic `ifort` behind Spack's compiler wrapper, ecbuild's compiler-flag probe can reject target flags even though the compiler accepts the corresponding compile command. A benign target-option diagnostic is interpreted as a failed probe.

[JCSDA/spack-stack#1775](https://github.com/JCSDA/spack-stack/issues/1775) contains the original reproducer, including direct `ifort` and `ifx` commands that successfully accept the relevant flags.

`+trust_ecbuild_flags` exposes ecbuild's built-in `ECBUILD_TRUST_FLAGS` mechanism for this situation. The default behavior remains unchanged; affected sites can explicitly opt in.

## Testing

A fresh Spack Stack build with this variant enabled is in progress on the affected oneAPI configurations.

## Disclosure

GPT-5.6 Terra assisted with investigating the failure mode and preparing this change.