### PR TITLE
spades: fix missing <cstdint> under GCC 14

### DIFF
--- a/repos/spack_repo/builtin/packages/spades/package.py
+++ b/repos/spack_repo/builtin/packages/spades/package.py
@@ -42,6 +42,20 @@ class Spades(CMakePackage):
 
     root_cmakelists_dir = "src"
 
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        # id_map.hpp (binspreader project) uses uint64_t without including
+        # <cstdint> -- older GCC pulled it in transitively, GCC 14's
+        # libstdc++ does not. A static scan of the whole source tree found
+        # 111 files with the same pattern (relying on transitive includes
+        # for fixed-width int types), way too many to patch file by file
+        # and too easy for the build to hit a new one further along.
+        # Force the header into every translation unit at the compiler
+        # level instead.
+        # <cstdint> is the C++ wrapper header, not visible to the plain C
+        # compiler -- the equivalent for .c files is <stdint.h>.
+        env.append_flags("CFLAGS", "-include stdint.h")
+        env.append_flags("CXXFLAGS", "-include cstdint")
+
     def cmake_args(self):
         args = [self.define_from_variant("SPADES_USE_NCBISDK", "sra")]
         if self.spec.satisfies("+tools"):


### PR DESCRIPTION
## Summary
Building spades@4.0.0 with GCC 14 fails with e.g.:
```
src/projects/binspreader/id_map.hpp:18:35: error: 'uint64_t' does not name a type
```
`id_map.hpp` uses `uint64_t` as a default template parameter but never includes `<cstdint>` -- older GCC pulled it in transitively (via `<boost/iterator/iterator_facade.hpp>` or one of the other headers it includes), GCC 14's libstdc++ does not.

A static scan of the whole `src/` tree found **111 files** with the same pattern (using fixed-width int types while relying on a transitive include for `<cstdint>`/`<stdint.h>`) -- too many to patch file by file, and too easy for the build to hit a new one further along depending on which `+tools`/`+sra` targets get compiled. Forcing the header into every translation unit at the compiler level (`-include cstdint` for C++, `-include stdint.h` for C, since `<cstdint>` is the C++ wrapper and isn't visible to the plain C compiler) covers all of them at once.

## Testing
Installed `spades@4.0.0 +sra +tools` (all optional projects enabled, `SPADES_ENABLE_PROJECTS=all`) with `%gcc@14.2.0` end to end, confirmed `spades.py --version` and a real assembly run (contigs.fasta/scaffolds.fasta produced) work.
