### PR TITLE
metaeuk: fix missing <cstdint> under GCC 14

### DIFF
--- a/repos/spack_repo/builtin/packages/metaeuk/package.py
+++ b/repos/spack_repo/builtin/packages/metaeuk/package.py
@@ -24,3 +24,17 @@ class Metaeuk(CMakePackage):
     depends_on("cxx", type="build")  # generated
 
     depends_on("cmake@2.8.12:", type="build")
+
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        # Same class of bug as spades: mmseqs2 (vendored inside metaeuk)
+        # uses fixed-width int types (uint32_t/uint64_t/...) all over the
+        # place but relies on getting <cstdint> transitively from whatever
+        # standard header happened to pull it in on older GCC -- GCC 14's
+        # libstdc++ doesn't. A static scan found 47 affected files, way
+        # too many to patch one by one and too easy for a 48th to slip
+        # through later. Force the header into every translation unit at
+        # the compiler level instead of chasing individual includes.
+        # <cstdint> is the C++ wrapper header, not visible to the plain C
+        # compiler -- the equivalent for .c files is <stdint.h>.
+        env.append_flags("CFLAGS", "-include stdint.h")
+        env.append_flags("CXXFLAGS", "-include cstdint")


### PR DESCRIPTION
## Summary
Same class of bug as in `spades` (same root cause, unrelated codebase -- both packages independently hit this): metaeuk vendors mmseqs2 under `lib/mmseqs`, and its C++ sources use fixed-width int types (`uint32_t`/`uint64_t`/...) throughout while relying on getting `<cstdint>` transitively from whatever standard header happened to pull it in on older GCC. GCC 14's libstdc++ doesn't, so the build fails, e.g.:
```
lib/mmseqs/src/commons/Util.h:87:12: error: 'uint64_t' does not name a type
lib/mmseqs/src/prefiltering/Indexer.h:125:9: error: 'uint64_t' was not declared in this scope
```

A static scan found **47 affected files**. Rather than patch each one (and risk missing a 48th), force the header into every translation unit at the compiler level: `-include cstdint` for C++ sources, `-include stdint.h` for C sources (the plain C compiler doesn't see the C++ wrapper header).

## Testing
Installed `metaeuk@6-a5d39d9` with `%gcc@14.2.0` as a dependency of `busco@6.1.0`, confirmed it builds clean and busco runs a real gene-prediction pipeline end to end using it.
