### PR TITLE
sepp: fix build with Python 3.12+ (distutils removal)

### DIFF
--- a/repos/spack_repo/builtin/packages/sepp/package.py
+++ b/repos/spack_repo/builtin/packages/sepp/package.py
@@ -29,6 +29,36 @@ class Sepp(Package):
 
     extends("python")
 
+    def patch(self):
+        # setup.py bootstraps via a 2010-era "distribute_setup.py" helper
+        # (from back when setuptools/distribute were separate forks) and
+        # separately imports "from distutils.core import setup, Command"
+        # directly. distutils was removed from the stdlib in Python 3.12+,
+        # breaking both. setuptools has been a strict superset for over a
+        # decade (find_packages is already imported from it two lines
+        # above) and setuptools.Command is a drop-in replacement -- the
+        # docstring on the Command subclass below even says "setuptools
+        # Command". Drop the obsolete bootstrap entirely and import
+        # setup/Command from setuptools instead.
+        filter_file(
+            "from distribute_setup import use_setuptools\n",
+            "",
+            "setup.py",
+            string=True,
+        )
+        filter_file(
+            "from distutils.core import setup, Command",
+            "from setuptools import setup, Command",
+            "setup.py",
+            string=True,
+        )
+        filter_file(
+            'use_setuptools(version="0.6.24")\n',
+            "",
+            "setup.py",
+            string=True,
+        )
+
     def install(self, spec, prefix):
         dirs = ["sepp", "tools"]
         for d in dirs:


### PR DESCRIPTION
## Summary
`sepp`'s `setup.py` fails under Python 3.12+ with:
```
File ".../distribute_setup.py", line 25, in <module>
    from distutils import log
ModuleNotFoundError: No module named 'distutils'
```
Two separate issues in `setup.py`, both from the same root cause (`distutils` removed from the stdlib in 3.12+):
1. `from distribute_setup import use_setuptools` + `use_setuptools(version="0.6.24")` -- a 2010-era helper script (from back when `setuptools`/`distribute` were separate forks, merged back together in 2013) that bootstraps installing setuptools if it's missing. Completely obsolete: setuptools has shipped by default for well over a decade, and this package already unconditionally does `from setuptools import find_packages` two lines below. Dropped entirely.
2. `from distutils.core import setup, Command` -- `setuptools.Command` is a documented drop-in for `distutils.core.Command` (the `ConfigSepp` subclass's own docstring literally says "setuptools Command"), and `setuptools.setup` for `distutils.core.setup`. Switched the import.

## Testing
Installed `sepp@4.5.1` (a `busco@6.1.0` dependency) end to end with Python 3.14, confirmed the install phase completes and produces working binaries.
