### PR TITLE
autotools: skip compiler prefixes during aclocal directory search

### DIFF
--- a/repos/spack_repo/builtin/build_systems/autotools.py
+++ b/repos/spack_repo/builtin/build_systems/autotools.py
@@ -6,6 +6,7 @@ import stat
 import subprocess
 from typing import Callable, List, Optional, Set, Tuple, Union
 
+from spack import deptypes
 from spack.package import (
     BuilderWithDefaults,
     Executable,
@@ -856,7 +857,11 @@ def _autoreconf_search_path_args(spec: Spec) -> List[str]:
         except OSError:
             pass
 
-    for dep in spec.dependencies(deptype="build"):
+    for edge in spec.edges_to_dependencies(depflag=deptypes.BUILD):
+        # compiler prefixes might have foreign aclocal files which we do not want to include
+        if any(language in edge.virtuals for language in ("c", "cxx", "fortran")):
+            continue
+        dep = edge.spec
         path = dep.prefix.share.aclocal
         # Skip non-existing aclocal paths
         try:

--- a/tests/build_systems.py
+++ b/tests/build_systems.py
@@ -448,6 +448,24 @@ def test_autoreconf_search_path_args_external_order(
     ]
 
 
+def test_autoreconf_search_path_args_skip_compiler(
+    default_mock_concretization, tmp_path: pathlib.Path
+):
+    """Compiler prefixes are not aclocal macro providers."""
+    spec = default_mock_concretization("dttop")
+    compiler, macro_provider = spec.dependencies(deptype="build")
+    compiler_aclocal = tmp_path / "compiler" / "share" / "aclocal"
+    provider_aclocal = tmp_path / "provider" / "share" / "aclocal"
+    compiler_aclocal.mkdir(parents=True)
+    provider_aclocal.mkdir(parents=True)
+    compiler.external_path = str(tmp_path / "compiler")
+    macro_provider.set_prefix(str(tmp_path / "provider"))
+    compiler_edge = next(edge for edge in spec.edges_to_dependencies() if edge.spec is compiler)
+    compiler_edge.virtuals = ("c", "cxx")
+
+    assert autotools._autoreconf_search_path_args(spec) == ["-I", str(provider_aclocal)]
+
+
 def test_autoreconf_search_path_skip_nonexisting(
     default_mock_concretization, tmp_path: pathlib.Path
 ):


### PR DESCRIPTION
## autotools: skip compiler prefixes during aclocal directory search

For packages using autotools, spack creates a list of search paths for `prefix/share/aclocal` directories for `aclocal -I`.
- This is done by the function `_autoreconf_search_path_args` of `autotools.py`. It checks the prefixes of all dependencies for `prefix/share/aclocal` directories.
- This is good and needed, but when compilers used for a `spack install` have a prefix e.g. in `/usr` and the host has an installation of `autoconf` in the same prefix, the `aclocal -I` search path created also contains `/usr`, as if it was a prefix of a regular dependency that needs it aclocal directory.
- This happens because the function loops over all dependencies without excluding compiler prefixes from the search.

This is of course an unwanted external inclusion of host-installed aclocal files into the build which we don't want unless needed e.g. for external packages.

This behaviour can be confirmed by making `/usr/share/aclocal` inaccessible using `sudo chmod 700 /usr/share/aclocal`. After that, a `spack install --overwrite -y gmp` from source demonstrates the issue:
```py
> aclocal: error: couldn't open directory '/usr/share/aclocal': Permission denied
> autoreconf: error: aclocal failed with exit status: 1
```

To only use the needed aclocal paths, do not add prefixes when they're only for compilers when searching for aclocal directories:

- [x] This skips aclocal directories from compilers in general, e.g. some toolchains might come with an "foreign" aclocal directory, which we would not want to add to spack.
- [x] Prefixes for external packages are already ordered last in the aclocal search order, so they are not a problem even when their prefix is /usr.
- [x] The effect is that the compiler prefixes are no longer included in the reglar aclocal search purely because they are dependencies, a prefix has to come from a non-compiler package to be added.
   - If an external package uses `prefix: /usr`, `/usr/share/aclocal` would still be added for such external packages, but it would be at the end of the search order, after the internal spack prefixes.

PS: I considered also a wider check for inaccessible directories, but I don't propose it because:
- [x] The compiler check is the targeted check for this change (no further code and unit-test needed - which had written already)
- [x] Silently discarding non-accessible/non-scannable directores which might be wrongly blocked by a sandbox tool would silently remove the inclusions of potentially needed aclocal directories, leading to build failures where you don't see the permission error but have to trace back from the resulting build failure to the missing aclocal path to ultimatively find the permission access denial as the root cause, which could affect external packages.
    - Therefore, I'm not submitting that wider skip: https://github.com/bernhardkaindl/spack-packages/pull/3/changes#diff-e4cafdc751689cf075985b0b1a2f695da8b2ebacc0bebbbbbc860e82d4991927R874