### PR TITLE
boost: add v1.92.0, v1.91.0

### DIFF
--- a/repos/spack_repo/builtin/packages/boost/package.py
+++ b/repos/spack_repo/builtin/packages/boost/package.py
@@ -31,6 +31,8 @@ class Boost(Package):
     license("BSL-1.0")
 
     version("develop", branch="develop", submodules=True)
+    version("1.92.0", sha256="5c1d40cb8e19adbf740a4ec2da35b3e58f3f5804b1dce44deb53df72193cbc6c")
+    version("1.91.0", sha256="de5e6b0e4913395c6bdfa90537febd9028ea4c0735d2cdb0cd9b45d5f51264f5")
     version("1.90.0", sha256="49551aff3b22cbc5c5a9ed3dbc92f0e23ea50a0f7325b0d198b705e8ee3fc305")
     version("1.89.0", sha256="85a33fa22621b4f314f8e85e1a5e2a9363d22e4f4992925d4bb3bc631b5a0c7a")
     version("1.88.0", sha256="46d9d2c06637b219270877c9e16155cbd015b6dc84349af064c088e9b5b12f7b")
@@ -360,9 +362,10 @@ class Boost(Package):
     patch("boost_11856.patch", when="@1.60.0%gcc@4.4.7")
 
     # Patch fix from https://svn.boost.org/trac/boost/ticket/11120
-    patch("python_jam-1_77.patch", when="@1.77:     ^python@3:")
+    patch("python_jam-1_91.patch", when="@1.91: ^python@3:")
+    patch("python_jam-1_77.patch", when="@1.77:1.90 ^python@3:")
     patch("python_jam.patch", when="@1.56:1.76 ^python@3:")
-    patch("python_jam_pre156.patch", when="@:1.55.0   ^python@3:")
+    patch("python_jam_pre156.patch", when="@:1.55.0 ^python@3:")
 
     # Patch fix for IBM XL compiler
     patch("xl_1_62_0_le.patch", when="@1.62.0%xl_r")

--- a/repos/spack_repo/builtin/packages/boost/python_jam-1_91.patch
+++ b/repos/spack_repo/builtin/packages/boost/python_jam-1_91.patch
@@ -1,0 +1,42 @@
+Index: spack-src/tools/build/src/tools/python.jam
+===================================================================
+--- spack-src/tools/build/src/tools/python.jam
++++ spack-src/tools/build/src/tools/python.jam
+@@ -504,6 +504,10 @@ local rule probe ( python-cmd )
+                 sys.$(s) = [ SUBST $(output) "\\<$(s)=([^\r\n]+)" $1 ] ;
+             }
+         }
++         # Try to get python abiflags
++        full-cmd = $(python-cmd)" -c \"from sys import abiflags; print(abiflags, end='')\"" ;
++
++        sys.abiflags = [ SHELL $(full-cmd) ] ;
+         return $(output) ;
+     }
+ }
+@@ -513,7 +517,7 @@ local rule probe ( python-cmd )
+ # have a value based on the information given.
+ #
+ local rule compute-default-paths ( target-os : version ? : prefix ? :
+-    exec-prefix ? )
++    exec-prefix ? : abiflags ? )
+ {
+     exec-prefix ?= $(prefix) ;
+ 
+@@ -550,7 +554,7 @@ local rule compute-default-paths ( target-os : version ? : prefix ? :
+     }
+     else
+     {
+-        local default-include-path = $(prefix)/include/python$(version) ;
++        local default-include-path = $(prefix)/include/python$(version)$(abiflags) ;
+         if ! [ path.exists $(default-include-path) ] && [ path.exists $(default-include-path)t ]
+         {
+             default-include-path = $(default-include-path)t ;
+@@ -849,7 +853,7 @@ local rule configure ( version ? : cmd-or-prefix ? : includes * : libraries ? :
+                     exec-prefix = $(sys.exec_prefix) ;
+ 
+                     compute-default-paths $(target-os) : $(sys.version) :
+-                        $(sys.prefix) : $(sys.exec_prefix) ;
++                        $(sys.prefix) : $(sys.exec_prefix) : $(sys.abiflags) ;
+ 
+                     version = $(sys.version) ;
+                     interpreter-cmd ?= $(cmd) ;


### PR DESCRIPTION
This PR adds `boost`, v1.91.0 ([release notes](https://www.boost.org/releases/1.91.0/)) and v1.92.0 ([release notes](https://www.boost.org/releases/1.92.0/)). 

Notes for 1.91.0:
- StaticAssert: This component was merged in Config, both header-only. 
- Decimal: This new component is header-only.
- System: "A CMake config file is now installed, even though the library is header-only."
  This will fix a bunch of packages that have `find_package(Boost REQUIRED system)`.

(There was a 1.91.0-1 release tag without artifacts, and it only differs in a CI yml file.)

Notes for 1.92.0:
- "Support requesting header-only libraries as `find_package` components"
  This should now allow `find_package(Boost REQUIRED system)` to work for all header-only components (or library components that become header-only).

Relevant upstream commit for the changed patch (it is literally just a change from 'm' to 't' in the patch): https://github.com/boostorg/build/commit/125be3e86c24257a749c1acb7f0335f6cf5e7475. Technically, this may make the patch unnecessary in some cases, but the patch introduces a more robust approach (e.g. it handles all ABI flags, including 'd', which the upstream commit will still fail to catch).

Test build:
```
ejhvr2l boost@1.92.0~atomic~charconv~chrono~clanglibcpp~cobalt~container~context~contract~conversion~date_time~debug~exception~fiber+filesystem~graph~graph_parallel+icu+iostreams~json+locale+log+math~mpi~mqtt5+multithreaded+nowide~numpy~openmethod~pic+program_options+python~random~regex~serialization+shared~signals2~singlethreaded~stacktrace+system~taggedlayout+test+thread~timer~type_erasure~url~versionedlayout~wave build_system=generic cxxstd=20 patches:=a440f96 visibility=hidden
```