### PR TITLE
`gettext`: disable modula-2

### DIFF
--- a/repos/spack_repo/builtin/packages/gettext/package.py
+++ b/repos/spack_repo/builtin/packages/gettext/package.py
@@ -130,9 +130,10 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
         else:
             config_args.append("--with-included-gettext")
 
-        # Until we know why we need them, do not build D sources:
+        # Until we know why we need them, do not build D or modula2 sources:
         if spec.satisfies("@0.25:"):
             config_args.append("--disable-d")
+            config_args.append("--disable-modula2")
 
         config_args.extend(self.enable_or_disable("shared"))
 


### PR DESCRIPTION
Gettext has optional support for D and modula2. We already disable D; disable modula2 as well, at least until someone says we need to have it.
