### PR TITLE
parallelio: add pkgconfig build dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/parallelio/package.py
+++ b/repos/spack_repo/builtin/packages/parallelio/package.py
@@ -66,6 +66,7 @@ class Parallelio(CMakePackage):
     depends_on("fortran", type="build")  # generated
 
     depends_on("cmake@3.7:", type="build")
+    depends_on("pkgconfig", type="build", when="@2.6.9:")
     depends_on("mpi", when="+mpi")
     depends_on("mpi-serial", when="~mpi")
     depends_on("netcdf-c +mpi", type="link", when="+mpi")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->


ParallelIO 2.6.9 added a pkg-config fallback while locating NetCDF C. When `find_package(NetCDF ...)` does not succeed, CMake calls `find_package(PkgConfig REQUIRED)`.

The Spack package did not declare this build tool, so builds on hosts without a system `pkg-config` fail during configuration with:

```
  Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
```

Add Spack's `pkgconfig` virtual build dependency for versions 2.6.9 and newer. The virtual lets Spack choose the configured provider (normally `pkgconf`).
