### PR TITLE
expat: 2.8.4 + deprecate vulnerable 2.8.3

### DIFF
--- a/repos/spack_repo/builtin/packages/expat/package.py
+++ b/repos/spack_repo/builtin/packages/expat/package.py
@@ -22,11 +22,12 @@ class Expat(AutotoolsPackage, CMakePackage):
         "2.8.4",
         sha256="963250a823c16a498582b4ad82ad0f88926be0769675d3b6956be4d769a1cd8f",
     )
+    # deprecate all releases before 2.8.4 because of various security issues
     version(
         "2.8.3",
         sha256="b4cc2483927d5e90bf8c40b44a6b95b368b42a8a96e25883fce188b48a92b670",
+        deprecated=True,
     )
-    # deprecate all releases before 2.8.3 because of various security issues
     version(
         "2.8.2",
         sha256="69e7f52417d85b1c2b7fe855e176eec55d0b2d7d92d691372d833a1c7df7923b",

--- a/repos/spack_repo/builtin/packages/expat/package.py
+++ b/repos/spack_repo/builtin/packages/expat/package.py
@@ -19,6 +19,10 @@ class Expat(AutotoolsPackage, CMakePackage):
 
     license("MIT")
     version(
+        "2.8.4",
+        sha256="963250a823c16a498582b4ad82ad0f88926be0769675d3b6956be4d769a1cd8f",
+    )
+    version(
         "2.8.3",
         sha256="b4cc2483927d5e90bf8c40b44a6b95b368b42a8a96e25883fce188b48a92b670",
     )


### PR DESCRIPTION
Similar to #6041

Related blog post: https://blog.hartwork.org/posts/expat-2-8-4-released/

- CVE-2026-66046
- CVE-2026-76641
- CVE-2026-76956
- CVE-2026-76957

CC @wdconinc