### PR TITLE
Add support for running Linux-based actions workflows locally using nektos/act

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,3 @@
+--env=PIP_BREAK_SYSTEM_PACKAGES=1
+--env=PIP_ROOT_USER_ACTION=ignore
+--eventpath=.github/act/push-and-merge-group-events.json

--- a/.github/act/push-and-merge-group-events.json
+++ b/.github/act/push-and-merge-group-events.json
@@ -1,0 +1,9 @@
+{
+  "ref": "",
+  "repository": {
+    "default_branch": "develop"
+  },
+  "merge_group": {
+    "base_ref": "develop"
+  }
+}

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -19,10 +19,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        system:
-        - { os: windows-latest, shell: powershell }
-        - { os: ubuntu-latest, shell: bash }
-        - { os: macos-latest, shell: bash }
+        # In a local docker-based workflow run using act, only Linux-based systems are available
+        system: >-
+          ${{ github.actor == 'nektos/act'
+              && fromJSON('[{"os":"ubuntu-latest","shell":"bash"}]')
+              || fromJSON('[{"os":"ubuntu-latest","shell":"bash"},
+                           {"os":"windows-latest","shell":"powershell"},
+                           {"os":"macos-latest","shell":"bash"}]') }}
         # An empty ref means the commit pinned in .ci/env, the others are the
         # released versions we keep the packages repository compatible with
         spack_ref: ['', 'v1.2.2', 'v1.1.1']

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -69,6 +69,11 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
+      - name: Install Node.js for local workflow runs using act
+        if: ${{ github.actor == 'nektos/act' }}
+        run: |
+          yum update -y
+          yum install -y nodejs
       - uses: ./.github/actions/checkout-spack
       - name: Bootstrap clingo
         run: |
@@ -176,6 +181,7 @@ jobs:
 
   bootstrap-dev-rhel8:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'nektos/act' }}
     container: registry.access.redhat.com/ubi8/ubi
     steps:
       - name: Install dependencies
@@ -187,6 +193,11 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
+      - name: Install Node.js for local workflow runs using act
+        if: ${{ github.actor == 'nektos/act' }}
+        run: |
+          yum update -y
+          yum install -y nodejs
       - uses: ./.github/actions/checkout-spack
         with:
           fetch-depth: 0

--- a/.github/workflows/prechecks.yml
+++ b/.github/workflows/prechecks.yml
@@ -80,6 +80,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
+      - name: Install Node.js for local workflow runs using act
+        if: ${{ github.actor == 'nektos/act' }}
+        run: |
+          apt-get update
+          apt-get install -y nodejs
       - uses: ./.github/actions/checkout-spack
 
       - name: Test package.py canonicalization

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   pr:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'nektos/act' }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -1,6 +1,9 @@
 name: unit tests
 
 on:
+  # Allows act's default push event to select this workflow locally. The job
+  # guards below prevent this local-only trigger from running tests on GitHub.
+  push:
   workflow_dispatch:
   workflow_call:
 
@@ -11,6 +14,9 @@ concurrency:
 jobs:
   # Run unit tests with different configurations on linux
   ubuntu:
+    # Run act's synthetic push, or GitHub's workflow_call/dispatch events, but
+    # skip ordinary GitHub push events introduced only for act compatibility.
+    if: ${{ github.actor == 'nektos/act' || github.event_name != 'push' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -39,6 +45,8 @@ jobs:
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
     - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+      # In local workflow runs using act, setup-python is not supported and not needed
+      if: ${{ github.actor != 'nektos/act' }}
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install System packages
@@ -56,6 +64,8 @@ jobs:
 
   # Run unit tests on MacOS
   macos:
+    # Keep the same event guard as the Linux matrix; act skips this platform.
+    if: ${{ github.actor == 'nektos/act' || github.event_name != 'push' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -76,6 +86,8 @@ jobs:
 
   # Run unit tests on Windows
   windows:
+    # Keep the same event guard as the Linux matrix; act skips this platform.
+    if: ${{ github.actor == 'nektos/act' || github.event_name != 'push' }}
     defaults:
       run:
         shell:


### PR DESCRIPTION
Hi, I think this PR needs a small introduction:

The `act` tool ([github.com/nektos/act](https://github.com/nektos/act#overview---)) is an established Go tool which developers can use to run jobs defined in GitHub Actions locally in Linux-based docker or podman containers.
Because it uses docker, it uses regular docker images, not the special Linux distrubution images used by GitHub and as it does not run inside a real GitHub push or PR workflow event, there are some differences.

With a few tweaks to the workflows, `act` can a number of worflows in these docker containers.

The idea behind this PR is that, for example, also with some nice user interfaces (see belwo), it can be interesting to be able to run spack's GitHub workflow-defined CI jobs locally before pushing to GitHub to utilize local feedback loops for development.

A further motivation for supporing this path can be to support users to contain their code execution in `docker` or `podman` containers, so the code can't access or modify user's files outside of the spack-packages repo (when using or configuring act --bind, the source repo would be bind-mounted, in this case it would be able to modifiy the source repo, but without `--bind` configured, the job only gets a copy of the source repo and any changes it would make are local to the container and ephermeral)

Possibly other ways to implement support for using act can be found (e.g. configuring it to not simulate the GitHub push event for the jobs), so please see this as proposal for consideration in general, not as the only way this can be done.

PS: The [Act Visual Runner](https://github.com/fean-developer/vscode-act-runner-local#summary) (A MIT-licensed VS Code extension by a brazilian Web developer, he also merged [my 15 PRs](https://github.com/fean-developer/vscode-act-runner-local/pulls?q=author%3Abernhardkaindl), including one that enables it to use English/Brazilian localisation strings - the last release was only using Brazilian Portuguese translations unconditionally, the next release will be bilinugal - to be done) is very nice graphical frontend for `act` that even provides some interfaces GitHub doesn't even provide:
![analytics](https://raw.githubusercontent.com/fean-developer/vscode-act-runner-local/main/images/image-analytic.png)