### PR TITLE
harfbuzz/cairo: Add glib/gobject dependencies only with +gobject

### DIFF
--- a/repos/spack_repo/builtin/packages/cairo/package.py
+++ b/repos/spack_repo/builtin/packages/cairo/package.py
@@ -109,7 +109,7 @@ class Cairo(AutotoolsPackage, MesonPackage):
 
     depends_on("freetype", when="+ft")
     depends_on("libpng", when="+png")
-    depends_on("glib")
+    depends_on("glib", when="+gobject")
     depends_on("pixman@0.30.0:")
     depends_on("pixman@0.36.0:", when="@1.17.2:")
     depends_on("fontconfig@2.10.91:", when="+fc")

--- a/repos/spack_repo/builtin/packages/harfbuzz/package.py
+++ b/repos/spack_repo/builtin/packages/harfbuzz/package.py
@@ -121,8 +121,8 @@ class Harfbuzz(MesonPackage, AutotoolsPackage, CMakePackage):
                 description="Build harfbuzz utils",
             )
             depends_on("pkgconfig", type="build")
-            depends_on("glib")
-            depends_on("gobject-introspection")
+            depends_on("glib", when="+gobject")
+            depends_on("gobject-introspection", when="+gobject")
             depends_on("cairo+pdf+ft")
 
     depends_on("icu4c")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
