### PR TITLE
Scotch: Set compression libraries options according to compression variant

### DIFF
--- a/repos/spack_repo/builtin/packages/scotch/package.py
+++ b/repos/spack_repo/builtin/packages/scotch/package.py
@@ -170,10 +170,16 @@ class CMakeBuilder(cmake.CMakeBuilder):
             self.define_from_variant("BUILD_PTSCOTCH", "mpi"),
             self.define_from_variant("THREADS", "threads"),
             self.define_from_variant("MPI_THREAD_MULTIPLE", "mpi_thread"),
-            self.define_from_variant("USE_ZLIB", "compression"),
-            self.define("USE_LZMA", False),
-            self.define("USE_BZ2", False),
         ]
+
+        if self.spec.satisfies("@7.0.2:"):
+            args.extend(
+                [
+                    self.define_from_variant("USE_ZLIB", "compression"),
+                    self.define("USE_LZMA", False),
+                    self.define("USE_BZ2", False),
+                ]
+            )
 
         if self.spec.satisfies("@7.0.5:"):
             args.append(self.define("ENABLE_TESTS", self.pkg.run_tests))

--- a/repos/spack_repo/builtin/packages/scotch/package.py
+++ b/repos/spack_repo/builtin/packages/scotch/package.py
@@ -170,6 +170,9 @@ class CMakeBuilder(cmake.CMakeBuilder):
             self.define_from_variant("BUILD_PTSCOTCH", "mpi"),
             self.define_from_variant("THREADS", "threads"),
             self.define_from_variant("MPI_THREAD_MULTIPLE", "mpi_thread"),
+            self.define_from_variant("USE_ZLIB", "compression"),
+            self.define("USE_LZMA", False),
+            self.define("USE_BZ2", False),
         ]
 
         if self.spec.satisfies("@7.0.5:"):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This PR enables the `USE_ZLIB` CMake option only if the `compression` variant is set. The `USE_LZMA` and `USE_BZ2` CMake options are permanently disabled.

@AlexanderRichert-NOAA @climbfuji 

Fixes #6299.