### PR TITLE
openCARP: add v20.0

### DIFF
--- a/repos/spack_repo/builtin/packages/meshtool/package.py
+++ b/repos/spack_repo/builtin/packages/meshtool/package.py
@@ -19,6 +19,7 @@ class Meshtool(MakefilePackage):
     # Version to use with openCARP releases
     # It is possible that different openCARP releases rely on the same
     # meshtool version
+    version("oc20.0", commit="d6ab63fa6915995b203f4f6b278ed0c853ad15fa")
     version("oc19.0", commit="d6ab63fa6915995b203f4f6b278ed0c853ad15fa")
     version("oc18.1", commit="d6ab63fa6915995b203f4f6b278ed0c853ad15fa")
     version("oc18.0", commit="d6ab63fa6915995b203f4f6b278ed0c853ad15fa")

--- a/repos/spack_repo/builtin/packages/opencarp/package.py
+++ b/repos/spack_repo/builtin/packages/opencarp/package.py
@@ -20,11 +20,17 @@ class Opencarp(CMakePackage):
     maintainers("MarieHouillon")
 
     version(
+        "20.0",
+        commit="ffce19513ca90235192fff261160f53167921877",
+        submodules=False,
+        no_cache=True,
+        preferred=True,
+    )
+    version(
         "19.0",
         commit="9accae0522f4108774ed8eb1df90b8ef0afd4c8e",
         submodules=False,
         no_cache=True,
-        preferred=True,
     )
     version(
         "18.1", commit="6eaa147d18b69a6037d05a90b841e23301048a59", submodules=False, no_cache=True
@@ -91,6 +97,7 @@ class Opencarp(CMakePackage):
     depends_on("meshtool", when="+meshtool", type=("build", "run"))
     # Use specific versions of carputils and meshtool for releases
     for ver in [
+        "20.0",
         "19.0",
         "18.1",
         "18.0",

--- a/repos/spack_repo/builtin/packages/py_carputils/package.py
+++ b/repos/spack_repo/builtin/packages/py_carputils/package.py
@@ -19,6 +19,7 @@ class PyCarputils(PythonPackage):
 
     version("master", branch="master")
     # Version to use with openCARP releases
+    version("oc20.0", commit="49bc2a4eabc5efc019aab174142ddf89fda18812")
     version("oc19.0", commit="8d7a402760192493447cd35893abd147fee1e35a")
     version("oc18.1", commit="0b56f65dd32649bfd8033c5407273aa8ff006608")
     version("oc18.0", commit="e66c3ca6c5016d12b651a4e58a54430af3b91a44")


### PR DESCRIPTION
Add a new version for the packages of the openCARP ecosystem, opencarp, meshtool and py_carputils.