### PR TITLE
petsc: use linker flags for system BLAS/LAPACK

### DIFF
--- a/repos/spack_repo/builtin/packages/petsc/package.py
+++ b/repos/spack_repo/builtin/packages/petsc/package.py
@@ -494,9 +494,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
             ]
         )
 
-        options.append(
-            "--with-blas-lapack-lib={}".format(blas_lapack_flags)
-        )
+        options.append("--with-blas-lapack-lib={}".format(blas_lapack_flags))
 
         if "+batch" in spec:
             options.append("--with-batch=1")

--- a/repos/spack_repo/builtin/packages/petsc/package.py
+++ b/repos/spack_repo/builtin/packages/petsc/package.py
@@ -487,10 +487,16 @@ class Petsc(Package, CudaPackage, ROCmPackage):
             ]
         )
 
-        # Make sure we use exactly the same Blas/Lapack libraries
-        # across the DAG. To that end list them explicitly
-        lapack_blas = spec["lapack"].libs + spec["blas"].libs
-        options.extend(["--with-blas-lapack-lib=%s" % lapack_blas.joined()])
+        blas_lapack_flags = " ".join(
+            [
+                spec["lapack"].libs.ld_flags,
+                spec["blas"].libs.ld_flags,
+            ]
+        )
+
+        options.append(
+            "--with-blas-lapack-lib={}".format(blas_lapack_flags)
+        )
 
         if "+batch" in spec:
             options.append("--with-batch=1")


### PR DESCRIPTION
PETSc was configured with absolute system library paths such as /usr/lib64/liblapack.so and /usr/lib64/libblas.so. These paths were propagated through PETSc’s exported link metadata and later passed to nvcc as input files, causing the compiler to interpret the binary libraries as source text.

>   258 > /usr/lib64/liblapack.so:1:8: warning: null character(s) ignored

This change converts system BLAS/LAPACK libraries to linker flags, such as -llapack and -lblas, preventing them from being passed as source files while preserving the intended link behavior.