### PR TITLE
HDF5 patch: h5open_f failing to re-initialize the Fortran interface

### DIFF
--- a/repos/spack_repo/builtin/packages/hdf5/hdf5_h5close_f_alialising.patch
+++ b/repos/spack_repo/builtin/packages/hdf5/hdf5_h5close_f_alialising.patch
@@ -1,0 +1,44 @@
+--- a/fortran/src/H5_ff.F90
++++ b/fortran/src/H5_ff.F90
+@@ -830,7 +830,7 @@
+          integer_types, INTEGER_TYPES_LEN )
+ 
+     ! Reset the number of open objects from h5open_f to zero
+-    CALL h5fget_obj_count_f(INT(H5F_OBJ_ALL_F,HID_T), H5F_OBJ_ALL_F, H5OPEN_NUM_OBJ,  error)
++    H5OPEN_NUM_OBJ = 0
+ 
+   END SUBROUTINE h5close_f
+ 
+--- a/fortran/src/H5Fff.F90
++++ b/fortran/src/H5Fff.F90
+@@ -860,6 +860,8 @@
+     INTEGER(SIZE_T), INTENT(OUT) :: obj_count
+     INTEGER        , INTENT(OUT) :: hdferr
+ 
++    INTEGER(SIZE_T) :: count_loc
++
+     INTERFACE
+        INTEGER(SIZE_T) FUNCTION H5Fget_obj_count(file_id, obj_type) BIND(C,NAME='H5Fget_obj_count')
+          IMPORT :: C_INT
+@@ -870,16 +872,18 @@
+        END FUNCTION H5Fget_obj_count
+     END INTERFACE
+ 
+-    obj_count = H5Fget_obj_count(file_id, INT(obj_type, C_INT))
++    count_loc = H5Fget_obj_count(file_id, INT(obj_type, C_INT))
+ 
+     hdferr = 0
+-    IF(obj_count.LT.0) hdferr = -1
++    IF(count_loc.LT.0) hdferr = -1
+ 
+     ! Don't include objects created by H5open in the H5F_OBJ_ALL_F count
+     IF(file_id.EQ.INT(H5F_OBJ_ALL_F,HID_T))THEN
+-       obj_count = obj_count - H5OPEN_NUM_OBJ
++       count_loc = count_loc - H5OPEN_NUM_OBJ
+     ENDIF
+ 
++    obj_count = count_loc
++
+   END SUBROUTINE h5fget_obj_count_f
+ 
+ !>

--- a/repos/spack_repo/builtin/packages/hdf5/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5/package.py
@@ -222,6 +222,11 @@ class Hdf5(CMakePackage):
         "+fortran", when="@1.13.3:^cmake@:3.22", msg="cmake_minimum_required is not set correctly."
     )
 
+    # https://github.com/HDFGroup/hdf5/issues/6642
+    # Issue present also in earlier versions, starting from 1.13.2;
+    # patch only works for 1.14.5 and newer
+    patch("hdf5_h5close_f_alialising.patch", when="@1.14.5:")
+
     # https://github.com/HDFGroup/hdf5/pull/6267
     patch(
         "https://github.com/HDFGroup/hdf5/commit/84e5adf753cdd97a807df2da6338bb0e0cdf9862.patch?full_index=1",


### PR DESCRIPTION
## Description

This PR introduces a patch for hdf5 versions 1.14.5 to the most recent release 2.1.0 for a bug reported upstream as [h5open_f silently fails to re-initialize the Fortran interface after h5close_f (prohibited argument aliasing in h5close_f)](https://github.com/HDFGroup/hdf5/issues/6642) and fixed in https://github.com/HDFGroup/hdf5/pull/6649.

The upstream bug fix is more comprehensive than the patch added here. The patch also only works for versions 1.14.5 and newer (I tested all the way up to and including 2.1.0), even though the bug was introduced in earlier versions (1.13.2).

I tested the patch on the system and with the compiler that triggered the issue, and it fixed the problem.