### PR TITLE
LBANN: support newer protobuf

### DIFF
--- a/repos/spack_repo/builtin/packages/lbann/package.py
+++ b/repos/spack_repo/builtin/packages/lbann/package.py
@@ -231,9 +231,9 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("python@3: +shared", type=("build", "run"), when="+pfe")
     extends("python", when="+pfe")
     depends_on("py-setuptools", type="build", when="+pfe")
-    depends_on("py-protobuf@3.10.0:4.21.12", type=("build", "run"), when="+pfe")
+    depends_on("py-protobuf@3.10.0:", type=("build", "run"), when="+pfe")
 
-    depends_on("protobuf@3.10.0:21.12")
+    depends_on("protobuf@3.10.0:")
     depends_on("zlib-api", when="^protobuf@3.11.0:")
 
     # using cereal@1.3.1 and above requires changing the


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
LBANN requires ancient protobuf which requires ancient setuptools which contains known security vulnerabilities. Trying to deprecate ancient setuptools, but need to see if LBANN supports newer protobuf first.