### PR TITLE
ZFIT: drop setuptools-scm-git-archive dep

### DIFF
--- a/repos/spack_repo/builtin/packages/py_zfit/package.py
+++ b/repos/spack_repo/builtin/packages/py_zfit/package.py
@@ -55,7 +55,8 @@ class PyZfit(PythonPackage):
     depends_on("py-hatch-vcs", type="build", when="@0.26:")
 
     depends_on("py-setuptools@42:", type="build", when="@:0.25")
-    depends_on("py-setuptools-scm-git-archive", type="build", when="@:0.25")
+    # setuptools-scm supports git now
+    # depends_on("py-setuptools-scm-git-archive", type="build", when="@:0.25")
     depends_on("py-setuptools-scm@3.4:+toml", type="build", when="@:0.25")
 
     variant("nlopt", default=False, description="Enable nlopt support")

--- a/repos/spack_repo/builtin/packages/py_zfit_interface/package.py
+++ b/repos/spack_repo/builtin/packages/py_zfit_interface/package.py
@@ -24,7 +24,8 @@ class PyZfitInterface(PythonPackage):
 
     depends_on("py-setuptools@42:", type="build")
     depends_on("py-setuptools-scm@3.4:+toml", type="build")
-    depends_on("py-setuptools-scm-git-archive", type="build")
+    # setuptools-scm supports git now
+    # depends_on("py-setuptools-scm-git-archive", type="build")
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-uhi", type=("build", "run"))
     depends_on("py-typing-extensions", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_zfit_physics/package.py
+++ b/repos/spack_repo/builtin/packages/py_zfit_physics/package.py
@@ -28,7 +28,8 @@ class PyZfitPhysics(PythonPackage):
 
     depends_on("py-setuptools@42:", type="build", when="@:0.7")
     depends_on("py-setuptools-scm@3.4:+toml", type="build", when="@:0.7")
-    depends_on("py-setuptools-scm-git-archive", type="build", when="@:0.7")
+    # setuptools-scm supports git now
+    # depends_on("py-setuptools-scm-git-archive", type="build", when="@:0.7")
 
     # TODO: remove "build" once fixed in spack that tests need "run", not "build"
     with default_args(type=("build", "run")):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
setuptools-scm-git-archive is abandoned as setuptools-scm now supports all of its features natively. Also, it requires an ancient version of setuptools with known CVEs. Trying to deprecate this, but need to figure out if we can skip this dep first.