### PR TITLE
llama-cpp: add v0.3.0

### DIFF
--- a/repos/spack_repo/builtin/packages/ggml/package.py
+++ b/repos/spack_repo/builtin/packages/ggml/package.py
@@ -92,5 +92,5 @@ class Ggml(GGMLPackageBase):
     license("MIT")
 
     version("master", branch="master")
-    version("0.22.0", sha256="34006b8c637dd507c4c9772cf826d8c3fcec00f49c094e74bb6e9e40c26d891d")
+    version("0.22.0", tag="v0.22.0", commit="34dc0e5589504286cb40e13cbdae4bf2b5b4071b", preferred=True)
     version("0.9.4", tag="v0.9.4", commit="72632094336524a9c809e129e8b1c52154543a5a")

--- a/repos/spack_repo/builtin/packages/ggml/package.py
+++ b/repos/spack_repo/builtin/packages/ggml/package.py
@@ -30,7 +30,7 @@ class GGMLPackageBase(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("hipblas", when="+rocm")
     depends_on("rocblas", when="+rocm")
-    depends_on("rccl", when="+rccl")
+    depends_on("rccl", when="+rocm")
 
     depends_on("nccl", when="+cuda")
 
@@ -72,7 +72,7 @@ class GGMLPackageBase(CMakePackage, CudaPackage, ROCmPackage):
                     "CMAKE_HIP_COMPILER", f"{self.spec['llvm-amdgpu'].prefix}/bin/amdclang++"
                 )
             )
-            args.append(self.define_from_variant("GGML_HIP_RCCL", "rccl"))
+            args.append(self.define("GGML_HIP_RCCL", "ON"))
             if not self.spec.satisfies("amdgpu_target=none"):
                 archs = self.spec.variants["amdgpu_target"].value
                 arch_str = ";".join(archs)
@@ -85,7 +85,6 @@ class Ggml(GGMLPackageBase):
 
     homepage = "https://github.com/ggml-org/ggml"
     git = "https://github.com/ggml-org/ggml.git"
-    url = "https://github.com/ggml-org/ggml/archive/refs/tags/v0.22.0.tar.gz"
 
     maintainers("rbberger")
 

--- a/repos/spack_repo/builtin/packages/ggml/package.py
+++ b/repos/spack_repo/builtin/packages/ggml/package.py
@@ -16,6 +16,7 @@ class GGMLPackageBase(CMakePackage, CudaPackage, ROCmPackage):
     variant("openmp", default=True, description="build OpenMP backend")
     variant("cuda", default=False, description="build CUDA backend")
     variant("rocm", default=False, description="build HIP backend")
+    variant("rccl", default=False, description="Use ROCm Collective Comm. Library", when="+rocm")
     variant("metal", default=True, description="build Metal backend", when="platform=darwin")
     variant("rpc", default=False, description="build with RPC support")
 
@@ -29,6 +30,9 @@ class GGMLPackageBase(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("hipblas", when="+rocm")
     depends_on("rocblas", when="+rocm")
+    depends_on("rccl", when="+rccl")
+
+    depends_on("nccl", when="+cuda")
 
     def cmake_args(self):
         args = [
@@ -55,6 +59,8 @@ class GGMLPackageBase(CMakePackage, CudaPackage, ROCmPackage):
 
         if self.spec.satisfies("+cuda"):
             args.append(self.define("CMAKE_CUDA_COMPILER", f"{self.spec['cuda'].prefix}/bin/nvcc"))
+            args.append(self.define("GGML_CUDA_GRAPHS", "ON"))
+            args.append(self.define("GGML_CUDA_NCCL", "ON"))
             if not self.spec.satisfies("cuda_arch=none"):
                 archs = self.spec.variants["cuda_arch"].value
                 arch_str = ";".join(archs)
@@ -66,6 +72,7 @@ class GGMLPackageBase(CMakePackage, CudaPackage, ROCmPackage):
                     "CMAKE_HIP_COMPILER", f"{self.spec['llvm-amdgpu'].prefix}/bin/amdclang++"
                 )
             )
+            args.append(self.define_from_variant("GGML_HIP_RCCL", "rccl"))
             if not self.spec.satisfies("amdgpu_target=none"):
                 archs = self.spec.variants["amdgpu_target"].value
                 arch_str = ";".join(archs)
@@ -78,10 +85,12 @@ class Ggml(GGMLPackageBase):
 
     homepage = "https://github.com/ggml-org/ggml"
     git = "https://github.com/ggml-org/ggml.git"
+    url = "https://github.com/ggml-org/ggml/archive/refs/tags/v0.22.0.tar.gz"
 
     maintainers("rbberger")
 
     license("MIT")
 
     version("master", branch="master")
+    version("0.22.0", sha256="34006b8c637dd507c4c9772cf826d8c3fcec00f49c094e74bb6e9e40c26d891d")
     version("0.9.4", tag="v0.9.4", commit="72632094336524a9c809e129e8b1c52154543a5a")

--- a/repos/spack_repo/builtin/packages/ggml/package.py
+++ b/repos/spack_repo/builtin/packages/ggml/package.py
@@ -92,5 +92,7 @@ class Ggml(GGMLPackageBase):
     license("MIT")
 
     version("master", branch="master")
-    version("0.22.0", tag="v0.22.0", commit="34dc0e5589504286cb40e13cbdae4bf2b5b4071b", preferred=True)
+    version(
+        "0.22.0", tag="v0.22.0", commit="34dc0e5589504286cb40e13cbdae4bf2b5b4071b", preferred=True
+    )
     version("0.9.4", tag="v0.9.4", commit="72632094336524a9c809e129e8b1c52154543a5a")

--- a/repos/spack_repo/builtin/packages/llama_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/llama_cpp/package.py
@@ -23,7 +23,9 @@ class LlamaCpp(GGMLPackageBase):
     license("MIT")
 
     version("master", branch="master")
-    version("0.3.0", tag="v0.3.0", commit="c1d0e7a004015f23bc0233470b747b596f29b264", preferred=True)
+    version(
+        "0.3.0", tag="v0.3.0", commit="c1d0e7a004015f23bc0233470b747b596f29b264", preferred=True
+    )
     version("7158", tag="b7158", commit="b3b03a7baf387cfeaf56641bd14c06dbd3d2fcf0")
     version("7086", tag="b7086", commit="7aaeedc098a77e9323044187101db4f6b69988da")
 

--- a/repos/spack_repo/builtin/packages/llama_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/llama_cpp/package.py
@@ -16,20 +16,26 @@ class LlamaCpp(GGMLPackageBase):
 
     homepage = "https://github.com/ggml-org/llama.cpp"
     git = "https://github.com/ggml-org/llama.cpp.git"
+    url = "https://github.com/ggml-org/llama.cpp/archive/refs/tags/v0.3.0.tar.gz"
 
     maintainers("rbberger")
 
     license("MIT")
 
     version("master", branch="master")
+    version("0.3.0", sha256="d94c02d86db22d68692f6bb5b3854763d5091e52142868dc7251995517c666d1")
     version("7158", tag="b7158", commit="b3b03a7baf387cfeaf56641bd14c06dbd3d2fcf0")
     version("7086", tag="b7086", commit="7aaeedc098a77e9323044187101db4f6b69988da")
 
     variant("curl", default=True, description="use curl for model download")
     variant("system_ggml", default=False, description="use external GGML library")
+    variant("numactl", default=True, description="use numactl core binding option")
 
     depends_on("curl", when="+curl")
     depends_on("ggml", when="+system_ggml")
+    depends_on("numactl", type="run", when="+numactl")
+    depends_on("openssl")
+    depends_on("pkgconfig", type="build")
 
     for v in ("cpu", "blas", "openmp", "cuda", "rocm", "metal", "rpc"):
         depends_on(f"ggml+{v}", when=f"+system_ggml +{v}")

--- a/repos/spack_repo/builtin/packages/llama_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/llama_cpp/package.py
@@ -16,7 +16,6 @@ class LlamaCpp(GGMLPackageBase):
 
     homepage = "https://github.com/ggml-org/llama.cpp"
     git = "https://github.com/ggml-org/llama.cpp.git"
-    url = "https://github.com/ggml-org/llama.cpp/archive/refs/tags/v0.3.0.tar.gz"
 
     maintainers("rbberger")
 

--- a/repos/spack_repo/builtin/packages/llama_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/llama_cpp/package.py
@@ -23,7 +23,7 @@ class LlamaCpp(GGMLPackageBase):
     license("MIT")
 
     version("master", branch="master")
-    version("0.3.0", sha256="d94c02d86db22d68692f6bb5b3854763d5091e52142868dc7251995517c666d1")
+    version("0.3.0", tag="v0.3.0", commit="c1d0e7a004015f23bc0233470b747b596f29b264", preferred=True)
     version("7158", tag="b7158", commit="b3b03a7baf387cfeaf56641bd14c06dbd3d2fcf0")
     version("7086", tag="b7086", commit="7aaeedc098a77e9323044187101db4f6b69988da")
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
ggml-org projects released their versioning policy in Aug(https://github.com/ggml-org/ggml/discussions/1579).
This PR appends llama-cpp and ggml's newest versioned releases to spack builtin repo, and adds several missing dependencies for the two packages.