### PR TITLE
latex2html: fix dependency on dvipng for png support

### DIFF
--- a/repos/spack_repo/builtin/packages/latex2html/package.py
+++ b/repos/spack_repo/builtin/packages/latex2html/package.py
@@ -39,6 +39,7 @@ class Latex2html(AutotoolsPackage):
     depends_on("perl", type=("build", "run"))
     # Provides pdfcrop scheme=full
     depends_on("texlive", type=("build", "run"))
+    depends_on("texlive+dvipng", type=("build", "run"), when="+png")
 
     depends_on("netpbm", type=("build", "run"))
     # Provides pdftocairo
@@ -106,13 +107,15 @@ class Latex2html(AutotoolsPackage):
             "initex",
             "latex",
             "dvips",
-            "dvipng",
             "pdflatex",
             "lualatex",
             "dvilualatex",
             "kpsewhich",
             "mktexlsr",
         ]
+        if spec.satisfies("+png"):
+            lats.append("dvipng")
+
         for p in lats:
             exe = join_path(spec["texlive"].prefix.bin, self.tex_arch(), p)
             if os.path.exists(exe):


### PR DESCRIPTION
Fix new style dependency and improve old lats block dependency.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
