### PR TITLE
voms: allow to compile even when gsoap and zlib-ng are not loaded

### DIFF
--- a/repos/spack_repo/builtin/packages/voms/package.py
+++ b/repos/spack_repo/builtin/packages/voms/package.py
@@ -45,8 +45,14 @@ class Voms(AutotoolsPackage):
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         # https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=voms
         pkgconfig = Executable(join_path(self.spec["pkgconfig"].prefix.bin, "pkg-config"))
-        env.set("GSOAP_SSL_PP_CFLAGS", pkgconfig("--cflags", "gsoapssl++", "zlib", output=str))
-        env.set("GSOAP_SSL_PP_LIBS", pkgconfig("--libs", "gsoapssl++", "zlib", output=str))
+        env.set(
+            "GSOAP_SSL_PP_CFLAGS",
+            pkgconfig("--cflags", "gsoapssl++", "zlib", env=env, output=str),
+        )
+        env.set(
+            "GSOAP_SSL_PP_LIBS",
+            pkgconfig("--libs", "gsoapssl++", "zlib", env=env, output=str),
+        )
 
     def autoreconf(self, spec, prefix):
         autogen = Executable("./autogen.sh")


### PR DESCRIPTION
The current voms implementation breaks (at least on MacOS), unless gsoap and zlib-ng are loaded.
This happens because the build runtime environment needs to set some flags taken from gsoap and zlib with pkgconfig, but, at build time, those libraries are not in the PKG_CONFIG_PATH.
With this PR, the pkgconfig path of the two libraries is filled from the path, so that the command setting the flag does not crash.