### PR TITLE
meson: patch incorrect compiler version search

### DIFF
--- a/repos/spack_repo/builtin/packages/meson/package.py
+++ b/repos/spack_repo/builtin/packages/meson/package.py
@@ -50,6 +50,15 @@ class Meson(PythonPackage):
     # Python 3.12 detection support
     patch("python-3.12-support.patch", when="@1.1:1.2.2")
 
+    # search_version() could match a version-shaped substring embedded in
+    # unrelated text (e.g. a compiler's own install path, such as
+    # ".../gcc-11.4.1/...") in preference to the compiler's real version,
+    # silently corrupting capability detection (e.g. c_std/cpp_std support)
+    # for any compiler invoked from such a path. Planned to be fixed in version 1.12.1;
+    # backported here for older releases. Verified to apply cleanly back to
+    # 1.0.2.
+    patch("search_version_no_trailing_digits.patch", when="@1.0.2:1.12.0")
+
     executables = ["^meson$"]
 
     @classmethod

--- a/repos/spack_repo/builtin/packages/meson/search_version_no_trailing_digits.patch
+++ b/repos/spack_repo/builtin/packages/meson/search_version_no_trailing_digits.patch
@@ -1,0 +1,14 @@
+diff --git a/mesonbuild/utils/universal.py b/mesonbuild/utils/universal.py
+index 1f89fb8b8..875c3a760 100644
+--- a/mesonbuild/utils/universal.py
++++ b/mesonbuild/utils/universal.py
+@@ -1228,7 +1228,8 @@ def search_version(text: str) -> str:
+         (
+             -[a-zA-Z0-9]+   # Hyphen and one or more alphanumeric
+         )?              # Zero or one occurrence
+-    )                   # One occurrence
++    )
++    (?!\S)              # Must not be followed by non-space char
+     """, re.VERBOSE)
+     match = version_regex.search(text)
+     if match:


### PR DESCRIPTION
The planned `meson@12.1.1` release [fixes an issue](https://github.com/mesonbuild/meson/commit/b43e7ed27e82f4243c24a7bf36f2ff571b17dfd7) in which their compiler `search_version()` contained a regex that incorrectly captured the compiler version when (a) the compiler version has a 4 digit major version and (b) the compiler path, when output by `./compiler --version`, outputs the path to the compiler and the path contains a spurious 1 or 2 digit major version (e.g., the OS version). Such a situation car arise when (in particular, an older version of) spack is used to install the Intel OneAPI compiler binaries. See [this issue](https://github.com/JCSDA/spack-stack/issues/2093#issuecomment-5345536296) for a complete description of the bug.

This PR backports their fix to a range of meson versions. Note that their fix was prompted by a different (but very similar) regression. I've confirmed though testing that each minor version for which the patch applies yields the correct compiler version when, without the patch, a spurious version is detected by their `search_version()` utility. I've confirmed with `meson@1.11.1` that `glib@2.88.1` is buildable in a situation where, without the patch, one otherwise receives an error.