### PR TITLE
Add ectrans versions 1.9.0 and 2.0.0

### DIFF
--- a/repos/spack_repo/builtin/packages/ectrans/package.py
+++ b/repos/spack_repo/builtin/packages/ectrans/package.py
@@ -28,6 +28,8 @@ class Ectrans(CMakePackage):
 
     version("develop", branch="develop", no_cache=True)
     version("main", branch="main", no_cache=True)
+    version("2.0.0", sha256="dbe7875fca912a431b01defa2c6af51982c1ae1fb9f8eaa3504c40c8762e0638")
+    version("1.9.0", sha256="4e42eafce3acea88d0a48007fda33b620f8468c54b238103648ace6dc82c3b59")
     version("1.8.0", sha256="9a6576215296a91b05e778b3ad3454d44437653355b37526e2f53f6b3617824c")
     version("1.7.0", sha256="224893a8edeaaf76140842340eb30ad4f9ab772591a55aab4e4493a978e086c7")
     version("1.6.2", sha256="63e01a5106fb4eee70a4e544b84300b104507a3fbeb9b7374964c8c48e06acda")
@@ -76,6 +78,7 @@ class Ectrans(CMakePackage):
 
     depends_on("ecbuild", type="build")
     depends_on("ecbuild@3.6:", when="+trust_ecbuild_flags", type="build")
+    depends_on("ecbuild@3.14.2:", when="@1.9:", type="build")
     depends_on("mpi", when="+mpi")
     depends_on("blas")
     depends_on("lapack")


### PR DESCRIPTION
## Description

This PR adds ectrans@1.9.0 and ectrans@2.0.0. It doesn't configure any new build options. I noticed that these build options were incomplete for earlier versions as well, and because there are so many new and complicated options, I believe that the package developers (@samhatfield & colleagues) can do a better job here.

I did, however, verify that the find-lapack patch is no longer required to find the correct, spack-provided LAPACK libraries. I also checked FFTW, and those are correct as well. For example, on a Cray with Intel oneAPI MKL instead of cray-libsci as lapack/blas providers, the Intel oneAPI mkl packages were found and used for both LAPACK and FFTW.

