### PR TITLE
packages: remove duplicate variant definitions

### DIFF
--- a/repos/spack_repo/builtin/packages/e3sm_scorpio/package.py
+++ b/repos/spack_repo/builtin/packages/e3sm_scorpio/package.py
@@ -31,9 +31,6 @@ class E3smScorpio(CMakePackage):
     version("1.4.2", sha256="e41b2725b2389df48b91932224a0dfb8c8fe6e98c7a49e1dfd65f7d49f7ffa81")
     version("1.4.1", sha256="7cb4589410080d7e547ef17ddabe68f749e6af019c1d0e6ee9f11554f3ff6b1a")
 
-    variant("timing", default=False, description="Enable timing")
-    variant("mpi", default=True, description="Enable MPI")
-
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated

--- a/repos/spack_repo/builtin/packages/gfal2/package.py
+++ b/repos/spack_repo/builtin/packages/gfal2/package.py
@@ -24,7 +24,6 @@ class Gfal2(CMakePackage):
     variant("gridftp", default=False, description="Enable gridftp plugin")
     variant("http", default=False, description="Enable http plugin")
     variant("sftp", default=False, description="Enable sftp plugin")
-    variant("sftp", default=False, description="Enable sftp plugin")
     variant("srm", default=False, description="Enable srm plugin")
     variant("xrootd", default=False, description="Enable xrootd plugin")
 

--- a/repos/spack_repo/builtin/packages/py_htseq/package.py
+++ b/repos/spack_repo/builtin/packages/py_htseq/package.py
@@ -22,7 +22,6 @@ class PyHtseq(PythonPackage):
     version("0.9.1", sha256="af5bba775e3fb45ed4cde64c691ebef36b0bf7a86efd35c884ad0734c27ad485")
 
     variant("qa", default=True, description="Quality assessment")
-    variant("mtx", default=True, description="BigWig manipulation", when="@2:")
     variant("mtx", default=True, description="mtx output files", when="@2:")
     variant("h5ad", default=True, description="h5ad output files", when="@2:")
     variant("loom", default=True, description="loom output files", when="@2:")


### PR DESCRIPTION
Found these duplications while looking for other variant related info in the `builtin` repo

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
