### PR TITLE
fontconfig: Add deps to bzip2 and libpng

### DIFF
--- a/repos/spack_repo/builtin/packages/fontconfig/package.py
+++ b/repos/spack_repo/builtin/packages/fontconfig/package.py
@@ -54,6 +54,8 @@ class Fontconfig(AutotoolsPackage):
         ldflags = []
         libs = []
         deps = []
+        # if freetype is an external, we can't access its DAG (bzip2 and libpng specs)
+        # we assume that the externals are shared libs
         if not self.spec["freetype"].external and self.spec["bzip2"].satisfies("~shared"):
             deps.append("bzip2")
         if not self.spec["freetype"].external and not self.spec["libpng"].satisfies("libs=shared"):

--- a/repos/spack_repo/builtin/packages/fontconfig/package.py
+++ b/repos/spack_repo/builtin/packages/fontconfig/package.py
@@ -54,9 +54,9 @@ class Fontconfig(AutotoolsPackage):
         ldflags = []
         libs = []
         deps = []
-        if self.spec["bzip2"].satisfies("~shared"):
+        if not self.spec["freetype"].external and self.spec["bzip2"].satisfies("~shared"):
             deps.append("bzip2")
-        if not self.spec["libpng"].satisfies("libs=shared"):
+        if not self.spec["freetype"].external and not self.spec["libpng"].satisfies("libs=shared"):
             deps.append("libpng")
         if self.spec["libxml2"].satisfies("~shared"):
             deps.append("libxml-2.0")


### PR DESCRIPTION
The recipe tries to access these deps as part of
fontconfig's spec. If these are only pulled in recursively through other specs installing fontconfig fails if these intermediate specs are provided externaly.

Resolves #6327.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
