### PR TITLE
edm4hep: Add version 1.1.1

### DIFF
--- a/repos/spack_repo/builtin/packages/edm4hep/package.py
+++ b/repos/spack_repo/builtin/packages/edm4hep/package.py
@@ -96,6 +96,12 @@ class Edm4hep(CMakePackage):
         sha256="374f0b7635c632e5a57d23ad163efab7370ab471c62e2713a41aa26e33d8f221",
     )
 
+    patch(
+        "https://github.com/key4hep/EDM4hep/commit/f87de123bb1a56dfab7cdcb7f3cfb9dd51fc9313.patch?full_index=1",
+        when="@=1.1 %podio+arrow",
+        sha256="d4412d1340481a741893dd8684400eb3662c76f63d47cc940e38091c0ae9e766",
+    )
+
     def cmake_args(self):
         args = [
             self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),

--- a/repos/spack_repo/builtin/packages/edm4hep/package.py
+++ b/repos/spack_repo/builtin/packages/edm4hep/package.py
@@ -22,6 +22,7 @@ class Edm4hep(CMakePackage):
     license("Apache-2.0")
 
     version("main", branch="main")
+    version("1.1.1", sha256="14165219c74c48549cdd1ad7ea5e3cf0e7bed86688a1e037fde39a51d2e7edd0")
     version("1.1", sha256="a45c849e69ae23640086315547a3bf480aaab954168043c82ccf9a7d372bffdd")
     version("1.0", sha256="7bb76479883997ba39357b0db65d96d5f1201bc8a79b47866db8b44f76a231be")
     version("0.99.4", sha256="34a76e74a3199b96d8108425fdf894cafa7e4a71483d4893537c3026b4e666d6")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Add EDM4hep version 1.1.1 ([release notes](https://github.com/key4hep/EDM4hep/releases/tag/v01-01-01)).

I have also added [this commit](https://github.com/key4hep/EDM4hep/commit/f87de123bb1a56dfab7cdcb7f3cfb9dd51fc9313) as a patch to allow building edm4hep against `podio+arrow` always.

edit: I have also verified that `edm4hep@=1.1` builds against `podio@1.8 +arrow` (i.e. the patch is applied correctly).