### PR TITLE
Update package tl-expected: make build possible in air-gapped environments

### DIFF
--- a/repos/spack_repo/builtin/packages/tl_expected/package.py
+++ b/repos/spack_repo/builtin/packages/tl_expected/package.py
@@ -16,6 +16,14 @@ class TlExpected(CMakePackage):
 
     maintainers("charmoniumQ")
 
+    resource(
+        name="Catch2",
+        git="https://github.com/catchorg/Catch2.git",
+        commit="182c910b4b63ff587a3440e08f84f70497e49a81",
+        destination="deps",
+        placement="Catch2",
+    )
+
     license("CC0-1.0", checked_by="wdconinc")
 
     version("1.2.0", sha256="f5424f5fc74e79157b9981ba2578a28e0285ac6ec2a8f075e86c41226fe33386")
@@ -23,3 +31,11 @@ class TlExpected(CMakePackage):
     version("1.0.0", sha256="8f5124085a124113e75e3890b4e923e3a4de5b26a973b891b3deb40e19c03cee")
 
     depends_on("cxx", type="build")
+
+    def cmake_args(self):
+        return [
+            self.define(
+                "FETCHCONTENT_SOURCE_DIR_CATCH2",
+                join_path(self.stage.source_path, "deps", "Catch2"),
+            ),
+        ]


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

tl-expected uses Cmake command FetchContent: https://github.com/TartanLlama/expected/blob/master/CMakeLists.txt#L70
This generates errors when building in an airgapped environment

This patches the recipe to prefetch  the sources using ressource command and FETCHCONTENT_SOURCE_DIR variable