### PR TITLE
CMake: add v4.2.8

### DIFF
--- a/repos/spack_repo/builtin/packages/cmake/package.py
+++ b/repos/spack_repo/builtin/packages/cmake/package.py
@@ -36,6 +36,7 @@ class Cmake(Package):
     version("4.4.1", sha256="95d4721f3625fb0d9d6ca480dd59a46c84b4c157f7fadd2e9b179ef9c871174d")
     version("4.3.4", sha256="fdeff897b9eb49d764539f2b1edc6eb7e1440df325678a97c1978499e931adda")
     version("4.3.3", sha256="cba4bb7a44edf2877bb6f059932896383babe435b3a8c3b5df48b4aa41c9bb85")
+    version("4.2.8", sha256="f1fbcf2756029e14fb4ff37b4582d6c81a51f43d5ffa7b0849fccbf53cf39bf9")
     version("4.2.4", sha256="93e02d41330250d12362541c63963a469e7c24fb894fab6dbb30082a0a1f0edd")
     version("4.2.3", sha256="7efaccde8c5a6b2968bad6ce0fe60e19b6e10701a12fce948c2bf79bac8a11e9")
     version("4.1.5", sha256="50ce77215cf266630fa5de97c360f4c313bb79f94b35236b63c1216de3196356")


### PR DESCRIPTION
Release notes: https://cmake.org/cmake/help/v4.2/release/4.2.html

Release milestone: https://gitlab.kitware.com/cmake/cmake/-/milestones/212

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
