### PR TITLE
vermin: run with `--eval-annotations`

### DIFF
--- a/.github/workflows/prechecks.yml
+++ b/.github/workflows/prechecks.yml
@@ -26,7 +26,7 @@ jobs:
         pip install -r .github/workflows/requirements/style/requirements.txt
     - name: vermin (Repositories)
       run: |
-        vermin --backport importlib --backport argparse --violations --backport typing -t=3.6- -vvv repos tests
+        vermin --backport importlib --backport argparse --violations --backport typing --eval-annotations -t=3.6- -vvv repos tests
 
   # Run style checks on the files that have been changed
   style:

--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -884,7 +884,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
                     f.write(bd.read())
 
     # https://gcc.gnu.org/install/configure.html
-    def configure_args(self) -> list[str]:
+    def configure_args(self):
         spec = self.spec
 
         # Generic options to compile GCC

--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -884,7 +884,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
                     f.write(bd.read())
 
     # https://gcc.gnu.org/install/configure.html
-    def configure_args(self):
+    def configure_args(self) -> list[str]:
         spec = self.spec
 
         # Generic options to compile GCC


### PR DESCRIPTION
Here's an example of failure: https://github.com/spack/spack-packages/actions/runs/34095093218/job/101657006763?pr=6372

Started this PR since #6219 was not failing on a Python version check.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
