### PR TITLE
py-awkward-cpp: require py-pybind11@3: for @48:

### DIFF
--- a/repos/spack_repo/builtin/packages/py_awkward_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/py_awkward_cpp/package.py
@@ -44,8 +44,10 @@ class PyAwkwardCpp(PythonPackage):
 
     depends_on("python@3.7:", type=("build", "run"))
     depends_on("python@3.8:", type=("build", "run"), when="@19:")
+    depends_on("python@3.9:", type=("build", "run"), when="@42:")
     depends_on("py-scikit-build-core@0.9:", when="@36:", type="build")
     depends_on("py-scikit-build-core@0.10:", when="@38:", type="build")
+    depends_on("py-scikit-build-core@0.11:", when="@48:", type="build")
     depends_on("py-pybind11", type=("build", "link"))
     depends_on("py-pybind11@3:", type=("build", "link"), when="@48:")
     depends_on("py-numpy@1.17.0:", when="@12:", type=("build", "run"))

--- a/repos/spack_repo/builtin/packages/py_awkward_cpp/package.py
+++ b/repos/spack_repo/builtin/packages/py_awkward_cpp/package.py
@@ -47,6 +47,7 @@ class PyAwkwardCpp(PythonPackage):
     depends_on("py-scikit-build-core@0.9:", when="@36:", type="build")
     depends_on("py-scikit-build-core@0.10:", when="@38:", type="build")
     depends_on("py-pybind11", type=("build", "link"))
+    depends_on("py-pybind11@3:", type=("build", "link"), when="@48:")
     depends_on("py-numpy@1.17.0:", when="@12:", type=("build", "run"))
     depends_on("py-numpy@1.18.0:", when="@19:", type=("build", "run"))
 


### PR DESCRIPTION
awkward-cpp 48–52 list `pybind11>=3` in their pyproject build requirements. The recipe had no version constraint, so a reused `py-pybind11@2.13.6` satisfied it and 52 failed to compile: `no member named 'multiple_interpreters' in namespace 'pybind11'`.

Adds `depends_on("py-pybind11@3:", type=("build", "link"), when="@48:")`.
