### PR TITLE
python-venv: extension's site-packages on build PYTHONPATH

### DIFF
--- a/repos/spack_repo/builtin/packages/python_venv/package.py
+++ b/repos/spack_repo/builtin/packages/python_venv/package.py
@@ -87,6 +87,14 @@ class PythonVenv(Package):
     def libs(self):
         return LibraryList([])
 
+    def setup_dependent_build_environment(
+        self, env: EnvironmentModifications, dependent_spec: Spec
+    ) -> None:
+        """Put the extension's own site-packages on PYTHONPATH. They do not exist yet
+        when the build environment is set up, and install-time tests import from them."""
+        for directory in {self.platlib, self.purelib}:
+            env.prepend_path("PYTHONPATH", os.path.join(dependent_spec.prefix, directory))
+
     def setup_dependent_run_environment(
         self, env: EnvironmentModifications, dependent_spec: Spec
     ) -> None:


### PR DESCRIPTION
`spack install --test root` runs `test_imports` in the build environment, which is set up before the extension is installed. `python-venv.setup_dependent_run_environment` (also used for the build context) adds the extension's `purelib`/`platlib` only if they already exist, so a from-source pure-Python package is not importable at that point (`spack install --no-cache --test root py-colorama` → `ModuleNotFoundError: No module named 'colorama'`). The `python` package's own hooks add these directories without such a guard.

Adds `python-venv.setup_dependent_build_environment`: prepends the extension's own `purelib`/`platlib` unconditionally; the run-environment hook keeps its guard. Verified on Spack 1.2.2 with py-colorama



Reported as spack/spack#45801. spack/spack#48394 ran the test in the run-environment context instead and was closed after the repository split.
PythonPackage.test_imports and SIPPackage.test_imports are fixed with this