### PR TITLE
aotriton-llvm: add version bounds for py-nanobind

### DIFF
--- a/repos/spack_repo/builtin/packages/aotriton_llvm/package.py
+++ b/repos/spack_repo/builtin/packages/aotriton_llvm/package.py
@@ -36,7 +36,7 @@ class AotritonLlvm(CMakePackage, CudaPackage, CompilerPackage):
     depends_on("libxml2", type="link")
     depends_on("py-pybind11")
     depends_on("pkgconfig", type="build")
-    depends_on("py-nanobind", when="@0.10")
+    depends_on("py-nanobind@2.4:2", when="@0.10")
 
     root_cmakelists_dir = "llvm"
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
aotriton-llvm@0.10 requires py-nanobind@2.4:2

See:
- LLVM/MLIR CMake logic: https://github.com/llvm/llvm-project/blob/3c709802d31b5bc5ed3af8284b40593ff39b9eec/mlir/cmake/modules/MLIRDetectPythonEnv.cmake#L57
- the failling pipeline job: https://gitlab.spack.io/spack/spack-packages/-/jobs/24194045#L596 for https://github.com/spack/spack-packages/pull/6262

