### PR TITLE
py-onnxruntime: use Spack's protoc on darwin

### DIFF
--- a/repos/spack_repo/builtin/packages/py_onnxruntime/package.py
+++ b/repos/spack_repo/builtin/packages/py_onnxruntime/package.py
@@ -248,6 +248,13 @@ class PyOnnxruntime(CMakePackage, PythonExtension, ROCmPackage, CudaPackage):
                     define("onnxruntime_USE_COMPOSABLE_KERNEL", "OFF"),
                 )
             )
+
+        if self.spec.satisfies("platform=darwin"):
+            # avoid onnxruntime's vendored protoc, which can be older than the
+            # protobuf found by find_package and generate incompatible code
+            args.append(
+                define("ONNX_CUSTOM_PROTOC_EXECUTABLE", self.spec["protobuf"].prefix.bin.protoc)
+            )
         return args
 
     @run_after("install")

--- a/repos/spack_repo/builtin/packages/py_onnxruntime/package.py
+++ b/repos/spack_repo/builtin/packages/py_onnxruntime/package.py
@@ -250,8 +250,7 @@ class PyOnnxruntime(CMakePackage, PythonExtension, ROCmPackage, CudaPackage):
             )
 
         if self.spec.satisfies("platform=darwin"):
-            # avoid onnxruntime's vendored protoc, which can be older than the
-            # protobuf found by find_package and generate incompatible code
+            # avoid onnxruntime's vendored protoc
             args.append(
                 define("ONNX_CUSTOM_PROTOC_EXECUTABLE", self.spec["protobuf"].prefix.bin.protoc)
             )


### PR DESCRIPTION
This PR fixes an issue building `py-onnxruntime` on macOS since it defers to vendored `protoc` which leads to incompatibilities. This fix causes us to use spack's `protobuf`. On linux we already prefer a system `protobuf` and don't use the vendored `protoc`.

### Claude says
onnxruntime's CMake (`cmake/external/onnxruntime_external_deps.cmake`, `CMAKE_HOST_APPLE` branch) always downloads its own pinned protoc (v21.12) for Apple host builds, regardless of the protobuf version Spack provides for linking. Code generated by that protoc can be rejected by a newer protobuf's headers ("generated by a newer version of protoc which is incompatible with your Protocol Buffer headers"), e.g. building `py-onnxruntime@1.22.2` against `protobuf@32.1` on macOS ([failing CI run](https://github.com/eic/eic-spack/actions/runs/34168585503/job/101886125424)).

Related upstream reports of the same failure: microsoft/onnxruntime#26637, microsoft/onnxruntime#18077.

This points `ONNX_CUSTOM_PROTOC_EXECUTABLE` at Spack's own `protobuf`'s protoc on darwin, which onnxruntime's CMake already supports for exactly this case.

Opening as draft to confirm CI passes before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)