### PR TITLE
llvm, py-llvmlite: Fix choosing the correct llvm-config executiable

### DIFF
--- a/repos/spack_repo/builtin/packages/llvm/package.py
+++ b/repos/spack_repo/builtin/packages/llvm/package.py
@@ -1273,6 +1273,16 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
         # have to add rpaths to `bin/llvm-omp-*` and `share/gdb/python/ompd/ompdModule.so`.
         return ["libpython*.so.*", "libomp.so*", "libomptarget*.so*", "libunwind.so.*"]
 
+    def setup_dependent_package(self, module, dependent_spec):
+        """Set the llvm_config attribute for the dependent package to use"""
+        # This ensures that the dependent packages can find the correct llvm-config executable.
+        spec = self.spec
+        # Especially if llvm is external, it may have a versioned llvm-config executable.
+        spec.llvm_config = spec.prefix.bin.join(f"llvm-config-{spec.version.up_to(1)}")
+        if not os.path.exists(spec.llvm_config):
+            # Fall back to the unversioned llvm-config if the versioned one does not exist.
+            spec.llvm_config = self.prefix.bin.join("llvm-config")
+
 
 def get_gcc_install_dir_flag(spec: Spec, compiler) -> Optional[str]:
     """Get the --gcc-install-dir=... flag, so that clang does not do a system scan for GCC."""

--- a/repos/spack_repo/builtin/packages/py_llvmlite/package.py
+++ b/repos/spack_repo/builtin/packages/py_llvmlite/package.py
@@ -91,6 +91,8 @@ class PyLlvmlite(PythonPackage):
         depends_on("llvm@10.0", when=f"@0.34:0.36 target={t}")
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        # Used to specify the path to the llvm-config executable for the build process
+        env.set("LLVM_CONFIG", self.spec["llvm"].llvm_config)
         if self.spec.satisfies("%fj"):
             env.set("CXX_FLTO_FLAGS", "{0}".format(self.compiler.cxx_pic_flag))
             env.set("LD_FLTO_FLAGS", "-Wl,--exclude-libs=ALL")


### PR DESCRIPTION
llvm, py-llvmlite: Fix choosing the correct llvm-config executable

## Background

The `llvmlite` package requires a specific LLVM version range for each release:
```py
    # https://github.com/numba/llvmlite#compatibility
    depends_on("llvm@22", when="@0.48:")
    depends_on("llvm@20", when="@0.45:0.47")
    depends_on("llvm@15:16", when="@0.44")
    depends_on("llvm@14", when="@0.41:0.43")
    depends_on("llvm@11:14", when="@0.40")
    depends_on("llvm@11", when="@0.37:0.39")
```

## Problem

When spack has an an external llvm package that matches the required LLVM version, but the host has other LLVM versions in the same bin-prefix (e.g. /usr/bin), where the executable name `llvm-config` resolves to another LLVM version that is not compatible with the required version, the build script of `llvmlite` fails because the `llvm-config` executable e.g. provides LLVM-18, while the required LLVM version for an older version of llvmlite would be LLVM-16:

```py
ls -l /usr/bin/llvm-config*
lrwxrwxrwx 1 root root 30 Mar 30  2024 /usr/bin/llvm-config -> ../lib/llvm-18/bin/llvm-config
lrwxrwxrwx 1 root root 30 Apr  7  2024 /usr/bin/llvm-config-15 -> ../lib/llvm-15/bin/llvm-config
lrwxrwxrwx 1 root root 30 Apr 14  2024 /usr/bin/llvm-config-16 -> ../lib/llvm-16/bin/llvm-config
lrwxrwxrwx 1 root root 30 Apr 14  2024 /usr/bin/llvm-config-17 -> ../lib/llvm-17/bin/llvm-config
lrwxrwxrwx 1 root root 30 May 27  2024 /usr/bin/llvm-config-18 -> ../lib/llvm-18/bin/llvm-config
```

## Fix

Add the ability to get the `llvm-config` executable path for the requested external LLVM version by adding a new llvm_config property to the LLVM package spec very much like the `mpicc` and other properties of the MPI packages and use it to pass the correct `llvm-config` executable to the build.

Declaration: AI was not used in any phase of the development of this PR except for:
- Searching the spack-packages repo for examples where the path of a tool is exported to dependents