### PR TITLE
kokkos: clean up usage of kokkos_cxx

### DIFF
--- a/repos/spack_repo/builtin/packages/dealii/package.py
+++ b/repos/spack_repo/builtin/packages/dealii/package.py
@@ -558,8 +558,8 @@ class Dealii(CMakePackage, CudaPackage):
                     ]
                 )
             # Make sure we use the same compiler that Trilinos uses
-            if spec.satisfies("+trilinos"):
-                options.extend([self.define("CMAKE_CXX_COMPILER", self["trilinos"].kokkos_cxx)])
+            if spec.satisfies("+trilinos ^trilinos+kokkos ^kokkos+wrapper"):
+                options.extend([self.define("CMAKE_CXX_COMPILER", self["kokkos"].kokkos_cxx)])
 
         # Complex support
         options.append(self.define_from_variant("DEAL_II_WITH_COMPLEX_VALUES", "complex"))

--- a/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -445,8 +445,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     def kokkos_cxx(self) -> str:
         if self.spec.satisfies("+wrapper"):
             return self["kokkos-nvcc-wrapper"].kokkos_cxx
-        # Assumes build-time globals have been set already
-        return spack_cxx
+        return self["cxx"].cxx
 
     def cmake_args(self):
         spec = self.spec

--- a/repos/spack_repo/builtin/packages/trilinos/package.py
+++ b/repos/spack_repo/builtin/packages/trilinos/package.py
@@ -6,6 +6,7 @@ import os
 import pathlib
 import re
 import sys
+import warnings
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
@@ -760,10 +761,8 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
 
     @property
     def kokkos_cxx(self) -> str:
-        if self.spec.satisfies("+wrapper"):
-            return self["kokkos-nvcc-wrapper"].kokkos_cxx
-        # Assumes build-time globals have been set already
-        return spack_cxx
+        warnings.warn("Trilinos.kokkos_cxx is deprecated. Use Kokkos.kokkos_cxx instead.")
+        return self["kokkos"].kokkos_cxx
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         spec = self.spec


### PR DESCRIPTION
Fixes #3419 

Three separate commits:

1. Make the `kokkos_cxx` variable computation more robust
2. Make `dealii` only rely on it when it's relevant, and otherwise use the spack compiler wrappers
3. Remove the matching trilinos variable in favor of relying directly on kokkos
