### PR TITLE
gfe: Update GFE packages: Fixes for Intel on Windows

### DIFF
--- a/repos/spack_repo/builtin/packages/fargparse/package.py
+++ b/repos/spack_repo/builtin/packages/fargparse/package.py
@@ -23,6 +23,7 @@ class Fargparse(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("1.12.0", sha256="171abd64f42503603715721faf0e262209145450ac38edb0bfa9cdb5c06423ef")
     version("1.11.0", sha256="867854b0d312ef22ba3938f5398727973942a31d75f4e1abd3cd9d35f0159691")
     version("1.10.0", sha256="c2f2b2c2f0dc263e484f7f5f6918d93f40c5b96b8970b5f19426f0a89e14a8f9")
     version("1.9.0", sha256="c83c13fa90b6b45adf8d84fe00571174acfa118d2a0d1e8c467f74bbd7dec49d")

--- a/repos/spack_repo/builtin/packages/pflogger/package.py
+++ b/repos/spack_repo/builtin/packages/pflogger/package.py
@@ -23,6 +23,7 @@ class Pflogger(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("1.19.0", sha256="231abcb7dfc8f5ca6145eebaa7eda1c9dda4ecc20c3dad214f5ab78f35ad2681")
     version("1.18.1", sha256="e88bb22bc1212bdbfade87bc16ec3ba8306540ef66cd99f201633f86043c3f89")
     version("1.18.0", sha256="e4ccd77b4fbe49396f0659c2f3a82622ed7a3ad3d89574fda6783fc8cf6d6b3e")
     version("1.17.0", sha256="44dd57fd63a9036dc3ca0dee6847042468e5f39f776188a1d140847005e4f828")

--- a/repos/spack_repo/builtin/packages/pflogger/package.py
+++ b/repos/spack_repo/builtin/packages/pflogger/package.py
@@ -23,7 +23,7 @@ class Pflogger(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
-    version("1.19.0", sha256="231abcb7dfc8f5ca6145eebaa7eda1c9dda4ecc20c3dad214f5ab78f35ad2681")
+    version("1.19.1", sha256="a4653af271fa32b16ee77dc25e867d40707912eb30d63954ffe9943a31ee16ec")
     version("1.18.1", sha256="e88bb22bc1212bdbfade87bc16ec3ba8306540ef66cd99f201633f86043c3f89")
     version("1.18.0", sha256="e4ccd77b4fbe49396f0659c2f3a82622ed7a3ad3d89574fda6783fc8cf6d6b3e")
     version("1.17.0", sha256="44dd57fd63a9036dc3ca0dee6847042468e5f39f776188a1d140847005e4f828")

--- a/repos/spack_repo/builtin/packages/pfunit/package.py
+++ b/repos/spack_repo/builtin/packages/pfunit/package.py
@@ -23,7 +23,7 @@ class Pfunit(CMakePackage):
     license("NASA-1.3", checked_by="mathomp4", when="@:4.16")
     license("Apache-2.0", checked_by="mathomp4", when="@4.17:")
 
-    version("4.20.0", sha256="b651f4c7d73952b901f2036504a9cd4ac8e646289909b48580644f4719e3e506")
+    version("4.20.1", sha256="3d1789f08c71748e9c5cd4822217e7cbe8a3c7df81d166b3a862b536a281fcb9")
     version("4.19.0", sha256="ec84e2e17d79598d782edc5468e7ebfe392ccf5aff9170a15c10f0b52f9f62b4")
     version("4.18.2", sha256="d2bdc52372e42d8f0e27d06325c73ce0133b886d207cb5efb6d7fc6f0b536f48")
     version("4.18.1", sha256="34654ac27c3498333210cac480d6319d3d8c0230057fd0974f3e3c4d656b8cd9")

--- a/repos/spack_repo/builtin/packages/pfunit/package.py
+++ b/repos/spack_repo/builtin/packages/pfunit/package.py
@@ -23,6 +23,7 @@ class Pfunit(CMakePackage):
     license("NASA-1.3", checked_by="mathomp4", when="@:4.16")
     license("Apache-2.0", checked_by="mathomp4", when="@4.17:")
 
+    version("4.20.0", sha256="b651f4c7d73952b901f2036504a9cd4ac8e646289909b48580644f4719e3e506")
     version("4.19.0", sha256="ec84e2e17d79598d782edc5468e7ebfe392ccf5aff9170a15c10f0b52f9f62b4")
     version("4.18.2", sha256="d2bdc52372e42d8f0e27d06325c73ce0133b886d207cb5efb6d7fc6f0b536f48")
     version("4.18.1", sha256="34654ac27c3498333210cac480d6319d3d8c0230057fd0974f3e3c4d656b8cd9")

--- a/repos/spack_repo/builtin/packages/yafyaml/package.py
+++ b/repos/spack_repo/builtin/packages/yafyaml/package.py
@@ -31,6 +31,7 @@ class Yafyaml(CMakePackage):
 
     version("main", branch="main")
 
+    version("1.7.1", sha256="28bc68f8097016fe48a189756ecd47916971a24aee25d4f02e144bf594968ca9")
     version("1.7.0", sha256="46fc4761aa61afa32c6e0000468989035a1f8d2526519ff9cc5309f346e7c866")
     version("1.6.0", sha256="4eb4834c40e70eb1d81669e4397fe09e9f08dde292feb3a889362debdbf9d339")
     version("1.5.1", sha256="c9e7f873fdcb579fca53196f3a1ad68149dc6e980e6533e1119687f5a7463cc1")

--- a/repos/spack_repo/builtin/packages/yafyaml/package.py
+++ b/repos/spack_repo/builtin/packages/yafyaml/package.py
@@ -31,6 +31,7 @@ class Yafyaml(CMakePackage):
 
     version("main", branch="main")
 
+    version("1.7.0", sha256="46fc4761aa61afa32c6e0000468989035a1f8d2526519ff9cc5309f346e7c866")
     version("1.6.0", sha256="4eb4834c40e70eb1d81669e4397fe09e9f08dde292feb3a889362debdbf9d339")
     version("1.5.1", sha256="c9e7f873fdcb579fca53196f3a1ad68149dc6e980e6533e1119687f5a7463cc1")
     version("1.4.0", sha256="2a415087eb26d291ff40da4430d668c702d22601ed52a72d001140d97372bc7d")

--- a/repos/spack_repo/builtin/packages/yafyaml/package.py
+++ b/repos/spack_repo/builtin/packages/yafyaml/package.py
@@ -32,7 +32,6 @@ class Yafyaml(CMakePackage):
     version("main", branch="main")
 
     version("1.7.1", sha256="28bc68f8097016fe48a189756ecd47916971a24aee25d4f02e144bf594968ca9")
-    version("1.7.0", sha256="46fc4761aa61afa32c6e0000468989035a1f8d2526519ff9cc5309f346e7c866")
     version("1.6.0", sha256="4eb4834c40e70eb1d81669e4397fe09e9f08dde292feb3a889362debdbf9d339")
     version("1.5.1", sha256="c9e7f873fdcb579fca53196f3a1ad68149dc6e980e6533e1119687f5a7463cc1")
     version("1.4.0", sha256="2a415087eb26d291ff40da4430d668c702d22601ed52a72d001140d97372bc7d")

--- a/repos/spack_repo/builtin/packages/yafyaml/package.py
+++ b/repos/spack_repo/builtin/packages/yafyaml/package.py
@@ -31,7 +31,7 @@ class Yafyaml(CMakePackage):
 
     version("main", branch="main")
 
-    version("1.7.1", sha256="28bc68f8097016fe48a189756ecd47916971a24aee25d4f02e144bf594968ca9")
+    version("1.7.2", sha256="788404c262077a7e49a0d9fd343c8063aff2a72dc884b8c4d81b168c2b6cd982")
     version("1.6.0", sha256="4eb4834c40e70eb1d81669e4397fe09e9f08dde292feb3a889362debdbf9d339")
     version("1.5.1", sha256="c9e7f873fdcb579fca53196f3a1ad68149dc6e980e6533e1119687f5a7463cc1")
     version("1.4.0", sha256="2a415087eb26d291ff40da4430d668c702d22601ed52a72d001140d97372bc7d")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR updates four of the GFE packages with their latest versions. All of these new tags were made to fix issues with CMake on Windows with Intel compilers (see https://github.com/Goddard-Fortran-Ecosystem/yaFyaml/issues/95)
