### PR TITLE
fix papi for version 7.0.1

### DIFF
--- a/repos/spack_repo/builtin/packages/papi/package.py
+++ b/repos/spack_repo/builtin/packages/papi/package.py
@@ -157,7 +157,7 @@ class Papi(AutotoolsPackage, ROCmPackage):
         options = ["MPICC=:"]
         # Build a list of PAPI components
         components = filter(
-            lambda x: spec.variants[x].value,
+            lambda x: x in spec.variants and spec.variants[x].value,
             [
                 "example",
                 "infiniband",


### PR DESCRIPTION
I got a key error  KeyError: 'rocp_sdk' because this variant is only present in 7.2: but the configure logic tried to access it for all versions (including version 7.0.1 which I was testing)

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
