### PR TITLE
xyce: make patch conditional and use fftw dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/xyce/package.py
+++ b/repos/spack_repo/builtin/packages/xyce/package.py
@@ -185,7 +185,7 @@ class Xyce(CMakePackage):
             options.append("-DXyce_VERBOSE_TIME=ON")
         if "+fftw" in spec:
             options.append("-DXyce_USE_FFTW=ON")
-            options.append("-DFFTW_ROOT:PATH={0}".format(spec['fftw'].prefix))
+            options.append(f"-DFFTW_ROOT:PATH={spec['fftw'].prefix}")
 
         return options
 

--- a/repos/spack_repo/builtin/packages/xyce/package.py
+++ b/repos/spack_repo/builtin/packages/xyce/package.py
@@ -84,6 +84,7 @@ class Xyce(CMakePackage):
     depends_on("fftw~mpi", type=("build", "run"), when="+fftw~mpi")
     depends_on("fftw+mpi", type=("build", "run"), when="+fftw+mpi")
 
+    variant("verbose", default=False, description="Increase Xyce verbosity")
     # https://github.com/Xyce/Xyce/commit/ddec31a9c42c683831937be17fd6ffc3180e77a1
     # requirement because of use of std::filesystem
     conflicts("@7.10:", when="%gcc@:8")
@@ -178,6 +179,13 @@ class Xyce(CMakePackage):
             options.append("-Dpybind11_DIR:PATH={0}".format(pybind11.prefix))
             options.append("-DPython_ROOT_DIR:FILEPATH={0}".format(python.prefix))
             options.append("-DPython_FIND_STRATEGY=LOCATION")
+        if "+verbose" in spec:
+            options.append("-DXyce_VERBOSE_LINEAR=ON")
+            options.append("-DXyce_VERBOSE_NONLINEAR=ON")
+            options.append("-DXyce_VERBOSE_TIME=ON")
+        if "+fftw" in spec:
+            options.append("-DXyce_USE_FFTW=ON")
+            options.append("-DFFTW_ROOT:PATH={0}".format(spec['fftw'].prefix))
 
         return options
 

--- a/repos/spack_repo/builtin/packages/xyce/package.py
+++ b/repos/spack_repo/builtin/packages/xyce/package.py
@@ -150,6 +150,7 @@ class Xyce(CMakePackage):
     patch(
         "454-cmake-xyce.patch",
         sha256="4d47cd1f10607205e64910ac124c6dd329f1ecbf861416e9da24a1736f2149ff",
+        when="@:7.10",
     )
 
     def cmake_args(self):

--- a/repos/spack_repo/builtin/packages/xyce/package.py
+++ b/repos/spack_repo/builtin/packages/xyce/package.py
@@ -176,8 +176,8 @@ class Xyce(CMakePackage):
             pybind11 = spec["py-pybind11"]
             python = spec["python"]
             options.append("-DXyce_PYMI:BOOL=ON")
-            options.append("-Dpybind11_DIR:PATH={0}".format(pybind11.prefix))
-            options.append("-DPython_ROOT_DIR:FILEPATH={0}".format(python.prefix))
+            options.append(f"-Dpybind11_DIR:PATH={pybind11.prefix}")
+            options.append(f"-DPython_ROOT_DIR:FILEPATH={python.prefix}")
             options.append("-DPython_FIND_STRATEGY=LOCATION")
         if "+verbose" in spec:
             options.append("-DXyce_VERBOSE_LINEAR=ON")
@@ -206,6 +206,6 @@ class Xyce(CMakePackage):
                     libgfortran = fc("--print-file-name", "libgfortran.a", output=str).strip()
                 # -L<libdir> -lgfortran required for OSX
                 # https://github.com/spack/spack/pull/25823#issuecomment-917231118
-                flags.append("-L{0} -lgfortran".format(os.path.dirname(libgfortran)))
+                flags.append(f"-L{os.path.dirname(libgfortran)} -lgfortran")
 
         return (flags, None, None)


### PR DESCRIPTION
- Patch for issue 454 no longer needed after version 7.10.
- Adds `+verbose` variant
- Modifies CMake options for `+fftw` dependency, when specified
