### PR TITLE
grpc: add v1.83.1

### DIFF
--- a/repos/spack_repo/builtin/packages/grpc/package.py
+++ b/repos/spack_repo/builtin/packages/grpc/package.py
@@ -14,6 +14,7 @@ class Grpc(CMakePackage):
 
     license("Apache-2.0 AND BSD-3-Clause AND MIT")
 
+    version("1.83.1", sha256="60caa8397426d8a500e3e57ab6a49d1cb5aa62a36f2591eb9da3d77fa38ad8c9")
     version("1.78.1", sha256="961a44a2a5a50670e58f5e887c17fe70529253da23802245326d681f6d8d1ba6")
     version("1.76.0", sha256="0af37b800953130b47c075b56683ee60bdc3eda3c37fc6004193f5b569758204")
     version("1.67.1", sha256="d74f8e99a433982a12d7899f6773e285c9824e1d9a173ea1d1fb26c9bd089299")
@@ -86,7 +87,7 @@ class Grpc(CMakePackage):
         depends_on("abseil-cpp@20240116.1:20240117.0", when="@1.67")
         depends_on("abseil-cpp@20240722.0", when="@1.78")
 
-    depends_on("re2+pic@2023-09-01", when="@1.33.1:")
+    depends_on("re2+pic", when="@1.33.1:")
 
     def cmake_args(self):
         args = [
@@ -116,7 +117,10 @@ class Grpc(CMakePackage):
     def patch(self):
         # GCC 13+ and Clang 15+ removed implicit transitive includes (e.g. <string>,
         # <cstdint>, <limits>, <algorithm>). Inject them into the portability header
-        if self.spec.satisfies("%gcc@13:") or self.spec.satisfies("%clang@15:"):
+        # The includes were added added in grpc v1.70.0
+        if self.spec.satisfies("@:1.69") and (
+            self.spec.satisfies("%gcc@13:") or self.spec.satisfies("%clang@15:")
+        ):
             filter_file(
                 r"(#define GRPC_SUPPORT_PORT_PLATFORM_H)",
                 r"\1"
@@ -130,15 +134,15 @@ class Grpc(CMakePackage):
                 join_path(self.stage.source_path, "include/grpc/support/port_platform.h"),
             )
 
-        # glob.cc uses std::min/std::max but omits <algorithm>
-        # File location changed in grpc 1.67.0+
-        if self.spec.satisfies("@1.67"):
-            glob_path = join_path(self.stage.source_path, "src/core/lib/gprpp/glob.cc")
-        else:
-            glob_path = join_path(self.stage.source_path, "src/core/util/glob.cc")
+            # glob.cc uses std::min/std::max but omits <algorithm>
+            # File location changed in grpc 1.67.0+
+            if self.spec.satisfies("@1.67"):
+                glob_path = join_path(self.stage.source_path, "src/core/lib/gprpp/glob.cc")
+            else:
+                glob_path = join_path(self.stage.source_path, "src/core/util/glob.cc")
 
-        filter_file(
-            r'(#include "absl/strings/string_view.h")',
-            '#include <algorithm>\n#include "absl/strings/string_view.h"',
-            glob_path,
-        )
+            filter_file(
+                r'(#include "absl/strings/string_view.h")',
+                '#include <algorithm>\n#include "absl/strings/string_view.h"',
+                glob_path,
+            )


### PR DESCRIPTION
grpc: update to 1.83.1 and fix build issues:                                                                                                                                                                                                                                                                                                                                                                   
- Add [grpc 1.83.1 ](https://github.com/grpc/grpc/releases/tag/v1.83.1) version                                                                                                                                                                                                                                                                                                                                                                              
- Remove pinned re2 version constraint (2023-09-01) (build fails on newer systems, and there does not seem to be a requirement for this specific version anyway)                                                                                       
- Make patch for missing includes conditional on `@:1.69` since the fix was merged upstream in v1.70.0 (fixed in [this](https://github.com/grpc/grpc/commit/d54219b508423f0) commit)                                                                                                                                                                                                                                                                                                        
                                                                                                                                      