### PR TITLE
OpenBLAS: add `no_avx512` variant

### DIFF
--- a/repos/spack_repo/builtin/packages/openblas/package.py
+++ b/repos/spack_repo/builtin/packages/openblas/package.py
@@ -153,6 +153,8 @@ class Openblas(CMakePackage, MakefilePackage):
             when=_when_condition,
         )
 
+    variant("no_avx512", default=False, description="Disable AVX-512 vectorization")
+
     # virtual dependency
     provides("blas", "lapack")
     provides("lapack@3.9.1:", when="@0.3.15:")
@@ -535,6 +537,10 @@ class MakefileBuilder(makefile.MakefileBuilder):
 
         else:
             args.append("TARGET=" + microarch.name.upper())
+
+        # Disable AVX-512 vectorization of x86_64 architectures if requested
+        if self.spec.satisfies("+no_avx512") and self.spec.target.family == "x86_64":
+            args.append("NO_AVX512=1")
 
         return args
 


### PR DESCRIPTION
Working on the introduction of Spack into the [thermo-hydraulics solver Trust](https://gitlab.com/cea-trust-platform/trust/trust-code), developped at CEA, we systematically used to pass the `NO_AVX512` flag when building OpenBLAS. Our early work adopting Spack showed that some of our own tests are failing when the flag is not passed (note that OpenBLAS' own unit tests pass indifferently with or without the flag). We checked that, in the package, the flag is passed for some micro-architectures (e.g. Skylake), but not for all of them (e.g. Zen5).

We see two ways to circumvent this problem: first, by supporting more architectures in the package file, which would pass the `NO_AVX512` flag automatically when needed. This would certainly be the best way, but it's very possible that not all architectures will be taken into consideration. Second, by adding a variant, disabled by default, to enforce the `NO_AVX512` flag. This seems reasonable, as this would be a variant reflecting a valid, documented flag of OpenBLAS.

This PR proposes the second way, but I am open to discuss about a better way.

@mathomp4, @sethrj 