### PR TITLE
acts: depends on hepmc3 +rootio when necessary

### DIFF
--- a/repos/spack_repo/builtin/packages/acts/package.py
+++ b/repos/spack_repo/builtin/packages/acts/package.py
@@ -220,6 +220,7 @@ class Acts(CMakePackage, CudaPackage):
     depends_on("gperftools", when="+profilemem")
     depends_on("hepmc3 @3.2.1:", when="+hepmc3")
     depends_on("hepmc3 @3.2.4:", when="@42: +hepmc3")
+    depends_on("hepmc3 +rootio", when="@45.1: +hepmc3 +examples +root")
     depends_on("intel-tbb @2020.1:", when="+examples")
     depends_on("millepede@01-00-00:", when="+mille")
     depends_on("nlohmann-json @3.10.5:", when="+json")


### PR DESCRIPTION
This PR updates `acts` to depend correctly on the `hepmc3 +rootio` variant when `@45.1: +examples +root` as added in https://github.com/acts-project/acts/commit/5174d7662519e3177221881198d336bfa368f30e. This avoids configuration failures like:
```
> CMake Error at CMakeLists.txt:686 (find_package):
    Found package configuration file:
  
      /home/runner/work/eic-spack/eic-spack/spack/opt/spack/linux-x86_64_v3/hepmc3-3.3.1-nx2b463k6vxppfwoqmrssxbibcusnnjh/share/HepMC3/cmake/HepMC3Config.cmake
  
    but it set HepMC3_FOUND to FALSE so package "HepMC3" is considered to be
    NOT FOUND.
```