### PR TITLE
gcc: build Release by default

### DIFF
--- a/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/repos/spack_repo/builtin/packages/gcc/package.py
@@ -196,7 +196,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     )
     variant(
         "build_type",
-        default="RelWithDebInfo",
+        default="Release",
         values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
         description="CMake-like build type. "
         "Debug: -O0 -g; Release: -O3; "


### PR DESCRIPTION
The gcc `build_type` variant (spack/spack#30660) predates the change to using Release by default (spack/spack#36679) and must've been missed in the transition. This changes the default to  Release (exceedingly rare to need debug symbols for a compiler).

P.S. There still seem to be quite a few "build_type" variants elsewhere in the packages repo, even when they're CMakePackages…