### PR TITLE
mctc_lib: Refactor shared/static variants

### DIFF
--- a/repos/spack_repo/builtin/packages/mctc_lib/package.py
+++ b/repos/spack_repo/builtin/packages/mctc_lib/package.py
@@ -34,7 +34,21 @@ class MctcLib(MesonPackage, CMakePackage):
     version("0.3.1", sha256="a5032a0bbbbacc952037c5215b71aa6b438767a84bafb60fda25ba43c8835513")
     version("0.3.0", sha256="81f3edbf322e6e28e621730a796278498b84af0f221f785c537a315312059bf0")
 
-    variant("shared", default=True, description="Build shared libraries")
+    variant(
+            "shared", 
+            default=True, 
+            description="Build shared libraries",
+            when="build_system=cmake",
+        )
+    # redefine since mctc-lib does not seem to support building both at once
+    variant(
+            "default_library",
+            default="shared",
+            values=("shared", "static"),
+            multi=False,
+            description="Build shared libs or static libs",
+            when="build_system=meson",
+        )
     variant("json", default=False, description="Enable support for JSON")
     variant("openmp", default=False, description="Enable OpenMP support")
 
@@ -66,7 +80,6 @@ class CMakeBuilder(cmake.CMakeBuilder):
 class MesonBuilder(meson.MesonBuilder):
     def meson_args(self):
         return [
-            "-Ddefault_library={0}".format("shared" if "+shared" in self.spec else "static"),
             "-Djson={0}".format("enabled" if "+json" in self.spec else "disabled"),
             "-Dopenmp={0}".format("true" if "+openmp" in self.spec else "false"),
         ]

--- a/repos/spack_repo/builtin/packages/mctc_lib/package.py
+++ b/repos/spack_repo/builtin/packages/mctc_lib/package.py
@@ -35,20 +35,20 @@ class MctcLib(MesonPackage, CMakePackage):
     version("0.3.0", sha256="81f3edbf322e6e28e621730a796278498b84af0f221f785c537a315312059bf0")
 
     variant(
-            "shared", 
-            default=True, 
-            description="Build shared libraries",
-            when="build_system=cmake",
-        )
+        "shared",
+        default=True,
+        description="Build shared libraries",
+        when="build_system=cmake",
+    )
     # redefine since mctc-lib does not seem to support building both at once
     variant(
-            "default_library",
-            default="shared",
-            values=("shared", "static"),
-            multi=False,
-            description="Build shared libs or static libs",
-            when="build_system=meson",
-        )
+        "default_library",
+        default="shared",
+        values=("shared", "static"),
+        multi=False,
+        description="Build shared libs or static libs",
+        when="build_system=meson",
+    )
     variant("json", default=False, description="Enable support for JSON")
     variant("openmp", default=False, description="Enable OpenMP support")
 


### PR DESCRIPTION
Should fix #6426

Basically:
1) boolean shared variant made dependent on build_system=cmake 2) In meson_args, remove the setting of -Ddefault_library, as the default
   methods of MesonBuilder will set appropriately
3) redefine the build_system=meson dependent variant default_library to
   only be single valued (in my admittedly limitted testing, mctc-lib with
   meson build system will only build shared or static in a single run, not
   both)

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
