### PR TITLE
Fix package builds for xcode tools v27 when on MacOS v26

### DIFF
--- a/repos/spack_repo/builtin/build_systems/autotools.py
+++ b/repos/spack_repo/builtin/build_systems/autotools.py
@@ -335,6 +335,15 @@ To resolve this problem, please try the following:
         """
         os.environ["FORCE_UNSAFE_CONFIGURE"] = "1"
 
+        # The macOS 27 SDK exposes these functions as weak imports when
+        # targeting older macOS releases. Autoconf link tests mistake that for
+        # runtime availability and the resulting binaries call through NULL.
+        deployment_target = os.environ.get("MACOSX_DEPLOYMENT_TARGET")
+        if self.spec.satisfies("platform=darwin") and deployment_target:
+            if int(deployment_target.split(".", 1)[0]) < 27:
+                os.environ["ac_cv_func_dup3"] = "no"
+                os.environ["ac_cv_func_pipe2"] = "no"
+
     @run_before("configure")
     def _do_patch_libtool_configure(self) -> None:
         """Patch bugs that propagate from libtool macros into "configure" and

--- a/repos/spack_repo/builtin/packages/perl/package.py
+++ b/repos/spack_repo/builtin/packages/perl/package.py
@@ -222,6 +222,14 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         if spec.version[1] % 2 == 1:
             config_args.append("-Dusedevel")
 
+        # The macOS 27 SDK exposes these functions as weak imports when
+        # targeting older macOS releases. Perl's Configure mistakes that for
+        # runtime availability and the resulting binary calls through NULL.
+        deployment_target = os.environ.get("MACOSX_DEPLOYMENT_TARGET")
+        if spec.satisfies("platform=darwin") and deployment_target:
+            if int(deployment_target.split(".", 1)[0]) < 27:
+                config_args.extend(["-Ud_dup3", "-Ud_pipe2"])
+
         return config_args
 
     def configure(self, spec, prefix):

--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -736,6 +736,14 @@ class Python(Package):
             else:
                 options = getattr(self, "configure_flag_args", [])
                 options += ["--prefix={0}".format(prefix)]
+
+                # Python drives Autoconf directly instead of using AutotoolsBuilder.
+                # Keep its macOS availability cache consistent with that builder.
+                deployment_target = os.environ.get("MACOSX_DEPLOYMENT_TARGET")
+                if spec.satisfies("platform=darwin") and deployment_target:
+                    if int(deployment_target.split(".", 1)[0]) < 27:
+                        options += ["ac_cv_func_dup3=no", "ac_cv_func_pipe2=no"]
+
                 options += self.configure_args()
                 configure(*options)
 


### PR DESCRIPTION
XCode 27 launched to the MacOS 26 users yesterday and immediately broke a large swath of Spack builds for me.

I traced this down to the MacOS 27 SDK which exposes `dup3` and `pipe2` implementations. However if you're using the newer version of xcode tools on an older MacOS (which to be clear is very much supported) the SDK incorrectly exposes these implementations which are not available. Thus we got segfaults and linker errors when attempting to make use of them. 

This PR patches the autotools builder, Perl, and Python packages to explicitly fall back to the portable implementation for the two methods that is packaged with autotools itself. This got all of the packages in my default development environment back into a building state.