### PR TITLE
libuv-julia: add v1.48.1rc2

### DIFF
--- a/repos/spack_repo/builtin/packages/libuv_julia/package.py
+++ b/repos/spack_repo/builtin/packages/libuv_julia/package.py
@@ -19,6 +19,7 @@ class LibuvJulia(AutotoolsPackage):
     license("CC-BY-4.0")
 
     # julia's libuv fork doesn't tag (all?) releases, so we fix commits.
+    version("1.48.1rc2", commit="b21d6d84e46f6c97ecbc8e4e8a8ea6ad98049ea8")  # used by Julia 1.13
     version("1.48.1rc1", commit="af4172ec713ee986ba1a989b9e33993a07c60c9e")  # used by Julia 1.12
     version("1.48.0", commit="ca3a5a431a1c37859b6508e6b2a288092337029a")  # used by Julia 1.11
     version("1.44.3", commit="2723e256e952be0b015b3c0086f717c3d365d97e")


### PR DESCRIPTION
Adding a new version used by Julia v1.13. The libuv-julia doesn't tag releases so commit is used.