### PR TITLE
esmf: add llvm-openmp dependency for Apple Clang

### DIFF
--- a/repos/spack_repo/builtin/packages/esmf/package.py
+++ b/repos/spack_repo/builtin/packages/esmf/package.py
@@ -108,6 +108,7 @@ class Esmf(MakefilePackage, PythonExtension):
     depends_on("fortran", type="build")  # generated
 
     # Optional dependencies
+    depends_on("llvm-openmp", when="@9: +openmp %apple-clang", type=("build", "run"))
     depends_on("mpi", when="+mpi")
     depends_on("lapack@3:", when="+external-lapack")
     depends_on("netcdf-c@3.6:", when="+netcdf")
@@ -344,6 +345,11 @@ class MakefileBuilder(makefile.MakefileBuilder):
 
         if spec.satisfies("+openmp"):
             env.set("ESMF_OPENMP", "ON")
+            if "llvm-openmp" in spec:
+                openmp = spec["llvm-openmp"]
+                env.append_flags("ESMF_CXXCOMPILEOPTS", openmp.headers.include_flags)
+                env.append_flags("ESMF_CXXLINKOPTS", openmp.libs.ld_flags)
+                env.append_flags("ESMF_SL_LIBOPTS", openmp.libs.ld_flags)
         else:
             env.set("ESMF_OPENMP", "OFF")
 

--- a/repos/spack_repo/builtin/packages/esmf/package.py
+++ b/repos/spack_repo/builtin/packages/esmf/package.py
@@ -108,7 +108,7 @@ class Esmf(MakefilePackage, PythonExtension):
     depends_on("fortran", type="build")  # generated
 
     # Optional dependencies
-    depends_on("llvm-openmp", when="@9: +openmp %apple-clang", type=("build", "run"))
+    depends_on("llvm-openmp", when="@9: +openmp %apple-clang")
     depends_on("mpi", when="+mpi")
     depends_on("lapack@3:", when="+external-lapack")
     depends_on("netcdf-c@3.6:", when="+netcdf")


### PR DESCRIPTION
In ESMF 9.0+, `Darwin.gfortranclang.default` honors `ESMF_OPENMP=ON` rather than forcing `ESMF_OPENMP=OFF` (as previous versions did).

When building with `%apple-clang` and `+openmp`, Apple Clang does not bundle OpenMP runtime headers or libraries, leading to missing `<omp.h>` and `-lomp` errors when compiling ESMF C++ source files.

This PR:
1. Adds `depends_on("llvm-openmp", when="@9: +openmp %apple-clang")`.
2. Injects the include directory and linker flags (`openmp.headers.include_flags`, `openmp.libs.ld_flags`) into `ESMF_CXXCOMPILEOPTS`, `ESMF_CXXLINKOPTS`, `ESMF_F90LINKOPTS`, and `ESMF_SL_LIBOPTS` in `setup_build_environment`. The Fortran compile configuration already supplies `-fopenmp`; the added Fortran link flags explicitly locate `libomp` for ESMF tests and applications.

> **Note on versioning:**
> This change is a complete **no-op for ESMF 8** (which continues to not pull in `llvm-openmp`). While ESMF 9.0.0 has not yet been officially tagged as a final release, this has been verified with `esmf@develop` and recent 9.0.0 beta snapshots. We wanted to get this PR upstream now so the fix is in place ahead of the upcoming ESMF 9.0 release and not lost.

Tested on macOS (Apple Silicon, Apple Clang + GCC 16 gfortran):
- `esmf@develop +openmp %apple-clang` builds and installs cleanly.
- Downstream packages (MAPL) compile successfully against the resulting ESMF installation.
- `spack style -b develop` is completely clean.
