### PR TITLE
root: depends on libxcrypt on linux

### DIFF
--- a/repos/spack_repo/builtin/packages/root/package.py
+++ b/repos/spack_repo/builtin/packages/root/package.py
@@ -371,6 +371,7 @@ class Root(CMakePackage):
     depends_on("xz")
     depends_on("zlib-api")
     depends_on("zstd")
+    depends_on("libxcrypt", when="platform=linux")
 
     # X-Graphics
     depends_on("libx11", when="+x")


### PR DESCRIPTION
Ever since https://github.com/root-project/root/commit/1bf25bf4d1db2f226be311391d616dc9b120b79a, v6-17-02, `root` has depended (unconditionally) on `libxcrypt` (or the system `libcrypt`); see also https://github.com/root-project/root/blame/v6-40-04/net/auth/CMakeLists.txt#L35 more recently. This makes it official (but only on linux).

Avoids warnings/errors like:
```
          libNet.so.6.40 => /home/runner/work/eic-spack/eic-spack/spack/opt/spack/linux-x86_64_v3/root-6.40.04-vivd6dctacpedmtsse7pmpqszhglzzix/lib/root/libNet.so.6.40
          libCore.so.6.40 => /home/runner/work/eic-spack/eic-spack/spack/opt/spack/linux-x86_64_v3/root-6.40.04-vivd6dctacpedmtsse7pmpqszhglzzix/lib/root/libCore.so.6.40
          libcrypt.so.1 => not found
```