### PR TITLE
alps: add 3.0.0 and system Boost support

### DIFF
--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -25,7 +25,7 @@ class Alps(CMakePackage):
     # v2.3.3's LICENSE.txt is already the MIT license
     license("MIT", checked_by="egull")
 
-    version("develop", branch="fix/system-boost-numpy-fallback")
+    version("develop", branch="master")
     version(
         "2.3.4-beta.2",
         sha256="ca2e1307630e6fccac279ab7711036f7c6dee43c386fd6f24cfc77c86a3c7f1c",
@@ -37,7 +37,9 @@ class Alps(CMakePackage):
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
-    depends_on("fortran", type="build")
+    # No fortran: ALPS_BUILD_FORTRAN defaults OFF and is not enabled here
+
+    depends_on("cmake@3.18:", type="build")
 
     # --- Boost, two schemes ---
     # @develop consumes an externally built (Spack) Boost via ALPS_USE_SYSTEM_BOOST.
@@ -70,13 +72,14 @@ class Alps(CMakePackage):
     # otherwise pull in an MPI that ALPS's CMake then finds and links.
     depends_on("fftw~mpi", when="~mpi")
     depends_on("lapack")
-    depends_on("python", type=("build", "link", "run"))
+    depends_on("python@3.9:", type=("build", "link", "run"))
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-scipy", type=("build", "run"))
     depends_on("py-matplotlib", type=("build", "run"))
     depends_on("mpi", when="+mpi")
-    depends_on("hdf5+mpi+hl", when="+mpi")
-    depends_on("hdf5~mpi+hl", when="~mpi")
+    # Serial HDF5 even for +mpi: ALPS's CMakeLists warns "ALPS does not use
+    # parallel HDF5. The standard version is preferred."
+    depends_on("hdf5~mpi+hl")
     depends_on("zlib-api")
 
     extends("python")
@@ -168,6 +171,9 @@ class Alps(CMakePackage):
             # ALPS's cache variable is ALPS_ENABLE_MPI and defaults to ON,
             # so it must be set OFF explicitly for ~mpi
             self.define_from_variant("ALPS_ENABLE_MPI", "mpi"),
+            # Explicit rather than relying on the double-negative
+            # NOT_ALPS_BUILD_PYTHON default in ALPS's CMakeLists
+            self.define("ALPS_BUILD_PYTHON", True),
             self.define("CMAKE_INSTALL_RPATH_USE_LINK_PATH", True),
             self.define("CMAKE_BUILD_WITH_INSTALL_RPATH", True),
             self.define("HDF5_DIR", self.spec["hdf5"].prefix),

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -32,7 +32,7 @@ class Alps(CMakePackage):
     # Compiled Boost with all required library components.
     # ALPS_USE_SYSTEM_BOOST=ON consumes this instead of downloading Boost from source.
     depends_on(
-        "boost@1.80:"
+        "boost@1.63:"
         "+filesystem+serialization+system+program_options"
         "+regex+thread+date_time+chrono+timer+iostreams+test+python",
         type=("build", "link"),

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -144,10 +144,11 @@ class Alps(CMakePackage):
 
         # MPI support
         if self.spec.satisfies("+mpi"):
+            args.append(self.define("ALPS_ENABLE_MPI", True))
             args.append(self.define("MPI_CXX_COMPILER", self.spec["mpi"].mpicxx))
             args.append(self.define("MPI_C_COMPILER", self.spec["mpi"].mpicc))
         else:
-            args.append(self.define("ENABLE_MPI", False))
+            args.append(self.define("ALPS_ENABLE_MPI", False))
 
         # RPATH settings
         args.append(self.define("CMAKE_INSTALL_RPATH_USE_LINK_PATH", True))

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -59,12 +59,10 @@ class Alps(CMakePackage):
     extends("python")
 
     def cmake_args(self):
-        cstdlibstr = " -stdlib=libc++" if self.spec.satisfies("platform=darwin") else ""
         cxx_flags = (
             self.compiler.cxx14_flag
             + " -fpermissive -DBOOST_NO_AUTO_PTR -DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF"
             + " -DBOOST_TIMER_ENABLE_DEPRECATED"
-            + cstdlibstr
         )
         args = [
             self.define("CMAKE_CXX_FLAGS", cxx_flags),

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -25,7 +25,7 @@ class Alps(CMakePackage):
     # v2.3.3's LICENSE.txt is already the MIT license
     license("MIT", checked_by="egull")
 
-    version("develop", branch="master")
+    version("master", branch="master")
     version(
         "2.3.4-beta.2",
         sha256="ca2e1307630e6fccac279ab7711036f7c6dee43c386fd6f24cfc77c86a3c7f1c",
@@ -42,7 +42,7 @@ class Alps(CMakePackage):
     depends_on("cmake@3.18:", type="build")
 
     # --- Boost, two schemes ---
-    # @develop consumes an externally built (Spack) Boost via ALPS_USE_SYSTEM_BOOST.
+    # @master consumes an externally built (Spack) Boost via ALPS_USE_SYSTEM_BOOST.
     # Compiled Boost with all required library components.
     # Minimum 1.69: boost::system became header-only in 1.69; ALPS_USE_SYSTEM_BOOST
     # omits it from the explicit link list, which is only valid for Boost >= 1.69.
@@ -51,15 +51,15 @@ class Alps(CMakePackage):
         "+filesystem+serialization+system+program_options"
         "+regex+thread+date_time+chrono+timer+iostreams+test+python",
         type=("build", "link"),
-        when="@develop",
+        when="@master",
     )
-    depends_on("boost+mpi", when="@develop +mpi")
-    depends_on("boost~mpi", when="@develop ~mpi")
+    depends_on("boost+mpi", when="@master +mpi")
+    depends_on("boost~mpi", when="@master ~mpi")
     # Boost.Python numpy submodule needs boost+numpy when it is safe to use:
     # Boost >= 1.87 fixed NumPy 2.0 support; older Boost is safe only with NumPy < 2.
     # For Boost 1.69-1.86 + NumPy >= 2.0, ALPS falls back to boost::python::numeric::array.
-    depends_on("boost+numpy", when="@develop ^boost@1.87:")
-    depends_on("boost+numpy", when="@develop ^boost@1.69:1.86 ^py-numpy@:1")
+    depends_on("boost+numpy", when="@master ^boost@1.87:")
+    depends_on("boost+numpy", when="@master ^boost@1.69:1.86 ^py-numpy@:1")
 
     # Released versions compile Boost from a source tree staged as a resource;
     # this dependency only selects which source tarball resource is staged
@@ -113,9 +113,9 @@ class Alps(CMakePackage):
         )
 
     # Patch for >=Boost 1.88.0 compatibility (released versions only; the
-    # develop branch already carries these fixes in the ALPS sources)
+    # master branch already carries these fixes in the ALPS sources)
     def patch(self):
-        if self.spec.satisfies("@develop"):
+        if self.spec.satisfies("@master"):
             return
 
         # Only apply patch for Boost versions greater than 1.87
@@ -185,7 +185,7 @@ class Alps(CMakePackage):
                 self.define("MPI_C_COMPILER", self.spec["mpi"].mpicc),
             ]
 
-        if self.spec.satisfies("@develop"):
+        if self.spec.satisfies("@master"):
             # Consume the Spack-built Boost directly
             args += [
                 self.define("ALPS_USE_SYSTEM_BOOST", True),
@@ -230,7 +230,7 @@ class Alps(CMakePackage):
             if hasattr(self.spec["mpi"], "headers"):
                 env.append_path("CPLUS_INCLUDE_PATH", self.spec["mpi"].headers.directories[0])
 
-        if self.spec.satisfies("@develop"):
+        if self.spec.satisfies("@master"):
             # BOOST_ROOT as env var for FindBoost module-mode detection
             env.set("BOOST_ROOT", self.spec["boost"].prefix)
         else:

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -19,7 +19,7 @@ class Alps(CMakePackage):
 
     maintainers("Ooolab", "egull", "Sinan81")
 
-    license("MIT")
+    license("MIT", checked_by="egull")
 
     version("develop", branch="fix/system-boost-numpy-fallback")
 

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -15,21 +15,13 @@ class Alps(CMakePackage):
     """
 
     homepage = "https://github.com/ALPSim/ALPS"
-    url = "https://github.com/ALPSim/ALPS/archive/refs/tags/v2.3.4-beta.2.tar.gz"
     git = "https://github.com/ALPSim/ALPS.git"
 
     maintainers("Ooolab", "egull", "Sinan81")
 
-    license("BSL-1.0", when="@:2.3.3", checked_by="Sinan81")
-    license("MIT", when="@2.3.4:", checked_by="Ooolab")
+    license("MIT")
 
     version("develop", branch="fix/system-boost-numpy-fallback")
-    version(
-        "2.3.4-beta.2",
-        sha256="ca2e1307630e6fccac279ab7711036f7c6dee43c386fd6f24cfc77c86a3c7f1c",
-        preferred=True,
-    )
-    version("2.3.3", sha256="73d8c9038d00c7f768f65474b2a657d5c49daf105ddfcaef7d16737500b5d02f")
 
     variant("mpi", default=True, description="Build with MPI support")
 
@@ -37,9 +29,8 @@ class Alps(CMakePackage):
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
 
-    # Boost: compiled dependency with all required library variants.
-    # ALPS uses ALPS_USE_SYSTEM_BOOST=ON to consume Spack-built Boost directly
-    # instead of downloading and compiling Boost from source internally.
+    # Compiled Boost with all required library components.
+    # ALPS_USE_SYSTEM_BOOST=ON consumes this instead of downloading Boost from source.
     depends_on(
         "boost@1.80:"
         "+filesystem+serialization+system+program_options"
@@ -48,10 +39,9 @@ class Alps(CMakePackage):
     )
     depends_on("boost+mpi", when="+mpi")
     depends_on("boost~mpi", when="~mpi")
-    # Boost.Python numpy submodule: only safe when Boost >= 1.87 (fixed for
-    # NumPy 2.0), or when Boost < 1.87 is paired with NumPy < 2.0.
-    # For Boost 1.63-1.86 + NumPy >= 2.0, ALPS falls back automatically to
-    # boost::python::numeric::array — no boost+numpy needed in that case.
+    # Boost.Python numpy submodule needs boost+numpy when it is safe to use:
+    # Boost >= 1.87 fixed NumPy 2.0 support; older Boost is safe only with NumPy < 2.
+    # For Boost 1.63-1.86 + NumPy >= 2.0, ALPS falls back to boost::python::numeric::array.
     depends_on("boost+numpy", when="^boost@1.87:")
     depends_on("boost+numpy", when="^boost@1.63:1.86 ^py-numpy@:1")
 
@@ -68,120 +58,49 @@ class Alps(CMakePackage):
 
     extends("python")
 
-    # Patch for >=Boost 1.88.0 compatibility
     def patch(self):
-        # Only apply patch for Boost versions greater than 1.87
-        # Check if boost dependency is specified and get its version
-        if "boost" not in self.spec:
+        # Boost >= 1.88 moved boost::is_same / boost::add_const to std::
+        if "boost" not in self.spec or self.spec["boost"].version <= Version("1.87"):
             return
-
-        boost_spec = self.spec["boost"]
-        # Compare versions: only apply patch if boost version > 1.87
-        if boost_spec.version > Version("1.87"):
-            # Fix boost::is_same and boost::add_const for >=Boost 1.88.0 compatibility
-            # These type traits were moved to std:: in >=Boost 1.88.0
-
-            # First, let's add necessary includes
+        for path in [
+            "src/alps/numeric/matrix/strided_iterator.hpp",
+            "src/alps/numeric/matrix/matrix_element_iterator.hpp",
+        ]:
             filter_file(
                 "#include <boost/type_traits.hpp>",
                 "#include <boost/type_traits.hpp>\n#include <type_traits>",
-                "src/alps/numeric/matrix/strided_iterator.hpp",
+                path,
             )
-
-            filter_file(
-                "#include <boost/type_traits.hpp>",
-                "#include <boost/type_traits.hpp>\n#include <type_traits>",
-                "src/alps/numeric/matrix/matrix_element_iterator.hpp",
-            )
-
-            # Now replace boost::is_same with std::is_same
-            filter_file(
-                "boost::is_same", "std::is_same", "src/alps/numeric/matrix/strided_iterator.hpp"
-            )
-
-            filter_file(
-                "boost::is_same",
-                "std::is_same",
-                "src/alps/numeric/matrix/matrix_element_iterator.hpp",
-            )
-
-            # Replace boost::add_const with std::add_const
-            filter_file(
-                "boost::add_const",
-                "std::add_const",
-                "src/alps/numeric/matrix/strided_iterator.hpp",
-            )
-
-            filter_file(
-                "boost::add_const",
-                "std::add_const",
-                "src/alps/numeric/matrix/matrix_element_iterator.hpp",
-            )
+            filter_file("boost::is_same", "std::is_same", path)
+            filter_file("boost::add_const", "std::add_const", path)
 
     def cmake_args(self):
-        args = []
-
-        # Platform-specific C++ flags (e.g., -stdlib=libc++ on macOS)
-        cstdlibstr = ""
-        if self.spec.satisfies("platform=darwin"):
-            cstdlibstr = " -stdlib=libc++"
-
-        # Assemble the full C++ flags string
+        cstdlibstr = " -stdlib=libc++" if self.spec.satisfies("platform=darwin") else ""
         cxx_flags = (
             self.compiler.cxx14_flag
             + " -fpermissive -DBOOST_NO_AUTO_PTR -DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF"
             + " -DBOOST_TIMER_ENABLE_DEPRECATED"
             + cstdlibstr
         )
-
-        args.append(self.define("CMAKE_CXX_FLAGS", cxx_flags))
-
-        # Use Spack-installed Boost instead of building from source
-        args.append(self.define("ALPS_USE_SYSTEM_BOOST", True))
-        args.append(self.define("BOOST_ROOT", self.spec["boost"].prefix))
-        # Match the static/shared choice Spack built Boost with
-        args.append(self.define("Boost_USE_STATIC_LIBS", self.spec["boost"].satisfies("~shared")))
-
-        # MPI support
+        args = [
+            self.define("CMAKE_CXX_FLAGS", cxx_flags),
+            self.define("ALPS_USE_SYSTEM_BOOST", True),
+            self.define("BOOST_ROOT", self.spec["boost"].prefix),
+            self.define("Boost_USE_STATIC_LIBS", self.spec["boost"].satisfies("~shared")),
+            self.define_from_variant("ALPS_ENABLE_MPI", "mpi"),
+            self.define("CMAKE_INSTALL_RPATH_USE_LINK_PATH", True),
+            self.define("CMAKE_BUILD_WITH_INSTALL_RPATH", True),
+            self.define("HDF5_DIR", self.spec["hdf5"].prefix),
+        ]
         if self.spec.satisfies("+mpi"):
-            args.append(self.define("ALPS_ENABLE_MPI", True))
-            args.append(self.define("MPI_CXX_COMPILER", self.spec["mpi"].mpicxx))
-            args.append(self.define("MPI_C_COMPILER", self.spec["mpi"].mpicc))
-        else:
-            args.append(self.define("ALPS_ENABLE_MPI", False))
-
-        # RPATH settings
-        args.append(self.define("CMAKE_INSTALL_RPATH_USE_LINK_PATH", True))
-        args.append(self.define("CMAKE_BUILD_WITH_INSTALL_RPATH", True))
-
-        # Point to Spack's HDF5
-        args.append(self.define("HDF5_DIR", self.spec["hdf5"].prefix))
-
+            args += [
+                self.define("MPI_CXX_COMPILER", self.spec["mpi"].mpicxx),
+                self.define("MPI_C_COMPILER", self.spec["mpi"].mpicc),
+            ]
         return args
 
     def setup_build_environment(self, env):
-        # Point to Spack's installed Boost
+        # BOOST_ROOT as env var for FindBoost module-mode detection (belt-and-suspenders)
         env.set("BOOST_ROOT", self.spec["boost"].prefix)
-
-        # Include paths for compilation
+        # Python headers for ALPS C extension compilation
         env.append_path("CPLUS_INCLUDE_PATH", self.spec["python"].headers.directories[0])
-
-        # For MPI - set compiler wrappers
-        if "+mpi" in self.spec:
-            env.set("MPI_CXX", self.spec["mpi"].mpicxx)
-            env.set("MPI_CC", self.spec["mpi"].mpicc)
-            env.set("MPICXX", self.spec["mpi"].mpicxx)
-
-        # Add MPI include path if available
-        if "+mpi" in self.spec and hasattr(self.spec["mpi"], "headers"):
-            env.append_path("CPLUS_INCLUDE_PATH", self.spec["mpi"].headers.directories[0])
-
-        # For Python
-        env.set("PYTHON", self.spec["python"].command.path)
-
-        # Compiler flags
-        env.append_flags("CXXFLAGS", "-fpermissive")
-        env.append_flags("CXXFLAGS", "-DBOOST_NO_AUTO_PTR")
-        env.append_flags("CXXFLAGS", "-DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF")
-        env.append_flags("CXXFLAGS", "-DBOOST_TIMER_ENABLE_DEPRECATED")
-        env.append_flags("CXXFLAGS", self.compiler.cxx14_flag)

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -21,8 +21,8 @@ class Alps(CMakePackage):
 
     maintainers("Ooolab", "egull", "Sinan81")
 
-    license("BSL-1.0", when="@:2.3.3", checked_by="Sinan81")
-    license("MIT", when="@2.3.4:", checked_by="Ooolab")
+    # v2.3.3's LICENSE.txt is already the MIT license
+    license("MIT", checked_by="Ooolab")
 
     version(
         "2.3.4-beta.2",
@@ -36,10 +36,13 @@ class Alps(CMakePackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
-    depends_on(
-        "boost@1.80:", type="build"
-    )  # Just for headers. Note that the checksums are listed below
+    # Selects which boost source tarball resource is staged (see resources below).
+    # Upper bound must match the last entry in the resource table.
+    depends_on("boost@1.80:1.90", type="build")
     depends_on("fftw")
+    # Keep the DAG truly serial for ~mpi: fftw defaults to +mpi, which would
+    # otherwise pull in an MPI that ALPS's CMake then finds and links.
+    depends_on("fftw~mpi", when="~mpi")
     depends_on("lapack")
     depends_on("python", type=("build", "link", "run"))
     depends_on("py-numpy", type=("build", "run"))
@@ -56,6 +59,7 @@ class Alps(CMakePackage):
     # for why this is needed
     for boost_version, boost_checksum in (
         # boost version, shasum
+        ("1.90.0", "49551aff3b22cbc5c5a9ed3dbc92f0e23ea50a0f7325b0d198b705e8ee3fc305"),
         ("1.89.0", "85a33fa22621b4f314f8e85e1a5e2a9363d22e4f4992925d4bb3bc631b5a0c7a"),
         ("1.88.0", "46d9d2c06637b219270877c9e16155cbd015b6dc84349af064c088e9b5b12f7b"),
         ("1.87.0", "af57be25cb4c4f4b413ed692fe378affb4352ea50fbe294a11ef548f4d527d89"),
@@ -156,12 +160,12 @@ class Alps(CMakePackage):
             self.define("Boost_USE_STATIC_RUNTIME", False)
         )  # → -DBoost_USE_STATIC_RUNTIME=OFF
 
-        # MPI support
+        # MPI support (ALPS's cache variable is ALPS_ENABLE_MPI and defaults to ON,
+        # so it must be set OFF explicitly for ~mpi)
+        args.append(self.define_from_variant("ALPS_ENABLE_MPI", "mpi"))
         if self.spec.satisfies("+mpi"):
             args.append(self.define("MPI_CXX_COMPILER", self.spec["mpi"].mpicxx))
             args.append(self.define("MPI_C_COMPILER", self.spec["mpi"].mpicc))
-        else:
-            args.append(self.define("ENABLE_MPI", False))
 
         # RPATH settings
         args.append(self.define("CMAKE_INSTALL_RPATH_USE_LINK_PATH", True))
@@ -186,10 +190,8 @@ class Alps(CMakePackage):
             env.set("MPI_CXX", self.spec["mpi"].mpicxx)
             env.set("MPI_CC", self.spec["mpi"].mpicc)
             env.set("MPICXX", self.spec["mpi"].mpicxx)
-
-        # Add MPI include path if available
-        if hasattr(self.spec["mpi"], "headers"):
-            env.append_path("CPLUS_INCLUDE_PATH", self.spec["mpi"].headers.directories[0])
+            if hasattr(self.spec["mpi"], "headers"):
+                env.append_path("CPLUS_INCLUDE_PATH", self.spec["mpi"].headers.directories[0])
 
         # For Python
         env.set("PYTHON", self.spec["python"].command.path)

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -40,9 +40,11 @@ class Alps(CMakePackage):
     # No fortran: ALPS_BUILD_FORTRAN defaults OFF and is not enabled here
 
     depends_on("cmake@3.18:", type="build")
+    depends_on("cmake@3.22:", type="build", when="@3:")
 
     # --- Boost, two schemes ---
-    # @master consumes an externally built (Spack) Boost via ALPS_USE_SYSTEM_BOOST.
+    # @3: consumes an externally built (Spack) Boost via ALPS_USE_SYSTEM_BOOST.
+    # Spack's infinity-version ordering means that @master also satisfies @3:.
     # Compiled Boost with all required library components.
     # Minimum 1.69: boost::system became header-only in 1.69; ALPS_USE_SYSTEM_BOOST
     # omits it from the explicit link list, which is only valid for Boost >= 1.69.
@@ -51,17 +53,17 @@ class Alps(CMakePackage):
         "+filesystem+serialization+system+program_options"
         "+regex+thread+date_time+chrono+timer+iostreams+test+python",
         type=("build", "link"),
-        when="@master",
+        when="@3:",
     )
-    depends_on("boost+mpi", when="@master +mpi")
-    depends_on("boost~mpi", when="@master ~mpi")
+    depends_on("boost+mpi", when="@3: +mpi")
+    depends_on("boost~mpi", when="@3: ~mpi")
     # Boost.Python numpy submodule needs boost+numpy when it is safe to use:
     # Boost >= 1.87 fixed NumPy 2.0 support; older Boost is safe only with NumPy < 2.
     # For Boost 1.69-1.86 + NumPy >= 2.0, ALPS falls back to boost::python::numeric::array.
-    requires("^boost+numpy", when="@master ^boost@1.87:")
-    requires("^boost+numpy", when="@master ^boost@1.69:1.86 ^py-numpy@:1")
+    requires("^boost+numpy", when="@3: ^boost@1.87:")
+    requires("^boost+numpy", when="@3: ^boost@1.69:1.86 ^py-numpy@:1")
 
-    # Released versions compile Boost from a source tree staged as a resource;
+    # Legacy 2.x releases compile Boost from a source tree staged as a resource;
     # this dependency only selects which source tarball resource is staged
     # (see the resource table below). Upper bound must match the last entry
     # in that table.
@@ -84,7 +86,7 @@ class Alps(CMakePackage):
 
     extends("python")
 
-    # Boost source tree for released versions, which build Boost themselves.
+    # Boost source tree for legacy 2.x releases, which build Boost themselves.
     # See https://github.com/ALPSim/ALPS/issues/6#issuecomment-2604912169
     # for why this is needed
     for boost_version, boost_checksum in (
@@ -112,10 +114,10 @@ class Alps(CMakePackage):
             placement="boost_source_files",
         )
 
-    # Patch for >=Boost 1.88.0 compatibility (released versions only; the
-    # master branch already carries these fixes in the ALPS sources)
+    # Patch for >=Boost 1.88.0 compatibility (legacy 2.x releases only; the
+    # 3.x sources already carry these fixes)
     def patch(self):
-        if self.spec.satisfies("@master"):
+        if self.spec.satisfies("@3:"):
             return
 
         # Only apply patch for Boost versions greater than 1.87
@@ -185,7 +187,7 @@ class Alps(CMakePackage):
                 self.define("MPI_C_COMPILER", self.spec["mpi"].mpicc),
             ]
 
-        if self.spec.satisfies("@master"):
+        if self.spec.satisfies("@3:"):
             # Consume the Spack-built Boost directly
             args += [
                 self.define("ALPS_USE_SYSTEM_BOOST", True),
@@ -193,7 +195,7 @@ class Alps(CMakePackage):
                 self.define("Boost_USE_STATIC_LIBS", self.spec["boost"].satisfies("~shared")),
             ]
         else:
-            # Released versions build Boost from the staged source tree.
+            # Legacy 2.x releases build Boost from the staged source tree.
             # Platform-specific C++ flags: -stdlib=libc++ defeats ALPS's
             # obsolete clang logic that would otherwise force libstdc++
             cstdlibstr = ""
@@ -230,7 +232,7 @@ class Alps(CMakePackage):
             if hasattr(self.spec["mpi"], "headers"):
                 env.append_path("CPLUS_INCLUDE_PATH", self.spec["mpi"].headers.directories[0])
 
-        if self.spec.satisfies("@master"):
+        if self.spec.satisfies("@3:"):
             # BOOST_ROOT as env var for FindBoost module-mode detection
             env.set("BOOST_ROOT", self.spec["boost"].prefix)
         else:

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -58,8 +58,8 @@ class Alps(CMakePackage):
     # Boost.Python numpy submodule needs boost+numpy when it is safe to use:
     # Boost >= 1.87 fixed NumPy 2.0 support; older Boost is safe only with NumPy < 2.
     # For Boost 1.69-1.86 + NumPy >= 2.0, ALPS falls back to boost::python::numeric::array.
-    depends_on("boost+numpy", when="@master ^boost@1.87:")
-    depends_on("boost+numpy", when="@master ^boost@1.69:1.86 ^py-numpy@:1")
+    requires("^boost+numpy", when="@master ^boost@1.87:")
+    requires("^boost+numpy", when="@master ^boost@1.69:1.86 ^py-numpy@:1")
 
     # Released versions compile Boost from a source tree staged as a resource;
     # this dependency only selects which source tarball resource is staged

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
@@ -18,12 +16,14 @@ class Alps(CMakePackage):
 
     homepage = "https://github.com/ALPSim/ALPS"
     url = "https://github.com/ALPSim/ALPS/archive/refs/tags/v2.3.4-beta.2.tar.gz"
+    git = "https://github.com/ALPSim/ALPS.git"
 
     maintainers("Ooolab", "egull", "Sinan81")
 
     license("BSL-1.0", when="@:2.3.3", checked_by="Sinan81")
     license("MIT", when="@2.3.4:", checked_by="Ooolab")
 
+    version("develop", branch="fix/system-boost-numpy-fallback")
     version(
         "2.3.4-beta.2",
         sha256="ca2e1307630e6fccac279ab7711036f7c6dee43c386fd6f24cfc77c86a3c7f1c",
@@ -36,9 +36,25 @@ class Alps(CMakePackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
+
+    # Boost: compiled dependency with all required library variants.
+    # ALPS uses ALPS_USE_SYSTEM_BOOST=ON to consume Spack-built Boost directly
+    # instead of downloading and compiling Boost from source internally.
     depends_on(
-        "boost@1.80:", type="build"
-    )  # Just for headers. Note that the checksums are listed below
+        "boost@1.80:"
+        "+filesystem+serialization+system+program_options"
+        "+regex+thread+date_time+chrono+timer+iostreams+test+python",
+        type=("build", "link"),
+    )
+    depends_on("boost+mpi", when="+mpi")
+    depends_on("boost~mpi", when="~mpi")
+    # Boost.Python numpy submodule: only safe when Boost >= 1.87 (fixed for
+    # NumPy 2.0), or when Boost < 1.87 is paired with NumPy < 2.0.
+    # For Boost 1.63-1.86 + NumPy >= 2.0, ALPS falls back automatically to
+    # boost::python::numeric::array — no boost+numpy needed in that case.
+    depends_on("boost+numpy", when="^boost@1.87:")
+    depends_on("boost+numpy", when="^boost@1.63:1.86 ^py-numpy@:1")
+
     depends_on("fftw")
     depends_on("lapack")
     depends_on("python", type=("build", "link", "run"))
@@ -51,32 +67,6 @@ class Alps(CMakePackage):
     depends_on("zlib-api")
 
     extends("python")
-
-    # See https://github.com/ALPSim/ALPS/issues/6#issuecomment-2604912169
-    # for why this is needed
-    for boost_version, boost_checksum in (
-        # boost version, shasum
-        ("1.89.0", "85a33fa22621b4f314f8e85e1a5e2a9363d22e4f4992925d4bb3bc631b5a0c7a"),
-        ("1.88.0", "46d9d2c06637b219270877c9e16155cbd015b6dc84349af064c088e9b5b12f7b"),
-        ("1.87.0", "af57be25cb4c4f4b413ed692fe378affb4352ea50fbe294a11ef548f4d527d89"),
-        ("1.86.0", "1bed88e40401b2cb7a1f76d4bab499e352fa4d0c5f31c0dbae64e24d34d7513b"),
-        ("1.85.0", "7009fe1faa1697476bdc7027703a2badb84e849b7b0baad5086b087b971f8617"),
-        ("1.84.0", "cc4b893acf645c9d4b698e9a0f08ca8846aa5d6c68275c14c3e7949c24109454"),
-        ("1.83.0", "6478edfe2f3305127cffe8caf73ea0176c53769f4bf1585be237eb30798c3b8e"),
-        ("1.82.0", "a6e1ab9b0860e6a2881dd7b21fe9f737a095e5f33a3a874afc6a345228597ee6"),
-        ("1.81.0", "71feeed900fbccca04a3b4f2f84a7c217186f28a940ed8b7ed4725986baf99fa"),
-        ("1.80.0", "1e19565d82e43bc59209a168f5ac899d3ba471d55c7610c677d4ccf2c9c500c0"),
-    ):
-        resource(
-            when="^boost@{0}".format(boost_version),
-            name="boost_source_files",
-            url="https://downloads.sourceforge.net/project/boost/boost/{0}/boost_{1}.tar.bz2".format(
-                boost_version, boost_version.replace(".", "_")
-            ),
-            sha256=boost_checksum,
-            destination="",
-            placement="boost_source_files",
-        )
 
     # Patch for >=Boost 1.88.0 compatibility
     def patch(self):
@@ -146,15 +136,11 @@ class Alps(CMakePackage):
 
         args.append(self.define("CMAKE_CXX_FLAGS", cxx_flags))
 
-        # Boost source directory
-        boost_src_dir = os.path.join(self.stage.source_path, "boost_source_files")
-        args.append(self.define("Boost_SRC_DIR", boost_src_dir))
-
-        # Boost linking options
-        args.append(self.define("Boost_USE_STATIC_LIBS", True))  # → -DBoost_USE_STATIC_LIBS=ON
-        args.append(
-            self.define("Boost_USE_STATIC_RUNTIME", False)
-        )  # → -DBoost_USE_STATIC_RUNTIME=OFF
+        # Use Spack-installed Boost instead of building from source
+        args.append(self.define("ALPS_USE_SYSTEM_BOOST", True))
+        args.append(self.define("BOOST_ROOT", self.spec["boost"].prefix))
+        # Match the static/shared choice Spack built Boost with
+        args.append(self.define("Boost_USE_STATIC_LIBS", self.spec["boost"].satisfies("~shared")))
 
         # MPI support
         if self.spec.satisfies("+mpi"):
@@ -173,10 +159,8 @@ class Alps(CMakePackage):
         return args
 
     def setup_build_environment(self, env):
-        # Set up environment for boost source compilation
-        boost_src_dir = os.path.join(self.stage.source_path, "boost_source_files")
-        env.set("BOOST_ROOT", boost_src_dir)
-        env.set("Boost_SRC_DIR", boost_src_dir)
+        # Point to Spack's installed Boost
+        env.set("BOOST_ROOT", self.spec["boost"].prefix)
 
         # Include paths for compilation
         env.append_path("CPLUS_INCLUDE_PATH", self.spec["python"].headers.directories[0])
@@ -188,7 +172,7 @@ class Alps(CMakePackage):
             env.set("MPICXX", self.spec["mpi"].mpicxx)
 
         # Add MPI include path if available
-        if hasattr(self.spec["mpi"], "headers"):
+        if "+mpi" in self.spec and hasattr(self.spec["mpi"], "headers"):
             env.append_path("CPLUS_INCLUDE_PATH", self.spec["mpi"].headers.directories[0])
 
         # For Python

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -179,6 +179,12 @@ class Alps(CMakePackage):
             self.define("CMAKE_INSTALL_RPATH_USE_LINK_PATH", True),
             self.define("CMAKE_BUILD_WITH_INSTALL_RPATH", True),
             self.define("HDF5_DIR", self.spec["hdf5"].prefix),
+            # Hand the concretized BLAS/LAPACK to ALPS explicitly.  Its
+            # FindLapack.cmake otherwise probes the host first (MKLROOT in the
+            # environment, Accelerate on macOS) and links whatever it finds
+            # there instead of the Spack-built provider.
+            self.define("BLAS_LIBRARY", self.spec["blas"].libs.joined(";")),
+            self.define("LAPACK_LIBRARY", self.spec["lapack"].libs.joined(";")),
         ]
 
         if self.spec.satisfies("+mpi"):

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -14,7 +14,7 @@ class Alps(CMakePackage):
     algorithm for many others.
     """
 
-    homepage = "https://github.com/ALPSim/ALPS"
+    homepage = "https://alps.comp-phys.org"
     git = "https://github.com/ALPSim/ALPS.git"
 
     maintainers("Ooolab", "egull", "Sinan81")

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -58,22 +58,6 @@ class Alps(CMakePackage):
 
     extends("python")
 
-    def patch(self):
-        # Boost >= 1.88 moved boost::is_same / boost::add_const to std::
-        if "boost" not in self.spec or self.spec["boost"].version <= Version("1.87"):
-            return
-        for path in [
-            "src/alps/numeric/matrix/strided_iterator.hpp",
-            "src/alps/numeric/matrix/matrix_element_iterator.hpp",
-        ]:
-            filter_file(
-                "#include <boost/type_traits.hpp>",
-                "#include <boost/type_traits.hpp>\n#include <type_traits>",
-                path,
-            )
-            filter_file("boost::is_same", "std::is_same", path)
-            filter_file("boost::add_const", "std::add_const", path)
-
     def cmake_args(self):
         cstdlibstr = " -stdlib=libc++" if self.spec.satisfies("platform=darwin") else ""
         cxx_flags = (

--- a/repos/spack_repo/builtin/packages/alps/package.py
+++ b/repos/spack_repo/builtin/packages/alps/package.py
@@ -30,9 +30,10 @@ class Alps(CMakePackage):
     depends_on("fortran", type="build")
 
     # Compiled Boost with all required library components.
-    # ALPS_USE_SYSTEM_BOOST=ON consumes this instead of downloading Boost from source.
+    # Minimum 1.69: boost::system became header-only in 1.69; ALPS_USE_SYSTEM_BOOST
+    # omits it from the explicit link list, which is only valid for Boost >= 1.69.
     depends_on(
-        "boost@1.63:"
+        "boost@1.69:"
         "+filesystem+serialization+system+program_options"
         "+regex+thread+date_time+chrono+timer+iostreams+test+python",
         type=("build", "link"),
@@ -41,9 +42,9 @@ class Alps(CMakePackage):
     depends_on("boost~mpi", when="~mpi")
     # Boost.Python numpy submodule needs boost+numpy when it is safe to use:
     # Boost >= 1.87 fixed NumPy 2.0 support; older Boost is safe only with NumPy < 2.
-    # For Boost 1.63-1.86 + NumPy >= 2.0, ALPS falls back to boost::python::numeric::array.
+    # For Boost 1.69-1.86 + NumPy >= 2.0, ALPS falls back to boost::python::numeric::array.
     depends_on("boost+numpy", when="^boost@1.87:")
-    depends_on("boost+numpy", when="^boost@1.63:1.86 ^py-numpy@:1")
+    depends_on("boost+numpy", when="^boost@1.69:1.86 ^py-numpy@:1")
 
     depends_on("fftw")
     depends_on("lapack")
@@ -59,13 +60,7 @@ class Alps(CMakePackage):
     extends("python")
 
     def cmake_args(self):
-        cxx_flags = (
-            self.compiler.cxx14_flag
-            + " -fpermissive -DBOOST_NO_AUTO_PTR -DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF"
-            + " -DBOOST_TIMER_ENABLE_DEPRECATED"
-        )
         args = [
-            self.define("CMAKE_CXX_FLAGS", cxx_flags),
             self.define("ALPS_USE_SYSTEM_BOOST", True),
             self.define("BOOST_ROOT", self.spec["boost"].prefix),
             self.define("Boost_USE_STATIC_LIBS", self.spec["boost"].satisfies("~shared")),


### PR DESCRIPTION
## Summary

Add ALPS 3.0.0 and use Spack-built Boost for 3.x and `@master`. Removing the preference for 2.3.4-beta.2 makes 3.0.0 the default; future stable versions can become the default when added to the recipe.

- Enable system Boost and Python bindings for 3.x/master, require the compiled Boost components, and require Boost >=1.87 with NumPy 2.
- Preserve the staged Boost source build for legacy releases and add the Boost 1.90 source resource.
- Correct MPI selection with `ALPS_ENABLE_MPI`, serial Boost/FFTW for `~mpi`, and serial HDF5 for both variants.
- Declare BLAS and LAPACK and pass the selected libraries explicitly to CMake.
- Disable ALPS's independent optional SZIP lookup: HDF5 supplies its compression dependencies, and this lookup can introduce unrelated host headers. Local testing caught Homebrew Boost headers shadowing Spack Boost.
- Set the CMake/Python minimum versions, remove the unused Fortran dependency, and correct the license to MIT.

## Local validation

Built from source on Apple M4 / macOS, Apple Clang 21.0.0, using Spack 1.3.0.dev0 (`6c999ba261f0626bde87e9ebd7daf914bcabd215`).

| Spec | Build/install | Installed runtime checks | Bundled CTest |
| --- | --- | --- | --- |
| `alps` (selects `3.0.0+mpi`) | Passed | Python/HDF5, serial and 2-process MPI simulations passed | Not run for this variant |
| `alps@3.0.0~mpi %c,cxx=apple-clang@21.0.0` | Passed | Python/HDF5 and serial simulation passed | 162/162 passed |
| `alps@master` at `d9a85e793b7f6fa60c80132853fe04c320ef67c4` | Passed | Python/HDF5, serial and 2-process MPI simulations passed | 162/162 passed |

Runtime checks imported `pyalps` from each tested installation, round-tripped integer/float/complex NumPy arrays and a string through HDF5, ran a 4x4 Ising simulation, and read finite energy measurements back through `pyalps`. MPI runs used two processes. Inspection of 54 native artifacts per installation confirmed Spack Boost and OpenBLAS linkage; the serial installation had no MPI library references and its dependency graph contained no MPI provider.

CTest ran sequentially. An initial parallel run exposed a test-file collision on this case-insensitive filesystem: `signed` uses `Observableset.dump` while `testobservableset` uses `observableset.dump`. The complete sequential suite passed without source changes or exclusions.

Dependencies: Spack-built Boost 1.90.0; Python 3.14.7, NumPy 2.5.3, SciPy 1.18.1, Matplotlib 3.11.2, HDF5 2.2.0, OpenBLAS 0.3.34, and Open MPI 5.0.9. To fit local disk space, Python/numeric packages and several native dependencies were configured as externals; their compilation is not covered by these tests. Serial FFTW was built by Spack. Validation covers this macOS platform, not Linux or older ALPS releases with the final recipe.

Additional checks passed: release archive SHA-256 verification, default-version selection, Spack package audit, Ruff lint/format, and `git diff --check`. The initial real builds identified and resolved the missing BLAS declaration, Boost/NumPy incompatibility, and host-header contamination described above.

## References

- [ALPS 3.0.0 release](https://github.com/ALPSim/ALPS/releases/tag/v3.0.0)
- [System Boost implementation](https://github.com/ALPSim/ALPS/pull/84)
- [Development and earlier test history](https://github.com/ALPSim/spack-packages/pull/1)
